### PR TITLE
docs: add introspection to the evolution cycle

### DIFF
--- a/AUTO_UPGRADE.md
+++ b/AUTO_UPGRADE.md
@@ -170,9 +170,10 @@ and overwrites any existing task on re-run. (Manual equivalent, if you prefer:
 
 ## ⏰ Evolution cron jobs
 
-Evolution's scheduled tasks (research/issues/analysis/implementation/upstream-sync)
-live as YAML in `cron/evolution/*.yaml`, but Hermes schedules from its native
-registry `~/.hermes/cron/jobs.json`. Register them (idempotent):
+Evolution's scheduled tasks (research / introspection / issues / analysis /
+implementation / upstream-sync) live as YAML in `cron/evolution/*.yaml`, but
+Hermes schedules from its native registry `~/.hermes/cron/jobs.json`. Register
+them (idempotent):
 
 ```bash
 "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/scripts/register_evolution_cron.py"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ open pull requests, push branches, and cut releases. You own the repo, so use a
 ## 🧬 What you get
 
 - **Daily research** — scans other AI agents, papers, and trends for ideas.
+- **Introspection** — reviews its own past sessions with you to find what
+  blocked real tasks, and proposes fixes for *those* (not just shiny features).
 - **Proposals** — opens GitHub issues with concrete improvement suggestions.
 - **Self-update** — pulls the latest improvements automatically every day.
 - **Stays current** — periodically brings in useful changes from the original


### PR DESCRIPTION
Document the new evolution-introspection role in README (What you get) and AUTO_UPGRADE (cron list) so docs match the 6 actual cron jobs.