### PR TITLE
fix(evolution): force correct token per role (resolves issues 401)

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -21,6 +21,9 @@ Analyze all created issues and PRs, and determine priority for implementation.
    `gh` is already authorized through `GITHUB_PRIVATE_TOKEN` from the environment:
 
 ```bash
+# analysis runs in the PRIVATE owner role — force the private token explicitly
+# so `gh` cannot pick the wrong token when both are present in the env:
+export GH_TOKEN="$GITHUB_PRIVATE_TOKEN"
 gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
   --limit 50 --json number,title,body,labels,createdAt
 ```

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -33,6 +33,15 @@ git checkout -b evolution/issue-123-feature-name
 - Add tests
 - Add documentation
 
+### Authorize git + gh (PRIVATE owner role)
+```bash
+# implementation runs in the PRIVATE owner role — force the private token and
+# make git use it for push, so neither gh nor git can pick the wrong token
+# when both are present in the env:
+export GH_TOKEN="$GITHUB_PRIVATE_TOKEN"
+gh auth setup-git    # routes git https push/pull auth through gh's token
+```
+
 ### Commit
 ```bash
 git add .

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -28,6 +28,10 @@ Create GitHub issues and pull requests based on research.
 
 ```bash
 REPO=Lexus2016/hermes-agent-evolution
+# issues run in the PUBLIC proposer role — ALWAYS use the public GITHUB_TOKEN
+# (account that only opens issues), NEVER GITHUB_PRIVATE_TOKEN. Force it
+# explicitly so `gh` cannot pick the wrong token when both are in the env:
+export GH_TOKEN="$GITHUB_TOKEN"
 gh label create proposal          --repo "$REPO" --color 0e8a16 --description "Evolution-generated improvement proposal" 2>/dev/null || true
 gh label create research-generated --repo "$REPO" --color 1d76db --description "Created by the evolution research cycle"     2>/dev/null || true
 # 'enhancement' — a standard GitHub label, present by default.

--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -108,6 +108,11 @@ git revert -m 1 <merge-commit>
 upstream changes go **through a separate branch + PR + CI** — NOT a direct merge:
 
 ```bash
+# 0. PRIVATE owner role — force the private token and route git auth through gh
+#    so neither gh nor git picks the wrong token when both are in the env:
+export GH_TOKEN="$GITHUB_PRIVATE_TOKEN"
+gh auth setup-git
+
 # 1. Separate branch from the current main:
 git checkout main && git pull && git checkout -b sync/upstream-YYYY-MM-DD
 


### PR DESCRIPTION
Live cron output showed: research works, issues agent selected 5 proposals, but gh issue create got HTTP 401 — it used GITHUB_PRIVATE_TOKEN (detect_mode=PRIVATE) for a PUBLIC role, and that token was stale. Skills now force the right token per role (issues=GITHUB_TOKEN public; analysis/impl/upstream=GITHUB_PRIVATE_TOKEN) and run gh auth setup-git for git push auth.