### PR TITLE
feat(evolution): local idea dedup cache — O(new) dedup (Closes #91 core)

### DIFF
--- a/scripts/evolution_dedup.py
+++ b/scripts/evolution_dedup.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Evolution idea dedup cache — O(new) instead of re-comparing all history.
+
+evolution-issues / evolution-introspection must not re-propose an idea this
+install has already filed or had rejected. The naive check pulls up to 300
+issues every run and compares each proposal by meaning in-context — a cost that
+grows forever with repo age (#91).
+
+This maintains a tiny local cache keyed on the NORMALIZED proposal title:
+
+    ~/.hermes/profiles/user1/evolution/dedup-cache.json
+    { "<key>": {"title": "...", "status": "filed|rejected|considered",
+                "issue": 123, "date": "YYYY-MM-DD"} }
+
+A proposal whose key is already in the cache is skipped in O(1) — no gh query,
+no in-context comparison. Only cache-MISSES fall back to the (smaller) `gh issue
+list` query to catch ideas filed by OTHER installs; their outcome is then
+recorded so the next run short-circuits. The cache is purely a NEGATIVE
+fast-path: it never causes a false "new" (a miss just means "do the gh check"),
+so it can never make us file a dup the gh fallback would have caught.
+
+CLI (so the skill can call it from the terminal tool):
+    evolution_dedup.py check  "<title>"            # exit 0 = NEW, 1 = already seen
+    evolution_dedup.py record "<title>" <status> [issue] [date]
+Pure functions are import-safe for unit tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+# Tag prefixes the pipeline puts on titles, e.g. "[FIX] ", "[IMPROVEMENT] ".
+_TAG_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
+_NONWORD_RE = re.compile(r"[^a-z0-9]+")
+_MAX_ENTRIES = 5000  # cap so the cache file can't grow unbounded
+
+
+def normalize_title(title: str) -> str:
+    """Canonicalize a proposal title for meaning-stable matching.
+
+    Strips a leading ``[TAG]``, lowercases, drops punctuation, and collapses
+    whitespace so cosmetic edits ("Fix the X" vs "[FIX] fix  the X.") map to the
+    same key. Deliberately simple + deterministic (no stemming) — false
+    NEGATIVES (two phrasings -> different keys) are safe: the gh fallback still
+    runs for a miss. False positives (different ideas -> same key) would be bad,
+    so we keep the normalized form information-rich.
+    """
+    s = _TAG_RE.sub("", title or "")
+    s = s.lower().strip()
+    s = _NONWORD_RE.sub(" ", s).strip()
+    return s
+
+
+def idea_key(title: str) -> str:
+    norm = normalize_title(title)
+    return hashlib.sha1(norm.encode("utf-8")).hexdigest()[:16]
+
+
+def load_cache(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def save_cache(path: Path, cache: Dict[str, Any]) -> None:
+    # Cap: drop oldest entries (by date) if over the limit, so the file stays small.
+    if len(cache) > _MAX_ENTRIES:
+        items = sorted(cache.items(), key=lambda kv: str(kv[1].get("date", "")))
+        cache = dict(items[-_MAX_ENTRIES:])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cache, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def is_seen(cache: Dict[str, Any], title: str) -> bool:
+    return idea_key(title) in cache
+
+
+def record(cache: Dict[str, Any], title: str, status: str, issue: Any = None, date: str = "") -> Dict[str, Any]:
+    """Add/update an entry. Returns the cache (mutated in place)."""
+    key = idea_key(title)
+    entry: Dict[str, Any] = {"title": title, "status": status}
+    if issue:
+        entry["issue"] = issue
+    if date:
+        entry["date"] = date
+    cache[key] = entry
+    return cache
+
+
+def _cache_path() -> Path:
+    return Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    ) / "dedup-cache.json"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: evolution_dedup.py check|record \"<title>\" [status] [issue] [date]", file=sys.stderr)
+        return 2
+    action, title = argv[1], argv[2]
+    path = _cache_path()
+    cache = load_cache(path)
+
+    if action == "check":
+        seen = is_seen(cache, title)
+        print("seen" if seen else "new")
+        return 1 if seen else 0
+    if action == "record":
+        status = argv[3] if len(argv) > 3 else "considered"
+        issue = argv[4] if len(argv) > 4 else None
+        date = argv[5] if len(argv) > 5 else ""
+        record(cache, title, status, issue=issue, date=date)
+        save_cache(path, cache)
+        print(f"recorded {idea_key(title)} status={status}")
+        return 0
+    print(f"unknown action: {action}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -37,8 +37,23 @@ Create GitHub issues and pull requests based on research.
 2b. **Deduplicate against EXISTING issues — MANDATORY (many installations file in
     parallel).** Hundreds or thousands of installs research the same trends, so
     the SAME proposal WILL be filed by others. At scale this is the #1 source of
-    noise. Before creating ANY issue, fetch what already exists and SKIP anything
-    already covered — OPEN or already CLOSED/rejected:
+    noise. Before creating ANY issue, SKIP anything already covered.
+
+    **Fast-path — local dedup cache (O(1), avoids re-pulling history every run).**
+    This install keeps a cache of every idea it has already filed/considered at
+    `~/.hermes/profiles/user1/evolution/dedup-cache.json`. Check each proposal
+    against it FIRST; a hit means we already handled this idea — skip it with no
+    gh query, no in-context comparison:
+    ```bash
+    python scripts/evolution_dedup.py check "<proposal title>"   # exit 1 = already seen → SKIP
+    ```
+    The cache is a pure NEGATIVE fast-path: a MISS (exit 0) only means "not seen
+    locally yet" — fall through to the gh query below, which still catches ideas
+    filed by OTHER installs. (Issue #91 — dedup cost stops growing with repo age.)
+
+    **Fallback — only for cache-misses:** fetch what already exists and compare
+    by meaning. Bounded by the cache (historical-rejected ideas are cached, so
+    this can stay small):
     ```bash
     gh issue list --repo Lexus2016/hermes-agent-evolution --state all --limit 300 \
       --json number,title,state,labels \
@@ -119,6 +134,16 @@ gh issue create \
 
    After creation, **verify that the issue actually appeared** (otherwise do not
    count it in the report): `gh issue list --repo "$REPO" --state open --limit 5`.
+
+   **Then record the outcome in the dedup cache** (so this idea short-circuits on
+   every future run — issue #91). Record BOTH filed issues AND proposals you
+   skipped as duplicates, so neither is ever re-evaluated from scratch:
+   ```bash
+   # filed:
+   python scripts/evolution_dedup.py record "<title>" filed <issue#> "$(date +%F)"
+   # skipped as an existing dup:
+   python scripts/evolution_dedup.py record "<title>" considered "" "$(date +%F)"
+   ```
 
 > Do NOT use the web tool to create an issue — it does not make an
 > authorized POST. Issue creation is only via `gh` (terminal).

--- a/tests/scripts/test_evolution_dedup.py
+++ b/tests/scripts/test_evolution_dedup.py
@@ -1,0 +1,72 @@
+"""Tests for scripts/evolution_dedup.py — local idea dedup cache (#91)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_dedup import (  # noqa: E402
+    idea_key,
+    is_seen,
+    load_cache,
+    normalize_title,
+    record,
+    save_cache,
+)
+
+
+class TestNormalize:
+    def test_strips_tag_and_punctuation_and_case(self):
+        # Cosmetic variants map to the same canonical form.
+        a = normalize_title("[FIX] Fix the X  problem.")
+        b = normalize_title("fix the x problem")
+        assert a == b
+
+    def test_different_ideas_differ(self):
+        assert normalize_title("[FIX] web scraping 403") != normalize_title("[UX] preflight checks")
+
+    def test_key_stable_and_short(self):
+        k = idea_key("[IMPROVEMENT] Per-cycle funnel metrics")
+        assert k == idea_key("per-cycle funnel metrics")
+        assert len(k) == 16
+
+
+class TestCacheRoundTrip:
+    def test_record_then_seen(self, tmp_path):
+        cache = {}
+        record(cache, "[FIX] Something broke", "filed", issue=42, date="2026-06-13")
+        assert is_seen(cache, "something broke")  # normalized match
+        assert not is_seen(cache, "a totally different idea")
+
+    def test_save_load(self, tmp_path):
+        p = tmp_path / "dedup-cache.json"
+        cache = {}
+        record(cache, "Idea one", "filed", issue=1, date="2026-06-12")
+        save_cache(p, cache)
+        loaded = load_cache(p)
+        assert is_seen(loaded, "idea one")
+        assert loaded[idea_key("Idea one")]["issue"] == 1
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert load_cache(tmp_path / "nope.json") == {}
+
+    def test_malformed_file_is_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{ not json", encoding="utf-8")
+        assert load_cache(p) == {}
+
+    def test_cap_keeps_newest(self, tmp_path):
+        from evolution_dedup import _MAX_ENTRIES
+
+        p = tmp_path / "c.json"
+        cache = {}
+        for i in range(_MAX_ENTRIES + 50):
+            # date ordering: later i -> later date so newest survive
+            record(cache, f"idea number {i}", "considered", date=f"2026-06-{(i % 28) + 1:02d}")
+        # force distinct, monotonic dates so the cap is deterministic
+        for i, k in enumerate(list(cache)):
+            cache[k]["date"] = f"{2000 + i:04d}-01-01"
+        save_cache(p, cache)
+        loaded = load_cache(p)
+        assert len(loaded) == _MAX_ENTRIES


### PR DESCRIPTION
Closes #91 (core). `evolution-issues` pulled up to 300 issues EVERY run and re-compared each proposal by meaning in-context — a cost that grows forever with repo age.

**Added — deterministic local dedup cache:**
- `scripts/evolution_dedup.py`: normalized-title keys (strip `[TAG]`, lowercase, drop punctuation → sha1); `check`/`record` CLI (`check` exits 1=seen / 0=new) + pure functions; cache at `~/.hermes/profiles/user1/evolution/dedup-cache.json`, capped at 5000 (newest kept). 8 tests.
- `evolution-issues` skill: check each proposal against the cache **first** (O(1) skip on hit); the `gh issue list` query is now the **fallback for cache-misses only** (still catches cross-install dups). Record every filed/skipped idea so it short-circuits next run.

**Safety:** pure NEGATIVE fast-path — a cache miss just runs the gh check, so it can never cause a false "new" / file a dup the gh fallback would have caught. Graceful when the cache is absent (rebuilds as it records).

**Scope:** delivers the measured dedup hot-path (#91 title: "O(new) instead of re-pulling 300"). The issue’s secondary bullets — extend tqmemory semantic memory to all 5 stages; `last_success` per stage — are deferred as separate work (`last_upstream_sha` already lives in `.evolution/upstream-sync-state.json`).