### PR TITLE
fix(tests): complete gateway fake dotenv modules — unblock PR #125 deadlock

### DIFF
--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -31,6 +31,8 @@ def _bootstrap(monkeypatch, tmp_path):
     """Minimal GatewayRunner setup shared by all tests in this module."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     config = GatewayConfig()

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -160,6 +160,8 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *a, **k: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -135,6 +135,8 @@ async def _run_once(monkeypatch, tmp_path, agent_cls, session_id):
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -252,6 +252,8 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -299,6 +301,8 @@ async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypa
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -338,6 +342,8 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -388,6 +394,8 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -430,6 +438,8 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -486,6 +496,8 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -696,6 +708,8 @@ async def _run_with_agent(
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -1136,6 +1150,8 @@ async def test_run_agent_drops_tool_progress_after_generation_invalidation(monke
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -1198,6 +1214,8 @@ async def test_run_agent_drops_interim_commentary_after_generation_invalidation(
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -1354,6 +1372,8 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -1407,6 +1427,8 @@ async def test_terminal_progress_verbose_shows_full_command(monkeypatch, tmp_pat
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -1455,6 +1477,8 @@ async def test_terminal_progress_no_bash_block_in_verbose_mode(monkeypatch, tmp_
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -302,6 +302,8 @@ class TestTokenEstimation:
 async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, tmp_path):
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     class FakeCompressAgent:
@@ -404,6 +406,8 @@ async def test_session_hygiene_warns_user_when_compression_aborts(monkeypatch, t
     topic/thread) saying the conversation is unchanged and how to retry."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     class FakeCompressAgentWithSummaryFailure:
@@ -523,6 +527,8 @@ async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(mo
     hides a misconfig only they can resolve."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     class FakeCompressAgentWithAuxRecovery:
@@ -651,6 +657,8 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
     """
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     class FakeCompressAgent:
@@ -765,6 +773,8 @@ async def test_session_hygiene_default_hard_message_limit_does_not_fire_at_12_me
     passes without changes, the override test's finding is meaningful."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.dotenv_values = lambda *a, **k: {}
+    fake_dotenv.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     class FakeCompressAgent:

--- a/tests/gateway/test_shutdown_memory_provider_messages.py
+++ b/tests/gateway/test_shutdown_memory_provider_messages.py
@@ -31,6 +31,8 @@ def _mock_dotenv(monkeypatch):
     """gateway.run imports dotenv at module load; stub so tests run bare."""
     fake = types.ModuleType("dotenv")
     fake.load_dotenv = lambda *a, **kw: None
+    fake.dotenv_values = lambda *a, **k: {}
+    fake.find_dotenv = lambda *a, **k: ""
     monkeypatch.setitem(sys.modules, "dotenv", fake)
 
 


### PR DESCRIPTION
## Симптом
PR #125 (issue-124) висить >1 доби: падає на `test (4)`:
```
cron/scheduler.py:41: from dotenv import dotenv_values
ImportError: cannot import name 'dotenv_values' from 'dotenv' (unknown location)
(через tests/gateway/test_42039_duplicate_user_message.py)
```

## Корінь (продовження #152)
Шість gateway-тестів ставлять фейковий `dotenv` у sys.modules лише з `load_dotenv`. Коли gateway-тест біжить у шарді ДО першого імпорту `cron.scheduler`, лінива гілка `gateway.run._home_target_env_var → cron/__init__ → cron/scheduler` натикається на `from dotenv import dotenv_values` під активним неповним фейком → ImportError.

PR #125 САМ легітимно додає цей імпорт у scheduler (читає .env у dict для no_agent скриптів) — тому саме він ловить міну. Це той самий клас неповних моків, що conftest уже стереже для telegram/discord.

## Фікс
Зробити всі 6 gateway-фейків правдивими до публічного API python-dotenv (`dotenv_values`, `find_dotenv`), щоб будь-який продакшн-код під тестовим двійником працював незалежно від порядку колекції шарда.

## Доказ
- Сценарій #125 (`from dotenv import dotenv_values` під повним фейком) відтворено зеленим.
- Усі 6 файлів локально: 73 passed.

Розблоковує PR #125 / issue #124. Доповнює #152.