### PR TITLE
fix(upstream-sync): never commit conflict markers — guard + defer

### DIFF
--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -193,8 +193,17 @@ gh pr view <pr> --repo nousresearch/hermes-agent --json mergeCommit -q .mergeCom
 git cherry-pick <hash>                 # one commit (or a contiguous range) at a time
 # On conflict: resolve THAT commit (keep our evolution changes), `git add`,
 # `git cherry-pick --continue`. If a commit is too entangled to resolve cleanly,
-# `git cherry-pick --skip` and note it in the report for a future run — do NOT
+# `git cherry-pick --skip` and DEFER it (record in deferred[] + report) — do NOT
 # fall back to a full merge to "get everything".
+#
+# ⛔ NEVER COMMIT CONFLICT MARKERS. After EVERY cherry-pick (and before
+#    --continue / before the PR), scan the worktree — a leftover marker is
+#    invalid code (it broke a sync PR once: a committed `>>>>>>>` in web_server.py
+#    = 99 syntax errors). If ANY marker remains, you did NOT resolve cleanly:
+#    abort/skip that commit and DEFER it; never `git add` a file with markers.
+# Practical guard — run after EACH cherry-pick, before committing/--continue.
+# It MUST print nothing; any output = unresolved markers = abort/skip + defer:
+git grep -lnE '^(<<<<<<<|=======|>>>>>>>)' -- ':!*.md' 2>/dev/null
 
 # 2a. WORKFLOW FILES: pushing a branch that edits `.github/workflows/**` needs the
 #     `workflow` token scope. If a picked commit touches workflows and the push is


### PR DESCRIPTION
The forced priority-first sync run (per owner request) **validated selection** — security fixes (#45947, #46083, #46112) were ordered FIRST — but exposed a real agent bug: the #46083 cherry-pick conflicted with our diverged `hermes_cli/web_server.py`, the agent **botched the resolution and committed a leftover `>>>>>>>` marker** → 99 ruff invalid-syntax errors + e2e fail (PR #206, now closed).

## Fix
Add an explicit guard to the cherry-pick instructions: after EVERY cherry-pick, before committing/`--continue`, `git grep` for conflict markers — any hit means the resolution isn't clean → abort/skip and **defer** (record in `deferred[]`). NEVER `git add` a file with markers. (The skill said "resolve or defer" but never guarded against committing a half-resolved marker.)

Selection logic unchanged — priority-first works. `skill-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)