### PR TITLE
evolution: idempotent issue filing — search exact title before gh issue create

### DIFF
--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -124,10 +124,22 @@ BODY="$CLEANED"
 
 Then create:
 
+   **Idempotency guard — search GitHub by EXACT title before creating.** The
+   local cache check above does NOT protect against a `gh issue create` that
+   silently succeeds but whose response times out, so you "retry" and file a true
+   duplicate (this happened — #193/#194, identical body, 13s apart, one proposal).
+   So immediately before creating, confirm no OPEN issue already has this exact
+   title; if one does, SKIP the create and just record it:
 ```bash
-gh issue create \
+TITLE="[FEATURE] <short title>"   # right prefix per category: [FEATURE]/[FIX]/[IMPROVEMENT]/...
+existing=$(gh issue list --repo "$REPO" --state open --search "in:title $TITLE" \
+  --json number,title --jq ".[] | select(.title==\"$TITLE\") | .number" | head -1)
+```
+   Create ONLY when `$existing` is empty:
+```bash
+[ -z "$existing" ] && gh issue create \
   --repo "$REPO" \
-  --title "[FEATURE] <short title>" \
+  --title "$TITLE" \
   --label "enhancement,proposal,research-generated" \
   --body "$BODY"
 ```


### PR DESCRIPTION
The autonomous issues stage filed a **true duplicate** today (#193/#194: identical body, 13s apart, ONE proposal, recorded once in the dedup cache).

## Root cause
`gh issue create` silently succeeded but its response timed out → the agent "retried" → a second identical issue. The local dedup-cache check can't catch this: the proposal was in the list once and the cache was written once.

## Fix
Before creating, search GitHub by **exact title** and skip the create if a matching OPEN issue already exists — making filing **idempotent** against retry / in-run / cross-cycle duplicates, regardless of cause. Closed #194 as the duplicate.

Skill-only change; `skill-lint` stays clean. Also a live exercise of the #190 `docs_only` fix — a `skills/**` PR now runs the full test job (incl. the skill-integrity gate) instead of skipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)