### PR TITLE
fix(watchdog): grace period for never-ran jobs younger than their cadence

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -128,6 +128,11 @@ def check_jobs(jobs_file: Path, now: datetime) -> List[str]:
         stale_hours = WEEKLY_STALE_HOURS if name in WEEKLY_JOBS else DAILY_STALE_HOURS
         last_run = _parse_iso(job.get("last_run_at"))
         if last_run is None:
+            created = _parse_iso(job.get("created_at"))
+            if created is not None and now - created <= timedelta(hours=stale_hours):
+                # Freshly (re)registered job — its first slot hasn't come yet.
+                # Re-registration wipes run history; alerting here is noise.
+                continue
             alerts.append(f"job '{name}': has never recorded a run")
         elif now - last_run > timedelta(hours=stale_hours):
             alerts.append(

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -111,10 +111,24 @@ class TestJobsHealth:
         assert "26h" in alerts[0] or "stale" in alerts[0]
 
     def test_never_ran_alerts(self, tmp_path):
-        p = self._jobs_file(tmp_path, [self._job(last_run_at=None, last_status=None)])
+        old_created = (NOW - timedelta(days=5)).isoformat()
+        p = self._jobs_file(
+            tmp_path,
+            [self._job(last_run_at=None, last_status=None, created_at=old_created)],
+        )
         alerts = check_jobs(p, NOW)
         assert len(alerts) == 1
         assert "never" in alerts[0]
+
+    def test_freshly_registered_never_ran_is_quiet(self, tmp_path):
+        # Re-registration wipes run history; a job younger than its cadence
+        # window must not alert (its first slot simply hasn't come yet).
+        fresh_created = (NOW - timedelta(hours=5)).isoformat()
+        p = self._jobs_file(
+            tmp_path,
+            [self._job(last_run_at=None, last_status=None, created_at=fresh_created)],
+        )
+        assert check_jobs(p, NOW) == []
 
     def test_non_evolution_jobs_ignored(self, tmp_path):
         p = self._jobs_file(


### PR DESCRIPTION
First server smoke run of the watchdog (#116) correctly detected both real incidents from the night of 2026-06-10 (missing implementation report, integration ok-on-nothing) — but also alerted `evolution-upstream-sync: has never recorded a run`, which is pure re-registration noise: `hermes cron remove` + re-register (the documented flow for cron-yaml changes) wipes run history, and the weekly job's Sunday slot simply hasn't arrived.

Skip the never-ran alert while the job is younger than its own staleness window (26h daily / 8d weekly). 20/20 tests (1 new, 1 extended).