### PR TITLE
fix(upstream-sync): conflict-marker guard matches only <<<<<<< / >>>>>>>

### DIFF
--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -202,8 +202,12 @@ git cherry-pick <hash>                 # one commit (or a contiguous range) at a
 #    = 99 syntax errors). If ANY marker remains, you did NOT resolve cleanly:
 #    abort/skip that commit and DEFER it; never `git add` a file with markers.
 # Practical guard — run after EACH cherry-pick, before committing/--continue.
-# It MUST print nothing; any output = unresolved markers = abort/skip + defer:
-git grep -lnE '^(<<<<<<<|=======|>>>>>>>)' -- ':!*.md' 2>/dev/null
+# It MUST print nothing; any output = unresolved markers = abort/skip + defer.
+# Match ONLY the unambiguous sentinels `<<<<<<<` / `>>>>>>>` (a real conflict
+# always has both). Do NOT match bare `=======` — that is a legitimate comment/
+# divider in lots of code and would false-positive, needlessly deferring clean
+# commits:
+git grep -lnE '^(<<<<<<<|>>>>>>>)' -- ':!*.md' 2>/dev/null
 
 # 2a. WORKFLOW FILES: pushing a branch that edits `.github/workflows/**` needs the
 #     `workflow` token scope. If a picked commit touches workflows and the push is


### PR DESCRIPTION
The conflict-marker guard added in #207 also matched bare `=======` — but 7+ equals is a common legitimate comment/divider in code, so `git grep` flagged ~24 clean files and would **needlessly defer clean cherry-picks**.

Found while manually porting a security fix: `#45947` cherry-picked cleanly, yet the guard "saw markers" on `=======` dividers. A real conflict ALWAYS carries `<<<<<<<` and `>>>>>>>`, so matching those two unambiguous sentinels is sufficient and false-positive-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)