### PR TITLE
Agent-as-a-Judge scoring core (first increment of #226)

### DIFF
--- a/agent/agent_judge.py
+++ b/agent/agent_judge.py
@@ -1,0 +1,718 @@
+"""Agent-as-a-Judge evaluation harness (first increment of #226).
+
+A self-contained, post-hoc evaluator that scores an agent execution trace
+against a structured rubric.  Mirrors the shape of ``agent.entropy_eval`` (a
+behavioural-metrics sibling): it runs against a session message list with no
+runtime dependency on the agent loop, exposes plain dataclasses, and offers a
+``to_dict`` / ``format_report_terminal`` pair for downstream consumers.
+
+Two scoring paths share one rubric:
+
+* **deterministic** (``score_trace_heuristic``) — no LLM, no cost.  Derives a
+  defensible baseline score per dimension from structural trace signals (tool
+  failures, repetition, refusals, whether the agent finished).  Always
+  available, used as the fallback when no LLM provider is configured.
+* **LLM-backed** (``score_trace_llm``) — sends a compact, schema-constrained
+  prompt to the shared auxiliary client (``agent.auxiliary_client.call_llm``,
+  the same router session-titling and compression use) and parses a STRICT
+  JSON object back.  Malformed or out-of-range model output is rejected, never
+  silently trusted (see the held-out-evaluation lesson: the judge computes the
+  verdict itself and clamps every number).
+
+Public API
+----------
+    from agent.agent_judge import AgentJudge, DEFAULT_RUBRIC
+
+    judge = AgentJudge()                      # default rubric
+    verdict = judge.score(session_id, messages, task="…")  # LLM if available
+    print(judge.format_report_terminal(verdict))
+    verdict.to_dict()                         # JSON-serialisable
+
+Wiring this into a post-execution hook / regression dashboard (success
+criteria 3 & 4 of #226) is intentionally DEFERRED — this increment delivers
+the standalone, independently-testable scoring core other code can call.
+
+Reference
+---------
+* Agent-as-a-Judge, ICML 2025 — https://proceedings.mlr.press/v267/zhuge25a.html
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Score bounds.  Every dimension and the overall score live on [0, 1] so the
+# rubric weights compose into a clean weighted mean.
+MIN_SCORE = 0.0
+MAX_SCORE = 1.0
+
+
+def _clamp(value: float) -> float:
+    """Clamp a score into [MIN_SCORE, MAX_SCORE]; coerce non-finite to 0.0.
+
+    The judge NEVER trusts a raw model-emitted number — out-of-range or NaN
+    values are silently corrected here rather than propagated into a verdict.
+    """
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return MIN_SCORE
+    if f != f:  # NaN
+        return MIN_SCORE
+    return max(MIN_SCORE, min(MAX_SCORE, f))
+
+
+# ── Rubric ──────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RubricDimension:
+    """One scored axis of the rubric.
+
+    Attributes:
+        key: Stable machine identifier (used as the JSON field the LLM emits).
+        title: Human-readable label for terminal output.
+        description: What "high" means — included verbatim in the LLM prompt
+            so the model and the deterministic heuristic share one definition.
+        weight: Relative weight in the overall score (weights are normalised,
+            so absolute magnitude is irrelevant — only ratios matter).
+    """
+
+    key: str
+    title: str
+    description: str
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class Rubric:
+    """An ordered set of weighted scoring dimensions."""
+
+    dimensions: Sequence[RubricDimension]
+
+    def __post_init__(self) -> None:
+        if not self.dimensions:
+            raise ValueError("Rubric requires at least one dimension")
+        keys = [d.key for d in self.dimensions]
+        if len(keys) != len(set(keys)):
+            raise ValueError("Rubric dimension keys must be unique")
+
+    def keys(self) -> List[str]:
+        return [d.key for d in self.dimensions]
+
+    def total_weight(self) -> float:
+        total = sum(d.weight for d in self.dimensions)
+        # Guard a degenerate all-zero-weight rubric so weighting falls back to
+        # an unweighted mean instead of dividing by zero.
+        return total if total > 0 else float(len(self.dimensions))
+
+
+# Default rubric aligned with the human-judgment criteria named in #226:
+# does the trace show planning, does it actually solve the task, does it use
+# tools soundly and verify, and is it efficient (no spinning).
+DEFAULT_RUBRIC = Rubric(
+    dimensions=(
+        RubricDimension(
+            key="task_completion",
+            title="Task completion",
+            description=(
+                "The agent fully accomplished what the task asked, with a clear "
+                "final result. Partial or abandoned work scores low."
+            ),
+            weight=2.0,
+        ),
+        RubricDimension(
+            key="tool_use",
+            title="Tool use & verification",
+            description=(
+                "Tools were used soundly: appropriate tools, recovered from "
+                "errors, and verified results rather than asserting success blindly."
+            ),
+            weight=1.5,
+        ),
+        RubricDimension(
+            key="reasoning",
+            title="Reasoning & planning",
+            description=(
+                "The trajectory shows coherent planning and step-by-step "
+                "reasoning toward the goal, not flailing or guessing."
+            ),
+            weight=1.0,
+        ),
+        RubricDimension(
+            key="efficiency",
+            title="Efficiency",
+            description=(
+                "The agent reached the result without redundant, repeated, or "
+                "wasted steps. Loops and repetition score low."
+            ),
+            weight=1.0,
+        ),
+    )
+)
+
+
+# ── Trace extraction ──────────────────────────────────────────────────────
+
+
+@dataclass
+class TraceSummary:
+    """Structural signals distilled from a session message list.
+
+    Deliberately the SAME message shape ``agent.entropy_eval`` consumes
+    (OpenAI-style ``{"role", "content", "tool_calls"}`` dicts) so any caller
+    that already has a trajectory can feed both evaluators.
+    """
+
+    message_count: int = 0
+    user_turns: int = 0
+    assistant_turns: int = 0
+    tool_calls: int = 0
+    tool_results: int = 0
+    tool_failures: int = 0
+    repeated_tool_runs: int = 0
+    refusals: int = 0
+    has_final_answer: bool = False
+    tool_names: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "message_count": self.message_count,
+            "user_turns": self.user_turns,
+            "assistant_turns": self.assistant_turns,
+            "tool_calls": self.tool_calls,
+            "tool_results": self.tool_results,
+            "tool_failures": self.tool_failures,
+            "repeated_tool_runs": self.repeated_tool_runs,
+            "refusals": self.refusals,
+            "has_final_answer": self.has_final_answer,
+            "tool_names": list(self.tool_names),
+        }
+
+
+# Failure / refusal markers. Reuse loop_guard's failure detector when present
+# (single source of truth, consistent with introspection_extract.py), keeping
+# a small literal fallback so this module stays importable standalone.
+try:  # pragma: no cover - exercised indirectly; import shape varies by tree
+    from agent.loop_guard import _looks_like_failure as _looks_like_failure
+except Exception:  # pragma: no cover
+    _FAILURE_MARKERS = (
+        "error:", "failed", "permission denied", "command not found",
+        "no such file", "timed out", "timeout", "traceback (most recent call",
+    )
+
+    def _looks_like_failure(content: Any) -> bool:
+        return isinstance(content, str) and any(
+            m in content.lower() for m in _FAILURE_MARKERS
+        )
+
+
+_REFUSAL_RE = re.compile(
+    r"\b(i can'?t|i cannot|i'?m (?:unable|not able)|no access|access denied|"
+    r"not permitted|don'?t have (?:access|permission))\b",
+    re.IGNORECASE,
+)
+# A repeated-run spiral: the SAME tool fired this many times in a row.
+_REPEAT_THRESHOLD = 3
+
+
+def _tool_name(tool_call: Any) -> str:
+    if not isinstance(tool_call, dict):
+        return "unknown"
+    fn = tool_call.get("function")
+    if isinstance(fn, dict) and fn.get("name"):
+        return str(fn["name"])
+    return str(tool_call.get("name") or "unknown")
+
+
+def summarize_trace(messages: Sequence[Dict[str, Any]]) -> TraceSummary:
+    """Extract structural signals from a session message list.
+
+    Pure and deterministic — no LLM, no I/O.  Drives the heuristic score and
+    is embedded (compactly) into the LLM prompt so the model sees the same
+    objective signals the heuristic does.
+    """
+    summary = TraceSummary(message_count=len(messages))
+    last_assistant_text = ""
+    consecutive_tool = ""
+    consecutive_count = 0
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "")
+        content = msg.get("content")
+        tool_calls = msg.get("tool_calls") or []
+
+        if role == "user":
+            summary.user_turns += 1
+        elif role == "assistant":
+            summary.assistant_turns += 1
+            if tool_calls:
+                for tc in tool_calls:
+                    name = _tool_name(tc)
+                    summary.tool_calls += 1
+                    summary.tool_names.append(name)
+                    if name == consecutive_tool:
+                        consecutive_count += 1
+                    else:
+                        consecutive_tool = name
+                        consecutive_count = 1
+                    if consecutive_count == _REPEAT_THRESHOLD:
+                        # Count the spiral once, when it crosses the threshold.
+                        summary.repeated_tool_runs += 1
+            elif isinstance(content, str) and content.strip():
+                last_assistant_text = content
+                if _REFUSAL_RE.search(content):
+                    summary.refusals += 1
+        elif role == "tool":
+            summary.tool_results += 1
+            if _looks_like_failure(content):
+                summary.tool_failures += 1
+
+    # A trace "has a final answer" when its last substantive assistant message
+    # is plain text (a delivered result) rather than a dangling tool call.
+    summary.has_final_answer = bool(last_assistant_text.strip())
+    return summary
+
+
+# ── Verdict ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class JudgeVerdict:
+    """The structured result of scoring one trace."""
+
+    session_id: str
+    overall_score: float
+    dimension_scores: Dict[str, float]
+    rationale: str
+    method: str  # "llm" | "heuristic"
+    trace_summary: TraceSummary
+    model: Optional[str] = None
+
+    def passed(self, threshold: float = 0.7) -> bool:
+        """Whether the verdict clears a pass/fail threshold (default 0.7)."""
+        return self.overall_score >= threshold
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "overall_score": round(self.overall_score, 4),
+            "dimension_scores": {
+                k: round(v, 4) for k, v in self.dimension_scores.items()
+            },
+            "rationale": self.rationale,
+            "method": self.method,
+            "model": self.model,
+            "trace_summary": self.trace_summary.to_dict(),
+        }
+
+
+# ── Prompt construction & parsing ──────────────────────────────────────────
+
+
+def _build_rubric_block(rubric: Rubric) -> str:
+    lines = []
+    for d in rubric.dimensions:
+        lines.append(f'- "{d.key}" ({d.title}, weight {d.weight:g}): {d.description}')
+    return "\n".join(lines)
+
+
+def build_judge_messages(
+    session_id: str,
+    summary: TraceSummary,
+    transcript_excerpt: str,
+    rubric: Rubric,
+    task: Optional[str],
+) -> List[Dict[str, str]]:
+    """Assemble the chat messages for an LLM scoring call.
+
+    The system prompt pins the output to a strict JSON schema; the user message
+    carries the rubric, the objective trace signals, and a bounded transcript
+    excerpt.  Kept compact on purpose — this is a cheap auxiliary call, not a
+    full replay (success criterion 2: cost well under an external baseline).
+    """
+    keys = rubric.keys()
+    schema_fields = ", ".join(f'"{k}": <0.0-1.0>' for k in keys)
+    system = (
+        "You are a strict, impartial evaluator of AI-agent execution traces. "
+        "Score the trace against the rubric. Be skeptical: reward verified "
+        "results, penalise unrecovered tool failures, repetition, and "
+        "abandoned work. Compute every score yourself from the evidence; do "
+        "not trust any number the trace asserts about itself.\n\n"
+        "Respond with ONLY a single JSON object, no markdown, no prose, of the "
+        "exact form:\n"
+        f'{{"scores": {{{schema_fields}}}, "rationale": "<=2 sentences"}}\n'
+        "Every score is a float in [0.0, 1.0]. Include every rubric key."
+    )
+    parts = [f"## Rubric\n{_build_rubric_block(rubric)}"]
+    if task:
+        parts.append(f"## Task the agent was given\n{task.strip()[:1000]}")
+    parts.append(
+        "## Objective trace signals\n"
+        + json.dumps(summary.to_dict(), ensure_ascii=False, indent=2)
+    )
+    parts.append(f"## Trace excerpt\n{transcript_excerpt}")
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "\n\n".join(parts)},
+    ]
+
+
+_JSON_DECODER = json.JSONDecoder()
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    """Pull the first parseable top-level JSON object out of model text.
+
+    Tolerates code fences and leading/trailing prose (small models sometimes
+    wrap JSON despite instructions). Each ``{`` is handed to the stdlib
+    decoder's ``raw_decode`` — the C-optimised parser owns string-escape and
+    brace-balancing, so prose braces or a ``{}`` inside a string literal never
+    confuse the boundary. Returns None if nothing parseable.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    start = stripped.find("{")
+    while start != -1:
+        try:
+            obj, _ = _JSON_DECODER.raw_decode(stripped, start)
+        except (json.JSONDecodeError, ValueError):
+            start = stripped.find("{", start + 1)
+            continue
+        if isinstance(obj, dict):
+            return obj
+        # Parsed a non-object (e.g. set-like text the decoder rejected as
+        # something else); keep scanning for a real object.
+        start = stripped.find("{", start + 1)
+    return None
+
+
+def parse_judge_response(text: str, rubric: Rubric) -> Optional[Dict[str, Any]]:
+    """Validate and normalise a raw LLM judge response.
+
+    Enforces the strict schema: a ``scores`` object must be present and must
+    cover EVERY rubric dimension. Any missing dimension rejects the whole
+    response (returns None) — a partial score is worse than falling back to the
+    deterministic heuristic, because it silently hides the gap.
+
+    Returns ``{"scores": {key: clamped float}, "rationale": str}`` or None.
+    """
+    obj = _extract_json_object(text)
+    if obj is None:
+        return None
+    raw_scores = obj.get("scores")
+    if not isinstance(raw_scores, dict):
+        return None
+    scores: Dict[str, float] = {}
+    for key in rubric.keys():
+        if key not in raw_scores:
+            return None  # incomplete -> reject, fall back to heuristic
+        scores[key] = _clamp(raw_scores[key])
+    rationale = obj.get("rationale")
+    if not isinstance(rationale, str):
+        rationale = ""
+    return {"scores": scores, "rationale": rationale.strip()}
+
+
+def _weighted_overall(scores: Dict[str, float], rubric: Rubric) -> float:
+    total_w = rubric.total_weight()
+    acc = 0.0
+    for d in rubric.dimensions:
+        acc += scores.get(d.key, 0.0) * d.weight
+    return _clamp(acc / total_w)
+
+
+# ── Deterministic heuristic scoring ──────────────────────────────────────────
+
+
+def score_trace_heuristic(
+    session_id: str,
+    messages: Sequence[Dict[str, Any]],
+    rubric: Rubric = DEFAULT_RUBRIC,
+    *,
+    summary: Optional[TraceSummary] = None,
+) -> JudgeVerdict:
+    """Score a trace from structural signals only — no LLM, no cost.
+
+    A defensible baseline: it cannot judge semantic correctness, but it
+    reliably penalises the failure shapes the trace makes objective (unrecovered
+    tool errors, refusal, repetition spirals, no delivered answer). Always
+    available, and the automatic fallback when no LLM provider is configured.
+
+    Only the rubric dimensions present in ``DEFAULT_RUBRIC`` get a tailored
+    signal; any custom dimension falls back to a neutral 0.5 so a custom rubric
+    still produces a usable score rather than crashing.
+    """
+    summary = summary if summary is not None else summarize_trace(messages)
+    scores: Dict[str, float] = {}
+
+    # task_completion: did the agent deliver a final answer, undamaged by
+    # refusal? Heavily binary by nature.
+    completion = 0.0
+    if summary.has_final_answer:
+        completion = 0.8
+        if summary.refusals == 0:
+            completion = 1.0
+    if summary.refusals and not summary.has_final_answer:
+        completion = 0.1
+
+    # tool_use: clean if there were tool calls and few/no failures.
+    if summary.tool_calls == 0:
+        tool_use = 0.6  # no tools used — neutral, can't fault tool handling
+    else:
+        fail_ratio = summary.tool_failures / max(summary.tool_results, 1)
+        tool_use = _clamp(1.0 - fail_ratio)
+
+    # reasoning: proxy via turn structure — some assistant turns relative to
+    # tool churn. Very rough; the LLM path is where real reasoning is judged.
+    if summary.assistant_turns == 0:
+        reasoning = 0.0
+    else:
+        reasoning = 0.7 if summary.has_final_answer else 0.4
+
+    # efficiency: penalise repetition spirals.
+    efficiency = _clamp(1.0 - 0.3 * summary.repeated_tool_runs)
+
+    tailored = {
+        "task_completion": completion,
+        "tool_use": tool_use,
+        "reasoning": reasoning,
+        "efficiency": efficiency,
+    }
+    for d in rubric.dimensions:
+        scores[d.key] = _clamp(tailored.get(d.key, 0.5))
+
+    overall = _weighted_overall(scores, rubric)
+    rationale = (
+        f"Heuristic: {'delivered' if summary.has_final_answer else 'no'} final "
+        f"answer, {summary.tool_failures}/{summary.tool_results} tool failures, "
+        f"{summary.repeated_tool_runs} repetition spiral(s), "
+        f"{summary.refusals} refusal(s)."
+    )
+    return JudgeVerdict(
+        session_id=session_id,
+        overall_score=overall,
+        dimension_scores=scores,
+        rationale=rationale,
+        method="heuristic",
+        trace_summary=summary,
+        model=None,
+    )
+
+
+# ── Transcript rendering for the LLM ──────────────────────────────────────────
+
+
+def render_transcript_excerpt(
+    messages: Sequence[Dict[str, Any]],
+    *,
+    max_chars: int = 6000,
+    max_messages: int = 40,
+) -> str:
+    """Render a bounded, role-tagged transcript for the LLM prompt.
+
+    Bounded on BOTH message count and total characters so an enormous trace
+    cannot blow the auxiliary call's context or cost. When truncated, the head
+    and tail are kept (the task setup and the outcome are the most diagnostic
+    parts) with an elision marker between them.
+    """
+    rendered: List[str] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "unknown")
+        content = msg.get("content")
+        tool_calls = msg.get("tool_calls") or []
+        if role == "assistant" and tool_calls:
+            names = ", ".join(_tool_name(tc) for tc in tool_calls)
+            text = (content or "").strip()
+            line = f"[assistant] calls tools: {names}"
+            if text:
+                line += f"\n  {text}"
+        elif role == "tool":
+            body = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+            line = f"[tool result] {body}"
+        else:
+            body = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+            line = f"[{role}] {body}"
+        rendered.append(line)
+
+    if len(rendered) > max_messages:
+        head = rendered[: max_messages // 2]
+        tail = rendered[-(max_messages // 2):]
+        rendered = head + [f"… ({len(rendered) - max_messages} messages elided) …"] + tail
+
+    excerpt = "\n".join(rendered)
+    if len(excerpt) > max_chars:
+        keep = max_chars // 2
+        excerpt = (
+            excerpt[:keep]
+            + f"\n… ({len(excerpt) - max_chars} chars elided) …\n"
+            + excerpt[-keep:]
+        )
+    return excerpt
+
+
+# ── LLM-backed scoring ──────────────────────────────────────────────────────
+
+
+def score_trace_llm(
+    session_id: str,
+    messages: Sequence[Dict[str, Any]],
+    rubric: Rubric = DEFAULT_RUBRIC,
+    *,
+    task: Optional[str] = None,
+    timeout: float = 60.0,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    summary: Optional[TraceSummary] = None,
+) -> Optional[JudgeVerdict]:
+    """Score a trace with an LLM via the shared auxiliary client.
+
+    Returns a ``JudgeVerdict`` (method="llm") on success, or ``None`` if no
+    provider is configured or the response can't be validated against the
+    rubric schema. Callers that want a guaranteed result use ``AgentJudge.score``
+    which falls back to the deterministic heuristic on None.
+
+    The LLM is imported lazily so this module stays importable (and the
+    heuristic path stays usable) in environments where the auxiliary client or
+    its provider chain is unavailable.
+    """
+    # The objective trace signals are computed from the FULL message list
+    # (summarize_trace), never the truncated excerpt — only the LLM-facing
+    # transcript is bounded. This keeps the failure/repetition counts the model
+    # sees (and the heuristic uses) accurate even when the trace is huge.
+    summary = summary if summary is not None else summarize_trace(messages)
+    excerpt = render_transcript_excerpt(messages)
+    chat = build_judge_messages(session_id, summary, excerpt, rubric, task)
+
+    try:
+        from agent.auxiliary_client import call_llm
+    except Exception as e:  # pragma: no cover - import-time only
+        logger.debug("agent_judge: auxiliary client unavailable: %s", e)
+        return None
+
+    try:
+        response = call_llm(
+            task="agent_judge",
+            messages=chat,
+            max_tokens=600,
+            temperature=0.0,  # deterministic verdicts
+            timeout=timeout,
+            main_runtime=main_runtime,
+        )
+    except Exception as e:
+        logger.warning("agent_judge: LLM scoring failed: %s", e)
+        logger.debug("agent_judge LLM traceback", exc_info=True)
+        return None
+
+    content = ""
+    model = None
+    try:
+        content = response.choices[0].message.content or ""
+        model = getattr(response, "model", None)
+    except (AttributeError, IndexError, TypeError):
+        logger.warning("agent_judge: unexpected LLM response shape")
+        return None
+
+    parsed = parse_judge_response(content, rubric)
+    if parsed is None:
+        logger.warning("agent_judge: LLM response failed schema validation")
+        return None
+
+    scores = parsed["scores"]
+    overall = _weighted_overall(scores, rubric)
+    return JudgeVerdict(
+        session_id=session_id,
+        overall_score=overall,
+        dimension_scores=scores,
+        rationale=parsed["rationale"],
+        method="llm",
+        trace_summary=summary,
+        model=model,
+    )
+
+
+# ── Engine + formatting ──────────────────────────────────────────────────────
+
+
+class AgentJudge:
+    """Score agent execution traces against a rubric.
+
+    Usage
+    -----
+        from agent.agent_judge import AgentJudge
+
+        judge = AgentJudge()
+        verdict = judge.score(session_id, messages, task="fix the failing test")
+        print(judge.format_report_terminal(verdict))
+    """
+
+    def __init__(self, rubric: Rubric = DEFAULT_RUBRIC):
+        self.rubric = rubric
+
+    def score(
+        self,
+        session_id: str,
+        messages: Sequence[Dict[str, Any]],
+        *,
+        task: Optional[str] = None,
+        use_llm: bool = True,
+        timeout: float = 60.0,
+        main_runtime: Optional[Dict[str, Any]] = None,
+    ) -> JudgeVerdict:
+        """Score a trace, preferring the LLM and falling back to the heuristic.
+
+        Always returns a verdict: if ``use_llm`` is False, or no provider is
+        configured, or the LLM output fails validation, the deterministic
+        heuristic verdict is returned instead.
+        """
+        summary = summarize_trace(messages)
+        if use_llm:
+            verdict = score_trace_llm(
+                session_id,
+                messages,
+                self.rubric,
+                task=task,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                summary=summary,
+            )
+            if verdict is not None:
+                return verdict
+        return score_trace_heuristic(
+            session_id, messages, self.rubric, summary=summary
+        )
+
+    def format_report_terminal(self, verdict: JudgeVerdict) -> str:
+        """Return a compact, terminal-ready verdict summary."""
+        return format_report_terminal(verdict, self.rubric)
+
+
+def format_report_terminal(verdict: JudgeVerdict, rubric: Rubric = DEFAULT_RUBRIC) -> str:
+    """Render a verdict for the terminal (mirrors entropy_eval's formatter)."""
+    sid = verdict.session_id
+    sid_display = f"{sid[:24]}..." if len(sid) > 24 else sid
+    titles = {d.key: d.title for d in rubric.dimensions}
+    verdict_word = "PASS" if verdict.passed() else "FAIL"
+    lines = [
+        f"  ⚖️  Agent-as-a-Judge verdict (session {sid_display})",
+        f"  {'─' * 44}",
+        f"  Overall:  {verdict.overall_score:6.3f}  [{verdict_word}]  ({verdict.method})",
+        f"  {'─' * 44}",
+    ]
+    for key, score in verdict.dimension_scores.items():
+        label = titles.get(key, key)
+        lines.append(f"  {label:<24} {score:6.3f}")
+    lines.append(f"  {'─' * 44}")
+    if verdict.rationale:
+        lines.append(f"  {verdict.rationale}")
+    return "\n".join(lines)

--- a/tests/agent/test_agent_judge.py
+++ b/tests/agent/test_agent_judge.py
@@ -1,0 +1,403 @@
+"""Tests for the Agent-as-a-Judge evaluation harness (issue #226)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.agent_judge import (
+    DEFAULT_RUBRIC,
+    AgentJudge,
+    JudgeVerdict,
+    Rubric,
+    RubricDimension,
+    TraceSummary,
+    _clamp,
+    _extract_json_object,
+    build_judge_messages,
+    format_report_terminal,
+    parse_judge_response,
+    render_transcript_excerpt,
+    score_trace_heuristic,
+    score_trace_llm,
+    summarize_trace,
+)
+
+
+def _llm_response(content: str, model: str = "test-judge-model") -> MagicMock:
+    """Build a MagicMock shaped like an OpenAI chat completion response."""
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    resp.model = model
+    return resp
+
+
+# A small, well-behaved trace: user asks, agent uses a tool, gets a result,
+# delivers a plain-text final answer.
+SUCCESS_TRACE = [
+    {"role": "user", "content": "list the files"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "a.py\nb.py"},
+    {"role": "assistant", "content": "There are two files: a.py and b.py."},
+]
+
+# A failing trace: tool errors repeatedly, never delivers a final answer.
+FAILING_TRACE = [
+    {"role": "user", "content": "run the build"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "2"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "3"}]},
+    {"role": "tool", "content": "error: command not found"},
+]
+
+
+class TestClamp:
+    def test_in_range(self):
+        assert _clamp(0.5) == 0.5
+
+    def test_above_range(self):
+        assert _clamp(1.7) == 1.0
+
+    def test_below_range(self):
+        assert _clamp(-2.0) == 0.0
+
+    def test_non_numeric(self):
+        assert _clamp("not a number") == 0.0
+
+    def test_nan(self):
+        assert _clamp(float("nan")) == 0.0
+
+
+class TestRubric:
+    def test_default_rubric_keys_unique(self):
+        keys = DEFAULT_RUBRIC.keys()
+        assert len(keys) == len(set(keys))
+        assert "task_completion" in keys
+
+    def test_empty_rubric_rejected(self):
+        with pytest.raises(ValueError):
+            Rubric(dimensions=())
+
+    def test_duplicate_keys_rejected(self):
+        with pytest.raises(ValueError):
+            Rubric(dimensions=(
+                RubricDimension("x", "X", "desc"),
+                RubricDimension("x", "X2", "desc2"),
+            ))
+
+    def test_total_weight(self):
+        # 2.0 + 1.5 + 1.0 + 1.0
+        assert DEFAULT_RUBRIC.total_weight() == pytest.approx(5.5)
+
+    def test_zero_weight_falls_back_to_count(self):
+        r = Rubric(dimensions=(
+            RubricDimension("a", "A", "d", weight=0.0),
+            RubricDimension("b", "B", "d", weight=0.0),
+        ))
+        assert r.total_weight() == 2.0
+
+
+class TestSummarizeTrace:
+    def test_empty(self):
+        s = summarize_trace([])
+        assert s.message_count == 0
+        assert s.has_final_answer is False
+        assert s.tool_calls == 0
+
+    def test_success_trace_signals(self):
+        s = summarize_trace(SUCCESS_TRACE)
+        assert s.user_turns == 1
+        assert s.assistant_turns == 2
+        assert s.tool_calls == 1
+        assert s.tool_results == 1
+        assert s.tool_failures == 0
+        assert s.has_final_answer is True
+        assert s.tool_names == ["terminal"]
+
+    def test_failing_trace_signals(self):
+        s = summarize_trace(FAILING_TRACE)
+        assert s.tool_calls == 3
+        assert s.tool_results == 3
+        assert s.tool_failures == 3
+        # Three consecutive identical tool calls -> one repetition spiral.
+        assert s.repeated_tool_runs == 1
+        assert s.has_final_answer is False
+
+    def test_refusal_detected(self):
+        trace = [
+            {"role": "user", "content": "delete the database"},
+            {"role": "assistant", "content": "I can't do that without confirmation."},
+        ]
+        s = summarize_trace(trace)
+        assert s.refusals == 1
+        # A refusal-only assistant turn IS a final-text answer, but completion
+        # scoring handles that downstream.
+        assert s.has_final_answer is True
+
+    def test_ignores_non_dict_messages(self):
+        s = summarize_trace([None, "garbage", {"role": "user", "content": "hi"}])
+        assert s.user_turns == 1
+        assert s.message_count == 3
+
+    def test_to_dict_roundtrip(self):
+        s = summarize_trace(SUCCESS_TRACE)
+        d = s.to_dict()
+        assert d["tool_calls"] == 1
+        assert d["has_final_answer"] is True
+
+
+class TestHeuristicScoring:
+    def test_success_scores_high(self):
+        v = score_trace_heuristic("s1", SUCCESS_TRACE)
+        assert v.method == "heuristic"
+        assert v.overall_score > 0.7
+        assert v.passed()
+        assert set(v.dimension_scores.keys()) == set(DEFAULT_RUBRIC.keys())
+
+    def test_failure_scores_low(self):
+        v = score_trace_heuristic("s2", FAILING_TRACE)
+        assert v.method == "heuristic"
+        assert v.overall_score < 0.5
+        assert not v.passed()
+        # Tool-use must be penalised: every tool result failed.
+        assert v.dimension_scores["tool_use"] == 0.0
+
+    def test_all_scores_in_range(self):
+        for trace in (SUCCESS_TRACE, FAILING_TRACE, []):
+            v = score_trace_heuristic("s", trace)
+            for score in v.dimension_scores.values():
+                assert 0.0 <= score <= 1.0
+            assert 0.0 <= v.overall_score <= 1.0
+
+    def test_custom_dimension_gets_neutral(self):
+        rubric = Rubric(dimensions=(
+            RubricDimension("task_completion", "Task", "d", weight=1.0),
+            RubricDimension("novel_axis", "Novel", "d", weight=1.0),
+        ))
+        v = score_trace_heuristic("s", SUCCESS_TRACE, rubric)
+        assert v.dimension_scores["novel_axis"] == 0.5
+
+
+class TestJsonExtraction:
+    def test_plain_object(self):
+        assert _extract_json_object('{"a": 1}') == {"a": 1}
+
+    def test_object_with_prose_around(self):
+        text = 'Here is my verdict:\n{"scores": {"x": 0.5}}\nThanks!'
+        assert _extract_json_object(text) == {"scores": {"x": 0.5}}
+
+    def test_object_in_code_fence(self):
+        text = '```json\n{"a": 2}\n```'
+        assert _extract_json_object(text) == {"a": 2}
+
+    def test_braces_inside_string_dont_break_parsing(self):
+        text = '{"rationale": "it used a {placeholder} token"}'
+        assert _extract_json_object(text) == {"rationale": "it used a {placeholder} token"}
+
+    def test_first_object_with_trailing_garbage(self):
+        # raw_decode must stop at the end of the first object and ignore the
+        # trailing prose rather than choke on it.
+        text = '{"scores": {"x": 0.5}} and then some closing remarks.'
+        assert _extract_json_object(text) == {"scores": {"x": 0.5}}
+
+    def test_skips_unparseable_leading_brace(self):
+        # A bare "{" that isn't valid JSON, then the real object later.
+        text = "note: { incomplete ... actually here: {\"a\": 1}"
+        assert _extract_json_object(text) == {"a": 1}
+
+    def test_no_json_returns_none(self):
+        assert _extract_json_object("no json here at all") is None
+
+    def test_empty_returns_none(self):
+        assert _extract_json_object("") is None
+
+
+class TestParseJudgeResponse:
+    def test_valid_full_response(self):
+        content = (
+            '{"scores": {"task_completion": 0.9, "tool_use": 0.8, '
+            '"reasoning": 0.7, "efficiency": 1.0}, "rationale": "Solid work."}'
+        )
+        parsed = parse_judge_response(content, DEFAULT_RUBRIC)
+        assert parsed is not None
+        assert parsed["scores"]["task_completion"] == 0.9
+        assert parsed["rationale"] == "Solid work."
+
+    def test_missing_dimension_rejected(self):
+        # Missing "efficiency" -> whole response rejected.
+        content = (
+            '{"scores": {"task_completion": 0.9, "tool_use": 0.8, '
+            '"reasoning": 0.7}}'
+        )
+        assert parse_judge_response(content, DEFAULT_RUBRIC) is None
+
+    def test_out_of_range_scores_clamped(self):
+        content = (
+            '{"scores": {"task_completion": 1.9, "tool_use": -0.5, '
+            '"reasoning": 0.5, "efficiency": 0.5}}'
+        )
+        parsed = parse_judge_response(content, DEFAULT_RUBRIC)
+        assert parsed is not None
+        assert parsed["scores"]["task_completion"] == 1.0
+        assert parsed["scores"]["tool_use"] == 0.0
+
+    def test_missing_scores_object_rejected(self):
+        assert parse_judge_response('{"rationale": "hi"}', DEFAULT_RUBRIC) is None
+
+    def test_garbage_rejected(self):
+        assert parse_judge_response("the agent did great", DEFAULT_RUBRIC) is None
+
+    def test_non_string_rationale_coerced(self):
+        content = (
+            '{"scores": {"task_completion": 0.5, "tool_use": 0.5, '
+            '"reasoning": 0.5, "efficiency": 0.5}, "rationale": 123}'
+        )
+        parsed = parse_judge_response(content, DEFAULT_RUBRIC)
+        assert parsed is not None
+        assert parsed["rationale"] == ""
+
+
+class TestBuildJudgeMessages:
+    def test_includes_rubric_and_schema(self):
+        summary = summarize_trace(SUCCESS_TRACE)
+        msgs = build_judge_messages("s", summary, "excerpt", DEFAULT_RUBRIC, "do a thing")
+        assert msgs[0]["role"] == "system"
+        # Schema must name every rubric key.
+        for key in DEFAULT_RUBRIC.keys():
+            assert key in msgs[0]["content"]
+        assert "do a thing" in msgs[1]["content"]
+        assert "Objective trace signals" in msgs[1]["content"]
+
+    def test_task_optional(self):
+        summary = summarize_trace(SUCCESS_TRACE)
+        msgs = build_judge_messages("s", summary, "excerpt", DEFAULT_RUBRIC, None)
+        assert "Task the agent was given" not in msgs[1]["content"]
+
+
+class TestRenderTranscriptExcerpt:
+    def test_tool_calls_rendered(self):
+        out = render_transcript_excerpt(SUCCESS_TRACE)
+        assert "calls tools: terminal" in out
+        assert "[tool result]" in out
+        assert "[user]" in out
+
+    def test_message_count_bounded(self):
+        big = [{"role": "user", "content": f"m{i}"} for i in range(200)]
+        out = render_transcript_excerpt(big, max_messages=20)
+        assert "messages elided" in out
+
+    def test_char_bound(self):
+        big = [{"role": "user", "content": "x" * 1000} for _ in range(50)]
+        out = render_transcript_excerpt(big, max_messages=100, max_chars=2000)
+        assert "chars elided" in out
+        assert len(out) < 3000
+
+
+class TestScoreTraceLlm:
+    def test_success_path(self):
+        content = (
+            '{"scores": {"task_completion": 1.0, "tool_use": 0.9, '
+            '"reasoning": 0.8, "efficiency": 0.9}, "rationale": "Clean run."}'
+        )
+        with patch("agent.auxiliary_client.call_llm", return_value=_llm_response(content)):
+            v = score_trace_llm("s1", SUCCESS_TRACE, task="list files")
+        assert v is not None
+        assert v.method == "llm"
+        assert v.model == "test-judge-model"
+        assert v.overall_score > 0.85
+        assert v.rationale == "Clean run."
+
+    def test_returns_none_on_invalid_schema(self):
+        with patch("agent.auxiliary_client.call_llm", return_value=_llm_response("garbage")):
+            assert score_trace_llm("s1", SUCCESS_TRACE) is None
+
+    def test_returns_none_on_llm_exception(self):
+        with patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("no provider")):
+            assert score_trace_llm("s1", SUCCESS_TRACE) is None
+
+    def test_returns_none_on_bad_response_shape(self):
+        broken = MagicMock()
+        broken.choices = []
+        with patch("agent.auxiliary_client.call_llm", return_value=broken):
+            assert score_trace_llm("s1", SUCCESS_TRACE) is None
+
+    def test_passes_judge_task_name(self):
+        content = (
+            '{"scores": {"task_completion": 0.5, "tool_use": 0.5, '
+            '"reasoning": 0.5, "efficiency": 0.5}, "rationale": "ok"}'
+        )
+        with patch("agent.auxiliary_client.call_llm", return_value=_llm_response(content)) as m:
+            score_trace_llm("s1", SUCCESS_TRACE)
+        assert m.call_args.kwargs["task"] == "agent_judge"
+        assert m.call_args.kwargs["temperature"] == 0.0
+
+
+class TestAgentJudgeEngine:
+    def test_score_uses_llm_when_available(self):
+        content = (
+            '{"scores": {"task_completion": 1.0, "tool_use": 1.0, '
+            '"reasoning": 1.0, "efficiency": 1.0}, "rationale": "Perfect."}'
+        )
+        judge = AgentJudge()
+        with patch("agent.auxiliary_client.call_llm", return_value=_llm_response(content)):
+            v = judge.score("s1", SUCCESS_TRACE, task="x")
+        assert v.method == "llm"
+        assert v.overall_score == 1.0
+
+    def test_score_falls_back_to_heuristic_when_llm_fails(self):
+        judge = AgentJudge()
+        with patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("no provider")):
+            v = judge.score("s1", SUCCESS_TRACE)
+        assert v.method == "heuristic"
+        assert v.overall_score > 0.7
+
+    def test_use_llm_false_skips_llm(self):
+        judge = AgentJudge()
+        with patch("agent.auxiliary_client.call_llm") as m:
+            v = judge.score("s1", SUCCESS_TRACE, use_llm=False)
+        m.assert_not_called()
+        assert v.method == "heuristic"
+
+
+class TestVerdict:
+    def test_to_dict_serializable(self):
+        v = score_trace_heuristic("session-abc", SUCCESS_TRACE)
+        d = v.to_dict()
+        import json as _json
+
+        # Must be JSON-serialisable for storage / dashboards.
+        _json.dumps(d)
+        assert d["session_id"] == "session-abc"
+        assert "trace_summary" in d
+        assert d["method"] == "heuristic"
+
+    def test_passed_threshold(self):
+        v = JudgeVerdict(
+            session_id="s",
+            overall_score=0.65,
+            dimension_scores={},
+            rationale="",
+            method="heuristic",
+            trace_summary=TraceSummary(),
+        )
+        assert not v.passed()
+        assert not v.passed(0.7)
+        assert v.passed(0.6)
+
+
+class TestFormatReport:
+    def test_contains_score_and_verdict(self):
+        v = score_trace_heuristic("abc123", SUCCESS_TRACE)
+        text = format_report_terminal(v)
+        assert "Agent-as-a-Judge" in text
+        assert "Overall" in text
+        assert ("PASS" in text or "FAIL" in text)
+        # Each dimension title shows up.
+        assert "Task completion" in text
+
+    def test_failing_verdict_shows_fail(self):
+        v = score_trace_heuristic("abc", FAILING_TRACE)
+        text = format_report_terminal(v)
+        assert "FAIL" in text


### PR DESCRIPTION
## What this is

The smallest coherent, independently-mergeable slice of #226 (Built-in Agent-as-a-Judge evaluation harness): a **standalone judge module** (`agent/agent_judge.py`) that scores an agent execution trace against a structured rubric. No pipeline wiring — that is deferred.

It is modelled on the existing `agent/entropy_eval` sibling (a recently-added post-hoc behavioural-metrics module): plain dataclasses, runs against a session message list with no runtime coupling to the agent loop, and ships a `to_dict()` / `format_report_terminal()` pair. The LLM path reuses the existing shared `agent.auxiliary_client.call_llm` router (same one session-titling and context-compression use) — no new provider plumbing.

## Implemented

- **Rubric model** (`Rubric`, `RubricDimension`) — frozen dataclasses, weighted dimensions, validated (unique keys, non-empty). `DEFAULT_RUBRIC` covers task completion / tool use & verification / reasoning / efficiency, aligned with #226's human-judgment criteria.
- **Deterministic trace summary** (`summarize_trace` -> `TraceSummary`) — extracts objective signals (tool calls/results/failures, repetition spirals, refusals, final-answer presence) from the same OpenAI-style message shape `entropy_eval` consumes.
- **Two scoring paths, one rubric:**
  - `score_trace_heuristic` — no LLM, no cost. Defensible baseline from structural signals. Always available; the automatic fallback.
  - `score_trace_llm` — schema-constrained `call_llm(task="agent_judge", temperature=0)` returning **strict JSON** `{"scores": {...}, "rationale": ...}`. Every number is clamped to `[0,1]`; the judge computes the weighted overall **itself** and never trusts a model-asserted score. A missing rubric dimension rejects the whole response (falls back to heuristic) rather than emitting a partial verdict.
- **Robust parsing** — JSON pulled from possibly-prose-wrapped model text via stdlib `JSONDecoder.raw_decode` (C-parser owns string-escape + brace balancing; prose braces and `{}` inside string literals can't corrupt the boundary).
- **Bounded LLM payload** — transcript excerpt capped at 40 msgs / 6000 chars (head+tail kept). Heuristic counts are computed on the **full** trace, not the excerpt (invariant documented in code).
- **Public API** — `AgentJudge.score(session_id, messages, task=...)` returns a JSON-serialisable `JudgeVerdict` (overall score, per-dimension scores, rationale, method, trace summary, model). Prefers the LLM, falls back to the heuristic when no provider is configured or output fails validation.

## Deferred (not in this increment)

- Post-execution hook that submits selected traces to the judge (#226 step 3).
- Regression dashboard that flags score drops between releases (#226 step 4).
- Persistent memory of prior verdicts (#226 step 2).
- The 50-trace human-alignment calibration (success criterion 1) — needs the module landed first to run against real traces.

## How verified

- `uv run --extra dev python -m pytest tests/agent/test_agent_judge.py -q` -> **51 passed** (rubric validation, trace summarisation, heuristic scoring high/low, JSON extraction edge cases incl. prose-wrapped and example-then-real, strict schema reject/clamp, LLM path mocked success + every failure mode, engine LLM->heuristic fallback, verdict serialisation, formatting).
- `uv run --extra dev ruff check agent/agent_judge.py tests/agent/test_agent_judge.py` -> clean.
- `uv run --extra dev ty check agent/agent_judge.py` -> clean.
- Sibling suites (`test_entropy_eval`, `test_title_generator`) still green — no regression.
- Design reviewed by an independent non-Claude advisor (Gemini via consilium); its strongest catch (hand-rolled JSON scanner) was adopted (`raw_decode`), and the truncation/heuristic ordering invariant it flagged was confirmed correct and documented.

This is a **first increment**, not a full close of #226.