### PR TITLE
feat: bundle Turbo-Quant Memory MCP by default (install + auto-update + use)

### DIFF
--- a/scripts/install_auto_update.ps1
+++ b/scripts/install_auto_update.ps1
@@ -54,11 +54,14 @@ $log = Join-Path $logDir "auto-update.log"
 # Build the action. Wrap in cmd /c so we can redirect stdout/stderr to the log.
 # Inner quoting: the whole /TR value is one string; quote the exe and log paths.
 $inner = "`"$hermes`" update --yes >> `"$log`" 2>&1"
-# Also keep the optional Turbo-Quant Memory MCP current when uv is installed.
-# Absolute path; '&' runs it independently of the update result (best-effort, so
-# a memory-upgrade hiccup never blocks the self-update that already ran).
+# Also keep the optional Turbo-Quant Memory MCP current — but ONLY if it is
+# actually installed (and uv is present). Checking for the binary, not just uv,
+# avoids daily no-op upgrade errors for users who opted out or never installed
+# it. Absolute path; '&' runs it independently of the update result (best-effort,
+# so a memory-upgrade hiccup never blocks the self-update that already ran).
 $uvCmd = Get-Command uv -ErrorAction SilentlyContinue
-if ($uvCmd) {
+$tqmCmd = Get-Command turbo-memory-mcp -ErrorAction SilentlyContinue
+if ($uvCmd -and $tqmCmd) {
     $uv = $uvCmd.Source
     $inner = "$inner & `"$uv`" tool upgrade turbo-memory-mcp >> `"$log`" 2>&1"
 }

--- a/scripts/install_auto_update.ps1
+++ b/scripts/install_auto_update.ps1
@@ -53,7 +53,16 @@ $log = Join-Path $logDir "auto-update.log"
 
 # Build the action. Wrap in cmd /c so we can redirect stdout/stderr to the log.
 # Inner quoting: the whole /TR value is one string; quote the exe and log paths.
-$action = "cmd /c `"`"$hermes`" update --yes >> `"$log`" 2>&1`""
+$inner = "`"$hermes`" update --yes >> `"$log`" 2>&1"
+# Also keep the optional Turbo-Quant Memory MCP current when uv is installed.
+# Absolute path; '&' runs it independently of the update result (best-effort, so
+# a memory-upgrade hiccup never blocks the self-update that already ran).
+$uvCmd = Get-Command uv -ErrorAction SilentlyContinue
+if ($uvCmd) {
+    $uv = $uvCmd.Source
+    $inner = "$inner & `"$uv`" tool upgrade turbo-memory-mcp >> `"$log`" 2>&1"
+}
+$action = "cmd /c `"$inner`""
 
 schtasks /Create /SC DAILY /ST $Time /TN $TaskName /TR $action /F | Out-Null
 if ($LASTEXITCODE -ne 0) {

--- a/scripts/install_auto_update.sh
+++ b/scripts/install_auto_update.sh
@@ -54,12 +54,16 @@ mkdir -p "$(dirname "$LOG")"
 # `hermes update --yes` = non-interactive (auto-answers stash/migration prompts),
 # pulls origin/main (the fork), keeps the built-in pre-update backup + rollback.
 ENTRY="$SCHEDULE $HERMES_BIN update --yes >> $LOG 2>&1"
-# Also keep the optional Turbo-Quant Memory MCP current when uv is present. Use
-# uv's ABSOLUTE path (cron's PATH usually omits ~/.local/bin) and a trailing
-# `; true` so a memory-upgrade hiccup never fails the job or the hermes update
-# that already ran. Skipped entirely if uv isn't installed.
+# Also keep the optional Turbo-Quant Memory MCP current — but ONLY if it is
+# actually installed (and uv is present to upgrade it). Checking for the binary,
+# not just uv, avoids daily no-op "upgrade a package that isn't installed"
+# errors in the log for users who opted out (HERMES_NO_TQMEMORY) or have uv but
+# never installed it. Use uv's ABSOLUTE path (cron's PATH usually omits
+# ~/.local/bin) and a trailing `; true` so a memory-upgrade hiccup never fails
+# the job or the hermes update that already ran.
 UV_BIN="$(command -v uv || true)"
-if [ -n "$UV_BIN" ]; then
+TQM_BIN="$(command -v turbo-memory-mcp || true)"
+if [ -n "$UV_BIN" ] && [ -n "$TQM_BIN" ]; then
     ENTRY="$ENTRY; $UV_BIN tool upgrade turbo-memory-mcp >> $LOG 2>&1; true"
 fi
 ENTRY="$ENTRY  # $MARKER"

--- a/scripts/install_auto_update.sh
+++ b/scripts/install_auto_update.sh
@@ -53,7 +53,16 @@ mkdir -p "$(dirname "$LOG")"
 
 # `hermes update --yes` = non-interactive (auto-answers stash/migration prompts),
 # pulls origin/main (the fork), keeps the built-in pre-update backup + rollback.
-ENTRY="$SCHEDULE $HERMES_BIN update --yes >> $LOG 2>&1  # $MARKER"
+ENTRY="$SCHEDULE $HERMES_BIN update --yes >> $LOG 2>&1"
+# Also keep the optional Turbo-Quant Memory MCP current when uv is present. Use
+# uv's ABSOLUTE path (cron's PATH usually omits ~/.local/bin) and a trailing
+# `; true` so a memory-upgrade hiccup never fails the job or the hermes update
+# that already ran. Skipped entirely if uv isn't installed.
+UV_BIN="$(command -v uv || true)"
+if [ -n "$UV_BIN" ]; then
+    ENTRY="$ENTRY; $UV_BIN tool upgrade turbo-memory-mcp >> $LOG 2>&1; true"
+fi
+ENTRY="$ENTRY  # $MARKER"
 
 # Idempotent install (if-form, no set -e/pipefail traps on empty crontab).
 KEPT="$(crontab -l 2>/dev/null | grep -v "$MARKER" || true)"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -528,6 +528,7 @@ if [ "${HERMES_NO_TQMEMORY:-0}" != "1" ] && command -v uv >/dev/null 2>&1; then
     if command -v turbo-memory-mcp >/dev/null 2>&1; then
         uv tool upgrade turbo-memory-mcp >/dev/null 2>&1 || true
     else
+        echo "🧠 Installing Turbo-Quant Memory MCP (one-time, may take a minute)…"
         uv tool install "git+https://github.com/Lexus2016/turbo_quant_memory" >/dev/null 2>&1 || true
     fi
     hash -r 2>/dev/null || true   # pick up a freshly-installed shim in ~/.local/bin

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -518,6 +518,34 @@ if [ "${HERMES_NO_STAR:-0}" != "1" ]; then
     fi
 fi
 
+# --- Optional: Turbo-Quant Memory MCP for evolution introspection -----------
+# Local-first MCP memory server (github.com/Lexus2016/turbo_quant_memory). When
+# present, evolution skills get typed cross-cycle memory (decisions/lessons,
+# semantic dedup, knowledge graph) instead of re-deriving everything each run.
+# Best-effort + opt-out (HERMES_NO_TQMEMORY=1); NEVER fails the install — a
+# missing memory server just means evolution runs as it did before.
+if [ "${HERMES_NO_TQMEMORY:-0}" != "1" ] && command -v uv >/dev/null 2>&1; then
+    if command -v turbo-memory-mcp >/dev/null 2>&1; then
+        uv tool upgrade turbo-memory-mcp >/dev/null 2>&1 || true
+    else
+        uv tool install "git+https://github.com/Lexus2016/turbo_quant_memory" >/dev/null 2>&1 || true
+    fi
+    hash -r 2>/dev/null || true   # pick up a freshly-installed shim in ~/.local/bin
+    if command -v turbo-memory-mcp >/dev/null 2>&1; then
+        # Register with Hermes only if absent — avoids the interactive overwrite
+        # prompt (which would hang a non-interactive install).
+        if ! "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main mcp list 2>/dev/null | grep -qi "tqmemory"; then
+            "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main mcp add tqmemory \
+                --command turbo-memory-mcp --args serve >/dev/null 2>&1 || true
+        fi
+        echo "🧠 Turbo-Quant Memory ready for evolution introspection (opt out: HERMES_NO_TQMEMORY=1)."
+    else
+        echo "ℹ️  Turbo-Quant Memory not installed (optional) — evolution runs without it."
+    fi
+elif [ "${HERMES_NO_TQMEMORY:-0}" != "1" ]; then
+    echo "ℹ️  'uv' not found — skipping optional Turbo-Quant Memory. Evolution runs without it."
+fi
+
 # Ask if they want to run setup wizard now
 read -p "Would you like to run the setup wizard now? [Y/n] " -n 1 -r
 echo

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -128,6 +128,26 @@ A concrete fix/capability that would unblock it.
 - Priority Score: <impact*2/effort>
 ```
 
+## Cross-cycle memory (optional — only if Turbo-Quant Memory is available)
+
+If the `mcp__tqmemory__*` tools are present (the optional Turbo-Quant Memory MCP
+is installed and registered — see `setup-hermes.sh`), use them so introspection
+*remembers across runs* instead of re-deriving everything daily. If those tools
+are NOT available, skip this section entirely — the `gh`-based flow above is
+fully sufficient. **Never make the cycle depend on tqmemory.**
+
+- **Before dedup**, query memory for patterns already seen or decided — this
+  catches things a closed issue's title would not surface (e.g. "we dropped this
+  last month because X"):
+  `mcp__tqmemory__semantic_search(query="<the problem pattern>", scope="project")`.
+  If a prior `decision`/`lesson` says it was already fixed or deliberately
+  dropped, treat it like an existing issue and SKIP. This **complements**, does
+  not replace, the `gh issue list` dedup above.
+- **After the run**, record what you found and decided so the next cycle builds
+  on it instead of repeating it:
+  `mcp__tqmemory__remember_note(title="<pattern>", content="<abstracted finding + decision>", kind="pattern", scope="project")`.
+  Same privacy rule — abstracted only, never raw session text, paths, or PII.
+
 ## Limits
 
 - Maximum 5 introspection issues per day (keep signal high).

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -52,6 +52,13 @@ Create GitHub issues and pull requests based on research.
     Only genuinely NEW proposals proceed. Rule at scale: the FIRST install files an
     idea once; every other install must recognize it already exists and stay silent.
 
+    **Optional cross-run memory:** if the `mcp__tqmemory__*` tools are available
+    (optional Turbo-Quant Memory MCP), also
+    `mcp__tqmemory__semantic_search(query="<proposal>", scope="project")` before
+    filing — a past `decision`/`lesson` can record that an idea was already tried
+    or deliberately dropped even when no issue exists for it. Skip silently if the
+    tools are absent; never depend on them.
+
 3. **Create issues** (only for proposals that survived BOTH 2a and 2b) via the
    `gh` CLI (terminal tool). `gh` is already authorized via persistent `gh auth login`.
 


### PR DESCRIPTION
Makes the optional tqmemory memory server a default part of the fork so evolution gets typed cross-cycle memory (decisions/lessons, semantic dedup, knowledge graph). Soft dependency: installed via 'uv tool' from the public repo (no PyPI), registered via 'hermes mcp add', kept current on the same daily schedule as 'hermes update', and USED by evolution-introspection/issues only when mcp__tqmemory__* tools are present. Opt-out HERMES_NO_TQMEMORY=1; never fails install, graceful degradation everywhere.