### PR TITLE
fix(evolution): unblock pipeline — editor-guard false-positive + funnel list report

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -47,16 +47,29 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     Every field defaults to 0 / {} so a missing stage report never crashes the
     metric — it just shows that stage produced nothing recorded that day.
     """
-    issues = _load_json(evolution_dir / "issues" / f"{date}.json") or {}
-    analysis = _load_json(evolution_dir / "analysis" / f"{date}.json") or {}
-    integration = _load_json(evolution_dir / "integration" / f"{date}.json") or {}
-    introspection = _load_json(evolution_dir / "introspection" / f"{date}.json") or {}
+    # Stage reports are normally dicts, but some stages write a bare LIST (e.g.
+    # introspection emits a list of patterns). Coerce non-dicts to {} so .get()
+    # never crashes the metric — a list-shaped report previously raised
+    # AttributeError and killed the whole funnel job (and the realized-impact
+    # sidecar refresh that now rides on it).
+    def _as_dict(x: Any) -> Dict[str, Any]:
+        return x if isinstance(x, dict) else {}
+
+    issues_raw = _load_json(evolution_dir / "issues" / f"{date}.json")
+    analysis = _as_dict(_load_json(evolution_dir / "analysis" / f"{date}.json"))
+    integration = _as_dict(_load_json(evolution_dir / "integration" / f"{date}.json"))
+    introspection_raw = _load_json(evolution_dir / "introspection" / f"{date}.json")
+    issues = _as_dict(issues_raw)
 
     selected = analysis.get("selected_for_implementation") or []
     rejected = analysis.get("rejected") or []
     merged = integration.get("merged") or []
     skipped = integration.get("skipped") or []
-    patterns = introspection.get("patterns_found") or []
+    # introspection may be a bare list of patterns OR a dict with patterns_found.
+    if isinstance(introspection_raw, list):
+        patterns = introspection_raw
+    else:
+        patterns = _as_dict(introspection_raw).get("patterns_found") or []
     created = issues.get("issues_created") or []
 
     return {

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -69,6 +69,24 @@ class TestComputeFunnel:
         r = compute_funnel(tmp_path, "2026-01-02")
         assert r["selected"] == 0  # treated as absent, no exception
 
+    def test_introspection_list_report_does_not_crash(self, tmp_path):
+        # introspection emits a bare LIST of patterns, not a dict. Regression:
+        # `.get()` on a list raised AttributeError and killed the whole funnel
+        # job (and the realized-impact sidecar refresh riding on it).
+        d = "2026-01-03"
+        _write(tmp_path / "introspection" / f"{d}.json", [{"p": 1}, {"p": 2}, {"p": 3}])
+        r = compute_funnel(tmp_path, d)
+        assert r["introspection_patterns"] == 3  # counted straight from the list
+        assert r["selected"] == 0  # other stages absent — no crash
+
+    def test_list_shaped_reports_coerced_not_crashed(self, tmp_path):
+        # Any stage report arriving as a list must degrade to 0, never crash.
+        d = "2026-01-04"
+        _write(tmp_path / "analysis" / f"{d}.json", ["unexpected", "list"])
+        _write(tmp_path / "integration" / f"{d}.json", [{"merged": "x"}])
+        r = compute_funnel(tmp_path, d)
+        assert r["selected"] == 0 and r["merged"] == 0
+
 
 class TestCycleDate:
     def test_morning_run_measures_yesterday(self):

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -270,6 +270,25 @@ def test_editor_with_pty_allowed():
     assert _INTERACTIVE_EDITOR_RE.search("vim config.txt")
 
 
+def test_editor_name_as_argument_substring_not_rejected():
+    """An editor NAME inside an argument (a branch name, a message) must NOT
+    trigger the guard — only an editor in COMMAND position does. Regression:
+    `git push origin evolution/issue-215-execute-code-diagnostics` matched
+    `\\bcode\\b` and was wrongly rejected, silently blocking the pipeline's pushes."""
+    from tools.terminal_tool import _INTERACTIVE_EDITOR_RE
+
+    assert not _INTERACTIVE_EDITOR_RE.search(
+        "git push origin evolution/issue-215-execute-code-diagnostics"
+    )
+    assert not _INTERACTIVE_EDITOR_RE.search(
+        "gh pr create --head evolution/issue-215-execute-code-diagnostics --title x"
+    )
+    # genuine command-position editor invocations are still caught
+    assert _INTERACTIVE_EDITOR_RE.search("echo done && vim notes.txt")
+    assert _INTERACTIVE_EDITOR_RE.search("code .")
+    assert _INTERACTIVE_EDITOR_RE.search("sudo nano /etc/hosts")
+
+
 def test_non_editor_command_unchanged():
     """Non-editor commands should not be affected by the editor guard."""
     from tools.terminal_tool import _INTERACTIVE_EDITOR_RE, _strip_quotes

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1692,8 +1692,18 @@ _SHELL_LEVEL_BACKGROUND_RE = re.compile(
 _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
 
+# Match an interactive editor only when it is the COMMAND being run — at the
+# start of the command line or right after a shell separator (``;`` ``&`` ``|``
+# ``&&`` ``||`` ``$(``), optionally behind ``sudo``/``env VAR=…``. A bare ``\b``
+# match falsely fired on editor NAMES appearing as substrings in arguments — e.g.
+# ``git push origin evolution/issue-215-execute-code-diagnostics`` matched
+# ``\bcode\b`` and was wrongly rejected as "interactive editor", silently blocking
+# the evolution pipeline's pushes. Mirrors the background-command detector above.
 _INTERACTIVE_EDITOR_RE = re.compile(
-    r"\b(?:nano|vi|vim|emacs|micro|joe|jed|kate|gedit|subl|code)\b", re.IGNORECASE
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)"
+    r"(?:sudo\s+)?(?:env\s+\S+=\S+\s+)*"
+    r"(?:nano|vi|vim|emacs|micro|joe|jed|kate|gedit|subl|code)\b",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 


### PR DESCRIPTION
Two deterministic bugs broke the autonomous run (watchdog alert 2026-06-15).

**1. terminal_tool interactive-editor guard — false positive on `code`/`vi` substrings.**
The guard matched editor names anywhere via `\b…\b`, so `git push origin evolution/issue-215-execute-code-diagnostics` matched `\bcode\b` and was rejected as "interactive editor — require pty=true". This **silently blocked every push / `gh pr create`** whose branch or args contain an editor name — the implementation job couldn't push #215 and died with a RuntimeError. Fix: match an editor only in **command position** (start, or after `;` `&` `|` `&&` `||` `$(`, optionally behind `sudo`/`env VAR=…`), mirroring the existing background-command detector.

**2. `evolution_funnel.compute_funnel` — crash on list-shaped report.**
It called `.get()` on every stage report assuming dicts, but **introspection emits a bare LIST** → `AttributeError: 'list' object has no attribute 'get'` killed the whole funnel job (and the realized-impact sidecar refresh now riding on it). Fix: coerce non-dict reports to `{}`, and count introspection patterns whether the report is a list or a dict.

Regression tests added for both (`test_editor_name_as_argument_substring_not_rejected`, `test_introspection_list_report_does_not_crash`, `test_list_shaped_reports_coerced_not_crashed`). 20 passed locally; ruff clean.

> Server-side follow-up (handled separately): the #215 work was accidentally committed to the agent clone's `main` and is being landed as its own PR; the clone's `main` divergence is being reset to `origin/main`.