### PR TITLE
fix(delegate): artifact contract + shallow-delegation flag (issue 102)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2797,3 +2797,64 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestArtifactContract(unittest.TestCase):
+    """Issue 102: the child prompt must demand real tool work + artifacts."""
+
+    def test_contract_present_in_child_prompt(self):
+        prompt = _build_child_system_prompt("Read foo.py and quote its first line")
+        self.assertIn("ARTIFACT CONTRACT", prompt)
+        self.assertIn("verbatim", prompt)
+
+
+class TestShallowDelegationDetector(unittest.TestCase):
+    """Issue 102: a 'completed' child that made ZERO tool calls answered from
+    model memory — for read/filter/compute delegations that is a non-result.
+    The parent must see an unmissable flag instead of a plausible narrative."""
+
+    def _run_child(self, messages):
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "m"
+            mock_child.session_prompt_tokens = 10
+            mock_child.session_completion_tokens = 5
+            mock_child.run_conversation.return_value = {
+                "final_response": "Here is a plausible-sounding answer.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": messages,
+            }
+            MockAgent.return_value = mock_child
+            return json.loads(
+                delegate_task(
+                    goal="read file X and quote line 1", parent_agent=parent
+                )
+            )
+
+    def test_zero_tool_calls_flagged_shallow(self):
+        entry = self._run_child(messages=[])["results"][0]
+        self.assertTrue(entry.get("shallow_result"))
+        self.assertIn("SHALLOW DELEGATION", entry["summary"])
+        # The original narrative is preserved below the flag.
+        self.assertIn("plausible-sounding answer", entry["summary"])
+        self.assertEqual(entry["status"], "completed")
+
+    def test_tool_using_child_not_flagged(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "t1",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "t1", "content": "line 1: hello"},
+        ]
+        entry = self._run_child(messages=messages)["results"][0]
+        self.assertNotIn("shallow_result", entry)
+        self.assertNotIn("SHALLOW DELEGATION", entry["summary"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -640,7 +640,16 @@ def _build_child_system_prompt(
         "Important workspace rule: Never assume a repository lives at /workspace/... or any other container-style path unless the task/context explicitly gives that path. "
         "If no exact local path is provided, discover it first before issuing git/workdir-specific commands.\n\n"
         "Be thorough but concise -- your response is returned to the "
-        "parent agent as a summary."
+        "parent agent as a summary.\n\n"
+        "ARTIFACT CONTRACT (non-negotiable): you must actually PERFORM the "
+        "task with your tools — read the files, run the commands, do the "
+        "computation. Answering from prior knowledge without tool use is a "
+        "failed delegation, even if your answer sounds plausible. Your final "
+        "summary MUST quote the concrete artifacts the task asked for "
+        "verbatim: exact file paths, extracted snippets, counts, command "
+        "output. A generic narrative without the requested data is useless "
+        "to the parent — it will have to redo the work, which defeats the "
+        "purpose of delegating to you."
     )
     if role == "orchestrator":
         child_note = (
@@ -1770,6 +1779,22 @@ def _run_single_child(
         }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+
+        # Shallow-delegation detector (issue 102): a child that made ZERO
+        # tool calls answered from its own head. For the dominant delegation
+        # use case (read/filter/compute on real data) that narrative is a
+        # non-result — flag it loudly IN the summary so the parent model
+        # cannot miss it, plus a structured field for programmatic callers.
+        if status == "completed" and not tool_trace:
+            entry["shallow_result"] = True
+            entry["summary"] = (
+                "⚠️ SHALLOW DELEGATION: this subagent made NO tool calls — "
+                "the text below is narrative from model memory, not "
+                "extracted data. If you asked for file contents, search "
+                "results, or computed values, treat this as a failure and "
+                "either re-delegate with explicit tool instructions or do "
+                "the work inline.\n\n" + summary
+            )
 
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent


### PR DESCRIPTION
Implements issue 102 (operator-implemented per owner's request). Especially relevant since #96 enabled the delegation toolset for all evolution cron jobs — shallow children would silently hollow out the pipeline's context-economy strategy.

## Root behavior (from introspection evidence, 5/25 sessions)
A child 'completes' in ~3s / one API call with a plausible narrative but none of the requested data: it answers from model memory without a single tool call. The parent accepts the text and redoes the work inline.

## Fix (both sides of the contract)
1. **Child prompt — ARTIFACT CONTRACT**: must perform the task with tools; the final summary must quote the requested artifacts verbatim (paths, snippets, counts, command output). Answering from prior knowledge = failed delegation.
2. **Parent-side detector**: a `completed` child with an EMPTY `tool_trace` gets `shallow_result: true` plus an unmissable ⚠️ prefix injected into the summary (a structured field alone is too easy for the parent model to ignore), advising re-delegation with explicit tool steps or inline work.

Legit no-tool delegations (pure rewording) still complete — they just carry the advisory prefix; the dominant use case (read/filter/compute) is exactly what the flag protects.

## Tests
4 new (contract present; zero-tool flagged with narrative preserved; tool-using child unflagged); full `tests/tools/test_delegate.py` 143/143.

Closes #102