### PR TITLE
feat(evolution): Self-Harness trace miner — weakness records from own traces (first increment of #248)

### DIFF
--- a/scripts/evolution_trace_miner.py
+++ b/scripts/evolution_trace_miner.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Self-Harness trace miner — first increment (#248).
+
+The evolution pipeline is fed almost entirely by the nightly research job: a
+single external signal of "what should we improve?". The much richer signal is
+already on disk — the agent's OWN execution traces — and #238 taught
+``introspection_extract`` to read them (``*.jsonl`` + ``request_dump_*.json``)
+and emit an aggregated, anonymized digest of recurring failures.
+
+This miner is the next layer: it turns that digest into structured **weakness
+records** that the ``evolution-issues`` stage can consume alongside the research
+report. A weakness record is just a typed cluster that recurred at least
+``min_count`` times — no new pipeline, no LLM, no raw content. It is the
+deterministic core of the Self-Harness loop (arXiv 2606.09498); the LLM
+harness-proposal generator and the regression gate are deliberately deferred to
+later increments.
+
+Output: JSON weakness records to stdout, and (in main) a sidecar
+``<evolution_dir>/weaknesses-<cycle>.json`` the issues stage reads.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from introspection_extract import _sessions_dir, build_digest
+except Exception:  # pragma: no cover - keep import path explicit on failure
+    raise
+
+DEFAULT_MIN_COUNT = 5  # a cluster must recur this often to become a weakness
+
+
+def mine_weaknesses(digest: Dict[str, Any], min_count: int = DEFAULT_MIN_COUNT) -> List[Dict[str, Any]]:
+    """Turn an introspection digest's aggregated signals into structured weakness
+    records for clusters that recur >= ``min_count`` times. Pure + deterministic;
+    operates only on the anonymized digest, never raw traces."""
+    signals = digest.get("signals", {}) if isinstance(digest, dict) else {}
+    window = digest.get("window_days", 0) if isinstance(digest, dict) else 0
+    records: List[Dict[str, Any]] = []
+
+    # Repeated tool failures attributed to a tool.
+    for tool, n in (signals.get("tool_failures") or {}).items():
+        if isinstance(n, int) and n >= min_count:
+            records.append({
+                "kind": "tool_failure",
+                "tool": tool,
+                "occurrences": n,
+                "severity": n,
+                "label": f"`{tool}` results look like failures {n}x in {window}d — "
+                         f"harden the tool wrapper or its preconditions.",
+            })
+
+    # Provider-layer errors, keyed by recovery class (#236 failure_category).
+    for sig, n in (signals.get("provider_errors") or {}).items():
+        if isinstance(n, int) and n >= min_count:
+            records.append({
+                "kind": "provider_error",
+                "signature": sig,
+                "occurrences": n,
+                "severity": n,
+                "label": f"provider error `{sig}` recurs {n}x — check fallback chain / "
+                         f"model-provider config for this class.",
+            })
+
+    # Retry spirals (the loop_guard shape): same tool many times in a row.
+    for tool, info in (signals.get("repeated_tool_runs") or {}).items():
+        if not isinstance(info, dict):
+            continue
+        runs = info.get("max_consecutive", 0)
+        if isinstance(runs, int) and runs >= min_count:
+            records.append({
+                "kind": "retry_spiral",
+                "tool": tool,
+                "max_consecutive": runs,
+                "sessions": info.get("sessions", 0),
+                "severity": runs,
+                "label": f"`{tool}` retry spiral up to {runs} consecutive across "
+                         f"{info.get('sessions', 0)} session(s) — add a non-retryable "
+                         f"diagnostic or a fallback path.",
+            })
+
+    # Highest-severity first so the issues stage triages the worst clusters early.
+    records.sort(key=lambda r: -int(r.get("severity") or 0))
+    return records
+
+
+def format_weaknesses(records: List[Dict[str, Any]], window_days: int = 0) -> str:
+    """One-line-per-record human summary for the issues-stage prompt / watchdog."""
+    if not records:
+        return f"[evolution-trace-miner] no recurring weaknesses (window {window_days}d)"
+    lines = [f"[evolution-trace-miner] {len(records)} weakness cluster(s), window {window_days}d:"]
+    for r in records:
+        lines.append(f"  - [{r['kind']}] {r['label']}")
+    return "\n".join(lines)
+
+
+def main(argv: List[str]) -> int:
+    days = 7
+    min_count = DEFAULT_MIN_COUNT
+    for a in argv[1:]:
+        if a.startswith("--days="):
+            try:
+                days = int(a.split("=", 1)[1])
+            except ValueError:
+                pass
+        elif a.startswith("--min-count="):
+            try:
+                min_count = int(a.split("=", 1)[1])
+            except ValueError:
+                pass
+
+    sessions_dir = _sessions_dir()
+    digest = build_digest(sessions_dir, window_days=days)
+    records = mine_weaknesses(digest, min_count=min_count)
+
+    payload = {
+        "window_days": days,
+        "min_count": min_count,
+        "sessions_scanned": digest.get("sessions_scanned", 0),
+        "weaknesses": records,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+    # Sidecar for the issues stage: <evolution_dir>/weaknesses-latest.json.
+    # evolution_dir is the sessions dir's parent's evolution profile, mirroring
+    # how the funnel writes its sidecars. Best-effort; never fail the run on IO.
+    try:
+        import os
+
+        prof = os.environ.get("EVOLUTION_PROFILE_DIR")
+        if prof:
+            out = Path(prof) / "weaknesses-latest.json"
+            out.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except Exception:  # pragma: no cover - environment dependent
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -17,6 +17,18 @@ Create GitHub issues and pull requests based on research.
 ## Process
 
 1. **Load** the latest research report from `~/.hermes/profiles/user1/evolution/research/`
+1a. **Also mine the agent's OWN traces for weaknesses (#248).** Research is the
+    external signal; the agent's own execution traces are the internal one. Run
+    the deterministic trace miner and consider its weakness records alongside the
+    research proposals — a recurring `provider_error` / `retry_spiral` /
+    `tool_failure` cluster from real usage is a high-signal candidate (it's a
+    *demonstrated* problem, not a trend):
+    ```bash
+    python scripts/evolution_trace_miner.py --days=7    # JSON weakness records (or read weaknesses-latest.json sidecar)
+    ```
+    Treat each weakness cluster as a proposal input: run it through the same
+    self-critique + dedup gates below before filing. The miner emits only
+    anonymized counts/classes/labels — never raw trace content.
 2. **Select** proposals with Priority Score >= 0.7
 2a. **Self-critique BEFORE you file (do not propose noise).** A high priority
     score is not enough. For EACH candidate, honestly ask — and DROP it (don't

--- a/tests/scripts/test_evolution_trace_miner.py
+++ b/tests/scripts/test_evolution_trace_miner.py
@@ -1,0 +1,86 @@
+"""Tests for scripts/evolution_trace_miner.py (#248 first increment)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_trace_miner import format_weaknesses, mine_weaknesses  # noqa: E402
+
+
+def _digest(*, tool_failures=None, provider_errors=None, repeated=None, window=7, scanned=10):
+    return {
+        "window_days": window,
+        "sessions_scanned": scanned,
+        "signals": {
+            "tool_failures": tool_failures or {},
+            "provider_errors": provider_errors or {},
+            "repeated_tool_runs": repeated or {},
+        },
+    }
+
+
+class TestMineWeaknesses:
+    def test_threshold_filters_low_counts(self):
+        d = _digest(tool_failures={"terminal": 6, "read_file": 2})
+        recs = mine_weaknesses(d, min_count=5)
+        assert len(recs) == 1
+        assert recs[0]["tool"] == "terminal" and recs[0]["occurrences"] == 6
+
+    def test_provider_errors_keyed_by_class(self):
+        d = _digest(provider_errors={"429:rate_limit": 60, "400:format_error": 1})
+        recs = mine_weaknesses(d, min_count=5)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["kind"] == "provider_error" and r["signature"] == "429:rate_limit"
+        assert r["occurrences"] == 60
+
+    def test_retry_spiral_from_repeated_runs(self):
+        d = _digest(repeated={"browser_navigate": {"max_consecutive": 15, "sessions": 3}})
+        recs = mine_weaknesses(d, min_count=5)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["kind"] == "retry_spiral" and r["max_consecutive"] == 15 and r["sessions"] == 3
+
+    def test_sorted_by_severity_desc(self):
+        d = _digest(
+            tool_failures={"terminal": 6},
+            provider_errors={"429:rate_limit": 60},
+            repeated={"browser_navigate": {"max_consecutive": 15, "sessions": 3}},
+        )
+        recs = mine_weaknesses(d, min_count=5)
+        sev = [r["severity"] for r in recs]
+        assert sev == sorted(sev, reverse=True)
+        assert recs[0]["severity"] == 60  # the 429 cluster is worst
+
+    def test_empty_digest_no_weaknesses(self):
+        assert mine_weaknesses(_digest(), min_count=5) == []
+        assert mine_weaknesses({}, min_count=5) == []
+
+    def test_malformed_repeated_entry_skipped(self):
+        d = _digest(repeated={"x": "not-a-dict", "browser": {"max_consecutive": 9, "sessions": 1}})
+        recs = mine_weaknesses(d, min_count=5)
+        assert len(recs) == 1 and recs[0]["tool"] == "browser"
+
+    def test_no_raw_content_only_counts_and_labels(self):
+        # mined records carry only tool names, counts, and our labels.
+        d = _digest(tool_failures={"terminal": 9}, provider_errors={"429:rate_limit": 9})
+        blob = json.dumps(mine_weaknesses(d, min_count=5))
+        assert "rate_limit" in blob  # the class label is fine
+        # no free-form/raw fields leak in
+        for r in mine_weaknesses(d, min_count=5):
+            assert set(r).issubset(
+                {"kind", "tool", "occurrences", "severity", "label", "signature",
+                 "max_consecutive", "sessions"}
+            )
+
+
+class TestFormat:
+    def test_empty(self):
+        assert "no recurring weaknesses" in format_weaknesses([], window_days=7)
+
+    def test_lists_records(self):
+        recs = mine_weaknesses(_digest(tool_failures={"terminal": 8}), min_count=5)
+        out = format_weaknesses(recs, window_days=7)
+        assert "1 weakness cluster" in out and "terminal" in out


### PR DESCRIPTION
## What (first increment of #248)

The evolution pipeline was fed almost entirely by the **nightly research job** — a single *external* signal. #238 taught `introspection_extract` to read the agent's **own execution traces** (`*.jsonl` + `request_dump_*.json`) and emit an aggregated, anonymized digest. This PR is the next Self-Harness layer (arXiv 2606.09498): it turns that digest into typed **weakness records** the `evolution-issues` stage consumes alongside research.

## Implemented

- **`scripts/evolution_trace_miner.py`** — `mine_weaknesses(digest, min_count)` → severity-sorted typed clusters that recurred ≥ `min_count`:
  - `tool_failure` (a tool's results look like failures N×),
  - `provider_error` keyed by recovery class (`429:rate_limit` — from #236's `failure_category`),
  - `retry_spiral` (loop-guard shape: same tool many times in a row).
  Pure + deterministic, **reuses `introspection_extract.build_digest`**, no LLM, no raw content. `main()` writes a `weaknesses-latest.json` sidecar. Part of the `evolution_*` family → the registrar auto-installs it (#245).
- **`evolution-issues` SKILL** — new step 1a runs the miner and feeds weakness clusters through the same self-critique + dedup gates as research proposals. A *demonstrated* recurring failure is higher-signal than a trend.

## Deferred (documented in #248, later increments)
The LLM harness-proposal generator and the regression-suite gate. This increment delivers the **internal-signal source end-to-end** — the highest-leverage missing piece.

## Verification
9 tests (threshold, provider-class keying, retry-spiral, severity sort, empty, malformed, no-raw-content contract, format). ruff clean. Runs end-to-end against `build_digest` on real session data.

First increment of #248.
