### PR TITLE
State-grounded skill retrieval (first increment of #247)

### DIFF
--- a/tests/tools/test_skill_retrieval.py
+++ b/tests/tools/test_skill_retrieval.py
@@ -1,0 +1,237 @@
+"""Tests for state-grounded skill retrieval (first increment of #247).
+
+Covers the pure ``rank_skills`` API (deterministic lexical scoring, field
+weighting, usage tie-break, filtering, limit) and the ``skills_search`` tool
+wrapper end-to-end against an on-disk skills tree.
+"""
+
+import json
+from unittest.mock import patch
+
+from tools.skill_retrieval import (
+    RankedSkill,
+    _extract_tags,
+    _tokenize,
+    rank_skills,
+)
+from tools.skills_tool import skills_search
+
+
+# Candidate fixtures — explicit dicts so ranking tests don't touch disk.
+CANDIDATES = [
+    {
+        "name": "docker-deploy",
+        "description": "Build and deploy container images to a registry.",
+        "category": "ops",
+        "tags": ["docker", "deployment", "containers"],
+    },
+    {
+        "name": "git-commit-helper",
+        "description": "Write conventional commit messages and stage changes.",
+        "category": "git",
+        "tags": ["git", "commit"],
+    },
+    {
+        "name": "pdf-extract",
+        "description": "Extract text and tables from PDF documents.",
+        "category": "docs",
+        "tags": ["pdf", "extraction"],
+    },
+]
+
+
+class TestTokenize:
+    def test_lowercases_and_splits(self):
+        assert _tokenize("Deploy Docker Image") == ["deploy", "docker", "image"]
+
+    def test_drops_stop_words_and_tiny_tokens(self):
+        # "the", "to", "a" are stop/short; "ci" (2 chars) is kept.
+        assert _tokenize("the ci to a registry") == ["ci", "registry"]
+
+    def test_empty(self):
+        assert _tokenize("") == []
+        assert _tokenize("   ") == []
+
+
+class TestRankSkills:
+    def test_matches_relevant_skill_first(self):
+        out = rank_skills(
+            "I need to deploy a docker container",
+            candidates=CANDIDATES,
+            use_usage_signal=False,
+        )
+        assert out, "expected at least one match"
+        assert out[0].name == "docker-deploy"
+
+    def test_zero_score_candidates_dropped(self):
+        # Query is only relevant to the pdf skill.
+        out = rank_skills(
+            "extract tables from a pdf",
+            candidates=CANDIDATES,
+            use_usage_signal=False,
+        )
+        names = [r.name for r in out]
+        assert names == ["pdf-extract"]
+
+    def test_empty_query_returns_empty(self):
+        assert rank_skills("", candidates=CANDIDATES) == []
+        # A query made only of stop words has no scorable terms.
+        assert rank_skills("the and for with", candidates=CANDIDATES) == []
+
+    def test_name_weighted_above_description(self):
+        # "alpha" only in the name of skill A; "alpha" only in the description
+        # of skill B. The name hit must outrank the description hit.
+        cands = [
+            {"name": "alpha", "description": "unrelated text", "category": "x"},
+            {"name": "beta", "description": "this mentions alpha once", "category": "x"},
+        ]
+        out = rank_skills("alpha", candidates=cands, use_usage_signal=False)
+        assert [r.name for r in out] == ["alpha", "beta"]
+        assert out[0].score > out[1].score
+
+    def test_tags_contribute_to_score(self):
+        cands = [
+            {"name": "s1", "description": "nothing", "category": "x", "tags": ["kubernetes"]},
+            {"name": "s2", "description": "nothing", "category": "x", "tags": ["unrelated"]},
+        ]
+        out = rank_skills("kubernetes", candidates=cands, use_usage_signal=False)
+        assert [r.name for r in out] == ["s1"]
+
+    def test_limit_caps_results(self):
+        cands = [
+            {"name": f"deploy-{i}", "description": "deploy things", "category": "ops"}
+            for i in range(10)
+        ]
+        out = rank_skills("deploy", candidates=cands, limit=3, use_usage_signal=False)
+        assert len(out) == 3
+
+    def test_matched_terms_reported(self):
+        out = rank_skills(
+            "deploy docker", candidates=CANDIDATES, use_usage_signal=False
+        )
+        top = out[0]
+        assert top.name == "docker-deploy"
+        assert set(top.matched_terms) >= {"deploy", "docker"}
+
+    def test_stable_tie_break_by_name(self):
+        # Identical relevance -> alphabetical by name.
+        cands = [
+            {"name": "zeta", "description": "deploy", "category": "x"},
+            {"name": "alpha", "description": "deploy", "category": "x"},
+        ]
+        out = rank_skills("deploy", candidates=cands, use_usage_signal=False)
+        assert [r.name for r in out] == ["alpha", "zeta"]
+
+    def test_usage_boost_breaks_lexical_tie(self):
+        cands = [
+            {"name": "zeta", "description": "deploy", "category": "x"},
+            {"name": "alpha", "description": "deploy", "category": "x"},
+        ]
+        # Without usage, alpha wins on name tie-break. With usage favoring zeta,
+        # zeta should overtake alpha.
+        fake_usage = {
+            "zeta": {"use_count": 9, "view_count": 0, "patch_count": 0},
+            "alpha": {"use_count": 0, "view_count": 0, "patch_count": 0},
+        }
+        with patch("tools.skill_usage.load_usage", return_value=fake_usage):
+            out = rank_skills("deploy", candidates=cands, use_usage_signal=True)
+        assert out[0].name == "zeta"
+
+    def test_usage_boost_never_surfaces_irrelevant_skill(self):
+        # A wildly-used but irrelevant skill must NOT appear for an unrelated query.
+        cands = [
+            {"name": "popular-but-irrelevant", "description": "knitting patterns", "category": "craft"},
+            {"name": "docker-deploy", "description": "deploy containers", "category": "ops"},
+        ]
+        fake_usage = {
+            "popular-but-irrelevant": {"use_count": 999, "view_count": 999, "patch_count": 0},
+        }
+        with patch("tools.skill_usage.load_usage", return_value=fake_usage):
+            out = rank_skills("deploy a container", candidates=cands, use_usage_signal=True)
+        assert [r.name for r in out] == ["docker-deploy"]
+
+    def test_candidate_without_name_skipped(self):
+        cands = [
+            {"description": "deploy stuff", "category": "ops"},
+            {"name": "real", "description": "deploy stuff", "category": "ops"},
+        ]
+        out = rank_skills("deploy", candidates=cands, use_usage_signal=False)
+        assert [r.name for r in out] == ["real"]
+
+    def test_returns_ranked_skill_dataclass(self):
+        out = rank_skills("deploy docker", candidates=CANDIDATES, use_usage_signal=False)
+        assert all(isinstance(r, RankedSkill) for r in out)
+
+
+class TestExtractTags:
+    def test_metadata_hermes_tags_preferred(self):
+        fm = {
+            "tags": ["toplevel"],
+            "metadata": {"hermes": {"tags": ["nested-a", "nested-b"]}},
+        }
+        assert _extract_tags(fm) == ["nested-a", "nested-b"]
+
+    def test_toplevel_tags_fallback(self):
+        assert _extract_tags({"tags": ["a", "b"]}) == ["a", "b"]
+
+    def test_comma_string_tags(self):
+        assert _extract_tags({"tags": "a, b, c"}) == ["a", "b", "c"]
+
+    def test_bracketed_string_tags(self):
+        assert _extract_tags({"tags": "[a, b]"}) == ["a", "b"]
+
+    def test_no_tags(self):
+        assert _extract_tags({}) == []
+
+
+def _make_skill(skills_dir, name, description, tags=None, body="Do the thing."):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    tag_block = ""
+    if tags:
+        tag_list = ", ".join(tags)
+        tag_block = f"metadata:\n  hermes:\n    tags: [{tag_list}]\n"
+    content = f"""\
+---
+name: {name}
+description: {description}
+{tag_block}---
+
+# {name}
+
+{body}
+"""
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+class TestSkillsSearchTool:
+    def test_ranks_live_skills(self, tmp_path):
+        # The registry loader reads skills_tool.SKILLS_DIR directly, so patching
+        # it is enough to drive ranking against an on-disk tree end-to-end.
+        _make_skill(tmp_path, "docker-deploy", "Deploy containers to a registry.", tags=["docker"])
+        _make_skill(tmp_path, "pdf-extract", "Extract text from PDF files.", tags=["pdf"])
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skills_search("deploy a docker container", limit=5))
+        assert result["success"] is True
+        assert result["count"] >= 1
+        assert result["skills"][0]["name"] == "docker-deploy"
+
+    def test_empty_query_errors(self):
+        result = json.loads(skills_search("", limit=5))
+        assert result.get("success") is False
+        assert "query" in result.get("error", "")
+
+    def test_no_match_returns_empty_list(self, tmp_path):
+        _make_skill(tmp_path, "pdf-extract", "Extract text from PDF files.", tags=["pdf"])
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skills_search("brew a cup of coffee", limit=5))
+        assert result["success"] is True
+        assert result["skills"] == []
+        assert result["count"] == 0
+
+    def test_invalid_limit_defaults(self, tmp_path):
+        _make_skill(tmp_path, "docker-deploy", "Deploy containers.", tags=["docker"])
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skills_search("docker", limit=0))
+        assert result["success"] is True

--- a/tools/skill_retrieval.py
+++ b/tools/skill_retrieval.py
@@ -1,0 +1,376 @@
+"""State-grounded skill retrieval — first increment of online skill acquisition (#247).
+
+Issue #247 ("Online skill acquisition via state-grounded dynamic retrieval")
+describes a full system: an in-session online skill pool, an embedding trigger
+that surfaces a candidate skill when the current state recurs, write-gating with
+similarity dedup + a confidence threshold, and a nightly promotion pathway.
+
+This module ships the smallest coherent, self-contained slice that the rest of
+that system builds on: a *state-grounded retrieval helper*. Given the current
+task / state text, it ranks the skills already in the registry by relevance and
+surfaces the best matches — going beyond the static, alphabetical ``skills_list``
+the agent has today. Without this, "retrieve the most relevant skill for the
+current state" has no implementation to call; with it, the online pool, the
+embedding trigger, and promotion can be layered on later as separate increments.
+
+Deliberately deferred (NOT in this increment):
+  - the writable ``skills/online/`` pool and its manifest ``source: online`` mark
+  - the post-tool-call embedding trigger that auto-surfaces a recurring skill
+  - skill-write gating (embedding dedup ``sim >= 0.9`` + confidence ``>= 0.7``)
+  - the nightly evolution job's promotion / review gate
+  - any ``sentence-transformers`` / embedding dependency
+
+Scoring is intentionally lexical and dependency-free. The registry has no
+embedding index wired in (the ``embedding`` hits elsewhere in the tree are
+Unicode-direction characters in the skills security scanner, not vectors), and
+#247 itself says to fall back to a small implementation when no embedding
+infrastructure is available. Term-overlap over a skill's name / description /
+category / tags is a deterministic, well-understood relevance signal that is
+easy to test and easy to swap for embeddings in a later increment — the public
+``rank_skills`` API is the seam where that swap happens.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Field weights. Name and tags are the most intentional relevance signals a
+# skill author controls; the description is longer and noisier, so a single term
+# hit there counts for less. Category is the coarsest signal of all.
+_WEIGHT_NAME = 3.0
+_WEIGHT_TAGS = 2.5
+_WEIGHT_DESCRIPTION = 1.0
+_WEIGHT_CATEGORY = 1.5
+
+# A skill the agent has actually used before is a slightly better bet than a
+# never-touched one when lexical relevance ties. Kept small so usage can only
+# break ties / nudge ordering — it must never float an irrelevant-but-popular
+# skill above a relevant one.
+_USAGE_BOOST_MAX = 0.5
+
+# Tokens shorter than this are dropped from the query (e.g. "a", "to", "of") so
+# stop-word noise doesn't manufacture spurious overlap. Two chars keeps useful
+# short identifiers like "ci", "db", "ai".
+_MIN_TOKEN_LEN = 2
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Common English stop words that carry no relevance signal in a task
+# description. Kept deliberately small — the goal is to drop obvious noise, not
+# to do real linguistics.
+_STOP_WORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "with",
+        "this",
+        "that",
+        "from",
+        "into",
+        "have",
+        "has",
+        "was",
+        "are",
+        "you",
+        "your",
+        "our",
+        "can",
+        "how",
+        "use",
+        "using",
+        "need",
+        "want",
+        "please",
+        "help",
+        "make",
+        "get",
+        "set",
+        "via",
+        "out",
+        "now",
+        "all",
+        "any",
+        "some",
+        "what",
+        "when",
+        "where",
+        "which",
+        # Common two-letter function words — pure noise, no relevance signal.
+        "to",
+        "of",
+        "in",
+        "on",
+        "is",
+        "it",
+        "be",
+        "by",
+        "or",
+        "as",
+        "at",
+        "an",
+        "we",
+        "do",
+        "if",
+        "so",
+        "up",
+        "my",
+        "me",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RankedSkill:
+    """A single ranked retrieval result.
+
+    ``score`` is a non-negative relevance number (higher is more relevant); it is
+    not normalised to any fixed range because callers only ever compare scores
+    against each other within one query, never across queries.
+    """
+
+    name: str
+    description: str
+    category: Optional[str]
+    score: float
+    matched_terms: List[str]
+
+
+def _tokenize(text: str) -> List[str]:
+    """Lowercase, split on non-alphanumerics, drop stop words and tiny tokens."""
+    if not text:
+        return []
+    tokens = _TOKEN_RE.findall(text.lower())
+    return [
+        t for t in tokens if len(t) >= _MIN_TOKEN_LEN and t not in _STOP_WORDS
+    ]
+
+
+def _field_overlap(
+    query_terms: set, field_text: str, weight: float
+) -> tuple[float, set]:
+    """Score one skill field against the query.
+
+    Returns ``(weighted_score, matched_query_terms)``. Each distinct query term
+    that appears in the field contributes ``weight`` once — repeated occurrences
+    don't compound, so a description that spams a keyword can't out-rank a
+    genuine name match.
+    """
+    field_terms = set(_tokenize(field_text))
+    if not field_terms:
+        return 0.0, set()
+    matched = query_terms & field_terms
+    return len(matched) * weight, matched
+
+
+def _usage_boost(name: str, usage: Dict[str, Dict[str, Any]]) -> float:
+    """Small additive boost in ``[0, _USAGE_BOOST_MAX]`` from prior usage.
+
+    Uses the combined use+view+patch activity count, squashed through a
+    saturating curve so the first few uses matter and heavy use can't dominate
+    lexical relevance. Best-effort: any malformed record yields no boost.
+    """
+    record = usage.get(name)
+    if not isinstance(record, dict):
+        return 0.0
+    try:
+        from tools.skill_usage import activity_count
+    except Exception:  # pragma: no cover - skill_usage always importable in tree
+        return 0.0
+    count = activity_count(record)
+    if count <= 0:
+        return 0.0
+    # 1 use -> 0.5*MAX, 3 -> 0.75*MAX, saturating toward MAX. count/(count+1)
+    # is a cheap saturating curve that never reaches the ceiling.
+    return _USAGE_BOOST_MAX * (count / (count + 1.0))
+
+
+def _candidate_text_fields(candidate: Dict[str, Any]) -> Dict[str, str]:
+    """Pull the scorable text out of a candidate dict, tolerant of shape.
+
+    Tags may arrive as a list (from frontmatter) or be absent; everything else
+    is coerced to a string. ``_find_all_skills`` does not currently surface
+    tags, so this helper also reads a ``tags`` key when a richer candidate
+    source provides one.
+    """
+    tags_value = candidate.get("tags")
+    if isinstance(tags_value, (list, tuple)):
+        tags_text = " ".join(str(t) for t in tags_value)
+    else:
+        tags_text = str(tags_value or "")
+    return {
+        "name": str(candidate.get("name") or ""),
+        "description": str(candidate.get("description") or ""),
+        "category": str(candidate.get("category") or ""),
+        "tags": tags_text,
+    }
+
+
+def rank_skills(
+    query: str,
+    *,
+    limit: int = 5,
+    candidates: Optional[Sequence[Dict[str, Any]]] = None,
+    use_usage_signal: bool = True,
+) -> List[RankedSkill]:
+    """Rank registry skills by relevance to the current task / state *query*.
+
+    This is the state-grounded retrieval seam from #247: the caller passes the
+    text that describes "where the agent is right now" (the task, the last few
+    turns, a tool result summary — anything) and gets back the skills most
+    likely to help, best-first.
+
+    Args:
+        query: Free-form text describing the current task or state.
+        limit: Maximum number of results to return (results with a zero
+            relevance score are always dropped, so fewer may come back).
+        candidates: Optional explicit list of skill metadata dicts (each with at
+            least ``name``; ``description``/``category``/``tags`` optional). When
+            omitted, the live registry is enumerated via
+            ``skills_tool._find_all_skills`` and enriched with frontmatter tags.
+        use_usage_signal: When True (default), apply a small prior-usage boost so
+            proven skills win ties. Disable for fully deterministic, usage-free
+            ranking (used by tests and by callers that want pure lexical order).
+
+    Returns:
+        A list of ``RankedSkill`` ordered by descending score, then by name for
+        a stable tie-break. Empty when the query has no scorable terms or no
+        candidate matches it.
+    """
+    query_terms = set(_tokenize(query))
+    if not query_terms:
+        return []
+
+    if candidates is None:
+        candidates = _load_candidates_from_registry()
+
+    usage: Dict[str, Dict[str, Any]] = {}
+    if use_usage_signal:
+        try:
+            from tools.skill_usage import load_usage
+
+            usage = load_usage()
+        except Exception:  # pragma: no cover - best-effort telemetry read
+            logger.debug("Could not load skill usage for ranking", exc_info=True)
+            usage = {}
+
+    ranked: List[RankedSkill] = []
+    for candidate in candidates:
+        name = str(candidate.get("name") or "").strip()
+        if not name:
+            continue
+        fields = _candidate_text_fields(candidate)
+
+        score = 0.0
+        matched: set = set()
+        for field_name, weight in (
+            ("name", _WEIGHT_NAME),
+            ("tags", _WEIGHT_TAGS),
+            ("category", _WEIGHT_CATEGORY),
+            ("description", _WEIGHT_DESCRIPTION),
+        ):
+            field_score, field_matched = _field_overlap(
+                query_terms, fields[field_name], weight
+            )
+            score += field_score
+            matched |= field_matched
+
+        if score <= 0.0:
+            # No lexical relevance — a usage boost alone must never surface a
+            # skill the current state has nothing to do with.
+            continue
+
+        if use_usage_signal:
+            score += _usage_boost(name, usage)
+
+        ranked.append(
+            RankedSkill(
+                name=name,
+                description=fields["description"],
+                category=candidate.get("category"),
+                score=round(score, 4),
+                matched_terms=sorted(matched),
+            )
+        )
+
+    ranked.sort(key=lambda r: (-r.score, r.name))
+    if limit is not None and limit >= 0:
+        ranked = ranked[:limit]
+    return ranked
+
+
+def _load_candidates_from_registry() -> List[Dict[str, Any]]:
+    """Enumerate live skills and enrich each with frontmatter tags.
+
+    ``skills_tool._find_all_skills`` already does the platform/environment/
+    disabled filtering and dedup we want, but returns only name/description/
+    category. Tags are a strong relevance signal, so we re-read each skill's
+    frontmatter to attach them. Tag enrichment is best-effort: a skill whose
+    frontmatter can't be read still ranks on its name/description/category.
+    """
+    from tools import skills_tool
+    from agent.skill_utils import iter_skill_index_files, parse_frontmatter
+
+    skills = skills_tool._find_all_skills()
+
+    # Build a name -> tags map by scanning the same dirs _find_all_skills uses.
+    tags_by_name: Dict[str, List[str]] = {}
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        scan_dirs = []
+        if skills_tool.SKILLS_DIR.exists():
+            scan_dirs.append(skills_tool.SKILLS_DIR)
+        scan_dirs.extend(get_external_skills_dirs())
+
+        for scan_dir in scan_dirs:
+            for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+                try:
+                    content = skill_md.read_text(encoding="utf-8")[:4000]
+                    frontmatter, _ = parse_frontmatter(content)
+                except Exception:
+                    continue
+                name = str(frontmatter.get("name") or skill_md.parent.name)
+                if name in tags_by_name:
+                    continue
+                tags_by_name[name] = _extract_tags(frontmatter)
+    except Exception:  # pragma: no cover - enrichment is best-effort
+        logger.debug("Skill tag enrichment failed", exc_info=True)
+
+    for skill in skills:
+        tags = tags_by_name.get(skill.get("name", ""))
+        if tags:
+            skill["tags"] = tags
+    return skills
+
+
+def _extract_tags(frontmatter: Dict[str, Any]) -> List[str]:
+    """Read tags from frontmatter, honouring the metadata.hermes.* convention.
+
+    Mirrors the lookup ``skills_tool.skill_view`` does: ``metadata.hermes.tags``
+    first (agentskills.io convention), then a top-level ``tags`` fallback.
+    """
+    metadata = frontmatter.get("metadata")
+    hermes_meta: Dict[str, Any] = {}
+    if isinstance(metadata, dict):
+        candidate = metadata.get("hermes")
+        if isinstance(candidate, dict):
+            hermes_meta = candidate
+
+    raw = hermes_meta.get("tags")
+    if raw is None:
+        raw = frontmatter.get("tags")
+    if not raw:
+        return []
+    if isinstance(raw, (list, tuple)):
+        return [str(t).strip() for t in raw if str(t).strip()]
+    # Comma / bracket separated string fallback.
+    text = str(raw).strip()
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1]
+    return [t.strip().strip("\"'") for t in text.split(",") if t.strip()]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -749,6 +749,60 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         return tool_error(str(e), success=False)
 
 
+def skills_search(query: str, limit: int = 5) -> str:
+    """Rank skills by relevance to the current task/state (state-grounded retrieval).
+
+    First increment of #247 ("Online skill acquisition via state-grounded dynamic
+    retrieval"). Unlike ``skills_list`` (a static, alphabetical dump of every
+    skill), this surfaces the few skills most relevant to *what the agent is doing
+    right now*, given a free-form description of the current task or state.
+
+    Args:
+        query: Free-form text describing the current task or state.
+        limit: Maximum number of results to return (default 5).
+
+    Returns:
+        JSON string with the best-first ranked skills (name, description,
+        category, score, matched_terms).
+    """
+    try:
+        from tools.skill_retrieval import rank_skills
+
+        if not isinstance(query, str) or not query.strip():
+            return tool_error("query must be a non-empty string", success=False)
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            limit_int = 5
+        if limit_int <= 0:
+            limit_int = 5
+
+        ranked = rank_skills(query, limit=limit_int)
+        results = [
+            {
+                "name": r.name,
+                "description": r.description,
+                "category": r.category,
+                "score": r.score,
+                "matched_terms": r.matched_terms,
+            }
+            for r in ranked
+        ]
+        return json.dumps(
+            {
+                "success": True,
+                "query": query,
+                "skills": results,
+                "count": len(results),
+                "hint": "Use skill_view(name) to load full content for a relevant skill",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return tool_error(str(e), success=False)
+
+
 # ── Plugin skill serving ──────────────────────────────────────────────────
 
 
@@ -1647,4 +1701,40 @@ registry.register(
     handler=_skill_view_with_bump,
     check_fn=check_skills_requirements,
     emoji="📚",
+)
+
+SKILLS_SEARCH_SCHEMA = {
+    "name": "skills_search",
+    "description": (
+        "Rank available skills by relevance to the CURRENT task or state, "
+        "best-first. Prefer this over skills_list when you know what you are "
+        "trying to do — pass a short description of the task/state as the query "
+        "and get back only the few most relevant skills (with match terms and a "
+        "relevance score), then skill_view the one you want."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Free-form text describing the current task or state to match skills against.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of ranked skills to return (default 5).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+registry.register(
+    name="skills_search",
+    toolset="skills",
+    schema=SKILLS_SEARCH_SCHEMA,
+    handler=lambda args, **kw: skills_search(
+        query=args.get("query", ""), limit=args.get("limit", 5)
+    ),
+    check_fn=check_skills_requirements,
+    emoji="🔎",
 )


### PR DESCRIPTION
## First increment of #247 — Online skill acquisition via state-grounded dynamic retrieval

This is a **self-contained first increment**, not the full system. It ships the
smallest coherent slice the rest of #247 depends on: a **state-grounded skill
retrieval helper** that ranks the skills already in the registry by relevance to
the current task/state — going beyond the static, alphabetical `skills_list`.

### Implemented
- `tools/skill_retrieval.py` — `rank_skills(query, *, limit, candidates, use_usage_signal)` returning best-first `RankedSkill` results.
  - Deterministic lexical term-overlap scoring over a skill's **name / tags / category / description** (weighted: name 3.0, tags 2.5, category 1.5, description 1.0). Distinct query terms count once per field so keyword-spam can't out-rank a real name match.
  - Small saturating **prior-usage tie-break** from `tools/skill_usage.py` (`activity_count`), capped so a popular-but-irrelevant skill can never surface for an unrelated query.
  - Stop-word + min-length tokenization; zero-relevance candidates are dropped.
  - Registry candidates loaded via the existing `skills_tool._find_all_skills` (keeps platform/environment/disabled filtering + dedup) and enriched with frontmatter tags (`metadata.hermes.tags` convention).
- `tools/skills_tool.py` — new `skills_search` tool (toolset `skills`) wrapping `rank_skills`, registered alongside `skills_list` / `skill_view`.
- `tests/tools/test_skill_retrieval.py` — 24 tests: tokenization, field weighting (name > description), tag scoring, zero-score filtering, limit, stable tie-break, usage boost breaking a tie, usage boost NOT surfacing irrelevant skills, tag extraction, and the `skills_search` tool end-to-end against an on-disk skills tree.

**No new dependencies.** The registry has no embedding index wired in, and #247 explicitly allows a small fallback when embedding infra is absent. Lexical scoring is the deterministic, testable seam where embeddings can be swapped in later — the `rank_skills` API stays the same.

### Deferred (explicitly out of scope for this increment)
- Writable `skills/online/` per-profile pool + manifest `source: online` mark.
- Post-tool-call **embedding trigger** that auto-surfaces a recurring skill (cosine ≥ 0.85).
- Skill-**write gating**: embedding-similarity dedup (reject ≥ 0.9) + confidence threshold (≥ 0.7).
- Nightly evolution-job **promotion / review gate** for online skills.

### Verification
- `uv run --extra dev python -m pytest tests/tools/test_skill_retrieval.py -q` → **24 passed**
- Existing skills suites unaffected: `test_skills_tool.py` + `test_skill_suggestions.py` + `test_skill_usage.py` → **134 passed**
- Toolset registration intact: `test_toolsets.py` + `test_toolset_distributions.py` → **42 passed**
- `uv run --extra dev ruff check` on all changed files → **All checks passed**

This is a **first increment** — it does not fully close #247. It delivers the retrieval foundation; the online pool, embedding trigger, write-gating, and promotion remain as follow-up increments.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>