### PR TITLE
test(telemetry): add agent.run span wiring test, symmetric with cron.job (#167)

### DIFF
--- a/tests/agent/test_conversation_telemetry_span.py
+++ b/tests/agent/test_conversation_telemetry_span.py
@@ -1,0 +1,82 @@
+"""Wiring test: run_conversation emits an agent.run span when telemetry is
+enabled (#167).
+
+Symmetric with tests/cron/test_cron_telemetry_span.py. Proves the thin
+run_conversation wrapper opens the span, stamps task_id/provider/failed/
+interrupted, and delegates to (a stubbed) _run_conversation_impl returning its
+result verbatim — so a future refactor can't silently drop the span.
+"""
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult  # noqa: E402
+
+import agent.conversation_loop as cl  # noqa: E402
+import hermes_telemetry as tel  # noqa: E402
+
+
+class _Collect(SpanExporter):
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        pass
+
+
+class _FakeAgent:
+    provider = "anthropic"
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    tel._reset_for_test()
+    yield
+    tel._reset_for_test()
+
+
+def test_run_conversation_emits_agent_run_span(monkeypatch):
+    exp = _Collect()
+    tel._force_enable_with_exporter(exp)
+    monkeypatch.setattr(
+        cl,
+        "_run_conversation_impl",
+        lambda *a, **k: {"failed": False, "interrupted": False, "final_response": "ok"},
+    )
+
+    res = cl.run_conversation(_FakeAgent(), "hi", task_id="t-123")
+
+    assert res["final_response"] == "ok"  # wrapper returns impl result verbatim
+    span = next(s for s in exp.spans if s.name == "agent.run")
+    attrs = dict(span.attributes)
+    assert attrs.get("hermes.task_id") == "t-123"
+    assert attrs.get("hermes.provider") == "anthropic"
+    assert attrs.get("hermes.failed") is False
+    assert attrs.get("hermes.interrupted") is False
+
+
+def test_run_conversation_span_marks_failed_result(monkeypatch):
+    exp = _Collect()
+    tel._force_enable_with_exporter(exp)
+    monkeypatch.setattr(
+        cl,
+        "_run_conversation_impl",
+        lambda *a, **k: {"failed": True, "interrupted": False},
+    )
+
+    cl.run_conversation(_FakeAgent(), "hi", task_id="t-9")
+
+    span = next(s for s in exp.spans if s.name == "agent.run")
+    assert dict(span.attributes).get("hermes.failed") is True
+
+
+def test_run_conversation_disabled_is_noop(monkeypatch):
+    monkeypatch.setattr(tel, "_otel_config", lambda: {})
+    monkeypatch.setattr(cl, "_run_conversation_impl", lambda *a, **k: {"final_response": "x"})
+    res = cl.run_conversation(_FakeAgent(), "hi")
+    assert res["final_response"] == "x"
+    assert tel.is_enabled() is False


### PR DESCRIPTION
Follow-up to #167/#181. Closes a coverage asymmetry: \`cron.job\` had a wiring test but \`agent.run\` did not.

## Why
The \`run_conversation\` thin wrapper (added in #181) was only covered indirectly — the ~434 tests that call \`run_conversation\` exercise its **no-op** (telemetry-disabled) delegation path, but nothing asserted the **enabled-path** \`agent.run\` span actually emits. A future refactor could silently drop it (exactly the break class the \`inspect.getsource\` tests caught when the body moved to \`_run_conversation_impl\`).

## Change
Test-only. New \`tests/agent/test_conversation_telemetry_span.py\` (3 tests, mirror of \`tests/cron/test_cron_telemetry_span.py\`): enabled-path span + attributes (task_id/provider/failed/interrupted), failed-result attribute, disabled no-op. \`importorskip\`-guarded. **No behavior change → no deploy needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)