### PR TITLE
feat: deliberate-work + self-review guidance for user tasks

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -329,6 +329,27 @@ ATTENTION_RESET_GUIDANCE = (
     "genuinely stuck or about to commit to something hard to undo."
 )
 
+# Deliberate work + self-review. A behavioural standard the agent applies to the
+# USER'S tasks (not just evolution): judge whether something is worth doing
+# before doing it, and audit your own work after. Scoped to NON-trivial work so
+# it does not slow down simple replies.
+DELIBERATE_WORK_GUIDANCE = (
+    "# Deliberate decisions + self-review\n"
+    "For any non-trivial task or decision, work as if it were your own project:\n"
+    "1. Before doing it, judge the step itself — is it actually NECESSARY, "
+    "APPROPRIATE, and USEFUL? Be honest that it is needed AND that you would want "
+    "it done this way for yourself. Don't add or do things that aren't required; "
+    "skipping unneeded work is a valid, good outcome.\n"
+    "2. After you implement something non-trivial, review your OWN work: go "
+    "through it step by step, check it actually does what was asked (not just "
+    "looks like it), and rate it honestly 1–10.\n"
+    "3. If it scores below 10, find what's wrong, fix it, and re-review — repeat "
+    "until there are no remaining problems and you are genuinely confident.\n"
+    "Keep this proportionate: a quick answer doesn't need a formal audit, but "
+    "anything you'd be embarrassed to ship wrong does. Honesty over speed: report "
+    "real results and real blockers, never a plausible-looking guess."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
     ATTENTION_RESET_GUIDANCE,
+    DELIBERATE_WORK_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
@@ -116,6 +117,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # itself to break tunnel vision. Always on — cheap, static text, helps every
     # model avoid repeating failed approaches.
     stable_parts.append(ATTENTION_RESET_GUIDANCE)
+
+    # Deliberate work + self-review on the USER'S tasks: judge necessity before
+    # acting, audit and rate your own work after. Always on — static text, scoped
+    # to non-trivial work, so it raises quality without slowing simple replies.
+    stable_parts.append(DELIBERATE_WORK_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []


### PR DESCRIPTION
Adds DELIBERATE_WORK_GUIDANCE to the stable system-prompt tier (sibling of ATTENTION_RESET_GUIDANCE). On non-trivial user tasks the agent judges necessity/usefulness before acting, then reviews and rates its own work 1-10 and fixes until solid. Scoped to non-trivial work; static text, always on.