### PR TITLE
Orchestrator-workers evaluator-optimizer gate (first increment of #230)

### DIFF
--- a/scripts/evolution_evaluator.py
+++ b/scripts/evolution_evaluator.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Evaluator-optimizer gate for the orchestrator-workers research loop (#230).
+
+The orchestrator-workers + evaluator-optimizer workflow (Anthropic, "Building
+Effective Agents") is: an orchestrator fans a research sub-task out to N worker
+passes, each worker returns a candidate result, an EVALUATOR scores each
+candidate against a small correctness rubric, and an OPTIMIZER decides whether
+to ACCEPT the best one or run another refinement pass — bounded so the loop
+always terminates (issue #230 success criterion: "the loop terminates within a
+bounded number of evaluator passes").
+
+The hard, repeatable part of that loop is NOT the LLM reasoning — it's the
+DECISION LOGIC that keeps it honest and bounded. A model asked to grade its own
+work converges to a false 10/10 and never stops (the same failure that motivated
+the `evolution_skill_lint` gate). So this module makes the scoring + termination
+DETERMINISTIC:
+
+  * a fixed rubric of weighted criteria (each 0..1),
+  * a single fused score per candidate (weighted mean of present criteria),
+  * pick-the-best across candidates,
+  * a verdict — ACCEPT (>= threshold), OPTIMIZE (below threshold, budget left),
+    or STOP_BUDGET (below threshold, no passes left) — that an orchestrator
+    follows verbatim instead of re-deciding with the model.
+
+The LLM still does the open-ended work (decompose, run workers, write the
+refinement). This module is the small deterministic referee that the skill
+calls between passes. Pure functions + a thin CLI mirror the other
+``scripts/evolution_*.py`` helpers so it is import-safe and unit-testable, and
+the CLI gives the skill's terminal toolset a real call site (no dead code).
+
+CLI (the skill calls this from its terminal tool with the candidates JSON on
+stdin or a path):
+
+    evolution_evaluator.py --threshold 0.75 --max-passes 3 candidates.json
+    cat candidates.json | evolution_evaluator.py --threshold 0.75 --pass 1
+
+It prints one JSON object: ``{"verdict", "best_index", "best_score", ...}`` and
+exits 0 on ACCEPT, 10 on OPTIMIZE (run another pass), 11 on STOP_BUDGET, 2 on
+bad input. The distinct exit codes let a shell loop branch without parsing JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Default rubric for a research sub-task. Weights are relative (renormalized over
+# whichever criteria a candidate actually scores), so an orchestrator can ship a
+# partial rubric without skewing the scale. Kept deliberately small and generic —
+# the skill MAY override per task, but these are sensible research defaults.
+DEFAULT_RUBRIC: Dict[str, float] = {
+    "relevance": 1.0,      # answers the actual sub-task, not an adjacent one
+    "evidence": 1.0,       # claims are backed by cited sources, not asserted
+    "specificity": 0.8,    # concrete + actionable vs. vague generality
+    "correctness": 1.2,    # no detectable factual / logical errors
+}
+
+# Verdicts. ACCEPT = good enough, stop. OPTIMIZE = below bar but budget remains,
+# run another refinement pass. STOP_BUDGET = below bar and out of passes; the
+# orchestrator returns the best-so-far and flags it as unconverged.
+ACCEPT = "ACCEPT"
+OPTIMIZE = "OPTIMIZE"
+STOP_BUDGET = "STOP_BUDGET"
+
+# Exit codes for the shell-loop fast-path (distinct so a caller can branch on
+# $? without parsing the JSON payload).
+EXIT_ACCEPT = 0
+EXIT_OPTIMIZE = 10
+EXIT_STOP_BUDGET = 11
+EXIT_BAD_INPUT = 2
+
+
+def _clamp01(x: Any) -> float:
+    """Coerce a score to a float in [0, 1]; non-numeric -> 0.0."""
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return 0.0
+    if v < 0.0:
+        return 0.0
+    if v > 1.0:
+        return 1.0
+    return v
+
+
+def score_candidate(scores: Dict[str, Any], rubric: Dict[str, float]) -> float:
+    """Fuse a candidate's per-criterion scores into one [0, 1] number.
+
+    Weighted mean over the rubric criteria the candidate actually scored. A
+    missing criterion is OMITTED (not counted as 0) so a partial rubric does not
+    artificially deflate the score — the weights renormalize over what's present.
+    If the candidate scores NOTHING in the rubric, the result is 0.0 (it cannot
+    be judged, so it cannot pass).
+    """
+    num = 0.0
+    den = 0.0
+    for crit, weight in rubric.items():
+        if crit in scores:
+            w = max(0.0, float(weight))
+            num += w * _clamp01(scores[crit])
+            den += w
+    if den == 0.0:
+        return 0.0
+    return num / den
+
+
+def evaluate_candidates(
+    candidates: List[Dict[str, Any]],
+    rubric: Optional[Dict[str, float]] = None,
+) -> List[Tuple[int, float]]:
+    """Score every candidate, returning ``(original_index, fused_score)`` pairs
+    sorted best-first. Ties keep the earlier (lower-index) candidate first, so
+    selection is stable and an earlier worker pass is preferred on a tie."""
+    rubric = rubric or DEFAULT_RUBRIC
+    scored: List[Tuple[int, float]] = []
+    for i, cand in enumerate(candidates):
+        cand_scores = cand.get("scores", {}) if isinstance(cand, dict) else {}
+        if not isinstance(cand_scores, dict):
+            cand_scores = {}
+        scored.append((i, score_candidate(cand_scores, rubric)))
+    # Sort by score desc, then original index asc (stable tie-break to earlier).
+    scored.sort(key=lambda pair: (-pair[1], pair[0]))
+    return scored
+
+
+def decide(
+    candidates: List[Dict[str, Any]],
+    *,
+    threshold: float = 0.75,
+    current_pass: int = 1,
+    max_passes: int = 3,
+    rubric: Optional[Dict[str, float]] = None,
+) -> Dict[str, Any]:
+    """Run one evaluator-optimizer decision over the current pass's candidates.
+
+    Returns a verdict record an orchestrator follows verbatim:
+
+        {
+          "verdict": ACCEPT | OPTIMIZE | STOP_BUDGET,
+          "best_index": int | None,   # index into the input candidates list
+          "best_score": float,        # fused rubric score of the best candidate
+          "threshold": float,
+          "pass": int,                # the pass this decision was made on
+          "max_passes": int,
+          "passes_remaining": int,    # how many optimize passes are still allowed
+          "ranking": [[index, score], ...],  # all candidates, best-first
+          "reason": str,              # human-readable one-liner
+        }
+
+    Termination is GUARANTEED: ``OPTIMIZE`` is only returned while
+    ``current_pass < max_passes``; once the budget is spent the worst case is
+    ``STOP_BUDGET`` (return best-so-far, flagged unconverged). With no candidates
+    at all the verdict is OPTIMIZE if budget remains (let the orchestrator try
+    again) else STOP_BUDGET — never a crash.
+    """
+    threshold = _clamp01(threshold)
+    max_passes = max(1, int(max_passes))
+    current_pass = max(1, int(current_pass))
+    passes_remaining = max(0, max_passes - current_pass)
+    has_budget = current_pass < max_passes
+
+    ranking = evaluate_candidates(candidates, rubric)
+
+    if not ranking:
+        verdict = OPTIMIZE if has_budget else STOP_BUDGET
+        reason = (
+            "no candidates this pass; budget remains, run another"
+            if has_budget
+            else "no candidates and no passes left"
+        )
+        return {
+            "verdict": verdict,
+            "best_index": None,
+            "best_score": 0.0,
+            "threshold": threshold,
+            "pass": current_pass,
+            "max_passes": max_passes,
+            "passes_remaining": passes_remaining,
+            "ranking": [],
+            "reason": reason,
+        }
+
+    best_index, best_score = ranking[0]
+
+    if best_score >= threshold:
+        verdict = ACCEPT
+        reason = f"best score {best_score:.3f} >= threshold {threshold:.3f}"
+    elif has_budget:
+        verdict = OPTIMIZE
+        reason = (
+            f"best score {best_score:.3f} < threshold {threshold:.3f}; "
+            f"{passes_remaining} pass(es) left — refine and re-evaluate"
+        )
+    else:
+        verdict = STOP_BUDGET
+        reason = (
+            f"best score {best_score:.3f} < threshold {threshold:.3f} and "
+            f"pass {current_pass}/{max_passes} exhausted — return best-so-far, unconverged"
+        )
+
+    return {
+        "verdict": verdict,
+        "best_index": best_index,
+        "best_score": round(best_score, 6),
+        "threshold": threshold,
+        "pass": current_pass,
+        "max_passes": max_passes,
+        "passes_remaining": passes_remaining,
+        "ranking": [[i, round(s, 6)] for i, s in ranking],
+        "reason": reason,
+    }
+
+
+def _exit_code(verdict: str) -> int:
+    return {
+        ACCEPT: EXIT_ACCEPT,
+        OPTIMIZE: EXIT_OPTIMIZE,
+        STOP_BUDGET: EXIT_STOP_BUDGET,
+    }.get(verdict, EXIT_BAD_INPUT)
+
+
+def _parse_args(argv: List[str]) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Tiny hand-rolled arg parse (matches the other evolution_* CLIs' style).
+
+    Returns (opts, error). ``opts`` carries threshold/current_pass/max_passes and
+    an optional ``path`` (positional; absent -> read stdin)."""
+    opts: Dict[str, Any] = {
+        "threshold": 0.75,
+        "current_pass": 1,
+        "max_passes": 3,
+        "path": None,
+    }
+    i = 0
+    rest = argv[1:]
+    while i < len(rest):
+        arg = rest[i]
+        if arg in ("--threshold", "--pass", "--max-passes"):
+            if i + 1 >= len(rest):
+                return opts, f"{arg} needs a value"
+            val = rest[i + 1]
+            try:
+                if arg == "--threshold":
+                    opts["threshold"] = float(val)
+                elif arg == "--pass":
+                    opts["current_pass"] = int(val)
+                else:
+                    opts["max_passes"] = int(val)
+            except ValueError:
+                return opts, f"{arg} value must be a number, got {val!r}"
+            i += 2
+            continue
+        if arg.startswith("-"):
+            return opts, f"unknown flag: {arg}"
+        opts["path"] = arg
+        i += 1
+    return opts, None
+
+
+def _load_candidates(opts: Dict[str, Any]) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Read the candidates payload from the positional path or stdin.
+
+    Accepts either a bare JSON list of candidate objects, or an object with a
+    ``"candidates"`` key (so a richer orchestrator payload also works)."""
+    path = opts.get("path")
+    try:
+        raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    except OSError as exc:
+        return None, f"cannot read input: {exc}"
+    try:
+        data = json.loads(raw)
+    except ValueError as exc:
+        return None, f"input is not valid JSON: {exc}"
+    if isinstance(data, dict) and "candidates" in data:
+        data = data["candidates"]
+    if not isinstance(data, list):
+        return None, "expected a JSON list of candidates (or {\"candidates\": [...]})"
+    return [c if isinstance(c, dict) else {} for c in data], None
+
+
+def main(argv: List[str]) -> int:
+    opts, err = _parse_args(argv)
+    if err:
+        print(f"[evolution-evaluator] {err}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+    candidates, load_err = _load_candidates(opts)
+    if load_err:
+        print(f"[evolution-evaluator] {load_err}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+    result = decide(
+        candidates,
+        threshold=opts["threshold"],
+        current_pass=opts["current_pass"],
+        max_passes=opts["max_passes"],
+    )
+    print(json.dumps(result, sort_keys=True))
+    return _exit_code(result["verdict"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -219,6 +219,46 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
       alerts) but proceed.
     - healthy / missing → proceed normally.
 
+## Orchestrator-workers evaluator-optimizer gate (research synthesis) — #230
+
+When a single issue is open-ended enough that one reasoning pass under-serves it
+(a `[FEATURE]`/`[IMPROVEMENT]` that asks you to *synthesize a recommendation* or
+*compare options*, not a one-line fix), run it as an **orchestrator-workers +
+evaluator-optimizer** loop instead of a single shot:
+
+1. **Orchestrate** — fan the sub-task out into N independent worker passes
+   (`delegate_task`, the `delegation` toolset is enabled here). Each worker
+   returns one candidate result.
+2. **Evaluate (deterministic)** — score each candidate against a small rubric
+   (`relevance`, `evidence`, `specificity`, `correctness`, each 0..1), then let a
+   deterministic gate pick the best and decide whether to accept or refine. Do
+   NOT grade your own work with the model and declare victory — that converges to
+   a false 10/10 and never stops. Use the gate:
+
+```bash
+# candidates.json = [{"scores": {"relevance": 0.8, "evidence": 0.7,
+#                                "specificity": 0.6, "correctness": 0.9}}, ...]
+# (one object per worker pass; "scores" are YOUR rubric grades of that candidate)
+python scripts/evolution_evaluator.py --threshold 0.75 --pass 1 --max-passes 3 candidates.json
+```
+   It prints one JSON verdict and sets a distinct exit code so a shell loop can
+   branch without parsing JSON:
+   - `ACCEPT` (exit 0) — best candidate clears the bar; use `best_index`, stop.
+   - `OPTIMIZE` (exit 10) — below the bar but passes remain; have the optimizer
+     refine the best candidate (feed it the gaps), bump `--pass`, re-run workers,
+     re-evaluate.
+   - `STOP_BUDGET` (exit 11) — below the bar and the pass budget is spent; take
+     the best-so-far and flag it unconverged. **The loop ALWAYS terminates** —
+     `OPTIMIZE` is only ever returned while `--pass` < `--max-passes`.
+3. **Optimize** — on `OPTIMIZE`, the refinement is the model's job (rewrite the
+   best candidate addressing its weakest rubric criteria); the gate only decides
+   *whether* to keep looping and *which* candidate is current best.
+
+This is a self-contained first increment of #230: the deterministic referee
+(`scripts/evolution_evaluator.py`) that keeps the loop honest and bounded. Deep
+pipeline wiring — automatic worker fan-out for every issue, persisting per-pass
+candidates to the kanban board — is deferred.
+
 ## Status labels — accept/reject visible in the issue list
 
 The evolution pipeline tags every issue with ONE canonical status label so the

--- a/tests/scripts/test_evolution_evaluator.py
+++ b/tests/scripts/test_evolution_evaluator.py
@@ -1,0 +1,205 @@
+"""Tests for scripts/evolution_evaluator.py — deterministic evaluator-optimizer
+gate for the orchestrator-workers research loop (#230)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_evaluator import (  # noqa: E402
+    ACCEPT,
+    DEFAULT_RUBRIC,
+    EXIT_ACCEPT,
+    EXIT_BAD_INPUT,
+    EXIT_OPTIMIZE,
+    EXIT_STOP_BUDGET,
+    OPTIMIZE,
+    STOP_BUDGET,
+    decide,
+    evaluate_candidates,
+    main,
+    score_candidate,
+)
+
+
+class TestScoreCandidate:
+    def test_weighted_mean_over_full_rubric(self):
+        # All criteria present, all 1.0 -> 1.0 regardless of weights.
+        s = score_candidate(
+            {"relevance": 1, "evidence": 1, "specificity": 1, "correctness": 1},
+            DEFAULT_RUBRIC,
+        )
+        assert s == 1.0
+
+    def test_partial_rubric_renormalizes(self):
+        # Only "relevance" scored -> result is just that criterion's value,
+        # NOT deflated by the missing ones (renormalized over present weights).
+        assert score_candidate({"relevance": 0.5}, DEFAULT_RUBRIC) == 0.5
+
+    def test_weights_actually_weight(self):
+        # correctness weight (1.2) dominates relevance (1.0): a high-correctness
+        # / low-relevance candidate scores above the plain average.
+        s = score_candidate({"relevance": 0.0, "correctness": 1.0}, DEFAULT_RUBRIC)
+        assert abs(s - (1.2 * 1.0) / (1.0 + 1.2)) < 1e-9
+
+    def test_out_of_range_and_nonnumeric_clamped(self):
+        assert score_candidate({"relevance": 5}, {"relevance": 1.0}) == 1.0
+        assert score_candidate({"relevance": -3}, {"relevance": 1.0}) == 0.0
+        assert score_candidate({"relevance": "nope"}, {"relevance": 1.0}) == 0.0
+
+    def test_no_rubric_overlap_is_zero(self):
+        # Candidate scores criteria not in the rubric -> cannot be judged -> 0.
+        assert score_candidate({"unknown_metric": 1.0}, DEFAULT_RUBRIC) == 0.0
+
+
+class TestEvaluateCandidates:
+    def test_sorted_best_first(self):
+        cands = [
+            {"scores": {"relevance": 0.2}},
+            {"scores": {"relevance": 0.9}},
+            {"scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert [i for i, _ in ranking] == [1, 2, 0]
+
+    def test_tie_prefers_earlier_index(self):
+        cands = [
+            {"scores": {"relevance": 0.5}},
+            {"scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 0  # earlier worker pass wins a tie
+
+    def test_malformed_candidate_scores_to_zero(self):
+        cands = [{"scores": "not-a-dict"}, {"no_scores_key": True}, "totally-bad"]
+        ranking = evaluate_candidates(cands)  # must not crash
+        assert all(score == 0.0 for _, score in ranking)
+
+
+class TestDecideVerdicts:
+    def _cand(self, val):
+        return {"scores": {"relevance": val, "evidence": val, "specificity": val, "correctness": val}}
+
+    def test_accept_when_best_meets_threshold(self):
+        r = decide([self._cand(0.6), self._cand(0.8)], threshold=0.75, current_pass=1, max_passes=3)
+        assert r["verdict"] == ACCEPT
+        assert r["best_index"] == 1
+        assert r["best_score"] == 0.8
+
+    def test_optimize_when_below_and_budget_remains(self):
+        r = decide([self._cand(0.5)], threshold=0.75, current_pass=1, max_passes=3)
+        assert r["verdict"] == OPTIMIZE
+        assert r["passes_remaining"] == 2
+        assert r["best_index"] == 0
+
+    def test_stop_budget_when_below_and_exhausted(self):
+        # Last allowed pass, still below bar -> terminate with best-so-far.
+        r = decide([self._cand(0.5)], threshold=0.75, current_pass=3, max_passes=3)
+        assert r["verdict"] == STOP_BUDGET
+        assert r["passes_remaining"] == 0
+        assert r["best_index"] == 0  # best-so-far still surfaced
+
+    def test_loop_is_bounded_and_terminates(self):
+        # Success criterion #3: the loop terminates within a bounded number of
+        # passes. Even with candidates that NEVER meet the bar, walking the pass
+        # counter up to max_passes must end in a terminal (non-OPTIMIZE) verdict.
+        max_passes = 4
+        verdicts = [
+            decide([self._cand(0.1)], threshold=0.9, current_pass=p, max_passes=max_passes)["verdict"]
+            for p in range(1, max_passes + 1)
+        ]
+        assert verdicts[:-1] == [OPTIMIZE] * (max_passes - 1)
+        assert verdicts[-1] == STOP_BUDGET  # guaranteed terminal at the budget
+
+    def test_no_candidates_with_budget_optimizes(self):
+        r = decide([], threshold=0.75, current_pass=1, max_passes=2)
+        assert r["verdict"] == OPTIMIZE
+        assert r["best_index"] is None and r["best_score"] == 0.0
+
+    def test_no_candidates_no_budget_stops(self):
+        r = decide([], threshold=0.75, current_pass=2, max_passes=2)
+        assert r["verdict"] == STOP_BUDGET
+        assert r["best_index"] is None
+
+    def test_max_passes_one_never_optimizes(self):
+        # A single-shot budget (max_passes=1) can only ACCEPT or STOP_BUDGET.
+        below = decide([self._cand(0.1)], threshold=0.75, current_pass=1, max_passes=1)
+        assert below["verdict"] == STOP_BUDGET
+        above = decide([self._cand(0.9)], threshold=0.75, current_pass=1, max_passes=1)
+        assert above["verdict"] == ACCEPT
+
+    def test_degenerate_pass_and_budget_coerced(self):
+        # pass 0 / max_passes 0 must be coerced to >=1, not crash or loop forever.
+        r = decide([self._cand(0.1)], threshold=0.75, current_pass=0, max_passes=0)
+        assert r["pass"] == 1 and r["max_passes"] == 1
+        assert r["verdict"] == STOP_BUDGET
+
+    def test_ranking_present_in_record(self):
+        r = decide([self._cand(0.2), self._cand(0.9)], threshold=0.75)
+        assert r["ranking"][0][0] == 1  # best candidate index first
+
+
+class TestCli:
+    def _run(self, argv, monkeypatch, capsys, stdin_text=None):
+        if stdin_text is not None:
+            import io
+
+            monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+        rc = main(argv)
+        out = capsys.readouterr()
+        return rc, out
+
+    def test_accept_exit_code_and_json(self, tmp_path, capsys):
+        p = tmp_path / "cands.json"
+        p.write_text(json.dumps([{"scores": {"relevance": 0.9, "evidence": 0.9,
+                                              "specificity": 0.9, "correctness": 0.9}}]),
+                     encoding="utf-8")
+        rc = main(["evolution_evaluator.py", "--threshold", "0.75", str(p)])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == EXIT_ACCEPT
+        assert payload["verdict"] == ACCEPT
+
+    def test_optimize_exit_code(self, tmp_path):
+        p = tmp_path / "cands.json"
+        p.write_text(json.dumps([{"scores": {"relevance": 0.4}}]), encoding="utf-8")
+        rc = main(["evolution_evaluator.py", "--threshold", "0.75",
+                   "--pass", "1", "--max-passes", "3", str(p)])
+        assert rc == EXIT_OPTIMIZE
+
+    def test_stop_budget_exit_code(self, tmp_path):
+        p = tmp_path / "cands.json"
+        p.write_text(json.dumps([{"scores": {"relevance": 0.4}}]), encoding="utf-8")
+        rc = main(["evolution_evaluator.py", "--threshold", "0.75",
+                   "--pass", "3", "--max-passes", "3", str(p)])
+        assert rc == EXIT_STOP_BUDGET
+
+    def test_stdin_and_candidates_wrapper(self, monkeypatch, capsys):
+        rc, out = self._run(
+            ["evolution_evaluator.py", "--threshold", "0.5"],
+            monkeypatch, capsys,
+            stdin_text=json.dumps({"candidates": [{"scores": {"relevance": 0.9}}]}),
+        )
+        assert rc == EXIT_ACCEPT
+        assert json.loads(out.out)["verdict"] == ACCEPT
+
+    def test_bad_json_exit_2(self, tmp_path, capsys):
+        p = tmp_path / "bad.json"
+        p.write_text("{ not json", encoding="utf-8")
+        rc = main(["evolution_evaluator.py", str(p)])
+        assert rc == EXIT_BAD_INPUT
+        assert "not valid JSON" in capsys.readouterr().err
+
+    def test_non_list_payload_exit_2(self, tmp_path, capsys):
+        p = tmp_path / "obj.json"
+        p.write_text(json.dumps({"unexpected": "shape"}), encoding="utf-8")
+        rc = main(["evolution_evaluator.py", str(p)])
+        assert rc == EXIT_BAD_INPUT
+
+    def test_unknown_flag_exit_2(self, capsys):
+        rc = main(["evolution_evaluator.py", "--bogus", "1"])
+        assert rc == EXIT_BAD_INPUT
+
+    def test_bad_numeric_flag_exit_2(self, capsys):
+        rc = main(["evolution_evaluator.py", "--threshold", "high"])
+        assert rc == EXIT_BAD_INPUT


### PR DESCRIPTION
First increment of #230 (Orchestrator-workers evaluator-optimizer loop for research tasks). The issue is a large `roadmap` epic; this PR ships the smallest self-contained, independently-mergeable slice — the **deterministic evaluator-optimizer gate** that keeps such a loop honest and bounded — and defers the deep pipeline wiring.

## Implemented

- **`scripts/evolution_evaluator.py`** — pure functions + a thin CLI mirroring the sibling `scripts/evolution_*.py` helpers:
  - scores N worker candidates against a small weighted rubric (`relevance`, `evidence`, `specificity`, `correctness`), **renormalizing over the criteria a candidate actually scored** so a partial rubric doesn't deflate the score (zero rubric-overlap → 0.0, can't pass unjudged);
  - picks the best candidate, with a **stable tie-break to the earlier worker pass**;
  - emits a verdict `ACCEPT` / `OPTIMIZE` / `STOP_BUDGET` with **guaranteed termination** — `OPTIMIZE` is only ever returned while `pass < max_passes`, so the loop always ends (directly satisfies #230's success criterion "the loop terminates within a bounded number of evaluator passes");
  - CLI uses **distinct exit codes** (`0` accept / `10` optimize / `11` stop-budget / `2` bad input) so a shell loop can branch without parsing JSON; reads candidates from a path or stdin, accepts a bare list or `{"candidates": [...]}`.
- **Real call site (no dead code)** — `skills/evolution/evolution-analysis/SKILL.md` gains an "Orchestrator-workers evaluator-optimizer gate" section wiring the gate into open-ended research-synthesis triage. The analysis stage has `web/file/terminal(+delegation)`, so it can actually run the script. The existing **`evolution_skill_lint` CI gate** (`tests/scripts/test_evolution_skill_integrity.py`) mechanically verifies this wiring — it fails the build if a SKILL cites a script that doesn't exist or whose owning cron stage lacks `terminal`.

Why deterministic: the rationale matches the existing `evolution_skill_lint` precedent — an LLM grading its own work converges to a false 10/10 and never stops. The model still does the open-ended work (decompose, run workers, refine the best candidate); this module is the small deterministic referee that decides *whether* to keep looping and *which* candidate is current best.

## Deferred (still part of the #230 epic)

- Automatic worker fan-out for every issue (full orchestrator decomposition).
- Persisting per-pass candidates to the kanban board / audit trail.
- A code-review variant of the loop.

## Verification

- `uv run --extra dev python -m pytest tests/scripts/test_evolution_evaluator.py tests/scripts/test_evolution_skill_integrity.py -q` → **36 passed** (25 new gate tests + 11 skill-integrity, incl. the new call site).
- `uv run --extra dev ruff check scripts/evolution_evaluator.py tests/scripts/test_evolution_evaluator.py skills/evolution/evolution-analysis/SKILL.md` → **All checks passed**.
- `python scripts/evolution_skill_lint.py` → **OK — no dead skill→script wiring**.

This is a **first increment**, not a full close of #230.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>