### PR TITLE
evolution(mechanics): close the realized-impact loop + serve the mission

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -250,6 +250,30 @@ def main(argv: list[str]) -> int:
     except Exception:
         pass
 
+    # Refresh the realized-impact sidecar (post-merge feedback loop): "did what we
+    # MERGED actually help?" — read by analysis to shift into consolidation when
+    # the agent is shipping plausible-but-useless code, and by the watchdog to
+    # alert. Closes the blind-evolution gap (predicted impact never checked vs
+    # reality). Lazy import; never let it break the funnel job.
+    try:
+        from evolution_realized_impact import (
+            compute_realized,
+            format_realized,
+            load_ledger,
+        )
+
+        (evolution_dir / "realized-impact.txt").write_text(
+            format_realized(
+                compute_realized(
+                    load_ledger(evolution_dir / "realized" / "ledger.jsonl"), today=date
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Realized-impact feedback — did a MERGED change actually help, or was it blind?
+
+The funnel/metrics measure the pipeline up to the merge (proposed -> merged) and
+its calibration (selection_efficiency = merged/selected). They do NOT answer the
+question that closes the loop: *of what we merged, what actually delivered real
+value?* Without that, evolution is blind — the agent optimizes a PREDICTED impact
+it never checks against reality, and can keep shipping plausible-but-useless code.
+
+This is the measurement spine for that loop. It is a LIGHT, deterministic
+aggregator: the agent (integration + introspection skills) writes a ledger; this
+script reads it and reports the realized-impact rate + flags. It does no judging
+itself (no creds, no LLM) — the verdicts come from the agent verifying real
+sessions; this turns those verdicts into an evidence signal the pipeline acts on.
+
+Ledger: ``<evolution_dir>/realized/ledger.jsonl`` — one JSON object per line.
+  * at merge (integration):   {"issue", "merged_at": "YYYY-MM-DD",
+                               "predicted_impact": <0..1>, "target": "<one line>"}
+  * at verification later (introspection):
+                               {"issue", "verdict": "confirmed|no-signal|regressed",
+                               "verified_at": "YYYY-MM-DD", "note": "<one line>"}
+Lines with the same ``issue`` are folded (latest verdict wins; merge metadata
+kept). A change is "matured" once ``maturity_days`` have passed since merge — only
+then is the absence of a verdict a problem (the verification step didn't run).
+
+Pure functions + explicit IO so it is import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+VERDICTS_GOOD = {"confirmed"}
+VERDICTS_BAD = {"no-signal", "regressed"}
+
+
+def load_ledger(ledger_file: Path) -> List[Dict[str, Any]]:
+    """Read the realized-impact ledger (one JSON object per line), oldest-first.
+
+    Folds multiple lines for the same ``issue`` into one record: merge metadata
+    from the first sighting, latest verdict/verified_at/note from the last.
+    Malformed lines are skipped (the ledger must never crash the pipeline).
+    """
+    if not ledger_file.exists():
+        return []
+    folded: Dict[Any, Dict[str, Any]] = {}
+    order: List[Any] = []
+    for ln in ledger_file.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            rec = json.loads(ln)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(rec, dict) or "issue" not in rec:
+            continue
+        key = rec["issue"]
+        if key not in folded:
+            folded[key] = {}
+            order.append(key)
+        # Later lines override earlier keys for this issue (verdict supersedes).
+        for k, v in rec.items():
+            if v is not None:
+                folded[key][k] = v
+    return [folded[k] for k in order]
+
+
+def _days_between(a: Optional[str], b: Optional[str]) -> Optional[int]:
+    """Whole days from ISO date ``a`` to ISO date ``b`` (both YYYY-MM-DD)."""
+    if not a or not b:
+        return None
+    try:
+        from datetime import date
+
+        ya, ma, da = (int(x) for x in str(a)[:10].split("-"))
+        yb, mb, db = (int(x) for x in str(b)[:10].split("-"))
+        return (date(yb, mb, db) - date(ya, ma, da)).days
+    except (ValueError, TypeError):
+        return None
+
+
+def compute_realized(
+    records: List[Dict[str, Any]],
+    today: str,
+    last: int = 30,
+    maturity_days: int = 5,
+    streak_k: int = 3,
+) -> Dict[str, Any]:
+    """Aggregate the ledger into a realized-impact signal.
+
+    ``today`` is passed in (never read the clock here — keeps it deterministic
+    and testable, same discipline as the rest of the evolution scripts).
+    """
+    window = records[-last:] if last and last > 0 else list(records)
+
+    verdicted = [r for r in window if r.get("verdict") in (VERDICTS_GOOD | VERDICTS_BAD)]
+    confirmed = [r for r in verdicted if r.get("verdict") in VERDICTS_GOOD]
+
+    # Matured-but-unverified: merged long enough ago to have been exercised, yet
+    # the verification step never recorded a verdict — the loop isn't closing.
+    matured_unverified = [
+        r
+        for r in window
+        if r.get("verdict") not in (VERDICTS_GOOD | VERDICTS_BAD)
+        and (_days_between(r.get("merged_at"), today) or 0) >= maturity_days
+    ]
+
+    realized_rate = (len(confirmed) / len(verdicted)) if verdicted else None
+
+    # Consecutive-miss streak over the most recent verdicted changes (by order).
+    streak = 0
+    for r in reversed(verdicted):
+        if r.get("verdict") in VERDICTS_BAD:
+            streak += 1
+        else:
+            break
+
+    flags: List[str] = []
+    if len(verdicted) >= streak_k and streak >= streak_k:
+        flags.append(
+            f"REALIZED_IMPACT_LOW: last {streak} merged changes delivered no real "
+            "value — shift to consolidation/refactor and require owner sign-off "
+            "before new features"
+        )
+    if len(verdicted) >= 3 and realized_rate is not None and realized_rate < 0.5:
+        flags.append(
+            "REALIZED_RATE_LOW: <50% of verified merges actually helped — predicted "
+            "impact is over-optimistic; raise the bar and recalibrate"
+        )
+    if len(matured_unverified) >= streak_k:
+        flags.append(
+            f"UNVERIFIED_BACKLOG: {len(matured_unverified)} matured merges never "
+            "verified — the post-merge verification step is not running"
+        )
+
+    return {
+        "merged_tracked": len(window),
+        "verified": len(verdicted),
+        "confirmed": len(confirmed),
+        "matured_unverified": len(matured_unverified),
+        "realized_impact_rate": round(realized_rate, 3) if realized_rate is not None else None,
+        "miss_streak": streak,
+        "flags": flags,
+    }
+
+
+def _pct(x: Optional[float]) -> str:
+    return "n/a" if x is None else f"{x:.0%}"
+
+
+def format_realized(h: Dict[str, Any]) -> str:
+    tail = " | ".join(h["flags"]) if h["flags"] else "healthy"
+    return (
+        f"[evolution-realized-impact] tracked={h['merged_tracked']} "
+        f"verified={h['verified']} confirmed={h['confirmed']} "
+        f"realized_rate={_pct(h['realized_impact_rate'])} "
+        f"miss_streak={h['miss_streak']} unverified_matured={h['matured_unverified']} | {tail}"
+    )
+
+
+def main(argv: List[str]) -> int:
+    import os
+
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    )
+    args = argv[1:]
+    last = 30
+    if "--last" in args:
+        i = args.index("--last")
+        if i + 1 < len(args):
+            try:
+                last = int(args[i + 1])
+            except ValueError:
+                last = 30
+    today = None
+    if "--today" in args:
+        i = args.index("--today")
+        if i + 1 < len(args):
+            today = args[i + 1]
+    if not today:
+        # The only clock read, and only in the CLI entrypoint (not the pure core).
+        from datetime import date, timezone, datetime
+
+        today = datetime.now(timezone.utc).date().isoformat()
+
+    records = load_ledger(evolution_dir / "realized" / "ledger.jsonl")
+    health = compute_realized(records, today=today, last=last)
+    line = format_realized(health)
+    print(line)
+
+    if "--summary" in args:
+        sidecar = evolution_dir / "realized-impact.txt"
+        try:
+            sidecar.parent.mkdir(parents=True, exist_ok=True)
+            sidecar.write_text(line + "\n", encoding="utf-8")
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -205,6 +205,24 @@ def check_health(evolution_dir: Path) -> List[str]:
     return [f"pipeline health degraded: {line}"]
 
 
+def check_realized_impact(evolution_dir: Path) -> List[str]:
+    """Alert when the post-merge realized-impact sidecar reports blind evolution.
+
+    evolution_realized_impact writes ``realized-impact.txt`` ending in
+    ``| healthy`` when merged changes land real value, or ``| <FLAGS>``
+    (REALIZED_IMPACT_LOW / REALIZED_RATE_LOW / UNVERIFIED_BACKLOG) when the agent
+    is shipping plausible-but-useless code or the verification step has stopped
+    running. This is the loop that stops the agent from optimizing a predicted
+    impact it never checks against reality. Silent when healthy or absent."""
+    try:
+        line = (evolution_dir / "realized-impact.txt").read_text(encoding="utf-8").strip()
+    except OSError:
+        return []
+    if not line or line.endswith("| healthy"):
+        return []
+    return [f"realized-impact degraded: {line}"]
+
+
 def main() -> int:
     hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     evolution_dir = Path(
@@ -232,6 +250,7 @@ def main() -> int:
     alerts += check_jobs(jobs_file, now)
     alerts += check_gh()
     alerts += check_health(evolution_dir)
+    alerts += check_realized_impact(evolution_dir)
 
     if alerts:
         print("🐶 Evolution watchdog — pipeline anomalies detected:")

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -138,13 +138,24 @@ gh issue view <N> --repo Lexus2016/hermes-agent-evolution --json body,comments
 - Age: days / 30 (max 1.0)
 - Compatibility: 1.0 (good) / 0.5 (needs refactoring) / 0.1 (breaks)
 - Safety: 0.0 (risky) / 0.5 (needs tests) / 1.0 (safe)
+- Complexity (codebase health): **+1.0** if it net-REMOVES / refactors / dedups
+  (negative LOC, kills dead code); **0.0** if neutral or a well-tested addition;
+  **−1.0** if it grows the codebase a lot with no tests/refactor (entropy). A
+  self-modifying agent that only ADDS rots its own base until it can no longer
+  understand it — so cleanups outrank equal-impact bloat, and pure-growth changes
+  are dampened.
 
 5. **Compute Priority Score**
 
 ```python
 base_priority = impact * 2 * (1.0 - 0.4 * effort)   # effort DAMPENS (≤40%), never divides
-final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + safety*0.3
+final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + safety*0.3 + complexity*0.2
 ```
+
+   **All extra terms are bounded penalties/bonuses, never divisors** (a divisor
+   reintroduces the calibration bug — see effort below). `complexity ∈ [−1, 1]`,
+   weight 0.2, so it shifts a score by at most ±0.2 — enough to make a refactor
+   beat equal-impact bloat, not enough to override real impact.
 
    **Effort is a bounded penalty, not a divisor.** The old `(impact*2)/effort`
    let a trivial-but-easy issue (impact 0.2, effort 0.1 → **4.0**) outrank a
@@ -180,6 +191,33 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
     - Tag the chosen issue's output entry `"selected_reason": "anti-starvation"`;
       all score-selected entries get `"selected_reason": "score"`. This makes
       starvation rescues visible in the report and in funnel metrics.
+
+6b. **Decomposition gate — long-horizon tasks of ANY level (goal 1).** A
+    high-effort issue (`effort > 0.6`: new runtime/subsystem rework, multi-file
+    capability) must NOT be selected for monolithic implementation — that is how
+    big work fails at the merge gate, so the agent learns to avoid hard tasks
+    (the opposite of "best at any level"). Instead, **decompose it first**: open
+    linked child issues (label `needs-decomposition` on the parent, reference the
+    parent in each child), each a shippable slice with `effort ≤ 0.6`, then let
+    those children compete normally. Select children, not the monolith. This is
+    how the agent takes on complexity without choking on it.
+
+6c. **Realized-impact feedback — don't evolve blind (goal 3).** Read the sidecar
+    `~/.hermes/profiles/user1/evolution/realized-impact.txt` (one
+    `[evolution-realized-impact] …` line, refreshed by the funnel job; missing →
+    treat as `healthy`). It closes the loop: it reports whether what we MERGED
+    actually delivered value. Let its flags set this cycle's bar, silently (this
+    is internal plumbing — keep it OUT of any delivered report):
+    - `REALIZED_IMPACT_LOW` (last K merges delivered nothing real) → **shift to
+      consolidation**: this cycle prefer refactor/cleanup/reliability + the
+      anti-starvation rescue; do NOT select new speculative features; note in the
+      report that the pipeline is in consolidation mode pending owner review.
+    - `REALIZED_RATE_LOW` (<50% of verified merges helped) → predicted impact is
+      over-optimistic; **raise the bar** — demand harder evidence of real impact
+      and discount your own impact estimates accordingly.
+    - `UNVERIFIED_BACKLOG` → verification isn't running; surface it (watchdog also
+      alerts) but proceed.
+    - healthy / missing → proceed normally.
 
 ## Status labels — accept/reject visible in the issue list
 

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -165,6 +165,13 @@ gh pr list --repo "$REPO" --state open --limit 50 \
        is not a 10, it's an unverified guess: treat it as < 10, fix the gap, and
        restart from step 0. Act only when independent evidence — not your own
        sureness — backs the verdict.
+    5. **Anti-regression — never make the agent WORSE.** Green CI proves nothing
+       broke; it does NOT prove the change didn't quietly remove capability. Send
+       back any PR that deletes/weakens an existing test, removes a working
+       capability or flow, or drops coverage of a path it doesn't replace — UNLESS
+       that removal is itself the issue's goal (an explicit, justified cleanup).
+       "It still passes CI" is not enough: the agent must come out at least as
+       capable and reliable as before — every cycle a step up, never a step down.
     Treat it as your own project shipping to `main`: a wrong merge and a wrongly-
     dropped good idea both cost more than one outside look.
 
@@ -199,6 +206,19 @@ hermes update --yes
 ```
    If `hermes update` reports failure/rollback, STOP merging further PRs this
    cycle and record it — a merged change broke the build and was rolled back.
+
+6. **Record the merge for the realized-impact loop** (so evolution is not blind —
+   we later verify whether this change actually helped). For EACH merged PR,
+   append one line to `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`:
+```bash
+mkdir -p ~/.hermes/profiles/user1/evolution/realized
+echo '{"issue": <#>, "merged_at": "<YYYY-MM-DD>", "predicted_impact": <the issue'"'"'s analysis impact 0..1>, "target": "<one line: the concrete problem this was meant to fix>"}' \
+  >> ~/.hermes/profiles/user1/evolution/realized/ledger.jsonl
+```
+   `predicted_impact` is the impact the analysis stage assigned the issue; `target`
+   is what "done" means for it. introspection later appends a `verdict` line for
+   the same issue once it has matured. NEVER omit this — an unrecorded merge is
+   an unmeasured one.
 
 ## What to NEVER merge
 

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -92,9 +92,27 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    - **Impact** = how often this blocks real user tasks × how badly
      (Critical 1.0 = task impossible / Low 0.2 = minor friction).
    - **Effort** = estimated work to fix.
-   - **Priority Score = Impact × 2 / Effort.** Keep only `>= 0.7`.
+   - **Priority Score = Impact × 2 × (1 − 0.4 × Effort).** Keep only `>= 0.7`.
+     Effort DAMPENS (≤40%), never divides — a hard-but-critical blocker must not
+     lose to a trivial-but-easy one (same calibration fix as evolution-analysis).
    - Practical blockers usually outscore nice-to-have features here — that's the
      point: real work comes first.
+
+6. **Post-merge verification — close the realized-impact loop (goal 3).** Evolution
+   is blind unless we check whether what we MERGED actually helped. You are already
+   reading real sessions here, so verify recent merges in the same pass:
+   - Read `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`; take entries
+     **merged ≥ 5 days ago with no `verdict` yet** (matured + unverified).
+   - For each, judge from the real sessions since its merge: did the `target`
+     problem RECUR (the fix didn't hold)? is the merged capability actually used?
+     did the friction it targeted disappear?
+   - Append ONE verdict line per such issue to the same ledger:
+     `{"issue": <#>, "verdict": "confirmed|no-signal|regressed", "verified_at": "<YYYY-MM-DD>", "note": "<one line of session evidence>"}`
+     — `confirmed` = problem gone / change used; `no-signal` = no evidence it
+     changed anything; `regressed` = problem recurred or got worse.
+   - Be honest: a `no-signal`/`regressed` verdict on the agent's OWN past change is
+     exactly the feedback that stops blind feature-piling (analysis reads it and
+     shifts to consolidation). Confirming uselessly to look good defeats the loop.
 
 ## Creating issues
 
@@ -186,7 +204,7 @@ A concrete fix/capability that would unblock it.
 ### Value
 - Impact: <0.2–1.0>
 - Effort: <0.1–1.0>
-- Priority Score: <impact*2/effort>
+- Priority Score: <impact*2*(1 − 0.4*effort)>
 ```
 
 ## Cross-cycle memory (optional — only if Turbo-Quant Memory is available)

--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -94,9 +94,14 @@ Save the result to `~/.hermes/profiles/user1/evolution/research/YYYY-MM-DD.md`:
 
 ### [FEATURE] Better memory management
 - **Source**: https://github.com/microsoft/autogen/pull/123
+- **Frontier standing**: behind | at-par | ahead — where THIS agent stands vs the
+  best on this capability today (the measured side of "be the best"). `behind` →
+  catch up AND surpass; `at-par` → differentiate / pull ahead; `ahead` → maintain
+  the lead. A finding that leaves us merely at-par with the field is weak.
 - **Impact**: High
 - **Effort**: Medium
-- **Priority Score**: 1.6 (0.8 * 2 / 0.5)
+- **Priority Score**: 1.36 (impact 0.8 × 2 × (1 − 0.4 × effort 0.5) — effort
+  DAMPENS, never divides; matches evolution-analysis)
 
 Description...
 

--- a/tests/scripts/test_evolution_realized_impact.py
+++ b/tests/scripts/test_evolution_realized_impact.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/evolution_realized_impact.py — post-merge realized-impact loop."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_realized_impact import (  # noqa: E402
+    compute_realized,
+    format_realized,
+    load_ledger,
+)
+
+
+def _merge(issue, merged_at, predicted=0.8, target="fix X"):
+    return {"issue": issue, "merged_at": merged_at, "predicted_impact": predicted, "target": target}
+
+
+def _verdict(issue, verdict, verified_at="2026-06-20", note=""):
+    return {"issue": issue, "verdict": verdict, "verified_at": verified_at, "note": note}
+
+
+class TestLoadLedger:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_ledger(tmp_path / "nope.jsonl") == []
+
+    def test_folds_merge_and_verdict_lines_for_same_issue(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        f.write_text(
+            "\n".join(
+                [
+                    '{"issue": 1, "merged_at": "2026-06-01", "predicted_impact": 0.9, "target": "t1"}',
+                    '{"issue": 2, "merged_at": "2026-06-02", "predicted_impact": 0.5, "target": "t2"}',
+                    '{"issue": 1, "verdict": "confirmed", "verified_at": "2026-06-10"}',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        recs = load_ledger(f)
+        assert len(recs) == 2  # folded by issue, original order preserved
+        assert recs[0]["issue"] == 1
+        assert recs[0]["verdict"] == "confirmed"  # verdict line merged in
+        assert recs[0]["target"] == "t1"  # merge metadata retained
+        assert "verdict" not in recs[1]
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        f.write_text(
+            'not json\n{"no_issue": true}\n{"issue": 5, "merged_at": "2026-06-01"}\n',
+            encoding="utf-8",
+        )
+        recs = load_ledger(f)
+        assert len(recs) == 1 and recs[0]["issue"] == 5
+
+
+class TestComputeRealized:
+    def test_rate_and_confirmed_count(self):
+        recs = [
+            _merge(1, "2026-06-01") | _verdict(1, "confirmed"),
+            _merge(2, "2026-06-02") | _verdict(2, "confirmed"),
+            _merge(3, "2026-06-03") | _verdict(3, "no-signal"),
+        ]
+        h = compute_realized(recs, today="2026-06-30")
+        assert h["verified"] == 3
+        assert h["confirmed"] == 2
+        assert h["realized_impact_rate"] == round(2 / 3, 3)
+
+    def test_consecutive_miss_streak_flags_low_impact(self):
+        recs = [
+            _merge(1, "2026-06-01") | _verdict(1, "confirmed"),
+            _merge(2, "2026-06-02") | _verdict(2, "regressed"),
+            _merge(3, "2026-06-03") | _verdict(3, "no-signal"),
+            _merge(4, "2026-06-04") | _verdict(4, "regressed"),
+        ]
+        h = compute_realized(recs, today="2026-06-30", streak_k=3)
+        assert h["miss_streak"] == 3
+        assert any("REALIZED_IMPACT_LOW" in f for f in h["flags"])
+
+    def test_matured_unverified_backlog_flagged(self):
+        # merged long ago, never verified -> the verification step isn't running
+        recs = [_merge(i, "2026-06-01") for i in range(1, 5)]
+        h = compute_realized(recs, today="2026-06-30", maturity_days=5)
+        assert h["verified"] == 0
+        assert h["matured_unverified"] == 4
+        assert any("UNVERIFIED_BACKLOG" in f for f in h["flags"])
+
+    def test_recent_unverified_not_counted_as_matured(self):
+        recs = [_merge(1, "2026-06-29")]  # merged yesterday
+        h = compute_realized(recs, today="2026-06-30", maturity_days=5)
+        assert h["matured_unverified"] == 0
+        assert h["flags"] == []
+
+    def test_healthy_when_mostly_confirmed(self):
+        recs = [_merge(i, "2026-06-0%d" % i) | _verdict(i, "confirmed") for i in range(1, 4)]
+        h = compute_realized(recs, today="2026-06-30")
+        assert h["realized_impact_rate"] == 1.0
+        assert h["flags"] == []
+
+
+class TestFormat:
+    def test_format_includes_rate_and_tail(self):
+        recs = [_merge(1, "2026-06-01") | _verdict(1, "confirmed")]
+        line = format_realized(compute_realized(recs, today="2026-06-30"))
+        assert line.startswith("[evolution-realized-impact]")
+        assert "realized_rate=" in line
+        assert "healthy" in line


### PR DESCRIPTION
Mechanics layer in service of the canonical mission (PR #217): *be the BEST — autonomous real work of any level, most useful, evolve faster/better; "best" measured, not declared.* Mission first; this is the machinery under it.

## 1. Realized-impact feedback — stop evolving blind (goal 3)
The pipeline measured up to the *merge* (selection_efficiency) but never whether a merge **actually helped** — so it optimized a PREDICTED impact it never checked. New closed loop:
- **`scripts/evolution_realized_impact.py`** (+9 tests) — light, deterministic aggregator over a ledger the agent writes (no creds/LLM).
- **integration** records each merge `{issue, merged_at, predicted_impact, target}` to `realized/ledger.jsonl`.
- **introspection** (already reading real sessions) appends a verdict `confirmed|no-signal|regressed` once a merge has matured.
- **funnel** job refreshes a `realized-impact.txt` sidecar; **analysis** reads it → shifts to **consolidation** when merges stop delivering value; **watchdog** alerts (`REALIZED_IMPACT_LOW` / `REALIZED_RATE_LOW` / `UNVERIFIED_BACKLOG`).

## 2. Decomposition gate — tasks of ANY level (goal 1)
analysis must **decompose** high-effort issues (`>0.6`) into linked shippable children instead of attempting monoliths that choke at the merge gate (which teaches the agent to avoid hard work — the opposite of "best at any level").

## 3. Codebase health
- **Complexity** as a BOUNDED scoring term (`+1` cleanup … `−1` entropy, weight 0.2 — **never a divisor**): refactors beat equal-impact bloat; a self-modifying agent that only ADDS rots its own base.
- **Anti-regression gate** in integration: never merge something that quietly removes capability/tests/coverage — green CI is not enough.

## 4. Benchmark sense — best = MEASURED (goals 1+3)
research reframed to *match-and-surpass* the frontier with a per-finding **frontier standing** (`behind|at-par|ahead`). Also fixed the effort-as-**divisor** leftover in introspection + research → bounded form (consistency with analysis' calibration fix).

## Verification
compile OK · skill-lint OK · **56** evolution-script tests green · funnel writes the realized-impact sidecar · watchdog alerts on the flag.