### PR TITLE
feat(agent): loop/repeated-failure guard — break tool spirals (Closes #173, #143)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -485,6 +485,27 @@ def run_conversation(
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
 
+        # Loop guard: if the model is stuck repeating one tool (or repeatedly
+        # failing the same tool), inject a ONE-TIME advisory nudge to break the
+        # spiral and re-check the goal (#173/#174/#175/#176/#143). Advisory only:
+        # it appends a user message, never blocks a tool call. Nudges once per
+        # stuck run (tracked by the trailing tool name) to avoid spamming.
+        try:
+            from agent import loop_guard as _loop_guard
+
+            _lg_sig = _loop_guard.current_run_signature(messages)
+            _lg_tool = _lg_sig[0] if _lg_sig else None
+            if _lg_tool != getattr(agent, "_loop_guard_nudged_tool", None):
+                agent._loop_guard_nudged_tool = None  # run changed/ended — re-arm
+                _lg_nudge = _loop_guard.maybe_nudge(messages) if _lg_tool else None
+                if _lg_nudge:
+                    messages.append({"role": "user", "content": _lg_nudge})
+                    agent._loop_guard_nudged_tool = _lg_tool
+                    if not agent.quiet_mode:
+                        agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
+        except Exception as _lg_err:  # never let the guard break the loop
+            logger.debug("loop_guard error (iteration %s): %s", api_call_count, _lg_err)
+
         # Fire step_callback for gateway hooks (agent:step event)
         if agent.step_callback is not None:
             try:

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -1,0 +1,159 @@
+"""Loop / repeated-failure guard for the agent tool-calling loop.
+
+Addresses a whole cluster of observed failure modes where the agent stops making
+progress and keeps hammering the same tool:
+
+  * same single tool called many turns in a row with no progress (#173)
+  * terminal commands repeatedly failing on missing prereqs / errors (#174)
+  * hard limits / access denials retried instead of routed around (#175)
+  * an unreachable MCP server looped on health checks (#176)
+  * spirals that eventually hit the max-iteration abort (#143)
+
+Mechanism (deliberately conservative — advisory, never blocking):
+inspect the most recent CONSECUTIVE assistant tool-call turns. If the SAME tool
+is used `repeat_threshold` times in a row, or its last `fail_threshold` results
+look like failures, return a one-time nudge string. The caller injects it as a
+user-role message (the codebase's mid-loop guidance pattern) telling the model
+to stop, re-check the goal, and change strategy. A real loop is broken; a rare
+false positive costs one advisory message.
+
+Pure functions over the `messages` list → fully unit-testable, no agent state
+required (the caller tracks "already nudged this run" to avoid spamming).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+# Failure shapes cited in the cluster issues. Matched case-insensitively against
+# tool result content. Kept specific to avoid flagging benign output.
+_FAILURE_MARKERS = (
+    "command not found",
+    "no such file",
+    "permission denied",
+    "access denied",
+    "refusing to write",
+    "forbidden",
+    "timed out",
+    "timeout",
+    "traceback (most recent call",
+    "closedresourceerror",
+    "unreachable",
+    "externally-managed-environment",
+    "error:",
+    "failed",
+    "exit status",
+    "is not recognized",
+    "could not be found",
+)
+
+_EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
+
+
+def _looks_like_failure(content: Any) -> bool:
+    if not isinstance(content, str) or not content:
+        return False
+    low = content.lower()
+    if any(m in low for m in _FAILURE_MARKERS):
+        return True
+    return bool(_EXIT_CODE_RE.search(content))
+
+
+def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool]]:
+    """Most-recent-first list of (single_tool_name, result_failed) for the
+    trailing run of assistant turns that each called EXACTLY ONE tool.
+
+    Stops at the first assistant turn that is not a single-tool call (a text
+    reply, or a multi-tool turn) — that breaks the "stuck on one tool" run.
+    Multi-tool turns are normal varied work, not a single-tool spiral.
+    """
+    runs: List[Tuple[str, bool]] = []
+    i = len(messages) - 1
+    # Collect tool results by id as we walk back so we can mark failures.
+    while i >= 0:
+        msg = messages[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            tcs = [tc for tc in msg["tool_calls"] if isinstance(tc, dict)]
+            names = [
+                tc.get("function", {}).get("name")
+                for tc in tcs
+                if tc.get("function")
+            ]
+            names = [n for n in names if n]
+            if len(set(names)) != 1:
+                break  # text turn or multi-tool turn — run ends
+            tool = names[0]
+            if runs and tool != runs[0][0]:
+                break  # tool changed — the same-tool run ends here
+            # Results for this turn are the "tool" messages that follow it.
+            failed = False
+            for j in range(i + 1, len(messages)):
+                tm = messages[j]
+                if tm.get("role") != "tool":
+                    break
+                if _looks_like_failure(tm.get("content")):
+                    failed = True
+            runs.append((tool, failed))
+            i -= 1
+        elif msg.get("role") == "tool":
+            i -= 1  # skip result messages; handled with their assistant turn
+        else:
+            break  # user/system/text-assistant turn breaks the run
+    return runs
+
+
+def maybe_nudge(
+    messages: List[Dict[str, Any]],
+    *,
+    repeat_threshold: int = 6,
+    fail_threshold: int = 3,
+) -> Optional[str]:
+    """Return a nudge string if the trailing single-tool run is stuck, else None.
+
+    Two triggers (failure takes precedence — it's the higher-signal one):
+      * the same tool's last `fail_threshold` results all look like failures
+      * the same tool was called `repeat_threshold`+ times in a row
+    """
+    runs = _recent_tool_runs(messages)
+    if not runs:
+        return None
+    tool = runs[0][0]
+    # All entries in `runs` share the same tool (run breaks on tool change),
+    # but guard anyway:
+    same = [r for r in runs if r[0] == tool]
+    count = len(same)
+    consec_fail = 0
+    for _t, failed in same:
+        if failed:
+            consec_fail += 1
+        else:
+            break
+
+    if consec_fail >= fail_threshold:
+        return (
+            f"[loop-guard] The `{tool}` tool has failed {consec_fail} times in a "
+            f"row with the same approach. STOP repeating it. Diagnose the actual "
+            f"blocker first (check prerequisites / environment / the exact error "
+            f"class), then either switch to a different tool or strategy, or — if "
+            f"the blocker can't be resolved — report it concisely instead of "
+            f"retrying. Do not call `{tool}` again the same way."
+        )
+    if count >= repeat_threshold:
+        return (
+            f"[loop-guard] You have called `{tool}` {count} times in a row without "
+            f"resolving the task. Pause and re-read the goal: what concrete "
+            f"progress have these calls made? Check your plan/success criterion, "
+            f"then either change strategy, move to the next step, or report the "
+            f"blocker. Avoid another near-identical `{tool}` call."
+        )
+    return None
+
+
+def current_run_signature(messages: List[Dict[str, Any]]) -> Optional[Tuple[str, int]]:
+    """(tool, count) of the trailing single-tool run, or None. Callers use this
+    to nudge once per escalating run instead of every iteration."""
+    runs = _recent_tool_runs(messages)
+    if not runs:
+        return None
+    return (runs[0][0], len(runs))

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -1,0 +1,82 @@
+"""Tests for agent/loop_guard.py — advisory loop / repeated-failure detection."""
+
+from agent.loop_guard import current_run_signature, maybe_nudge
+
+
+def _asst(tool, args="{}", call_id="c"):
+    return {
+        "role": "assistant",
+        "tool_calls": [{"id": call_id, "function": {"name": tool, "arguments": args}}],
+    }
+
+
+def _result(content, call_id="c"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _run(tool, n, *, result="ok"):
+    """n consecutive single-tool turns, each with a (non-failing) result."""
+    msgs = [{"role": "user", "content": "do the thing"}]
+    for i in range(n):
+        cid = f"c{i}"
+        msgs.append(_asst(tool, call_id=cid))
+        msgs.append(_result(result, call_id=cid))
+    return msgs
+
+
+class TestRepeatTrigger:
+    def test_below_threshold_is_quiet(self):
+        assert maybe_nudge(_run("terminal", 5)) is None
+
+    def test_at_threshold_nudges(self):
+        n = maybe_nudge(_run("terminal", 6))
+        assert n is not None and "terminal" in n and "loop-guard" in n
+
+    def test_signature_counts_the_run(self):
+        assert current_run_signature(_run("read_file", 4)) == ("read_file", 4)
+
+    def test_no_tools_no_nudge(self):
+        assert maybe_nudge([{"role": "user", "content": "hi"}]) is None
+
+
+class TestFailureTrigger:
+    def test_three_consecutive_failures_nudges_even_below_repeat(self):
+        msgs = _run("terminal", 3, result="bash: foo: command not found")
+        n = maybe_nudge(msgs)
+        assert n is not None and "failed 3 times" in n
+
+    def test_two_failures_not_enough(self):
+        assert maybe_nudge(_run("terminal", 2, result="permission denied")) is None
+
+    def test_exit_code_marker_counts_as_failure(self):
+        msgs = _run("execute_code", 3, result="process finished, exit code: 1")
+        assert maybe_nudge(msgs) is not None
+
+    def test_mcp_unreachable_failures(self):
+        msgs = _run("mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError")
+        n = maybe_nudge(msgs)
+        assert n is not None
+
+
+class TestRunBoundaries:
+    def test_tool_change_breaks_the_run(self):
+        # 5x terminal then 1x read_file at the tail -> only the read_file run (len 1)
+        msgs = _run("terminal", 5) + _run("read_file", 1)[1:]
+        assert current_run_signature(msgs) == ("read_file", 1)
+        assert maybe_nudge(msgs) is None
+
+    def test_text_reply_breaks_the_run(self):
+        msgs = _run("terminal", 8)
+        msgs.append({"role": "assistant", "content": "Here is my summary."})
+        assert maybe_nudge(msgs) is None  # the run was broken by a text turn
+
+    def test_multi_tool_turn_breaks_the_run(self):
+        msgs = _run("terminal", 8)
+        msgs.append({
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "m1", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "m2", "function": {"name": "terminal", "arguments": "{}"}},
+            ],
+        })
+        assert maybe_nudge(msgs) is None  # varied multi-tool work, not a spiral


### PR DESCRIPTION
A cluster of introspection issues share ONE root: the agent stops progressing and hammers a tool — same-tool loops (#173), terminal error spirals (#174), retried limits/denials (#175), MCP-unreachable health loops (#176), spirals hitting the max-iteration abort (#143).

**`agent/loop_guard.py`** (pure, unit-tested): inspect the trailing run of single-tool assistant turns; nudge if the SAME tool ran **≥6 times in a row**, OR its last **≥3 results look like failures** (command-not-found, permission/access denied, timeout, ClosedResourceError, non-zero exit, traceback…). `conversation_loop` injects a **one-time advisory** user message → stop, re-check the goal, change strategy or report the blocker.

- **Once per stuck run** (tracked by trailing tool name) — no spam.
- **Advisory only** — appends a message, never blocks a tool call; wrapped in try/except so it can never break the loop.
- Run boundaries tested: tool-change / text reply / multi-tool turn all break the run → **no false positives** on varied legit work.

Raising the iteration ceiling (#143’s alternative) was **rejected** — it would only let spirals run longer; breaking the spiral is the correct fix.

Tests: 11. **Closes #173, #143.** Mitigates the loop core of #174/#175/#176 (their tool-specific extras — preflight, failure-taxonomy-in-results, MCP circuit-breaker — tracked separately).