### PR TITLE
fix(cron): make register interpreter-agnostic — no human picks venv python

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,8 +38,6 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from dotenv import dotenv_values
-
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
@@ -1045,8 +1043,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     # Load secrets from HERMES_HOME/.env so no_agent cron scripts can access
     # API keys (OpenRouter, OpenAI, etc.) without hard-coding them.
-    # See issue #124.
+    # See issue #124. Import dotenv lazily (like load_dotenv below) so that
+    # merely importing cron.scheduler / cron.jobs does NOT require python-dotenv
+    # — lightweight importers (e.g. scripts/register_evolution_cron.py run under
+    # a bare interpreter) must not break just because this runtime helper uses it.
     try:
+        from dotenv import dotenv_values
+
         _env_path = _get_hermes_home() / ".env"
         if _env_path.exists():
             _env_data = dotenv_values(_env_path)

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -29,8 +29,23 @@ Exit codes: 0 ok, 1 setup error, 2 one or more jobs failed to register.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+
+def _find_venv_python(repo_root: Path) -> str | None:
+    """Locate the install's venv interpreter (has the full Hermes deps)."""
+    for rel in (
+        "venv/bin/python",
+        ".venv/bin/python",
+        "venv/bin/python3",
+        ".venv/bin/python3",
+    ):
+        cand = repo_root / rel
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return str(cand)
+    return None
 
 
 def _load_yaml(path: Path) -> dict:
@@ -117,6 +132,24 @@ def main(argv: list[str]) -> int:
     sys.path.insert(0, str(repo_root))
     try:
         from cron.jobs import create_job, load_jobs, parse_schedule, update_job
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment dependent
+        # A Hermes dependency (e.g. python-dotenv) isn't importable under the
+        # current interpreter. Re-exec under the install's venv python — which
+        # has the full dependency set — so this script "just works" no matter
+        # which interpreter launched it. Nobody (human OR agent) should ever
+        # have to pick `venv/bin/python` by hand. Guard against re-exec loops.
+        if os.environ.get("_HERMES_REG_REEXEC") != "1":
+            venv_py = _find_venv_python(repo_root)
+            if venv_py and Path(venv_py).resolve() != Path(sys.executable).resolve():
+                os.environ["_HERMES_REG_REEXEC"] = "1"
+                print(
+                    f"[evolution-cron] re-executing under venv python ({venv_py}) "
+                    f"— current interpreter lacks: {exc}",
+                    file=sys.stderr,
+                )
+                os.execv(venv_py, [venv_py, str(Path(__file__).resolve()), *argv[1:]])
+        print(f"[evolution-cron] cannot import cron.jobs: {exc}", file=sys.stderr)
+        return 1
     except Exception as exc:  # pragma: no cover - environment dependent
         print(f"[evolution-cron] cannot import cron.jobs: {exc}", file=sys.stderr)
         return 1

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -249,3 +249,30 @@ class TestReconcileExistingJob:
 
         assert rc == 0
         assert calls == {}  # no update_job call — nothing changed
+
+
+class TestFindVenvPython:
+    """The registrar self-locates the install venv interpreter so it runs with
+    the full Hermes deps regardless of which python launched it (no human/agent
+    has to pick `venv/bin/python` by hand)."""
+
+    def test_finds_venv_python(self, tmp_path):
+        mod = _import_module()
+        venv_py = tmp_path / "venv" / "bin" / "python"
+        venv_py.parent.mkdir(parents=True)
+        venv_py.write_text("#!/bin/sh\n")
+        venv_py.chmod(0o755)
+
+        assert mod._find_venv_python(tmp_path) == str(venv_py)
+
+    def test_returns_none_when_absent(self, tmp_path):
+        mod = _import_module()
+        assert mod._find_venv_python(tmp_path) is None
+
+    def test_non_executable_is_ignored(self, tmp_path):
+        mod = _import_module()
+        venv_py = tmp_path / "venv" / "bin" / "python"
+        venv_py.parent.mkdir(parents=True)
+        venv_py.write_text("#!/bin/sh\n")
+        venv_py.chmod(0o644)  # not executable
+        assert mod._find_venv_python(tmp_path) is None


### PR DESCRIPTION
Owner principle: an autonomous agent's scripts must never require a human (or agent) to know "run it with venv/bin/python". Two fixes so `register_evolution_cron.py` just works under ANY interpreter:

## 1. Root — lazy dotenv import in `cron/scheduler.py`
#125 added a module-level `from dotenv import dotenv_values` (used only inside `_run_job_script`), which made importing `cron.jobs` — and thus the registrar — fail under any interpreter lacking python-dotenv (e.g. system `python3`). Moved it to a local import right before use, mirroring the already-lazy `load_dotenv` below it. `cron.jobs` now imports with no dotenv requirement; the dep is only needed when a no_agent script actually runs (always in the venv gateway).

## 2. Bulletproof — registrar self-execs under venv
If the current interpreter is missing a Hermes dep (`ModuleNotFoundError` on the `cron.jobs` import), register re-execs under the install's `venv/bin/python` (loop-guarded via `_HERMES_REG_REEXEC`). So `python3 scripts/register_evolution_cron.py` works as well as the venv one.

The automated flows (`upgrade.sh` `PY=venv/bin/python`, `AUTO_UPGRADE.md`) already used the venv python — this removes the footgun for every other invocation.

## Tests
16 register tests (+3 for `_find_venv_python`); `cron.jobs`+`scheduler` import cleanly without dotenv; 165 cron/scheduler/no_agent tests green.