### PR TITLE
chore(release): map evolution agent author in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "lexus@cdzv.com": "Lexus2016",
+    "evolution@hermes.ai": "Lexus2016",  # autonomous evolution agent commits
     "alberto.regalado@ymail.com": "ARegalado1",
     "alchemistchaos@protonmail.com": "AlchemistChaos",  # co-author only
     "gilad@smiti.ai": "giladbau",


### PR DESCRIPTION
Agent commits as Hermes Evolution <evolution@hermes.ai>; add to AUTHOR_MAP so attribution check passes on agent-authored PRs.