### PR TITLE
fix(persistence): don't drop assistant turns when alternation-repair shrinks the message list

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1073,6 +1073,7 @@ def init_agent(
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+    agent._history_repaired_count = 0  # messages repair_message_sequence removed this turn
     agent._session_db_created = False  # DB row deferred to run_conversation()
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -442,6 +442,22 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         # value, session DB flush) see the repaired sequence.
         messages[:] = merged
 
+        # Shrinking `messages` in place invalidates the SQLite flush
+        # boundaries, which are computed from the *pre-repair* sizes:
+        #   * ``len(conversation_history)`` (loaded-history floor), and
+        #   * ``_last_flushed_db_idx`` (this agent's flush cursor).
+        # Each repair drops exactly one message from the already-loaded
+        # prefix, so pull both markers back by ``repairs``. Without this
+        # the flush computes ``flush_from`` past the end of the shrunk
+        # list and silently drops the turn's new assistant/tool messages
+        # (see tests/test_flush_repair_shrink_regression.py).
+        agent._history_repaired_count = (
+            getattr(agent, "_history_repaired_count", 0) + repairs
+        )
+        cursor = getattr(agent, "_last_flushed_db_idx", 0)
+        if isinstance(cursor, int) and cursor > 0:
+            agent._last_flushed_db_idx = max(0, cursor - repairs)
+
     return repairs
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -177,6 +177,12 @@ def build_turn_context(
     # Initialize conversation (copy to avoid mutating the caller's list).
     messages = list(conversation_history) if conversation_history else []
 
+    # Reset the per-turn repair counter that keeps the SQLite flush boundary
+    # aligned when repair_message_sequence shrinks `messages` in place. Must
+    # be zeroed each turn so it never accumulates across turns (which would
+    # drag the flush floor toward 0 and re-write already-persisted rows).
+    agent._history_repaired_count = 0
+
     # Hydrate todo store from conversation history.
     if conversation_history and not agent._todo_store.has_items():
         agent._hydrate_todo_store(conversation_history)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1560,6 +1560,15 @@ class AIAgent:
             if not self._session_db_created:
                 self._ensure_db_session()
             start_idx = len(conversation_history) if conversation_history else 0
+            # Role-alternation repair (repair_message_sequence) can shrink the
+            # live `messages` list in place after load, while
+            # `conversation_history` keeps its pre-repair length. Pull the
+            # loaded-history floor back by the number of messages repair
+            # removed this turn, otherwise `flush_from` overshoots the shrunk
+            # list and this turn's assistant/tool messages are never written
+            # (silent transcript loss that snowballs into consecutive-user
+            # corruption — see tests/test_flush_repair_shrink_regression.py).
+            start_idx = max(0, start_idx - getattr(self, "_history_repaired_count", 0))
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:
                 role = msg.get("role", "unknown")

--- a/tests/test_flush_repair_shrink_regression.py
+++ b/tests/test_flush_repair_shrink_regression.py
@@ -1,0 +1,127 @@
+"""Regression: role-alternation repair shrinks ``messages`` in place, which made
+``_flush_messages_to_session_db`` overshoot its flush boundary and silently drop
+the turn's assistant reply.
+
+Field investigation (2026-06-13): a long-lived Telegram "General"-topic session
+stopped persisting *any* assistant message for three days while user messages
+kept landing.  The stored transcript degenerated into a run of consecutive
+``user`` rows, so every subsequent turn fed the model a history with none of its
+own prior answers — the user-reported "agent forgets / answers the wrong thing /
+pulls context from nowhere".
+
+Root cause: ``repair_message_sequence`` rewrites ``messages`` in place to a
+*shorter* list (drops orphan tool results, merges consecutive user turns), but
+``conversation_history`` keeps its pre-repair length and the flush cursor
+(``_last_flushed_db_idx``) keeps a stale, larger value.  ``flush_from`` then
+points at/past the end of the shrunk list, so ``messages[flush_from:]`` is empty
+and the freshly-appended assistant turn is never written.  The loss is
+self-reinforcing: a missing assistant reply creates another consecutive-user
+violation next load, which makes the next repair shrink even more.
+"""
+import types
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from agent.agent_runtime_helpers import repair_message_sequence
+
+
+def _make_flusher(db, session_id):
+    """A minimal stand-in exposing the real flush method against a real DB."""
+    stub = types.SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _last_flushed_db_idx=0,
+        _history_repaired_count=0,
+        session_id=session_id,
+    )
+    stub._apply_persist_user_message_override = lambda messages: None
+    stub._ensure_db_session = lambda: None
+    stub._flush_messages_to_session_db = types.MethodType(
+        AIAgent._flush_messages_to_session_db, stub
+    )
+    return stub
+
+
+def _assistant_texts(db, session_id):
+    return [
+        m.get("content")
+        for m in db.get_messages_as_conversation(session_id)
+        if m.get("role") == "assistant" and (m.get("content") or "").strip()
+    ]
+
+
+def test_assistant_reply_persists_when_repair_shrinks_history(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session(session_id="telegram-topic-1", source="telegram")
+
+    # Loaded history with a role-alternation violation already in the DB:
+    # two consecutive user turns (the shape voice bursts / interrupted turns
+    # leave behind).
+    loaded = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2a"},
+        {"role": "user", "content": "q2b"},  # consecutive-user violation
+    ]
+    for m in loaded:
+        db.append_message(sid, role=m["role"], content=m["content"])
+
+    conversation_history = [dict(m) for m in loaded]
+    messages = list(conversation_history)
+    messages.append({"role": "user", "content": "q3"})  # this turn's user input
+
+    flusher = _make_flusher(db, sid)
+
+    # Turn-start persist (mirrors turn_context._persist_session before the loop).
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    # Defensive role-alternation repair runs before the API call and shrinks
+    # `messages` in place (merges the consecutive user turns).
+    repaired = repair_message_sequence(flusher, messages)
+    assert repaired >= 1, "expected the consecutive-user violation to be repaired"
+
+    # Model produces its answer; appended to the live list.
+    messages.append({"role": "assistant", "content": "THE_REPLY"})
+
+    # Turn-end persist.
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    texts = _assistant_texts(db, sid)
+    assert "THE_REPLY" in texts, (
+        "assistant reply was dropped from the transcript — flush boundary "
+        f"overshot the repair-shrunk messages list. assistant rows={texts}"
+    )
+
+
+def test_no_duplicate_writes_on_normal_turns(tmp_path):
+    """Guard the #860 invariant: a clean turn (no repair) writes each new
+    message exactly once across multiple persist calls."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session(session_id="telegram-clean", source="telegram")
+
+    loaded = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    for m in loaded:
+        db.append_message(sid, role=m["role"], content=m["content"])
+
+    conversation_history = [dict(m) for m in loaded]
+    messages = list(conversation_history)
+
+    flusher = _make_flusher(db, sid)
+
+    # New user turn + assistant reply, persisted via two flush calls (as the
+    # turn-start and turn-end paths both do).
+    messages.append({"role": "user", "content": "how are you"})
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+    messages.append({"role": "assistant", "content": "doing well"})
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+    # An extra redundant flush must be a no-op.
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    rows = db.get_messages_as_conversation(sid)
+    contents = [m.get("content") for m in rows]
+    assert contents.count("how are you") == 1, contents
+    assert contents.count("doing well") == 1, contents
+    assert contents == ["hello", "hi there", "how are you", "doing well"], contents


### PR DESCRIPTION
## Problem

Field report: a long-lived Telegram "General"-topic session stopped persisting **any** assistant message for ~3 days while user messages kept landing. The stored transcript degenerated into a run of consecutive `user` rows, so every later turn fed the model a history with none of its own prior answers — surfacing to the user as *"the agent forgets / answers the wrong message / pulls context from nowhere"*.

## Root cause

`repair_message_sequence` rewrites the live `messages` list **in place** to a shorter sequence (drops orphan tool results, merges consecutive user turns). But the SQLite flush in `_flush_messages_to_session_db` computes its write boundary from **pre-repair** sizes:

- `len(conversation_history)` — the loaded-history floor, and
- `_last_flushed_db_idx` — this agent's flush cursor.

After the shrink, `flush_from` lands at/past the end of the now-shorter list, so `messages[flush_from:]` is empty and the turn's freshly-appended assistant/tool messages are **never written**. Only user messages (persisted separately by the gateway) survive. The loss is self-reinforcing: a missing assistant reply leaves another consecutive-user violation for the next load, which makes the next repair shrink even more.

Confirmed on a live gateway with temporary flush instrumentation: a fresh session persisted correctly (`flush_from=1`, assistant written), while the corrupted session's `flush_from` overshot the repaired list and dropped the reply.

## Fix

Track how many messages `repair_message_sequence` removes this turn and pull **both** boundary markers back by that count:

- new per-turn counter `_history_repaired_count` — initialized in `agent_init`, reset each turn in `build_turn_context`, accumulated in `repair_message_sequence`;
- `repair_message_sequence` also decrements `_last_flushed_db_idx`;
- `_flush_messages_to_session_db` reduces `start_idx` by the per-turn count.

Each repair removes exactly one message from the already-loaded prefix, so the decrement is exact.

## Tests

- `tests/test_flush_repair_shrink_regression.py`
  - **reproduction** — the assistant reply is dropped on the pre-fix code, persisted after the fix;
  - **#860 guard** — a clean (no-repair) turn writes each message exactly once across multiple flush calls.
- 346 targeted persistence / session / repair tests pass, including `tests/run_agent/test_message_sequence_repair.py`, `test_lazy_session_regressions`, `test_hermes_state`, `test_state_db_malformed_repair`.

## Risk / scope

Additive and guarded — no behavior change on turns without repair (`getattr` defaults everywhere). No duplicate-write regression (#860 invariant covered by a test). Residual: a transcript already corrupted before this fix keeps its stale rows (harmlessly re-repaired on each load); the fix stops further loss rather than rewriting history.
