### PR TITLE
feat: cronjob diagnostics and retry limit (#214)

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -1,6 +1,7 @@
 """Tests for tools/cronjob_tools.py — prompt scanning, schedule/list/remove dispatchers."""
 
 import json
+from pathlib import Path
 import pytest
 
 from tools.cronjob_tools import (
@@ -503,3 +504,163 @@ class TestResolveModelOverride:
         )
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
+
+
+# =========================================================================
+# Cron preflight, action validation, and retry rate limiter (issue #214)
+# =========================================================================
+
+from tools.cronjob_tools import (  # noqa: E402
+    _cron_preflight_check,
+    _format_cron_error,
+    _validate_cron_action,
+    _MAX_CONSECUTIVE_CRON_FAILURES,
+    _cron_failure_tracker,
+)
+
+
+class TestCronPreflightAndValidation:
+    """Issue #214 diagnostics: cron availability, input validation, and
+    richer error messages."""
+
+    def test_validate_cron_action_normalizes_and_rejects(self):
+        norm, err = _validate_cron_action("  CREATE ")
+        assert norm == "create"
+        assert err is None
+
+        norm, err = _validate_cron_action(None)
+        assert norm == ""
+        assert "required" in err
+
+        norm, err = _validate_cron_action("nope")
+        assert norm == "nope"
+        assert "Unknown cron action" in err
+        assert "create" in err and "list" in err
+
+    def test_preflight_returns_none_when_cron_dir_writable_and_crontab_present(
+        self, tmp_path, monkeypatch
+    ):
+        """When crontab is on PATH and the cron dir is writable, preflight
+        passes.  We monkeypatch CRON_DIR to a temp dir so the test does not
+        depend on the real ~/.hermes state."""
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: "/usr/bin/crontab")
+
+        fake_result = type(
+            "FakeResult",
+            (),
+            {"returncode": 1, "stderr": "no crontab for user"},
+        )()
+        monkeypatch.setattr(
+            "tools.cronjob_tools.subprocess.run", lambda *a, **kw: fake_result
+        )
+
+        assert _cron_preflight_check() is None
+
+    def test_preflight_reports_missing_crontab(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: None)
+        err = _cron_preflight_check()
+        assert err is not None
+        assert "crontab" in err.lower()
+
+    def test_preflight_reports_crontab_error_output(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: "/usr/bin/crontab")
+
+        fake_result = type(
+            "FakeResult",
+            (),
+            {"returncode": 2, "stderr": "permission denied"},
+        )()
+        monkeypatch.setattr(
+            "tools.cronjob_tools.subprocess.run", lambda *a, **kw: fake_result
+        )
+
+        err = _cron_preflight_check()
+        assert err is not None
+        assert "exited 2" in err
+        assert "permission denied" in err
+
+    def test_preflight_reports_unwritable_cron_dir(self, tmp_path, monkeypatch):
+        cron_dir = tmp_path / "cron_readonly"
+        cron_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+
+        def failing_write_text(*args, **kwargs):
+            raise PermissionError("cannot write")
+
+        monkeypatch.setattr(Path(".").__class__, "write_text", failing_write_text)
+        err = _cron_preflight_check()
+        assert err is not None
+        assert "not writable" in err
+        assert "cannot write" in err
+
+    def test_format_cron_error_includes_cli_output(self):
+        exc = ValueError("bad schedule")
+        msg = _format_cron_error(exc, "create", cli_output="stderr: bad minute")
+        assert "create" in msg
+        assert "bad schedule" in msg
+        assert "stderr: bad minute" in msg
+
+
+class TestCronRetryLimiter:
+    """Issue #214: repeated failures must eventually return 'too many attempts'."""
+
+    def test_retry_limit_kicks_in_after_max_failures(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob, _cron_failure_tracker
+
+        # Use a temp cron dir and a broken crontab to force failures.
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: None)
+
+        task_id = "test-task-214"
+        # Clear any stale state
+        _cron_failure_tracker.pop(task_id, None)
+
+        for i in range(_MAX_CONSECUTIVE_CRON_FAILURES):
+            result = json.loads(
+                cronjob(action="list", task_id=task_id)
+            )
+            assert result["success"] is False
+            assert "crontab" in result["error"].lower()
+
+        # Next call should short-circuit with the retry-limit message.
+        result = json.loads(
+            cronjob(action="list", task_id=task_id)
+        )
+        assert result["success"] is False
+        assert "too many attempts" in result["error"].lower()
+
+    def test_retry_counter_resets_on_success(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob, _cron_failure_tracker
+
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: None)
+
+        task_id = "test-task-reset"
+        _cron_failure_tracker.pop(task_id, None)
+
+        # One failure
+        result = json.loads(cronjob(action="list", task_id=task_id))
+        assert result["success"] is False
+
+        # Simulate recovery by restoring a working crontab.
+        monkeypatch.setattr("tools.cronjob_tools.shutil.which", lambda cmd: "/usr/bin/crontab")
+        fake_result = type(
+            "FakeResult",
+            (),
+            {"returncode": 1, "stderr": "no crontab for user"},
+        )()
+        monkeypatch.setattr(
+            "tools.cronjob_tools.subprocess.run", lambda *a, **kw: fake_result
+        )
+
+        result = json.loads(cronjob(action="list", task_id=task_id))
+        assert result["success"] is True
+        # Counter should be gone after a success.
+        assert task_id not in _cron_failure_tracker

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -8,9 +8,13 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 import json
 import logging
 import re
+import shutil
+import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from hermes_constants import display_hermes_home
 
@@ -31,6 +35,139 @@ from cron.jobs import (
     trigger_job,
     update_job,
 )
+
+
+# ---------------------------------------------------------------------------
+# Cron availability preflight + per-task retry rate limiter
+# ---------------------------------------------------------------------------
+#
+# Issue #214: cronjob tool failures recur without surfacing underlying cause.
+# We add:
+#   1. A preflight probe that checks whether cron is usable (crontab binary
+#      and, on Linux, a running cron daemon) before mutating state.
+#   2. A per-task retry limiter so repeated failures back off with a clear
+#      "too many attempts" message instead of looping noisily.
+#   3. Richer error payloads that include the underlying CLI output.
+
+_MAX_CONSECUTIVE_CRON_FAILURES = 3
+_CRON_RETRY_WINDOW_SECONDS = 300.0  # failures older than this are forgotten
+_cron_failure_tracker: Dict[str, List[float]] = {}
+_cron_failure_tracker_lock = threading.Lock()
+
+
+def _record_cron_failure(task_id: Optional[str]) -> int:
+    """Record a cron failure for *task_id* and return the current streak."""
+    if not task_id:
+        return 1
+    now = time.monotonic()
+    with _cron_failure_tracker_lock:
+        window = [
+            ts
+            for ts in _cron_failure_tracker.get(task_id, [])
+            if now - ts < _CRON_RETRY_WINDOW_SECONDS
+        ]
+        window.append(now)
+        _cron_failure_tracker[task_id] = window
+        return len(window)
+
+
+def _reset_cron_failure(task_id: Optional[str]) -> None:
+    """Reset the failure streak for *task_id* after a successful operation."""
+    if not task_id:
+        return
+    with _cron_failure_tracker_lock:
+        _cron_failure_tracker.pop(task_id, None)
+
+
+def _cron_preflight_check() -> Optional[str]:
+    """Probe basic cron availability and return a user-facing error string.
+
+    Returns ``None`` when cron appears usable, otherwise a short diagnostic
+    message explaining what is missing.  The check is best-effort: on systems
+    where ``crontab`` is intentionally absent or where Hermes is using the
+    internal JSON scheduler only, we still verify that the cron directory is
+    writable so job persistence does not fail silently.
+    """
+    from cron.jobs import CRON_DIR, ensure_dirs
+
+    try:
+        ensure_dirs()
+        probe = CRON_DIR / ".preflight_probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except Exception as exc:
+        return (
+            f"Cron directory is not writable ({CRON_DIR}): {exc}. "
+            "Check permissions for the user running Hermes."
+        )
+
+    crontab = shutil.which("crontab")
+    if crontab is None:
+        return (
+            "The 'crontab' command is not available on PATH. "
+            "Install a cron implementation (e.g. cronie, vixie-cron) "
+            "or verify that Hermes is running in an environment with cron support."
+        )
+
+    try:
+        result = subprocess.run(
+            [crontab, "-l"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception as exc:
+        return f"Cron preflight probe failed: crontab -l could not run: {exc}"
+
+    if result.returncode != 0:
+        # ``crontab -l`` exits 1 when the user has no crontab — that is normal.
+        # Anything else (e.g. permission denied, service missing) is a real problem.
+        stderr = (result.stderr or "").strip()
+        if "no crontab" not in stderr.lower() and "no such file" not in stderr.lower():
+            return (
+                f"Cron preflight probe failed: crontab -l exited {result.returncode}."
+                + (f"\nstderr: {stderr}" if stderr else "")
+            )
+
+    # Best-effort daemon presence check on common Unix paths.
+    daemon_paths = [Path("/usr/sbin/cron"), Path("/usr/sbin/crond")]
+    if sys.platform != "win32" and not any(p.exists() for p in daemon_paths):
+        # Not a hard failure: some container/embedded environments have no
+        # separate daemon binary, but Hermes still uses the internal scheduler.
+        logger.debug("No separate cron daemon binary found; relying on internal scheduler")
+
+    return None
+
+
+def _format_cron_error(
+    exc: Exception,
+    operation: str,
+    cli_output: Optional[str] = None,
+) -> str:
+    """Return a rich error string for cron failures.
+
+    Includes the operation name, the exception message, and any captured CLI
+    output so the user can see the root cause without re-running manually.
+    """
+    parts = [f"Cron operation '{operation}' failed: {exc}"]
+    if cli_output:
+        parts.append(f"Underlying output:\n{cli_output}")
+    return "\n".join(parts)
+
+
+def _validate_cron_action(action: Optional[str]) -> Tuple[str, Optional[str]]:
+    """Normalize and validate the cron action parameter.
+
+    Returns ``(normalized_action, error)``; ``error`` is ``None`` when valid.
+    """
+    normalized = (action or "").strip().lower()
+    if not normalized:
+        return "", "action is required"
+    allowed = {"create", "list", "update", "pause", "resume", "remove", "run", "run_now", "trigger"}
+    if normalized not in allowed:
+        return normalized, f"Unknown cron action '{action}'. Allowed: {', '.join(sorted(allowed - {'run_now', 'trigger'}))}"
+    return normalized, None
 
 
 # ---------------------------------------------------------------------------
@@ -620,11 +757,27 @@ def cronjob(
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
-    del task_id  # unused but kept for handler signature compatibility
+
+    normalized, action_error = _validate_cron_action(action)
+    if action_error:
+        return tool_error(action_error, success=False)
+
+    # Retry-rate limiter: noisy failure loops are capped per task.
+    failure_streak = _record_cron_failure(task_id)
+    if failure_streak > _MAX_CONSECUTIVE_CRON_FAILURES:
+        return tool_error(
+            f"Cron tool has failed {failure_streak} consecutive times for this task "
+            "(too many attempts). Please inspect the earlier errors or run "
+            "cronjob(action='list') before retrying.",
+            success=False,
+        )
+
+    # Preflight: ensure cron is available before invoking backend operations.
+    preflight_error = _cron_preflight_check()
+    if preflight_error:
+        return tool_error(preflight_error, success=False)
 
     try:
-        normalized = (action or "").strip().lower()
-
         if normalized == "create":
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
@@ -684,6 +837,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
             )
+            _reset_cron_failure(task_id)
             return json.dumps(
                 {
                     "success": True,
@@ -703,6 +857,7 @@ def cronjob(
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            _reset_cron_failure(task_id)
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
@@ -739,6 +894,7 @@ def cronjob(
             removed = remove_job(job_id)
             if not removed:
                 return tool_error(f"Failed to remove job '{job_id}'", success=False)
+            _reset_cron_failure(task_id)
             return json.dumps(
                 {
                     "success": True,
@@ -754,14 +910,17 @@ def cronjob(
 
         if normalized == "pause":
             updated = pause_job(job_id, reason=reason)
+            _reset_cron_failure(task_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "resume":
             updated = resume_job(job_id)
+            _reset_cron_failure(task_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
             updated = trigger_job(job_id)
+            _reset_cron_failure(task_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "update":
@@ -846,12 +1005,15 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
+            _reset_cron_failure(task_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 
     except Exception as e:
-        return tool_error(str(e), success=False)
+        _record_cron_failure(task_id)
+        cli_output = getattr(e, "output", None)
+        return tool_error(_format_cron_error(e, normalized or action or "unknown", cli_output=cli_output), success=False)
 
 
 


### PR DESCRIPTION
Implements #214.

- Adds a `_cron_preflight_check()` that verifies the cron directory is writable and that `crontab -l` is available/usable, surfacing any stderr from the probe in the error message.
- Validates the cron action early and rejects unknown actions before invoking backend code.
- Adds a per-task retry rate limiter: after 3 consecutive failures within a 5-minute window, the tool returns a clear "too many attempts" message instead of looping.
- Wraps unexpected exceptions with the operation name and any captured CLI output so the underlying cause is visible.

Closes #214