### PR TITLE
feat(install): onboarding robustness — auto-star, gh check, Windows auto-update (#10/#11/#12)

### DIFF
--- a/AUTO_UPGRADE.md
+++ b/AUTO_UPGRADE.md
@@ -152,13 +152,19 @@ bash "$INSTALL_DIR/scripts/install_auto_update.sh" --remove
 This installs one cron line: `hermes update --yes` (non-interactive, keeps the
 pre-update backup).
 
-**Windows (Task Scheduler):**
+**Windows (Task Scheduler):** use the bundled PowerShell installer — it registers
+the daily task for you (the equivalent of the cron line above), idempotently:
 ```powershell
-# Run hermes update daily at 04:17 (native, no WSL needed):
-schtasks /Create /SC DAILY /ST 04:17 /TN "HermesEvolutionUpdate" /TR "hermes update --yes" /F
-# remove:
-schtasks /Delete /TN "HermesEvolutionUpdate" /F
+# Install daily `hermes update --yes` (default 04:17):
+powershell -ExecutionPolicy Bypass -File scripts\install_auto_update.ps1
+# Custom time:
+powershell -ExecutionPolicy Bypass -File scripts\install_auto_update.ps1 -Time 05:30
+# Remove:
+powershell -ExecutionPolicy Bypass -File scripts\install_auto_update.ps1 -Remove
 ```
+It resolves the `hermes` path, logs to `%USERPROFILE%\.hermes\logs\auto-update.log`,
+and overwrites any existing task on re-run. (Manual equivalent, if you prefer:
+`schtasks /Create /SC DAILY /ST 04:17 /TN "HermesEvolutionUpdate" /TR "hermes update --yes" /F`.)
 
 ---
 

--- a/scripts/install_auto_update.ps1
+++ b/scripts/install_auto_update.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    Schedule the OFFICIAL `hermes update --yes` to run daily on Windows.
+
+.DESCRIPTION
+    Windows has no cron, so the bash scripts/install_auto_update.sh cannot run
+    here. This is the Windows equivalent: it registers a Task Scheduler job that
+    runs `hermes update --yes` once a day. `hermes update` updates the real
+    install dir, has built-in snapshot/rollback, and pulls THIS fork's `origin`
+    (evolution) plus `upstream` (NousResearch) — same behaviour as the cron path.
+
+    Idempotent: re-running overwrites the existing task (/F). Off-zero minute
+    (04:17) on purpose to avoid the :00 thundering herd.
+
+.PARAMETER Remove
+    Delete the scheduled task instead of creating it.
+
+.PARAMETER Time
+    Daily run time as HH:mm (24h). Default 04:17.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File scripts/install_auto_update.ps1
+    powershell -ExecutionPolicy Bypass -File scripts/install_auto_update.ps1 -Time 05:30
+    powershell -ExecutionPolicy Bypass -File scripts/install_auto_update.ps1 -Remove
+#>
+param(
+    [switch]$Remove,
+    [string]$Time = "04:17"
+)
+
+$ErrorActionPreference = "Stop"
+$TaskName = "HermesEvolutionUpdate"
+
+if ($Remove) {
+    schtasks /Delete /TN $TaskName /F 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Removed scheduled task '$TaskName'."
+    } else {
+        Write-Host "No scheduled task '$TaskName' to remove."
+    }
+    exit 0
+}
+
+# Resolve the hermes executable. Prefer an absolute path so the task does not
+# depend on the service account's PATH; fall back to bare 'hermes' if unknown.
+$hermesCmd = Get-Command hermes -ErrorAction SilentlyContinue
+if ($hermesCmd) { $hermes = $hermesCmd.Source } else { $hermes = "hermes" }
+
+# Ensure the log directory exists.
+$logDir = Join-Path $env:USERPROFILE ".hermes\logs"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+$log = Join-Path $logDir "auto-update.log"
+
+# Build the action. Wrap in cmd /c so we can redirect stdout/stderr to the log.
+# Inner quoting: the whole /TR value is one string; quote the exe and log paths.
+$action = "cmd /c `"`"$hermes`" update --yes >> `"$log`" 2>&1`""
+
+schtasks /Create /SC DAILY /ST $Time /TN $TaskName /TR $action /F | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to register scheduled task '$TaskName' (schtasks exit $LASTEXITCODE)."
+    exit 1
+}
+
+Write-Host "[OK] Scheduled daily 'hermes update --yes' at $Time (task: $TaskName)."
+Write-Host "     Log:    $log"
+Write-Host "     Remove: powershell -ExecutionPolicy Bypass -File scripts/install_auto_update.ps1 -Remove"
+Write-Host ""
+Write-Host "NOTE: self-update needs the install's git 'origin' to point at this fork."
+Write-Host "      See AUTO_UPGRADE.md for switching an existing install onto the fork."

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -452,6 +452,43 @@ echo "  hermes cron list     # View scheduled jobs"
 echo "  hermes doctor        # Diagnose issues"
 echo ""
 
+# --- Evolution prerequisite: GitHub CLI (gh) -------------------------------
+# The evolution cycle (issues / analysis / implementation / upstream-sync)
+# drives GitHub through `gh`. Warn if it's missing so the user can install it.
+# Research still works without gh; issue/PR creation does not.
+if command -v gh >/dev/null 2>&1; then
+    echo "✅ GitHub CLI (gh) present — evolution can create issues/PRs."
+else
+    echo "⚠️  GitHub CLI ('gh') not found — evolution issue/PR creation needs it."
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "   Install:  sudo apt-get install gh    (or https://cli.github.com)"
+    elif command -v brew >/dev/null 2>&1; then
+        echo "   Install:  brew install gh"
+    elif command -v winget >/dev/null 2>&1; then
+        echo "   Install:  winget install GitHub.cli"
+    else
+        echo "   Install:  https://cli.github.com"
+    fi
+fi
+echo ""
+
+# --- Community signal: star the repo (best-effort, opt-out) -----------------
+# Every install gives the fork a star so the project's reach is visible.
+# Opt out with HERMES_NO_STAR=1. Uses gh (env GITHUB_TOKEN) or curl; never fails
+# the install if it can't authenticate.
+if [ "${HERMES_NO_STAR:-0}" != "1" ]; then
+    EVO_REPO="Lexus2016/hermes-agent-evolution"
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        gh api -X PUT "/user/starred/$EVO_REPO" >/dev/null 2>&1 \
+            && echo "⭐ Starred $EVO_REPO — thanks for the support! (opt out: HERMES_NO_STAR=1)" || true
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+        curl -fsS -X PUT -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/user/starred/$EVO_REPO" >/dev/null 2>&1 \
+            && echo "⭐ Starred $EVO_REPO — thanks! (opt out: HERMES_NO_STAR=1)" || true
+    fi
+fi
+
 # Ask if they want to run setup wizard now
 read -p "Would you like to run the setup wizard now? [Y/n] " -n 1 -r
 echo


### PR DESCRIPTION
**#10** Every install (setup-hermes.sh, not just upgrade.sh) stars the repo — best-effort (gh/GITHUB_TOKEN or curl), opt-out HERMES_NO_STAR=1, never fails install.
**#12** setup checks for gh (evolution needs it for issues/PRs) and prints an OS-appropriate install hint (apt/brew/winget) if missing — surfaces the dependency instead of a silent no-op.