### PR TITLE
docs: add evolution audit + improvement-recommendations reports

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,259 @@
+# Повний аудит hermes-agent-evolution
+
+**Дата аудиту:** 2026-06-13  
+**Директорія:** `/Users/admin/_Projects/hermes-agent-evolution`  
+**Версія проєкту:** `0.16.0` (`hermes_cli/__init__.py:17`)  
+**Upstream sync:** `v2026.6.5` (`.evolution/upstream-sync-state.json`)
+
+---
+
+## 📊 Загальні метрики
+
+| Показник | Значення |
+|---|---|
+| Python-файлів | 2239 |
+| Рядків Python-коду | ~515 660 |
+| Рядків Python-тестів | ~544 163 |
+| Співвідношення тест/код | 1.06× |
+| TypeScript/TSX-файлів | 833 |
+| Рядків TS/TSX-коду | ~126 000 |
+| Загальна кількість тестів | 30 619+ |
+| Залежностей у venv | 136 |
+| Розмір `uv.lock` | 618 KB |
+| Активність за 30 днів | 3046 комітів |
+
+---
+
+## ✅ Що зроблено добре
+
+1. **Ізоляція тестів** — `scripts/run_tests_parallel.py` запускає кожен тестовий файл у окремому процесі, що закриває міжфайлове забруднення стану.
+2. **Hermetic fixtures** — `tests/conftest.py` скидає credential-змінні середовища, ізолює `HERMES_HOME`, фіксує `TZ=UTC` і `PYTHONHASHSEED=0`.
+3. **Windows-footguns guard** — `scripts/check-windows-footguns.py` пройшов без знахідок (`624 file(s) scanned`).
+4. **Guard оновлення** — `_validate_critical_files_syntax()` у `hermes_cli/main.py` перевіряє синтаксис критичних файлів після `git pull`.
+5. **CODEOWNERS для evolution** — критичні шляхи self-update, CI, cron та evolution-skills вимагають рев’ю власника (`.github/CODEOWNERS`).
+6. **UV lockfile синхронізований** — `uv lock --check` пройшов успішно.
+7. **Політика pinning** — `pyproject.toml` використовує exact-pinned залежності в ядрі з чітким обґрунтуванням безпеки.
+8. **Багатий CI/CD** — 17 workflow у `.github/workflows/`: тести, lint, supply-chain audit, OSV scanner, Nix, Docker.
+9. **Безпечний YAML frontmatter** — `agent/skill_utils.py:76` використовує `CSafeLoader`/`SafeLoader`.
+10. **Актуальна upstream sync-інформація** — `.evolution/upstream-sync-state.json` відображає synced_through_tag = `v2026.6.5`.
+
+---
+
+## 🔴 Критичні проблеми (треба виправити негайно)
+
+### 1. Ліцензійна невідповідність
+- `README.md:7` — значок `License: Apache 2.0`.
+- `README.md:148` — текст `Apache License 2.0`.
+- `EVOLUTION_README.md:261` — `Apache 2.0`.
+- `LICENSE`, `pyproject.toml:22`, `package.json:29`, `README.ur-pk.md`, `README.zh-CN.md` — **MIT**.
+
+**Виправлення:** привести `README.md` та `EVOLUTION_README.md` до MIT або змінити `LICENSE` і всі metadata на Apache 2.0. Рекомендовано MIT, оскільки більшість файлів уже вказують MIT.
+
+### 2. `package.json` вказує на оригінальний репозиторій
+- `package.json:3` — `"version": "1.0.0"` (не відповідає `pyproject.toml:10` = `0.16.0`).
+- `package.json:27` — `repository.url` = `https://github.com/NousResearch/Hermes-Agent.git`.
+
+**Виправлення:**
+```json
+"version": "0.16.0",
+"repository": {
+  "type": "git",
+  "url": "git+https://github.com/Lexus2016/hermes-agent-evolution.git"
+}
+```
+
+### 3. Тестова suite не проходить на macOS
+Запущено 2 з 6 slices:
+
+- **Slice 1/6**: 139 passed, **6 failed** (`tests/hermes_cli/test_gateway_service.py`) — через відсутність user systemd/D-Bus на macOS.
+- **Slice 2/6**: 252 passed, **13 failed**:
+  - `tests/hermes_cli/test_gateway_service.py` (6) — systemd;
+  - `tests/hermes_cli/test_gateway_wsl.py` (2) — WSL-only;
+  - `tests/agent/test_bedrock_integration.py` (1) — AWS credentials;
+  - `tests/acp/test_permissions.py::test_scheduler_failure_closes_permission_coroutine` — coroutine frame cleanup;
+  - `tests/tools/test_file_state_registry.py` (2) — `/var/folders/...` визнається sensitive system path;
+  - `tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint`.
+
+**Виправлення:** додати `@pytest.mark.skipif(sys.platform == "darwin", ...)` або подібні guards для платформо-специфічних тестів.
+
+### 4. Ложне спрацьовування на macOS temp-шляхах
+`tests/tools/test_file_state_registry.py:283` падає з помилкою:
+```python
+{'error': 'Refusing to write to sensitive system path: /var/folders/...'}
+```
+Логіка в `tools/file_operations.py`/`tools/write_file` вважає `/var/folders` системним шляхом, хоча це стандартний macOS temp.
+
+**Виправлення:** розширити білий список temp-директорій для macOS (`/var/folders/`).
+
+---
+
+## 🟠 Серйозні недоліки
+
+### 5. 8913 діагностик type-checker `ty`
+Команда `ty check --output-format concise .` завершилася з:
+```
+Found 8913 diagnostics
+WARN A fatal error occurred while checking some files.
+```
+Приклади:
+- `utils.py:195:28` — `Expected Path, found str`.
+- `utils.py:261:28` — `Expected Path, found str`.
+- `tui_gateway/server.py:9308:50` — type mismatch.
+
+**Вплив:** регресії типів не ловляться CI, бо `lint.yml` використовує `ty` лише в advisory-режимі (`--exit-zero`).
+
+**Покращення:** виправляти критичні типи поступово, починаючи з core (`run_agent.py`, `model_tools.py`, `hermes_state.py`, `utils.py`).
+
+### 6. God-файли без тестів
+Великі модулі без відповідних тестів:
+
+| Файл | Рядків |
+|---|---|
+| `gateway/run.py` | 16 015 |
+| `cli.py` | 13 701 |
+| `hermes_cli/main.py` | 11 730 |
+| `tui_gateway/server.py` | 9 468 |
+| `hermes_cli/auth.py` | 7 864 |
+| `plugins/platforms/discord/adapter.py` | 6 633 |
+| `gateway/platforms/telegram.py` | 6 179 |
+| `run_agent.py` | 5 361 |
+| `gateway/platforms/yuanbao.py` | 5 057 |
+| `gateway/platforms/base.py` | 4 841 |
+| `agent/conversation_loop.py` | 4 221 |
+
+**Покращення:** рефакторити на mixins/модулі та додати unit-тести.
+
+### 7. 6198 викликів `print()` у production-коді
+Розподілені по `cli.py`, `batch_runner.py`, `hermes_cli/main.py`, `hermes_cli/web_server.py` тощо.
+
+**Покращення:** замінити на structured logging (`hermes_logging.py`).
+
+### 8. `yaml.load()` без safe loader
+- `hermes_cli/xai_retirement.py:207`:
+  ```python
+  yaml = YAML(typ="rt")
+  doc = yaml.load(fh)
+  ```
+  `ruamel.yaml.YAML(typ="rt")` — round-trip loader, безпечний для довірених файлів, але краще явно використовувати `SafeLoader`.
+
+**Покращення:** додати коментар або перейти на `SafeLoader`.
+
+### 9. `subprocess(..., shell=True)` у production
+- `cli.py:7545` — quick commands (user-defined).
+- `tools/transcription_tools.py:1236` — local STT command template з user env var `LOCAL_STT_COMMAND_ENV`.
+- `hermes_cli/tools_config.py:813` — встановлення `cua-driver` через `curl | bash`.
+- `hermes_cli/mcp_catalog.py:367` — bootstrap commands для MCP catalog.
+
+**Ризик:** command injection у місцях, де вхідні дані можуть містити пробіли/метасимволи.
+
+**Покращення:** де можливо, використовувати список аргументів замість shell; для обов’язкових shell-викликів додати валідацію вхідних даних.
+
+### 10. `HERMES_*` env-змінні для non-secret конфігурації
+У `.env.example` є:
+- `HERMES_QWEN_BASE_URL` (рядок 116)
+- `HERMES_DOCKER_BINARY` (рядок 179)
+- `HERMES_HUMAN_DELAY_MODE` / `HERMES_HUMAN_DELAY_MIN_MS` / `HERMES_HUMAN_DELAY_MAX_MS` (рядки 375–377)
+
+`AGENTS.md` прямо забороняє нові `HERMES_*` env-змінні для non-secret config; усе поведінкове налаштування має йти в `config.yaml`.
+
+**Виправлення:** перенести ці параметри в `config.yaml`/`hermes_cli/config.py`.
+
+---
+
+## 🟡 Помилки та недоліки середньої важливості
+
+### 11. Незареєстровані pytest marks
+- `pytest.mark.xdist_group` у `tests/hermes_cli/test_dashboard_auth_*.py`.
+- `pytest.mark.ssh` у `tests/tools/test_file_sync_perf.py`.
+
+Викликає `PytestUnknownMarkWarning` і може ламати запуск з `--strict-markers`.
+
+**Виправлення:** додати marks у `[tool.pytest.ini_options] markers` у `pyproject.toml`:
+```toml
+markers = [
+    "integration: ...",
+    "real_concurrent_gate: ...",
+    "xdist_group: ...",
+    "ssh: ...",
+]
+```
+
+### 12. Неправильна інструкція в `EVOLUTION_README.md`
+- `EVOLUTION_README.md:253`:
+  > Запустіть тести: `pytest tests/`
+
+Канонічний запуск — `python scripts/run_tests_parallel.py` або `scripts/run_tests.sh`.
+
+**Виправлення:** оновити інструкцію.
+
+### 13. Відсутні `__init__.py` в тестових пакетах
+- `tests/acp_adapter/`
+- `tests/hermes_state/`
+- `tests/openviking_plugin/`
+- `tests/plugins/dashboard_auth/`
+- `tests/plugins/model_providers/`
+- `tests/scripts/`
+- `tests/skills/`
+- `tests/stress/`
+- `tests/tool_cache/`
+
+Це не критично для pytest, але може викликати проблеми з імпортами.
+
+### 14. `README.md` не відображає статус форку
+`README.md` не згадує, що це форк, і спрощує ризики автономного self-merging.
+
+**Покращення:** додати посилання на `SECURITY_EVOLUTION.md` та `EVOLUTION_README.md` в шапці `README.md`.
+
+### 15. Велика кількість core tools у схемі
+`toolsets.py:_HERMES_CORE_TOOLS` містить 35+ інструментів. Хоча багато gated через `check_fn`, сама схема велика.
+
+**Покращення:** перенести менш універсальні інструменти (kanban, computer-use) у service-gated extras або MCP.
+
+### 16. Підозрілий hardcoded запис у `scripts/release.py`
+- `scripts/release.py:1303`:
+  ```python
+  "23yntong@stu.edu.cn": "iuyup",  # PR #6155 salvage (shell=True hardening)
+  ```
+
+**Перевірити**, чи це справжній обліковий запис/ключ. Коментар виглядає підозрілим.
+
+### 17. `audioop` deprecation warning
+`discord-py` імпортує `audioop`, який deprecated у Python 3.12 і буде видалений у 3.13.
+
+**Покращення:** оновити `discord-py` або додати fallback.
+
+### 18. Аномально висока активність комітів
+3046 комітів за 30 днів. Ймовірно, це squash/rebase-імпорт upstream або автоматичні коміти evolution.
+
+**Ризик:** важко рев’ювити історію та бісектити регресії.
+
+**Покращення:** впровадити політику squash merge та осмислені commit messages.
+
+---
+
+## 🔧 Рекомендований план виправлень
+
+### Терміново (цього тижня)
+1. Виправити ліцензію в `README.md` та `EVOLUTION_README.md` на MIT.
+2. Оновити `package.json`: `version` → `0.16.0`, `repository.url` → форк.
+3. Пофіксити macOS-специфічні тести (`test_file_state_registry.py`, `test_gateway_service.py`, `test_gateway_wsl.py`).
+4. Зареєструвати `xdist_group` та `ssh` marks у `pyproject.toml`.
+
+### Короткостроково (2–4 тижні)
+5. Перенести `HERMES_QWEN_BASE_URL`, `HERMES_DOCKER_BINARY`, `HERMES_HUMAN_DELAY_*` з `.env.example` у `config.yaml`.
+6. Додати `__init__.py` у тестові пакети, де цього бракує.
+7. Перевірити `scripts/release.py:1303` та видалити/пояснити hardcoded значення.
+8. Додати platform-guards для systemd/WSL-тестів.
+9. Виправити `yaml.load` у `hermes_cli/xai_retirement.py`.
+
+### Середньостроково (1–3 місяці)
+10. Почати рефакторинг god-файлів (`gateway/run.py`, `cli.py`, `hermes_cli/main.py`) на mixins.
+11. Поступово знижувати кількість `ty` diagnostics (ціль: <1000).
+12. Замінити частину `print()` на logging.
+13. Зменшити кількість core tools у схемі, переносячи нішеві інструменти в extras/MCP.
+
+---
+
+## 🛡️ Підсумок
+
+Проєкт **hermes-agent-evolution** — це масштабний, активно розвиваний форк Hermes Agent із сильними інженерними практиками (isolated tests, supply-chain pinning, Windows guards, evolution safety gate). Основні ризики зараз — це **документаційні невідповідності**, **платформо-специфічні падіння тестів на macOS** та **велика технічна заборгованість у типах і розмірі модулів**. Критичні проблеми не блокують production на Linux, але ускладнюють локальну розробку та довгострокову підтримку.

--- a/EVOLUTION_IMPROVEMENT_RECOMMENDATIONS.md
+++ b/EVOLUTION_IMPROVEMENT_RECOMMENDATIONS.md
@@ -1,0 +1,255 @@
+# Рекомендації по покращенню до цілі — автономний самоеволюціонуючий агент
+
+**Дата:** 2026-06-13
+**Базується на:** аудиті 7 скілів, 9 cron-задач, 7 допоміжних скриптів, конфігурації безпеки
+
+---
+
+## РІВЕНЬ 1 — ВИПРАВИТИ ЗАРАЗ (тиждень)
+
+### 1.1. БАГ ACCESS GATE — Bearer ***
+
+`scripts/evolution_access_gate.sh`, рядок 30. Замінити:
+
+```diff
+-        curl -fsS -H "Authorization: Bearer *** \
++        curl -fsS -H "Authorization: Bearer $_tok" \
+```
+
+Це блокує всю самоеволюцію на установках без persistent gh auth. Fallback на сирий токен з env-файлу ЗАВЖДИ падає, бо змінна ніколи не підставляється.
+
+### 1.2. ПРІОРИТЕТНА ФОРМУЛА — прибрати знаменник
+
+Зараз: `base_priority = (impact * 2) / effort`
+
+effort у знаменнику означає: trivial задача (effort=0.1, impact=0.2) = priority 4.0, тоді як критична (impact=1.0, effort=0.8) = лише 2.5. Агент постійно обирає дрібниці.
+
+Запропоновані варіанти:
+
+**Варіант A** — пом'якшити:
+```
+base_priority = impact * 2 * (1.0 - effort * 0.4)
+```
+
+**Варіант B** — effort як штраф, не дільник:
+```
+final_priority = impact * 1.5 + age_bonus + community_bonus - effort_penalty
+```
+де effort_penalty ∈ [0, 0.5]. Це робить impact головним драйвером.
+
+### 1.3. ЗОВНІШНІЙ REVIEW GATE — детермінований, замість self-audit
+
+Додати `scripts/evolution_review_gate.py` (no_agent), який ПЕРЕД merge перевіряє кожен PR:
+
+- **Dead-code check (AST-аналіз):** чи викликається новий символ хоча б з одного non-test модуля в runtime-доступному шлязі.
+- **Diff-size anomaly:** PR > 500 рядків коду (без тестів) → ручне підтвердження. PR > 1000 → автоматичний reject з лейблом `needs-split`.
+- **Coverage delta:** PR додає код, але не додає тестів → reject.
+- **Dependency audit:** PR додає нову залежність → flag (supply-chain ризик).
+- **Breaking-change detection:** PR модифікує public API → ручне рев'ю.
+
+Скрипт запускається в integration ДО виклику LLM. PR не пройшов → автоматично закривається з конкретним reason.
+
+### 1.4. CANARY ROLLOUT — затримка перед поширенням
+
+Проблема: `hermes update --yes` (щоденний cron) підтягує main на КОЖНУ установку. Поганий merge розповсюджується за 24 години.
+
+Рішення:
+
+- **Мінімум:** понизити auto-update до щотижневого (раз на неділю). PR-и мержуються щодня, але поширення — раз на тиждень = 7 днів "карантину".
+- **Повне:** integration створює tag `canary-YYYY-MM-DD`. Лише через 48 годин чистого watchdog tag підвищується до `stable-YYYY-MM-DD`. Щойно тоді `hermes update` на інших установках підтягує.
+
+---
+
+## РІВЕНЬ 2 — КОРОТКОСТРОКОВО (2-4 тижні)
+
+### 2.1. МЕТА-ЕВОЛЮЦІЯ — адаптивні інструкції (lessons.json)
+
+Проблема: скіли не можуть адаптуватись в межах циклу. Уроки вшиті в текст SKILL.md, оновлення вимагає PR + CI.
+
+Рішення: `~/.hermes/profiles/user1/evolution/lessons.json` — структурований журнал:
+
+```json
+{
+  "lessons": [
+    {
+      "date": "2026-06-13",
+      "source": "integration-review",
+      "pattern": "dead-code: PR added module with no call sites",
+      "rule": "ALWAYS run evolution_review_gate.py dead-code check before merge",
+      "severity": "high",
+      "occurrences": 3
+    }
+  ]
+}
+```
+
+Integration СКІЛ читає цей файл на початку кожного циклу і застосовує правила. Файл еволюціонує швидше за SKILL.md і є per-installation. Якщо правило стабільно працює 10 циклів — "підвищується" до пропозиції оновити SKILL.md через нормальний PR-процес.
+
+### 2.2. ЗВОРОТНИЙ ЗВ'ЯЗОК FUNNEL → RESEARCH
+
+Проблема: funnel metrics write-only. Ніщо в конвеєрі їх не читає.
+
+Рішення:
+- evolution-research читає останні 7 записів `metrics.jsonl`.
+- Якщо reject_rate > 70% — директива: "Бути вдвічі вибірковішим, лише високодоказові ідеї".
+- Якщо merged=0 три цикли поспіль — flag у watchdog-звіті.
+
+Реалізація: `python scripts/evolution_funnel.py --summary --last=7` виводить one-liner з якістю сигналу.
+
+### 2.3. КОРИСНИЦЬКИЙ ЗВОРОТНИЙ ЗВ'ЯЗОК — "task resolved?" сигнал
+
+Проблема: introspection не знає, чи користувач був задоволений.
+
+Рішення: після сесії з 5+ інструментами або 10+ ходів, агент запитує через MEMORY: "Чи розв'язав я твою задачу? (так/частково/ні)". Відповідь зберігається в session metadata.
+
+introspection_extract.py агрегує ці сигнали і додає `task_completion_rate` в digest. Non-blocking: немає відповіді і немає retry → вважати успішною.
+
+### 2.4. СПІЛЬНИЙ ДЕДУП-КАШ ДЛЯ ВСІХ УСТАНОВОК
+
+Проблема: dedup-cache.json локальний. Сотні установок досліджують ті ж тренди.
+
+Варіанти:
+- **A:** `.evolution/dedup-cache.json` у репозиторії (committed). Кожна установка перевіряє через `git pull`, записує через push (з retry при конфлікті).
+- **B:** GitHub labels як колективний дедуп: `evolution-filed-<hash>`.
+- **C:** При gh issue list >50 results — семантичний dedup через делегований subagent (не в головному контексті).
+
+### 2.5. RATE-LIMIT-AWARE SCHEDULING
+
+Додати `scripts/evolution_rate_limit.py` — pre-check перед кожною стадією:
+
+```bash
+gh api rate_limit --jq '.resources.core.remaining'
+```
+
+Якщо <500 залишилось — стадія відкладається на годину. Запобігає ситуаціям, де integration не може змержити бо research+issues+analysis вичерпали ліміт.
+
+Cron YAML: `script: evolution_rate_limit.py` (exit 0 = proceed, exit 1 = defer).
+
+---
+
+## РІВЕНЬ 3 — АРХІТЕКТУРНІ ЗМІНИ (1-3 місяці)
+
+### 3.1. БАГАТОШАРОВЕ РЕВ'Ю замість одного LLM-self-review
+
+Проблема: implementation і integration працюють на одній моделі. Self-audit (крок 2b) просить модель оцінити себе 1-10 — гарантовано сходиться до 10.
+
+Рішення — 4 послідовні шари, жоден не використовує ту ж модель, що писала код:
+
+- **Шар 1 — Детермінований** (`evolution_review_gate.py`): dead-code, coverage, diff-size, dependencies, breaking-changes. БЕЗ LLM.
+- **Шар 2 — Крос-модельний рев'ю:** PR диф відправляється в ОКРЕМУ subagent з ДРУГОЮ моделлю (delegate_task з іншим provider). Інша модель = інші сліпі плями.
+- **Шар 3 — Semantic test:** для кожного PR генерується тест-сценарій "що цей код робить?" і перевіряється, чи результат відповідає опису issue.
+- **Шар 4 — (опційно) Human review** для PR > 200 рядків або critical paths (вже частково є через CODEOWNERS).
+
+Fail на будь-якому → PR не мержиться.
+
+### 3.2. DISTRIBUTED PRIVATE MODE — fault tolerance
+
+Проблема: одна PRIVATE installation = єдина точка відмови.
+
+Рішення:
+- "Owner pool": 2+ серверів з GITHUB_PRIVATE_TOKEN. Distributed lock через GitHub: перший, хто пише comment "claiming cycle YYYY-MM-DD" на спеціальному issue, виконує.
+- Якщо заявлений сервер не завершив за 2 години — watchdog знімає lock.
+- PUBLIC стадії вже розподілені — лише PRIVATE потребує координації.
+
+### 3.3. UPSTREAM SYNC — ПРІОРИТЕТНА ЧЕРГА замість FIFO
+
+Проблема: 25 найстаріших комітів/запуск. Upstream має ~100 комітів/день. Форк НІКОЛИ не наздожене.
+
+Рішення: `scripts/evolution_classify_upstream.py` (no_agent) класифікує коміти:
+
+- CRITICAL: security, auth, data-loss fixes → processed first (без обмеження)
+- HIGH: bug fixes affecting core
+- MEDIUM: features, perf
+- LOW: docs, tests, cosmetic
+
+Ліміт 25/запуск: спершу всі CRITICAL, потім HIGH, потім решта. Security fixes не застрягають за 200 комітами з doc-оновленнями.
+
+### 3.4. КОРИСНИЦЬКИЙ ВПЛИВ НА ДОСЛІДЖЕННЯ
+
+Проблема: research читає фіксовані джерела (autogen, AutoGPT). introspection аналізує сесії заднім числом.
+
+Рішення:
+- introspection ranked feed: топ-5 problems за частотою → research отримує як "priorities to find solutions for".
+- Configurable sources: `config.yaml` дозволяє додати власні джерела дослідження.
+- Trend detection: динамічні web_search запити на основі introspection findings замість читання фіксованого списку.
+
+---
+
+## РІВЕНЬ 4 — ФУНДАМЕНТАЛЬНІ НАПРЯМКИ (дослідницькі)
+
+### 4.1. САМОМОДИФІКАЦІЯ З ГАРАНТОВАНИМИ МЕЖАМИ
+
+CI перевіряє "чи не зламалося", а не "чи покращилося". Замість тестів — formal verification constraints:
+
+- Інваріанти, що МАЮТЬ виконуватись завжди: "prompt cache розмір не зростає", "кількість core tools не перевищує N".
+- PR, що порушує інваріант — відхиляється автоматично.
+
+### 4.2. CURRICULUM LEARNING ДЛЯ САМОЕВОЛЮЦІЇ
+
+Замість випадкового порядку — навчальна траєкторія:
+
+- Фаза 1 (місяць 1): лише bug fixes (висока ймовірність успіху). Success rate target: 80%.
+- Фаза 2 (місяць 2): дрібні features (medium ризик).
+- Фаза 3 (місяць 3+): архітектурні зміни (високий ризик).
+
+Якщо success rate падає — повернутись на попередню фазу.
+
+### 4.3. META-EVOLUTION METRICS
+
+Відповісти на питання: "чи еволюціонує агент КРАЩЕ з часом?"
+
+Метрики (почати збирати негайно — безкоштовно):
+- **Cycle success rate:** % циклів, що produced merged code (має зростати).
+- **Rework rate:** % PR, що потребують rework (має знижуватись).
+- **User task completion rate:** зростає з часом?
+- **Reject reason diversity:** різноманітність причин відхилення (має зростати).
+- **Time-to-merge:** час від issue до merge (має знижуватись для trivial задач).
+
+Якщо метрики НЕ покращуються за 30 днів — самоеволюція стагнує.
+
+### 4.4. ADVERSARIAL SELF-TESTING
+
+Замість тестування "чи працює" — тестування "чи можна зламати":
+
+Для кожного змержженого PR, no_agent скрипт шукає edge case: fuzzing inputs, boundary conditions, error paths. Знайдено → issue з категорією `regression-risk`. Доповнює coverage-delta: код може мати 100% coverage, але покривати лише happy path.
+
+---
+
+## ПРІОРИТЕЗАЦІЯ
+
+### Негайно (цієї неділі)
+1. Фікс access gate баг (1.1)
+2. Пріоритетна формула (1.2)
+3. External review gate — детермінований (1.3)
+4. Canary rollout — мінімум понизити auto-update до щотижневого (1.4)
+
+### Цього місяця
+5. Meta-evolution lessons.json (2.1)
+6. Funnel feedback loop (2.2)
+7. User feedback signal (2.3)
+8. Спільний дедуп-каш (2.4)
+9. Rate-limit-aware scheduling (2.5)
+
+### Наступний квартал
+10. Multi-layer review (3.1)
+11. Distributed private mode (3.2)
+12. Priority upstream queue (3.3)
+13. Користувацький вплив на дослідження (3.4)
+
+### Дослідницькі
+14. Formal verification constraints (4.1)
+15. Curriculum learning (4.2)
+16. Meta-evolution metrics (4.3) — почати збирати негайно
+17. Adversarial self-testing (4.4)
+
+---
+
+## КЛЮЧОВИЙ ПРИНЦИП
+
+Зараз система оптимізована для THROUGHPUT (більше PR, швидше merge). Для автономної самоеволюції треба оптимізувати для CALIBRATION — здатності агента знати, що він не знає, і НЕ робити те, у чому він не впевнений:
+
+- Відхиляти більше, ніж впроваджувати (reject rate 60-70% — здоровий).
+- Зупинятись при невпевненості, а не гадати.
+- Враховувати границі власної компетенції (якщо LLM пише код, то LLM не повинен бути єдиним рев'юером цього коду).
+
+Найкраща самоеволюція — та, що еволюціонує повільно, але кожна зміна реально корисна. Швидка самоеволюція з 30% сміттєвих PR — це ентропія, а не еволюція.


### PR DESCRIPTION
Two point-in-time planning/analysis docs for the self-evolution pipeline (dated 2026-06-13), committed for traceability of the roadmap that drove this session's calibration hardening (#187-203):

- **AUDIT_REPORT.md** — full audit of skills, cron jobs, helper scripts, and security config at v0.16.0.
- **EVOLUTION_IMPROVEMENT_RECOMMENDATIONS.md** — the 4-tier improvement roadmap toward autonomous self-evolution.

Docs-only. No secrets (scanned). 🤖 Generated with [Claude Code](https://claude.com/claude-code)