### PR TITLE
fix(tests): stop real 'hermes update' spawns from platform-gate tests (Closes #85)

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -395,6 +395,38 @@ def _run_one_file(
             timeout_note=f"per-file timeout on exit-4 retry {attempt}",
         )
 
+    if rc == 4 and not _file_present(file):
+        # Tripwire (#85): the file existed at plan time (its tests were
+        # counted by the bulk --collect-only) but is genuinely gone now.
+        # The known cause was a test spawning the real `hermes update`,
+        # whose orphaned process ran `git checkout main` on the workspace
+        # and deleted every file new relative to main. Dump the tree state
+        # into the failure block so any recurrence is diagnosable from the
+        # CI log alone.
+        diag_cmds = [
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            ["git", "rev-parse", "HEAD"],
+            ["git", "status", "--porcelain"],
+            ["git", "reflog", "-5"],
+        ]
+        diag_lines = [
+            "",
+            "[tripwire] file vanished from disk after plan time — "
+            "workspace tree state:",
+        ]
+        for diag_cmd in diag_cmds:
+            try:
+                diag_out = subprocess.run(
+                    diag_cmd, cwd=repo_root, capture_output=True,
+                    text=True, timeout=10,
+                ).stdout.strip()
+            except Exception as exc:  # noqa: BLE001 — diagnostics only
+                diag_out = f"<failed: {exc}>"
+            shown = diag_out.splitlines()[:10] or ["<empty>"]
+            diag_lines.append(f"  $ {' '.join(diag_cmd)}")
+            diag_lines.extend(f"    {line}" for line in shown)
+        output += "\n".join(diag_lines) + "\n"
+
     if rc == 5:
         # No tests collected — every test in the file was filtered out.
         # Treat as a pass; surface info in a slightly distinct status

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -42,6 +42,28 @@ def _make_runner():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _no_real_update_spawn():
+    """Hard guard: never spawn the real ``hermes update --gateway``.
+
+    The platform-allowlist tests (``TestUpdateCommandPlatformGate``'s
+    ``test_allows_*``) drive the real handler all the way to the spawn.
+    Without this guard they launch a REAL detached (setsid)
+    ``hermes update --gateway`` against the repo checkout the tests run
+    from: the orphaned updater then runs ``git fetch origin main;
+    git checkout main`` mid-test-run, deleting every file that is new
+    relative to main. On CI (detached merge-ref HEAD) the tree never
+    switches back, which deterministically broke any PR adding new test
+    files (issue #85).
+
+    Module-level autouse so every present and future test in this file is
+    covered. Tests that assert on spawn behaviour still patch
+    ``subprocess.Popen`` themselves; their inner patch nests inside this one.
+    """
+    with patch("subprocess.Popen") as popen_guard:
+        yield popen_guard
+
+
 class TestHandleUpdateCommand:
     """Tests for GatewayRunner._handle_update_command."""
 


### PR DESCRIPTION
## Root cause (found empirically, local repro + git-shim process-ancestry logging)

`TestUpdateCommandPlatformGate`'s `test_allows_*` tests call the real `_handle_update_command` **without mocking `subprocess.Popen`**. The handler finds the real `.git` and the real `hermes` binary in `.venv` and spawns a **detached (setsid) real `hermes update --gateway`**. Seconds after the test itself goes green, the orphaned updater runs:

```
git fetch origin main
git checkout main        # ← every file new relative to main vanishes
... (update flow)
git checkout <prev>      # ← restores locally; IMPOSSIBLE on CI (detached merge-ref HEAD)
```

On CI the tree stays on main forever → any new-in-PR test file whose per-file pytest subprocess starts after that moment fails with exit 4 "file or directory not found". This is the exact deterministic signature that blocked #73, #79, #95, #96.

Why static inspection kept clearing this file: locally the final `checkout <prev>` restores the tree, and the damage window is seconds wide — the file looks innocent and its own tests always pass.

Evidence trail (local reproduction in a throwaway clone):
- full slice-6 run: victim file deleted mid-run; clone reflog showed `checkout: moving from <pr-branch> to main` at the deletion timestamp
- git-shim (PATH-prepended logging wrapper) captured `checkout main` with full process ancestry: `pytest test_update_command.py` → `bash -c ... hermes update --gateway` → `git checkout main`, cwd = repo root
- running ONLY `test_update_command.py` (1.9 s) flipped the clone to main within 2 seconds; 25 s later orphans switched it back — masking the crime locally
- after the fix: same runs spawn **zero** updater processes, git-shim log empty, reflog untouched, victim file intact, 35/35 tests pass

## Fix
1. **Module-level autouse fixture** in `tests/gateway/test_update_command.py` patches `subprocess.Popen` for every test in the file (covers all 4 `test_allows_*` + any future test). Spawn-asserting tests nest their own patch inside it, unchanged behaviour.
2. **Tripwire in `scripts/run_tests_parallel.py`** (attack-plan item 1 from #85): on exit-4 with the file genuinely absent, the failure block now dumps `HEAD`, `git status --porcelain` and `git reflog -5` — any recurrence of this defect class becomes diagnosable from the CI log alone.

## Side note for reviewers
`gateway.run._hermes_home` is a module-level value cached at first import — during a pytest session every later test sees the FIRST test's tmpdir. Latent test-infra wart, separate from this fix; not addressed here.

Closes #85