### PR TITLE
fix(evolution): browser_navigate taxonomy + web_extract fallback + per-URL cap (Closes #234, #213)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -598,12 +598,21 @@ def _run_conversation_impl(
 
             _lg_sig = _loop_guard.current_run_signature(messages)
             _lg_tool = _lg_sig[0] if _lg_sig else None
-            if _lg_tool != getattr(agent, "_loop_guard_nudged_tool", None):
-                agent._loop_guard_nudged_tool = None  # run changed/ended — re-arm
-                _lg_nudge = _loop_guard.maybe_nudge(messages) if _lg_tool else None
+            _lg_count = _lg_sig[1] if _lg_sig else 0
+            _lg_prev = getattr(agent, "_loop_guard_nudged", None)  # (tool, count) | None
+            # Re-nudge when the stuck run is NEW (tool changed/ended) OR it has
+            # grown by >=3 calls since the last nudge. Without the growth check a
+            # single nudge fired once and then went silent for the next dozen
+            # identical calls — the spiral ran on to 15+ unguided (#231). Escalating
+            # re-nudges keep pressure on a persistent loop.
+            if _lg_tool is None:
+                agent._loop_guard_nudged = None  # run ended — re-arm
+            elif (_lg_prev is None or _lg_prev[0] != _lg_tool
+                  or _lg_count - _lg_prev[1] >= 3):
+                _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
                     messages.append({"role": "user", "content": _lg_nudge})
-                    agent._loop_guard_nudged_tool = _lg_tool
+                    agent._loop_guard_nudged = (_lg_tool, _lg_count)
                     if not agent.quiet_mode:
                         agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
         except Exception as _lg_err:  # never let the guard break the loop

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -50,6 +50,25 @@ _FAILURE_MARKERS = (
 
 _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
 
+# Failure classes (from tool_diagnostics) that are DETERMINISTIC — a near-identical
+# retry reproduces them, so they must not be looped on (#231). Distinct from
+# change-and-retry classes (not_found, runtime_error) where a corrected retry can
+# legitimately succeed. Two of these in a row already warrants a hard stop, below
+# the generic fail_threshold.
+_NON_RETRYABLE = frozenset({"timeout", "permission", "missing_command", "limit"})
+_NONRETRY_THRESHOLD = 2
+
+
+def _failure_category(content: Any) -> Optional[str]:
+    """The tool_diagnostics failure class of a result, or None if not a failure.
+    Imported lazily with a no-op fallback so loop_guard stays standalone."""
+    try:
+        from agent.tool_diagnostics import classify
+    except Exception:  # pragma: no cover - keep standalone if import path differs
+        return None
+    hit = classify(content)
+    return hit[0] if hit else None
+
 
 def _looks_like_failure(content: Any) -> bool:
     if not isinstance(content, str) or not content:
@@ -60,15 +79,17 @@ def _looks_like_failure(content: Any) -> bool:
     return bool(_EXIT_CODE_RE.search(content))
 
 
-def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool]]:
-    """Most-recent-first list of (single_tool_name, result_failed) for the
-    trailing run of assistant turns that each called EXACTLY ONE tool.
+def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, Optional[str]]]:
+    """Most-recent-first list of (single_tool_name, result_failed, failure_class)
+    for the trailing run of assistant turns that each called EXACTLY ONE tool.
+    ``failure_class`` is the tool_diagnostics category of the failing result (or
+    None when the turn did not fail).
 
     Stops at the first assistant turn that is not a single-tool call (a text
     reply, or a multi-tool turn) — that breaks the "stuck on one tool" run.
     Multi-tool turns are normal varied work, not a single-tool spiral.
     """
-    runs: List[Tuple[str, bool]] = []
+    runs: List[Tuple[str, bool, Optional[str]]] = []
     i = len(messages) - 1
     # Collect tool results by id as we walk back so we can mark failures.
     while i >= 0:
@@ -88,13 +109,15 @@ def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool]]:
                 break  # tool changed — the same-tool run ends here
             # Results for this turn are the "tool" messages that follow it.
             failed = False
+            category: Optional[str] = None
             for j in range(i + 1, len(messages)):
                 tm = messages[j]
                 if tm.get("role") != "tool":
                     break
                 if _looks_like_failure(tm.get("content")):
                     failed = True
-            runs.append((tool, failed))
+                    category = _failure_category(tm.get("content")) or category
+            runs.append((tool, failed, category))
             i -= 1
         elif msg.get("role") == "tool":
             i -= 1  # skip result messages; handled with their assistant turn
@@ -124,11 +147,37 @@ def maybe_nudge(
     same = [r for r in runs if r[0] == tool]
     count = len(same)
     consec_fail = 0
-    for _t, failed in same:
+    consec_nonretry = 0
+    nonretry_class: Optional[str] = None
+    counting_nonretry = True
+    for _t, failed, category in same:
         if failed:
             consec_fail += 1
         else:
             break
+        # Trailing run of failures that are all the SAME deterministic class.
+        if counting_nonretry and category in _NON_RETRYABLE:
+            if nonretry_class is None or category == nonretry_class:
+                nonretry_class = category
+                consec_nonretry += 1
+            else:
+                counting_nonretry = False
+        else:
+            counting_nonretry = False
+
+    # Highest-priority: a DETERMINISTIC failure repeated even once (#231). These
+    # reproduce on a near-identical retry, so the generic 3-strike threshold is
+    # too lenient — two in a row is already a spiral (terminal timeouts, denied
+    # paths, missing binaries, size-limit caps). Stop hard and name the class.
+    if consec_nonretry >= _NONRETRY_THRESHOLD:
+        return (
+            f"[loop-guard] `{tool}` returned a non-retryable `{nonretry_class}` "
+            f"failure {consec_nonretry} times in a row. This class is DETERMINISTIC "
+            f"— the same call reproduces it, so retrying is futile. Do NOT call "
+            f"`{tool}` the same way again. Change the approach now: adjust the "
+            f"parameters/path/command, route to a fallback tool, or report the "
+            f"blocker concisely if it can't be resolved."
+        )
 
     if consec_fail >= fail_threshold:
         return (

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -41,12 +41,15 @@ class TestRepeatTrigger:
 
 class TestFailureTrigger:
     def test_three_consecutive_failures_nudges_even_below_repeat(self):
-        msgs = _run("terminal", 3, result="bash: foo: command not found")
+        # A change-and-retry class (runtime_error) needs the generic 3-strike.
+        msgs = _run("terminal", 3, result="error: build step blew up")
         n = maybe_nudge(msgs)
         assert n is not None and "failed 3 times" in n
 
-    def test_two_failures_not_enough(self):
-        assert maybe_nudge(_run("terminal", 2, result="permission denied")) is None
+    def test_two_change_and_retry_failures_not_enough(self):
+        # runtime_error is NOT deterministic — a corrected retry can succeed, so
+        # two is below the generic 3-strike and stays quiet.
+        assert maybe_nudge(_run("terminal", 2, result="error: transient blip")) is None
 
     def test_exit_code_marker_counts_as_failure(self):
         msgs = _run("execute_code", 3, result="process finished, exit code: 1")
@@ -56,6 +59,33 @@ class TestFailureTrigger:
         msgs = _run("mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError")
         n = maybe_nudge(msgs)
         assert n is not None
+
+
+class TestNonRetryableTrigger:
+    """#231 — DETERMINISTIC failure classes (timeout/permission/missing_command/
+    limit) reproduce on retry, so two in a row trip a hard stop below the generic
+    3-strike threshold."""
+
+    def test_two_permission_denials_stop_hard(self):
+        n = maybe_nudge(_run("terminal", 2, result="permission denied"))
+        assert n is not None and "non-retryable" in n and "permission" in n
+
+    def test_two_timeouts_stop_hard(self):
+        n = maybe_nudge(_run("terminal", 2, result="failure-class=timeout — The operation timed out"))
+        assert n is not None and "non-retryable" in n and "timeout" in n
+
+    def test_single_deterministic_failure_is_quiet(self):
+        assert maybe_nudge(_run("terminal", 1, result="permission denied")) is None
+
+    def test_mixed_deterministic_classes_do_not_accumulate(self):
+        # A permission failure then a timeout failure are different classes — the
+        # deterministic counter only fires on the SAME class repeating, so this
+        # falls through to the generic path (2 < 3) and stays quiet.
+        msgs = [{"role": "user", "content": "go"}]
+        msgs += [_asst("terminal", call_id="c0"), _result("permission denied", "c0")]
+        msgs += [_asst("terminal", call_id="c1"), _result("connection timed out", "c1")]
+        # most-recent-first: timeout(1) then permission — classes differ, counter=1
+        assert maybe_nudge(msgs) is None
 
 
 class TestRunBoundaries:

--- a/tests/tools/test_browser_navigate_fallback.py
+++ b/tests/tools/test_browser_navigate_fallback.py
@@ -1,0 +1,72 @@
+"""Tests for tools/browser_navigate_fallback.py (#234/#213)."""
+
+import tools.browser_navigate_fallback as bnf
+
+
+class TestClassify:
+    def test_cdp_unavailable(self):
+        assert bnf.classify_navigation_error("CDP command timed out: Page.navigate") in (
+            "cdp_unavailable", "navigation_timeout")  # both are valid; timeout wins by order
+
+    def test_pure_cdp(self):
+        assert bnf.classify_navigation_error("Could not connect to Chrome backend") == "cdp_unavailable"
+
+    def test_timeout(self):
+        assert bnf.classify_navigation_error("navigation timed out after 60s") == "navigation_timeout"
+
+    def test_tool_not_present(self):
+        assert bnf.classify_navigation_error("Tool does not exist. Available tools: open, click") == "tool_not_present"
+
+    def test_dom_error(self):
+        assert bnf.classify_navigation_error("Could not compute box model") == "dom_error"
+
+    def test_generic(self):
+        assert bnf.classify_navigation_error("something weird happened") == "navigation_error"
+
+    def test_empty(self):
+        assert bnf.classify_navigation_error(None) == "navigation_error"
+        assert bnf.classify_navigation_error("") == "navigation_error"
+
+
+class TestFailureCounter:
+    def setup_method(self):
+        bnf._nav_failures.clear()
+
+    def test_increments_and_resets(self):
+        assert bnf.record_nav_failure("u") == 1
+        assert bnf.record_nav_failure("u") == 2
+        bnf.reset_nav_failures("u")
+        assert bnf.record_nav_failure("u") == 1
+
+    def test_independent_urls(self):
+        bnf.record_nav_failure("a")
+        assert bnf.record_nav_failure("b") == 1
+
+
+class TestBuildNavigationFailure:
+    def setup_method(self):
+        bnf._nav_failures.clear()
+
+    def test_fallback_content_returned(self, monkeypatch):
+        monkeypatch.setattr(bnf, "web_extract_fallback", lambda url: ("# Page text", None))
+        r = bnf.build_navigation_failure("https://x", "CDP command timed out")
+        assert r["success"] is False
+        assert r["fallback_used"] == "web_extract"
+        assert r["fallback_content"] == "# Page text"
+        assert "do NOT re-navigate" in r["recovery"]
+
+    def test_fallback_failed_gives_taxonomy_hint(self, monkeypatch):
+        monkeypatch.setattr(bnf, "web_extract_fallback", lambda url: (None, "extract boom"))
+        r = bnf.build_navigation_failure("https://x", "Could not connect to Chrome")
+        assert r["fallback_used"] is None
+        assert r["failure_class"] == "cdp_unavailable"
+        assert r["fallback_error"] == "extract boom"
+        assert "web_search" in r["recovery"] or "extracted" in r["recovery"]
+
+    def test_cap_message_after_threshold(self, monkeypatch):
+        monkeypatch.setattr(bnf, "web_extract_fallback", lambda url: (None, "no"))
+        for _ in range(bnf.MAX_NAV_FAILURES - 1):
+            bnf.build_navigation_failure("https://x", "timeout")
+        r = bnf.build_navigation_failure("https://x", "timeout")
+        assert r["nav_failures_for_url"] == bnf.MAX_NAV_FAILURES
+        assert "cap" in r["recovery"].lower() and "STOP" in r["recovery"]

--- a/tools/browser_navigate_fallback.py
+++ b/tools/browser_navigate_fallback.py
@@ -1,0 +1,147 @@
+"""Fallback + failure-taxonomy helpers for ``browser_navigate`` (#234/#213).
+
+When navigation fails the agent used to retry ``browser_navigate`` up to 15× in
+a row with no recovery. This module gives the failure a small, stable TAXONOMY
+and an active fallback to ``web_extract`` (text retrieval of the same URL), plus
+a per-URL retry cap so a broken page/backend can't drive an unbounded spiral.
+
+Kept in its own module to avoid a top-level import cycle between
+``tools.browser_tool`` and ``tools.web_tools`` — ``browser_tool`` imports it
+lazily inside the failure branch, so the heavy web-tools chain only loads once
+navigation has already failed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Per-URL consecutive navigation-failure counts. After ``MAX_NAV_FAILURES`` the
+# fallback layer stops re-attempting the browser for that URL and tells the agent
+# to use the extracted text / web_search / report instead of looping. Reset on a
+# successful navigation. Process-local; bounded by URL cardinality in a session.
+_nav_failures: dict[str, int] = {}
+MAX_NAV_FAILURES = 3
+
+# Ordered most-specific first; first match wins. (regex, taxonomy_class).
+_NAV_ERROR_RULES: tuple[tuple[re.Pattern, str], ...] = (
+    (re.compile(r"tool does not exist|available tools:|unknown ref|no such tool", re.I),
+     "tool_not_present"),
+    (re.compile(r"\bCDP\b|chrome devtools|websocketdebugger|could not connect to (chrome|browser)|browser (backend|session) (unavailable|not)", re.I),
+     "cdp_unavailable"),
+    (re.compile(r"timed out|timeout|deadline exceeded|navigation timeout|Page\.navigate", re.I),
+     "navigation_timeout"),
+    (re.compile(r"could not compute box model|detached|stale element|DOM|selector|element not found", re.I),
+     "dom_error"),
+)
+
+_TAXONOMY_HINT = {
+    "tool_not_present": "The browser backend exposed a different tool set. Do NOT repeat the same "
+                        "call — use the extracted text below, web_search, or report the gap.",
+    "cdp_unavailable": "The browser backend (CDP/Chrome) is unavailable. Retrying navigation will "
+                       "keep failing — use the extracted text below or web_search for this URL.",
+    "navigation_timeout": "Navigation timed out. This is deterministic for a slow/blocked page — "
+                          "use the extracted text below or web_search instead of re-navigating.",
+    "dom_error": "The page DOM could not be read. Use the extracted text below, or fetch via "
+                 "web_extract/web_search rather than re-driving the browser.",
+    "navigation_error": "Navigation failed. Use the extracted text below or web_search for this URL "
+                        "rather than repeating browser_navigate.",
+}
+
+
+def classify_navigation_error(error: Optional[str]) -> str:
+    """Map a navigation error string to a stable taxonomy class."""
+    if not isinstance(error, str) or not error.strip():
+        return "navigation_error"
+    for pattern, klass in _NAV_ERROR_RULES:
+        if pattern.search(error):
+            return klass
+    return "navigation_error"
+
+
+def record_nav_failure(url: str) -> int:
+    """Increment and return the consecutive failure count for ``url``."""
+    _nav_failures[url] = _nav_failures.get(url, 0) + 1
+    return _nav_failures[url]
+
+
+def reset_nav_failures(url: str) -> None:
+    """Clear the failure count for ``url`` after a successful navigation."""
+    _nav_failures.pop(url, None)
+
+
+def web_extract_fallback(url: str) -> Tuple[Optional[str], Optional[str]]:
+    """Attempt ``web_extract`` for the URL. Returns (content, error).
+
+    Runs the async web_extract tool in a fresh event loop. If a loop is already
+    running in this thread (unexpected for the sync tool-dispatch path), reports
+    that rather than crashing the navigation result.
+    """
+    import asyncio
+
+    try:
+        from tools.web_tools import web_extract_tool
+    except Exception as exc:  # pragma: no cover - import path/env dependent
+        return None, f"web_extract unavailable: {exc}"
+
+    try:
+        try:
+            asyncio.get_running_loop()
+            return None, "web_extract fallback skipped: event loop already running"
+        except RuntimeError:
+            pass  # no running loop — safe to use asyncio.run
+        extracted = asyncio.run(
+            web_extract_tool([url], format="markdown", use_llm_processing=False)
+        )
+        parsed = json.loads(extracted)
+    except Exception as exc:
+        return None, f"web_extract fallback errored: {exc}"
+
+    if parsed.get("success") is False:
+        return None, parsed.get("error", "web_extract returned an error")
+    results = parsed.get("results", [])
+    if results and results[0].get("content"):
+        return results[0]["content"], None
+    if results:
+        return None, results[0].get("error") or "web_extract returned empty content"
+    return None, "web_extract returned no results"
+
+
+def build_navigation_failure(url: str, error: Optional[str]) -> dict:
+    """Build the structured browser_navigate failure result (#234/#213):
+    classify, count toward the per-URL cap, attempt the web_extract fallback,
+    and attach an actionable recovery directive."""
+    klass = classify_navigation_error(error)
+    failures = record_nav_failure(url)
+    capped = failures >= MAX_NAV_FAILURES
+
+    content, fb_error = web_extract_fallback(url)
+
+    response: dict = {
+        "success": False,
+        "error": error or "Navigation failed",
+        "failure_class": klass,
+        "nav_failures_for_url": failures,
+    }
+    if content:
+        response["fallback_used"] = "web_extract"
+        response["fallback_content"] = content
+        response["recovery"] = (
+            "browser_navigate failed but web_extract retrieved the page text "
+            "(in fallback_content). Use it directly; do NOT re-navigate."
+        )
+    else:
+        response["fallback_used"] = None
+        response["fallback_error"] = fb_error
+        hint = _TAXONOMY_HINT.get(klass, _TAXONOMY_HINT["navigation_error"])
+        if capped:
+            hint = (
+                f"Reached the {MAX_NAV_FAILURES}-attempt cap for this URL. STOP "
+                f"navigating here. " + hint
+            )
+        response["recovery"] = hint
+    return response

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2506,12 +2506,30 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         except Exception as e:
             logger.debug("Auto-snapshot after navigate failed: %s", e)
 
+        # Navigation succeeded — clear this URL's failure streak (#234/#213).
+        try:
+            from tools.browser_navigate_fallback import reset_nav_failures
+            reset_nav_failures(url)
+        except Exception:  # pragma: no cover - never let bookkeeping break nav
+            pass
         return json.dumps(response, ensure_ascii=False)
     else:
-        return json.dumps({
-            "success": False,
-            "error": result.get("error", "Navigation failed")
-        }, ensure_ascii=False)
+        # Navigation failed. Classify the failure, attempt a web_extract fallback
+        # for the same URL, and cap per-URL retries so a broken page/backend can't
+        # drive an unbounded browser_navigate spiral (#234/#213). Lazy import to
+        # avoid a browser_tool <-> web_tools cycle.
+        try:
+            from tools.browser_navigate_fallback import build_navigation_failure
+            return json.dumps(
+                build_navigation_failure(url, result.get("error")),
+                ensure_ascii=False,
+            )
+        except Exception as _fb_err:  # pragma: no cover - degrade to plain error
+            logger.debug("browser_navigate fallback failed: %s", _fb_err)
+            return json.dumps({
+                "success": False,
+                "error": result.get("error", "Navigation failed"),
+            }, ensure_ascii=False)
 
 
 def browser_snapshot(


### PR DESCRIPTION
## Problem (#234, #213 — same bug)

`browser_navigate` failures (CDP timeouts, unknown refs, DOM errors, page-load failures) were retried up to **15× in a row** (confirmed in live introspection: `browser_navigate ×15` spirals) with no fallback or diagnostic.

## Fix — new `tools/browser_navigate_fallback.py`

- **Taxonomy**: `classify_navigation_error` → `cdp_unavailable`, `navigation_timeout`, `dom_error`, `tool_not_present`, `navigation_error`.
- **Active fallback**: on failure, `web_extract` retrieves the same URL's text so the task proceeds without the browser (guarded against a running event loop; lazy import avoids a `browser_tool`↔`web_tools` cycle).
- **Per-URL retry cap**: failure counter + `MAX_NAV_FAILURES=3`; past the cap the recovery directive says STOP navigating here (use extracted text / web_search / report). Reset on a successful nav.

`browser_navigate`'s failure branch now returns a structured result (`failure_class`, `fallback_content` or `fallback_error`, `recovery`). Pairs with the #231 loop-guard fix (CDP timeouts are a deterministic class, stopped at 2 consecutive).

## Tests

12 (classify cases, failure counter, build-with/without-fallback-content, cap message). ruff clean; browser_tool imports clean.

Closes #234. Closes #213.