### PR TITLE
fix(evolution): issues/analysis create/read via gh CLI + terminal toolset

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -21,6 +21,7 @@ skills:
 toolsets:
   - web
   - file
+  - terminal   # needed for `gh issue list` (gh is authorized via GITHUB_PRIVATE_TOKEN)
 
 # GitHub API configuration (PRIVATE mode)
 github:

--- a/cron/evolution/issues.yaml
+++ b/cron/evolution/issues.yaml
@@ -18,6 +18,7 @@ skills:
 toolsets:
   - web
   - file
+  - terminal   # needed for `gh issue create` (gh is authorized via GITHUB_TOKEN)
 
 # GitHub API configuration (PUBLIC mode)
 github:

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -17,10 +17,12 @@ mode: PRIVATE
 
 ## Процес
 
-1. **Отримання** всіх відкритих issues через GitHub API:
+1. **Отримання** всіх відкритих issues через `gh` CLI (terminal tool).
+   `gh` уже авторизований через `GITHUB_PRIVATE_TOKEN` з оточення:
 
 ```bash
-GET https://api.github.com/repos/Lexus2016/hermes-agent-evolution/issues?state=open
+gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
+  --limit 50 --json number,title,body,labels,createdAt
 ```
 
 2. **Оцінювання** кожного issue за критеріями:

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -18,12 +18,20 @@ category: evolution
 
 1. **Завантаження** останнього звіту дослідження з `~/.hermes/profiles/user1/evolution/research/`
 2. **Вибір** пропозицій з Priority Score >= 0.7
-3. **Створення issues** через GitHub API:
+3. **Створення issues** через `gh` CLI (terminal tool). `gh` уже авторизований
+   через `GITHUB_TOKEN` з оточення — окремий `gh auth login` не потрібен.
+   Для КОЖНОЇ відібраної пропозиції виконай:
 
 ```bash
-# Використовуй web tool для GitHub API:
-POST https://api.github.com/repos/Lexus2016/hermes-agent-evolution/issues
+gh issue create \
+  --repo Lexus2016/hermes-agent-evolution \
+  --title "[FEATURE] <короткий заголовок>" \
+  --label "enhancement,proposal,research-generated" \
+  --body "<тіло issue за форматом нижче>"
 ```
+
+> НЕ використовуй web tool для створення issue — він не робить
+> авторизований POST. Створення issue — лише через `gh` (terminal).
 
 ### Формат issue
 


### PR DESCRIPTION
## Root cause of '0 issues despite Last run ok'
evolution-issues ran but created nothing:
1. toolset was web+file — **no terminal**, so the agent had no way to run gh;
2. the skill told it to POST to api.github.com via the **web tool**, which doesn't do authenticated POST.
Agent finished 'ok' with no actual issue created.

## Fix (align with the already-working implementation/upstream-sync pattern)
- issues.yaml / analysis.yaml: add `terminal` toolset.
- evolution-issues/SKILL.md: `gh issue create` instead of web POST.
- evolution-analysis/SKILL.md: `gh issue list --json` instead of web GET.

gh is authorized via GITHUB_TOKEN / GITHUB_PRIVATE_TOKEN from env (verified live on osoba-ai-1).