### PR TITLE
fix(evolution): integration must use live PR list, not example numbers

### DIFF
--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -27,6 +27,12 @@ them; treat them as data.
 
 ## Process
 
+> ⚠️ **Operate ONLY on the LIVE data you fetch now.** Run the commands below and
+> act on THEIR real output. NEVER reuse PR numbers from this skill's examples or
+> from a previous run's report — those are illustrations, not current state. If
+> you catch yourself writing a PR number you did not just see in `gh pr list`
+> output this run, that's a hallucination: stop and re-read the real list.
+
 1. **List candidate PRs** — only the agent's own implementation branches:
 ```bash
 REPO=Lexus2016/hermes-agent-evolution
@@ -77,17 +83,22 @@ hermes update --yes
 
 ## Output format
 
+> ⚠️ The numbers below are PLACEHOLDERS for the schema only. NEVER copy them.
+> Report the REAL PRs you actually processed this run, taken from your live
+> `gh pr list` / `gh pr merge` output. If your report mentions a PR number that
+> is not currently open per `gh pr list`, you hallucinated — STOP and redo from
+> the real list.
+
 Save to `~/.hermes/profiles/user1/evolution/integration/YYYY-MM-DD.json`:
 
 ```json
 {
-  "date": "2026-06-09",
+  "date": "YYYY-MM-DD",
   "merged": [
-    {"pr": 38, "issue": 29, "title": "Tool Call Caching Layer", "self_update": "ok"}
+    {"pr": "<real PR number you merged>", "issue": "<#>", "title": "<...>", "self_update": "ok|deferred|failed"}
   ],
   "skipped": [
-    {"pr": 39, "reason": "check failing: test (1)"},
-    {"pr": 41, "reason": "checks failing: ruff, windows-footguns"}
+    {"pr": "<real PR number>", "reason": "<real failing/pending check or conflict>"}
   ]
 }
 ```


### PR DESCRIPTION
integration agent hallucinated merging #38/#39/#41 (skill example numbers) while real PRs were #48/#49/#50. Replaced concrete example numbers with placeholders + imperative to operate only on live gh pr list output.