### PR TITLE
fix(models): accept curated models absent from a provider's live listing

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3875,27 +3875,35 @@ def validate_requested_model(
                 "recognized": True,
                 "message": None,
             }
-        else:
-            # API responded but model is not listed.  Accept anyway —
-            # the user may have access to models not shown in the public
-            # listing (e.g. Z.AI Pro/Max plans can use glm-5 on coding
-            # endpoints even though it's not in /models).  Warn but allow.
 
-            # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
-            if auto:
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
-                }
+        # Check if the model is in our static curated listing for this provider
+        curated_models = _PROVIDER_MODELS.get(normalized, [])
+        if requested_for_lookup in set(curated_models):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": (
+                    f"Note: `{requested}` was not found in this provider's live model listing, "
+                    f"but is recognized by Hermes."
+                ),
+            }
 
-            suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
-            suggestion_text = ""
-            if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+        # Auto-correct if the top match is very similar (e.g. typo)
+        auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+        if auto:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "corrected_model": auto[0],
+                "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+            }
+
+        suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
+        suggestion_text = ""
+        if suggestions:
+            suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
 
         return {
             "accepted": False,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -800,3 +800,15 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
+
+
+class TestValidateCuratedFallback:
+    def test_curated_model_not_in_live_api_is_accepted(self):
+        # "glm-5.2[1m]" is in _PROVIDER_MODELS for "zai" but we mock the live API to return other models
+        live_models = ["glm-5.1", "glm-5", "glm-4.7"]
+        result = _validate("glm-5.2[1m]", provider="zai", api_models=live_models)
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert "not found in this provider's live model listing" in result["message"]
+        assert "recognized by Hermes" in result["message"]


### PR DESCRIPTION
## Symptom
\`/model\` (or \`/mode\`) on **\`glm-5.2[1m]\`** — the real 1M-context GLM-5.2 variant (Z.AI flagship; \`ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1m]\`) — showed:
\`\`\`
✗ Model \`glm-5.2[1m]\` was not found in this provider's model listing.
  Similar models: \`glm-5.1\`, \`glm-5\`, \`glm-4.7\`
\`\`\`
even though it's a real, curated, usable model. Provider \`/models\` listings lag fresh releases, and \`validate_requested_model\` hard-rejected anything absent from the live listing.

## Fix
When the live listing is reachable but lacks the requested model, check the curated \`_PROVIDER_MODELS[provider]\` catalog **first**: if present → \`accepted/persist/recognized = True\` with a soft note (*"not found in this provider's live model listing, but is recognized by Hermes"*) instead of a hard \`✗\`. Genuinely-unknown models still fall through to typo auto-correct and the reject-with-suggestions path. Mirrors the existing "curated lags live" handling already used for anthropic/openai in \`provider_model_ids\`.

## Tests
New \`TestValidateCuratedFallback::test_curated_model_not_in_live_api_is_accepted\` (glm-5.2[1m] on \`zai\` vs a live list of glm-5.1/glm-5/glm-4.7). Full \`test_model_validation.py\` + \`test_gmi_provider.py\` green (101). ruff clean; the 2 \`ty\` diagnostics in \`models.py\` are pre-existing (\`atomic_json_write\`, lines 2486/3469) and outside the changed region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)