### PR TITLE
feat(evolution): accepted/rejected status labels on issues

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -34,7 +34,8 @@ gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
    away a wanted idea. Instead SELECT it for implementation (give it priority, it
    has momentum) so implementation can read the brief and finish it properly (or
    consciously drop it). Only skip a `needs-work` issue if it is now genuinely
-   harmful or obsolete — and then close it with a reason, don't just ignore it.
+   harmful or obsolete — and then close it with a reason AND the `rejected` label
+   (see step 3), don't just ignore it.
 
 3. **Viability triage — REJECT before you rank.** Implementing the wrong thing
    costs far more than skipping it. For EACH remaining open issue (NOT already
@@ -52,12 +53,16 @@ gh issue list --repo Lexus2016/hermes-agent-evolution --state open \
      outweighing its value.
    - **Duplicate** — another open issue already covers it.
 
-   CLOSE every rejected issue with a clear reason + label, so the backlog stays
-   honest and the same idea isn't re-proposed next cycle:
+   CLOSE every rejected issue with a clear reason + the canonical `rejected`
+   status label, so the backlog shows at a glance what was turned down (the
+   *why* is in the closing comment) and the same idea isn't re-proposed:
    ```bash
+   # Ensure the status label exists (idempotent), then close + label:
+   gh label create rejected --color b60205 \
+     --description "Not accepted by evolution — see closing comment" 2>/dev/null || true
    gh issue close <N> --repo Lexus2016/hermes-agent-evolution \
      --comment "Rejected by evolution-analysis: <already-exists|out-of-scope|harmful|duplicate> — <one-line reason>."
-   gh issue edit <N> --repo Lexus2016/hermes-agent-evolution --add-label wontfix 2>/dev/null || true
+   gh issue edit <N> --repo Lexus2016/hermes-agent-evolution --add-label rejected 2>/dev/null || true
    ```
    Only issues that SURVIVE triage proceed to scoring. Be conservative.
 
@@ -93,6 +98,24 @@ final_priority = base_priority + community*0.1 + age*0.05 + compatibility*0.2 + 
    step 2):
    - Min priority: 0.7
    - Max total effort: 2.0
+
+## Status labels — accept/reject visible in the issue list
+
+The evolution pipeline tags every issue with ONE canonical status label so the
+owner can see, straight from the GitHub issue list, what happened to each idea
+(the *reason* is always in a closing comment — click in to read it):
+
+| Label | Color | Meaning | Set by |
+|-------|-------|---------|--------|
+| `accepted` | green `0e8a16` | Sent to a PR / implemented | evolution-implementation (when the PR is opened) |
+| `rejected` | red `b60205` | Turned down — see closing comment | analysis triage, or implementation final re-check / conscious drop |
+| `needs-work` | orange `d93f0b` | A PR was bounced back; rework in progress | evolution-integration (code-review gate) |
+
+`accepted` and `rejected` are terminal. `needs-work` is transient: it becomes
+`accepted` once a reworked PR is opened, or `rejected` if implementation drops
+it. **This skill only ever sets `rejected`** (on triage rejects). Do NOT mark an
+issue `accepted` here — selection is a recommendation; `accepted` means the code
+actually went to a PR, which only implementation can confirm.
 
 ## Output format
 

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -29,10 +29,20 @@ Implement selected issues, create versions, and self-update.
       was usually the failure), then proceed to implement + open a fresh PR.
     - **DROP** — if, looking closer, it's genuinely too complex for its value,
       out of scope, or would harm the project: close the issue with an HONEST
-      reason. This is a legitimate decision, not a failure — *"reconsidered: not
-      worth the complexity because X"* is a fine outcome.
+      reason and flip it to the terminal `rejected` status. This is a legitimate
+      decision, not a failure — *"reconsidered: not worth the complexity because
+      X"* is a fine outcome.
+      ```bash
+      gh label create rejected --color b60205 \
+        --description "Not accepted by evolution — see closing comment" 2>/dev/null || true
+      gh issue edit <N> --repo Lexus2016/hermes-agent-evolution \
+        --add-label rejected --remove-label needs-work 2>/dev/null || true
+      gh issue close <N> --repo Lexus2016/hermes-agent-evolution \
+        --comment "Dropped after rework review: <honest reason>."
+      ```
     Do NOT silently skip a `needs-work` issue and leave it hanging — either
-    rework it or close it with a reason. The choice is yours; own it.
+    rework it or close it with a reason + the `rejected` label. The choice is
+    yours; own it.
 
 2. **Final viability re-check (last line of defense).** analysis already triaged,
    but you are about to write real code into the project — confirm once more,
@@ -48,6 +58,9 @@ Implement selected issues, create versions, and self-update.
      change just because it was selected. Shipping the wrong code is worse than
      shipping nothing.
    ```bash
+   gh label create rejected --color b60205 \
+     --description "Not accepted by evolution — see closing comment" 2>/dev/null || true
+   gh issue edit <N> --repo Lexus2016/hermes-agent-evolution --add-label rejected 2>/dev/null || true
    gh issue close <N> --repo Lexus2016/hermes-agent-evolution \
      --comment "Skipped at implementation: <already-exists|out-of-scope|harmful|too-large> — <reason>."
    ```
@@ -78,9 +91,16 @@ python -m pytest tests/ -x -q
 ```
 - If anything is red → FIX it and re-run. Iterate until lint + tests are green.
 - If after a few honest attempts you cannot get it green (the change is harder
-  or more fragile than estimated) → do NOT open a red PR. SKIP and close the
-  issue with a clear reason (`gh issue close <N> --comment "..."`). A red PR is
-  worse than no PR: it wastes the integration step and never merges.
+  or more fragile than estimated) → do NOT open a red PR. SKIP, label it
+  `rejected`, and close the issue with a clear reason. A red PR is worse than no
+  PR: it wastes the integration step and never merges.
+  ```bash
+  gh label create rejected --color b60205 \
+    --description "Not accepted by evolution — see closing comment" 2>/dev/null || true
+  gh issue edit <N> --repo Lexus2016/hermes-agent-evolution --add-label rejected 2>/dev/null || true
+  gh issue close <N> --repo Lexus2016/hermes-agent-evolution \
+    --comment "Skipped at implementation: could not get CI green — <what failed>."
+  ```
 - Only when local checks are green do you continue to commit + push + PR.
 
 ### Authorize git (gh is already logged in)
@@ -114,6 +134,16 @@ git push origin evolution/issue-123-feature-name
 gh pr create --base main --head evolution/issue-123-feature-name \
   --title "feat: <feature name> (Closes #123)" \
   --body "Automated evolution PR for issue #123."
+```
+
+Once the PR is open, flip the issue to the terminal `accepted` status so the
+owner sees — straight from the issue list — that this idea actually went to a
+PR. If it was a `needs-work` rework, drop that transient label now:
+```bash
+gh label create accepted --color 0e8a16 \
+  --description "Accepted by evolution — sent to a PR" 2>/dev/null || true
+gh issue edit <issue#> --repo Lexus2016/hermes-agent-evolution \
+  --add-label accepted --remove-label needs-work 2>/dev/null || true
 ```
 
 Merging happens ONLY after green CI tests

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -92,9 +92,15 @@ gh pr list --repo "$REPO" --state open --limit 50 \
        call `format_report(...)` from the CLI session-summary path
        (run_agent.py end-of-session) so it actually runs. Re-open a PR once it's
        invoked."* Be concrete: the integration point + the definition of done.
-    3. Label the issue `needs-work` (`gh label create needs-work --color d93f0b
-       --description "Blocked by code-review; needs rework" 2>/dev/null || true`;
-       then `gh issue edit <issue> --add-label needs-work`).
+    3. Flip the issue from `accepted` to the transient `needs-work` status — the
+       PR is dead, so it is no longer "sent to a PR"; it is back in the queue for
+       rework:
+       ```bash
+       gh label create needs-work --color d93f0b \
+         --description "Blocked by code-review; needs rework" 2>/dev/null || true
+       gh issue edit <issue> --repo "$REPO" \
+         --add-label needs-work --remove-label accepted 2>/dev/null || true
+       ```
     Keep the ISSUE OPEN. The next implementation run will see `needs-work`, read
     the brief, and either fix it properly OR consciously decide to drop it — that
     decision belongs to implementation, not to a silent skip here.

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -47,8 +47,8 @@ Create GitHub issues and pull requests based on research.
     Compare each surviving proposal by MEANING (not exact string) to that list:
     - an equivalent issue is **OPEN** → do NOT create a duplicate. Optionally signal
       demand instead: `gh issue comment <N> --repo "$REPO" --body "+1 from evolution research"`.
-    - an equivalent issue is **CLOSED** as `wontfix`/rejected → do NOT re-file it
-      (the project already decided against it).
+    - an equivalent issue is **CLOSED** with the `rejected` label (or legacy
+      `wontfix`) → do NOT re-file it (the project already decided against it).
     Only genuinely NEW proposals proceed. Rule at scale: the FIRST install files an
     idea once; every other install must recognize it already exists and stay silent.
 


### PR DESCRIPTION
Owner-visibility request: see from the issue list whether each evolution idea was accepted (went to a PR) or rejected (turned down), with the reason in the closing comment. Adds two canonical terminal labels (accepted=green, rejected=red) plus the existing transient needs-work, sets one on every close path (previously some issues closed with no label), and keeps the states mutually exclusive. Markdown-only (skill docs).