### PR TITLE
fix(tests): deterministic tui_gateway browser + process-registry isolation

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9,9 +9,27 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_registry():
+    """Isolate every test in this file from the global ``process_registry``
+    singleton. It is one-per-process, so queued completion events / leftover
+    watchers / consumed-session markers from one notification-poller test leak
+    into the next, inflating the emitted count (the intermittent
+    ``len(status_calls) == 3`` flake). Reset before and after each test so the
+    registry always starts empty. Scoped to this file — the poller tests and the
+    one flaky assertion all live here and run in the same shard."""
+    from tools.process_registry import process_registry
+
+    process_registry.reset()
+    yield
+    process_registry.reset()
 
 
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
@@ -5844,6 +5862,15 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
             patch(
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
+            ),
+            # No launch command available on ANY platform. Without this, macOS
+            # (Darwin) returns an `open -a "Google Chrome"` fallback even with zero
+            # candidates, so the "no executable found" branch is never hit and the
+            # test fails on macOS while passing on Linux. Patch the direct lever so
+            # the no-browser scenario is deterministic across platforms.
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
             ),
         ):
             resp = server.handle_request(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -181,6 +181,33 @@ class ProcessRegistry:
         self._global_watch_tripped_until: float = 0.0
         self._global_watch_suppressed_during_trip: int = 0
 
+    def reset(self) -> None:
+        """Clear all in-memory state: running/finished sessions, pending
+        watchers, the completion queue, consumed-completion markers, and the
+        global watch-match circuit-breaker counters.
+
+        This object is a single per-process singleton. Without an explicit reset,
+        state from one unit test (queued events, leftover watchers, consumed
+        session ids) leaks into the next and makes queue-draining tests flaky — a
+        stale event sneaks past a drain-then-fill and inflates the count. Safe to
+        call any time: it only drops in-memory bookkeeping, never touching live
+        OS processes."""
+        with self._lock:
+            self._running.clear()
+            self._finished.clear()
+            self.pending_watchers.clear()
+            self._completion_consumed.clear()
+            while not self.completion_queue.empty():
+                try:
+                    self.completion_queue.get_nowait()
+                except Exception:
+                    break
+        with self._global_watch_lock:
+            self._global_watch_window_start = 0.0
+            self._global_watch_window_hits = 0
+            self._global_watch_tripped_until = 0.0
+            self._global_watch_suppressed_during_trip = 0
+
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
         """Strip shell startup warnings from the beginning of output."""


### PR DESCRIPTION
Fixes the test reliability issues in `tests/test_tui_gateway_server.py` that intermittently red CI (shard 2).

**1. `test_browser_manage_connect_default_local_reports_launch_hint` — platform-deterministic.**
Failed on macOS, passed on Linux. It patched `get_chrome_debug_candidates → []` expecting the "no executable found" branch, but `manual_chrome_debug_command` returns an `open -a "Google Chrome"` fallback on **Darwin** even with zero candidates, so the branch was never hit. Now patches `manual_chrome_debug_command → None` directly → deterministic on all platforms.

**2. `test_notification_poller_emits_distinct_watch_matches_once` — order-flaky (intermittent `len(status_calls)==3`).**
The global one-per-process `process_registry` leaks queued events / watchers / consumed markers across tests. Added a thread-safe **`process_registry.reset()`** + a **file-scoped autouse fixture** that resets the registry around every test in this file (the poller tests + the flaky assertion run in the same shard). Blast radius kept to this file; `reset()` is additive.

Verified: full `test_tui_gateway_server.py` (271) + `test_process_registry.py` green; ruff clean.