### PR TITLE
A2A peer-agent bridge: wire models + outbound client (first increment of #227)

### DIFF
--- a/a2a_bridge/__init__.py
+++ b/a2a_bridge/__init__.py
@@ -1,0 +1,54 @@
+"""A2A (Agent2Agent) peer-agent protocol bridge for hermes-agent.
+
+First increment of issue #227. Provides A2A-compatible data models and a thin
+outbound JSON-RPC client so Hermes can describe itself as an A2A peer and
+delegate a task to another A2A agent.
+
+This is deliberately scoped to the *outbound* (client) side and the shared
+wire model. The inbound server adapter and live tool-dispatcher wiring are
+follow-up increments. Nothing here runs at import time or touches the MCP
+tool-call path, so there is no latency impact on existing flows.
+
+The bridge is gated behind the ``HERMES_A2A_BRIDGE`` feature flag
+(see :func:`a2a_bridge.is_enabled`); callers must check it before using the
+client.
+"""
+
+from __future__ import annotations
+
+from a2a_bridge.models import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    Artifact,
+    Message,
+    MessagePart,
+    Task,
+    TaskStatus,
+    build_hermes_agent_card,
+)
+
+__all__ = [
+    "AgentCapabilities",
+    "AgentCard",
+    "AgentSkill",
+    "Artifact",
+    "Message",
+    "MessagePart",
+    "Task",
+    "TaskStatus",
+    "build_hermes_agent_card",
+    "is_enabled",
+]
+
+
+def is_enabled() -> bool:
+    """Return True when the A2A peer bridge is explicitly enabled.
+
+    Off by default. Reading an environment variable keeps this dependency-free
+    and import-cheap; the live tool dispatcher must consult this before routing
+    any work over A2A so the feature stays inert until an operator opts in.
+    """
+    from utils import env_var_enabled
+
+    return env_var_enabled("HERMES_A2A_BRIDGE")

--- a/a2a_bridge/client.py
+++ b/a2a_bridge/client.py
@@ -1,0 +1,196 @@
+"""Outbound A2A client — delegate a task to a peer A2A agent.
+
+This is the client half of issue #227's plan step 3: serialize a request into
+the canonical A2A ``message/send`` JSON-RPC 2.0 envelope, POST it to a peer's
+endpoint, and parse the ``result`` (a :class:`~a2a_bridge.models.Task` or a
+bare :class:`~a2a_bridge.models.Message`) into typed objects the delegating
+agent can act on.
+
+Design notes:
+
+* Transport is injectable (``transport=`` callable). The default uses
+  ``httpx`` (already a core dependency). Tests pass a fake transport so the
+  whole request/response round-trip is exercised offline, with no network and
+  no running peer.
+* No import-time side effects and nothing wired into the live tool dispatcher,
+  so importing this module cannot affect MCP tool-call latency. Callers must
+  gate use behind :func:`a2a_bridge.is_enabled`.
+* Errors map to a single :class:`A2AClientError` so callers don't have to know
+  about httpx or JSON-RPC error codes.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Callable, Optional
+
+from a2a_bridge.models import (
+    AgentCard,
+    Message,
+    ROLE_USER,
+    Task,
+)
+
+# A transport takes (url, json_body, headers, timeout) and returns the decoded
+# JSON-RPC response dict. Kept as a plain callable so tests can inject a fake.
+Transport = Callable[[str, dict[str, Any], dict[str, str], float], dict[str, Any]]
+
+DEFAULT_TIMEOUT = 60.0
+# Canonical A2A JSON-RPC method for sending a message (spec >= 0.2).
+METHOD_MESSAGE_SEND = "message/send"
+# Well-known path for agent discovery (spec >= 0.3).
+AGENT_CARD_PATH = "/.well-known/agent-card.json"
+
+
+class A2AClientError(RuntimeError):
+    """Raised when an A2A request fails (transport, protocol, or peer error)."""
+
+
+def _default_transport(
+    url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
+) -> dict[str, Any]:
+    """httpx-backed POST that returns the decoded JSON body.
+
+    httpx is imported lazily so this module stays importable in minimal
+    environments and import time never pays for the HTTP stack.
+    """
+    import httpx
+
+    try:
+        resp = httpx.post(url, json=body, headers=headers, timeout=timeout)
+    except httpx.HTTPError as exc:
+        raise A2AClientError(f"A2A transport error contacting {url}: {exc}") from exc
+    if resp.status_code >= 400:
+        raise A2AClientError(
+            f"A2A peer {url} returned HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise A2AClientError(f"A2A peer {url} returned non-JSON response: {exc}") from exc
+
+
+def _default_card_fetch(url: str, headers: dict[str, str], timeout: float) -> dict[str, Any]:
+    import httpx
+
+    try:
+        resp = httpx.get(url, headers=headers, timeout=timeout, follow_redirects=True)
+    except httpx.HTTPError as exc:
+        raise A2AClientError(f"A2A card fetch error for {url}: {exc}") from exc
+    if resp.status_code >= 400:
+        raise A2AClientError(
+            f"A2A card endpoint {url} returned HTTP {resp.status_code}"
+        )
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise A2AClientError(f"A2A card endpoint {url} returned non-JSON: {exc}") from exc
+
+
+class A2AClient:
+    """A thin synchronous client for delegating tasks to one A2A peer."""
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        headers: Optional[dict[str, str]] = None,
+        transport: Optional[Transport] = None,
+        card_fetch: Optional[Callable[[str, dict[str, str], float], dict[str, Any]]] = None,
+    ) -> None:
+        if not endpoint_url or not str(endpoint_url).strip():
+            raise ValueError("endpoint_url is required")
+        self.endpoint_url = str(endpoint_url).strip()
+        self.timeout = float(timeout)
+        self.headers = {"content-type": "application/json", **(headers or {})}
+        self._transport = transport or _default_transport
+        self._card_fetch = card_fetch or _default_card_fetch
+
+    # -- discovery ---------------------------------------------------------
+
+    def fetch_agent_card(self, *, card_url: Optional[str] = None) -> AgentCard:
+        """Fetch and parse the peer's AgentCard.
+
+        Defaults to the well-known discovery path relative to the endpoint's
+        origin. A peer that serves its card elsewhere can be reached by passing
+        ``card_url`` explicitly.
+        """
+        target = card_url or _well_known_card_url(self.endpoint_url)
+        raw = self._card_fetch(target, self.headers, self.timeout)
+        if not isinstance(raw, dict):
+            raise A2AClientError(f"A2A card at {target} was not a JSON object")
+        return AgentCard.from_dict(raw)
+
+    # -- task delegation ---------------------------------------------------
+
+    def send_message(self, message: Message, *, request_id: Optional[Any] = None) -> Task | Message:
+        """Send a Message and return the peer's result.
+
+        Returns a :class:`Task` when the peer tracks the work as a task (the
+        common delegation case), or a bare :class:`Message` when the peer
+        answers inline. Raises :class:`A2AClientError` on any transport or
+        JSON-RPC error.
+        """
+        rpc_id = request_id if request_id is not None else uuid.uuid4().hex
+        body = {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "method": METHOD_MESSAGE_SEND,
+            "params": {"message": message.to_dict()},
+        }
+        response = self._transport(self.endpoint_url, body, self.headers, self.timeout)
+        return self._parse_rpc_result(response)
+
+    def delegate_text(
+        self, text: str, *, context_id: Optional[str] = None, request_id: Optional[Any] = None
+    ) -> Task | Message:
+        """Convenience: delegate a plain-text task and get the result back."""
+        message = Message.from_text(text, role=ROLE_USER, message_id=uuid.uuid4().hex)
+        if context_id is not None:
+            message.context_id = context_id
+        return self.send_message(message, request_id=request_id)
+
+    # -- internals ---------------------------------------------------------
+
+    @staticmethod
+    def _parse_rpc_result(response: dict[str, Any]) -> Task | Message:
+        if not isinstance(response, dict):
+            raise A2AClientError("A2A response was not a JSON-RPC object")
+
+        error = response.get("error")
+        if error is not None:
+            if isinstance(error, dict):
+                code = error.get("code")
+                msg = error.get("message")
+                raise A2AClientError(f"A2A peer returned JSON-RPC error {code}: {msg}")
+            raise A2AClientError(f"A2A peer returned JSON-RPC error: {error}")
+
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise A2AClientError("A2A response missing a result object")
+
+        # A2A nests the payload under "task"/"message"; some peers (and the
+        # spec's REST binding) return the Task/Message object directly. Handle
+        # both: explicit nesting wins, then fall back to shape detection.
+        if isinstance(result.get("task"), dict):
+            return Task.from_dict(result["task"])
+        if isinstance(result.get("message"), dict):
+            return Message.from_dict(result["message"])
+
+        kind = result.get("kind")
+        if kind == "message" or ("role" in result and "parts" in result and "status" not in result):
+            return Message.from_dict(result)
+        # Default: treat as a Task (it has id/status in the common case).
+        return Task.from_dict(result)
+
+
+def _well_known_card_url(endpoint_url: str) -> str:
+    """Derive the well-known AgentCard URL from a peer endpoint's origin."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(endpoint_url)
+    if not parts.scheme or not parts.netloc:
+        raise A2AClientError(f"Cannot derive card URL from invalid endpoint {endpoint_url!r}")
+    return urlunsplit((parts.scheme, parts.netloc, AGENT_CARD_PATH, "", ""))

--- a/a2a_bridge/models.py
+++ b/a2a_bridge/models.py
@@ -1,0 +1,461 @@
+"""A2A-compatible data models shared by the inbound/outbound bridge.
+
+The field names and JSON shapes here track the Agent2Agent (A2A) protocol
+specification (https://a2a-protocol.org/latest/specification): camelCase on the
+wire, snake_case in Python. They are deliberately a *minimal* subset — enough to
+describe an agent (``AgentCard``), send a request (``Message``), and read back a
+result (``Task``). Optional protocol features (push notifications, streaming,
+security schemes, signatures) are preserved on round-trip via the ``extra`` /
+``metadata`` escape hatches but are not modelled as typed fields in this first
+increment.
+
+A2A and IBM's ACP converge on the same primitives: an agent descriptor, a
+role/parts message, and a task with a status and artifacts. Keeping the model
+protocol-neutral (no transport assumptions) lets a later increment add an ACP
+serializer over the same objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# A2A task lifecycle states (subset). Mirrors the spec's TaskState enum values
+# in their canonical lowercase-dashed wire form.
+TASK_STATE_SUBMITTED = "submitted"
+TASK_STATE_WORKING = "working"
+TASK_STATE_INPUT_REQUIRED = "input-required"
+TASK_STATE_COMPLETED = "completed"
+TASK_STATE_FAILED = "failed"
+TASK_STATE_CANCELED = "canceled"
+
+# Message roles. A2A uses "user" for the requesting peer and "agent" for the
+# responding peer.
+ROLE_USER = "user"
+ROLE_AGENT = "agent"
+
+
+@dataclass
+class MessagePart:
+    """A single part of a message or artifact.
+
+    A2A parts are a tagged union (text / file / data). This increment models the
+    common ``text`` and ``data`` parts as typed fields and carries every other
+    part kind (e.g. ``file``) verbatim through the ``extra`` escape hatch so a
+    round-trip never drops data or crashes on an unmodeled kind.
+    """
+
+    text: Optional[str] = None
+    data: Optional[Any] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    # Any part fields this increment doesn't model (e.g. a ``file`` part's
+    # ``file`` payload, or a non-text ``kind``) are preserved here so unknown
+    # part types survive serialization losslessly.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = dict(self.extra)
+        if self.text is not None:
+            out["kind"] = "text"
+            out["text"] = self.text
+        elif self.data is not None:
+            out["kind"] = "data"
+            out["data"] = self.data
+        if self.metadata:
+            out["metadata"] = dict(self.metadata)
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "MessagePart":
+        text = raw.get("text")
+        data = raw.get("data")
+        # Drop ``kind`` from extra only for parts we re-derive it for (text /
+        # data). For any other kind (e.g. ``file``) keep ``kind`` so to_dict
+        # re-emits it verbatim — otherwise the tag would be lost on round-trip.
+        known = {"text", "data", "metadata"}
+        if text is not None or data is not None:
+            known = known | {"kind"}
+        return cls(
+            text=text,
+            data=data,
+            metadata=dict(raw.get("metadata") or {}),
+            extra={k: v for k, v in raw.items() if k not in known},
+        )
+
+
+@dataclass
+class Message:
+    """A request or response message exchanged between peers."""
+
+    role: str
+    parts: list[MessagePart] = field(default_factory=list)
+    message_id: Optional[str] = None
+    context_id: Optional[str] = None
+    task_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_text(cls, text: str, *, role: str = ROLE_USER, message_id: Optional[str] = None) -> "Message":
+        """Convenience constructor for a single-text-part message."""
+        return cls(role=role, parts=[MessagePart(text=text)], message_id=message_id)
+
+    def text(self) -> str:
+        """Concatenate all text parts (artifacts often arrive as several)."""
+        return "".join(p.text for p in self.parts if p.text is not None)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "role": self.role,
+            "parts": [p.to_dict() for p in self.parts],
+        }
+        if self.message_id is not None:
+            out["messageId"] = self.message_id
+        if self.context_id is not None:
+            out["contextId"] = self.context_id
+        if self.task_id is not None:
+            out["taskId"] = self.task_id
+        if self.metadata:
+            out["metadata"] = dict(self.metadata)
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Message":
+        return cls(
+            role=str(raw.get("role") or ROLE_AGENT),
+            parts=[MessagePart.from_dict(p) for p in (raw.get("parts") or []) if isinstance(p, dict)],
+            message_id=raw.get("messageId"),
+            context_id=raw.get("contextId"),
+            task_id=raw.get("taskId"),
+            metadata=dict(raw.get("metadata") or {}),
+        )
+
+
+@dataclass
+class TaskStatus:
+    """The status of a task: a state plus an optional timestamp and message."""
+
+    state: str
+    timestamp: Optional[str] = None
+    message: Optional[Message] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"state": self.state}
+        if self.timestamp is not None:
+            out["timestamp"] = self.timestamp
+        if self.message is not None:
+            out["message"] = self.message.to_dict()
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "TaskStatus":
+        msg_raw = raw.get("message")
+        return cls(
+            state=str(raw.get("state") or TASK_STATE_SUBMITTED),
+            timestamp=raw.get("timestamp"),
+            message=Message.from_dict(msg_raw) if isinstance(msg_raw, dict) else None,
+        )
+
+
+@dataclass
+class Artifact:
+    """A named output produced by a task."""
+
+    artifact_id: Optional[str] = None
+    name: Optional[str] = None
+    parts: list[MessagePart] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def text(self) -> str:
+        return "".join(p.text for p in self.parts if p.text is not None)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"parts": [p.to_dict() for p in self.parts]}
+        if self.artifact_id is not None:
+            out["artifactId"] = self.artifact_id
+        if self.name is not None:
+            out["name"] = self.name
+        if self.metadata:
+            out["metadata"] = dict(self.metadata)
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Artifact":
+        return cls(
+            artifact_id=raw.get("artifactId"),
+            name=raw.get("name"),
+            parts=[MessagePart.from_dict(p) for p in (raw.get("parts") or []) if isinstance(p, dict)],
+            metadata=dict(raw.get("metadata") or {}),
+        )
+
+
+@dataclass
+class Task:
+    """A unit of work tracked by an A2A agent, with status and artifacts."""
+
+    id: str
+    context_id: Optional[str] = None
+    status: TaskStatus = field(default_factory=lambda: TaskStatus(state=TASK_STATE_SUBMITTED))
+    artifacts: list[Artifact] = field(default_factory=list)
+    history: list[Message] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def state(self) -> str:
+        return self.status.state
+
+    def is_terminal(self) -> bool:
+        """True when the task has reached a state that won't change further."""
+        return self.status.state in {
+            TASK_STATE_COMPLETED,
+            TASK_STATE_FAILED,
+            TASK_STATE_CANCELED,
+        }
+
+    def result_text(self) -> str:
+        """Best-effort flattening of artifact text — the structured result a
+        delegating agent can act on. Falls back to the status message text when
+        the task carried no artifacts (e.g. an ``input-required`` turn)."""
+        artifact_text = "\n".join(a.text() for a in self.artifacts if a.text())
+        if artifact_text:
+            return artifact_text
+        if self.status.message is not None:
+            return self.status.message.text()
+        return ""
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "id": self.id,
+            "status": self.status.to_dict(),
+        }
+        if self.context_id is not None:
+            out["contextId"] = self.context_id
+        if self.artifacts:
+            out["artifacts"] = [a.to_dict() for a in self.artifacts]
+        if self.history:
+            out["history"] = [m.to_dict() for m in self.history]
+        if self.metadata:
+            out["metadata"] = dict(self.metadata)
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Task":
+        status_raw = raw.get("status")
+        return cls(
+            id=str(raw.get("id") or ""),
+            context_id=raw.get("contextId"),
+            status=(
+                TaskStatus.from_dict(status_raw)
+                if isinstance(status_raw, dict)
+                else TaskStatus(state=TASK_STATE_SUBMITTED)
+            ),
+            artifacts=[
+                Artifact.from_dict(a) for a in (raw.get("artifacts") or []) if isinstance(a, dict)
+            ],
+            history=[
+                Message.from_dict(m) for m in (raw.get("history") or []) if isinstance(m, dict)
+            ],
+            metadata=dict(raw.get("metadata") or {}),
+        )
+
+
+@dataclass
+class AgentSkill:
+    """A capability advertised by an agent in its AgentCard."""
+
+    id: str
+    name: str
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "AgentSkill":
+        return cls(
+            id=str(raw.get("id") or ""),
+            name=str(raw.get("name") or ""),
+            description=str(raw.get("description") or ""),
+            tags=[str(t) for t in (raw.get("tags") or [])],
+        )
+
+
+@dataclass
+class AgentCapabilities:
+    """Optional protocol features an agent supports.
+
+    All default to False so a freshly built Hermes card claims only what this
+    increment actually implements (synchronous request/response).
+    """
+
+    streaming: bool = False
+    push_notifications: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "streaming": self.streaming,
+            "pushNotifications": self.push_notifications,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "AgentCapabilities":
+        return cls(
+            streaming=bool(raw.get("streaming", False)),
+            push_notifications=bool(raw.get("pushNotifications", False)),
+        )
+
+
+@dataclass
+class AgentCard:
+    """A discoverable description of an agent and its skills.
+
+    The A2A discovery convention serves this JSON at
+    ``/.well-known/agent-card.json``. We model the load-bearing fields and keep
+    everything else (security schemes, provider, signatures) under ``extra`` so
+    parsing a richer peer card never loses data.
+    """
+
+    name: str
+    description: str
+    version: str
+    url: str
+    capabilities: AgentCapabilities = field(default_factory=AgentCapabilities)
+    default_input_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+    default_output_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+    skills: list[AgentSkill] = field(default_factory=list)
+    protocol_version: str = "0.3.0"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = dict(self.extra)
+        out.update(
+            {
+                "name": self.name,
+                "description": self.description,
+                "version": self.version,
+                "url": self.url,
+                "protocolVersion": self.protocol_version,
+                "capabilities": self.capabilities.to_dict(),
+                "defaultInputModes": list(self.default_input_modes),
+                "defaultOutputModes": list(self.default_output_modes),
+                "skills": [s.to_dict() for s in self.skills],
+            }
+        )
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "AgentCard":
+        known = {
+            "name",
+            "description",
+            "version",
+            "url",
+            "protocolVersion",
+            "capabilities",
+            "defaultInputModes",
+            "defaultOutputModes",
+            "skills",
+        }
+        caps_raw = raw.get("capabilities")
+        return cls(
+            name=str(raw.get("name") or ""),
+            description=str(raw.get("description") or ""),
+            version=str(raw.get("version") or ""),
+            url=str(raw.get("url") or ""),
+            protocol_version=str(raw.get("protocolVersion") or "0.3.0"),
+            capabilities=(
+                AgentCapabilities.from_dict(caps_raw)
+                if isinstance(caps_raw, dict)
+                else AgentCapabilities()
+            ),
+            default_input_modes=[str(m) for m in (raw.get("defaultInputModes") or ["text/plain"])],
+            default_output_modes=[
+                str(m) for m in (raw.get("defaultOutputModes") or ["text/plain"])
+            ],
+            skills=[AgentSkill.from_dict(s) for s in (raw.get("skills") or []) if isinstance(s, dict)],
+            extra={k: v for k, v in raw.items() if k not in known},
+        )
+
+
+def build_hermes_agent_card(url: str, *, version: Optional[str] = None) -> AgentCard:
+    """Build the AgentCard advertising this Hermes instance as an A2A peer.
+
+    ``url`` is the externally reachable A2A endpoint for this instance (the
+    caller owns deployment/routing). The version defaults to the installed
+    Hermes version. Skills are derived from Hermes's registered toolsets so the
+    card reflects what this build can actually do, rather than a hardcoded list
+    that drifts.
+    """
+    if version is None:
+        try:
+            from hermes_cli import __version__ as hermes_version
+
+            version = str(hermes_version)
+        except Exception:
+            version = "0.0.0"
+
+    skills = _derive_skills_from_toolsets()
+    return AgentCard(
+        name="Hermes Agent",
+        description=(
+            "Self-improving open-source AI agent with persistent memory, skills, "
+            "and rich tool support, exposed as an A2A peer for task delegation."
+        ),
+        version=version,
+        url=url,
+        capabilities=AgentCapabilities(streaming=False, push_notifications=False),
+        default_input_modes=["text/plain", "application/json"],
+        default_output_modes=["text/plain", "application/json"],
+        skills=skills,
+    )
+
+
+def _derive_skills_from_toolsets() -> list[AgentSkill]:
+    """Map Hermes toolsets to A2A skills.
+
+    Best-effort: if the toolset registry can't be imported (e.g. a partial
+    install), fall back to a single generic skill so the card is still valid.
+    """
+    try:
+        from toolsets import TOOLSETS
+    except Exception:
+        return [
+            AgentSkill(
+                id="general",
+                name="General task execution",
+                description="Execute a delegated task using Hermes' available tools.",
+                tags=["general"],
+            )
+        ]
+
+    skills: list[AgentSkill] = []
+    for name in sorted(TOOLSETS):
+        # Skip composite/platform/scenario toolsets — they aren't user-facing
+        # capabilities so much as internal bundles.
+        if name.startswith("hermes-") or name in {"safe", "debugging", "rl", "moa"}:
+            continue
+        defn = TOOLSETS.get(name) or {}
+        description = str(defn.get("description") or f"Hermes {name} capability.")
+        skills.append(
+            AgentSkill(
+                id=name,
+                name=name.replace("_", " ").title(),
+                description=description,
+                tags=[name],
+            )
+        )
+    if not skills:
+        skills.append(
+            AgentSkill(
+                id="general",
+                name="General task execution",
+                description="Execute a delegated task using Hermes' available tools.",
+                tags=["general"],
+            )
+        )
+    return skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,7 +333,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "a2a_bridge", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/a2a_bridge/test_client.py
+++ b/tests/a2a_bridge/test_client.py
@@ -1,0 +1,207 @@
+"""Tests for the outbound A2A client — JSON-RPC envelope, result parsing, errors.
+
+A fake transport exercises the whole request/response round-trip offline: no
+network, no running peer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import a2a_bridge
+from a2a_bridge.client import (
+    METHOD_MESSAGE_SEND,
+    A2AClient,
+    A2AClientError,
+    _well_known_card_url,
+)
+from a2a_bridge.models import (
+    ROLE_USER,
+    TASK_STATE_COMPLETED,
+    Message,
+    Task,
+)
+
+
+class _RecordingTransport:
+    """Captures the outbound request and returns a canned response."""
+
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def __call__(self, url, body, headers, timeout):
+        self.calls.append({"url": url, "body": body, "headers": headers, "timeout": timeout})
+        return self.response
+
+
+# ── envelope construction ─────────────────────────────────────────────────────
+
+
+def test_send_message_builds_jsonrpc_envelope():
+    transport = _RecordingTransport(
+        {"jsonrpc": "2.0", "id": "fixed", "result": {"task": {"id": "t1", "status": {"state": "completed"}}}}
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    client.send_message(Message.from_text("hi", message_id="m1"), request_id="fixed")
+
+    assert len(transport.calls) == 1
+    body = transport.calls[0]["body"]
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == "fixed"
+    assert body["method"] == METHOD_MESSAGE_SEND
+    assert body["params"]["message"]["parts"] == [{"kind": "text", "text": "hi"}]
+    assert transport.calls[0]["url"] == "https://peer.example.com/a2a"
+    assert transport.calls[0]["headers"]["content-type"] == "application/json"
+
+
+def test_delegate_text_round_trips_to_task():
+    transport = _RecordingTransport(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-abc",
+                    "contextId": "ctx-xyz",
+                    "status": {"state": "completed"},
+                    "artifacts": [{"artifactId": "a1", "parts": [{"text": "the answer"}]}],
+                }
+            },
+        }
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    result = client.delegate_text("compute the answer", context_id="ctx-xyz")
+
+    assert isinstance(result, Task)
+    assert result.id == "task-abc"
+    assert result.state == TASK_STATE_COMPLETED
+    assert result.result_text() == "the answer"
+    # The context id must have ridden along on the outbound message.
+    assert transport.calls[0]["body"]["params"]["message"]["contextId"] == "ctx-xyz"
+    assert transport.calls[0]["body"]["params"]["message"]["role"] == ROLE_USER
+
+
+# ── result parsing variants ────────────────────────────────────────────────────
+
+
+def test_parse_result_bare_message():
+    transport = _RecordingTransport(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"message": {"role": "agent", "parts": [{"text": "inline reply"}]}},
+        }
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    result = client.delegate_text("ping")
+    assert isinstance(result, Message)
+    assert result.text() == "inline reply"
+
+
+def test_parse_result_unnested_task_shape():
+    # REST-style peers may return the Task object directly under result.
+    transport = _RecordingTransport(
+        {"jsonrpc": "2.0", "id": 1, "result": {"id": "t9", "status": {"state": "working"}}}
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    result = client.delegate_text("go")
+    assert isinstance(result, Task)
+    assert result.id == "t9"
+
+
+def test_parse_result_unnested_message_shape():
+    transport = _RecordingTransport(
+        {"jsonrpc": "2.0", "id": 1, "result": {"role": "agent", "parts": [{"text": "hey"}]}}
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    result = client.delegate_text("go")
+    assert isinstance(result, Message)
+    assert result.text() == "hey"
+
+
+# ── error handling ─────────────────────────────────────────────────────────────
+
+
+def test_jsonrpc_error_raises_client_error():
+    transport = _RecordingTransport(
+        {"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "Method not found"}}
+    )
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    with pytest.raises(A2AClientError, match="-32601"):
+        client.delegate_text("go")
+
+
+def test_missing_result_raises_client_error():
+    transport = _RecordingTransport({"jsonrpc": "2.0", "id": 1})
+    client = A2AClient("https://peer.example.com/a2a", transport=transport)
+    with pytest.raises(A2AClientError, match="missing a result"):
+        client.delegate_text("go")
+
+
+def test_empty_endpoint_url_rejected():
+    with pytest.raises(ValueError):
+        A2AClient("")
+
+
+# ── agent card discovery ───────────────────────────────────────────────────────
+
+
+def test_fetch_agent_card_uses_well_known_path():
+    captured = {}
+
+    def fake_card_fetch(url, headers, timeout):
+        captured["url"] = url
+        return {
+            "name": "Peer Agent",
+            "description": "d",
+            "version": "1.0.0",
+            "url": "https://peer.example.com/a2a/v1",
+            "skills": [],
+        }
+
+    client = A2AClient("https://peer.example.com/a2a/v1", card_fetch=fake_card_fetch)
+    card = client.fetch_agent_card()
+    assert card.name == "Peer Agent"
+    assert captured["url"] == "https://peer.example.com/.well-known/agent-card.json"
+
+
+def test_fetch_agent_card_accepts_explicit_url():
+    def fake_card_fetch(url, headers, timeout):
+        assert url == "https://elsewhere.example.com/card.json"
+        return {"name": "P", "description": "", "version": "1", "url": "u", "skills": []}
+
+    client = A2AClient("https://peer.example.com/a2a", card_fetch=fake_card_fetch)
+    client.fetch_agent_card(card_url="https://elsewhere.example.com/card.json")
+
+
+def test_well_known_card_url_derivation():
+    assert (
+        _well_known_card_url("https://host.example.com:8080/a2a/v1?x=1")
+        == "https://host.example.com:8080/.well-known/agent-card.json"
+    )
+
+
+def test_well_known_card_url_rejects_invalid_endpoint():
+    with pytest.raises(A2AClientError):
+        _well_known_card_url("not-a-url")
+
+
+# ── feature flag gating ─────────────────────────────────────────────────────────
+
+
+def test_is_enabled_off_by_default(monkeypatch):
+    monkeypatch.delenv("HERMES_A2A_BRIDGE", raising=False)
+    assert a2a_bridge.is_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
+def test_is_enabled_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("HERMES_A2A_BRIDGE", value)
+    assert a2a_bridge.is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_is_enabled_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("HERMES_A2A_BRIDGE", value)
+    assert a2a_bridge.is_enabled() is False

--- a/tests/a2a_bridge/test_models.py
+++ b/tests/a2a_bridge/test_models.py
@@ -1,0 +1,226 @@
+"""Tests for the A2A bridge data models — wire-shape round-trips and helpers."""
+
+from __future__ import annotations
+
+from a2a_bridge.models import (
+    ROLE_AGENT,
+    ROLE_USER,
+    TASK_STATE_COMPLETED,
+    TASK_STATE_INPUT_REQUIRED,
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    Artifact,
+    Message,
+    MessagePart,
+    Task,
+    TaskStatus,
+    build_hermes_agent_card,
+)
+
+
+# ── MessagePart ─────────────────────────────────────────────────────────────
+
+
+def test_message_part_text_round_trip():
+    part = MessagePart(text="hello")
+    raw = part.to_dict()
+    assert raw == {"kind": "text", "text": "hello"}
+    assert MessagePart.from_dict(raw).text == "hello"
+
+
+def test_message_part_data_round_trip():
+    payload = {"ticketNumber": "REQ123"}
+    part = MessagePart(data=payload, metadata={"mediaType": "application/json"})
+    raw = part.to_dict()
+    assert raw["kind"] == "data"
+    assert raw["data"] == payload
+    assert raw["metadata"] == {"mediaType": "application/json"}
+    back = MessagePart.from_dict(raw)
+    assert back.data == payload
+    assert back.metadata == {"mediaType": "application/json"}
+
+
+def test_message_part_unmodeled_file_kind_round_trips_losslessly():
+    # A 'file' part is not modeled as a typed field; it must survive a
+    # round-trip verbatim via the extra escape hatch (no data dropped, no
+    # crash on the unknown kind).
+    raw = {
+        "kind": "file",
+        "file": {"uri": "https://x/report.pdf", "mimeType": "application/pdf"},
+        "metadata": {"source": "peer"},
+    }
+    part = MessagePart.from_dict(raw)
+    assert part.text is None
+    assert part.data is None
+    assert part.extra["kind"] == "file"
+    assert part.to_dict() == raw
+
+
+# ── Message ─────────────────────────────────────────────────────────────────
+
+
+def test_message_from_text_and_serialization():
+    msg = Message.from_text("do the thing", message_id="m1")
+    raw = msg.to_dict()
+    assert raw["role"] == ROLE_USER
+    assert raw["messageId"] == "m1"
+    assert raw["parts"] == [{"kind": "text", "text": "do the thing"}]
+
+
+def test_message_round_trip_with_context_and_task_ids():
+    msg = Message(
+        role=ROLE_AGENT,
+        parts=[MessagePart(text="part-a"), MessagePart(text="part-b")],
+        message_id="m2",
+        context_id="ctx-1",
+        task_id="task-1",
+        metadata={"k": "v"},
+    )
+    back = Message.from_dict(msg.to_dict())
+    assert back.role == ROLE_AGENT
+    assert back.text() == "part-apart-b"
+    assert back.context_id == "ctx-1"
+    assert back.task_id == "task-1"
+    assert back.metadata == {"k": "v"}
+
+
+def test_message_from_dict_defaults_role_to_agent():
+    # A peer reply that omits role should be read as an agent message.
+    back = Message.from_dict({"parts": [{"text": "x"}]})
+    assert back.role == ROLE_AGENT
+
+
+# ── Task / TaskStatus / Artifact ──────────────────────────────────────────────
+
+
+def test_task_parses_spec_response_shape():
+    # The exact shape from the A2A spec's structured-data example.
+    raw = {
+        "id": "d8c6243f",
+        "contextId": "c295ea44",
+        "status": {"state": "completed", "timestamp": "2025-04-17T17:47:09Z"},
+        "artifacts": [
+            {
+                "artifactId": "c5e0382f",
+                "parts": [{"text": '[{"ticketNumber":"REQ123"}]'}],
+            }
+        ],
+    }
+    task = Task.from_dict(raw)
+    assert task.id == "d8c6243f"
+    assert task.context_id == "c295ea44"
+    assert task.state == TASK_STATE_COMPLETED
+    assert task.is_terminal() is True
+    assert task.result_text() == '[{"ticketNumber":"REQ123"}]'
+
+
+def test_task_round_trip():
+    task = Task(
+        id="t1",
+        context_id="c1",
+        status=TaskStatus(state=TASK_STATE_COMPLETED, timestamp="2025-01-01T00:00:00Z"),
+        artifacts=[Artifact(artifact_id="a1", name="result", parts=[MessagePart(text="done")])],
+    )
+    back = Task.from_dict(task.to_dict())
+    assert back.id == "t1"
+    assert back.context_id == "c1"
+    assert back.state == TASK_STATE_COMPLETED
+    assert back.artifacts[0].name == "result"
+    assert back.result_text() == "done"
+
+
+def test_task_non_terminal_states():
+    assert Task(id="x", status=TaskStatus(state="working")).is_terminal() is False
+    assert (
+        Task(id="x", status=TaskStatus(state=TASK_STATE_INPUT_REQUIRED)).is_terminal()
+        is False
+    )
+
+
+def test_task_result_text_falls_back_to_status_message():
+    # An input-required turn carries no artifacts; the prompt lives in the
+    # status message, which result_text() should surface.
+    task = Task(
+        id="t2",
+        status=TaskStatus(
+            state=TASK_STATE_INPUT_REQUIRED,
+            message=Message(role=ROLE_AGENT, parts=[MessagePart(text="need more info")]),
+        ),
+    )
+    assert task.result_text() == "need more info"
+
+
+# ── AgentCard ─────────────────────────────────────────────────────────────────
+
+
+def test_agent_card_round_trip_preserves_unknown_fields():
+    raw = {
+        "name": "GeoSpatial Route Planner Agent",
+        "description": "Route planning.",
+        "version": "1.2.0",
+        "url": "https://georoute.example.com/a2a/v1",
+        "protocolVersion": "0.3.0",
+        "capabilities": {"streaming": True, "pushNotifications": True},
+        "defaultInputModes": ["application/json"],
+        "defaultOutputModes": ["image/png"],
+        "skills": [
+            {
+                "id": "route-optimizer",
+                "name": "Route Optimizer",
+                "description": "Optimal routes.",
+                "tags": ["maps", "routing"],
+            }
+        ],
+        # Fields this increment doesn't model as typed attributes:
+        "provider": {"organization": "Example Inc."},
+        "securitySchemes": {"google": {}},
+    }
+    card = AgentCard.from_dict(raw)
+    assert card.name == "GeoSpatial Route Planner Agent"
+    assert card.capabilities.streaming is True
+    assert card.capabilities.push_notifications is True
+    assert card.skills[0].id == "route-optimizer"
+    assert card.skills[0].tags == ["maps", "routing"]
+
+    out = card.to_dict()
+    # Unknown fields survive the round-trip via the extra escape hatch.
+    assert out["provider"] == {"organization": "Example Inc."}
+    assert out["securitySchemes"] == {"google": {}}
+    assert out["capabilities"] == {"streaming": True, "pushNotifications": True}
+
+
+def test_agent_capabilities_default_to_false():
+    caps = AgentCapabilities()
+    assert caps.streaming is False
+    assert caps.push_notifications is False
+
+
+def test_agent_skill_round_trip():
+    skill = AgentSkill(id="s1", name="Skill One", description="d", tags=["a", "b"])
+    assert AgentSkill.from_dict(skill.to_dict()) == skill
+
+
+# ── build_hermes_agent_card ───────────────────────────────────────────────────
+
+
+def test_build_hermes_agent_card_basic_shape():
+    card = build_hermes_agent_card("https://hermes.example.com/a2a", version="9.9.9")
+    assert card.name == "Hermes Agent"
+    assert card.version == "9.9.9"
+    assert card.url == "https://hermes.example.com/a2a"
+    assert "text/plain" in card.default_input_modes
+    # Skills are derived from real Hermes toolsets, so there must be several.
+    assert len(card.skills) >= 1
+    # Card must serialize to a valid, parseable A2A AgentCard.
+    assert AgentCard.from_dict(card.to_dict()).version == "9.9.9"
+
+
+def test_build_hermes_agent_card_skills_from_toolsets():
+    card = build_hermes_agent_card("https://hermes.example.com/a2a", version="1.0.0")
+    skill_ids = {s.id for s in card.skills}
+    # 'web' is a standard, stable Hermes toolset; composite/internal ones are
+    # excluded.
+    assert "web" in skill_ids
+    assert not any(sid.startswith("hermes-") for sid in skill_ids)
+    assert "safe" not in skill_ids


### PR DESCRIPTION
## First increment of #227 — A2A/ACP peer-agent protocol bridge

### Existing-code finding (no duplication)
The repo already has `acp_adapter/` + `acp_registry/`, but these implement the
**editor Agent Client Protocol** (Zed/IDE, `agent-client-protocol==0.9.0`,
JSON-RPC-over-stdio, Hermes-as-agent / editor-as-client). That is a **different**
protocol from issue #227's **peer-to-peer A2A** (Google Agent2Agent) / IBM-ACP.
A grep for `a2a`/`agent-to-agent`/`agentcard` found only false positives (a hex
color, a code comment, Chinese test text). So the peer bridge is genuinely
unimplemented — this is new, non-duplicate work.

### Implemented
New top-level package `a2a_bridge/` — the protocol foundation (plan steps 1 + the
client half of step 3):

- **`models.py`** — A2A-compatible dataclasses: `AgentCard`, `AgentSkill`,
  `AgentCapabilities`, `Message`, `MessagePart`, `Task`, `TaskStatus`, `Artifact`,
  each with `to_dict`/`from_dict` round-trips (camelCase on the wire, snake_case in
  Python). Fields this increment doesn't model — `file` parts, security schemes,
  provider, signatures — survive a round-trip **verbatim** via the `extra` escape
  hatch (no data loss, no crash on unknown kinds). `build_hermes_agent_card(url)`
  derives the advertised skills from Hermes's registered `TOOLSETS` so the card
  reflects what the build can actually do.
- **`client.py`** — outbound `A2AClient`. Serializes the canonical JSON-RPC 2.0
  `message/send` envelope, POSTs it via an **injectable transport** (default
  `httpx`, already a core dep), and parses `result.task` / `result.message` (plus
  unnested REST-style shapes) into typed objects a delegating agent can act on.
  Errors collapse to one `A2AClientError`. `fetch_agent_card()` resolves the
  well-known `/.well-known/agent-card.json` discovery path.
- **Gating** — `a2a_bridge.is_enabled()` reads `HERMES_A2A_BRIDGE` (off by
  default). No import-time side effects, and nothing is wired into the live tool
  dispatcher, so there is **no impact on MCP tool-call latency** (issue success
  criterion #3 protected by construction).

### Deferred to later increments
- Inbound server adapter exposing Hermes as an A2A peer (plan step 2).
- Wiring the outbound client into the live `delegate_tool` / tool dispatcher.
- An IBM-ACP serializer over the same protocol-neutral models.
- The two-Hermes-instance end-to-end smoke test (needs the inbound server first).

### Verification
- `uv run --extra dev python -m pytest tests/a2a_bridge -q` → **38 passed**.
  The whole request/response round-trip is exercised offline via a fake transport
  (no network, no running peer).
- `uv run --extra dev ruff check a2a_bridge/ tests/a2a_bridge/` → **clean**.
- Runtime import smoke test passes; AgentCard builds 31 skills from real toolsets;
  `is_enabled()` is `False` by default.

This is a **first increment**, not a full close of #227. It establishes the
protocol contract and the outbound delegation path; the inbound server and live
wiring follow in subsequent PRs.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>