### PR TITLE
feat(evolution): per-cycle funnel metrics (Closes #84)

### DIFF
--- a/cron/evolution/funnel.yaml
+++ b/cron/evolution/funnel.yaml
@@ -1,0 +1,24 @@
+name: evolution-funnel
+# 07:40 daily — before the watchdog (07:47). By morning the previous cycle
+# (research 09:00 … integration 23:00) is complete, so the funnel measures a
+# settled cycle. The script computes the cycle date itself (yesterday before
+# 08:00). Off the :00/:30 marks; jitter stays < 08:00.
+schedule: "40 7 * * *"
+enabled: true
+mode: PRIVATE
+
+# Deterministic metric — NO LLM agent. The script IS the job. It appends one
+# JSON line per cycle to evolution/metrics.jsonl (funnel: proposed -> selected
+# -> merged, plus reject reasons). Issue #84.
+no_agent: true
+script: evolution_funnel.py
+
+# Keep on disk for the owner + evolution-introspection to read the trend;
+# nothing is delivered to channels (a metric line is not an alert).
+deliver: local
+
+prompt: |
+  Deterministic per-cycle funnel metrics (no LLM). Appends one JSON line to
+  evolution/metrics.jsonl summarizing the previous cycle's
+  proposed->selected->merged funnel and reject-reason breakdown.
+  See scripts/evolution_funnel.py (issue 84).

--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Evolution funnel metrics — per-cycle aggregate of the pipeline's own output.
+
+Runs as a ``no_agent`` cron job (no LLM). For a given date it reads the structured
+stage reports the pipeline already writes and appends ONE JSON line to
+``<evolution_dir>/metrics.jsonl`` describing the funnel:
+
+    research proposals -> issues created -> selected -> merged
+                       \\-> rejected (by reason)   \\-> skipped
+
+This gives the owner (and evolution-introspection) a measurable view of the
+pipeline so it can improve ITSELF — e.g. "reject rate 90% => research-quality
+issue", "merged 0 for 3 cycles => integration stuck". Issue #84.
+
+Pure functions + explicit paths so it is import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _load_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _counts_by(items: list, key: str) -> Dict[str, int]:
+    """Count list items by a string field, tolerating missing keys."""
+    c: Counter = Counter()
+    for it in items if isinstance(items, list) else []:
+        if isinstance(it, dict):
+            c[str(it.get(key, "unknown"))] += 1
+    return dict(c)
+
+
+def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
+    """Build the funnel record for one date from whatever stage reports exist.
+
+    Every field defaults to 0 / {} so a missing stage report never crashes the
+    metric — it just shows that stage produced nothing recorded that day.
+    """
+    issues = _load_json(evolution_dir / "issues" / f"{date}.json") or {}
+    analysis = _load_json(evolution_dir / "analysis" / f"{date}.json") or {}
+    integration = _load_json(evolution_dir / "integration" / f"{date}.json") or {}
+    introspection = _load_json(evolution_dir / "introspection" / f"{date}.json") or {}
+
+    selected = analysis.get("selected_for_implementation") or []
+    rejected = analysis.get("rejected") or []
+    merged = integration.get("merged") or []
+    skipped = integration.get("skipped") or []
+    patterns = introspection.get("patterns_found") or []
+    created = issues.get("issues_created") or []
+
+    return {
+        "date": date,
+        # inflow
+        "research_proposals": int(issues.get("total_proposals", 0) or 0),
+        "proposals_passed_filter": int(issues.get("proposals_passed_filter", 0) or 0),
+        "issues_created": len(created) if isinstance(created, list) else 0,
+        "introspection_patterns": len(patterns) if isinstance(patterns, list) else 0,
+        # triage / selection
+        "selected": len(selected) if isinstance(selected, list) else 0,
+        "selected_by_reason": _counts_by(selected, "selected_reason"),
+        "rejected": len(rejected) if isinstance(rejected, list) else 0,
+        "rejected_by_reason": _counts_by(rejected, "reason_code"),
+        # outflow
+        "merged": len(merged) if isinstance(merged, list) else 0,
+        "skipped": len(skipped) if isinstance(skipped, list) else 0,
+    }
+
+
+def append_funnel(metrics_file: Path, record: Dict[str, Any]) -> None:
+    """Append one JSON line, idempotently: replace any existing line for the
+    same date so re-runs don't duplicate a day."""
+    lines = []
+    if metrics_file.exists():
+        for ln in metrics_file.read_text(encoding="utf-8").splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                obj = json.loads(ln)
+            except ValueError:
+                continue
+            if obj.get("date") != record["date"]:
+                lines.append(json.dumps(obj, sort_keys=True))
+    lines.append(json.dumps(record, sort_keys=True))
+    metrics_file.parent.mkdir(parents=True, exist_ok=True)
+    metrics_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def cycle_date(now) -> str:
+    """The date of the cycle to measure. This job runs in the MORNING (07:40,
+    before the watchdog), so before ~08:00 the cycle that just completed is
+    YESTERDAY's (research 09:00 .. integration 23:00). After 08:00, today's.
+    Jitter-safe: 07:40 + scheduler jitter stays < 08:00."""
+    from datetime import timedelta
+
+    day = now.date() if now.hour >= 8 else (now - timedelta(days=1)).date()
+    return day.isoformat()
+
+
+def main(argv: list[str]) -> int:
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    )
+    # Explicit arg wins (manual/backfill runs); else env; else the cycle date.
+    date = argv[1] if len(argv) > 1 and not argv[1].startswith("-") else ""
+    date = date or os.environ.get("EVOLUTION_FUNNEL_DATE", "")
+    if not date:
+        try:
+            from hermes_time import now as _now  # type: ignore
+
+            date = cycle_date(_now())
+        except Exception:
+            print("[evolution-funnel] no date given and clock unavailable", file=sys.stderr)
+            return 1
+
+    record = compute_funnel(evolution_dir, date)
+    append_funnel(evolution_dir / "metrics.jsonl", record)
+    # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
+    # one-liner only so the run log shows what was recorded.
+    print(
+        f"[evolution-funnel] {date}: created={record['issues_created']} "
+        f"selected={record['selected']} rejected={record['rejected']} "
+        f"merged={record['merged']} skipped={record['skipped']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/evolution_funnel.py — deterministic per-cycle funnel."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from datetime import datetime  # noqa: E402
+
+from evolution_funnel import append_funnel, compute_funnel, cycle_date  # noqa: E402
+
+
+def _write(p: Path, obj):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+class TestComputeFunnel:
+    def test_full_cycle(self, tmp_path):
+        d = "2026-06-13"
+        _write(tmp_path / "issues" / f"{d}.json", {
+            "total_proposals": 9, "proposals_passed_filter": 3,
+            "issues_created": [{"number": 1}, {"number": 2}, {"number": 3}],
+        })
+        _write(tmp_path / "analysis" / f"{d}.json", {
+            "rejected": [
+                {"reason_code": "already-exists"}, {"reason_code": "already-exists"},
+                {"reason_code": "out-of-scope"},
+            ],
+            "selected_for_implementation": [
+                {"selected_reason": "score"}, {"selected_reason": "score"},
+                {"selected_reason": "anti-starvation"},
+            ],
+        })
+        _write(tmp_path / "integration" / f"{d}.json", {
+            "merged": [{"pr": "1"}], "skipped": [{"pr": "2"}, {"pr": "3"}],
+        })
+        _write(tmp_path / "introspection" / f"{d}.json", {"patterns_found": [{"p": 1}]})
+
+        r = compute_funnel(tmp_path, d)
+        assert r["research_proposals"] == 9
+        assert r["issues_created"] == 3
+        assert r["selected"] == 3
+        assert r["selected_by_reason"] == {"score": 2, "anti-starvation": 1}
+        assert r["rejected"] == 3
+        assert r["rejected_by_reason"] == {"already-exists": 2, "out-of-scope": 1}
+        assert r["merged"] == 1
+        assert r["skipped"] == 2
+        assert r["introspection_patterns"] == 1
+
+    def test_missing_reports_default_to_zero(self, tmp_path):
+        r = compute_funnel(tmp_path, "2026-01-01")
+        assert r["date"] == "2026-01-01"
+        assert r["selected"] == 0 and r["merged"] == 0 and r["rejected"] == 0
+        assert r["selected_by_reason"] == {} and r["rejected_by_reason"] == {}
+
+    def test_malformed_report_does_not_crash(self, tmp_path):
+        p = tmp_path / "analysis" / "2026-01-02.json"
+        p.parent.mkdir(parents=True)
+        p.write_text("{ not json", encoding="utf-8")
+        r = compute_funnel(tmp_path, "2026-01-02")
+        assert r["selected"] == 0  # treated as absent, no exception
+
+
+class TestCycleDate:
+    def test_morning_run_measures_yesterday(self):
+        # 07:40 run -> previous cycle (yesterday)
+        assert cycle_date(datetime(2026, 6, 13, 7, 40)) == "2026-06-12"
+
+    def test_jitter_still_before_8_is_yesterday(self):
+        assert cycle_date(datetime(2026, 6, 13, 7, 55)) == "2026-06-12"
+
+    def test_after_8_is_today(self):
+        assert cycle_date(datetime(2026, 6, 13, 12, 0)) == "2026-06-13"
+
+
+class TestAppendFunnel:
+    def test_appends_one_line(self, tmp_path):
+        mf = tmp_path / "metrics.jsonl"
+        append_funnel(mf, {"date": "2026-06-12", "merged": 1})
+        append_funnel(mf, {"date": "2026-06-13", "merged": 2})
+        lines = mf.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[1])["date"] == "2026-06-13"
+
+    def test_rerun_same_date_replaces_not_duplicates(self, tmp_path):
+        mf = tmp_path / "metrics.jsonl"
+        append_funnel(mf, {"date": "2026-06-13", "merged": 1})
+        append_funnel(mf, {"date": "2026-06-13", "merged": 5})  # re-run, corrected
+        lines = mf.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["merged"] == 5


### PR DESCRIPTION
Closes #84. The pipeline had no aggregate view of its own performance — so introspection could not improve the PIPELINE itself.

**Added (deterministic, no LLM):**
- `scripts/evolution_funnel.py` — reads the structured stage reports (issues/analysis/integration/introspection `.json`) for a cycle date and appends ONE JSON line to `evolution/metrics.jsonl`: funnel counts (`research_proposals → issues_created → selected → merged`) + `selected_by_reason` (score vs anti-starvation) + `rejected_by_reason`. Missing reports default to 0 (never crashes); re-running a date replaces (idempotent).
- `cron/evolution/funnel.yaml` — `no_agent` job at 07:40 (before the watchdog), measures the just-completed cycle (yesterday before 08:00, jitter-safe). `deliver: local` — a metric line is not an alert.

**Value:** the owner + `evolution-introspection` get a measurable, self-optimizing signal (e.g. "reject rate 90% → research-quality issue", "merged 0 for N cycles → integration stuck").

Tests: 8 (compute, append idempotency, cycle-date). Registered automatically by `register_evolution_cron.py` (now self-healing).