### PR TITLE
fix(evolution): structured error_class + recovery routing for read_file/patch (Closes #216)

### DIFF
--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -1,0 +1,66 @@
+"""Tests for read/patch structured error_class + recovery routing (#216)."""
+
+from tools.file_operations import (
+    PatchResult,
+    ReadResult,
+    classify_file_error,
+)
+
+
+class TestClassifyFileError:
+    def test_none_when_no_error(self):
+        assert classify_file_error(None) is None
+        assert classify_file_error("") is None
+
+    def test_permission(self):
+        klass, rec = classify_file_error("Write denied: '/etc/x' is a protected system/credential file.")
+        assert klass == "permission" and "allowed path" in rec
+
+    def test_not_found_without_similars_routes_to_write_file(self):
+        klass, rec = classify_file_error("File not found: /tmp/missing.py")
+        assert klass == "not_found" and "write_file" in rec
+
+    def test_not_found_with_similars_is_fuzzy_match(self):
+        klass, rec = classify_file_error(
+            "File not found: /tmp/utils.py", similar_files=["/tmp/util.py", "/tmp/utils2.py"]
+        )
+        assert klass == "fuzzy_match" and "util.py" in rec
+
+    def test_patch_parse(self):
+        klass, rec = classify_file_error("Failed to parse patch: bad context")
+        assert klass == "patch_parse"
+
+    def test_block_no_match_is_fuzzy(self):
+        klass, rec = classify_file_error("search block did not match the file content")
+        assert klass == "fuzzy_match" and "EXACT" in rec
+
+    def test_verification(self):
+        klass, _ = classify_file_error("Post-write verification failed: could not re-read x")
+        assert klass == "verification"
+
+    def test_binary(self):
+        klass, _ = classify_file_error("Binary file - cannot display as text.")
+        assert klass == "binary"
+
+    def test_unknown_falls_back_to_error(self):
+        klass, rec = classify_file_error("something inexplicable happened")
+        assert klass == "error" and "CHANGE the call" in rec
+
+
+class TestResultToDict:
+    def test_read_result_success_has_no_error_class(self):
+        d = ReadResult(content="hi", total_lines=1).to_dict()
+        assert "error_class" not in d and "recovery" not in d
+
+    def test_read_result_not_found_routes(self):
+        d = ReadResult(error="File not found: /x", similar_files=["/y"]).to_dict()
+        assert d["error_class"] == "fuzzy_match"
+        assert "recovery" in d
+
+    def test_patch_result_error_classified(self):
+        d = PatchResult(success=False, error="Failed to parse patch: x").to_dict()
+        assert d["error_class"] == "patch_parse" and "recovery" in d
+
+    def test_patch_result_success_clean(self):
+        d = PatchResult(success=True, diff="--- a").to_dict()
+        assert "error_class" not in d

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -30,7 +30,7 @@ import re
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
 
@@ -152,6 +152,64 @@ def _is_write_denied(path: str) -> bool:
 # Result Data Classes
 # =============================================================================
 
+def classify_file_error(
+    error: Optional[str], *, similar_files: Optional[List[str]] = None
+) -> Optional[Tuple[str, str]]:
+    """Map a read/patch error string to ``(error_class, recovery)`` for #216, or
+    None when there is no error. Lets the model route to the right recovery —
+    create the file, fix the patch text, use a different tool — instead of
+    re-issuing the same failing call. Derived from the already-set ``error``
+    string so no error-producing site has to be touched."""
+    if not error:
+        return None
+    low = error.lower()
+    if "denied" in low or "protected" in low or "permission" in low:
+        return "permission", (
+            "The path is protected/denied and can't be elevated. Use an allowed "
+            "path — do NOT retry the same one."
+        )
+    if "binary file" in low:
+        return "binary", (
+            "This is a binary file. Don't read it as text; use a tool suited to the "
+            "file type."
+        )
+    if "not found" in low or "no such file" in low:
+        if similar_files:
+            return "fuzzy_match", (
+                "The exact path wasn't found. Did you mean one of: "
+                f"{', '.join(similar_files[:5])}? Otherwise create it with write_file."
+            )
+        return "not_found", (
+            "The file doesn't exist. Create it with write_file, or re-check the path "
+            "(it may be dynamic) — don't repeat the same read."
+        )
+    if "parse patch" in low or ("parse" in low and "patch" in low):
+        return "patch_parse", (
+            "The patch couldn't be parsed. Fix the patch format/markers before retrying."
+        )
+    if "verification" in low:
+        return "verification", (
+            "The write succeeded but re-read verification failed. Re-read the file to "
+            "see actual state before editing again."
+        )
+    if "did not match" in low or "no match" in low or ("match" in low and "block" in low):
+        return "fuzzy_match", (
+            "The search block didn't match the file. Re-read the file and copy the EXACT "
+            "current text into the patch — don't retry the same block."
+        )
+    if "failed to write" in low or ("write" in low and "fail" in low):
+        return "write_error", (
+            "The write failed. Check disk space / permissions and the path before retrying."
+        )
+    if "failed to read" in low:
+        return "read_error", (
+            "The read failed. Check the path/permissions; don't repeat the same call blindly."
+        )
+    return "error", (
+        "The operation failed. Read the message, fix the root cause, and CHANGE the call."
+    )
+
+
 @dataclass
 class ReadResult:
     """Result from reading a file."""
@@ -167,9 +225,13 @@ class ReadResult:
     dimensions: Optional[str] = None  # For images: "WIDTHxHEIGHT"
     error: Optional[str] = None
     similar_files: List[str] = field(default_factory=list)
-    
+
     def to_dict(self) -> dict:
-        return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
+        d = {k: v for k, v in self.__dict__.items() if v is not None and v != []}
+        hit = classify_file_error(self.error, similar_files=self.similar_files)
+        if hit:
+            d["error_class"], d["recovery"] = hit
+        return d
 
 
 @dataclass
@@ -221,6 +283,9 @@ class PatchResult:
             result["lsp_diagnostics"] = self.lsp_diagnostics
         if self.error:
             result["error"] = self.error
+            hit = classify_file_error(self.error)
+            if hit:
+                result["error_class"], result["recovery"] = hit
         return result
 
 


### PR DESCRIPTION
## Problem (#216)

`read_file` / `patch` returned a bare `error` string, so the agent often retried the same failing call with no idea whether to create the file, fix the patch text, or use a different tool.

## Fix

`classify_file_error(error, similar_files) -> (error_class, recovery)`, surfaced in `ReadResult.to_dict` / `PatchResult.to_dict`:

| class | route |
|---|---|
| `not_found` | create with write_file |
| `fuzzy_match` | 'did you mean <similar_files>?' / re-read & copy EXACT block |
| `permission` | use an allowed path, don't retry |
| `patch_parse` | fix the patch markers |
| `verification` / `write_error` / `read_error` / `binary` | targeted route each |

Derived from the already-set error string at **serialization time**, so no error-producing call site changes. Pairs with the #231 loop-guard fix (`permission` is a deterministic class).

## Tests

classify cases + to_dict integration (13); existing file_operations suite green (90 passed). ruff clean.

Closes #216.