### PR TITLE
fix(watchdog): integration stage reports are .json, not .md

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -35,13 +35,15 @@ from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
 # stage name -> (daily slot hour, report file extension)
-# Slots mirror cron/evolution/*.yaml schedules.
+# Slots and extensions mirror cron/evolution/*.yaml (schedule + output.file).
+# Drift is locked down by TestStagesMirrorCronSpecs in
+# tests/scripts/test_evolution_watchdog.py.
 STAGES: Dict[str, Tuple[int, str]] = {
     "research": (9, "md"),
     "introspection": (20, "json"),
     "analysis": (21, "json"),
     "implementation": (22, "md"),
-    "integration": (23, "md"),
+    "integration": (23, "json"),
 }
 
 GRACE_HOURS = 2

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -1,6 +1,7 @@
 """Tests for scripts/evolution_watchdog.py — deterministic pipeline health check."""
 
 import json
+import re
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -192,3 +193,34 @@ class TestGhCheck:
 
         alerts = check_gh(runner=fake_run)
         assert len(alerts) >= 1
+
+
+class TestStagesMirrorCronSpecs:
+    """STAGES duplicates cron/evolution/*.yaml; lock the two together.
+
+    Regression for the 2026-06-12 false alarm: integration writes
+    {date}.json (integration.yaml output.file) but STAGES said "md",
+    so the watchdog reported a healthy run as a dead job.
+    """
+
+    CRON_DIR = Path(__file__).resolve().parents[2] / "cron" / "evolution"
+
+    def test_extension_matches_output_file(self):
+        for stage, (_slot, ext) in STAGES.items():
+            spec = (self.CRON_DIR / f"{stage}.yaml").read_text()
+            m = re.search(r"^\s*file:.*\{current_date\}\.(\w+)\s*$", spec, re.M)
+            assert m, f"{stage}.yaml has no output.file with {{current_date}}"
+            assert m.group(1) == ext, (
+                f"watchdog STAGES says '{stage}' reports are .{ext}, "
+                f"but {stage}.yaml writes .{m.group(1)}"
+            )
+
+    def test_slot_hour_matches_schedule(self):
+        for stage, (slot, _ext) in STAGES.items():
+            spec = (self.CRON_DIR / f"{stage}.yaml").read_text()
+            m = re.search(r'^schedule:\s*"(\d+)\s+(\d+)\s', spec, re.M)
+            assert m, f"{stage}.yaml has no parsable daily schedule"
+            assert int(m.group(2)) == slot, (
+                f"watchdog STAGES says '{stage}' runs at {slot:02d}:00, "
+                f"but {stage}.yaml schedules hour {m.group(2)}"
+            )


### PR DESCRIPTION
## Що сталося
Watchdog 2026-06-12 07:47 поскаржився: `stage 'integration': expected report 2026-06-11.md is MISSING`. Насправді стадія відпрацювала нормально — на сервері лежить `2026-06-11.json` (374 B, merged PR #127, self_update ok). Хибна тривога.

## Корінь
`STAGES` у `scripts/evolution_watchdog.py` закодував `integration -> md`, але `cron/evolution/integration.yaml` від самого створення (#44) пише `{current_date}.json`. Watchdog (#116) народився з неправильним розширенням.

## Фікс
- `integration`: `md` -> `json` у STAGES.
- Регресійний тест `TestStagesMirrorCronSpecs`: звіряє КОЖНЕ розширення і slot-годину STAGES із `cron/evolution/*.yaml` — дрейф дубльованої правди тепер ловиться у CI.

## Перевірено
- `uv run --extra dev python -m pytest tests/scripts/test_evolution_watchdog.py -q` -> 22 passed (20 старих + 2 нові).