### PR TITLE
feat(evolution): rework loop — agent understands needs-work and chooses (rework/drop)

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -27,9 +27,19 @@ gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
   --limit 50 --json number,title,body,labels,createdAt
 ```
 
-2. **Viability triage — REJECT before you rank.** Implementing the wrong thing
-   costs far more than skipping it. For EACH open issue, first decide whether it
-   should exist at all. REJECT it (do not rank, do not implement) if ANY holds:
+2. **Rework first — `needs-work` issues are PRIORITY, not rejects.** An issue
+   labelled `needs-work` was ALREADY judged worth doing and attempted; a PR
+   failed code review and was sent back with a rework brief (in the issue
+   comments). Do NOT reject it as "already exists / already tried" — that throws
+   away a wanted idea. Instead SELECT it for implementation (give it priority, it
+   has momentum) so implementation can read the brief and finish it properly (or
+   consciously drop it). Only skip a `needs-work` issue if it is now genuinely
+   harmful or obsolete — and then close it with a reason, don't just ignore it.
+
+3. **Viability triage — REJECT before you rank.** Implementing the wrong thing
+   costs far more than skipping it. For EACH remaining open issue (NOT already
+   handled as `needs-work` above), first decide whether it should exist at all.
+   REJECT it (do not rank, do not implement) if ANY holds:
    - **Already implemented** — the capability already exists. You MUST check the
      codebase before assuming it's new, e.g.:
      ```bash
@@ -51,7 +61,7 @@ gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
    ```
    Only issues that SURVIVE triage proceed to scoring. Be conservative.
 
-3. **Evaluate** each SURVIVING issue against the criteria:
+4. **Evaluate** each SURVIVING issue against the criteria:
 
 ### Impact
 - Critical: 1.0 (security, critical bugs)
@@ -72,14 +82,15 @@ gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
 - Compatibility: 1.0 (good) / 0.5 (needs refactoring) / 0.1 (breaks)
 - Safety: 0.0 (risky) / 0.5 (needs tests) / 1.0 (safe)
 
-4. **Compute Priority Score**
+5. **Compute Priority Score**
 
 ```python
 base_priority = (impact * 2) / effort
 final_priority = base_priority + community*0.1 + age*0.05 + compatibility*0.2 + safety*0.3
 ```
 
-5. **Select** the top 5 for implementation:
+6. **Select** the top 5 for implementation (include any `needs-work` issues from
+   step 2):
    - Min priority: 0.7
    - Max total effort: 2.0
 

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -19,6 +19,21 @@ Implement selected issues, create versions, and self-update.
 
 1. **Load** the latest analysis from `~/.hermes/profiles/user1/evolution/analysis/`
 
+1a. **`needs-work` issues — YOUR call: rework or consciously drop.** If a selected
+    issue is labelled `needs-work`, a previous PR failed code review and was sent
+    back. FIRST read the rework brief in the issue comments
+    (`gh issue view <N> --repo Lexus2016/hermes-agent-evolution --comments`). Then
+    make a deliberate decision — you have TWO valid options, pick one:
+    - **REWORK** — if the idea is still worth it and the brief is doable: fix it
+      exactly as the brief says (esp. wire the code into a REAL call site — that
+      was usually the failure), then proceed to implement + open a fresh PR.
+    - **DROP** — if, looking closer, it's genuinely too complex for its value,
+      out of scope, or would harm the project: close the issue with an HONEST
+      reason. This is a legitimate decision, not a failure — *"reconsidered: not
+      worth the complexity because X"* is a fine outcome.
+    Do NOT silently skip a `needs-work` issue and leave it hanging — either
+    rework it or close it with a reason. The choice is yours; own it.
+
 2. **Final viability re-check (last line of defense).** analysis already triaged,
    but you are about to write real code into the project — confirm once more,
    per issue, BEFORE branching:

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -80,8 +80,24 @@ gh pr list --repo "$REPO" --state open --limit 50 \
       the diff against the issue's intent. Does the mechanism actually produce
       the requested effect, or just *look* like it? (e.g. an "LLM must emit X"
       requirement implemented with a random generator does NOT — the LLM never
-      acts.) If the approach cannot deliver the issue's goal → do NOT merge;
-      comment why and send it back.
+      acts.) If the approach cannot deliver the issue's goal → do NOT merge.
+
+    **When a PR FAILS review — send the IDEA back for REWORK; do NOT discard it.**
+    analysis already judged the idea worth doing, so the implementation was weak,
+    not the idea. Do all of:
+    1. Close the failed PR (its branch is a dead end) with a brief comment.
+    2. Post a SPECIFIC, actionable rework brief as a comment ON THE ISSUE — name
+       exactly what was wrong and what "done" looks like, e.g.:
+       *"Blocked: dead code — `agent/entropy_eval` has no call sites. To fix:
+       call `format_report(...)` from the CLI session-summary path
+       (run_agent.py end-of-session) so it actually runs. Re-open a PR once it's
+       invoked."* Be concrete: the integration point + the definition of done.
+    3. Label the issue `needs-work` (`gh label create needs-work --color d93f0b
+       --description "Blocked by code-review; needs rework" 2>/dev/null || true`;
+       then `gh issue edit <issue> --add-label needs-work`).
+    Keep the ISSUE OPEN. The next implementation run will see `needs-work`, read
+    the brief, and either fix it properly OR consciously decide to drop it — that
+    decision belongs to implementation, not to a silent skip here.
 
     Only PRs that pass BOTH the deterministic dead-code check and the judgement
     check proceed to merge.


### PR DESCRIPTION
Code-review could block a PR + label needs-work, but the agent did not understand that state (implementation skipped it, analysis rejected it) — so the wanted idea was dropped. Closes the loop: integration posts a concrete rework brief + keeps the issue open; analysis re-selects needs-work as priority; implementation reads the brief and makes a deliberate choice — REWORK (fix per brief, wire to real call site) OR consciously DROP (honest reason). The agent now recognizes needs-work and has agency.