### PR TITLE
fix(config): behavioral/tooling settings via config.yaml, env back-compat (Closes #164)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4014,24 +4014,39 @@ class BasePlatformAdapter(ABC):
         """
         Return a random delay in seconds for human-like response pacing.
 
-        Reads from env vars:
-          HERMES_HUMAN_DELAY_MODE: "off" (default) | "natural" | "custom"
-          HERMES_HUMAN_DELAY_MIN_MS: minimum delay in ms (default 800, custom mode)
-          HERMES_HUMAN_DELAY_MAX_MS: maximum delay in ms (default 2500, custom mode)
+        Behavioral config lives in config.yaml under ``gateway.human_delay``:
+          mode:   "off" (default) | "natural" | "custom"
+          min_ms: minimum delay in ms (default 800, custom mode)
+          max_ms: maximum delay in ms (default 2500, custom mode)
+        The legacy ``HERMES_HUMAN_DELAY_*`` env vars are still honored as a
+        fallback for back-compat (AGENTS.md: behavioral config belongs in
+        config.yaml, not new HERMES_* env vars — issue #164).
         """
-        mode = os.getenv("HERMES_HUMAN_DELAY_MODE", "off").lower()
+        hd: dict = {}
+        try:
+            # readonly = cached, no per-message disk read / deepcopy.
+            from hermes_cli.config import load_config_readonly as _load_ro
+
+            hd = (_load_ro().get("gateway", {}) or {}).get("human_delay", {}) or {}
+        except Exception:
+            hd = {}
+
+        def _setting(key: str, env: str, default):
+            v = hd.get(key)
+            return v if v is not None else os.getenv(env, default)
+
+        mode = str(_setting("mode", "HERMES_HUMAN_DELAY_MODE", "off")).lower()
         if mode == "off":
             return 0.0
         if mode == "natural":
-            min_ms, max_ms = 800, 2500
-            return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
-        # custom mode — tolerate malformed env vars instead of crashing.
+            return random.uniform(800 / 1000.0, 2500 / 1000.0)
+        # custom mode — tolerate malformed values instead of crashing.
         try:
-            min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
+            min_ms = int(_setting("min_ms", "HERMES_HUMAN_DELAY_MIN_MS", 800))
         except (TypeError, ValueError):
             min_ms = 800
         try:
-            max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
+            max_ms = int(_setting("max_ms", "HERMES_HUMAN_DELAY_MAX_MS", 2500))
         except (TypeError, ValueError):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1262,6 +1262,23 @@ class TestGetHumanDelay:
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.8 <= delay <= 2.5
 
+    def test_config_yaml_overrides_env(self):
+        # config.yaml gateway.human_delay wins over the legacy env var (#164).
+        cfg = {"gateway": {"human_delay": {"mode": "custom", "min_ms": 100, "max_ms": 200}}}
+        with patch.dict(os.environ, {"HERMES_HUMAN_DELAY_MODE": "off"}), patch(
+            "hermes_cli.config.load_config_readonly", return_value=cfg
+        ):
+            delay = BasePlatformAdapter._get_human_delay()
+            assert 0.1 <= delay <= 0.2
+
+    def test_env_used_when_config_absent(self):
+        # back-compat: no config section -> the HERMES_HUMAN_DELAY_* env still works.
+        with patch.dict(os.environ, {"HERMES_HUMAN_DELAY_MODE": "natural"}), patch(
+            "hermes_cli.config.load_config_readonly", return_value={}
+        ):
+            delay = BasePlatformAdapter._get_human_delay()
+            assert 0.8 <= delay <= 2.5
+
 
 # ---------------------------------------------------------------------------
 # utf16_len / _prefix_within_utf16_limit / truncate_message with len_fn

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -268,7 +268,8 @@ def find_docker() -> Optional[str]:
     """Locate the docker (or podman) CLI binary.
 
     Resolution order:
-    1. ``HERMES_DOCKER_BINARY`` env var — explicit override (e.g. ``/usr/bin/podman``)
+    1. Explicit override — config.yaml ``docker.binary`` (preferred), or the
+       legacy ``HERMES_DOCKER_BINARY`` env var (back-compat; e.g. ``/usr/bin/podman``)
     2. ``docker`` on PATH via ``shutil.which``
     3. ``podman`` on PATH via ``shutil.which``
     4. Well-known macOS Docker Desktop install locations
@@ -279,11 +280,19 @@ def find_docker() -> Optional[str]:
     if _docker_executable is not None:
         return _docker_executable
 
-    # 1. Explicit override via env var (e.g. for Podman on immutable distros)
-    override = os.getenv("HERMES_DOCKER_BINARY")
+    # 1. Explicit override: config.yaml `docker.binary` (AGENTS.md #164 — config,
+    #    not new HERMES_* env vars), falling back to the legacy env var.
+    override = None
+    try:
+        from hermes_cli.config import load_config_readonly as _load_ro
+
+        override = (_load_ro().get("docker", {}) or {}).get("binary")
+    except Exception:
+        override = None
+    override = override or os.getenv("HERMES_DOCKER_BINARY")
     if override and os.path.isfile(override) and os.access(override, os.X_OK):
         _docker_executable = override
-        logger.info("Using HERMES_DOCKER_BINARY override: %s", override)
+        logger.info("Using docker binary override: %s", override)
         return override
 
     # 2. docker on PATH


### PR DESCRIPTION
Closes #164. AGENTS.md forbids new `HERMES_*` env vars for non-secret config.

**Made config.yaml-driven (env kept as back-compat fallback):**
- `gateway.human_delay.{mode,min_ms,max_ms}` — `_get_human_delay` reads config first (via `load_config_readonly`, cached — no per-message disk hit), falls back to `HERMES_HUMAN_DELAY_*`. Config wins over env. +2 precedence tests.
- `docker.binary` — `find_docker` reads config first, falls back to `HERMES_DOCKER_BINARY`.

**Deliberately NOT changed — `HERMES_QWEN_BASE_URL`:** it is a *provider* base-url override wired through the provider overlay system (`providers.py base_url_env_var`, `OPTIONAL_ENV_VARS category=provider`), consistent with other providers' `*_BASE_URL` env vars — not arbitrary behavioral config. Forcing it into config.yaml would break the provider pattern.

**Note:** `.env.example` still lists these as commented back-compat examples — the harness blocks edits to `.env*` paths. They now resolve only as fallbacks behind config.yaml.

Tests: `TestGetHumanDelay` 8/8; docker tests unaffected.