### PR TITLE
feat(evolution): autonomous issue/PR throughput — anti-starvation + flaky-retry

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -41,6 +41,6 @@ log_level: DEBUG
 # Safety
 safety:
   require_private_mode: true
-  max_implementations_per_day: 5
-  max_total_effort: 2.0
+  max_implementations_per_day: 8
+  max_total_effort: 3.0
   min_priority_score: 0.7

--- a/cron/evolution/implementation.yaml
+++ b/cron/evolution/implementation.yaml
@@ -16,7 +16,7 @@ prompt: |
   1. NEVER merge without tests passing
   2. NEVER merge without documentation
   3. ALWAYS create rollback option
-  4. LIMIT: 3 auto-merges per day
+  4. LIMIT: 5 auto-merges per day
   5. Breaking changes need manual review
   
   This job ONLY runs in PRIVATE mode.
@@ -50,7 +50,7 @@ safety:
   require_private_mode: true
   require_tests_passing: true
   require_documentation: true
-  max_auto_merges_per_day: 3
+  max_auto_merges_per_day: 5
   breaking_changes_require_review: true
   auto_rollback_on_failure: true
 

--- a/cron/evolution/integration.yaml
+++ b/cron/evolution/integration.yaml
@@ -10,9 +10,10 @@ prompt: |
   (branches evolution/issue-*) into main, then self-update onto the merged code.
 
   Use the evolution-integration skill for instructions. Follow its safety gates
-  EXACTLY: only evolution/issue-* branches, only fully-green CI (zero failing,
-  zero pending checks), max 3 merges per run, and run `hermes update --yes`
-  after merging (it has built-in rollback).
+  EXACTLY: only evolution/issue-* branches, green CI at merge time (the skill's
+  gate ladder lets you re-run a failed check ONCE and wait for pending CI
+  in-cycle — but the state when you merge must be fully green), max 5 merges per
+  run, and run `hermes update --yes` after merging (it has built-in rollback).
 
   CRITICAL: This job ONLY runs in PRIVATE mode.
   If GITHUB_PRIVATE_TOKEN is not set, ABORT immediately.
@@ -43,6 +44,6 @@ log_level: INFO
 # Safety
 safety:
   require_private_mode: true
-  max_merges_per_run: 3
+  max_merges_per_run: 5
   only_branches: "evolution/issue-*"
   require_all_checks_green: true

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -127,13 +127,33 @@ gh issue view <N> --repo Lexus2016/hermes-agent-evolution --json body,comments
 
 ```python
 base_priority = (impact * 2) / effort
-final_priority = base_priority + community*0.1 + age*0.05 + compatibility*0.2 + safety*0.3
+final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + safety*0.3
 ```
 
-6. **Select** the top 5 for implementation (include any `needs-work` issues from
+   `age = min(days_since_created / 30, 1.0)`. The age weight is **0.15** (was
+   0.05) so a genuinely-valid issue that keeps losing the nightly contest still
+   climbs over time instead of rotting forever.
+
+6. **Select** the top 8 for implementation (include any `needs-work` issues from
    step 2):
    - Min priority: 0.7
-   - Max total effort: 2.0
+   - Max total effort: 3.0
+
+6a. **Anti-starvation slot — guarantee no valid issue rots for days.** Scoring
+    alone lets a sound-but-modest issue lose every single night. To prevent that,
+    RESERVE one selection slot for age:
+    - From the thin list, find the OLDEST **eligible** open issue — eligible =
+      not `rejected`, not currently in-flight `accepted` (an open PR already
+      exists for it), age **> 3 days**.
+    - If that issue was NOT already picked by score in step 6, **select it anyway**
+      — bypass the `min_priority 0.7` floor for THIS one slot (it still counts
+      toward `max_total_effort`; if it alone blows the effort budget, pick the
+      oldest eligible issue that fits).
+    - `needs-work` issues are already prioritized (step 2) and don't need this
+      slot. This slot is for issues the scorer keeps passing over.
+    - Tag the chosen issue's output entry `"selected_reason": "anti-starvation"`;
+      all score-selected entries get `"selected_reason": "score"`. This makes
+      starvation rescues visible in the report and in funnel metrics.
 
 ## Status labels — accept/reject visible in the issue list
 
@@ -175,7 +195,17 @@ Save to `~/.hermes/profiles/user1/evolution/analysis/YYYY-MM-DD.json`:
       "priority_score": 3.3,
       "impact_score": 0.8,
       "effort_score": 0.5,
-      "estimated_hours": 24
+      "estimated_hours": 24,
+      "selected_reason": "score"
+    },
+    {
+      "issue_number": 84,
+      "title": "[IMPROVEMENT] Per-cycle funnel metrics",
+      "priority_score": 0.62,
+      "impact_score": 0.5,
+      "effort_score": 0.3,
+      "estimated_hours": 4,
+      "selected_reason": "anti-starvation"
     }
   ]
 }

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -237,6 +237,6 @@ git tag -a v0.2.1 -m "Rollback"
 
 ## Limits
 
-- Maximum 5 implementations per day
-- Maximum 3 auto-merges per day
+- Maximum 8 implementations per day
+- Maximum 5 auto-merges per day
 - Breaking changes always require manual review

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -48,12 +48,40 @@ gh pr list --repo "$REPO" --state open --limit 50 \
      ```bash
      gh pr checks <N> --repo "$REPO"
      ```
-     If any check fails or is still pending → SKIP this PR this cycle.
    - **Mergeable** (no conflicts). If `mergeStateStatus` is `BEHIND`, update the
-     branch, then RE-VERIFY it's still green before merging:
+     branch first (this also kicks fresh CI):
      ```bash
      gh pr update-branch <N> --repo "$REPO"
      ```
+
+   **Do NOT skip on the first non-green snapshot — resolve it in-cycle (the whole
+   point of autonomous PR handling).** Apply this resolution ladder per PR:
+
+   - **PENDING checks** (incl. CI just kicked by `update-branch`): WAIT for them
+     to settle in THIS run, don't defer to tomorrow:
+     ```bash
+     gh pr checks <N> --repo "$REPO" --watch --interval 30   # ~40 min cap
+     ```
+     If still unsettled at the cap → SKIP this PR (next cycle picks it up).
+   - **FAILING checks, zero pending** → distinguish flake from real bug by
+     RE-RUNNING the failed jobs ONCE, then re-watching:
+     ```bash
+     RUN=$(gh pr checks <N> --repo "$REPO" --json link,state \
+       -q '[.[]|select(.state=="FAILURE"or.state=="failure")][0].link' \
+       | grep -oE '[0-9]+' | head -1)
+     gh run rerun "$RUN" --repo "$REPO" --failed
+     gh pr checks <N> --repo "$REPO" --watch --interval 30   # ~40 min cap
+     ```
+     - Re-run **GREEN** → it was a flake → proceed to code review (2a).
+     - Re-run **still FAILS** → treat as a REAL bug → do NOT merge; follow the
+       send-back-for-rework procedure in 2a (close PR, rework brief on issue,
+       flip to `needs-work`).
+   - **Hard limits so a run can't hang:** at most **1 re-run per PR** per cycle,
+     and at most **2 PRs** held in the WAIT/re-run path per run (the rest skip to
+     next cycle). Never re-run more than once — a test that needs two re-runs to
+     pass is itself broken (a real flake to fix at the source, issue #99), not
+     something to merge around.
+
    - **Closes a real, open issue** that analysis selected (sanity check the PR
      body's `Closes #NN`).
 
@@ -125,8 +153,10 @@ gh pr list --repo "$REPO" --state open --limit 50 \
     Treat it as if it were your own project shipping to `main`: a wrong merge or a
     wrongly-dropped good idea both cost more than a careful second look.
 
-3. **Daily limit — MAX 3 merges per run.** Quality over throughput. Merging a
-   flood of agent code unreviewed is exactly the risk we are guarding against.
+3. **Daily limit — MAX 5 merges per run.** Quality over throughput: each PR still
+   passes the full code review (2a) and self-audit (2b) before merging. The limit
+   bounds how much agent code lands on `main` per cycle; the per-PR review is what
+   guards quality, not a low ceiling.
 
 4. **Merge** (squash). `--admin` is required because branch protection mandates
    review; the owner token authorizes it:
@@ -144,7 +174,10 @@ hermes update --yes
 
 ## What to NEVER merge
 
-- Any PR with a failing OR pending check.
+- Any PR whose checks are not GREEN at merge time. (You MAY re-run failed jobs
+  once and wait for pending CI in-cycle per the gate ladder above — but the
+  state at the moment you call `gh pr merge` must be fully green. A PR that is
+  red after its one allowed re-run goes to rework, never to merge.)
 - Any non-`evolution/issue-*` branch (dependabot, human PRs, etc.).
 - Anything with merge conflicts you can't resolve via a clean branch update.
 - More than the daily limit.


### PR DESCRIPTION
Owner ask: issues must not rot for days; PRs must self-resolve without human intervention.

## Issues (analysis stage)
- **Anti-starvation slot**: reserve 1 selection slot/cycle for the oldest eligible open issue (>3d, not rejected, not in-flight accepted), bypassing the `min_priority 0.7` floor for that slot. Tagged `selected_reason: anti-starvation`.
- **Age weight** tripled in the priority formula: `age*0.05 -> age*0.15`.
- **Throughput**: `max_implementations 5->8`, `max_total_effort 2.0->3.0`, `max_merges 3->5`, `max_auto_merges 3->5`.

## PR (integration stage)
The >1-day deadlock cause was: any single red/pending check skipped a PR until tomorrow, with zero flaky-test handling.
- **Gate ladder**: wait for PENDING in-cycle (`gh pr checks --watch`, ~40min cap); on FAILING-only, re-run failed jobs ONCE — green=flake→proceed, still-red=real bug→send back for rework.
- Hard caps: 1 re-run/PR, <=2 PRs waiting/run. All existing review gates preserved; merge state must still be fully green.

Instruction-text + yaml-safety only; no executable change (limits are agent-followed, take effect on `hermes update`). Part 1 of 2 (upstream sync/version is the follow-up PR).