### PR TITLE
fix(evolution): introspection reads request_dump_*.json sessions — unblinds the loop (Closes #238)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -5,10 +5,17 @@ evolution-introspection previously loaded RAW session transcripts (last 7 days)
 into the LLM context — unbounded megabytes, the single largest context bomb in
 the pipeline, AND it put the user's private text into the model context.
 
-This script (no LLM) scans the session JSONL files for PROBLEM SIGNALS only and
-emits a compact, ANONYMIZED digest — counts per signal/tool, generic shapes,
-never raw content. The skill feeds ONLY this digest to the model. Raw private
-text never enters the context (complements the PII redaction gate #82).
+This script (no LLM) scans the session files for PROBLEM SIGNALS only and emits
+a compact, ANONYMIZED digest — counts per signal/tool, generic shapes, never
+raw content. The skill feeds ONLY this digest to the model. Raw private text
+never enters the context (complements the PII redaction gate #82).
+
+Two on-disk session formats are scanned (#238): the upstream ``*.jsonl``
+transcripts AND ``request_dump_*.json`` snapshots, which some installs persist
+instead. A request dump carries the same role-tagged messages at
+``request.body.messages`` plus a provider ``error`` object; ignoring it left
+those installs reporting ``sessions_scanned: 0`` and blinded the whole
+self-improvement loop.
 
 Signals extracted:
   * tool_failures  — tool results that look like failures, attributed to the
@@ -18,6 +25,9 @@ Signals extracted:
   * refusals       — assistant text expressing "I can't / no access / denied".
   * repeated_tool_runs — same tool called many times consecutively (the spiral
     shape loop_guard guards against), counted per session.
+  * provider_errors — from request_dump error objects: ``status_code:type``
+    only (never the response body/text, which can echo private content).
+  * models_used    — the model id from each request dump (anonymized metadata).
 
 Output: a JSON digest to stdout (and optionally a file), a few KB max.
 """
@@ -67,8 +77,11 @@ def _iter_lines(path: Path):
         return
 
 
-def scan_session(path: Path) -> Dict[str, Any]:
-    """Return per-session signal counts (no raw text)."""
+def scan_messages(messages) -> Dict[str, Any]:
+    """Return per-session signal counts (no raw text) from an iterable of
+    role-tagged message dicts. Shared by the JSONL transcript path and the
+    request_dump_*.json path (#238) so both formats yield the identical digest.
+    """
     tool_failures: Counter = Counter()
     timeouts = 0
     refusals = 0
@@ -77,7 +90,9 @@ def scan_session(path: Path) -> Dict[str, Any]:
     consec_n = 0
     max_runs: Counter = Counter()  # tool -> max consecutive in this session
 
-    for obj in _iter_lines(path):
+    for obj in messages:
+        if not isinstance(obj, dict):
+            continue
         role = obj.get("role")
         if role == "assistant":
             tcs = obj.get("tool_calls") or []
@@ -119,31 +134,104 @@ def scan_session(path: Path) -> Dict[str, Any]:
     }
 
 
+def scan_session(path: Path) -> Dict[str, Any]:
+    """Per-session signals from a JSONL transcript (one JSON object per line)."""
+    return scan_messages(_iter_lines(path))
+
+
+def _request_dump_messages(obj: Dict[str, Any]) -> List[Any]:
+    """The conversation messages carried inside a request_dump_*.json snapshot
+    live at request.body.messages — the same role-tagged shape as a JSONL
+    transcript, so scan_messages handles it directly."""
+    req = obj.get("request") if isinstance(obj, dict) else None
+    body = req.get("body") if isinstance(req, dict) else None
+    msgs = body.get("messages") if isinstance(body, dict) else None
+    return msgs if isinstance(msgs, list) else []
+
+
+def scan_request_dump(obj: Dict[str, Any]) -> Dict[str, Any]:
+    """Per-session signals from a request_dump_*.json snapshot (#238).
+
+    Reuses scan_messages over request.body.messages, and adds the provider-layer
+    error signal from the top-level ``error`` object — but ONLY its status code
+    and error type, never ``message``/``body``/``response_text`` (those can echo
+    private content; the no-raw-text contract still holds). Also records the
+    model id used, which is anonymized metadata, not user content."""
+    s = scan_messages(_request_dump_messages(obj))
+    provider_errors: Counter = Counter()
+    err = obj.get("error")
+    if isinstance(err, dict):
+        status = err.get("status_code") or err.get("response_status")
+        etype = err.get("type") or "error"
+        provider_errors[f"{status}:{etype}" if status else str(etype)] += 1
+    s["provider_errors"] = dict(provider_errors)
+    body = obj.get("request", {}).get("body") if isinstance(obj.get("request"), dict) else None
+    model = body.get("model") if isinstance(body, dict) else None
+    s["models"] = {model: 1} if isinstance(model, str) and model else {}
+    return s
+
+
+def _fresh(path: Path, cutoff: float) -> bool:
+    try:
+        return path.stat().st_mtime >= cutoff
+    except OSError:
+        return False
+
+
 def build_digest(sessions_dir: Path, window_days: int = 7, now: float | None = None) -> Dict[str, Any]:
     now = now if now is not None else time.time()
     cutoff = now - window_days * 86400
     failures: Counter = Counter()
     timeouts = 0
     refusals = 0
+    provider_errors: Counter = Counter()
+    models: Counter = Counter()
     repeated: Dict[str, Dict[str, int]] = {}  # tool -> {max_consecutive, sessions}
     scanned = 0
 
-    files = sorted(sessions_dir.glob("*.jsonl")) if sessions_dir.is_dir() else []
-    for path in files:
-        try:
-            if path.stat().st_mtime < cutoff:
-                continue
-        except OSError:
-            continue
-        scanned += 1
-        s = scan_session(path)
-        failures.update(s["tool_failures"])
-        timeouts += s["timeouts"]
-        refusals += s["refusals"]
-        for tool, n in s["repeated_tool_runs"].items():
+    def _aggregate(s: Dict[str, Any]) -> None:
+        nonlocal timeouts, refusals
+        failures.update(s.get("tool_failures", {}))
+        timeouts += s.get("timeouts", 0)
+        refusals += s.get("refusals", 0)
+        provider_errors.update(s.get("provider_errors", {}))
+        models.update(s.get("models", {}))
+        for tool, n in s.get("repeated_tool_runs", {}).items():
             r = repeated.setdefault(tool, {"max_consecutive": 0, "sessions": 0})
             r["max_consecutive"] = max(r["max_consecutive"], n)
             r["sessions"] += 1
+
+    if sessions_dir.is_dir():
+        # 1. Native JSONL transcripts (the upstream session format).
+        for path in sorted(sessions_dir.glob("*.jsonl")):
+            if not _fresh(path, cutoff):
+                continue
+            scanned += 1
+            _aggregate(scan_session(path))
+
+        # 2. request_dump_*.json snapshots (#238 — this install persists sessions
+        #    this way, so the JSONL glob found zero and the whole pipeline went
+        #    blind). Multiple dumps of one session each carry a growing prefix of
+        #    the same conversation, so dedup by session_id keeping the most
+        #    complete snapshot — one session contributes its signals once.
+        dumps: Dict[str, tuple] = {}  # session_id -> (msg_count, obj)
+        for path in sorted(sessions_dir.glob("request_dump_*.json")):
+            if not _fresh(path, cutoff):
+                continue
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                    obj = json.load(fh)
+            except (OSError, ValueError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            sid = obj.get("session_id") or path.stem
+            n_msgs = len(_request_dump_messages(obj))
+            if n_msgs >= dumps.get(sid, (-1, None))[0]:
+                dumps[sid] = (n_msgs, obj)
+        for _sid, (_n, obj) in dumps.items():
+            scanned += 1
+            _aggregate(scan_request_dump(obj))
 
     return {
         "window_days": window_days,
@@ -153,6 +241,8 @@ def build_digest(sessions_dir: Path, window_days: int = 7, now: float | None = N
             "timeouts": timeouts,
             "refusals_or_access_denied": refusals,
             "repeated_tool_runs": repeated,
+            "provider_errors": dict(provider_errors.most_common()),
+            "models_used": dict(models.most_common()),
         },
     }
 

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -89,3 +89,81 @@ class TestBuildDigest:
     def test_missing_dir_is_empty(self, tmp_path):
         d = build_digest(tmp_path / "nope", window_days=7)
         assert d["sessions_scanned"] == 0
+
+
+def _dump(tmp_path, name, messages, *, session_id, model="glm-5.2", error=None, age_days=0):
+    obj = {
+        "timestamp": "2026-06-16T00:00:00",
+        "session_id": session_id,
+        "reason": "error",
+        "request": {"method": "POST", "url": "https://x/api", "headers": {},
+                    "body": {"model": model, "messages": messages, "tools": []}},
+    }
+    if error is not None:
+        obj["error"] = error
+    p = tmp_path / f"request_dump_{name}.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    if age_days:
+        old = time.time() - age_days * 86400
+        import os
+        os.utime(p, (old, old))
+    return p
+
+
+class TestRequestDump:
+    """#238 — installs that persist sessions as request_dump_*.json must be
+    scanned too, else introspection reports zero signals and goes blind."""
+
+    def test_scanned_when_no_jsonl_present(self, tmp_path):
+        # The exact regression: a dir with only request dumps, no *.jsonl.
+        _dump(tmp_path, "d1", [
+            _asst("terminal", "c1"), _tool("c1", "bash: foo: command not found"),
+        ], session_id="sess-1", error={"type": "overloaded_error", "status_code": 529,
+                                        "message": "x", "response_text": "y"})
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 1
+        assert d["signals"]["tool_failures"] == {"terminal": 1}
+        assert d["signals"]["provider_errors"] == {"529:overloaded_error": 1}
+        assert d["signals"]["models_used"] == {"glm-5.2": 1}
+
+    def test_dedup_by_session_keeps_most_complete(self, tmp_path):
+        # Two dumps of ONE session (growing prefix) count once, via the larger.
+        short = [_asst("terminal", "c1"), _tool("c1", "permission denied")]
+        full = short + [_asst("terminal", "c2"), _tool("c2", "command not found")]
+        _dump(tmp_path, "early", short, session_id="sess-1")
+        _dump(tmp_path, "late", full, session_id="sess-1")
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 1  # one session, not two dumps
+        assert d["signals"]["tool_failures"] == {"terminal": 2}  # from the full one
+
+    def test_mixed_jsonl_and_dump_both_counted(self, tmp_path):
+        _session(tmp_path, "s1", [_asst("terminal", "c1"), _tool("c1", "command not found")])
+        _dump(tmp_path, "d1", [_asst("read_file", "c2"), _tool("c2", "no such file")],
+              session_id="sess-2")
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 2
+        assert d["signals"]["tool_failures"] == {"terminal": 1, "read_file": 1}
+
+    def test_window_excludes_old_dumps(self, tmp_path):
+        _dump(tmp_path, "old", [_asst("terminal", "c1"), _tool("c1", "command not found")],
+              session_id="sess-old", age_days=30)
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 0
+
+    def test_no_raw_text_from_error_or_messages(self, tmp_path):
+        secret = "bob@example.com at 5 Main St"
+        _dump(tmp_path, "d1", [
+            _asst("terminal", "c1"), _tool("c1", f"error: {secret}"),
+        ], session_id="sess-1", error={"type": "bad_request", "status_code": 400,
+                                       "message": secret, "response_text": secret,
+                                       "body": secret})
+        d = build_digest(tmp_path, window_days=7)
+        # Provider error contributes only status:type — never the echoed content.
+        assert d["signals"]["provider_errors"] == {"400:bad_request": 1}
+        assert secret not in json.dumps(d)
+
+    def test_malformed_dump_does_not_crash(self, tmp_path):
+        (tmp_path / "request_dump_bad.json").write_text("{ not json", encoding="utf-8")
+        (tmp_path / "request_dump_list.json").write_text("[1,2,3]", encoding="utf-8")
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 0  # both skipped, no exception


### PR DESCRIPTION
## Problem (#238)

`introspection_extract.py` only globbed `~/.hermes/sessions/*.jsonl`, but some installs persist sessions as `request_dump_*.json` (a full request/response object, not the JSONL role stream). On those installs the extractor reported `sessions_scanned: 0` — the introspection pre-filter ingested nothing, so evolution never saw real-usage failures and **stopped opening improvement issues**. The entire self-improvement loop went blind.

## Fix

- Refactor `scan_session` → shared `scan_messages(iterable)` so both formats produce the identical digest.
- Parse `request_dump_*.json`: messages live at `request.body.messages` (same role-tagged shape); dedup by `session_id` keeping the most complete snapshot (multiple dumps of one session carry a growing prefix).
- New signals from the dump's provider `error`: `provider_errors` (`status_code:type` **only** — never `message`/`body`/`response_text`, which can echo private content; the no-raw-text contract holds) + `models_used`.
- `build_digest` scans both globs; existing JSONL behavior unchanged (additive signal keys).

## Verification on the REAL install

Ran the patched extractor against the production `~/.hermes/sessions/`:

| | sessions_scanned |
|---|---|
| before | **0** (blind) |
| after | **86** |

Surfaced signals that were completely invisible: `429:RateLimitError ×60`, `403:PermissionDeniedError`, and retry spirals `browser_navigate ×15`, `terminal ×12`, `cronjob ×7`, `memory ×6` — the exact shapes issues #231/#234 describe.

Tests: 13 pass (7 original + 6 new covering jsonl-absent, session dedup, mixed, window, no-raw-text contract, malformed). ruff clean.

Closes #238.