### PR TITLE
docs(security): document shell=True trust boundaries (Closes #165)

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -361,6 +361,13 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 
     Each command runs through the shell (so `&&` etc. work). The output is
     streamed to the user's terminal for visibility.
+
+    Security (reviewed for #165): shell=True is intentional — bootstrap steps
+    are the MCP's own install recipe (git clone + dep install, analogous to a
+    package manager's post-install scripts) and require shell features. They run
+    ONLY on an explicit user-initiated MCP install from a catalog entry the user
+    chose; each command is echoed before it runs. The trust boundary is the
+    catalog source — do NOT wire agent/LLM-generated command strings into here.
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -810,6 +810,9 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
         _print_info(f"    {label} cua-driver...")
     driver_cmd = _cua_driver_cmd()
     try:
+        # shell=True is safe here: install_cmd is a FIXED literal (hard-coded
+        # upstream install URL, no user/agent-interpolated input), run only on
+        # an explicit user-initiated `hermes tools` install. Reviewed for #165.
         result = subprocess.run(install_cmd, shell=True, timeout=300)
         if result.returncode == 0 and shutil.which(driver_cmd):
             if verbose:


### PR DESCRIPTION
Closes #165. Audited all 4 production `subprocess(shell=True)` sites for command injection — full verdict table in the issue comment.

**Result:** no agent/LLM-controlled string reaches any `shell=True` call; every trust boundary is the **user** (config snippets, opt-in env template, user-initiated installs). Inputs are `shlex.quote`d or fixed literals; arg-lists are infeasible where shell features are required.

**Change:** trust-boundary comments only (no behavior change) — `cli.py` and `transcription_tools.py` were already documented; added comments to `tools_config.py` (cua install) and `mcp_catalog._run_bootstrap` (warns never to wire agent-generated strings in). ruff clean.