### PR TITLE
fix(evolution): wire funnel feedback through a file sidecar, not a script run

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -225,6 +225,18 @@ def main(argv: list[str]) -> int:
 
     record = compute_funnel(evolution_dir, date)
     append_funnel(evolution_dir / "metrics.jsonl", record)
+
+    # Refresh the rolling-summary sidecar so stages WITHOUT a terminal toolset
+    # (evolution-research has only web+file) can consume the funnel feedback via
+    # the `file` toolset — they can't run `--summary` themselves (#84 loop).
+    try:
+        (evolution_dir / "funnel-summary.txt").write_text(
+            format_summary(summarize(load_records(evolution_dir / "metrics.jsonl"), 7)) + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -35,8 +35,11 @@ Keywords: "agent", "autonomous", "LLM tool use", "multi-agent"
 ## Research process
 
 0. **Read the pipeline's own funnel signal FIRST** (closes the funnel feedback
-   loop — #84). Run `python scripts/evolution_funnel.py --summary --last 7` and
-   let it set this cycle's bar:
+   loop — #84). This stage has only the `web` + `file` toolsets (no `terminal`),
+   so READ the sidecar the nightly funnel job refreshes — do NOT try to run a
+   script: open `~/.hermes/profiles/user1/evolution/funnel-summary.txt` (a single
+   `[evolution-funnel] …` line). If it's missing, treat as `signal OK` and
+   proceed. Let its flags set this cycle's bar:
    - `HIGH_REJECT_RATE` flag → triage has been rejecting most of what research
      surfaces. **Raise the bar:** propose fewer, higher-evidence findings this
      cycle; a popular/new trend is not enough.

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -150,3 +150,24 @@ class TestSummary:
         s = summarize([], last=7)
         assert s["cycles"] == 0 and s["reject_rate"] == 0.0 and s["flags"] == []
         assert "[evolution-funnel]" in format_summary(s)
+
+
+class TestSummarySidecar:
+    def test_normal_run_writes_summary_sidecar(self, tmp_path, monkeypatch):
+        # evolution-research has no terminal toolset, so the no_agent funnel run
+        # must leave a file it can read. A normal main() run writes it.
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        (tmp_path / "metrics.jsonl").write_text(
+            json.dumps({"date": "2026-06-10", "selected": 1, "rejected": 9, "merged": 0}) + "\n",
+            encoding="utf-8",
+        )
+        from evolution_funnel import main
+
+        rc = main(["evolution_funnel.py", "2026-06-11"])
+        assert rc == 0
+        sidecar = tmp_path / "funnel-summary.txt"
+        assert sidecar.exists()
+        body = sidecar.read_text()
+        assert body.startswith("[evolution-funnel] last")
+        # the seeded 90% reject cycle should surface the directive
+        assert "HIGH_REJECT_RATE" in body


### PR DESCRIPTION
Self-audit caught a **dead wiring** shipped in #187.

## Bug
`evolution-research` has only the `web` + `file` toolsets (no `terminal` — unlike `evolution-issues` / `evolution-introspection`). So the step-0 instruction added in #187 to **run** `python scripts/evolution_funnel.py --summary` could never execute. The unit tests passed (they exercise the script in isolation) but the research→funnel integration was non-functional.

## Fix (no capability expansion, no cron re-registration)
- `evolution_funnel.py`: the normal `no_agent` run now also refreshes a rolling-summary sidecar at `<evolution_dir>/funnel-summary.txt` (best-effort, `OSError`-guarded). The funnel job runs 07:40 (PRIVATE), before research 09:00, writing to the shared default `EVOLUTION_PROFILE_DIR`.
- `evolution-research/SKILL.md` step 0: **read** that sidecar via the `file` toolset (graceful `signal OK` when missing — e.g. PUBLIC-only forks where the PRIVATE funnel job never runs) instead of running a script it has no terminal for.

## Tests
`TestSummarySidecar` asserts a normal `main()` run writes the sidecar with the directive. 15 funnel tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)