### PR TITLE
fix(watchdog): use Hermes' configured timezone for report-date math

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -193,7 +193,18 @@ def main() -> int:
         )
     )
     jobs_file = hermes_home / "cron" / "jobs.json"
-    now = datetime.now()
+    # Stage reports are dated in Hermes' CONFIGURED timezone (hermes_time.now),
+    # which may differ from the server's local zone — around midnight a naive
+    # datetime.now() would then look for the wrong report date. The scheduler
+    # runs this script from HERMES_HOME/scripts (outside the repo's sys.path),
+    # so hermes_time may not be importable — fall back to server-local wall
+    # time, which is identical whenever no explicit timezone is configured.
+    try:
+        from hermes_time import now as _hermes_now
+
+        now = _hermes_now().replace(tzinfo=None)
+    except ImportError:
+        now = datetime.now()
 
     alerts: List[str] = []
     alerts += check_stage_reports(evolution_dir, now)


### PR DESCRIPTION
Found in a post-implementation self-audit. Stage reports are dated in the **configured** Hermes timezone (`hermes_time.now`), while the watchdog compared against naive server-local `datetime.now()`. On installations whose configured zone differs from the server's, the watchdog would compute the wrong expected report date around midnight — false MISSING alerts or, worse, missed real gaps. Our own server has matching zones, which is why the smoke runs couldn't catch it; fork clients may not.

Import `hermes_time` when available and fall back to server-local time (identical whenever no explicit zone is configured) — the scheduler executes the installed copy from `HERMES_HOME/scripts`, outside the repo's `sys.path`, hence the guarded import.

20/20 watchdog tests (pure functions take `now` explicitly — unaffected).