### PR TITLE
evolution: measurement spine — longitudinal meta-evolution health metrics

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -237,6 +237,19 @@ def main(argv: list[str]) -> int:
     except OSError:
         pass
 
+    # Refresh the longitudinal health sidecar too (meta-evolution metrics, rec
+    # 4.3): "is the pipeline improving?" readable by any file-toolset stage. Lazy
+    # import avoids a module cycle (evolution_metrics imports load_records here).
+    try:
+        from evolution_metrics import compute_health, format_health
+
+        (evolution_dir / "evolution-health.txt").write_text(
+            format_health(compute_health(load_records(evolution_dir / "metrics.jsonl"), 30)) + "\n",
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Longitudinal meta-evolution metrics — is the pipeline actually getting better?
+
+The funnel records ONE per-cycle line; this reads the whole history and answers
+the meta question (issue #84 / recommendations rec 4.3): across cycles, is the
+pipeline healthy and improving, or stagnating? You cannot honestly trust a system
+for autonomy you cannot measure — this is the measurement spine that makes
+"is it good enough yet?" an evidence question instead of a vibe.
+
+Metrics (all deterministic, from the existing metrics.jsonl — no creds, no LLM):
+  * cycle_success_rate — of ACTIVE cycles (something was selected/created), the
+    fraction that landed >=1 merge. Idle days are not counted as failures.
+  * selection_efficiency — total merged / total selected over the window. A
+    CALIBRATION proxy: of what the pipeline DECIDED to implement, how much
+    actually merged. Low = it picks work it can't land (poor self-capability
+    calibration). Proxy only — selection and its merge can fall in different
+    cycles (the pipeline is async), so read it over a window, not per-cycle.
+  * reject_rate — rejected / (selected + rejected): triage selectivity.
+  * merged_trend — mean merges in the window's 2nd half vs 1st half: improving /
+    flat / declining.
+
+Pure functions + explicit IO so it is import-safe and unit-testable. Reuses
+evolution_funnel.load_records (single source of truth for reading the log).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from evolution_funnel import load_records  # noqa: E402
+
+
+def _int(rec: Dict[str, Any], key: str) -> int:
+    try:
+        return int(rec.get(key, 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_active(rec: Dict[str, Any]) -> bool:
+    """A cycle that actually had work — not an idle day or a premature/artifact
+    all-zero record. Idle days must not drag down success rate."""
+    return _int(rec, "selected") > 0 or _int(rec, "issues_created") > 0
+
+
+def _trend(values: List[int]) -> str:
+    """improving / flat / declining by comparing 2nd-half mean to 1st-half mean."""
+    n = len(values)
+    if n < 2:
+        return "n/a"
+    mid = n // 2
+    first = values[:mid]
+    second = values[mid:]
+    if not first or not second:
+        return "n/a"
+    a = sum(first) / len(first)
+    b = sum(second) / len(second)
+    if b > a * 1.15:
+        return "improving"
+    if b < a * 0.85:
+        return "declining"
+    return "flat"
+
+
+def compute_health(records: List[Dict[str, Any]], last: int = 30) -> Dict[str, Any]:
+    window = records[-last:] if last and last > 0 else list(records)
+    active = [r for r in window if _is_active(r)]
+
+    sel = sum(_int(r, "selected") for r in active)
+    mrg = sum(_int(r, "merged") for r in active)
+    rej = sum(_int(r, "rejected") for r in active)
+    created = sum(_int(r, "issues_created") for r in active)
+    triaged = sel + rej
+
+    succeeded = sum(1 for r in active if _int(r, "merged") > 0)
+    cycle_success_rate = (succeeded / len(active)) if active else None
+    selection_efficiency = (mrg / sel) if sel else None
+    reject_rate = (rej / triaged) if triaged else None
+
+    flags: List[str] = []
+    # Only judge once there is enough signal to mean anything.
+    if len(active) >= 3:
+        if cycle_success_rate is not None and cycle_success_rate < 0.34:
+            flags.append("LOW_SUCCESS: <1/3 of active cycles land a merge")
+        if selection_efficiency is not None and selection_efficiency < 0.34:
+            flags.append(
+                "LOW_SELECTION_EFFICIENCY: picks more than it can land "
+                "(poor self-capability calibration)"
+            )
+
+    return {
+        "cycles_total": len(window),
+        "cycles_active": len(active),
+        "issues_created": created,
+        "selected": sel,
+        "merged": mrg,
+        "rejected": rej,
+        "cycle_success_rate": round(cycle_success_rate, 3) if cycle_success_rate is not None else None,
+        "selection_efficiency": round(selection_efficiency, 3) if selection_efficiency is not None else None,
+        "reject_rate": round(reject_rate, 3) if reject_rate is not None else None,
+        "merged_trend": _trend([_int(r, "merged") for r in active]),
+        "flags": flags,
+    }
+
+
+def _pct(x: Optional[float]) -> str:
+    return "n/a" if x is None else f"{x:.0%}"
+
+
+def format_health(h: Dict[str, Any]) -> str:
+    tail = " | ".join(h["flags"]) if h["flags"] else "healthy"
+    return (
+        f"[evolution-metrics] {h['cycles_active']}/{h['cycles_total']} active cycles: "
+        f"success={_pct(h['cycle_success_rate'])} "
+        f"selection_efficiency={_pct(h['selection_efficiency'])} "
+        f"reject_rate={_pct(h['reject_rate'])} merged_trend={h['merged_trend']} "
+        f"(created={h['issues_created']} selected={h['selected']} merged={h['merged']}) | {tail}"
+    )
+
+
+def main(argv: List[str]) -> int:
+    import os
+
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    )
+    args = argv[1:]
+    last = 30
+    if "--last" in args:
+        i = args.index("--last")
+        if i + 1 < len(args):
+            try:
+                last = int(args[i + 1])
+            except ValueError:
+                last = 30
+    records = load_records(evolution_dir / "metrics.jsonl")
+    print(format_health(compute_health(records, last)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_metrics.py
+++ b/tests/scripts/test_evolution_metrics.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/evolution_metrics.py — longitudinal meta-evolution health."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_metrics import compute_health, format_health  # noqa: E402
+
+
+def _rec(date, created=0, selected=0, rejected=0, merged=0):
+    return {
+        "date": date,
+        "issues_created": created,
+        "selected": selected,
+        "rejected": rejected,
+        "merged": merged,
+    }
+
+
+class TestComputeHealth:
+    def test_idle_and_artifact_cycles_excluded_from_active(self):
+        recs = [
+            _rec("d1", selected=2, merged=1),
+            _rec("d2"),  # idle / all-zero artifact — must NOT count as a failed cycle
+            _rec("d3", created=3, selected=0, merged=0),  # active (created>0), no merge
+        ]
+        h = compute_health(recs)
+        assert h["cycles_total"] == 3
+        assert h["cycles_active"] == 2  # d2 excluded
+        # 1 of 2 active cycles merged
+        assert h["cycle_success_rate"] == 0.5
+
+    def test_selection_efficiency_proxy(self):
+        recs = [_rec(f"d{i}", selected=10, merged=3) for i in range(5)]
+        h = compute_health(recs)
+        assert h["selection_efficiency"] == round(15 / 50, 3)  # 0.3
+
+    def test_low_efficiency_flagged_only_with_enough_signal(self):
+        # < 3 active cycles → no judgement (insufficient signal)
+        few = [_rec("d1", selected=10, merged=0), _rec("d2", selected=10, merged=0)]
+        assert compute_health(few)["flags"] == []
+        # >= 3 active cycles with poor efficiency → flagged
+        many = [_rec(f"d{i}", selected=10, merged=0) for i in range(4)]
+        flags = compute_health(many)["flags"]
+        assert any("LOW_SUCCESS" in f for f in flags)
+        assert any("LOW_SELECTION_EFFICIENCY" in f for f in flags)
+
+    def test_healthy_pipeline_no_flags(self):
+        recs = [_rec(f"d{i}", selected=4, merged=3, rejected=1) for i in range(5)]
+        h = compute_health(recs)
+        assert h["flags"] == []
+        assert "healthy" in format_health(h)
+
+    def test_empty_history_no_crash(self):
+        h = compute_health([])
+        assert h["cycles_active"] == 0
+        assert h["cycle_success_rate"] is None
+        assert h["selection_efficiency"] is None
+        assert "[evolution-metrics]" in format_health(h)
+        assert "n/a" in format_health(h)
+
+    def test_merged_trend(self):
+        improving = [_rec(f"d{i}", selected=1, merged=m) for i, m in enumerate([0, 0, 3, 4])]
+        assert compute_health(improving)["merged_trend"] == "improving"
+        declining = [_rec(f"d{i}", selected=1, merged=m) for i, m in enumerate([4, 3, 0, 0])]
+        assert compute_health(declining)["merged_trend"] == "declining"
+
+    def test_window_last_n(self):
+        recs = [_rec(f"d{i}", selected=1, merged=1) for i in range(40)]
+        assert compute_health(recs, last=10)["cycles_total"] == 10


### PR DESCRIPTION
You cannot honestly trust a system for autonomy you cannot measure. This is the **evidence layer** (rec 4.3 / #84) that turns "is autonomy good enough yet?" into a data question — the prerequisite for ever being satisfied the pipeline is *improving*, not just running.

## Change
- **`scripts/evolution_metrics.py`** — deterministic longitudinal health from the existing `metrics.jsonl` (no creds, no LLM; reuses `evolution_funnel.load_records`):
  - `cycle_success_rate` over **active** cycles (idle / artifact all-zero days excluded → not counted as failures).
  - `selection_efficiency` = merged / selected — a **calibration proxy**: of what the pipeline chose to implement, how much actually landed (low = it picks work it can't land).
  - `reject_rate`; `merged_trend` (improving / flat / declining).
  - Flags only with ≥3 active cycles of signal — never judges on noise.
- **`evolution_funnel.py`** — the daily `no_agent` run now also refreshes an `evolution-health.txt` sidecar (lazy import avoids a module cycle), so the longitudinal signal is produced every cycle and readable by any file-toolset stage (same pattern as the funnel-summary sidecar, #188).
- **`tests/scripts/test_evolution_metrics.py`** — 7 tests.

## Verification
33 evolution-script tests green (metrics 7 + funnel 15 + skill-integrity 11); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)