### PR TITLE
fix(evolution): stop retry spirals on deterministic tool failures (Closes #231)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -598,12 +598,21 @@ def _run_conversation_impl(
 
             _lg_sig = _loop_guard.current_run_signature(messages)
             _lg_tool = _lg_sig[0] if _lg_sig else None
-            if _lg_tool != getattr(agent, "_loop_guard_nudged_tool", None):
-                agent._loop_guard_nudged_tool = None  # run changed/ended — re-arm
-                _lg_nudge = _loop_guard.maybe_nudge(messages) if _lg_tool else None
+            _lg_count = _lg_sig[1] if _lg_sig else 0
+            _lg_prev = getattr(agent, "_loop_guard_nudged", None)  # (tool, count) | None
+            # Re-nudge when the stuck run is NEW (tool changed/ended) OR it has
+            # grown by >=3 calls since the last nudge. Without the growth check a
+            # single nudge fired once and then went silent for the next dozen
+            # identical calls — the spiral ran on to 15+ unguided (#231). Escalating
+            # re-nudges keep pressure on a persistent loop.
+            if _lg_tool is None:
+                agent._loop_guard_nudged = None  # run ended — re-arm
+            elif (_lg_prev is None or _lg_prev[0] != _lg_tool
+                  or _lg_count - _lg_prev[1] >= 3):
+                _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
                     messages.append({"role": "user", "content": _lg_nudge})
-                    agent._loop_guard_nudged_tool = _lg_tool
+                    agent._loop_guard_nudged = (_lg_tool, _lg_count)
                     if not agent.quiet_mode:
                         agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
         except Exception as _lg_err:  # never let the guard break the loop

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -50,6 +50,25 @@ _FAILURE_MARKERS = (
 
 _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
 
+# Failure classes (from tool_diagnostics) that are DETERMINISTIC — a near-identical
+# retry reproduces them, so they must not be looped on (#231). Distinct from
+# change-and-retry classes (not_found, runtime_error) where a corrected retry can
+# legitimately succeed. Two of these in a row already warrants a hard stop, below
+# the generic fail_threshold.
+_NON_RETRYABLE = frozenset({"timeout", "permission", "missing_command", "limit"})
+_NONRETRY_THRESHOLD = 2
+
+
+def _failure_category(content: Any) -> Optional[str]:
+    """The tool_diagnostics failure class of a result, or None if not a failure.
+    Imported lazily with a no-op fallback so loop_guard stays standalone."""
+    try:
+        from agent.tool_diagnostics import classify
+    except Exception:  # pragma: no cover - keep standalone if import path differs
+        return None
+    hit = classify(content)
+    return hit[0] if hit else None
+
 
 def _looks_like_failure(content: Any) -> bool:
     if not isinstance(content, str) or not content:
@@ -60,15 +79,17 @@ def _looks_like_failure(content: Any) -> bool:
     return bool(_EXIT_CODE_RE.search(content))
 
 
-def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool]]:
-    """Most-recent-first list of (single_tool_name, result_failed) for the
-    trailing run of assistant turns that each called EXACTLY ONE tool.
+def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, Optional[str]]]:
+    """Most-recent-first list of (single_tool_name, result_failed, failure_class)
+    for the trailing run of assistant turns that each called EXACTLY ONE tool.
+    ``failure_class`` is the tool_diagnostics category of the failing result (or
+    None when the turn did not fail).
 
     Stops at the first assistant turn that is not a single-tool call (a text
     reply, or a multi-tool turn) — that breaks the "stuck on one tool" run.
     Multi-tool turns are normal varied work, not a single-tool spiral.
     """
-    runs: List[Tuple[str, bool]] = []
+    runs: List[Tuple[str, bool, Optional[str]]] = []
     i = len(messages) - 1
     # Collect tool results by id as we walk back so we can mark failures.
     while i >= 0:
@@ -88,13 +109,15 @@ def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool]]:
                 break  # tool changed — the same-tool run ends here
             # Results for this turn are the "tool" messages that follow it.
             failed = False
+            category: Optional[str] = None
             for j in range(i + 1, len(messages)):
                 tm = messages[j]
                 if tm.get("role") != "tool":
                     break
                 if _looks_like_failure(tm.get("content")):
                     failed = True
-            runs.append((tool, failed))
+                    category = _failure_category(tm.get("content")) or category
+            runs.append((tool, failed, category))
             i -= 1
         elif msg.get("role") == "tool":
             i -= 1  # skip result messages; handled with their assistant turn
@@ -124,11 +147,37 @@ def maybe_nudge(
     same = [r for r in runs if r[0] == tool]
     count = len(same)
     consec_fail = 0
-    for _t, failed in same:
+    consec_nonretry = 0
+    nonretry_class: Optional[str] = None
+    counting_nonretry = True
+    for _t, failed, category in same:
         if failed:
             consec_fail += 1
         else:
             break
+        # Trailing run of failures that are all the SAME deterministic class.
+        if counting_nonretry and category in _NON_RETRYABLE:
+            if nonretry_class is None or category == nonretry_class:
+                nonretry_class = category
+                consec_nonretry += 1
+            else:
+                counting_nonretry = False
+        else:
+            counting_nonretry = False
+
+    # Highest-priority: a DETERMINISTIC failure repeated even once (#231). These
+    # reproduce on a near-identical retry, so the generic 3-strike threshold is
+    # too lenient — two in a row is already a spiral (terminal timeouts, denied
+    # paths, missing binaries, size-limit caps). Stop hard and name the class.
+    if consec_nonretry >= _NONRETRY_THRESHOLD:
+        return (
+            f"[loop-guard] `{tool}` returned a non-retryable `{nonretry_class}` "
+            f"failure {consec_nonretry} times in a row. This class is DETERMINISTIC "
+            f"— the same call reproduces it, so retrying is futile. Do NOT call "
+            f"`{tool}` the same way again. Change the approach now: adjust the "
+            f"parameters/path/command, route to a fallback tool, or report the "
+            f"blocker concisely if it can't be resolved."
+        )
 
     if consec_fail >= fail_threshold:
         return (

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -41,12 +41,15 @@ class TestRepeatTrigger:
 
 class TestFailureTrigger:
     def test_three_consecutive_failures_nudges_even_below_repeat(self):
-        msgs = _run("terminal", 3, result="bash: foo: command not found")
+        # A change-and-retry class (runtime_error) needs the generic 3-strike.
+        msgs = _run("terminal", 3, result="error: build step blew up")
         n = maybe_nudge(msgs)
         assert n is not None and "failed 3 times" in n
 
-    def test_two_failures_not_enough(self):
-        assert maybe_nudge(_run("terminal", 2, result="permission denied")) is None
+    def test_two_change_and_retry_failures_not_enough(self):
+        # runtime_error is NOT deterministic — a corrected retry can succeed, so
+        # two is below the generic 3-strike and stays quiet.
+        assert maybe_nudge(_run("terminal", 2, result="error: transient blip")) is None
 
     def test_exit_code_marker_counts_as_failure(self):
         msgs = _run("execute_code", 3, result="process finished, exit code: 1")
@@ -56,6 +59,33 @@ class TestFailureTrigger:
         msgs = _run("mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError")
         n = maybe_nudge(msgs)
         assert n is not None
+
+
+class TestNonRetryableTrigger:
+    """#231 — DETERMINISTIC failure classes (timeout/permission/missing_command/
+    limit) reproduce on retry, so two in a row trip a hard stop below the generic
+    3-strike threshold."""
+
+    def test_two_permission_denials_stop_hard(self):
+        n = maybe_nudge(_run("terminal", 2, result="permission denied"))
+        assert n is not None and "non-retryable" in n and "permission" in n
+
+    def test_two_timeouts_stop_hard(self):
+        n = maybe_nudge(_run("terminal", 2, result="failure-class=timeout — The operation timed out"))
+        assert n is not None and "non-retryable" in n and "timeout" in n
+
+    def test_single_deterministic_failure_is_quiet(self):
+        assert maybe_nudge(_run("terminal", 1, result="permission denied")) is None
+
+    def test_mixed_deterministic_classes_do_not_accumulate(self):
+        # A permission failure then a timeout failure are different classes — the
+        # deterministic counter only fires on the SAME class repeating, so this
+        # falls through to the generic path (2 < 3) and stays quiet.
+        msgs = [{"role": "user", "content": "go"}]
+        msgs += [_asst("terminal", call_id="c0"), _result("permission denied", "c0")]
+        msgs += [_asst("terminal", call_id="c1"), _result("connection timed out", "c1")]
+        # most-recent-first: timeout(1) then permission — classes differ, counter=1
+        assert maybe_nudge(msgs) is None
 
 
 class TestRunBoundaries:


### PR DESCRIPTION
## Problem (#231)

Terminal timeout/clamp diagnostics were retried up to **15× in a row** (confirmed in live introspection data: `terminal ×12`, `browser_navigate ×15` consecutive spirals). Two gaps in the existing advisory machinery:

1. `loop_guard` only nudged at **3** consecutive failures, with a generic message. But deterministic classes (`timeout`, `permission`, `missing_command`, `limit` — from `tool_diagnostics`) **reproduce on a near-identical retry**, so 3 is too lenient.
2. The caller (`conversation_loop`) nudged **once per stuck run** then went silent — a 15-call spiral got one nudge and 14 unguided calls.

## Fix

1. New highest-priority `loop_guard` trigger: **2 in a row of the same deterministic class** → a hard, class-named stop ("non-retryable `timeout` failure… the same call reproduces it"). Change-and-retry classes (`not_found`, `runtime_error`) keep the 3-strike threshold — a corrected retry can legitimately succeed there.
2. Caller re-nudges when the run **grows by ≥3 calls** since the last nudge, so persistent loops keep getting (escalating) pressure instead of silence.

Reuses the existing `tool_diagnostics` classifier — no new taxonomy.

## Tests

`TestNonRetryableTrigger` (2-strike deterministic stop, single failure stays quiet, mixed classes don't accumulate) + reworked failure-trigger tests for the change-and-retry path. **15 pass, ruff clean.**

Closes #231.