### PR TITLE
fix(models): use clean 'glm-5.2' model ID, drop the '[1m]' annotation suffix

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,7 +210,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "minimax-m3": 1000000,
     "minimax": 204800,
     # GLM
-    "glm-5.2[1m]": 1000000,
+    "glm-5.2": 1000000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to
@@ -257,7 +257,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "mimo-v2-omni": 262144,
     "mimo-v2-flash": 262144,
     "zai-org/GLM-5": 202752,
-    "zai-org/GLM-5.2[1m]": 1000000,
+    "zai-org/GLM-5.2": 1000000,
 }
 
 # xAI Grok models that ACCEPT the `reasoning.effort` parameter on

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -61,7 +61,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
-    ("z-ai/glm-5.2[1m]",                       ""),
+    ("z-ai/glm-5.2",                       ""),
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
@@ -184,7 +184,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
-        "z-ai/glm-5.2[1m]",
+        "z-ai/glm-5.2",
         "z-ai/glm-5.1",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
@@ -260,7 +260,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
     ],
     "zai": [
-        "glm-5.2[1m]",
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",
@@ -282,7 +282,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/kimi-k2.7-code",
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m2.5",
-        "z-ai/glm-5.2[1m]",
+        "z-ai/glm-5.2",
         "z-ai/glm5",
         "openai/gpt-oss-120b",
     ],
@@ -369,7 +369,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "trinity-mini",
     ],
     "gmi": [
-        "zai-org/GLM-5.2[1m]",
+        "zai-org/GLM-5.2",
         "zai-org/GLM-5.1-FP8",
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",
@@ -418,7 +418,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
-        "glm-5.2[1m]",
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "mimo-v2.5-pro",
@@ -476,7 +476,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek-ai/DeepSeek-V3.2",
         "MiniMaxAI/MiniMax-M2.5",
         "zai-org/GLM-5",
-        "zai-org/GLM-5.2[1m]",
+        "zai-org/GLM-5.2",
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
         "moonshotai/Kimi-K2.6",

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -19,7 +19,7 @@ gmi = ProviderProfile(
     default_headers={"User-Agent": f"HermesAgent/{_HERMES_VERSION}"},
     default_aux_model="google/gemini-3.1-flash-lite-preview",
     fallback_models=(
-        "zai-org/GLM-5.2[1m]",
+        "zai-org/GLM-5.2",
         "zai-org/GLM-5.1-FP8",
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -804,9 +804,9 @@ class TestProbeApiModelsUserAgent:
 
 class TestValidateCuratedFallback:
     def test_curated_model_not_in_live_api_is_accepted(self):
-        # "glm-5.2[1m]" is in _PROVIDER_MODELS for "zai" but we mock the live API to return other models
+        # "glm-5.2" is in _PROVIDER_MODELS for "zai" but we mock the live API to return other models
         live_models = ["glm-5.1", "glm-5", "glm-4.7"]
-        result = _validate("glm-5.2[1m]", provider="zai", api_models=live_models)
+        result = _validate("glm-5.2", provider="zai", api_models=live_models)
         assert result["accepted"] is True
         assert result["persist"] is True
         assert result["recognized"] is True

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T20:29:19Z",
+  "updated_at": "2026-06-13T21:28:49Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -93,7 +93,7 @@
           "description": ""
         },
         {
-          "id": "z-ai/glm-5.2[1m]",
+          "id": "z-ai/glm-5.2",
           "description": ""
         },
         {
@@ -214,7 +214,7 @@
           "id": "minimax/minimax-m3"
         },
         {
-          "id": "z-ai/glm-5.2[1m]"
+          "id": "z-ai/glm-5.2"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
Per request: \`glm-5.2[1m]\` → \`glm-5.2\`.

## Why
The 1M-context GLM-5.2 was catalogued with Hermes' \`[1m]\` context-window display annotation baked into the model ID (\`glm-5.2[1m]\`, \`z-ai/glm-5.2[1m]\`, \`zai-org/GLM-5.2[1m]\`). Providers' OpenAI-compatible endpoints expect the clean slug **\`glm-5.2\`** — the 1M context is metadata, not part of the id — so the bracketed id mismatched live \`/models\` listings (the \`/mode ✗\` symptom).

## Change
Strip \`[1m]\` from every GLM-5.2 id:
- \`hermes_cli/models.py\` \`_PROVIDER_MODELS\` (zai/glm/openrouter/gmi/huggingface) + the openrouter curated tuple
- \`plugins/model-providers/gmi/__init__.py\` fallback_models
- \`agent/model_metadata.py\` context-window map — **key follows** so 1M is preserved: \`glm-5.2 → 1000000\`, \`zai-org/GLM-5.2 → 1000000\`
- \`tests/hermes_cli/test_model_validation.py\` (uses \`glm-5.2\` now)
- \`website/static/api/model-catalog.json\` — **regenerated** via \`scripts/build_model_catalog.py\` (only the 2 ids + \`updated_at\` changed)

No clean \`glm-5.2\` previously existed → no duplicates. Zero \`[1m]\` left anywhere in the repo.

## Tests
201 green (model_validation + gmi + model_metadata) + 38 (catalog + picker). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)