### PR TITLE
feat(evolution): GitHub-access wake-gate (no GitHub -> skip agent, save tokens)

### DIFF
--- a/scripts/evolution_access_gate.sh
+++ b/scripts/evolution_access_gate.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Evolution wake-gate: only wake the LLM agent if GitHub is actually reachable.
+#
+# WHY: the whole evolution cycle (research -> issues -> analysis ->
+# implementation -> integration) only has value if the agent can POST to GitHub
+# (open issues / PRs, merge). With no GitHub access the agent can produce nothing
+# durable — so running research/issues/etc would just BURN LLM tokens and
+# web-search quota for nothing. In that case the user simply runs plain Hermes
+# from our repo and receives our updates; the agent should NOT spend money trying
+# to self-evolve without an outlet.
+#
+# HOW: Hermes cron treats the LAST stdout line as a wake gate. Printing
+# `{"wakeAgent": false}` skips the agent entirely — no LLM run, no delivery.
+# This check is cheap (one gh/REST call), so it costs ~nothing to gate the
+# expensive agent run behind it.
+set +e
+
+ENVF="${HERMES_HOME:-$HOME/.hermes}/.env"
+[ -f "$ENVF" ] && { set -a; . "$ENVF" 2>/dev/null; set +a; }
+
+ok=0
+# 1) persistent gh auth (~/.config/gh) — the canonical path on a configured server
+if command -v gh >/dev/null 2>&1 && gh api user --jq .login >/dev/null 2>&1; then
+    ok=1
+fi
+# 2) fall back to a raw token from the env file
+if [ "$ok" = "0" ] && [ -n "${GITHUB_PRIVATE_TOKEN:-}${GITHUB_TOKEN:-}" ]; then
+    _tok="${GITHUB_PRIVATE_TOKEN:-$GITHUB_TOKEN}"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsS -H "Authorization: Bearer ${_tok}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user >/dev/null 2>&1 && ok=1
+    fi
+    unset _tok
+fi
+
+if [ "$ok" = "1" ]; then
+    echo "evolution access-gate: GitHub reachable — waking agent."
+    echo '{"wakeAgent": true}'
+else
+    echo "evolution access-gate: no GitHub access — skipping agent to avoid burning LLM tokens / web-search quota. Add a GitHub token to ${ENVF} (and run 'gh auth login') to enable self-evolution."
+    echo '{"wakeAgent": false}'
+fi

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -49,6 +49,34 @@ def _normalize_skills(raw) -> list[str] | None:
     return out or None
 
 
+def _install_access_gate(repo_root: Path) -> str | None:
+    """Copy the GitHub access wake-gate into HERMES_HOME/scripts so cron runs it
+    as a pre-check before each evolution job. Returns the script name to attach
+    to every job, or None on failure (jobs are still created, just ungated).
+
+    The gate prints ``{"wakeAgent": false}`` when GitHub is unreachable, which
+    makes the scheduler SKIP the LLM agent entirely — no tokens / web-search
+    spent when the cycle has no outlet to post issues/PRs.
+    """
+    import os
+    import shutil
+
+    src = repo_root / "scripts" / "evolution_access_gate.sh"
+    if not src.is_file():
+        return None
+    home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    dest_dir = home / "scripts"
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / src.name
+        shutil.copyfile(src, dest)
+        dest.chmod(0o755)
+        return src.name
+    except Exception as exc:  # pragma: no cover - environment dependent
+        print(f"[evolution-cron] warning: could not install access gate: {exc}", file=sys.stderr)
+        return None
+
+
 def main(argv: list[str]) -> int:
     dry_run = "--dry-run" in argv
     positional = [a for a in argv[1:] if not a.startswith("--")]
@@ -66,6 +94,10 @@ def main(argv: list[str]) -> int:
     except Exception as exc:  # pragma: no cover - environment dependent
         print(f"[evolution-cron] cannot import cron.jobs: {exc}", file=sys.stderr)
         return 1
+
+    # Install the GitHub-access wake-gate and attach it to every evolution job,
+    # so the expensive LLM agent only runs when GitHub is actually reachable.
+    gate_script = None if dry_run else _install_access_gate(repo_root)
 
     existing_names = {str(j.get("name", "")).strip() for j in load_jobs()}
     created: list[tuple[str, str]] = []
@@ -101,7 +133,7 @@ def main(argv: list[str]) -> int:
             continue
 
         try:
-            job = create_job(
+            create_kwargs = dict(
                 prompt=str(prompt),
                 schedule=schedule,
                 name=name,
@@ -109,6 +141,11 @@ def main(argv: list[str]) -> int:
                 enabled_toolsets=list(toolsets) if toolsets else None,
                 deliver="local",
             )
+            if gate_script:
+                # Pre-check script: skips the agent (no LLM/web spend) when
+                # GitHub is unreachable. Keeps the LLM agent (skills) for the run.
+                create_kwargs["script"] = gate_script
+            job = create_job(**create_kwargs)
             created.append((name, job["id"]))
             existing_names.add(name)
             if spec.get("enabled") is False:


### PR DESCRIPTION
Without GitHub access the evolution cycle has no outlet (cannot post issues/PRs) — running it just burns LLM tokens + web-search quota. Adds scripts/evolution_access_gate.sh: a cheap pre-run wake-gate (one gh/REST call) that prints {wakeAgent:false} when GitHub is unreachable, so Hermes cron skips the LLM agent entirely. register_evolution_cron installs it to HERMES_HOME/scripts and attaches it to every evolution job.