### PR TITLE
evolution: watchdog alerts on degraded pipeline health — close the measure loop

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -186,6 +186,25 @@ def check_gh(runner: Callable[[List[str]], Tuple[int, str]] = _default_runner) -
     return alerts
 
 
+def check_health(evolution_dir: Path) -> List[str]:
+    """Alert when the longitudinal health sidecar reports degraded calibration.
+
+    evolution_metrics writes ``evolution-health.txt`` ending in ``| healthy`` when
+    fine, or ``| <FLAGS>`` (LOW_SUCCESS / LOW_SELECTION_EFFICIENCY) when the
+    pipeline is selecting more than it can land / rarely merging. This is what
+    makes the measurement spine ACTIONABLE instead of write-only: the owner gets
+    pinged when the pipeline's own health degrades. Silent when healthy or when
+    there is no sidecar yet (the stage-report checks already cover 'funnel didn't
+    run')."""
+    try:
+        line = (evolution_dir / "evolution-health.txt").read_text(encoding="utf-8").strip()
+    except OSError:
+        return []
+    if not line or line.endswith("| healthy"):
+        return []
+    return [f"pipeline health degraded: {line}"]
+
+
 def main() -> int:
     hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     evolution_dir = Path(
@@ -212,6 +231,7 @@ def main() -> int:
     alerts += check_stage_reports(evolution_dir, now)
     alerts += check_jobs(jobs_file, now)
     alerts += check_gh()
+    alerts += check_health(evolution_dir)
 
     if alerts:
         print("🐶 Evolution watchdog — pipeline anomalies detected:")

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -224,3 +224,28 @@ class TestStagesMirrorCronSpecs:
                 f"watchdog STAGES says '{stage}' runs at {slot:02d}:00, "
                 f"but {stage}.yaml schedules hour {m.group(2)}"
             )
+
+
+class TestCheckHealth:
+    from evolution_watchdog import check_health
+
+    def test_healthy_sidecar_is_silent(self, tmp_path):
+        from evolution_watchdog import check_health
+        (tmp_path / "evolution-health.txt").write_text(
+            "[evolution-metrics] 5/5 active cycles: success=80% ... | healthy\n", encoding="utf-8"
+        )
+        assert check_health(tmp_path) == []
+
+    def test_flagged_sidecar_alerts(self, tmp_path):
+        from evolution_watchdog import check_health
+        (tmp_path / "evolution-health.txt").write_text(
+            "[evolution-metrics] 4/4 active cycles: success=10% ... | "
+            "LOW_SUCCESS: <1/3 of active cycles land a merge\n",
+            encoding="utf-8",
+        )
+        alerts = check_health(tmp_path)
+        assert len(alerts) == 1 and "health degraded" in alerts[0] and "LOW_SUCCESS" in alerts[0]
+
+    def test_missing_sidecar_is_silent(self, tmp_path):
+        from evolution_watchdog import check_health
+        assert check_health(tmp_path) == []


### PR DESCRIPTION
The measurement spine (#191) wrote `evolution-health.txt` but **nothing read it** — the same write-only mistake the funnel feedback loop (#188) fixed. A metric no one consumes is dead.

## Change
Makes the health signal **actionable**: the daily watchdog (`no_agent`, 07:47 — after the funnel writes the sidecar at 07:40) now reads the health line and **alerts the owner** when it carries a flag (`LOW_SUCCESS` / `LOW_SELECTION_EFFICIENCY`) — i.e. when the pipeline selects more than it can land or rarely merges.

- `evolution_watchdog.py`: `check_health()` — reads `evolution-health.txt`; alerts only when the line does **not** end in `| healthy`; silent when healthy or when there's no sidecar yet (dependency-free text read, matching the watchdog's alert-on-anomaly design).
- tests: healthy → silent, flagged → alert, missing → silent.

Completes the **produce → consume → alert** loop, so the owner is pinged when the pipeline's own calibration degrades — a real trust property for unattended runs.

## Verification
25 watchdog tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)