### PR TITLE
fix(skills): relocate bundled skills that move to a new category path

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -618,7 +618,8 @@ class TestSyncSkills:
             result = sync_skills(quiet=True)
         assert result == {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "suppressed": [], "total_bundled": 0,
+            "user_modified": [], "relocated": [], "cleaned": [], "suppressed": [],
+            "total_bundled": 0,
             "optional_provenance_backfilled": [],
         }
 
@@ -1067,3 +1068,99 @@ class TestOptOutToggleAndRemove:
             assert "EDITED" in (skills_dir / "beta" / "SKILL.md").read_text()
             # non-bundled local skill never considered
             assert (skills_dir / "mine" / "SKILL.md").exists()
+
+
+class TestRelocatedBundledSkill:
+    """A bundled skill MOVED to a new category path must follow the move on
+    the client instead of being treated as user-deleted.
+
+    The old behaviour stranded the old copy forever AND never seeded the new
+    location: the manifest still held the (unchanged) skill name, the new
+    dest did not exist, so the sync read it as "user deleted — respected".
+    Result on every pre-move install: stale copies accumulate at old paths,
+    the skill loader reports name collisions, and cron jobs bound to the
+    bare skill name silently skip.
+    """
+
+    def _patched(self, bundled, skills_dir, manifest_file, tmp_path):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        stack.enter_context(patch("tools.skills_sync.HERMES_HOME", tmp_path / "home"))
+        return stack
+
+    def _seed_then_move(self, tmp_path, bundled_rel_old="guard", bundled_rel_new="security/guard"):
+        """Sync a skill from its old bundled path, then move it in bundled."""
+        import shutil as _sh
+        bundled = tmp_path / "bundled"
+        old_src = bundled / bundled_rel_old
+        old_src.mkdir(parents=True)
+        (old_src / "SKILL.md").write_text("# Guard v1\n")
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        (tmp_path / "home").mkdir(exist_ok=True)
+        with self._patched(bundled, skills_dir, manifest_file, tmp_path):
+            sync_skills(quiet=True)
+        assert (skills_dir / bundled_rel_old / "SKILL.md").exists()
+        new_src = bundled / bundled_rel_new
+        new_src.parent.mkdir(parents=True, exist_ok=True)
+        _sh.move(str(old_src), str(new_src))
+        return bundled, skills_dir, manifest_file
+
+    def test_unmodified_copy_follows_the_move(self, tmp_path):
+        bundled, skills_dir, manifest_file = self._seed_then_move(tmp_path)
+
+        with self._patched(bundled, skills_dir, manifest_file, tmp_path):
+            result = sync_skills(quiet=True)
+
+        # New location seeded, old copy gone — no name collision left behind.
+        assert (skills_dir / "security" / "guard" / "SKILL.md").exists()
+        assert not (skills_dir / "guard").exists()
+        assert "guard" in result.get("relocated", [])
+
+    def test_modified_copy_is_kept_and_new_location_not_seeded(self, tmp_path):
+        bundled, skills_dir, manifest_file = self._seed_then_move(tmp_path)
+        # User customized the old copy after the original sync.
+        (skills_dir / "guard" / "SKILL.md").write_text("# Guard EDITED\n")
+
+        with self._patched(bundled, skills_dir, manifest_file, tmp_path):
+            result = sync_skills(quiet=True)
+
+        # The user's copy survives at the old path; the new location is NOT
+        # seeded (that would create exactly the collision we're preventing).
+        assert (skills_dir / "guard" / "SKILL.md").read_text() == "# Guard EDITED\n"
+        assert not (skills_dir / "security" / "guard").exists()
+        assert "guard" not in result.get("relocated", [])
+
+    def test_multiple_stale_unmodified_copies_all_cleaned(self, tmp_path):
+        import shutil as _sh
+        bundled, skills_dir, manifest_file = self._seed_then_move(tmp_path)
+        # Simulate a SECOND historical location left behind by an earlier
+        # move (identical, unmodified content).
+        (skills_dir / "autonomous").mkdir()
+        _sh.copytree(skills_dir / "guard", skills_dir / "autonomous" / "guard")
+
+        with self._patched(bundled, skills_dir, manifest_file, tmp_path):
+            result = sync_skills(quiet=True)
+
+        assert (skills_dir / "security" / "guard" / "SKILL.md").exists()
+        assert not (skills_dir / "guard").exists()
+        assert not (skills_dir / "autonomous" / "guard").exists()
+        assert "guard" in result.get("relocated", [])
+
+    def test_user_deleted_skill_still_respected_after_move(self, tmp_path):
+        import shutil as _sh
+        bundled, skills_dir, manifest_file = self._seed_then_move(tmp_path)
+        # User deliberately deleted their copy before the bundled move synced.
+        _sh.rmtree(skills_dir / "guard")
+
+        with self._patched(bundled, skills_dir, manifest_file, tmp_path):
+            result = sync_skills(quiet=True)
+
+        # Deletion is still respected: nothing reappears anywhere.
+        assert not (skills_dir / "guard").exists()
+        assert not (skills_dir / "security" / "guard").exists()
+        assert "guard" not in result.get("relocated", [])

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -469,7 +469,7 @@ def sync_skills(quiet: bool = False) -> dict:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "total_bundled": 0,
+            "user_modified": [], "relocated": [], "cleaned": [], "total_bundled": 0,
             "optional_provenance_backfilled": [], "skipped_opt_out": True,
         }
 
@@ -477,7 +477,8 @@ def sync_skills(quiet: bool = False) -> dict:
     if not bundled_dir.exists():
         return {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "suppressed": [], "total_bundled": 0,
+            "user_modified": [], "relocated": [], "cleaned": [], "suppressed": [],
+            "total_bundled": 0,
             "optional_provenance_backfilled": [],
         }
 
@@ -490,6 +491,7 @@ def sync_skills(quiet: bool = False) -> dict:
     copied = []
     updated = []
     user_modified = []
+    relocated: List[str] = []
     suppressed_skipped: List[str] = []
     skipped = 0
 
@@ -593,8 +595,65 @@ def sync_skills(quiet: bool = False) -> dict:
                 skipped += 1  # bundled unchanged, user unchanged
 
         else:
-            # ── In manifest but not on disk — user deleted it ──
-            skipped += 1
+            # ── In manifest but not at the current dest ──
+            # Two very different situations look identical here: the user
+            # deleted their copy, OR the bundled skill was MOVED to a new
+            # category path (the dest changed while the manifest key — the
+            # skill name — stayed the same). Treating a moved skill as
+            # user-deleted strands the old copy forever and never seeds the
+            # new location: the loader then reports a name collision once a
+            # fresh copy appears by any other route, and cron jobs bound to
+            # the bare skill name silently skip (e.g. the
+            # ai-safe-audit → security/ recategorization).
+            stale_copies = _find_skill_dirs_by_name(skill_name, exclude=dest)
+            if not stale_copies:
+                # Genuinely user-deleted — respected, not re-added.
+                skipped += 1
+                continue
+
+            origin_hash = manifest.get(skill_name, "")
+            kept_modified = []
+            for old_copy in stale_copies:
+                if origin_hash and _dir_hash(old_copy) == origin_hash:
+                    try:
+                        _rmtree_writable(old_copy)
+                    except (OSError, IOError):
+                        logger.debug(
+                            "Could not remove stale copy %s", old_copy,
+                            exc_info=True,
+                        )
+                        kept_modified.append(old_copy)
+                else:
+                    kept_modified.append(old_copy)
+
+            if kept_modified:
+                # A customized (or unremovable) copy remains at the old
+                # path. Do NOT seed the new location — that would create
+                # exactly the name collision this branch prevents.
+                user_modified.append(skill_name)
+                if not quiet:
+                    kept_str = ", ".join(
+                        str(p.relative_to(SKILLS_DIR)) for p in kept_modified
+                    )
+                    print(
+                        f"  ! {skill_name}: bundled moved to "
+                        f"{dest.relative_to(SKILLS_DIR)}, but your modified "
+                        f"copy at {kept_str} was kept — not relocating"
+                    )
+            else:
+                try:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(skill_src, dest)
+                    manifest[skill_name] = bundled_hash
+                    relocated.append(skill_name)
+                    if not quiet:
+                        print(
+                            f"  → {skill_name} (relocated to "
+                            f"{dest.relative_to(SKILLS_DIR)})"
+                        )
+                except (OSError, IOError) as e:
+                    if not quiet:
+                        print(f"  ! Failed to relocate {skill_name}: {e}")
 
     # Clean stale manifest entries (skills removed from bundled dir)
     cleaned = sorted(set(manifest.keys()) - bundled_names)
@@ -620,11 +679,39 @@ def sync_skills(quiet: bool = False) -> dict:
         "updated": updated,
         "skipped": skipped,
         "user_modified": user_modified,
+        "relocated": relocated,
         "cleaned": cleaned,
         "suppressed": suppressed_skipped,
         "total_bundled": len(bundled_skills),
         "optional_provenance_backfilled": optional_provenance_backfilled,
     }
+
+
+def _find_skill_dirs_by_name(skill_name: str, exclude: Path) -> List[Path]:
+    """Find every directory in SKILLS_DIR holding a skill with this name.
+
+    Used to detect copies stranded at OLD locations after a bundled skill
+    is recategorized (moved to a different category subdirectory). The
+    ``exclude`` path (the current canonical dest) is skipped, as are
+    transient ``.bak`` backups created by the update flow.
+    """
+    matches: List[Path] = []
+    try:
+        exclude_resolved = exclude.resolve()
+    except OSError:
+        exclude_resolved = exclude
+    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        skill_dir = skill_md.parent
+        if skill_dir.suffix == ".bak":
+            continue
+        try:
+            if skill_dir.resolve() == exclude_resolved:
+                continue
+        except OSError:
+            continue
+        if _read_skill_name(skill_md, skill_dir.name) == skill_name:
+            matches.append(skill_dir)
+    return matches
 
 
 def _rmtree_writable(path: Path) -> None:
@@ -890,6 +977,8 @@ if __name__ == "__main__":
         if len(names) > MAX_SHOW:
             shown += f", +{len(names) - MAX_SHOW} more"
         parts.append(f"{len(names)} user-modified (kept): {shown}")
+    if result.get("relocated"):
+        parts.append(f"{len(result['relocated'])} relocated: {', '.join(result['relocated'])}")
     if result["cleaned"]:
         parts.append(f"{len(result['cleaned'])} cleaned from manifest")
     if result.get("optional_provenance_backfilled"):


### PR DESCRIPTION
## Problem (hit production today)
When a bundled skill is recategorized (e.g. `ai-safe-audit` → `security/ai-safe-audit` in #16), the manifest key (the skill NAME) stays the same while the dest path changes. `sync_skills()` hits the *'in manifest but not on disk'* branch and treats the move as **user-deleted**: the new location is never seeded, the old copy is stranded forever.

Every install that predates a move accumulates stale copies (our server had TWO: the original root location and `autonomous-ai-agents/` from an earlier move). Once more than one copy exists, the skill loader refuses the ambiguous bare name, and any cron job bound to it **silently skips every run**:

```
WARNING cron.scheduler: Cron job 'AI Guard - Injection Detection Reference': skill not found, skipping —
Ambiguous skill name 'ai-safe-audit': 2 skills match
```

This affects EVERY existing client of the fork on their next `hermes update` after any skill recategorization — silently.

## Fix
Before concluding 'user deleted', `sync_skills()` now searches `SKILLS_DIR` for copies of the skill at other locations:
- **unmodified** stale copies (dir hash == manifest origin hash) are removed and the skill is seeded at its new canonical path — reported as `relocated` in the result dict and the `Done:` summary;
- a **user-modified** copy is kept where it is and the new location is NOT seeded (seeding would recreate the collision) — loud warning instead;
- **genuinely deleted** skills (no copy anywhere) stay respected, as before.

## Tests
5 new tests (relocation, modified-copy conservatism, multiple stale copies, deletion respected, result-dict shape) — 60/60 in `tests/tools/test_skills_sync.py`. No new test FILES (not subject to the late #85 defect, which is fixed anyway).

## Manual remediation already applied on our server
backup → remove stale copies → drop manifest entry → resync placed `security/ai-safe-audit`; the 'AI Guard' job was rebound to the categorized path. Other clients get the automatic path via this PR on their next auto-update.