### PR TITLE
evolution: research report hygiene — keep telemetry + monologue out of the delivered report

### DIFF
--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -39,12 +39,15 @@ Keywords: "agent", "autonomous", "LLM tool use", "multi-agent"
    so READ the sidecar the nightly funnel job refreshes — do NOT try to run a
    script: open `~/.hermes/profiles/user1/evolution/funnel-summary.txt` (a single
    `[evolution-funnel] …` line). If it's missing, treat as `signal OK` and
-   proceed. Let its flags set this cycle's bar:
+   proceed. This signal is **INTERNAL — it only sets your selectivity bar. Do
+   NOT mention it, the `[evolution-funnel]` line, `reject_rate`, or flag names in
+   your report** (that delivered report goes to the owner; pipeline telemetry is
+   noise there). Let its flags set this cycle's bar, silently:
    - `HIGH_REJECT_RATE` flag → triage has been rejecting most of what research
      surfaces. **Raise the bar:** propose fewer, higher-evidence findings this
      cycle; a popular/new trend is not enough.
    - `MERGED_ZERO xN` flag → downstream integration is stuck; piling on more
-     volume won't help. Keep output lean and note the stall in the report.
+     volume won't help. Keep output lean (and keep this to yourself).
    - `signal OK` → proceed normally.
 
 1. **Scan sources** using `web_search`
@@ -89,6 +92,14 @@ Description...
 ## Replacements
 ...
 ```
+
+**Your delivered final response = the report ITSELF, nothing else.** This output
+is sent straight to the owner. Start directly with `# Research Report - YYYY-MM-DD`
+and include ONLY the findings (the schema above). Do NOT prepend status narration
+or your own reasoning ("the report is saved", "now I'll provide my final
+response"), do NOT mention that you are a cron job / `send_message` / delivery
+mechanics, and do NOT include pipeline telemetry (the funnel signal). The owner
+wants the research, not the plumbing.
 
 ## Limits
 


### PR DESCRIPTION
**User-reported:** a research report arrived in Telegram "mixed with technical information".

## Diagnosis (on the server)
The scheduler delivers ONLY `final_response` (the full prompt/record stays on disk as `cron/output/.../*.md`), so the noise came from the report text itself. Today's delivered research `final_response` led with:
- the agent's **internal monologue** — *"the report is saved... I should NOT use send_message... since I'm running as a cron job..."*, then
- the **raw funnel signal** — *"Funnel signal: OK — 3 created, 7 selected, 0 rejected, 1 merged"*.

The funnel part is a **#188 regression**: research was told to READ the funnel signal and then printed it. That signal is INTERNAL — it only sets the selectivity bar; it must not reach the owner-facing report.

## Fix (research skill)
- **step 0:** the funnel signal is explicitly INTERNAL — do NOT mention it, the `[evolution-funnel]` line, `reject_rate`, or flag names in the report.
- **output format:** the delivered final response = the report ITSELF, starting at `# Research Report`; no status narration / reasoning, no cron/`send_message` mechanics, no pipeline telemetry.

`skill-lint` stays clean. Forward-looking — the already-delivered message can't be unsent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)