### PR TITLE
fix(evolution): close deploy gap — install whole evolution_* script family + re-register on update

### DIFF
--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -148,6 +148,25 @@ def _install_access_gate(repo_root: Path) -> str | None:
     return _install_script(repo_root, "evolution_access_gate.sh")
 
 
+def _install_evolution_helpers(repo_root: Path) -> list[str]:
+    """Install the whole ``evolution_*.py`` script family into HERMES_HOME/scripts.
+
+    The per-job loop installs only each no_agent job's own ``script``. But those
+    scripts IMPORT siblings — e.g. evolution_funnel imports evolution_metrics and
+    evolution_realized_impact to refresh its health/realized-impact sidecars. A
+    sibling that lives only in the repo checkout (not in HERMES_HOME/scripts, where
+    the scheduler runs) raises ImportError at runtime and the refresh silently
+    no-ops (the import is guarded), so the sidecars freeze and the watchdog reads
+    stale health. Installing the whole family keeps every intra-family import
+    resolvable from the one directory the scheduler executes from. Future helper
+    scripts are picked up automatically by the glob."""
+    installed: list[str] = []
+    for src in sorted((repo_root / "scripts").glob("evolution_*.py")):
+        if _install_script(repo_root, src.name):
+            installed.append(src.name)
+    return installed
+
+
 def main(argv: list[str]) -> int:
     dry_run = "--dry-run" in argv
     positional = [a for a in argv[1:] if not a.startswith("--")]
@@ -175,6 +194,10 @@ def main(argv: list[str]) -> int:
     # Install the GitHub-access wake-gate and attach it to every evolution job,
     # so the expensive LLM agent only runs when GitHub is actually reachable.
     gate_script = None if dry_run else _install_access_gate(repo_root)
+
+    # Install the whole evolution_* helper family so no_agent scripts' sibling
+    # imports (funnel -> metrics/realized_impact) resolve in HERMES_HOME/scripts.
+    helper_scripts = [] if dry_run else _install_evolution_helpers(repo_root)
 
     existing_jobs = {str(j.get("name", "")).strip(): j for j in load_jobs()}
     existing_names = set(existing_jobs)
@@ -301,7 +324,8 @@ def main(argv: list[str]) -> int:
     verb = "would register" if dry_run else "registered"
     print(
         f"[evolution-cron] {verb}={len(created)} reconciled={len(updated)} "
-        f"skipped(unchanged)={len(skipped)} failed={len(failed)}"
+        f"skipped(unchanged)={len(skipped)} failed={len(failed)} "
+        f"helper_scripts_installed={len(helper_scripts)}"
     )
     for name, jid in created:
         print(f"  + {name} ({jid})")

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -143,6 +143,21 @@ python -m pytest tests/ -x -q
   ```
 - Only when local checks are green do you continue to commit + push + PR.
 
+### ⛔ Protect your work — COMMIT before any cleanup
+NEVER run `git checkout -- <tracked file>`, `git restore`, `git reset --hard`, or
+`git stash` to "clean up reformat noise" on changes you have NOT yet committed —
+it silently discards the whole implementation. (This destroyed a completed run:
+the source files were reset to `main`, leaving only a broken half-re-applied
+patch and a missing PR.) The order is fixed and non-negotiable:
+1. **Commit first** — `git add -A && git commit …`. Your work is now safe in a
+   commit; nothing below can lose it.
+2. THEN, if there is genuine noise (e.g. an accidental full-file reformat), fix it
+   in a FOLLOW-UP commit, or `git checkout -- <only-that-one-file>` ONLY after
+   confirming that file has no changes you want. Never blanket-discard tracked
+   changes you haven't inspected file-by-file. When unsure, commit and let the
+   code-review gate sort it out — a noisy commit is recoverable, a discarded one
+   is not.
+
 ### Authorize git (gh is already logged in)
 ```bash
 # `gh` is authorized via persistent `gh auth login` (~/.config/gh), set up by

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -203,6 +203,15 @@ gh pr merge <N> --repo "$REPO" --squash --admin
    the OFFICIAL updater — it has snapshot + automatic rollback on failure:
 ```bash
 hermes update --yes
+# Re-deploy evolution scripts + cron from the freshly-updated checkout. The
+# scheduler runs scripts from HERMES_HOME/scripts and cron jobs from
+# ~/.hermes/cron/jobs.json — NOT from the repo checkout. `hermes update` only
+# refreshes the checkout, so a merged fix to scripts/evolution_*.py (e.g. a
+# funnel crash fix) or a cron yaml never reaches the scheduler until this runs.
+# Skipping it is exactly why a "merged + deployed" script fix kept failing in
+# prod with its old bug. register_evolution_cron copies the whole evolution_*
+# script family + reconciles jobs.json; it is idempotent.
+python3 scripts/register_evolution_cron.py
 ```
    If `hermes update` reports failure/rollback, STOP merging further PRs this
    cycle and record it — a merged change broke the build and was rolled back.

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -284,3 +284,67 @@ class TestFindVenvPython:
         venv_py.write_text("#!/bin/sh\n")
         venv_py.chmod(0o644)  # not executable
         assert mod._find_venv_python(tmp_path) is None
+
+
+class TestInstallEvolutionHelpers:
+    """The whole evolution_*.py family is mirrored into HERMES_HOME/scripts so a
+    no_agent script's sibling import (funnel -> metrics/realized_impact) resolves
+    from the one dir the scheduler executes from. Without this the import is
+    silently swallowed and the dependent sidecar freezes — the deploy gap that
+    let the funnel run against a stale copy on the server."""
+
+    def _fake_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        scripts = repo / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "evolution_funnel.py").write_text("# funnel\n")
+        (scripts / "evolution_metrics.py").write_text("# metrics\n")
+        (scripts / "evolution_realized_impact.py").write_text("# realized\n")
+        # A sibling that must NOT be picked up by the evolution_*.py glob.
+        (scripts / "register_evolution_cron.py").write_text("# registrar\n")
+        (scripts / "helper.py").write_text("# unrelated\n")
+        return repo
+
+    def test_installs_whole_family(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        repo = self._fake_repo(tmp_path)
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        installed = mod._install_evolution_helpers(repo)
+
+        assert sorted(installed) == [
+            "evolution_funnel.py",
+            "evolution_metrics.py",
+            "evolution_realized_impact.py",
+        ]
+        scripts = home / "scripts"
+        assert (scripts / "evolution_funnel.py").is_file()
+        assert (scripts / "evolution_metrics.py").is_file()
+        assert (scripts / "evolution_realized_impact.py").is_file()
+        # The registrar itself and unrelated scripts are NOT installed by glob.
+        assert not (scripts / "register_evolution_cron.py").exists()
+        assert not (scripts / "helper.py").exists()
+
+    def test_refreshes_stale_copies(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        repo = self._fake_repo(tmp_path)
+        (repo / "scripts" / "evolution_funnel.py").write_text("# NEW funnel\n")
+        home = tmp_path / "hermes-home"
+        (home / "scripts").mkdir(parents=True)
+        stale = home / "scripts" / "evolution_funnel.py"
+        stale.write_text("# stale\n")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        mod._install_evolution_helpers(repo)
+
+        assert stale.read_text() == "# NEW funnel\n"
+
+    def test_no_family_returns_empty(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        assert mod._install_evolution_helpers(repo) == []


### PR DESCRIPTION
## Problem

Two consecutive nightly incidents (2026-06-15, 2026-06-16) failed in prod with bugs that were already fixed in `main`. Root cause: the scheduler runs scripts from `HERMES_HOME/scripts` and cron from `jobs.json` — **not** the repo checkout. Deploys did `git pull + gateway restart` without re-running the registrar, so merged script fixes never reached the scheduler. The funnel kept crashing on a stale Jun-14 copy (`'list' object has no attribute 'get'`) even after the fix merged.

## Changes

- **register_evolution_cron.py**: `_install_evolution_helpers()` mirrors the WHOLE `evolution_*.py` family into `HERMES_HOME/scripts`. `no_agent` scripts import siblings (funnel → metrics/realized_impact); a sibling missing from that dir made the guarded import silently no-op and froze the sidecar. Reported via `helper_scripts_installed=N`.
- **evolution-integration/SKILL.md**: run `python3 scripts/register_evolution_cron.py` right after `hermes update --yes` — the permanent fix so every merged script/cron change is actually deployed.
- **evolution-implementation/SKILL.md**: guard against the agent destroying its own uncommitted work (`git checkout --` / `reset --hard` before commit) — incident-2 cause that reset a completed run to `main` and lost the PR.
- **tests**: `TestInstallEvolutionHelpers` — family install, stale refresh, glob exclusion of the registrar/unrelated scripts, empty dir.

## Verification

- `ruff check` clean; `pytest tests/scripts/test_register_evolution_cron.py tests/scripts/test_evolution_funnel.py` → 36 passed.
- Already deployed reactively on the server during incident triage: `/root/.hermes/scripts/evolution_funnel.py` refreshed, funnel exit 0. This PR makes that deployment step permanent + adds the missing sibling install.