### PR TITLE
feat(cron): durable in-flight marker + startup recovery for interrupted jobs (issue 105)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1009,6 +1009,84 @@ def advance_next_run(job_id: str) -> bool:
         return False
 
 
+def mark_job_started(job_id: str) -> None:
+    """Record that a job's execution has begun (interrupted-run forensics).
+
+    Leaves a durable ``state="running"`` + ``run_started_at`` marker in
+    jobs.json. ``mark_job_run()`` clears it on completion (it sets state to
+    scheduled/completed/error). If the gateway dies mid-run — a routine
+    planned restart is enough — the marker survives on disk, and
+    ``recover_interrupted_jobs()`` turns it into a visible ``interrupted``
+    record on the next startup instead of the run silently vanishing
+    (issue 105: the 2026-06-10 nightly cycle was lost exactly this way).
+    """
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                job["state"] = "running"
+                job["run_started_at"] = _hermes_now().isoformat()
+                save_jobs(jobs)
+                return
+        logger.warning("mark_job_started: job_id %s not found", job_id)
+
+
+def recover_interrupted_jobs(max_refire_age_hours: float = 6.0) -> List[str]:
+    """Turn stale ``running`` markers into visible interrupted records.
+
+    Call ONCE at gateway startup, BEFORE the first scheduler tick: this
+    process has not started any job yet, so every job still marked
+    ``running`` was killed mid-run by the previous process's death.
+
+    For each such job: record ``last_status="interrupted"`` with an
+    explanatory ``last_error``, restore ``state="scheduled"``, and — when
+    the interruption is recent (within ``max_refire_age_hours``) — re-fire
+    once by pulling ``next_run_at`` to now. The bounded re-fire window
+    preserves the at-most-once / anti-crash-loop semantics of
+    ``advance_next_run()``: an old marker just waits for its normal slot.
+
+    Returns human-readable descriptions of recovered jobs (for logging).
+
+    Do NOT call this from CLI ``cron tick`` paths — a tick alongside a live
+    gateway would misread that gateway's in-flight jobs as interrupted.
+    """
+    recovered: List[str] = []
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        now = _hermes_now()
+        changed = False
+        for job in jobs:
+            if job.get("state") != "running":
+                continue
+            started_raw = job.get("run_started_at")
+            started = None
+            try:
+                started = datetime.fromisoformat(str(started_raw))
+            except (TypeError, ValueError):
+                pass
+
+            job["state"] = "scheduled"
+            job["last_status"] = "interrupted"
+            job["last_error"] = (
+                "interrupted: the gateway restarted while this job was running "
+                f"(started {started_raw or 'unknown'})"
+            )
+            refired = False
+            if started is not None and (now - started) <= timedelta(
+                hours=max_refire_age_hours
+            ):
+                job["next_run_at"] = now.isoformat()
+                refired = True
+            changed = True
+            recovered.append(
+                f"{job.get('name', job['id'])}"
+                + (" (re-fired)" if refired else " (waits for its normal slot)")
+            )
+        if changed:
+            save_jobs(jobs)
+    return recovered
+
+
 def get_due_jobs() -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -149,7 +149,13 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    get_due_jobs,
+    mark_job_run,
+    mark_job_started,
+    save_job_output,
+    advance_next_run,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -2132,6 +2138,10 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
             try:
+                # Durable in-flight marker (issue 105): if the gateway dies
+                # while this job runs, recover_interrupted_jobs() makes the
+                # loss visible (and re-fires recent ones) on next startup.
+                mark_job_started(job["id"])
                 success, output, final_response, error = run_job(job)
 
                 output_file = save_job_output(job["id"], output)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15434,6 +15434,18 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
+    # Recover jobs that were in-flight when the previous gateway process died
+    # (issue 105). Must run ONCE, before the first tick: nothing is running
+    # in THIS process yet, so every persisted 'running' marker is stale.
+    try:
+        from cron.jobs import recover_interrupted_jobs
+
+        _recovered = recover_interrupted_jobs()
+        for _desc in _recovered:
+            logger.warning("cron: recovered interrupted job: %s", _desc)
+    except Exception:
+        logger.exception("cron: interrupted-job recovery failed (non-fatal)")
+
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour

--- a/tests/cron/test_interrupted_jobs.py
+++ b/tests/cron/test_interrupted_jobs.py
@@ -1,0 +1,113 @@
+"""Tests for the interrupted-job marker and startup recovery (issue 105).
+
+A gateway restart used to kill an in-flight cron job with no record at all:
+no last_run, no error, no retry — the daily slot silently vanished (the
+2026-06-10 incident). mark_job_started() leaves a durable 'running' marker;
+recover_interrupted_jobs() — called once at gateway startup — turns stale
+markers into a visible 'interrupted' record and re-fires the job once when
+the death is recent.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from cron.jobs import (
+    _hermes_now,
+    create_job,
+    load_jobs,
+    mark_job_run,
+    mark_job_started,
+    recover_interrupted_jobs,
+)
+
+
+@pytest.fixture
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def _make_job(**over):
+    job = create_job(prompt="do things", schedule="0 22 * * *", name="evolution-implementation")
+    return job
+
+
+class TestMarkJobStarted:
+    def test_sets_running_state_and_timestamp(self, tmp_cron_dir):
+        job = _make_job()
+        mark_job_started(job["id"])
+        stored = load_jobs()[0]
+        assert stored["state"] == "running"
+        assert stored["run_started_at"]
+
+    def test_mark_job_run_clears_running_state(self, tmp_cron_dir):
+        job = _make_job()
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=True)
+        stored = load_jobs()[0]
+        assert stored["state"] == "scheduled"
+        assert stored["last_status"] == "ok"
+
+    def test_unknown_job_id_is_noop(self, tmp_cron_dir):
+        _make_job()
+        mark_job_started("does-not-exist")  # must not raise
+        assert load_jobs()[0]["state"] == "scheduled"
+
+
+class TestRecoverInterruptedJobs:
+    def test_recent_interruption_refires_once(self, tmp_cron_dir):
+        job = _make_job()
+        mark_job_started(job["id"])
+        # Simulate "gateway restarted shortly after the job began".
+        recovered = recover_interrupted_jobs(max_refire_age_hours=6.0)
+
+        assert len(recovered) == 1
+        stored = load_jobs()[0]
+        assert stored["state"] == "scheduled"
+        assert stored["last_status"] == "interrupted"
+        assert "restart" in (stored["last_error"] or "")
+        # Re-fired: next_run_at pulled to ~now (well before the 22:00 slot).
+        now = _hermes_now()
+        from datetime import datetime
+
+        next_run = datetime.fromisoformat(stored["next_run_at"])
+        assert abs((next_run - now).total_seconds()) < 120
+
+    def test_old_interruption_records_but_does_not_refire(self, tmp_cron_dir):
+        job = _make_job()
+        mark_job_started(job["id"])
+        # Backdate the marker beyond the refire window.
+        jobs = load_jobs()
+        old = (_hermes_now() - timedelta(hours=20)).isoformat()
+        jobs[0]["run_started_at"] = old
+        from cron.jobs import save_jobs
+
+        save_jobs(jobs)
+        next_before = load_jobs()[0]["next_run_at"]
+
+        recovered = recover_interrupted_jobs(max_refire_age_hours=6.0)
+
+        assert len(recovered) == 1
+        stored = load_jobs()[0]
+        assert stored["last_status"] == "interrupted"
+        assert stored["state"] == "scheduled"
+        assert stored["next_run_at"] == next_before  # untouched — waits for its slot
+
+    def test_healthy_jobs_untouched(self, tmp_cron_dir):
+        job = _make_job()
+        before = load_jobs()[0]
+        recovered = recover_interrupted_jobs()
+        assert recovered == []
+        assert load_jobs()[0] == before
+
+    def test_completed_run_not_treated_as_interrupted(self, tmp_cron_dir):
+        job = _make_job()
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=True)
+        recovered = recover_interrupted_jobs()
+        assert recovered == []
+        assert load_jobs()[0]["last_status"] == "ok"


### PR DESCRIPTION
Implements issue 105 (operator-implemented per owner's request).

## Problem
A routine gateway restart (config change, nightly auto-update, /restart) kills any in-flight cron job with **no record at all**: no last_run, no error, no retry. The 2026-06-10 nightly cycle was lost exactly this way — `evolution-implementation` died 30 minutes into its run, `hermes cron list` showed no trace it ever fired, and downstream `integration` reported ok-on-nothing.

## Design (respects existing at-most-once semantics)
- **`mark_job_started()`** — durable `state='running'` + `run_started_at` in jobs.json at job start; `mark_job_run()` already flips state back on completion.
- **`recover_interrupted_jobs(max_refire_age_hours=6)`** — runs ONCE at gateway startup before the first tick (nothing runs in the new process yet ⇒ every persisted `running` marker is stale). Records `last_status='interrupted'` + explanatory `last_error`, restores `state='scheduled'`, and **re-fires only recent deaths** (`next_run_at=now`). The bounded window preserves `advance_next_run()`'s deliberate anti-crash-loop design — old markers just wait for their normal slot.
- Deliberately NOT called from CLI `cron tick`: a tick alongside a live gateway would misread its in-flight jobs as interrupted.
- Composes with the watchdog (#116): it independently alerts on jobs stuck `running` >12h.

## Tests
7 new (marker set/clear, recent-refire, old-no-refire, healthy untouched, completed-not-interrupted); full `tests/cron/` 417/417 locally.

Closes #105