### PR TITLE
fix(cron): strip only LEADING reasoning blocks — stop corrupting inline mentions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1417,19 +1417,26 @@ def strip_reasoning_for_delivery(text: str) -> str:
 
     Cron output must be the RESULT only — never the model's reasoning. The
     delivery hint asks the agent for clean output, but instructions are not a
-    guarantee, so we also strip any `<think>`/`<thinking>`/`<reasoning>` blocks
-    mechanically here, at the delivery boundary. This is CRON-ONLY (interactive
-    sessions may legitimately surface reasoning); inline untagged narration is
-    handled by the delivery-hint instruction, not here."""
+    guarantee, so we also strip `<think>`/`<thinking>`/`<reasoning>` blocks
+    mechanically here, at the delivery boundary (CRON-ONLY — interactive sessions
+    may legitimately surface reasoning).
+
+    Only LEADING / own-line blocks are stripped — Hermes prepends native
+    reasoning as ``<think>\\n...\\n</think>\\n`` (see agent_runtime_helpers), so a
+    reasoning block always starts a line. An INLINE ``<think>...</think>``
+    mid-sentence is left intact, because a report may legitimately quote/discuss
+    the tag (e.g. an agent-research report about reasoning models) and silently
+    deleting that content would be worse than the leak. Inline untagged narration
+    is handled by the delivery-hint instruction, not here."""
     if not text:
         return text
     import re
 
     return re.sub(
-        r"<(think|thinking|reasoning|reasoning_scratchpad)\b[^>]*>.*?</\1>",
+        r"^[ \t]*<(think|thinking|reasoning|reasoning_scratchpad)\b[^>]*>.*?</\1>[ \t]*\n?",
         "",
         text,
-        flags=re.IGNORECASE | re.DOTALL,
+        flags=re.IGNORECASE | re.DOTALL | re.MULTILINE,
     ).strip()
 
 

--- a/tests/cron/test_strip_reasoning_delivery.py
+++ b/tests/cron/test_strip_reasoning_delivery.py
@@ -34,3 +34,15 @@ def test_clean_text_unchanged():
 def test_empty_and_none_safe():
     assert strip("") == ""
     assert strip(None) is None
+
+
+def test_inline_mention_preserved_not_corrupted():
+    # A report may legitimately quote/discuss the tag — only LEADING/own-line
+    # reasoning is stripped, never an inline mid-sentence mention (regression:
+    # the first cut silently deleted '<think>hidden</think>' from real content).
+    rep = "# Report\nThe model emits <think>hidden</think> blocks we must strip."
+    assert strip(rep) == rep
+
+
+def test_own_line_block_stripped_but_surrounding_kept():
+    assert strip("intro\n<think>mid</think>\nmore") == "intro\nmore"


### PR DESCRIPTION
Self-check found a **content-corrupting false positive** in #202: the reasoning strip removed ANY `<think>...</think>` anywhere, including an **inline mid-sentence mention**. A report that legitimately quotes/discusses the tag — entirely plausible for an agent-research pipeline (e.g. *"the model emits `<think>…</think>` blocks"*) — would be **silently mangled**. Deleting real content is worse than the leak it prevents.

## Fix
Anchor the strip to **leading / own-line** blocks only (`^[ \t]*<think>...</think>`, `MULTILINE`). Hermes prepends native reasoning as `<think>\n...\n</think>\n` (see `agent_runtime_helpers`), so a real reasoning block always starts a line; an inline mid-sentence mention is now left intact.

Verified:
- leading Hermes reasoning → stripped ✓
- own-line block → stripped ✓
- **inline mention → preserved ✓ (regression test added)**
- clean report → unchanged ✓

8 strip tests + 134 scheduler tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)