### PR TITLE
fix(cron): mechanically strip model reasoning from delivered output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1412,6 +1412,27 @@ def _scan_assembled_cron_prompt(
     return assembled
 
 
+def strip_reasoning_for_delivery(text: str) -> str:
+    """Remove model reasoning/thinking blocks from a cron-delivered message.
+
+    Cron output must be the RESULT only — never the model's reasoning. The
+    delivery hint asks the agent for clean output, but instructions are not a
+    guarantee, so we also strip any `<think>`/`<thinking>`/`<reasoning>` blocks
+    mechanically here, at the delivery boundary. This is CRON-ONLY (interactive
+    sessions may legitimately surface reasoning); inline untagged narration is
+    handled by the delivery-hint instruction, not here."""
+    if not text:
+        return text
+    import re
+
+    return re.sub(
+        r"<(think|thinking|reasoning|reasoning_scratchpad)\b[^>]*>.*?</\1>",
+        "",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    ).strip()
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
@@ -2202,7 +2223,11 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 # Deliver the final response to the origin/target chat.
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                deliver_content = (
+                    strip_reasoning_for_delivery(final_response)
+                    if success
+                    else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                )
                 # Treat whitespace-only final responses the same as empty
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.

--- a/tests/cron/test_strip_reasoning_delivery.py
+++ b/tests/cron/test_strip_reasoning_delivery.py
@@ -1,0 +1,36 @@
+"""Cron deliveries must contain the RESULT only — never model reasoning."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from cron.scheduler import strip_reasoning_for_delivery as strip  # noqa: E402
+
+
+def test_strips_think_block():
+    assert strip("<think>let me reason</think>\n# Report\nresult") == "# Report\nresult"
+
+
+def test_strips_multiline_and_case_insensitive():
+    txt = "<Thinking>\nplan\nstep\n</Thinking>\n\nThe answer is 42."
+    assert strip(txt) == "The answer is 42."
+
+
+def test_strips_reasoning_and_scratchpad_tags():
+    assert strip("<reasoning>x</reasoning>RESULT") == "RESULT"
+    assert strip("<REASONING_SCRATCHPAD>y</REASONING_SCRATCHPAD>\nok") == "ok"
+
+
+def test_strips_multiple_blocks():
+    assert strip("<think>a</think>line1\n<think>b</think>line2") == "line1\nline2"
+
+
+def test_clean_text_unchanged():
+    rep = "# Research Report - 2026-06-14\n\n## New Features\n- X"
+    assert strip(rep) == rep
+
+
+def test_empty_and_none_safe():
+    assert strip("") == ""
+    assert strip(None) is None


### PR DESCRIPTION
**User directive:** cron jobs must deliver ONLY the result (or errors) — never the model's reasoning/thinking process.

#201 added the delivery-hint instruction ("clean output, no preamble"), but instructions are not a guarantee — the agent still leaked. This adds the **mechanical enforcement** at the delivery boundary:

- `strip_reasoning_for_delivery()` removes `<think>` / `<thinking>` / `<reasoning>` / `<reasoning_scratchpad>` blocks (Hermes embeds native reasoning in `<think>` tags — see `agent_runtime_helpers`) from the cron `final_response` before sending.
- **CRON-ONLY**: interactive sessions may legitimately surface reasoning; the success-path `final_response` (`conversation_loop.py` = `assistant_message.content`, not think-stripped) is left untouched for non-cron callers.

Two layers now cover the directive: (1) #201 instruction → the agent aims for clean output; (2) this mechanical strip → tagged reasoning is removed regardless of whether the agent complied. Inline *untagged* narration is only addressable by (1).

## Verification
6 new tests (`test_strip_reasoning_delivery.py`) + 134 scheduler tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)