### PR TITLE
feat(install): fresh installs pull the fork directly (one command for all)

### DIFF
--- a/AUTO_UPGRADE.md
+++ b/AUTO_UPGRADE.md
@@ -118,16 +118,21 @@ hermes cron list | grep -i evolution
 
 ---
 
-## 🅱️ Fresh install, then switch to the fork
+## 🅱️ Fresh install (no Hermes yet) — installs the fork directly
 
-The official installer clones the **original** repo, so install first, then do
-section 🅰️ steps 2–6:
+You do NOT need the original first. The one-command `upgrade.sh` detects there's
+no Hermes and installs **our fork** directly (our `scripts/install.sh` defaults
+its repo to this fork — root → `/usr/local/lib/hermes-agent`, non-root →
+`~/.hermes/hermes-agent`), then finishes evolution setup:
 
 ```bash
-# Official install (root → /usr/local/lib/hermes-agent, non-root → ~/.hermes/hermes-agent):
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
-# then run section 🅰️ (point origin at the fork, hermes update, register cron, schedule).
+curl -fsSL https://raw.githubusercontent.com/Lexus2016/hermes-agent-evolution/main/upgrade.sh | bash
 ```
+
+Prefer to run the installer by itself? It already clones the fork (code +
+evolution skills); afterwards `hermes` is ready and you can run `upgrade.sh`
+again to register cron + schedule. To install a different repo instead, set
+`HERMES_REPO_HTTPS=<url>`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,37 +34,53 @@ memory, and settings stay exactly as they were.
 
 ---
 
-## 🔑 One thing to set up: a GitHub token
+## 🔑 Set up a GitHub token
 
-For the agent to research and open improvement **issues** on GitHub, it needs a
-GitHub token. Here's how to get one (takes ~2 minutes, no coding):
+The agent needs a GitHub token to work with GitHub. There are **two cases** —
+pick the one that's you. (~2 minutes, no coding.)
 
-1. Open **[github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)**
-   (log in if asked). This is the **Fine-grained token** page.
-2. **Token name:** type `hermes-evolution`.
-3. **Expiration:** pick 90 days (or longer).
-4. **Repository access:** choose **“Only select repositories”** → pick
-   **`hermes-agent-evolution`**.
-5. **Permissions → Repository permissions**, set these three to **Read and write**:
-   - **Contents**
-   - **Issues**
-   - **Pull requests**
-6. Click **Generate token** at the bottom, then **copy** the token
-   (it starts with `github_pat_…`). Copy it now — GitHub shows it only once.
-7. Give it to your agent — paste this one line (replace the placeholder):
+### 👤 Regular user — let the agent open improvement *issues*
 
+The agent opens issues on the **shared Hermes Evolution repo**. That repo isn't
+yours, so a fine-grained token can't target it — use a **classic** token with
+the `public_repo` scope:
+
+1. Open **[github.com/settings/tokens/new](https://github.com/settings/tokens/new)**
+   — this is *Personal access token (classic)*.
+2. **Note:** `hermes-evolution`. **Expiration:** 90 days (or longer).
+3. Tick **`public_repo`** (under **repo** → “Access public repositories”). That's
+   the only box you need — it lets the agent open issues/PRs on public repos.
+4. Click **Generate token** → **copy** it (starts with `ghp_…`; shown once).
+5. Give it to your agent:
    ```bash
    echo 'GITHUB_TOKEN=PASTE_YOUR_TOKEN_HERE' >> ~/.hermes/.env
    ```
 
-Done. From now on your Hermes can research and open improvement issues on GitHub.
+Done — your Hermes can now research and open improvement issues.
 
-*That's all most people need. If you own the fork and want the agent to also
-implement changes and update the project itself, that uses a separate owner
-token — see [EVOLUTION_README.md](EVOLUTION_README.md).*
+### 🛠️ Repo owner — full self-evolution (issues, PRs, commits, pushes, releases)
 
-> Keep the token private — treat it like a password. Never share it or paste it
-> into a chat. If it ever leaks, delete it on GitHub and make a new one.
+If you **own** `hermes-agent-evolution`, the agent can also implement changes,
+open pull requests, push branches, and cut releases. You own the repo, so use a
+**fine-grained** token scoped to it:
+
+1. Open **[github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)**
+   — this is the *Fine-grained token* page.
+2. **Token name:** `hermes-evolution-owner`. **Expiration:** 90 days (or longer).
+3. **Repository access:** *Only select repositories* → pick
+   **`hermes-agent-evolution`** (you can select it because it's yours).
+4. **Permissions → Repository permissions** — set to **Read and write**:
+   - **Contents** — commits, pushes, tags **and releases**
+   - **Issues**
+   - **Pull requests**
+5. Click **Generate token** → **copy** it (starts with `github_pat_…`; shown once).
+6. Give it to your agent:
+   ```bash
+   echo 'GITHUB_PRIVATE_TOKEN=PASTE_YOUR_TOKEN_HERE' >> ~/.hermes/.env
+   ```
+
+> Keep tokens private — treat them like passwords. Never share them or paste them
+> into a chat. If one leaks, delete it on GitHub and create a new one.
 
 ---
 
@@ -87,7 +103,8 @@ No need to install the original Hermes first — the one command above installs
 It pulls Hermes Evolution, sets it up, and turns on the evolution features in
 one go.
 
-Windows works natively too — see **[AUTO_UPGRADE.md](AUTO_UPGRADE.md)**.
+Windows works natively too — a PowerShell installer (`scripts/install.ps1`) is
+included; see **[AUTO_UPGRADE.md](AUTO_UPGRADE.md)**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@
 
 ---
 
-## ⭐ Already running Hermes? Upgrade in one command
+## ⭐ Install or upgrade — one command
 
-If you installed Hermes Agent and went through its setup wizard, switch to
-Hermes Evolution by pasting **one line** into your terminal:
+Whether you're **starting from scratch** or **already running Hermes**, paste
+**one line** into your terminal. If Hermes isn't installed yet, it installs our
+version fresh; if it is, it switches your existing Hermes onto Evolution
+(your chats, memory, and settings are kept):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Lexus2016/hermes-agent-evolution/main/upgrade.sh | bash
@@ -78,14 +80,12 @@ Everything you already love about Hermes Agent still works exactly the same.
 
 ---
 
-## 🆕 Don't have Hermes yet?
+## 🆕 Starting from scratch?
 
-Install the original Hermes Agent first, then run the one-command upgrade above:
-
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
-# then the upgrade line from the top of this README
-```
+No need to install the original Hermes first — the one command above installs
+**our fork directly** (you do NOT end up on the original and then migrate).
+It pulls Hermes Evolution, sets it up, and turns on the evolution features in
+one go.
 
 Windows works natively too — see **[AUTO_UPGRADE.md](AUTO_UPGRADE.md)**.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,8 +43,11 @@ NC='\033[0m' # No Color
 BOLD='\033[1m'
 
 # Configuration
-REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
-REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+# This is the Hermes Evolution fork installer: a fresh install pulls OUR fork
+# directly (code + evolution skills), not the original. Override via env if you
+# really want a different repo (e.g. HERMES_REPO_HTTPS=...).
+REPO_URL_SSH="${HERMES_REPO_SSH:-git@github.com:Lexus2016/hermes-agent-evolution.git}"
+REPO_URL_HTTPS="${HERMES_REPO_HTTPS:-https://github.com/Lexus2016/hermes-agent-evolution.git}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -31,11 +31,19 @@ done
 echo "🧬 Hermes Evolution — upgrade existing Hermes onto the fork"
 echo "=========================================================="
 
-# 1. Locate the existing install from the hermes binary --------------------
+# 1. Locate the existing install — or do a FRESH install of the fork ---------
+# No Hermes yet? Don't make the user install the original first — install OUR
+# fork directly (install.sh defaults to this repo), then finish evolution setup.
 if ! command -v hermes >/dev/null 2>&1; then
-    echo "❌ 'hermes' not found on PATH. Install Hermes Agent first:"
-    echo "   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
-    exit 1
+    echo "ℹ️  No Hermes found — installing Hermes Evolution fresh (from this fork)..."
+    curl -fsSL https://raw.githubusercontent.com/Lexus2016/hermes-agent-evolution/main/scripts/install.sh | bash
+    hash -r 2>/dev/null || true
+    if ! command -v hermes >/dev/null 2>&1; then
+        echo "❌ Fresh install finished but 'hermes' isn't on PATH yet."
+        echo "   Open a NEW terminal (so PATH refreshes) and re-run this command."
+        exit 1
+    fi
+    echo "✅ Fresh install complete — continuing with evolution setup."
 fi
 HERMES_BIN="$(readlink -f "$(command -v hermes)" 2>/dev/null || command -v hermes)"
 INSTALL_DIR="$(dirname "$(dirname "$(dirname "$HERMES_BIN")")")"


### PR DESCRIPTION
Fixes the backwards fresh-install flow: new users no longer install the original Hermes then migrate. install.sh now defaults its repo to THIS fork (env-overridable), and upgrade.sh is universal (installs fork fresh if Hermes absent, upgrades if present). README/AUTO_UPGRADE updated: one command for both fresh and existing.