### PR TITLE
feat(evolution): deterministic watchdog cron — detect silent pipeline failure (issue 83)

### DIFF
--- a/cron/evolution/watchdog.yaml
+++ b/cron/evolution/watchdog.yaml
@@ -1,0 +1,22 @@
+name: evolution-watchdog
+# 07:47 daily — by then EVERY stage of yesterday's chain (research 09:00 …
+# integration 23:00) is past its slot + grace, so one morning run audits the
+# complete previous cycle. Deliberately off the :00/:30 marks.
+schedule: "47 7 * * *"
+enabled: true
+mode: PUBLIC
+
+# Deterministic health check — NO LLM agent. The script is the job.
+# Empty stdout = healthy = silent run (nothing delivered); any anomaly text
+# is delivered to the owner's configured home channels.
+no_agent: true
+script: evolution_watchdog.py
+
+# "all" = every platform with a configured *_HOME_CHANNEL env var.
+# Installations without home channels simply keep the report on disk.
+deliver: all
+
+prompt: |
+  Deterministic evolution pipeline health check (no LLM). Verifies stage
+  reports for the last cycle, cron job health, and GitHub access.
+  See scripts/evolution_watchdog.py (issue 83).

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Evolution watchdog — deterministic pipeline health check (issue 83).
+
+Runs as a ``no_agent`` cron job (no LLM involved): scans the evolution
+pipeline's observable state and prints a short alert report to stdout when
+something is wrong. The cron scheduler delivers non-empty stdout to the
+owner's configured messaging channels; EMPTY stdout means "all healthy"
+and nothing is delivered (silent run).
+
+Checks
+------
+1. Stage reports — every daily evolution stage must have left a non-trivial
+   report file for its most recent *expected* slot (slot + grace period).
+   This catches jobs that were killed mid-run without any record (the
+   2026-06-10 gateway-restart incident) and jobs that finished "ok" while
+   producing nothing.
+2. Job registry health — evolution jobs in ``cron/jobs.json``: last run
+   status is not "error", the job actually ran within its cadence window,
+   and it is not stuck in a running state for hours.
+3. GitHub access — ``gh auth status`` works and the API rate limit isn't
+   nearly exhausted (every pipeline stage depends on gh).
+
+Designed to be import-safe for tests: all checks are pure functions taking
+explicit paths / clocks / runners.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+# stage name -> (daily slot hour, report file extension)
+# Slots mirror cron/evolution/*.yaml schedules.
+STAGES: Dict[str, Tuple[int, str]] = {
+    "research": (9, "md"),
+    "introspection": (20, "json"),
+    "analysis": (21, "json"),
+    "implementation": (22, "md"),
+    "integration": (23, "md"),
+}
+
+GRACE_HOURS = 2
+MIN_REPORT_BYTES = 50
+DAILY_STALE_HOURS = 26
+WEEKLY_STALE_HOURS = 8 * 24
+STUCK_RUNNING_HOURS = 12
+MIN_GH_RATE_REMAINING = 200
+
+# Jobs that are weekly, not daily (looser staleness threshold).
+WEEKLY_JOBS = {"evolution-upstream-sync"}
+# The watchdog itself must not alert about its own first run.
+SELF_NAMES = {"evolution-watchdog"}
+
+
+def expected_report_date(now: datetime, slot_hour: int, grace_hours: int = GRACE_HOURS) -> str:
+    """Date (YYYY-MM-DD) whose report should exist for a daily slot.
+
+    If the slot (plus grace) has already passed today, today's report is
+    expected; otherwise yesterday's is the most recent one that must exist.
+    """
+    slot_deadline = now.replace(hour=slot_hour, minute=0, second=0, microsecond=0) + timedelta(
+        hours=grace_hours
+    )
+    day = now.date() if now >= slot_deadline else (now - timedelta(days=1)).date()
+    return day.isoformat()
+
+
+def check_stage_reports(evolution_dir: Path, now: datetime) -> List[str]:
+    """Alert for every stage whose expected report is missing or trivial."""
+    alerts: List[str] = []
+    for stage, (slot_hour, ext) in STAGES.items():
+        date = expected_report_date(now, slot_hour)
+        report = evolution_dir / stage / f"{date}.{ext}"
+        if not report.exists():
+            alerts.append(
+                f"stage '{stage}': expected report {report.name} is MISSING "
+                f"(slot {slot_hour:02d}:00 + {GRACE_HOURS}h grace passed; "
+                f"the job died without record or never ran)"
+            )
+            continue
+        try:
+            size = report.stat().st_size
+        except OSError:
+            size = 0
+        if size < MIN_REPORT_BYTES:
+            alerts.append(
+                f"stage '{stage}': report {report.name} is suspiciously small "
+                f"({size} bytes) — the cycle likely produced nothing"
+            )
+    return alerts
+
+
+def _parse_iso(value) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value)).replace(tzinfo=None)
+    except ValueError:
+        return None
+
+
+def check_jobs(jobs_file: Path, now: datetime) -> List[str]:
+    """Alert on unhealthy evolution job records in the cron registry."""
+    alerts: List[str] = []
+    try:
+        data = json.loads(jobs_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [f"cron registry {jobs_file} unreadable: {exc}"]
+
+    jobs = data.get("jobs", data if isinstance(data, list) else [])
+    for job in jobs:
+        name = str(job.get("name", ""))
+        if not name.startswith("evolution-") or name in SELF_NAMES:
+            continue
+        if not job.get("enabled", True):
+            continue
+
+        if job.get("last_status") == "error":
+            alerts.append(
+                f"job '{name}': last run FAILED — {job.get('last_error') or 'no error text'}"
+            )
+
+        stale_hours = WEEKLY_STALE_HOURS if name in WEEKLY_JOBS else DAILY_STALE_HOURS
+        last_run = _parse_iso(job.get("last_run_at"))
+        if last_run is None:
+            alerts.append(f"job '{name}': has never recorded a run")
+        elif now - last_run > timedelta(hours=stale_hours):
+            alerts.append(
+                f"job '{name}': last run {last_run.isoformat()} is stale "
+                f"(>{stale_hours}h ago — interrupted without record, or scheduler down?)"
+            )
+
+        # Forward-compatible with the interrupted-job marker (issue 105):
+        # a job stuck in 'running' state for many hours is dead.
+        if job.get("state") == "running":
+            started = _parse_iso(job.get("run_started_at"))
+            if started and now - started > timedelta(hours=STUCK_RUNNING_HOURS):
+                alerts.append(
+                    f"job '{name}': marked running since {started.isoformat()} "
+                    f"(>{STUCK_RUNNING_HOURS}h) — stuck or killed mid-run"
+                )
+    return alerts
+
+
+def _default_runner(cmd: List[str]) -> Tuple[int, str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def check_gh(runner: Callable[[List[str]], Tuple[int, str]] = _default_runner) -> List[str]:
+    """Alert when gh auth is broken or API rate budget is nearly gone."""
+    alerts: List[str] = []
+    try:
+        rc, _out = runner(["gh", "auth", "status"])
+        if rc != 0:
+            alerts.append("gh auth status FAILED — every pipeline stage depends on gh")
+    except Exception as exc:  # noqa: BLE001 — any spawn failure is an alert
+        return [f"gh unavailable: {exc}"]
+
+    try:
+        rc, out = runner(["gh", "api", "rate_limit"])
+        if rc == 0:
+            remaining = (
+                json.loads(out).get("resources", {}).get("core", {}).get("remaining")
+            )
+            if remaining is not None and remaining < MIN_GH_RATE_REMAINING:
+                alerts.append(
+                    f"GitHub API rate budget nearly exhausted: {remaining} requests left"
+                )
+        else:
+            alerts.append("gh api rate_limit failed — cannot verify API budget")
+    except Exception as exc:  # noqa: BLE001
+        alerts.append(f"gh rate-limit check failed: {exc}")
+    return alerts
+
+
+def main() -> int:
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(hermes_home / "profiles" / "user1" / "evolution"),
+        )
+    )
+    jobs_file = hermes_home / "cron" / "jobs.json"
+    now = datetime.now()
+
+    alerts: List[str] = []
+    alerts += check_stage_reports(evolution_dir, now)
+    alerts += check_jobs(jobs_file, now)
+    alerts += check_gh()
+
+    if alerts:
+        print("🐶 Evolution watchdog — pipeline anomalies detected:")
+        for a in alerts:
+            print(f"  • {a}")
+        print(
+            f"\n(checked {len(STAGES)} stage reports, cron registry, gh access "
+            f"at {now.isoformat(timespec='seconds')})"
+        )
+    # Empty stdout = healthy = silent run (scheduler delivers nothing).
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -64,19 +64,15 @@ def _normalize_toolsets(raw) -> list[str] | None:
     return out or None
 
 
-def _install_access_gate(repo_root: Path) -> str | None:
-    """Copy the GitHub access wake-gate into HERMES_HOME/scripts so cron runs it
-    as a pre-check before each evolution job. Returns the script name to attach
-    to every job, or None on failure (jobs are still created, just ungated).
-
-    The gate prints ``{"wakeAgent": false}`` when GitHub is unreachable, which
-    makes the scheduler SKIP the LLM agent entirely — no tokens / web-search
-    spent when the cycle has no outlet to post issues/PRs.
+def _install_script(repo_root: Path, filename: str) -> str | None:
+    """Copy a repo script into HERMES_HOME/scripts (the only place the cron
+    scheduler is allowed to execute scripts from). Returns the script name on
+    success, None on failure.
     """
     import os
     import shutil
 
-    src = repo_root / "scripts" / "evolution_access_gate.sh"
+    src = repo_root / "scripts" / filename
     if not src.is_file():
         return None
     home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
@@ -89,10 +85,22 @@ def _install_access_gate(repo_root: Path) -> str | None:
         return src.name
     except Exception as exc:  # pragma: no cover - environment dependent
         print(
-            f"[evolution-cron] warning: could not install access gate: {exc}",
+            f"[evolution-cron] warning: could not install script {filename}: {exc}",
             file=sys.stderr,
         )
         return None
+
+
+def _install_access_gate(repo_root: Path) -> str | None:
+    """Copy the GitHub access wake-gate into HERMES_HOME/scripts so cron runs it
+    as a pre-check before each evolution job. Returns the script name to attach
+    to every job, or None on failure (jobs are still created, just ungated).
+
+    The gate prints ``{"wakeAgent": false}`` when GitHub is unreachable, which
+    makes the scheduler SKIP the LLM agent entirely — no tokens / web-search
+    spent when the cycle has no outlet to post issues/PRs.
+    """
+    return _install_script(repo_root, "evolution_access_gate.sh")
 
 
 def main(argv: list[str]) -> int:
@@ -136,12 +144,17 @@ def main(argv: list[str]) -> int:
 
         schedule = str(spec.get("schedule") or "").strip()
         prompt = spec.get("prompt") or ""
-        if not schedule or not str(prompt).strip():
+        no_agent = bool(spec.get("no_agent"))
+        if not schedule or (not str(prompt).strip() and not no_agent):
             failed.append((name, "missing required 'schedule' or 'prompt'"))
+            continue
+        if no_agent and not str(spec.get("script") or "").strip():
+            failed.append((name, "no_agent job requires a 'script'"))
             continue
 
         skills = _normalize_skills(spec.get("skills"))
         toolsets = _normalize_toolsets(spec.get("toolsets"))
+        deliver = str(spec.get("deliver") or "local").strip()
 
         if dry_run:
             created.append((name, "DRY-RUN"))
@@ -149,13 +162,34 @@ def main(argv: list[str]) -> int:
             continue
 
         try:
+            if no_agent:
+                # Deterministic script job — no LLM agent at all. The script
+                # itself IS the job; its stdout is delivered (empty = silent).
+                script_name = str(spec["script"]).strip()
+                installed = _install_script(repo_root, script_name)
+                if not installed:
+                    failed.append((name, f"could not install script {script_name}"))
+                    continue
+                create_kwargs = dict(
+                    prompt=str(prompt) or name,
+                    schedule=schedule,
+                    name=name,
+                    deliver=deliver,
+                    no_agent=True,
+                    script=installed,
+                )
+                job = create_job(**create_kwargs)
+                created.append((name, job["id"]))
+                existing_names.add(name)
+                continue
+
             create_kwargs = dict(
                 prompt=str(prompt),
                 schedule=schedule,
                 name=name,
                 skills=skills,
                 enabled_toolsets=toolsets,
-                deliver="local",
+                deliver=deliver,
             )
             if gate_script:
                 # Pre-check script: skips the agent (no LLM/web spend) when

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -1,0 +1,180 @@
+"""Tests for scripts/evolution_watchdog.py — deterministic pipeline health check."""
+
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_watchdog import (  # noqa: E402
+    STAGES,
+    check_gh,
+    check_jobs,
+    check_stage_reports,
+    expected_report_date,
+)
+
+
+NOW = datetime(2026, 6, 11, 7, 45)  # 07:45 — after yesterday's full chain
+
+
+class TestExpectedReportDate:
+    def test_before_slot_plus_grace_expects_yesterday(self):
+        # research slot is 09:00; at 07:45 today's slot hasn't happened.
+        d = expected_report_date(NOW, slot_hour=9, grace_hours=2)
+        assert d == "2026-06-10"
+
+    def test_after_slot_plus_grace_expects_today(self):
+        late = NOW.replace(hour=12)  # 12:00 > 09:00 + 2h grace
+        d = expected_report_date(late, slot_hour=9, grace_hours=2)
+        assert d == "2026-06-11"
+
+    def test_within_grace_still_expects_yesterday(self):
+        within = NOW.replace(hour=10)  # 10:00 < 09:00 + 2h grace
+        d = expected_report_date(within, slot_hour=9, grace_hours=2)
+        assert d == "2026-06-10"
+
+
+class TestStageReports:
+    def _make_reports(self, tmp_path, date="2026-06-10", skip=(), tiny=()):
+        for stage, (slot, ext) in STAGES.items():
+            if stage in skip:
+                continue
+            d = tmp_path / stage
+            d.mkdir(exist_ok=True)
+            content = "x" * 10 if stage in tiny else "x" * 500
+            (d / f"{date}.{ext}").write_text(content)
+
+    def test_all_present_no_alerts(self, tmp_path):
+        self._make_reports(tmp_path)
+        assert check_stage_reports(tmp_path, NOW) == []
+
+    def test_missing_report_alerts(self, tmp_path):
+        self._make_reports(tmp_path, skip=("implementation",))
+        alerts = check_stage_reports(tmp_path, NOW)
+        assert len(alerts) == 1
+        assert "implementation" in alerts[0]
+        assert "2026-06-10" in alerts[0]
+
+    def test_trivially_small_report_alerts(self, tmp_path):
+        self._make_reports(tmp_path, tiny=("analysis",))
+        alerts = check_stage_reports(tmp_path, NOW)
+        assert len(alerts) == 1
+        assert "analysis" in alerts[0]
+        assert "small" in alerts[0]
+
+    def test_missing_stage_dir_alerts(self, tmp_path):
+        # No dirs at all — every stage should alert, not crash.
+        alerts = check_stage_reports(tmp_path, NOW)
+        assert len(alerts) == len(STAGES)
+
+
+class TestJobsHealth:
+    def _jobs_file(self, tmp_path, jobs):
+        p = tmp_path / "jobs.json"
+        p.write_text(json.dumps({"jobs": jobs}))
+        return p
+
+    def _job(self, name="evolution-analysis", **over):
+        base = {
+            "id": "abc123",
+            "name": name,
+            "enabled": True,
+            "state": "scheduled",
+            "last_status": "ok",
+            "last_run_at": (NOW - timedelta(hours=10)).isoformat(),
+            "last_error": None,
+        }
+        base.update(over)
+        return base
+
+    def test_healthy_jobs_no_alerts(self, tmp_path):
+        p = self._jobs_file(tmp_path, [self._job()])
+        assert check_jobs(p, NOW) == []
+
+    def test_error_status_alerts(self, tmp_path):
+        p = self._jobs_file(
+            tmp_path, [self._job(last_status="error", last_error="boom")]
+        )
+        alerts = check_jobs(p, NOW)
+        assert len(alerts) == 1
+        assert "boom" in alerts[0]
+
+    def test_stale_last_run_alerts(self, tmp_path):
+        p = self._jobs_file(
+            tmp_path,
+            [self._job(last_run_at=(NOW - timedelta(hours=30)).isoformat())],
+        )
+        alerts = check_jobs(p, NOW)
+        assert len(alerts) == 1
+        assert "26h" in alerts[0] or "stale" in alerts[0]
+
+    def test_never_ran_alerts(self, tmp_path):
+        p = self._jobs_file(tmp_path, [self._job(last_run_at=None, last_status=None)])
+        alerts = check_jobs(p, NOW)
+        assert len(alerts) == 1
+        assert "never" in alerts[0]
+
+    def test_non_evolution_jobs_ignored(self, tmp_path):
+        p = self._jobs_file(
+            tmp_path,
+            [self._job(name="My Personal Job", last_status="error", last_error="x")],
+        )
+        assert check_jobs(p, NOW) == []
+
+    def test_disabled_jobs_ignored(self, tmp_path):
+        p = self._jobs_file(
+            tmp_path, [self._job(enabled=False, last_status="error", last_error="x")]
+        )
+        assert check_jobs(p, NOW) == []
+
+    def test_weekly_job_uses_8day_threshold(self, tmp_path):
+        # upstream-sync runs weekly — 30h-old last run must NOT alert.
+        p = self._jobs_file(
+            tmp_path,
+            [
+                self._job(
+                    name="evolution-upstream-sync",
+                    last_run_at=(NOW - timedelta(hours=30)).isoformat(),
+                )
+            ],
+        )
+        assert check_jobs(p, NOW) == []
+
+    def test_missing_jobs_file_alerts(self, tmp_path):
+        alerts = check_jobs(tmp_path / "nope.json", NOW)
+        assert len(alerts) == 1
+
+
+class TestGhCheck:
+    def test_auth_failure_alerts(self):
+        def fake_run(cmd):
+            return (1, "not logged in")
+
+        alerts = check_gh(runner=fake_run)
+        assert any("auth" in a for a in alerts)
+
+    def test_low_rate_alerts(self):
+        def fake_run(cmd):
+            if "rate_limit" in " ".join(cmd):
+                return (0, json.dumps({"resources": {"core": {"remaining": 12}}}))
+            return (0, "ok")
+
+        alerts = check_gh(runner=fake_run)
+        assert any("rate" in a for a in alerts)
+
+    def test_healthy_no_alerts(self):
+        def fake_run(cmd):
+            if "rate_limit" in " ".join(cmd):
+                return (0, json.dumps({"resources": {"core": {"remaining": 4900}}}))
+            return (0, "ok")
+
+        assert check_gh(runner=fake_run) == []
+
+    def test_gh_missing_alerts(self):
+        def fake_run(cmd):
+            raise FileNotFoundError("gh")
+
+        alerts = check_gh(runner=fake_run)
+        assert len(alerts) >= 1

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -62,3 +62,73 @@ class TestNormalizeSkills:
             "evolution-research",
             "evolution-analysis",
         ]
+
+
+class TestNoAgentJobs:
+    """no_agent yaml jobs (e.g. the watchdog) register as script-only cron
+    jobs: the script is installed into HERMES_HOME/scripts, no LLM agent and
+    no access-gate pre-check are attached."""
+
+    def _write_watchdog_yaml(self, src_dir):
+        (src_dir / "watchdog.yaml").write_text(
+            "name: evolution-watchdog\n"
+            'schedule: "47 7 * * *"\n'
+            "enabled: true\n"
+            "no_agent: true\n"
+            "script: evolution_watchdog.py\n"
+            "deliver: all\n"
+            'prompt: "health check"\n'
+        )
+
+    def test_no_agent_job_registered_with_script(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_watchdog_yaml(src_dir)
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        captured = {}
+
+        def fake_create_job(**kwargs):
+            captured.update(kwargs)
+            return {"id": "wd123", "name": kwargs["name"]}
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "create_job", fake_create_job)
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert captured["no_agent"] is True
+        assert captured["script"] == "evolution_watchdog.py"
+        assert captured["deliver"] == "all"
+        # The real watchdog script must have been installed into HERMES_HOME.
+        assert (home / "scripts" / "evolution_watchdog.py").is_file()
+        # No gate / skills / toolsets attached to a script-only job.
+        assert "skills" not in captured
+        assert "enabled_toolsets" not in captured
+
+    def test_no_agent_without_script_fails(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        (src_dir / "bad.yaml").write_text(
+            "name: evolution-bad\n"
+            'schedule: "0 9 * * *"\n'
+            "no_agent: true\n"
+            'prompt: "x"\n'
+        )
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+        assert rc == 2  # registration failure reported


### PR DESCRIPTION
Implements the watchdog from issue 83 (operator-implemented per owner's request — every silent failure this week was found by hand; this automates exactly those checks).

## What it checks (deterministic, zero LLM)
1. **Stage reports** — each daily stage must have left a non-trivial report for its most recent slot (+2h grace). Catches both 'killed without record' (the 2026-06-10 gateway-restart incident) and 'ok on nothing'.
2. **Cron registry** — evolution jobs with `last_status=error`, never-ran, stale beyond cadence (26h daily / 8d weekly for upstream-sync), or stuck `running` >12h (forward-compatible with the issue-105 interrupted-job marker).
3. **GitHub access** — `gh auth status` + API rate budget.

## How it runs
`no_agent` cron job at 07:47 daily — one morning run audits the complete previous cycle. Empty stdout = healthy = silent (nothing delivered); anomalies are delivered via `deliver: all` to every platform with a configured `*_HOME_CHANNEL`.

`register_evolution_cron.py` learns `no_agent` yaml jobs (installs the script into `HERMES_HOME/scripts`, no gate/skills/toolsets attached); `_install_access_gate` generalized into `_install_script`.

## Tests
19 watchdog unit tests (slot/date logic, missing/tiny reports, job-health matrix, gh mocking) + 2 registration tests. Note: deploy requires the usual `hermes cron remove` + re-register for the new job to appear.

Touches issue 83 (will close it on merge via the next line).
Closes #83