### PR TITLE
feat(evolution): deterministic introspection pre-extract (Closes #89)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Deterministic pre-extract for evolution-introspection (#89).
+
+evolution-introspection previously loaded RAW session transcripts (last 7 days)
+into the LLM context — unbounded megabytes, the single largest context bomb in
+the pipeline, AND it put the user's private text into the model context.
+
+This script (no LLM) scans the session JSONL files for PROBLEM SIGNALS only and
+emits a compact, ANONYMIZED digest — counts per signal/tool, generic shapes,
+never raw content. The skill feeds ONLY this digest to the model. Raw private
+text never enters the context (complements the PII redaction gate #82).
+
+Signals extracted:
+  * tool_failures  — tool results that look like failures, attributed to the
+    tool (via tool_call_id -> name from the preceding assistant turn). Reuses
+    agent.loop_guard's failure markers for consistency.
+  * timeouts       — results mentioning timeout / timed out.
+  * refusals       — assistant text expressing "I can't / no access / denied".
+  * repeated_tool_runs — same tool called many times consecutively (the spiral
+    shape loop_guard guards against), counted per session.
+
+Output: a JSON digest to stdout (and optionally a file), a few KB max.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+try:
+    from agent.loop_guard import _looks_like_failure  # pure (re + typing only)
+except Exception:  # pragma: no cover - keep standalone if import path differs
+    _FALLBACK = ("error:", "failed", "permission denied", "command not found",
+                 "no such file", "timed out", "timeout", "traceback (most recent call")
+
+    def _looks_like_failure(content: Any) -> bool:  # type: ignore
+        return isinstance(content, str) and any(m in content.lower() for m in _FALLBACK)
+
+
+_TIMEOUT_RE = re.compile(r"\b(timed out|timeout)\b", re.IGNORECASE)
+_REFUSAL_RE = re.compile(
+    r"\b(i can('|no)?t|cannot|no access|access denied|not permitted|don'?t have (access|permission))\b",
+    re.IGNORECASE,
+)
+_REPEAT_THRESHOLD = 5  # same tool >=N consecutive in a session is a "repeated run"
+
+
+def _iter_lines(path: Path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except ValueError:
+                    continue
+    except OSError:
+        return
+
+
+def scan_session(path: Path) -> Dict[str, Any]:
+    """Return per-session signal counts (no raw text)."""
+    tool_failures: Counter = Counter()
+    timeouts = 0
+    refusals = 0
+    id_to_tool: Dict[str, str] = {}
+    consec_tool = None
+    consec_n = 0
+    max_runs: Counter = Counter()  # tool -> max consecutive in this session
+
+    for obj in _iter_lines(path):
+        role = obj.get("role")
+        if role == "assistant":
+            tcs = obj.get("tool_calls") or []
+            names = []
+            for tc in tcs:
+                if isinstance(tc, dict) and tc.get("function"):
+                    nm = tc["function"].get("name")
+                    if nm:
+                        names.append(nm)
+                        if tc.get("id"):
+                            id_to_tool[tc["id"]] = nm
+            # consecutive same-single-tool run tracking
+            if len(set(names)) == 1:
+                tool = names[0]
+                if tool == consec_tool:
+                    consec_n += 1
+                else:
+                    consec_tool, consec_n = tool, 1
+                max_runs[consec_tool] = max(max_runs[consec_tool], consec_n)
+            else:
+                consec_tool, consec_n = None, 0
+            content = obj.get("content")
+            if isinstance(content, str) and _REFUSAL_RE.search(content):
+                refusals += 1
+        elif role == "tool":
+            content = obj.get("content")
+            tool = id_to_tool.get(obj.get("tool_call_id"), "unknown")
+            if _looks_like_failure(content):
+                tool_failures[tool] += 1
+            if isinstance(content, str) and _TIMEOUT_RE.search(content):
+                timeouts += 1
+
+    repeated = {t: n for t, n in max_runs.items() if n >= _REPEAT_THRESHOLD}
+    return {
+        "tool_failures": dict(tool_failures),
+        "timeouts": timeouts,
+        "refusals": refusals,
+        "repeated_tool_runs": repeated,
+    }
+
+
+def build_digest(sessions_dir: Path, window_days: int = 7, now: float | None = None) -> Dict[str, Any]:
+    now = now if now is not None else time.time()
+    cutoff = now - window_days * 86400
+    failures: Counter = Counter()
+    timeouts = 0
+    refusals = 0
+    repeated: Dict[str, Dict[str, int]] = {}  # tool -> {max_consecutive, sessions}
+    scanned = 0
+
+    files = sorted(sessions_dir.glob("*.jsonl")) if sessions_dir.is_dir() else []
+    for path in files:
+        try:
+            if path.stat().st_mtime < cutoff:
+                continue
+        except OSError:
+            continue
+        scanned += 1
+        s = scan_session(path)
+        failures.update(s["tool_failures"])
+        timeouts += s["timeouts"]
+        refusals += s["refusals"]
+        for tool, n in s["repeated_tool_runs"].items():
+            r = repeated.setdefault(tool, {"max_consecutive": 0, "sessions": 0})
+            r["max_consecutive"] = max(r["max_consecutive"], n)
+            r["sessions"] += 1
+
+    return {
+        "window_days": window_days,
+        "sessions_scanned": scanned,
+        "signals": {
+            "tool_failures": dict(failures.most_common()),
+            "timeouts": timeouts,
+            "refusals_or_access_denied": refusals,
+            "repeated_tool_runs": repeated,
+        },
+    }
+
+
+def _sessions_dir() -> Path:
+    return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "sessions"
+
+
+def main(argv: List[str]) -> int:
+    days = 7
+    for a in argv[1:]:
+        if a.startswith("--days="):
+            try:
+                days = int(a.split("=", 1)[1])
+            except ValueError:
+                pass
+    digest = build_digest(_sessions_dir(), window_days=days)
+    print(json.dumps(digest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -31,8 +31,20 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
 
 ## Process
 
-1. **Load recent sessions** (e.g. the last 7 days). For each session reconstruct
-   the turn sequence: user request → agent actions (tool calls) → outcome.
+1. **Pre-extract signals deterministically — do NOT load raw transcripts into
+   context** (#89). Raw session JSONL is unbounded (megabytes) and full of the
+   user's private text. Run the no-LLM extractor first; it scans the last 7 days
+   of `~/.hermes/sessions/*.jsonl` and emits a compact, anonymized digest (counts
+   per signal/tool, generic shapes — never raw content):
+   ```bash
+   python scripts/introspection_extract.py --days=7
+   ```
+   Work from THAT digest (a few KB) — it gives tool_failures per tool, timeouts,
+   refusals/access-denials, and repeated-tool-runs per session. Only if the
+   digest is genuinely insufficient for a specific pattern should you read a
+   single targeted session (and even then, summarize locally; never paste raw
+   text). This both bounds context (unbounded → ~2-5k tokens) and keeps private
+   text out of the model entirely (complements the PII gate #82).
 
 2. **Detect problem signals** (non-exhaustive):
    - **Tool failures** — a tool returned an error / non-zero / exception,

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/introspection_extract.py — deterministic, anonymized digest (#89)."""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from introspection_extract import build_digest, scan_session  # noqa: E402
+
+
+def _session(tmp_path, name, lines, *, age_days=0):
+    p = tmp_path / f"{name}.jsonl"
+    p.write_text("\n".join(json.dumps(o) for o in lines) + "\n", encoding="utf-8")
+    if age_days:
+        old = time.time() - age_days * 86400
+        import os
+        os.utime(p, (old, old))
+    return p
+
+
+def _asst(tool, cid):
+    return {"role": "assistant", "tool_calls": [{"id": cid, "function": {"name": tool, "arguments": "{}"}}]}
+
+
+def _tool(cid, content):
+    return {"role": "tool", "tool_call_id": cid, "content": content}
+
+
+class TestScanSession:
+    def test_attributes_failures_to_tool(self, tmp_path):
+        p = _session(tmp_path, "s1", [
+            {"role": "session_meta"},
+            _asst("terminal", "c1"), _tool("c1", "bash: foo: command not found"),
+            _asst("terminal", "c2"), _tool("c2", "permission denied"),
+            _asst("read_file", "c3"), _tool("c3", "ok, file contents here"),
+        ])
+        s = scan_session(p)
+        assert s["tool_failures"] == {"terminal": 2}
+        assert "read_file" not in s["tool_failures"]
+
+    def test_counts_timeouts_and_refusals(self, tmp_path):
+        p = _session(tmp_path, "s2", [
+            _asst("mcp_health", "c1"), _tool("c1", "request timed out after 120s"),
+            {"role": "assistant", "content": "I can't access that path."},
+        ])
+        s = scan_session(p)
+        assert s["timeouts"] == 1
+        assert s["refusals"] == 1
+
+    def test_repeated_run_detected(self, tmp_path):
+        lines = [{"role": "session_meta"}]
+        for i in range(6):
+            lines += [_asst("terminal", f"c{i}"), _tool(f"c{i}", "ok")]
+        p = _session(tmp_path, "s3", lines)
+        s = scan_session(p)
+        assert s["repeated_tool_runs"].get("terminal") == 6
+
+    def test_no_raw_text_in_output(self, tmp_path):
+        secret = "USER SECRET email bob@example.com lives at 5 Main St"
+        p = _session(tmp_path, "s4", [
+            _asst("terminal", "c1"), _tool("c1", f"error: {secret}"),
+        ])
+        s = scan_session(p)
+        # Digest carries only counts/tool names — never the raw content.
+        assert secret not in json.dumps(s)
+
+
+class TestBuildDigest:
+    def test_window_excludes_old_sessions(self, tmp_path):
+        _session(tmp_path, "recent", [_asst("terminal", "c1"), _tool("c1", "command not found")])
+        _session(tmp_path, "old", [_asst("terminal", "c2"), _tool("c2", "command not found")], age_days=30)
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 1
+        assert d["signals"]["tool_failures"] == {"terminal": 1}
+
+    def test_aggregates_across_sessions(self, tmp_path):
+        for n in ("a", "b"):
+            lines = [{"role": "session_meta"}]
+            for i in range(5):
+                lines += [_asst("terminal", f"{n}{i}"), _tool(f"{n}{i}", "ok")]
+            _session(tmp_path, n, lines)
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 2
+        rr = d["signals"]["repeated_tool_runs"]["terminal"]
+        assert rr["sessions"] == 2 and rr["max_consecutive"] == 5
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        d = build_digest(tmp_path / "nope", window_days=7)
+        assert d["sessions_scanned"] == 0


### PR DESCRIPTION
Closes #89. `evolution-introspection` loaded RAW session transcripts (last 7 days) into the LLM context — unbounded megabytes (the pipeline’s biggest context bomb) and the user’s private text in-context.

**`scripts/introspection_extract.py`** (no LLM): scans `~/.hermes/sessions/*.jsonl` for problem signals only — tool failures per tool (`tool_call_id`→name; reuses `agent.loop_guard` failure markers), timeouts, refusals/access-denials, repeated-tool-runs per session — and emits a compact **anonymized** digest (counts + generic shapes, **never raw content**). The skill now works from that digest (~2-5k tokens) instead of raw transcripts.

**Privacy + perf:** unbounded → ~2-5k tokens; raw private text never enters the model (complements the PII gate #82). A no-raw-text assertion is in the tests (7 total: attribution, timeouts/refusals, repeated-run, window exclusion, cross-session aggregation).

The `needs-split` label was over-cautious — this is a single bounded script + skill rewiring.