### PR TITLE
fix(file-tools): allow OS temp dir in sensitive-path guard (Closes #166)

### DIFF
--- a/tests/tools/test_sensitive_path_guard.py
+++ b/tests/tools/test_sensitive_path_guard.py
@@ -22,3 +22,18 @@ def test_macos_var_folders_is_allowed():
 def test_real_system_paths_still_blocked():
     for p in ("/etc/passwd", "/private/etc/hosts", "/private/var/db/secret"):
         assert _check_sensitive_path(p) is not None, f"{p} must stay blocked"
+
+
+def test_hermes_config_inside_temp_still_blocked(monkeypatch):
+    # The temp exemption must NOT bypass the Hermes-config guard: a config file
+    # that resolves inside a temp dir (as in the test suite) must still be
+    # refused. Regression for the over-broad first cut of this fix.
+    import os
+    import tempfile
+
+    import tools.file_tools as ft
+
+    cfg = os.path.realpath(os.path.join(tempfile.gettempdir(), "cfgguard", "config.yaml"))
+    monkeypatch.setattr(ft, "_hermes_config_resolved", cfg)
+    monkeypatch.setattr(ft, "_hermes_config_resolved_loaded", True)
+    assert _check_sensitive_path(cfg) is not None

--- a/tests/tools/test_sensitive_path_guard.py
+++ b/tests/tools/test_sensitive_path_guard.py
@@ -1,0 +1,24 @@
+"""Regression for #166: the sensitive-path write guard must reject real system
+paths but ALLOW the OS temp dir (macOS temp lives under /var/folders ->
+/private/var/folders, which the /private/var/ prefix would otherwise reject)."""
+
+import os
+import tempfile
+
+from tools.file_tools import _check_sensitive_path
+
+
+def test_os_temp_dir_is_allowed():
+    p = os.path.join(tempfile.gettempdir(), "hermes_guard_probe.txt")
+    assert _check_sensitive_path(p) is None
+
+
+def test_macos_var_folders_is_allowed():
+    # The canonical macOS per-user temp root, both pre- and post-realpath forms.
+    assert _check_sensitive_path("/var/folders/jz/abc/T/x.txt") is None
+    assert _check_sensitive_path("/private/var/folders/jz/abc/T/x.txt") is None
+
+
+def test_real_system_paths_still_blocked():
+    for p in ("/etc/passwd", "/private/etc/hosts", "/private/var/db/secret"):
+        assert _check_sensitive_path(p) is not None, f"{p} must stay blocked"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import tempfile
 import threading
 from pathlib import Path
 
@@ -323,6 +324,20 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    # The OS temp dir is user scratch space, never a sensitive system path.
+    # On macOS it lives under /var/folders -> realpath /private/var/folders,
+    # which would otherwise be rejected by the /private/var/ prefix below.
+    # Exempt it FIRST so temp writes (incl. the test suite's tmp dirs) work.
+    try:
+        _tmp = os.path.realpath(tempfile.gettempdir())
+    except Exception:
+        _tmp = ""
+    _temp_roots = tuple(
+        p for p in (_tmp + os.sep if _tmp else "", "/var/folders/", "/private/var/folders/") if p
+    )
+    for safe in _temp_roots:
+        if resolved.startswith(safe) or normalized.startswith(safe):
+            return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -324,10 +324,11 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    # The OS temp dir is user scratch space, never a sensitive system path.
+    # The OS temp dir is user scratch space, never a sensitive SYSTEM path.
     # On macOS it lives under /var/folders -> realpath /private/var/folders,
-    # which would otherwise be rejected by the /private/var/ prefix below.
-    # Exempt it FIRST so temp writes (incl. the test suite's tmp dirs) work.
+    # which the /private/var/ prefix below would otherwise reject. Exempt temp
+    # from the SYSTEM-PATH checks ONLY — the Hermes-config guard further down
+    # still applies (a fake config placed in a temp dir must stay protected).
     try:
         _tmp = os.path.realpath(tempfile.gettempdir())
     except Exception:
@@ -335,14 +336,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     _temp_roots = tuple(
         p for p in (_tmp + os.sep if _tmp else "", "/var/folders/", "/private/var/folders/") if p
     )
-    for safe in _temp_roots:
-        if resolved.startswith(safe) or normalized.startswith(safe):
-            return None
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+    in_temp = any(resolved.startswith(s) or normalized.startswith(s) for s in _temp_roots)
+    if not in_temp:
+        for prefix in _SENSITIVE_PATH_PREFIXES:
+            if resolved.startswith(prefix) or normalized.startswith(prefix):
+                return _err
+        if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to


### PR DESCRIPTION
Closes #166 (substantive part).

**Bug:** `tools/file_tools._check_sensitive_path` rejected the macOS per-user temp dir — `/var/folders/...` realpaths to `/private/var/folders/...`, matching the `/private/var/` sensitive prefix → legitimate temp writes blocked ("Refusing to write to sensitive system path"), breaking `test_file_state_registry.py` on macOS.

**Fix:** exempt the OS temp root (`tempfile.gettempdir()` realpath + `/var/folders/` + `/private/var/folders/`) **before** the sensitive-prefix check. Narrow — only the temp subtree; `/private/var/db`, `/etc`, `/private/etc` stay blocked (verified).

**Tests:** +`test_sensitive_path_guard.py` (temp allowed, system paths still blocked); `test_file_state_registry.py` now 16/16 on macOS.

**Scope note:** the platform-only test failures listed in #166 (systemd / WSL / AWS-region tests) are intentionally **not** skipped — they correctly assert platform behavior and do not affect CI/Linux/production; skipping them on darwin is pure dev convenience, not worth weakening the suite.