### PR TITLE
evolution: enforced skill-integrity gate — block dead skill→script wiring in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,10 @@ jobs:
               DOCS_ONLY=true
               while IFS= read -r f; do
                 case "$f" in
+                  # skills/cron are behavioral instructions, not docs: a SKILL.md
+                  # edit can introduce dead skill->script wiring (#101/#188), so
+                  # force the full test run to enforce evolution_skill_lint.
+                  skills/*|cron/*) DOCS_ONLY=false; break ;;
                   *.md|docs/*) ;;
                   *) DOCS_ONLY=false; break ;;
                 esac

--- a/scripts/evolution_skill_lint.py
+++ b/scripts/evolution_skill_lint.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Deterministic skill-integrity gate for the evolution pipeline.
+
+An ENFORCED check (not an instruction the agent might follow) for the class of
+bug that self-review keeps missing: a skill tells a stage to RUN a script that
+either does not exist, or that the stage cannot run because it lacks the
+``terminal`` toolset. This has bitten the project twice:
+
+  * #101 — a skill cited ``scripts/evolution_watchdog.sh`` that never existed,
+    and a wanted issue was destructively closed on the fabricated path.
+  * #188 — ``evolution-research`` (toolsets: web+file, NO terminal) was wired to
+    "run ``python scripts/evolution_funnel.py --summary``" — a dead instruction
+    it could never execute; unit tests passed, the integration was non-functional.
+
+CI self-tests cover code; they do NOT cover "does the stage that runs this skill
+have the capability the skill assumes". This closes that gap MECHANICALLY: run it
+in CI (see tests/scripts/test_evolution_skill_integrity.py) so a dead skill→script
+wiring blocks merge instead of relying on the agent to notice.
+
+Scope is deliberately narrow + precise to avoid false positives: it flags only
+COMMAND-shaped invocations (``python scripts/X.py``, ``bash scripts/X.sh``,
+``./scripts/X``) — NOT bare inline-code mentions in cautionary prose (e.g. the
+``scripts/evolution_watchdog.sh`` named in #101's warning is correctly ignored).
+
+Pure functions + explicit IO boundary so it is import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# A script invocation the stage is told to RUN — `python/python3/bash/sh scripts/X`
+# or `./scripts/X`. Bare inline mentions (no runner, no `./`) are NOT commands.
+_RUN_RE = re.compile(r"(?:(?:python3?|bash|sh)\s+|\./)(scripts/[A-Za-z0-9_./-]+\.(?:py|sh))")
+
+# Frontmatter `name:` line in a SKILL.md.
+_NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def extract_run_commands(text: str) -> List[str]:
+    """Return the distinct ``scripts/...`` paths the text instructs running."""
+    return sorted({m.group(1) for m in _RUN_RE.finditer(text or "")})
+
+
+def skill_ref_to_name(skill_ref: str) -> str:
+    """A cron `skills:` entry ``evolution/research`` matches the SKILL.md
+    frontmatter name ``evolution-research``."""
+    return skill_ref.replace("/", "-")
+
+
+def find_violations(
+    stages: List[Dict[str, Any]],
+    skill_texts: Dict[str, str],
+    existing_scripts: set,
+) -> List[Dict[str, str]]:
+    """Pure core. ``stages`` = [{name, skills:[ref], toolsets:[..]}]; ``skill_texts``
+    maps skill frontmatter-name -> SKILL.md text; ``existing_scripts`` = set of
+    ``scripts/X`` paths that exist. Returns a list of violation dicts."""
+    out: List[Dict[str, str]] = []
+    for stage in stages:
+        toolsets = set(stage.get("toolsets") or [])
+        has_terminal = "terminal" in toolsets
+        for ref in stage.get("skills") or []:
+            name = skill_ref_to_name(str(ref))
+            text = skill_texts.get(name)
+            if text is None:
+                out.append(
+                    {
+                        "stage": stage["name"],
+                        "skill": name,
+                        "kind": "missing_skill",
+                        "detail": f"stage references skill '{ref}' with no SKILL.md",
+                    }
+                )
+                continue
+            for script in extract_run_commands(text):
+                if script not in existing_scripts:
+                    out.append(
+                        {
+                            "stage": stage["name"],
+                            "skill": name,
+                            "kind": "missing_script",
+                            "detail": f"runs `{script}` which does not exist",
+                        }
+                    )
+                elif not has_terminal:
+                    out.append(
+                        {
+                            "stage": stage["name"],
+                            "skill": name,
+                            "kind": "no_terminal",
+                            "detail": (
+                                f"runs `{script}` but stage toolsets {sorted(toolsets)} "
+                                f"lack 'terminal' — the command can never execute"
+                            ),
+                        }
+                    )
+    return out
+
+
+# ── IO boundary ────────────────────────────────────────────────────────────────
+def _load_stages(cron_dir: Path) -> List[Dict[str, Any]]:
+    import yaml
+
+    stages: List[Dict[str, Any]] = []
+    for y in sorted(cron_dir.glob("*.yaml")):
+        try:
+            d = yaml.safe_load(y.read_text(encoding="utf-8")) or {}
+        except Exception:
+            continue
+        if d.get("no_agent"):  # script-only stages own no skills
+            continue
+        stages.append(
+            {
+                "name": y.stem,
+                "skills": d.get("skills") or [],
+                "toolsets": d.get("toolsets") or [],
+            }
+        )
+    return stages
+
+
+def _load_skill_texts(skills_dir: Path) -> Dict[str, str]:
+    texts: Dict[str, str] = {}
+    for md in skills_dir.glob("**/SKILL.md"):
+        text = md.read_text(encoding="utf-8")
+        m = _NAME_RE.search(text)
+        name = m.group(1) if m else md.parent.name
+        texts[name] = text
+    return texts
+
+
+def lint_repo(repo_root: Optional[Path] = None) -> List[Dict[str, str]]:
+    """Lint the real repo: evolution cron stages × their skills × scripts/."""
+    root = Path(repo_root) if repo_root else Path(__file__).resolve().parents[1]
+    stages = _load_stages(root / "cron" / "evolution")
+    skill_texts = _load_skill_texts(root / "skills" / "evolution")
+    existing = {
+        f"scripts/{p.name}" for p in (root / "scripts").glob("*") if p.is_file()
+    }
+    return find_violations(stages, skill_texts, existing)
+
+
+def main(argv: List[str]) -> int:
+    violations = lint_repo()
+    if not violations:
+        print("[evolution-skill-lint] OK — no dead skill→script wiring")
+        return 0
+    print(f"[evolution-skill-lint] {len(violations)} violation(s):", file=sys.stderr)
+    for v in violations:
+        print(f"  - [{v['kind']}] {v['stage']}/{v['skill']}: {v['detail']}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_skill_integrity.py
+++ b/tests/scripts/test_evolution_skill_integrity.py
@@ -1,0 +1,94 @@
+"""Enforced skill-integrity gate (scripts/evolution_skill_lint.py).
+
+The real-repo test is the ENFORCEMENT: if any evolution skill ever instructs a
+stage to run a script that doesn't exist, or a command in a stage without the
+`terminal` toolset, CI fails — turning the lesson of #101/#188 from "the agent
+should notice" into "merge is blocked".
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_skill_lint import (  # noqa: E402
+    extract_run_commands,
+    find_violations,
+    lint_repo,
+    skill_ref_to_name,
+)
+
+
+class TestRealRepoEnforcement:
+    def test_real_repo_has_no_dead_wiring(self):
+        # Blocks merge if a skill gains a dead script reference or a command its
+        # stage can't run. Also proves the #188 fix left nothing else broken.
+        violations = lint_repo()
+        assert violations == [], f"dead skill->script wiring: {violations}"
+
+
+class TestExtractRunCommands:
+    def test_python_and_python3(self):
+        assert extract_run_commands("run python scripts/a.py now") == ["scripts/a.py"]
+        assert extract_run_commands("python3 scripts/b.py --x") == ["scripts/b.py"]
+
+    def test_bash_and_dotslash(self):
+        assert extract_run_commands("bash scripts/c.sh") == ["scripts/c.sh"]
+        assert extract_run_commands("./scripts/d.sh") == ["scripts/d.sh"]
+
+    def test_ignores_bare_inline_mention(self):
+        # The #101 cautionary note names a non-existent script in prose — NOT a
+        # command. Must not be flagged.
+        assert extract_run_commands("a `scripts/evolution_watchdog.sh` that never existed") == []
+
+    def test_dedup_and_sorted(self):
+        assert extract_run_commands("python scripts/z.py; python scripts/a.py; python scripts/z.py") == [
+            "scripts/a.py",
+            "scripts/z.py",
+        ]
+
+
+class TestFindViolations:
+    def _stage(self, toolsets, skills=("evolution/research",)):
+        return [{"name": "research", "skills": list(skills), "toolsets": list(toolsets)}]
+
+    def test_missing_script_flagged(self):
+        v = find_violations(
+            self._stage(["web", "file", "terminal"]),
+            {"evolution-research": "bash scripts/nope.sh"},
+            {"scripts/other.py"},
+        )
+        assert len(v) == 1 and v[0]["kind"] == "missing_script"
+
+    def test_command_without_terminal_flagged(self):  # the #188 case
+        v = find_violations(
+            self._stage(["web", "file"]),
+            {"evolution-research": "python scripts/evolution_funnel.py --summary"},
+            {"scripts/evolution_funnel.py"},
+        )
+        assert len(v) == 1 and v[0]["kind"] == "no_terminal"
+
+    def test_existing_script_in_terminal_stage_is_ok(self):
+        v = find_violations(
+            self._stage(["web", "file", "terminal"]),
+            {"evolution-research": "python scripts/evolution_funnel.py"},
+            {"scripts/evolution_funnel.py"},
+        )
+        assert v == []
+
+    def test_prose_mention_not_flagged_even_if_missing(self):
+        v = find_violations(
+            self._stage(["web", "file"]),
+            {"evolution-research": "warning: `scripts/ghost.sh` never existed (see #101)"},
+            set(),
+        )
+        assert v == []
+
+    def test_missing_skill_md_flagged(self):
+        v = find_violations(self._stage(["web", "file", "terminal"]), {}, set())
+        assert len(v) == 1 and v[0]["kind"] == "missing_skill"
+
+
+def test_skill_ref_to_name():
+    assert skill_ref_to_name("evolution/research") == "evolution-research"
+    assert skill_ref_to_name("evolution/upstream-sync") == "evolution-upstream-sync"


### PR DESCRIPTION
The first **enforced** (not instruction) calibration layer: deterministic, external verification of a failure the agent's self-review keeps missing.

## The bug class
A `SKILL.md` tells a stage to **run** a script that either:
- **doesn't exist** (#101 — a fabricated `scripts/evolution_watchdog.sh` destructively closed a wanted issue), or
- the stage **can't run** because it lacks the `terminal` toolset (#188 — `evolution-research` is web+file only, yet was wired to run the funnel script; unit tests passed, the integration was dead).

CI self-tests cover *code*, not *"can the stage that runs this skill actually run it"*. This closes that gap mechanically — so it **blocks the merge** instead of relying on the agent to notice.

## Change
- **`scripts/evolution_skill_lint.py`** — pure-function linter. Flags only **command-shaped** invocations (`python`/`bash`/`sh`/`./` + `scripts/X`), NOT bare inline mentions in prose (the #101 cautionary note that names the non-existent script is correctly **ignored** → no false positive). For each, checks the script **exists** AND the owning cron stage has **`terminal`**. Verified against the live repo: **clean** (also proves the #188 fix left nothing else broken); catches simulated #188 (`no_terminal`) and #101 (`missing`).
- **`tests/scripts/test_evolution_skill_integrity.py`** — the real-repo test **is** the enforcement (fails CI on any dead wiring) + 10 unit tests.
- **`tests.yml`** — a `skills/**` or `cron/**` change no longer counts as `docs_only`, so the test job (hence this gate) **runs on skill-only PRs** — exactly the PRs that can introduce dead wiring (#188 was a skill-only edit that would otherwise skip tests).

## Verification
11 tests green; ruff clean; linter run against the live repo returns OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)