### PR TITLE
fix(register): refresh installed no_agent scripts for already-registered jobs

### DIFF
--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -138,6 +138,16 @@ def main(argv: list[str]) -> int:
             continue
 
         name = str(spec.get("name") or yaml_file.stem).strip()
+
+        # Refresh installed no_agent scripts on EVERY run — including for
+        # already-registered jobs — mirroring the access gate above:
+        # `hermes update` refreshes the repo checkout, but the scheduler
+        # executes the copy in HERMES_HOME/scripts; without this refresh the
+        # installed script stays frozen at whatever version existed when the
+        # job was first registered.
+        if spec.get("no_agent") and str(spec.get("script") or "").strip() and not dry_run:
+            _install_script(repo_root, str(spec["script"]).strip())
+
         if name in existing_names:
             skipped.append(name)
             continue

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -132,3 +132,36 @@ class TestNoAgentJobs:
 
         rc = mod.main(["register_evolution_cron.py", str(src_dir)])
         assert rc == 2  # registration failure reported
+
+    def test_existing_no_agent_job_still_refreshes_script(self, tmp_path, monkeypatch):
+        """`hermes update` refreshes the repo, but the scheduler executes the
+        copy in HERMES_HOME/scripts — re-running the registrar must refresh
+        that copy even when the job itself is already registered."""
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_watchdog_yaml(src_dir)
+        home = tmp_path / "hermes-home"
+        (home / "scripts").mkdir(parents=True)
+        # Stale installed copy from a previous registration.
+        stale = home / "scripts" / "evolution_watchdog.py"
+        stale.write_text("# stale old version\n")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        import cron.jobs as jobs_mod
+
+        # Job already registered — create_job must NOT be called.
+        monkeypatch.setattr(
+            jobs_mod, "load_jobs", lambda: [{"name": "evolution-watchdog"}]
+        )
+        monkeypatch.setattr(
+            jobs_mod,
+            "create_job",
+            lambda **kw: (_ for _ in ()).throw(AssertionError("must not create")),
+        )
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        refreshed = stale.read_text()
+        assert "stale old version" not in refreshed  # real script copied over


### PR DESCRIPTION
Caught live during the watchdog deploy: PR #119's fix landed in the repo via `hermes update`, but the scheduler kept executing the OLD copy in `HERMES_HOME/scripts` — `_install_script` only ran inside the create branch, so an installed no_agent script stays frozen at whatever version existed when the job was first registered.

Mirror the access-gate behavior (which already refreshes unconditionally): install/refresh the script on every registrar run, BEFORE the existing-name skip. The registrar runs on every `upgrade.sh`, so installed scripts now track the repo.

1 new test (stale installed copy + already-registered job ⇒ copy refreshed, no job created); 51/51 scripts tests.