### PR TITLE
feat: PEP 668 externally-managed environment guards (Closes #69)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -246,6 +246,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             _probe_line = get_environment_probe_line()
             if _probe_line:
                 stable_parts.append(_probe_line)
+            # Extra PEP 668 install hint when the host is externally-managed
+            try:
+                from tools.python_install import get_install_hint
+                _install_hint = get_install_hint()
+                if _install_hint:
+                    stable_parts.append(_install_hint)
+            except Exception:
+                pass
         except Exception:
             # Probe failure must never block prompt build.
             pass

--- a/tests/tools/test_python_install.py
+++ b/tests/tools/test_python_install.py
@@ -1,0 +1,157 @@
+"""Tests for tools.python_install.py — PEP 668 transparent rewrite."""
+
+import os
+import pytest
+
+from tools import python_install as pi
+
+
+@pytest.fixture(autouse=True)
+def reset_venv_cache(monkeypatch):
+    """Each test starts with a clean venv cache and deterministic env."""
+    pi._TRANSIENT_VENV_DIR = None
+    yield
+    pi._TRANSIENT_VENV_DIR = None
+
+
+class TestIsPep668Active:
+    def test_returns_bool(self, monkeypatch):
+        """Smoke test: the function returns a boolean."""
+        result = pi.is_pep668_active()
+        assert isinstance(result, bool)
+
+    def test_true_when_marker_exists(self, monkeypatch, tmp_path):
+        fake_stdlib = str(tmp_path / "stdlib")
+        marker = os.path.join(fake_stdlib, "EXTERNALLY-MANAGED")
+        _real_join = os.path.join
+        os.makedirs(fake_stdlib, exist_ok=True)
+        open(marker, "w").close()
+        orig_dirname = pi.os.path.dirname
+        orig_join = pi.os.path.join
+        orig_exists = pi.os.path.exists
+
+        def _dirname(p):
+            return fake_stdlib
+
+        def _join(*a):
+            return _real_join(*a)
+
+        def _exists(p):
+            return p == marker
+
+        monkeypatch.setattr(pi.os.path, "dirname", _dirname)
+        monkeypatch.setattr(pi.os.path, "join", _join)
+        monkeypatch.setattr(pi.os.path, "exists", _exists)
+        assert pi.is_pep668_active() is True
+
+    def test_false_when_marker_missing(self, monkeypatch, tmp_path):
+        fake_stdlib = str(tmp_path / "stdlib")
+        os.makedirs(fake_stdlib, exist_ok=True)
+        orig_dirname = pi.os.path.dirname
+
+        def _dirname(p):
+            return fake_stdlib
+
+        def _exists(p):
+            return False
+
+        monkeypatch.setattr(pi.os.path, "dirname", _dirname)
+        monkeypatch.setattr(pi.os.path, "exists", _exists)
+        assert pi.is_pep668_active() is False
+
+
+class TestRewritePipCommand:
+    def test_noop_when_pep668_off(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: False)
+        assert pi.rewrite_pip_command("pip install markdown") is None
+
+    def test_noop_when_no_pip_install(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        assert pi.rewrite_pip_command("ls /tmp") is None
+
+    def test_noop_when_break_system_packages(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        assert pi.rewrite_pip_command("pip install --break-system-packages markdown") is None
+
+    def test_noop_when_user_flag(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        assert pi.rewrite_pip_command("pip install --user markdown") is None
+
+    def test_rewrites_with_uv(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        monkeypatch.setattr(pi.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(pi, "_uv_python_flag", lambda: "--python=/usr/bin/python3")
+        rewritten = pi.rewrite_pip_command("pip install markdown")
+        assert rewritten is not None
+        assert "uv pip install --python=/usr/bin/python3 markdown" in rewritten
+
+    def test_rewrites_without_uv(self, monkeypatch, tmp_path):
+        """When uv is missing, falls back to transient venv pip."""
+        # _rewrite_to_transient_venv expects bin/pip under the returned venv dir
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        fake_pip = fake_bin / "pip"
+        fake_pip.touch()
+
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        monkeypatch.setattr(pi.shutil, "which", lambda name: None)
+
+        # Stub venv creation so it "succeeds" instantly
+        def _stub_ensure():
+            venv = str(tmp_path)
+            pi._TRANSIENT_VENV_DIR = venv
+            return venv, True
+        monkeypatch.setattr(pi, "ensure_transient_venv", _stub_ensure)
+
+        rewritten = pi.rewrite_pip_command("pip install markdown")
+        assert rewritten is not None
+        assert str(fake_pip) in rewritten
+
+    def test_ignores_pip_uninstall(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        assert pi.rewrite_pip_command("pip uninstall markdown") is None
+
+    def test_preserves_compound_command(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        monkeypatch.setattr(pi.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(pi, "_uv_python_flag", lambda: "--python=/usr/bin/python3")
+        cmd = "cd /tmp && pip install markdown"
+        rewritten = pi.rewrite_pip_command(cmd)
+        assert rewritten is not None
+        assert "uv pip install --python=/usr/bin/python3 markdown" in rewritten
+
+
+class TestEnsureTransientVenv:
+    def test_reuse_when_exists(self, tmp_path, monkeypatch):
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        (venv_dir / "bin").mkdir()
+        (venv_dir / "bin" / "pip").touch()
+        pi._TRANSIENT_VENV_DIR = str(venv_dir)
+        path, created = pi.ensure_transient_venv()
+        assert path == str(venv_dir)
+        assert created is False
+
+    def test_creates_when_missing(self, monkeypatch, tmp_path):
+        """Actually creates a venv — slow but verifies the mechanism."""
+        # Force a unique path via monkeypatch on gettempdir so we never clash
+        monkeypatch.setattr(pi.tempfile, "gettempdir", lambda: str(tmp_path))
+        pi._TRANSIENT_VENV_DIR = None
+        # Force using a separate fake path instead of the marker-rewritten directory
+        path, created = pi.ensure_transient_venv()
+        assert created is True
+        assert os.path.isdir(path)
+        assert os.path.isfile(os.path.join(path, "bin", "pip"))
+
+
+class TestGetInstallHint:
+    def test_empty_when_pep668_off(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: False)
+        assert pi.get_install_hint() == ""
+
+    def test_hint_mentions_uv(self, monkeypatch):
+        monkeypatch.setattr(pi, "is_pep668_active", lambda: True)
+        monkeypatch.setattr(pi.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(pi, "_uv_python_flag", lambda: "--python=/usr/bin/python3")
+        hint = pi.get_install_hint()
+        assert "uv pip install" in hint

--- a/tools/python_install.py
+++ b/tools/python_install.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Safe Python package installation for PEP 668 externally-managed environments.
+
+When the active Python is PEP 668 managed (Debian/Ubuntu marker file),
+naive ``pip install`` fails immediately.  This module provides a transparent
+rewrite for ``terminal_tool`` and ``execute_code`` so that model-generated
+``pip install`` commands keep working without requiring the model to
+remember platform-specific workarounds.
+
+Public API:
+- :func:`is_pep668_active`: bool probe
+- :func:`rewrite_pip_command`: rewrite a shell command string
+- :func:`ensure_transient_venv`: create / return a transient venv path
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Stable prefix so repeated pip install calls reuse the same transient venv
+# within a single process lifetime (cheap — no duplicate creations).
+_TRANSIENT_VENV_DIR: Optional[str] = None
+
+
+def _run(cmd: list[str], timeout: float = 60.0, env: Optional[dict] = None) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False, env=env
+        )
+        return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
+    except FileNotFoundError:
+        return -1, "", "not found"
+    except subprocess.TimeoutExpired:
+        return -1, "", "timeout"
+
+
+def is_pep668_active() -> bool:
+    """True when ``sys.executable``'s stdlib directory contains EXTERNALLY-MANAGED."""
+    stdlib = os.path.dirname(os.__file__)
+    marker = os.path.join(stdlib, "EXTERNALLY-MANAGED")
+    return os.path.exists(marker)
+
+
+def has_uv() -> bool:
+    return shutil.which("uv") is not None
+
+
+def _uv_python_flag() -> Optional[str]:
+    """Return a ``--python=...`` flag targeting the current interpreter, or None."""
+    uv = shutil.which("uv")
+    if not uv:
+        return None
+    rc, _, _ = _run([uv, "python", "find", sys.executable])
+    if rc == 0:
+        return f"--python={sys.executable}"
+    return None
+
+
+def ensure_transient_venv() -> Tuple[str, bool]:
+    """Create (or reuse) a transient venv and return ``(venv_dir, created_now)``.
+
+    The venv is created under ``/tmp`` with a stable name derived from the
+    active interpreter path so that multiple calls within a session reuse it.
+    """
+    global _TRANSIENT_VENV_DIR
+    if _TRANSIENT_VENV_DIR is not None and os.path.isdir(_TRANSIENT_VENV_DIR):
+        logger.debug("Reusing transient venv %s", _TRANSIENT_VENV_DIR)
+        return _TRANSIENT_VENV_DIR, False
+
+    # Unique but deterministic per-interpreter path
+    import hashlib
+    suffix = hashlib.sha256(sys.executable.encode()).hexdigest()[:12]
+    venv_dir = os.path.join(tempfile.gettempdir(), f"hermes_pep668_venv_{suffix}")
+
+    if os.path.isdir(venv_dir):
+        pip = os.path.join(venv_dir, "bin", "pip")
+        if os.path.isfile(pip):
+            _TRANSIENT_VENV_DIR = venv_dir
+            return venv_dir, False
+
+    rc, out, err = _run([sys.executable, "-m", "venv", venv_dir], timeout=60)
+    if rc != 0:
+        logger.warning("Failed to create transient venv at %s: %s", venv_dir, err or out)
+        return "", False
+
+    _TRANSIENT_VENV_DIR = venv_dir
+    logger.info("Created transient venv at %s", venv_dir)
+    return venv_dir, True
+
+
+def _rewrite_to_uv(cmd: str) -> Optional[str]:
+    """Rewrite ``pip install ...`` to ``uv pip install --python=... ...``.
+
+    Returns None when uv is not available or the command doesn't match.
+    """
+    if not has_uv():
+        return None
+    flag = _uv_python_flag()
+    if not flag:
+        return None
+
+    # Match pip install ...  (allow leading whitespace or compound commands)
+    m = re.search(r"(?:^|[;&|]+)\s*pip\s+install\s+(.+?)(?:[;&|]|$)", cmd)
+    if not m:
+        return None
+    args = m.group(1).strip()
+    replacement = f"uv pip install {flag} {args}"
+    return cmd[:m.start()] + replacement + cmd[m.end():]
+
+
+def _rewrite_to_transient_venv(cmd: str) -> Optional[str]:
+    """Rewrite ``pip install ...`` to use transient-venv pip.
+
+    Returns None when venv creation fails or the command doesn't match.
+    """
+    venv_dir, _ = ensure_transient_venv()
+    if not venv_dir:
+        return None
+
+    pip_bin = os.path.join(venv_dir, "bin", "pip")
+    if sys.platform == "win32":
+        pip_bin = os.path.join(venv_dir, "Scripts", "pip.exe")
+    if not os.path.isfile(pip_bin):  # pragma: no cover
+        return None
+
+    m = re.search(r"(?:^|[;&|]+)\s*pip\s+install\s+(.+?)(?:[;&|]|$)", cmd)
+    if not m:
+        return None
+    args = m.group(1).strip()
+    replacement = f"{pip_bin} install {args}"
+    return cmd[:m.start()] + replacement + cmd[m.end():]
+
+
+def rewrite_pip_command(command: str) -> Optional[str]:
+    """Rewrite a shell command to avoid PEP 668 ``pip install`` failures.
+
+    Returns a rewritten command string when:
+      - the command contains a bare ``pip install`` invocation,
+      - PEP 668 is active,
+      - the command does NOT already contain ``--break-system-packages``,
+        ``--user``, ``pip uninstall``, or ``pip remove``.
+
+    Returns None when no rewrite is needed or no viable fallback exists.
+    """
+    if not is_pep668_active():
+        return None
+
+    # Only touch install commands
+    if not re.search(r"(?:^|[;&|]+)\s*pip\s+install\b", command):
+        return None
+
+    # Skip if the user already opted out of PEP 668
+    if "--break-system-packages" in command or "--user" in command:  # pragma: no cover
+        return None
+
+    # Try uv first
+    rewritten = _rewrite_to_uv(command)
+    if rewritten:
+        logger.info("Rewrote pip install → uv pip install for PEP 668")
+        return rewritten
+
+    # Fallback to transient venv
+    rewritten = _rewrite_to_transient_venv(command)
+    if rewritten:
+        logger.info("Rewrote pip install → transient venv pip for PEP 668")
+        return rewritten
+
+    return None
+
+
+def get_install_hint() -> str:
+    """Return a concise, actionable hint for the system prompt when PEP 668 is active.
+
+    The hint is ONE line so it doesn't dominate the prompt.
+    """
+    if not is_pep668_active():
+        return ""
+    if has_uv():
+        flag = _uv_python_flag() or "--python=<interpreter>"
+        return (
+            f"PEP 668=yes (externally-managed).  Use `uv pip install {flag} <pkg>` "
+            f"instead of `pip install`.  `uv pip install --python={sys.executable} <pkg>` is preferred."
+        )
+    venv_dir, ok = ensure_transient_venv()
+    if ok or venv_dir:
+        pip = os.path.join(venv_dir, "bin", "pip")
+        return (
+            f"PEP 668=yes (externally-managed).  Use `{pip} install <pkg>` "
+            f"instead of `pip install`; or first create a venv: "
+            f"`python3 -m venv /tmp/venv && /tmp/venv/bin/pip install <pkg>`."
+        )
+    return "PEP 668=yes (externally-managed).  pip install will fail — create a venv first."

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2065,6 +2065,19 @@ def terminal_tool(
                     "status": "blocked"
                 }, ensure_ascii=False)
 
+        # ── PEP 668 transparent rewrite for pip install ──
+        # When the host Python is externally-managed, naive `pip install`
+        # fails immediately. We transparently rewrite to `uv pip install`
+        # or a transient venv so the model doesn't have to remember
+        # platform-specific workarounds.
+        try:
+            from tools.python_install import rewrite_pip_command as _rewrite_pip
+            _rewritten = _rewrite_pip(command)
+            if _rewritten is not None:
+                command = _rewritten
+        except Exception:
+            pass
+
         # Prepare command for execution
         pty_disabled_reason = None
         effective_pty = pty


### PR DESCRIPTION
## Summary

Implements transparent handling of PEP 668 externally-managed Python environments so that model-generated  commands succeed without manual intervention.

### Changes
- **New**  — detection and rewrite logic
  -  probes for  marker in the active interpreter's stdlib directory.
  -  rewrites bare  →  when  is available; falls back to a transient  pip if not.
  -  creates (and reuses per-process) a lightweight virtual environment under .
- **Integration**  — transparent rewrite is injected immediately before command execution, guarded by a fail-open try/import to avoid blocking the terminal tool.
- **Integration**  — adds a concise PEP 668 install hint to the system prompt so the model knows the right patterns upfront.
- **Tests**  — 15 passing tests covering detection, rewrite (with and without ), compound commands, fallback venv creation, and system-prompt hint generation.

Closes #69
