### PR TITLE
feat(evolution): upstream PR analysis + version inheritance + faster sync

### DIFF
--- a/.evolution/upstream-sync-state.json
+++ b/.evolution/upstream-sync-state.json
@@ -1,0 +1,8 @@
+{
+  "synced_through_tag": "v2026.6.5",
+  "synced_through_commit": "d6b9cfa3e1f460f5729553ef42b174da28b765c7",
+  "synced_through_date": "2026-06-05",
+  "our_version": "0.16.0",
+  "synced_at": "2026-06-13",
+  "_note": "Newest upstream release tag that is an ancestor of our main. Updated by the evolution-upstream-sync skill on each sync. synced_through_date scopes the next upstream-PR query; __release_date__ in hermes_cli/__init__.py mirrors synced_through_tag for the banner."
+}

--- a/cron/evolution/upstream-sync.yaml
+++ b/cron/evolution/upstream-sync.yaml
@@ -1,5 +1,5 @@
 name: evolution-upstream-sync
-schedule: "0 8 * * 0"  # Weekly on Sunday at 8 AM
+schedule: "0 8 * * 1,3,5"  # Mon/Wed/Fri 8 AM — 3×/week to drain the upstream backlog
 enabled: true
 mode: PRIVATE
 
@@ -43,7 +43,7 @@ safety:
   require_private_mode: true
   test_after_merge: true
   auto_rollback_on_failure: true
-  max_commits_per_sync: 10
+  max_commits_per_sync: 25
 
 # Sync strategy
 strategy:

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -116,7 +116,7 @@ def main(argv: list[str]) -> int:
     # Import the canonical Hermes cron API (writes ~/.hermes/cron/jobs.json).
     sys.path.insert(0, str(repo_root))
     try:
-        from cron.jobs import create_job, load_jobs
+        from cron.jobs import create_job, load_jobs, parse_schedule, update_job
     except Exception as exc:  # pragma: no cover - environment dependent
         print(f"[evolution-cron] cannot import cron.jobs: {exc}", file=sys.stderr)
         return 1
@@ -125,8 +125,10 @@ def main(argv: list[str]) -> int:
     # so the expensive LLM agent only runs when GitHub is actually reachable.
     gate_script = None if dry_run else _install_access_gate(repo_root)
 
-    existing_names = {str(j.get("name", "")).strip() for j in load_jobs()}
+    existing_jobs = {str(j.get("name", "")).strip(): j for j in load_jobs()}
+    existing_names = set(existing_jobs)
     created: list[tuple[str, str]] = []
+    updated: list[tuple[str, str]] = []
     skipped: list[str] = []
     failed: list[tuple[str, str]] = []
 
@@ -148,10 +150,6 @@ def main(argv: list[str]) -> int:
         if spec.get("no_agent") and str(spec.get("script") or "").strip() and not dry_run:
             _install_script(repo_root, str(spec["script"]).strip())
 
-        if name in existing_names:
-            skipped.append(name)
-            continue
-
         schedule = str(spec.get("schedule") or "").strip()
         prompt = spec.get("prompt") or ""
         no_agent = bool(spec.get("no_agent"))
@@ -165,6 +163,39 @@ def main(argv: list[str]) -> int:
         skills = _normalize_skills(spec.get("skills"))
         toolsets = _normalize_toolsets(spec.get("toolsets"))
         deliver = str(spec.get("deliver") or "local").strip()
+
+        # Existing job: reconcile mutable config from YAML instead of blindly
+        # skipping. create_job() is idempotent-by-name, so without this an edit
+        # to schedule/prompt/skills/toolsets in a *.yaml would NEVER take effect
+        # on an already-registered job (the historical re-register gotcha — a
+        # changed upstream-sync frequency, say, would silently stay on the old
+        # schedule). We only touch jobs we own (everything here is evolution-*).
+        if name in existing_names:
+            cur = existing_jobs[name]
+            if not cur.get("id"):
+                # Malformed record without an id — cannot target an update.
+                skipped.append(name)
+                continue
+            changes: dict = {}
+            want_sched = parse_schedule(schedule).get("display", schedule)
+            cur_sched = (cur.get("schedule") or {}).get("display") or cur.get("schedule_display")
+            if want_sched != cur_sched:
+                changes["schedule"] = schedule
+            if not no_agent:
+                if str(prompt) != (cur.get("prompt") or ""):
+                    changes["prompt"] = str(prompt)
+                if list(skills) != list(cur.get("skills") or []):
+                    changes["skills"] = skills
+                if list(toolsets) != list(cur.get("enabled_toolsets") or []):
+                    changes["enabled_toolsets"] = toolsets
+            if not changes:
+                skipped.append(name)
+            elif dry_run:
+                updated.append((name, "DRY-RUN: " + ", ".join(sorted(changes))))
+            else:
+                update_job(cur["id"], changes)
+                updated.append((name, ", ".join(sorted(changes))))
+            continue
 
         if dry_run:
             created.append((name, "DRY-RUN"))
@@ -218,13 +249,15 @@ def main(argv: list[str]) -> int:
 
     verb = "would register" if dry_run else "registered"
     print(
-        f"[evolution-cron] {verb}={len(created)} "
-        f"skipped(existing)={len(skipped)} failed={len(failed)}"
+        f"[evolution-cron] {verb}={len(created)} reconciled={len(updated)} "
+        f"skipped(unchanged)={len(skipped)} failed={len(failed)}"
     )
     for name, jid in created:
         print(f"  + {name} ({jid})")
+    for name, fields in updated:
+        print(f"  ~ {name} (updated: {fields})")
     for name in skipped:
-        print(f"  = {name} (already registered)")
+        print(f"  = {name} (unchanged)")
     for name, err in failed:
         print(f"  ! {name}: {err}")
 

--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -17,10 +17,24 @@ Synchronize with the original Hermes Agent (upstream) and determine which change
 
 ## Process
 
-1. **Fetch changes from upstream:**
-
+0. **Read where we last synced through** (the baseline). This is recorded in
+   `.evolution/upstream-sync-state.json` at the repo root (created/updated in the
+   version-stamp step below). Use its `synced_through_date` to scope the PR query:
 ```bash
-git fetch upstream
+SYNCED_DATE=$(jq -r '.synced_through_date // "2026-01-01"' \
+  .evolution/upstream-sync-state.json 2>/dev/null || echo "2026-01-01")
+```
+
+1. **Fetch upstream and analyze at the PULL-REQUEST level (preferred), with the
+   commit log as a fallback.** A merged upstream PR carries a title, description
+   and labels — far richer grounds to judge relevance than an opaque commit:
+```bash
+git fetch upstream --tags
+# PRIMARY: upstream merged PRs since our baseline (richest context):
+gh pr list --repo nousresearch/hermes-agent --state merged --limit 50 \
+  --search "merged:>=$SYNCED_DATE" \
+  --json number,title,mergedAt,labels,url,mergeCommit
+# FALLBACK: raw commits not in our main (catches direct-push / PR-less commits):
 git log main..upstream/main --oneline
 ```
 
@@ -82,8 +96,9 @@ What changed in upstream...
 
 ## Sync frequency
 
-Recommended:
-- **Weekly** — full sync and analysis
+- **Mon / Wed / Fri** — full sync and analysis (the cron schedule). At up to 25
+  commits/run this closes a large backlog (e.g. 300+ commits behind) in weeks,
+  not months, then keeps pace.
 - **After critical updates** — if there are critical fixes in upstream
 
 ## Security
@@ -133,6 +148,46 @@ protection. Changes in critical paths (`.github/CODEOWNERS`) require owner
 review. This is the same gate that protects the entire self-evolution — upstream code is also
 untrusted until it has passed CI + review.
 
+## Inherit upstream version numbering (do this IN the sync PR)
+
+Upstream releases are tagged by calendar date (`vYYYY.M.D`, e.g. `v2026.6.5`),
+roughly weekly; their `pyproject.toml` version is static. So the meaningful
+"version" to inherit is **the newest upstream release tag your synced commits
+reach**. Stamp it as PART of the sync PR (same branch, so CI covers it):
+
+```bash
+# Newest upstream release tag that is actually an ancestor of THIS sync branch
+# (i.e. reached by the commits you just cherry-picked/merged) — NOT upstream's
+# tip, which may be tags ahead of the ≤25 commits you took this run:
+git fetch upstream --tags
+TAG=$(for t in $(git tag -l 'v20*' | sort -Vr); do \
+        git merge-base --is-ancestor "$t" HEAD 2>/dev/null && { echo "$t"; break; }; \
+      done)
+COMMIT=$(git rev-parse HEAD)
+DATE=$(echo "$TAG" | sed 's/^v//')                          # e.g. 2026.6.5
+# If TAG is unchanged from the current marker, the synced commits are post-release
+# (untagged) work — keep the existing tag/date, just bump synced_through_commit.
+```
+
+1. Update `hermes_cli/__init__.py` → set `__release_date__ = "<DATE>"` (the banner
+   already renders `Hermes Agent v<__version__> (<__release_date__>)`, so the
+   correspondence becomes visible immediately). Leave `__version__` (our own
+   semver) as-is.
+2. Write the baseline marker `.evolution/upstream-sync-state.json`:
+```json
+{
+  "synced_through_tag": "v2026.6.5",
+  "synced_through_commit": "<full sha>",
+  "synced_through_date": "2026-06-05",
+  "our_version": "0.16.0",
+  "synced_at": "<run date>"
+}
+```
+   `synced_through_date` (ISO `YYYY-MM-DD`, derived from the tag) is what step 0
+   reads next run to scope the PR query — so each run only looks at NEW upstream
+   work. Commit both files on the `sync/upstream-*` branch so they ride the same
+   PR + CI as the code.
+
 ## Output format
 
 Save the report to `~/.hermes/profiles/user1/evolution/upstream/YYYY-MM-DD.md`:
@@ -166,6 +221,6 @@ Save the report to `~/.hermes/profiles/user1/evolution/upstream/YYYY-MM-DD.md`:
 
 ## Limits
 
-- No more than 10 upstream commits at a time
+- No more than 25 upstream commits per run
 - Critical changes — priority
 - Breaking changes — always manual review

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -165,3 +165,87 @@ class TestNoAgentJobs:
         assert rc == 0
         refreshed = stale.read_text()
         assert "stale old version" not in refreshed  # real script copied over
+
+
+class TestReconcileExistingJob:
+    """An edit to an already-registered evolution job's YAML must be applied via
+    update_job — create_job is idempotent-by-name and would otherwise leave the
+    old config in place (the historical re-register gotcha that froze schedule
+    changes)."""
+
+    def _write_agent_yaml(self, src_dir, schedule):
+        (src_dir / "upstream-sync.yaml").write_text(
+            "name: evolution-upstream-sync\n"
+            f'schedule: "{schedule}"\n'
+            "enabled: true\n"
+            'prompt: "sync upstream"\n'
+            "skills:\n"
+            "  - evolution/upstream-sync\n"
+            "toolsets:\n"
+            "  - web\n"
+            "  - file\n"
+            "  - terminal\n"
+        )
+
+    def _existing(self, mod, jobs_mod, schedule):
+        sched = jobs_mod.parse_schedule(schedule)
+        return {
+            "id": "job-123",
+            "name": "evolution-upstream-sync",
+            "schedule": sched,
+            "schedule_display": sched.get("display"),
+            "prompt": "sync upstream",
+            "skills": mod._normalize_skills(["evolution/upstream-sync"]),
+            "enabled_toolsets": mod._normalize_toolsets(["web", "file", "terminal"]),
+        }
+
+    def _wire(self, mod, jobs_mod, monkeypatch, tmp_path, existing):
+        home = tmp_path / "hermes-home"
+        (home / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [existing])
+        monkeypatch.setattr(
+            jobs_mod,
+            "create_job",
+            lambda **kw: (_ for _ in ()).throw(AssertionError("must not create")),
+        )
+        calls = {}
+        monkeypatch.setattr(
+            jobs_mod,
+            "update_job",
+            lambda job_id, updates: calls.update(job_id=job_id, updates=updates)
+            or {**existing, **updates},
+        )
+        return calls
+
+    def test_changed_schedule_is_reconciled(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_agent_yaml(src_dir, "0 8 * * 1,3,5")  # new schedule in YAML
+        existing = self._existing(mod, jobs_mod, "0 8 * * 0")  # old weekly schedule
+        calls = self._wire(mod, jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls["job_id"] == "job-123"
+        # only the schedule changed → only the schedule is updated
+        assert calls["updates"] == {"schedule": "0 8 * * 1,3,5"}
+
+    def test_unchanged_job_is_left_alone(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_agent_yaml(src_dir, "0 8 * * 1,3,5")
+        existing = self._existing(mod, jobs_mod, "0 8 * * 1,3,5")  # matches YAML
+        calls = self._wire(mod, jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls == {}  # no update_job call — nothing changed


### PR DESCRIPTION
Owner ask: analyze upstream PRs (not just commits), pull them in faster, and inherit upstream version numbering.

## Upstream PR analysis
`evolution-upstream-sync` now analyzes at the **PR level** (`gh pr list --repo nousresearch/hermes-agent --state merged --search merged:>=<baseline>`) — richer relevance signal than opaque commits. Raw `git log main..upstream/main` kept as fallback.

## Version inheritance
Upstream releases by calendar tag (`vYYYY.M.D`). After a sync, stamp `hermes_cli __release_date__` to the newest such tag that is an ancestor of the synced branch, and record `.evolution/upstream-sync-state.json` `{synced_through_tag, synced_through_commit, synced_through_date, our_version}`. Banner already renders `__release_date__` → correspondence visible. **Seeded with our true baseline `v2026.6.5`** (verified ancestor of main; the 322-commit gap is untagged post-release work).

## Faster sync
`max_commits_per_run 10->25`; schedule weekly Sun -> **Mon/Wed/Fri**. Same separate-branch + PR + CI safety gate.

## Re-register gotcha fix
`register_evolution_cron.py` now **reconciles** existing `evolution-*` jobs from YAML (schedule/prompt/skills/toolsets via `update_job`) instead of skip-by-name — otherwise the new sync schedule would silently stay on the old value. +2 tests.

register tests: 13 passed. Part 2 of 2 (issue/PR autonomy is #154).