### PR TITLE
evolution: calibration improvements from recommendations review

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -97,6 +97,85 @@ def append_funnel(metrics_file: Path, record: Dict[str, Any]) -> None:
     metrics_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def load_records(metrics_file: Path) -> list[Dict[str, Any]]:
+    """Read all funnel records (one JSON object per line), oldest-first,
+    skipping blank/malformed lines."""
+    out: list[Dict[str, Any]] = []
+    if not metrics_file.exists():
+        return out
+    for ln in metrics_file.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def summarize(records: list[Dict[str, Any]], last: int = 7) -> Dict[str, Any]:
+    """Aggregate the last ``last`` funnel records into a signal-quality summary
+    that evolution-research reads to self-tune selectivity (#84 feedback loop —
+    closes the previously write-only metrics.jsonl).
+
+    reject_rate = rejected / (selected + rejected) over the window: of the issues
+    that reached triage, the fraction triage turned down. A high value means
+    research is surfacing low-quality proposals, so research should tighten up.
+    """
+    recent = records[-last:] if last and last > 0 else list(records)
+
+    def _tot(k: str) -> int:
+        return sum(int(r.get(k, 0) or 0) for r in recent)
+
+    created, selected = _tot("issues_created"), _tot("selected")
+    rejected, merged, skipped = _tot("rejected"), _tot("merged"), _tot("skipped")
+    triaged = selected + rejected
+    reject_rate = (rejected / triaged) if triaged else 0.0
+
+    # Trailing run of cycles with zero merges (integration-stuck signal).
+    merged_zero_streak = 0
+    for r in reversed(recent):
+        if int(r.get("merged", 0) or 0) == 0:
+            merged_zero_streak += 1
+        else:
+            break
+
+    flags: list[str] = []
+    if reject_rate > 0.70:
+        flags.append("HIGH_REJECT_RATE: be more selective — only high-evidence proposals")
+    if merged_zero_streak >= 3:
+        flags.append(
+            f"MERGED_ZERO x{merged_zero_streak}: integration looks stuck — check CI / flaky gates"
+        )
+
+    return {
+        "cycles": len(recent),
+        "issues_created": created,
+        "selected": selected,
+        "rejected": rejected,
+        "merged": merged,
+        "skipped": skipped,
+        "reject_rate": round(reject_rate, 3),
+        "merged_zero_streak": merged_zero_streak,
+        "flags": flags,
+    }
+
+
+def format_summary(summary: Dict[str, Any]) -> str:
+    """One-line, log/agent-friendly rendering of summarize()."""
+    tail = " | ".join(summary["flags"]) if summary["flags"] else "signal OK"
+    return (
+        f"[evolution-funnel] last {summary['cycles']} cycles: "
+        f"created={summary['issues_created']} selected={summary['selected']} "
+        f"rejected={summary['rejected']} merged={summary['merged']} "
+        f"skipped={summary['skipped']} reject_rate={summary['reject_rate']:.0%} "
+        f"merged_zero_streak={summary['merged_zero_streak']} | {tail}"
+    )
+
+
 def cycle_date(now) -> str:
     """The date of the cycle to measure. This job runs in the MORNING (07:40,
     before the watchdog), so before ~08:00 the cycle that just completed is
@@ -115,6 +194,23 @@ def main(argv: list[str]) -> int:
             str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
         )
     )
+    args = argv[1:]
+
+    # Read-side feedback path (#84): summarize recent cycles so evolution-research
+    # can self-tune selectivity. `--summary [--last N]` (default N=7).
+    if "--summary" in args:
+        last = 7
+        if "--last" in args:
+            i = args.index("--last")
+            if i + 1 < len(args):
+                try:
+                    last = int(args[i + 1])
+                except ValueError:
+                    last = 7
+        records = load_records(evolution_dir / "metrics.jsonl")
+        print(format_summary(summarize(records, last)))
+        return 0
+
     # Explicit arg wins (manual/backfill runs); else env; else the cycle date.
     date = argv[1] if len(argv) > 1 and not argv[1].startswith("-") else ""
     date = date or os.environ.get("EVOLUTION_FUNNEL_DATE", "")

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -126,9 +126,19 @@ gh issue view <N> --repo Lexus2016/hermes-agent-evolution --json body,comments
 5. **Compute Priority Score**
 
 ```python
-base_priority = (impact * 2) / effort
+base_priority = impact * 2 * (1.0 - 0.4 * effort)   # effort DAMPENS (≤40%), never divides
 final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + safety*0.3
 ```
+
+   **Effort is a bounded penalty, not a divisor.** The old `(impact*2)/effort`
+   let a trivial-but-easy issue (impact 0.2, effort 0.1 → **4.0**) outrank a
+   critical-but-hard one (impact 1.0, effort 0.8 → **2.5**) — so the agent kept
+   picking low-value quick wins (the calibration bug). With the bounded form,
+   effort only shaves up to 40% off, so **impact drives the ranking**: that same
+   critical issue now scores `1.36` base vs the trivial one's `0.38`.
+   Consequence: `base_priority` now ranges 0–2.0 (was up to ~20), so the
+   `min_priority 0.7` floor below is a **real filter** on weak/risky issues
+   instead of a near-vestigial gate everything cleared.
 
    `age = min(days_since_created / 30, 1.0)`. The age weight is **0.15** (was
    0.05) so a genuinely-valid issue that keeps losing the nightly contest still

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -159,7 +159,20 @@ gh pr list --repo "$REPO" --state open --limit 50 \
    guards quality, not a low ceiling.
 
 4. **Merge** (squash). `--admin` is required because branch protection mandates
-   review; the owner token authorizes it:
+   review; the owner token authorizes it.
+
+   **FIRST — branch-integrity check (you review a PR, then merge whatever its
+   branch HEAD is NOW; those can differ).** Another agent or a shared checkout
+   can push commits onto the branch between your review (2a) and this merge, and
+   `gh pr merge` lands the branch HEAD — so an un-reviewed commit rides in under
+   your approval. Before merging, confirm the commit set you reviewed is still
+   the whole PR:
+```bash
+gh pr view <N> --repo "$REPO" --json commits --jq '.commits[].oid'
+```
+   If a commit appeared that was NOT in your 2a review → do NOT merge blind:
+   re-run the code review (2a) + dead-code grep against the FULL current diff. If
+   it passes, merge; if not, send back. Only then:
 ```bash
 gh pr merge <N> --repo "$REPO" --squash --admin
 ```

--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -34,6 +34,16 @@ Keywords: "agent", "autonomous", "LLM tool use", "multi-agent"
 
 ## Research process
 
+0. **Read the pipeline's own funnel signal FIRST** (closes the funnel feedback
+   loop — #84). Run `python scripts/evolution_funnel.py --summary --last 7` and
+   let it set this cycle's bar:
+   - `HIGH_REJECT_RATE` flag → triage has been rejecting most of what research
+     surfaces. **Raise the bar:** propose fewer, higher-evidence findings this
+     cycle; a popular/new trend is not enough.
+   - `MERGED_ZERO xN` flag → downstream integration is stuck; piling on more
+     volume won't help. Keep output lean and note the stall in the report.
+   - `signal OK` → proceed normally.
+
 1. **Scan sources** using `web_search`
 2. **Offload bulky reads to subagents.** The `delegation` toolset is enabled for
    this job. Any web dump, large diff, or long log expected to exceed ~2k tokens

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -8,7 +8,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from datetime import datetime  # noqa: E402
 
-from evolution_funnel import append_funnel, compute_funnel, cycle_date  # noqa: E402
+from evolution_funnel import (  # noqa: E402
+    append_funnel,
+    compute_funnel,
+    cycle_date,
+    format_summary,
+    load_records,
+    summarize,
+)
 
 
 def _write(p: Path, obj):
@@ -91,3 +98,55 @@ class TestAppendFunnel:
         lines = mf.read_text().strip().splitlines()
         assert len(lines) == 1
         assert json.loads(lines[0])["merged"] == 5
+
+
+class TestSummary:
+    def _rec(self, date, created=0, selected=0, rejected=0, merged=0, skipped=0):
+        return {
+            "date": date, "issues_created": created, "selected": selected,
+            "rejected": rejected, "merged": merged, "skipped": skipped,
+        }
+
+    def test_load_records_skips_blank_and_malformed(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text(
+            json.dumps(self._rec("2026-06-10", merged=1)) + "\n\nnot-json\n"
+            + json.dumps(self._rec("2026-06-11", merged=2)) + "\n",
+            encoding="utf-8",
+        )
+        recs = load_records(f)
+        assert [r["date"] for r in recs] == ["2026-06-10", "2026-06-11"]
+
+    def test_load_records_missing_file(self, tmp_path):
+        assert load_records(tmp_path / "nope.jsonl") == []
+
+    def test_reject_rate_and_window(self):
+        recs = [self._rec(f"d{i}", selected=1, rejected=9, merged=1) for i in range(10)]
+        s = summarize(recs, last=7)
+        assert s["cycles"] == 7  # window honored
+        assert s["selected"] == 7 and s["rejected"] == 63
+        assert s["reject_rate"] == round(63 / 70, 3)  # 0.9
+        assert any("HIGH_REJECT_RATE" in f for f in s["flags"])
+
+    def test_healthy_signal_no_flags(self):
+        recs = [self._rec(f"d{i}", selected=8, rejected=2, merged=3) for i in range(5)]
+        s = summarize(recs, last=7)
+        assert s["reject_rate"] == 0.2
+        assert s["flags"] == []
+        assert "signal OK" in format_summary(s)
+
+    def test_merged_zero_streak_flag(self):
+        recs = [
+            self._rec("d1", merged=2),
+            self._rec("d2", merged=0),
+            self._rec("d3", merged=0),
+            self._rec("d4", merged=0),
+        ]
+        s = summarize(recs, last=7)
+        assert s["merged_zero_streak"] == 3
+        assert any("MERGED_ZERO" in f for f in s["flags"])
+
+    def test_empty_records_no_crash(self):
+        s = summarize([], last=7)
+        assert s["cycles"] == 0 and s["reject_rate"] == 0.0 and s["flags"] == []
+        assert "[evolution-funnel]" in format_summary(s)


### PR DESCRIPTION
Three confirmed, high-leverage fixes from the `EVOLUTION_IMPROVEMENT_RECOMMENDATIONS.md` review. Each claim was verified against the live code before implementing.

## 1. Priority formula — effort as bounded penalty, not divisor (rec 1.2)
`evolution-analysis/SKILL.md`: `base_priority = impact*2*(1-0.4*effort)` replaces `(impact*2)/effort`. The divisor let a trivial-but-easy issue (impact 0.2, effort 0.1 → **4.0**) outrank a critical-but-hard one (impact 1.0, effort 0.8 → **2.5**) — the calibration bug where the agent kept picking quick wins. Now impact drives ranking (**1.36** vs **0.38**). Base now ranges 0–2 (was ~20), so the `min_priority 0.7` floor becomes a real filter (documented inline).

## 2. Funnel feedback loop — close the write-only metrics.jsonl (rec 2.2 / #84)
`evolution_funnel.py` gains `--summary [--last N]`: reads recent cycles, emits `reject_rate` + `merged_zero_streak` + a directive (`HIGH_REJECT_RATE` / `MERGED_ZERO` / `signal OK`). `evolution-research/SKILL.md` step 0 now reads it and tightens selectivity when triage has been rejecting most proposals. The metrics were previously write-only — nothing consumed them. 6 new tests.

## 3. Branch-integrity check before merge (session-observed gap, not in the report)
`evolution-integration/SKILL.md`: before `gh pr merge`, diff the PR's current commit set (`gh pr view --json commits`) against what was reviewed. A shared checkout / concurrent agent can push an un-reviewed commit onto the branch that `merge` lands under your approval — this actually happened this session (`d89a34060` rode into #183). Re-review the full diff or send back.

## Not implemented (and why)
- **rec 1.1** (access-gate `Bearer ***`) — **refuted**: the file uses `Bearer ${_tok}` correctly; the `***` was a redaction artifact in the report author's tool output, not source.
- **rec 1.3** dead-code gate — the deterministic dead-code check **already exists** (`evolution-integration/SKILL.md`), running alongside self-audit. The genuinely-new parts (diff-size/coverage/dependency/breaking-change) are left as a follow-up.

## Tests
14 funnel (8 existing + 6 new) + watchdog/register adjacents green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)