### PR TITLE
feat(evolution): structured failure_category in request dumps + introspection (Closes #236)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1229,6 +1229,24 @@ def dump_api_request_debug(
                 except Exception as e:
                     _ra().logger.debug("Could not extract error response details: %s", e)
 
+            # Structured failure category from the shared classifier (#236): so a
+            # RuntimeError and a BadRequestError from the same model no longer look
+            # identical at the dump level, and introspection (#238) can group
+            # provider failures by recovery class instead of raw exception type.
+            # Pure classification — never touches dispatch/failover.
+            try:
+                from agent.error_classifier import classify_api_error
+
+                classified = classify_api_error(
+                    error,
+                    provider=getattr(agent, "provider", "") or "",
+                    model=getattr(agent, "model", "") or "",
+                )
+                error_info["failure_category"] = classified.reason.value
+                error_info["retryable"] = classified.retryable
+            except Exception as e:
+                _ra().logger.debug("Could not classify error for debug dump: %s", e)
+
             dump_payload["error"] = error_info
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")

--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -162,8 +162,12 @@ def scan_request_dump(obj: Dict[str, Any]) -> Dict[str, Any]:
     err = obj.get("error")
     if isinstance(err, dict):
         status = err.get("status_code") or err.get("response_status")
-        etype = err.get("type") or "error"
-        provider_errors[f"{status}:{etype}" if status else str(etype)] += 1
+        # Prefer the structured recovery class (#236) over the raw exception type:
+        # `rate_limit`/`auth`/`model_not_found` groups recurring bad provider-model
+        # pairs far better than `RuntimeError`/`BadRequestError` (#237 pt3). Falls
+        # back to the exception type for dumps written before failure_category.
+        label = err.get("failure_category") or err.get("type") or "error"
+        provider_errors[f"{status}:{label}" if status else str(label)] += 1
     s["provider_errors"] = dict(provider_errors)
     body = obj.get("request", {}).get("body") if isinstance(obj.get("request"), dict) else None
     model = body.get("model") if isinstance(body, dict) else None

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -167,3 +167,13 @@ class TestRequestDump:
         (tmp_path / "request_dump_list.json").write_text("[1,2,3]", encoding="utf-8")
         d = build_digest(tmp_path, window_days=7)
         assert d["sessions_scanned"] == 0  # both skipped, no exception
+
+    def test_failure_category_preferred_over_raw_type(self, tmp_path):
+        # #236: dumps now carry a structured failure_category; introspection keys
+        # provider_errors by it (recovery class) so recurring bad provider-model
+        # pairs group as e.g. 429:rate_limit instead of 429:RuntimeError (#237 pt3).
+        _dump(tmp_path, "d1", [_asst("x", "c1"), _tool("c1", "ok")],
+              session_id="s1", error={"type": "RuntimeError", "status_code": 429,
+                                      "failure_category": "rate_limit"})
+        d = build_digest(tmp_path, window_days=7)
+        assert d["signals"]["provider_errors"] == {"429:rate_limit": 1}


### PR DESCRIPTION
## Problem (#236)

Request dumps already captured `request_id`, `status_code`, and `response_text`, but a `RuntimeError` and a `BadRequestError` from the same model looked **identical** at the dump level — engineers (and the evolution loop) couldn't quickly tell whether a failure was a bad model id, an invalid key, a rate limit, or a malformed request.

## Fix

- `dump_api_request_debug` now annotates `error_info` with a structured **`failure_category`** (from the shared `error_classifier.FailoverReason`: `rate_limit` / `auth` / `model_not_found` / `overloaded` / `format_error` / …) plus `retryable`. Pure classification — it never touches the dispatch/failover path.
- `introspection_extract` keys `provider_errors` by `failure_category` when present (`429:rate_limit`) instead of the raw exception type (`429:RuntimeError`), so the evolution loop can spot recurring bad provider-model pairs (directly serves #237 point 3). Falls back to the exception type for older dumps.

**Scope note:** ask 1 (`request_id`) and ask 2 (final response body) were already captured. Ask 3 (full per-attempt retry history + backoff) needs new accumulation plumbing in the retry loop; the existing dump `reason` already conveys the terminal outcome (`non_retryable_client_error` / `max_retries_exhausted`), so the high-value structured-category gap (ask 4) is closed here and the per-attempt history is left as a follow-up.

## Tests

introspection `failure_category` preference; run_agent dump + 429-rotation paths green (4 passed). ruff clean.

Closes #236.
