### PR TITLE
feat(agent): normalize tool failures into actionable diagnostics (Closes #130)

### DIFF
--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -1,0 +1,67 @@
+"""Normalize tool failures into an actionable diagnostic hint (#130, #175).
+
+Raw tool failures arrive in many shapes (non-zero exits, permission errors,
+timeouts, not-found, char-limit caps). The model then has to interpret each one
+and often just retries the same call. This classifies a failing tool result into
+a small, stable TAXONOMY and returns a one-line recovery hint that
+``make_tool_result_message`` appends to the result the model sees.
+
+Pure + deterministic. Proactive, per-failure complement to ``loop_guard`` (which
+reacts only after a failure REPEATS). Categories deliberately map to the
+recovery routes the cluster issues asked for: limit / permission / not_found /
+timeout / missing_command / runtime_error.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional, Tuple
+
+# Ordered most-specific first; first match wins. (regex, category, hint).
+_RULES: tuple[tuple[re.Pattern, str, str], ...] = (
+    (re.compile(r"command not found|not recognized as|: No such file or directory.*\b(sh|bash|exec)\b|executable file not found", re.I),
+     "missing_command",
+     "A required binary/command is missing. Check prerequisites first "
+     "(`which <cmd>` / install it), or use a different tool — do NOT repeat the same command."),
+    (re.compile(r"permission denied|access denied|not permitted|forbidden|refusing to write|operation not permitted|EACCES", re.I),
+     "permission",
+     "Access is denied and the agent can't elevate. Do NOT retry the same path — "
+     "use an allowed path/tool, or report exactly what access is needed."),
+    (re.compile(r"timed out|timeout|deadline exceeded|ClosedResourceError|unreachable|connection refused|ETIMEDOUT", re.I),
+     "timeout",
+     "The operation timed out / the resource is unreachable. Set it aside, route to a "
+     "fallback if one exists, and do NOT loop on health checks or retry blindly."),
+    (re.compile(r"\b(char(acter)?s?|byte)s?\b.*\b(limit|exceed|too (long|large|big)|maximum)\b|exceeds the maximum|max(imum)? (length|size)|too many tokens|context length", re.I),
+     "limit",
+     "A size/length limit was hit. Don't resend as-is — chunk the work, summarize, "
+     "or raise the relevant config limit; a near-identical retry will fail the same way."),
+    (re.compile(r"no such file or directory|not found|does not exist|cannot find|no matches found|0 results|no results", re.I),
+     "not_found",
+     "The target wasn't found. Re-check the path/name (it may be dynamic), broaden the "
+     "search, or create the prerequisite first — don't repeat the same lookup."),
+    (re.compile(r"traceback \(most recent call|exit code[:\s]+[1-9]|exit status [1-9]|non-zero exit|error:|exception|failed", re.I),
+     "runtime_error",
+     "The call errored. Read the message, fix the root cause, and CHANGE the call — "
+     "retrying the same arguments will reproduce it."),
+)
+
+
+def classify(content: Any) -> Optional[Tuple[str, str]]:
+    """Return (category, recovery_hint) if the content looks like a failure, else None."""
+    if not isinstance(content, str) or not content.strip():
+        return None
+    for pattern, category, hint in _RULES:
+        if pattern.search(content):
+            return category, hint
+    return None
+
+
+def diagnostic_suffix(content: Any) -> str:
+    """Return a one-line diagnostic annotation to append to a failing tool
+    result, or '' if the result is not a recognized failure. Trusted text
+    (our annotation), kept outside any untrusted-content wrapper by the caller."""
+    hit = classify(content)
+    if not hit:
+        return ""
+    category, hint = hit
+    return f"\n\n[diagnostic] failure-class={category} — {hint}"

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -334,6 +334,17 @@ def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict
     list structure stays valid for vision-capable adapters.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
+    # Normalize failures into an actionable diagnostic hint (#130/#175): if the
+    # result looks like an error, append a one-line failure-class + recovery hint
+    # so the model adapts instead of retrying blindly. Trusted annotation, added
+    # AFTER any untrusted-content wrapper. Classify on the original content.
+    if isinstance(wrapped, str):
+        try:
+            from agent.tool_diagnostics import diagnostic_suffix
+
+            wrapped = wrapped + diagnostic_suffix(content)
+        except Exception:
+            pass
     return {
         "role": "tool",
         "name": name,

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -1,0 +1,52 @@
+"""Tests for agent/tool_diagnostics.py — normalized failure taxonomy (#130/#175)."""
+
+from agent.tool_diagnostics import classify, diagnostic_suffix
+from agent.tool_dispatch_helpers import make_tool_result_message
+
+
+class TestClassify:
+    def test_success_is_none(self):
+        assert classify("ok, wrote 3 files") is None
+        assert classify("") is None
+        assert classify(None) is None
+
+    def test_missing_command(self):
+        cat, hint = classify("bash: foo: command not found")
+        assert cat == "missing_command" and "prerequisites" in hint.lower()
+
+    def test_permission(self):
+        assert classify("Refusing to write to sensitive system path")[0] == "permission"
+        assert classify("error: permission denied")[0] in ("permission", "missing_command", "runtime_error")
+
+    def test_timeout(self):
+        assert classify("request timed out after 120s")[0] == "timeout"
+        assert classify("ClosedResourceError: server unreachable")[0] == "timeout"
+
+    def test_limit(self):
+        assert classify("value exceeds the maximum length of 2200 characters")[0] == "limit"
+
+    def test_not_found(self):
+        assert classify("grep: no matches found")[0] == "not_found"
+
+    def test_runtime_error_fallback(self):
+        assert classify("Traceback (most recent call last):\n  ...")[0] == "runtime_error"
+        assert classify("process exited, exit code: 1")[0] == "runtime_error"
+
+
+class TestDiagnosticSuffix:
+    def test_empty_for_success(self):
+        assert diagnostic_suffix("done, all good") == ""
+
+    def test_suffix_for_failure(self):
+        s = diagnostic_suffix("permission denied")
+        assert s.startswith("\n\n[diagnostic] failure-class=") and "permission" in s
+
+
+class TestWiredIntoToolResult:
+    def test_failure_result_gets_hint(self):
+        msg = make_tool_result_message("terminal", "bash: x: command not found", "c1")
+        assert "[diagnostic] failure-class=missing_command" in msg["content"]
+
+    def test_success_result_unchanged(self):
+        msg = make_tool_result_message("read_file", "file contents, all fine", "c2")
+        assert "[diagnostic]" not in msg["content"]


### PR DESCRIPTION
Closes #130. Substantially addresses #175 (failure taxonomy in tool results).

Raw tool failures arrive in many shapes; the model often just retries the same call.

- **`agent/tool_diagnostics.py`** (pure): `classify(content) → (category, hint)` over a stable taxonomy — `missing_command / permission / timeout / limit / not_found / runtime_error` — each mapping to the recovery route the cluster issues asked for.
- **`make_tool_result_message`** appends a one-line `[diagnostic] failure-class=… — <hint>` to string results that look like failures (after any untrusted-content wrapper; trusted annotation). Success results untouched.

Proactive, per-failure complement to the `loop_guard` (#178), which reacts only after a failure **repeats**. Tests: 11 (taxonomy + wired-into-result + success-unchanged); existing `tool_dispatch` tests green.