### PR TITLE
Policy interceptors for tool calls (first increment of #228)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1096,10 +1096,15 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
     try:
+        from agent.policy_interceptors import build_registry_from_config
+        _policy_registry = build_registry_from_config(
+            _agent_cfg.get("policy_interceptors", {})
+        )
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
                 _agent_cfg.get("tool_loop_guardrails", {})
-            )
+            ),
+            policy_registry=_policy_registry,
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)

--- a/agent/policy_interceptors.py
+++ b/agent/policy_interceptors.py
@@ -1,0 +1,342 @@
+"""Pluggable, deterministic per-policy tool-call interceptors.
+
+This module adds a user-authorable *policy* layer on top of the loop/limit
+guardrails in :mod:`agent.tool_guardrails`. Where the loop guardrails answer
+"is the model stuck repeating the same call?", policy interceptors answer
+"does this specific call satisfy the user's deterministic rules?" — e.g.
+"read a file before you write it", or "never run this command".
+
+Design contract (mirrors ``tool_guardrails`` intentionally):
+
+* Pure and side-effect free. A :class:`PolicyInterceptor` inspects an
+  immutable :class:`ToolCallContext` and returns a :class:`PolicyOutcome`
+  (allow / deny / rewrite). It never executes the tool or mutates state.
+* Deterministic. Same context + same per-turn observation ledger always
+  yields the same outcome. No clocks, no randomness, no network.
+* Decisions are expressed as :class:`agent.tool_guardrails.ToolGuardrailDecision`
+  so the existing dispatch path (``before_call`` → ``allows_execution``)
+  consumes them with zero new wiring.
+
+The registry is config-driven via the ``policy_interceptors`` section of
+``config.yaml``. Named, built-in policies are enabled/parametrized by config;
+the loop guardrails continue to run alongside them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+from agent.tool_guardrails import ToolCallSignature, ToolGuardrailDecision
+
+
+@dataclass(frozen=True)
+class ToolCallContext:
+    """Immutable view of a single tool call presented to a policy.
+
+    ``observations`` is the per-turn ledger of prior *successful* tool calls
+    (see :class:`ToolCallObservation`). Policies that enforce ordering rules
+    (read-before-write) read from it; stateless policies ignore it.
+    """
+
+    tool_name: str
+    args: Mapping[str, Any]
+    signature: ToolCallSignature
+    observations: tuple["ToolCallObservation", ...] = ()
+
+
+@dataclass(frozen=True)
+class ToolCallObservation:
+    """A prior tool call recorded this turn, for ordering-aware policies."""
+
+    tool_name: str
+    args: Mapping[str, Any]
+    failed: bool
+
+
+@dataclass(frozen=True)
+class PolicyOutcome:
+    """Result of evaluating one policy against one tool call.
+
+    * ``allow``   — policy has no objection (the default no-op outcome).
+    * ``deny``    — block execution; ``message`` explains the recoverable fix.
+    * ``rewrite`` — allow, but execute with ``rewritten_args`` instead.
+    """
+
+    action: str = "allow"  # allow | deny | rewrite
+    message: str = ""
+    rewritten_args: Mapping[str, Any] | None = None
+
+    @classmethod
+    def allow(cls) -> "PolicyOutcome":
+        return cls()
+
+    @classmethod
+    def deny(cls, message: str) -> "PolicyOutcome":
+        return cls(action="deny", message=message)
+
+    @classmethod
+    def rewrite(cls, args: Mapping[str, Any], message: str = "") -> "PolicyOutcome":
+        return cls(action="rewrite", rewritten_args=dict(args), message=message)
+
+
+# A policy is a pure function from a context to an outcome.
+PolicyInterceptor = Callable[[ToolCallContext], PolicyOutcome]
+
+
+@dataclass(frozen=True)
+class RegisteredPolicy:
+    """A built-in policy bound to its config-supplied name."""
+
+    name: str
+    interceptor: PolicyInterceptor
+
+
+class PolicyInterceptorRegistry:
+    """Ordered set of enabled policy interceptors for one agent turn.
+
+    Evaluation is first-match-wins on ``deny``: the registry returns the first
+    denying policy's decision. ``rewrite`` outcomes are composed in order so a
+    later policy sees the args produced by an earlier one. The combined result
+    is a :class:`ToolGuardrailDecision`, so callers reuse the exact same
+    ``allows_execution`` / ``should_halt`` contract as the loop guardrails.
+    """
+
+    def __init__(self, policies: list[RegisteredPolicy] | None = None):
+        self._policies: list[RegisteredPolicy] = list(policies or [])
+        self._observations: list[ToolCallObservation] = []
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._policies)
+
+    @property
+    def policy_names(self) -> tuple[str, ...]:
+        return tuple(p.name for p in self._policies)
+
+    def reset_for_turn(self) -> None:
+        """Clear the per-turn observation ledger (mirrors the controller)."""
+        self._observations = []
+
+    def record_observation(
+        self, tool_name: str, args: Mapping[str, Any] | None, *, failed: bool
+    ) -> None:
+        """Record a completed tool call so ordering-aware policies can see it."""
+        self._observations.append(
+            ToolCallObservation(
+                tool_name=tool_name,
+                args=_coerce_args(args),
+                failed=bool(failed),
+            )
+        )
+
+    def evaluate(
+        self, tool_name: str, args: Mapping[str, Any] | None
+    ) -> ToolGuardrailDecision:
+        """Run every enabled policy; return the combined guardrail decision.
+
+        Returns an ``allow`` decision (carrying possibly-rewritten args in
+        ``signature``) when no policy denies. Returns a ``block`` decision on
+        the first deny.
+        """
+        current_args = _coerce_args(args)
+        signature = ToolCallSignature.from_call(tool_name, current_args)
+        observations = tuple(self._observations)
+
+        for policy in self._policies:
+            context = ToolCallContext(
+                tool_name=tool_name,
+                args=current_args,
+                signature=ToolCallSignature.from_call(tool_name, current_args),
+                observations=observations,
+            )
+            outcome = policy.interceptor(context)
+
+            if outcome.action == "deny":
+                return ToolGuardrailDecision(
+                    action="block",
+                    code=f"policy_deny:{policy.name}",
+                    message=outcome.message
+                    or f"Blocked {tool_name}: denied by policy '{policy.name}'.",
+                    tool_name=tool_name,
+                    signature=ToolCallSignature.from_call(tool_name, current_args),
+                )
+
+            if outcome.action == "rewrite" and outcome.rewritten_args is not None:
+                current_args = _coerce_args(outcome.rewritten_args)
+
+        signature = ToolCallSignature.from_call(tool_name, current_args)
+        return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+
+# ── Built-in policies ────────────────────────────────────────────────────
+
+
+def make_require_read_before_write(
+    write_tools: frozenset[str],
+    read_tools: frozenset[str],
+    path_keys: tuple[str, ...],
+) -> PolicyInterceptor:
+    """Deny a write to a path that has not been successfully read this turn.
+
+    Implements the issue's headline success criterion: a write-before-read
+    sequence is rejected before execution with a clear, recoverable message.
+    A write whose path can't be determined is allowed (fail-open) so the
+    policy never blocks calls it can't reason about.
+    """
+
+    def policy(ctx: ToolCallContext) -> PolicyOutcome:
+        if ctx.tool_name not in write_tools:
+            return PolicyOutcome.allow()
+
+        target = _extract_path(ctx.args, path_keys)
+        if target is None:
+            return PolicyOutcome.allow()
+
+        for obs in ctx.observations:
+            if obs.failed or obs.tool_name not in read_tools:
+                continue
+            if _extract_path(obs.args, path_keys) == target:
+                return PolicyOutcome.allow()
+
+        return PolicyOutcome.deny(
+            f"Blocked {ctx.tool_name} on '{target}': policy requires reading a "
+            "file before writing it. Read the file first (e.g. with read_file), "
+            "then retry the write."
+        )
+
+    return policy
+
+
+def make_deny_tools(denied: frozenset[str]) -> PolicyInterceptor:
+    """Deny any call to a named tool outright (an allowlist's complement)."""
+
+    def policy(ctx: ToolCallContext) -> PolicyOutcome:
+        if ctx.tool_name in denied:
+            return PolicyOutcome.deny(
+                f"Blocked {ctx.tool_name}: this tool is disabled by policy."
+            )
+        return PolicyOutcome.allow()
+
+    return policy
+
+
+# Built-in policy factories keyed by the config ``policy`` field. Each factory
+# turns a config mapping into a concrete :class:`PolicyInterceptor`.
+DEFAULT_WRITE_TOOLS = frozenset({"write_file", "patch"})
+DEFAULT_READ_TOOLS = frozenset({"read_file"})
+DEFAULT_PATH_KEYS = ("path", "file_path", "filename")
+
+PolicyFactory = Callable[[Mapping[str, Any]], PolicyInterceptor]
+
+
+def _build_require_read_before_write(options: Mapping[str, Any]) -> PolicyInterceptor:
+    return make_require_read_before_write(
+        write_tools=_frozenset_opt(options.get("write_tools"), DEFAULT_WRITE_TOOLS),
+        read_tools=_frozenset_opt(options.get("read_tools"), DEFAULT_READ_TOOLS),
+        path_keys=_tuple_opt(options.get("path_keys"), DEFAULT_PATH_KEYS),
+    )
+
+
+def _build_deny_tools(options: Mapping[str, Any]) -> PolicyInterceptor:
+    return make_deny_tools(_frozenset_opt(options.get("tools"), frozenset()))
+
+
+BUILTIN_POLICY_FACTORIES: dict[str, PolicyFactory] = {
+    "require_read_before_write": _build_require_read_before_write,
+    "deny_tools": _build_deny_tools,
+}
+
+
+def build_registry_from_config(
+    data: Mapping[str, Any] | None,
+) -> PolicyInterceptorRegistry:
+    """Build a registry from the ``policy_interceptors`` config section.
+
+    Expected shape::
+
+        policy_interceptors:
+          enabled: true
+          policies:
+            - name: read-before-write     # optional label; defaults to policy id
+              policy: require_read_before_write
+              options: {}                 # optional, policy-specific
+            - policy: deny_tools
+              options: {tools: ["process"]}
+
+    Unknown ``policy`` ids and malformed entries are skipped (fail-open). When
+    ``enabled`` is false or absent the registry is empty and inert.
+    """
+    if not isinstance(data, Mapping):
+        return PolicyInterceptorRegistry()
+    if not _as_bool(data.get("enabled"), False):
+        return PolicyInterceptorRegistry()
+
+    raw_policies = data.get("policies")
+    if not isinstance(raw_policies, (list, tuple)):
+        return PolicyInterceptorRegistry()
+
+    registered: list[RegisteredPolicy] = []
+    for entry in raw_policies:
+        if not isinstance(entry, Mapping):
+            continue
+        policy_id = entry.get("policy")
+        if not isinstance(policy_id, str):
+            continue
+        factory = BUILTIN_POLICY_FACTORIES.get(policy_id)
+        if factory is None:
+            continue
+        options = entry.get("options")
+        if not isinstance(options, Mapping):
+            options = {}
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            name = policy_id
+        registered.append(RegisteredPolicy(name=name, interceptor=factory(options)))
+
+    return PolicyInterceptorRegistry(registered)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _extract_path(args: Mapping[str, Any], path_keys: tuple[str, ...]) -> str | None:
+    for key in path_keys:
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return args if isinstance(args, Mapping) else {}
+
+
+def _frozenset_opt(value: Any, default: frozenset[str]) -> frozenset[str]:
+    if isinstance(value, (list, tuple, set, frozenset)):
+        items = {str(item) for item in value if isinstance(item, str)}
+        return frozenset(items) if items else default
+    return default
+
+
+def _tuple_opt(value: Any, default: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(value, (list, tuple)):
+        items = tuple(str(item) for item in value if isinstance(item, str))
+        return items or default
+    return default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
+
+if TYPE_CHECKING:  # avoid a circular import; policy_interceptors imports this module
+    from agent.policy_interceptors import PolicyInterceptorRegistry
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -222,10 +225,21 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
 
 
 class ToolCallGuardrailController:
-    """Per-turn controller for repeated failed/non-progressing tool calls."""
+    """Per-turn controller for repeated failed/non-progressing tool calls.
 
-    def __init__(self, config: ToolCallGuardrailConfig | None = None):
+    Optionally evaluates a pluggable :class:`PolicyInterceptorRegistry` (passed
+    as ``policy_registry``) *before* the loop/limit checks. Policy denials are
+    hard constraints independent of ``hard_stop_enabled`` — that flag only
+    governs the loop-limit circuit breaker, not user-authored policies.
+    """
+
+    def __init__(
+        self,
+        config: ToolCallGuardrailConfig | None = None,
+        policy_registry: "PolicyInterceptorRegistry | None" = None,
+    ):
         self.config = config or ToolCallGuardrailConfig()
+        self.policy_registry = policy_registry
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -233,12 +247,22 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
+        if self.policy_registry is not None:
+            self.policy_registry.reset_for_turn()
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
+        # Policy interceptors run first and apply regardless of hard_stop_enabled:
+        # a denied policy is a deterministic user rule, not a loop limit.
+        if self.policy_registry is not None and self.policy_registry.enabled:
+            policy_decision = self.policy_registry.evaluate(tool_name, args)
+            if not policy_decision.allows_execution:
+                self._halt_decision = policy_decision
+                return policy_decision
+
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
@@ -294,6 +318,11 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        # Feed the per-turn observation ledger so ordering-aware policy
+        # interceptors (e.g. read-before-write) can see prior calls.
+        if self.policy_registry is not None and self.policy_registry.enabled:
+            self.policy_registry.record_observation(tool_name, args, failed=failed)
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1147,6 +1147,20 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Pluggable, deterministic per-policy interceptors that run before tool
+    # execution, alongside the loop guardrails above. Each named policy can
+    # allow / deny / rewrite a tool call. Disabled by default (opt-in); a
+    # denied policy blocks the call regardless of tool_loop_guardrails settings.
+    # Built-in policy ids: "require_read_before_write", "deny_tools".
+    "policy_interceptors": {
+        "enabled": False,
+        "policies": [
+            # Starter policy: reject a write to a path not yet read this turn.
+            # {"policy": "require_read_before_write"},
+            # {"policy": "deny_tools", "options": {"tools": []}},
+        ],
+    },
+
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio

--- a/tests/agent/test_policy_interceptors.py
+++ b/tests/agent/test_policy_interceptors.py
@@ -1,0 +1,268 @@
+"""Tests for pluggable per-policy tool-call interceptors."""
+
+from agent.policy_interceptors import (
+    PolicyInterceptorRegistry,
+    PolicyOutcome,
+    RegisteredPolicy,
+    ToolCallContext,
+    build_registry_from_config,
+    make_deny_tools,
+    make_require_read_before_write,
+)
+from agent.tool_guardrails import (
+    ToolCallGuardrailConfig,
+    ToolCallGuardrailController,
+    ToolCallSignature,
+)
+
+
+def _registry(*policies: RegisteredPolicy) -> PolicyInterceptorRegistry:
+    return PolicyInterceptorRegistry(list(policies))
+
+
+# ── PolicyOutcome / context primitives ──────────────────────────────────────
+
+
+def test_policy_outcome_constructors_set_expected_actions():
+    assert PolicyOutcome.allow().action == "allow"
+    deny = PolicyOutcome.deny("nope")
+    assert deny.action == "deny"
+    assert deny.message == "nope"
+    rewrite = PolicyOutcome.rewrite({"a": 1}, "tidied")
+    assert rewrite.action == "rewrite"
+    assert rewrite.rewritten_args == {"a": 1}
+    assert rewrite.message == "tidied"
+
+
+def test_empty_registry_is_inert_and_allows_everything():
+    registry = PolicyInterceptorRegistry()
+    assert registry.enabled is False
+    decision = registry.evaluate("write_file", {"path": "/tmp/x"})
+    assert decision.allows_execution is True
+    assert decision.action == "allow"
+
+
+# ── deny_tools policy ────────────────────────────────────────────────────────
+
+
+def test_deny_tools_blocks_named_tool_and_allows_others():
+    registry = _registry(
+        RegisteredPolicy("no-process", make_deny_tools(frozenset({"process"})))
+    )
+    assert registry.enabled is True
+
+    blocked = registry.evaluate("process", {"action": "spawn"})
+    assert blocked.allows_execution is False
+    assert blocked.action == "block"
+    assert blocked.code == "policy_deny:no-process"
+    assert "disabled by policy" in blocked.message
+
+    allowed = registry.evaluate("read_file", {"path": "/tmp/x"})
+    assert allowed.allows_execution is True
+
+
+# ── require_read_before_write policy ─────────────────────────────────────────
+
+
+def _read_before_write_registry() -> PolicyInterceptorRegistry:
+    policy = make_require_read_before_write(
+        write_tools=frozenset({"write_file", "patch"}),
+        read_tools=frozenset({"read_file"}),
+        path_keys=("path", "file_path"),
+    )
+    return _registry(RegisteredPolicy("read-before-write", policy))
+
+
+def test_write_before_read_is_denied_with_recoverable_message():
+    registry = _read_before_write_registry()
+
+    decision = registry.evaluate("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+    assert decision.action == "block"
+    assert decision.code == "policy_deny:read-before-write"
+    assert "/repo/a.py" in decision.message
+    assert "Read the file first" in decision.message
+
+
+def test_write_after_successful_read_of_same_path_is_allowed():
+    registry = _read_before_write_registry()
+
+    registry.record_observation("read_file", {"path": "/repo/a.py"}, failed=False)
+    decision = registry.evaluate("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is True
+    assert decision.action == "allow"
+
+
+def test_write_after_failed_read_is_still_denied():
+    registry = _read_before_write_registry()
+
+    registry.record_observation("read_file", {"path": "/repo/a.py"}, failed=True)
+    decision = registry.evaluate("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+
+
+def test_read_of_a_different_path_does_not_unlock_the_write():
+    registry = _read_before_write_registry()
+
+    registry.record_observation("read_file", {"path": "/repo/other.py"}, failed=False)
+    decision = registry.evaluate("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+
+
+def test_write_with_no_determinable_path_fails_open():
+    registry = _read_before_write_registry()
+
+    decision = registry.evaluate("write_file", {"content": "x"})
+    assert decision.allows_execution is True
+
+
+def test_reset_for_turn_clears_observation_ledger():
+    registry = _read_before_write_registry()
+
+    registry.record_observation("read_file", {"path": "/repo/a.py"}, failed=False)
+    registry.reset_for_turn()
+    decision = registry.evaluate("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+
+
+# ── rewrite composition ──────────────────────────────────────────────────────
+
+
+def test_rewrite_outcome_is_composed_in_order_for_later_policies():
+    def add_flag(ctx: ToolCallContext) -> PolicyOutcome:
+        args = dict(ctx.args)
+        args["flag"] = True
+        return PolicyOutcome.rewrite(args)
+
+    def deny_when_flagged(ctx: ToolCallContext) -> PolicyOutcome:
+        if ctx.args.get("flag") is True:
+            return PolicyOutcome.deny("flag present")
+        return PolicyOutcome.allow()
+
+    registry = _registry(
+        RegisteredPolicy("add-flag", add_flag),
+        RegisteredPolicy("deny-flagged", deny_when_flagged),
+    )
+    decision = registry.evaluate("write_file", {"path": "/tmp/x"})
+    assert decision.allows_execution is False
+    assert decision.code == "policy_deny:deny-flagged"
+
+
+def test_first_matching_deny_wins():
+    registry = _registry(
+        RegisteredPolicy("a", make_deny_tools(frozenset({"process"}))),
+        RegisteredPolicy("b", make_deny_tools(frozenset({"process"}))),
+    )
+    decision = registry.evaluate("process", {})
+    assert decision.code == "policy_deny:a"
+
+
+# ── config-driven registry construction ─────────────────────────────────────
+
+
+def test_build_registry_disabled_by_default():
+    assert build_registry_from_config(None).enabled is False
+    assert build_registry_from_config({}).enabled is False
+    assert build_registry_from_config({"enabled": False, "policies": []}).enabled is False
+
+
+def test_build_registry_enables_named_builtin_policies_in_order():
+    registry = build_registry_from_config(
+        {
+            "enabled": True,
+            "policies": [
+                {"name": "rbw", "policy": "require_read_before_write"},
+                {"policy": "deny_tools", "options": {"tools": ["process"]}},
+            ],
+        }
+    )
+    assert registry.enabled is True
+    assert registry.policy_names == ("rbw", "deny_tools")
+
+    # deny_tools is active
+    assert registry.evaluate("process", {}).allows_execution is False
+    # require_read_before_write is active
+    assert registry.evaluate("write_file", {"path": "/x"}).allows_execution is False
+
+
+def test_build_registry_skips_unknown_and_malformed_entries():
+    registry = build_registry_from_config(
+        {
+            "enabled": True,
+            "policies": [
+                "not-a-mapping",
+                {"name": "x"},  # missing policy id
+                {"policy": "does_not_exist"},
+                {"policy": "deny_tools", "options": {"tools": ["process"]}},
+            ],
+        }
+    )
+    assert registry.policy_names == ("deny_tools",)
+
+
+def test_build_registry_accepts_string_truthy_enabled_flag():
+    registry = build_registry_from_config(
+        {"enabled": "yes", "policies": [{"policy": "deny_tools", "options": {"tools": ["x"]}}]}
+    )
+    assert registry.enabled is True
+
+
+# ── controller integration (no new dispatch wiring) ──────────────────────────
+
+
+def test_controller_blocks_via_policy_before_loop_checks_even_with_hard_stop_disabled():
+    registry = build_registry_from_config(
+        {"enabled": True, "policies": [{"policy": "require_read_before_write"}]}
+    )
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False),
+        policy_registry=registry,
+    )
+
+    decision = controller.before_call("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+    assert decision.action == "block"
+    assert decision.code == "policy_deny:require_read_before_write"
+    assert controller.halt_decision is decision
+
+
+def test_controller_records_reads_via_after_call_then_allows_the_write():
+    registry = build_registry_from_config(
+        {"enabled": True, "policies": [{"policy": "require_read_before_write"}]}
+    )
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False),
+        policy_registry=registry,
+    )
+
+    # Successful read recorded through the normal after_call observation path.
+    assert controller.before_call("read_file", {"path": "/repo/a.py"}).allows_execution
+    controller.after_call("read_file", {"path": "/repo/a.py"}, "file contents", failed=False)
+
+    decision = controller.before_call("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is True
+
+
+def test_controller_reset_for_turn_clears_policy_ledger():
+    registry = build_registry_from_config(
+        {"enabled": True, "policies": [{"policy": "require_read_before_write"}]}
+    )
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False),
+        policy_registry=registry,
+    )
+
+    controller.after_call("read_file", {"path": "/repo/a.py"}, "contents", failed=False)
+    controller.reset_for_turn()
+    decision = controller.before_call("write_file", {"path": "/repo/a.py", "content": "x"})
+    assert decision.allows_execution is False
+
+
+def test_policy_decision_metadata_never_exposes_raw_args():
+    registry = build_registry_from_config(
+        {"enabled": True, "policies": [{"policy": "deny_tools", "options": {"tools": ["process"]}}]}
+    )
+    decision = registry.evaluate("process", {"secret": "token-value"})
+    metadata = decision.to_metadata()
+    assert "token-value" not in str(metadata)
+    assert isinstance(decision.signature, ToolCallSignature)


### PR DESCRIPTION
First increment of #228 — deterministic guardrail hooks / policy interceptors.

## Implemented
- **`agent/policy_interceptors.py`** — a pluggable, deterministic policy layer built **on top of** `agent/tool_guardrails.py` (does not duplicate it):
  - `PolicyInterceptorRegistry` (ordered, per-turn), `PolicyOutcome` (allow / deny / rewrite), `ToolCallContext`, `ToolCallObservation`.
  - Decisions are expressed as the existing `ToolGuardrailDecision`, so the dispatch path consumes them with **zero new wiring** via the existing `before_call() -> allows_execution` contract.
  - Built-in policies: `require_read_before_write` (rejects a write to a path not yet successfully read this turn — the issue's headline success criterion) and `deny_tools`.
  - Config-driven via a new `policy_interceptors` section in `config.yaml` (opt-in, `enabled: false` by default). Unknown / malformed policy entries fail open and are skipped.
- **`agent/tool_guardrails.py`** — `ToolCallGuardrailController` gains an optional `policy_registry`:
  - Policies are evaluated in `before_call()` **before** the loop-limit checks and **independently of `hard_stop_enabled`** (a denied policy is a deterministic user rule, not a loop limit).
  - `after_call()` feeds the per-turn observation ledger so ordering-aware policies work; `reset_for_turn()` clears it. `TYPE_CHECKING` import avoids a circular import.
- **`agent/agent_init.py`** — controller is constructed with a registry built from config.
- **`hermes_cli/config.py`** — new commented `policy_interceptors` default section.

Maps to the issue success criteria: write-before-read is rejected before execution; the block produces a clear, recoverable message ("Read the file first ... then retry the write."); existing tests pass with the layer enabled and disabled (default off = inert, identical prior behavior).

## Deferred
- Loading user-authored policy files from `.hermes/policies/` (this increment is config-driven only).
- `pre-LLM` and `post-tool` hook phases and `require-confirm` action (this increment covers the pre-tool allow/deny/rewrite phase).
- Deep dispatch rewiring — intentionally avoided; the policy layer rides the existing guardrail integration point.

## Verification
- `uv run --extra dev python -m pytest tests/agent/test_policy_interceptors.py tests/agent/test_tool_guardrails.py -q` → **32 passed** (13 existing guardrail tests still green).
- `uv run --extra dev ruff check` on all changed files → **All checks passed!**
- Backward-compat sanity: a controller with no registry behaves byte-for-byte as before.

Do not merge / no labels per request.
