### PR TITLE
fix(tests): complete leaked fake dotenv to unblock shard-order flake (#125/#126 deadlock)

### DIFF
--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -14,6 +14,16 @@ import pytest
 if "dotenv" not in sys.modules:
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    # This module-level fake is installed before any fixture can tear it down,
+    # so it LEAKS into the rest of the worker process. If we win the race
+    # against the real python-dotenv import, the leaked stub must expose the
+    # whole public API other modules import — otherwise a downstream
+    # `from dotenv import dotenv_values` raises
+    # "cannot import name 'dotenv_values' from 'dotenv' (unknown location)",
+    # which is exactly how this shard-order-dependent flake broke unrelated
+    # gateway tests (test_42039) and deadlocked evolution PRs #125/#126.
+    fake_dotenv.dotenv_values = lambda *args, **kwargs: {}
+    fake_dotenv.find_dotenv = lambda *args, **kwargs: ""
     sys.modules["dotenv"] = fake_dotenv
 
 from hermes_cli.auth import resolve_provider


### PR DESCRIPTION
## Симптом
PR #125 і #126 (валідні, MERGEABLE) висять >1 доби, бо обидва падають ТІЛЬКИ на `test (4)`:
```
ImportError: cannot import name 'dotenv_values' from 'dotenv' (unknown location)
(tests/gateway/test_42039_duplicate_user_message.py)
```
Жоден із цих PR не чіпає `dotenv`. main зелений на тому ж коді.

## Корінь
`tests/hermes_cli/test_gmi_provider.py` на рівні модуля (до будь-якої фікстури) ставить фейковий `dotenv` у `sys.modules`, якщо справжній python-dotenv ще не імпортовано. Фейк мав лише `load_dotenv`. У pytest-xdist воркері, якщо цей файл імпортується раніше за справжній dotenv, неповний фейк протікає на весь процес, і будь-який наступний `from dotenv import dotenv_values` падає. Залежить від складу шарда — тому main зелений, а на гілках PR шард 4 ловить колізію.

## Фікс
Зробити протічний фейк повним (`dotenv_values`, `find_dotenv`) — програна гонка стає нешкідливою за будь-якого порядку колекції.

## Доказ
- ImportError відтворено байт-у-байт у чистому процесі ДО фіксу; зник ПІСЛЯ.
- `pytest tests/hermes_cli/test_gmi_provider.py` → 23 passed.

Розблоковує issue #124 (PR #125) та #122 (PR #126).