### PR TITLE
Skills-as-Graph (AIP) dependency/composition layer (first increment of #246)

### DIFF
--- a/agent/skill_graph.py
+++ b/agent/skill_graph.py
@@ -1,0 +1,559 @@
+"""Skills-as-Graph: a typed dependency/composition/governance graph over skills.
+
+This is the first increment of the AIP ("A Graph Representation for Learning and
+Governing Agent Skills") layer described in issue #246.  It models the four AIP
+edge types between skills and exposes pure-Python composition/dependency queries
+on top of the existing skill registry — no new runtime dependencies, no agent
+behaviour change.
+
+Edge types (declared in each skill's ``SKILL.md`` frontmatter under
+``metadata.hermes.graph``)::
+
+    metadata:
+      hermes:
+        graph:
+          requires: [skill-a, skill-b]        # hard prerequisites (load these too)
+          conflicts-with: [skill-c]           # cannot be co-loaded with these
+          composes-with: [skill-d]            # canonical composition partners
+          deprecates: [skill-e]               # supersedes these (governance)
+
+Backward compatibility: the long-standing ``metadata.hermes.related_skills``
+list (present on ~40 skills today) is folded into ``composes-with`` so the graph
+has real edges from day one.  Skills with no graph declarations are isolated
+nodes — they keep working exactly as before.
+
+This module intentionally mirrors ``agent/skill_utils.py``: it avoids importing
+the tool registry, CLI config, or any heavy dependency chain so it is safe to
+import at module level.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from agent.skill_utils import (
+    iter_skill_index_files,
+    parse_frontmatter,
+)
+
+logger = logging.getLogger(__name__)
+
+# The four AIP edge types, plus the order they are reported in.  ``requires`` is
+# the only directed edge type that participates in closure/topological ordering;
+# the others are governance/composition relations.
+EDGE_TYPES: Tuple[str, ...] = (
+    "requires",
+    "conflicts-with",
+    "composes-with",
+    "deprecates",
+)
+
+
+def _normalize_edge_targets(value: Any) -> List[str]:
+    """Coerce a frontmatter edge value into a clean list of skill names.
+
+    Accepts an already-parsed list (the YAML-normal case), a single string, or
+    a bracketed/comma-separated string (defensive, mirrors ``_parse_tags`` in
+    ``skills_tool``).  Order is preserved and duplicates are dropped.
+    """
+    if not value:
+        return []
+    if isinstance(value, list):
+        items = value
+    else:
+        text = str(value).strip()
+        if text.startswith("[") and text.endswith("]"):
+            text = text[1:-1]
+        items = text.split(",")
+    out: List[str] = []
+    seen: Set[str] = set()
+    for item in items:
+        name = str(item).strip().strip("\"'")
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def extract_skill_edges(frontmatter: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Extract the typed graph edges declared by a skill's frontmatter.
+
+    Reads ``metadata.hermes.graph.<edge-type>`` for each of the four AIP edge
+    types and folds the legacy ``metadata.hermes.related_skills`` list into
+    ``composes-with`` (deduplicated, related_skills appended after explicit
+    composes-with so explicit declarations win on ordering).
+
+    Returns a dict keyed by every entry in :data:`EDGE_TYPES` (empty lists when
+    the skill declares nothing for that type).  Malformed structures are
+    tolerated by returning empty lists rather than raising.
+    """
+    edges: Dict[str, List[str]] = {etype: [] for etype in EDGE_TYPES}
+
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return edges
+    hermes = metadata.get("hermes")
+    if not isinstance(hermes, dict):
+        return edges
+
+    graph = hermes.get("graph")
+    if isinstance(graph, dict):
+        for etype in EDGE_TYPES:
+            edges[etype] = _normalize_edge_targets(graph.get(etype))
+
+    # Legacy compatibility: related_skills becomes a composes-with edge.
+    related = _normalize_edge_targets(hermes.get("related_skills"))
+    if related:
+        seen = set(edges["composes-with"])
+        for name in related:
+            if name not in seen:
+                seen.add(name)
+                edges["composes-with"].append(name)
+
+    return edges
+
+
+@dataclass
+class SkillNode:
+    """A single skill in the graph and its declared outbound edges."""
+
+    name: str
+    category: Optional[str] = None
+    path: Optional[str] = None
+    edges: Dict[str, List[str]] = field(default_factory=dict)
+
+    def targets(self, edge_type: str) -> List[str]:
+        return list(self.edges.get(edge_type, []))
+
+
+@dataclass
+class GraphValidation:
+    """Result of :meth:`SkillGraph.validate`.
+
+    ``ok`` is True only when there are no **errors**.  An error is either a
+    missing ``requires`` target (a hard prerequisite that cannot be satisfied =
+    a broken skill) or a ``requires`` cycle (no valid load order).
+
+    Missing targets on the advisory/governance edge types (``composes-with``,
+    ``conflicts-with``, ``deprecates``) are **warnings**, not errors: those
+    edges legitimately point at skills installed in another profile, a plugin,
+    or an optional-skills group, so a default profile must still validate as
+    ``ok``.  They are surfaced in ``missing_warnings`` so the data-quality
+    signal is never lost (a CI/registry "strict" mode that promotes them to
+    errors is left for a later increment).
+
+    ``conflicts`` are reported as facts — two skills declaring
+    ``conflicts-with`` each other is something the agent must avoid co-loading,
+    but it does not make the graph invalid.
+    """
+
+    ok: bool
+    # Errors (drive ok=False):
+    missing_requires: List[Tuple[str, str]]  # (source, missing_required_target)
+    requires_cycles: List[List[str]]
+    # Warnings (do NOT drive ok):
+    missing_warnings: List[Tuple[str, str, str]]  # (source, edge_type, missing_target)
+    conflicts: List[Tuple[str, str]]  # sorted (a, b) pairs
+
+    @property
+    def missing_targets(self) -> List[Tuple[str, str, str]]:
+        """All missing targets (errors + warnings), for callers that want one list."""
+        merged = [(s, "requires", t) for (s, t) in self.missing_requires]
+        merged.extend(self.missing_warnings)
+        merged.sort()
+        return merged
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "missing_requires": [
+                {"skill": s, "target": t} for (s, t) in self.missing_requires
+            ],
+            "requires_cycles": [list(c) for c in self.requires_cycles],
+            "missing_warnings": [
+                {"skill": s, "edge": e, "target": t}
+                for (s, e, t) in self.missing_warnings
+            ],
+            "conflicts": [{"a": a, "b": b} for (a, b) in self.conflicts],
+        }
+
+
+class SkillGraph:
+    """A typed graph over skills supporting dependency/composition queries.
+
+    Build with :meth:`from_skills_dirs` (scans ``SKILL.md`` files) or
+    :meth:`from_frontmatters` (in-memory, used by tests and the evolution
+    pipeline before a skill is written to disk).
+    """
+
+    def __init__(self, nodes: Dict[str, SkillNode]):
+        self._nodes: Dict[str, SkillNode] = nodes
+
+    # ── Construction ──────────────────────────────────────────────────────
+
+    @classmethod
+    def from_frontmatters(
+        cls,
+        skills: Iterable[Tuple[str, Dict[str, Any]]],
+        *,
+        categories: Optional[Dict[str, str]] = None,
+        paths: Optional[Dict[str, str]] = None,
+    ) -> "SkillGraph":
+        """Build a graph from ``(skill_name, frontmatter_dict)`` pairs.
+
+        Later entries with a name already seen are ignored (first definition
+        wins, matching the local-dir-precedence semantics of the registry).
+        """
+        categories = categories or {}
+        paths = paths or {}
+        nodes: Dict[str, SkillNode] = {}
+        for name, frontmatter in skills:
+            name = str(name).strip()
+            if not name or name in nodes:
+                continue
+            nodes[name] = SkillNode(
+                name=name,
+                category=categories.get(name),
+                path=paths.get(name),
+                edges=extract_skill_edges(frontmatter or {}),
+            )
+        return cls(nodes)
+
+    @classmethod
+    def from_skills_dirs(cls, skills_dirs: Iterable[Path]) -> "SkillGraph":
+        """Build a graph by scanning ``SKILL.md`` files under each directory.
+
+        Directories are scanned in order; the first definition of a given skill
+        name wins (local dir precedence).  Unreadable or unparseable skill files
+        are skipped with a debug log, never raising — a single bad skill must
+        not break graph queries over the rest.
+        """
+        nodes: Dict[str, SkillNode] = {}
+        for skills_dir in skills_dirs:
+            if not skills_dir.is_dir():
+                continue
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
+                try:
+                    content = skill_md.read_text(encoding="utf-8")
+                    frontmatter, _ = parse_frontmatter(content)
+                except Exception as exc:  # noqa: BLE001 - one bad skill is non-fatal
+                    logger.debug("skill_graph: skipping %s: %s", skill_md, exc)
+                    continue
+                name = str(frontmatter.get("name") or skill_md.parent.name).strip()
+                if not name or name in nodes:
+                    continue
+                category = skill_md.parent.parent.name if skill_md.parent.parent else None
+                try:
+                    rel = str(skill_md.relative_to(skills_dir))
+                except ValueError:
+                    rel = str(skill_md)
+                nodes[name] = SkillNode(
+                    name=name,
+                    category=category,
+                    path=rel,
+                    edges=extract_skill_edges(frontmatter),
+                )
+        return cls(nodes)
+
+    # ── Introspection ─────────────────────────────────────────────────────
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._nodes
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def names(self) -> List[str]:
+        return sorted(self._nodes)
+
+    def node(self, name: str) -> Optional[SkillNode]:
+        return self._nodes.get(name)
+
+    def edges_of(self, name: str) -> Dict[str, List[str]]:
+        """Outbound edges of *name*, or all-empty lists if the skill is unknown."""
+        node = self._nodes.get(name)
+        if node is None:
+            return {etype: [] for etype in EDGE_TYPES}
+        return {etype: node.targets(etype) for etype in EDGE_TYPES}
+
+    # ── Validation ────────────────────────────────────────────────────────
+
+    def validate(self) -> GraphValidation:
+        """Validate the graph.
+
+        Errors (set ``ok=False``):
+          * a ``requires`` edge points at a skill not in the graph (a hard
+            prerequisite that cannot be satisfied);
+          * a cycle exists in the ``requires`` relation.
+
+        Warnings (reported, do not affect ``ok``):
+          * a ``composes-with`` / ``conflicts-with`` / ``deprecates`` edge points
+            at a skill not in the graph — these are advisory/governance edges
+            that may legitimately reference skills in another profile or plugin;
+          * declared ``conflicts-with`` pairs.
+        """
+        missing_requires: List[Tuple[str, str]] = []
+        missing_warnings: List[Tuple[str, str, str]] = []
+        for node in self._nodes.values():
+            for etype in EDGE_TYPES:
+                for target in node.targets(etype):
+                    if target in self._nodes:
+                        continue
+                    if etype == "requires":
+                        missing_requires.append((node.name, target))
+                    else:
+                        missing_warnings.append((node.name, etype, target))
+
+        cycles = self._find_requires_cycles()
+        conflicts = self._collect_conflicts()
+
+        ok = not missing_requires and not cycles
+        # Sort for deterministic output.
+        missing_requires.sort()
+        missing_warnings.sort()
+        conflicts = sorted(conflicts)
+        return GraphValidation(
+            ok=ok,
+            missing_requires=missing_requires,
+            requires_cycles=cycles,
+            missing_warnings=missing_warnings,
+            conflicts=conflicts,
+        )
+
+    def _requires_targets(self, name: str) -> List[str]:
+        """``requires`` targets of *name* that actually exist in the graph."""
+        node = self._nodes.get(name)
+        if node is None:
+            return []
+        return [t for t in node.targets("requires") if t in self._nodes]
+
+    def _find_requires_cycles(self) -> List[List[str]]:
+        """Return every elementary cycle in the ``requires`` relation.
+
+        Uses iterative DFS with a three-colour marking (white/grey/black).  A
+        back-edge to a grey node closes a cycle; the cycle path is reconstructed
+        from the current DFS stack.  Each distinct cycle (by its set of nodes)
+        is reported once, normalised to start at its lexicographically smallest
+        member for stable output.
+        """
+        WHITE, GREY, BLACK = 0, 1, 2
+        colour: Dict[str, int] = {n: WHITE for n in self._nodes}
+        cycles: List[List[str]] = []
+        seen_cycle_keys: Set[frozenset] = set()
+
+        for start in sorted(self._nodes):
+            if colour[start] != WHITE:
+                continue
+            # Stack frames: (node, iterator over its requires targets).
+            stack: List[Tuple[str, Iterable[str]]] = [
+                (start, iter(self._requires_targets(start)))
+            ]
+            path: List[str] = [start]
+            colour[start] = GREY
+            while stack:
+                node, it = stack[-1]
+                advanced = False
+                for target in it:
+                    if colour[target] == WHITE:
+                        colour[target] = GREY
+                        path.append(target)
+                        stack.append((target, iter(self._requires_targets(target))))
+                        advanced = True
+                        break
+                    if colour[target] == GREY:
+                        # Back-edge: cycle from target..node.
+                        idx = path.index(target)
+                        cycle = path[idx:]
+                        key = frozenset(cycle)
+                        if key not in seen_cycle_keys:
+                            seen_cycle_keys.add(key)
+                            cycles.append(_canonical_cycle(cycle))
+                if advanced:
+                    continue
+                # Exhausted: pop.
+                colour[node] = BLACK
+                stack.pop()
+                if path:
+                    path.pop()
+        cycles.sort()
+        return cycles
+
+    def _collect_conflicts(self) -> List[Tuple[str, str]]:
+        """Collect declared ``conflicts-with`` pairs (deduped, undirected)."""
+        pairs: Set[Tuple[str, str]] = set()
+        for node in self._nodes.values():
+            for target in node.targets("conflicts-with"):
+                if target == node.name:
+                    continue
+                pair = tuple(sorted((node.name, target)))
+                pairs.add(pair)  # type: ignore[arg-type]
+        return list(pairs)
+
+    # ── Queries ───────────────────────────────────────────────────────────
+
+    def closure(self, name: str) -> List[str]:
+        """Minimal set of skills that must be loaded to satisfy *name*.
+
+        Returns the transitive ``requires`` closure of *name* **including**
+        *name* itself, in dependency-first topological order (a skill appears
+        after every skill it requires).  Raises :class:`KeyError` if *name* is
+        not in the graph.  ``requires`` cycles are tolerated — the closure is
+        still complete; ordering within a cycle is arbitrary but stable.
+
+        Edge targets that do not exist in the graph are silently skipped (they
+        are reported by :meth:`validate` as missing targets, not here).
+        """
+        if name not in self._nodes:
+            raise KeyError(name)
+
+        # Collect the reachable set via the requires relation.
+        reachable: Set[str] = set()
+        stack = [name]
+        while stack:
+            current = stack.pop()
+            if current in reachable:
+                continue
+            reachable.add(current)
+            for target in self._requires_targets(current):
+                if target not in reachable:
+                    stack.append(target)
+
+        return self._topo_sort(reachable)
+
+    def blast(self, name: str) -> Dict[str, List[str]]:
+        """Every skill affected if *name* were added, changed, or removed.
+
+        Returns a dict with three keys:
+          * ``dependents`` — skills that transitively ``require`` *name* (they
+            break if *name* changes/disappears);
+          * ``conflicts`` — skills that declare a ``conflicts-with`` edge to or
+            from *name* (adding *name* would collide with them);
+          * ``composes`` — direct ``composes-with`` partners of *name* (their
+            canonical composition with *name* changes).
+
+        *name* itself is never included.  ``KeyError`` is raised when *name* is
+        unknown, so callers can distinguish "no blast radius" from "no such
+        skill".
+        """
+        if name not in self._nodes:
+            raise KeyError(name)
+
+        # Reverse requires-reachability: who depends on `name`?
+        dependents: Set[str] = set()
+        stack = [name]
+        while stack:
+            current = stack.pop()
+            for other in self._nodes.values():
+                if other.name == name or other.name in dependents:
+                    continue
+                if current in self._requires_targets(other.name):
+                    dependents.add(other.name)
+                    stack.append(other.name)
+        dependents.discard(name)
+
+        conflicts: Set[str] = set()
+        node = self._nodes[name]
+        for target in node.targets("conflicts-with"):
+            if target in self._nodes and target != name:
+                conflicts.add(target)
+        for other in self._nodes.values():
+            if other.name == name:
+                continue
+            if name in other.targets("conflicts-with"):
+                conflicts.add(other.name)
+
+        composes: Set[str] = {
+            t for t in node.targets("composes-with") if t in self._nodes and t != name
+        }
+
+        return {
+            "dependents": sorted(dependents),
+            "conflicts": sorted(conflicts),
+            "composes": sorted(composes),
+        }
+
+    def topological_order(self) -> List[str]:
+        """Full graph in dependency-first ``requires`` order.
+
+        A skill appears after every skill it requires.  If ``requires`` cycles
+        exist the order is still total and stable but the cycle members'
+        relative order is arbitrary (a cycle has no valid topological order).
+        """
+        return self._topo_sort(set(self._nodes))
+
+    def _topo_sort(self, subset: Set[str]) -> List[str]:
+        """Dependency-first topological sort restricted to *subset*.
+
+        Deterministic (ties broken by name).  Cycle-tolerant: nodes still in the
+        cycle when no zero-in-degree node remains are emitted in name order so
+        the result is always a complete permutation of *subset*.
+        """
+        # Build in-degree over the requires relation, restricted to subset.
+        deps: Dict[str, Set[str]] = {}
+        for n in subset:
+            deps[n] = {t for t in self._requires_targets(n) if t in subset}
+
+        result: List[str] = []
+        placed: Set[str] = set()
+        remaining = set(subset)
+        while remaining:
+            ready = sorted(
+                n for n in remaining if deps[n] <= placed
+            )
+            if not ready:
+                # Cycle: nothing has all deps satisfied. Emit the rest in name
+                # order to guarantee termination and a complete result.
+                ready = sorted(remaining)
+            for n in ready:
+                result.append(n)
+                placed.add(n)
+                remaining.discard(n)
+        return result
+
+    # ── Rendering ─────────────────────────────────────────────────────────
+
+    def to_dot(self) -> str:
+        """Render the graph in Graphviz DOT format.
+
+        Edge styling encodes the relation type so a rendered graph is legible:
+        ``requires`` solid, ``conflicts-with`` red dashed (no direction),
+        ``composes-with`` dotted, ``deprecates`` bold grey.  ``conflicts-with``
+        is rendered once per undirected pair to avoid double arrows.
+        """
+        lines: List[str] = ["digraph skills {", "  rankdir=LR;", "  node [shape=box];"]
+        for name in sorted(self._nodes):
+            lines.append(f'  "{name}";')
+
+        seen_conflicts: Set[Tuple[str, str]] = set()
+        styles = {
+            "requires": '[label="requires"]',
+            "conflicts-with": '[label="conflicts-with" color="red" style="dashed" dir="none"]',
+            "composes-with": '[label="composes-with" style="dotted"]',
+            "deprecates": '[label="deprecates" color="gray" style="bold"]',
+        }
+        for name in sorted(self._nodes):
+            node = self._nodes[name]
+            for etype in EDGE_TYPES:
+                for target in node.targets(etype):
+                    if etype == "conflicts-with":
+                        pair = tuple(sorted((name, target)))
+                        if pair in seen_conflicts:
+                            continue
+                        seen_conflicts.add(pair)  # type: ignore[arg-type]
+                    lines.append(f'  "{name}" -> "{target}" {styles[etype]};')
+        lines.append("}")
+        return "\n".join(lines)
+
+
+def _canonical_cycle(cycle: List[str]) -> List[str]:
+    """Rotate *cycle* to start at its lexicographically smallest member.
+
+    Keeps cycle reporting stable regardless of which node the DFS entered from.
+    """
+    if not cycle:
+        return cycle
+    start = min(range(len(cycle)), key=lambda i: cycle[i])
+    return cycle[start:] + cycle[:start]

--- a/tests/tools/test_skill_graph.py
+++ b/tests/tools/test_skill_graph.py
@@ -1,0 +1,544 @@
+"""Tests for agent/skill_graph.py — the Skills-as-Graph (AIP) layer (issue #246).
+
+Covers the success criteria from the issue:
+  * empty graph,
+  * single-edge requires resolution,
+  * multi-hop transitive closure,
+  * conflict detection (conflicts-with),
+  * cycle detection (requires cycle = hard error),
+  * deprecation chains,
+  * blast radius (dependents / conflicts / composes),
+  * missing edge-target detection,
+  * topological ordering,
+  * legacy related_skills -> composes-with folding,
+  * DOT rendering,
+  * the tools.skills_tool.skill_relationships wiring over a real skills dir.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.skill_graph import (
+    EDGE_TYPES,
+    SkillGraph,
+    extract_skill_edges,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _fm(**graph_edges):
+    """Build a frontmatter dict with metadata.hermes.graph edges."""
+    graph = {k.replace("_", "-"): v for k, v in graph_edges.items()}
+    return {"metadata": {"hermes": {"graph": graph}}}
+
+
+def _graph(spec):
+    """Build a SkillGraph from a {name: frontmatter} dict."""
+    return SkillGraph.from_frontmatters(spec.items())
+
+
+# ── extract_skill_edges ───────────────────────────────────────────────────
+
+
+def test_extract_edges_empty_frontmatter():
+    edges = extract_skill_edges({})
+    assert set(edges) == set(EDGE_TYPES)
+    assert all(v == [] for v in edges.values())
+
+
+def test_extract_edges_all_types():
+    fm = _fm(
+        requires=["a", "b"],
+        conflicts_with=["c"],
+        composes_with=["d"],
+        deprecates=["e"],
+    )
+    edges = extract_skill_edges(fm)
+    assert edges["requires"] == ["a", "b"]
+    assert edges["conflicts-with"] == ["c"]
+    assert edges["composes-with"] == ["d"]
+    assert edges["deprecates"] == ["e"]
+
+
+def test_extract_edges_folds_related_skills_into_composes():
+    fm = {
+        "metadata": {
+            "hermes": {
+                "related_skills": ["legacy-x", "legacy-y"],
+                "graph": {"composes-with": ["explicit-z"]},
+            }
+        }
+    }
+    edges = extract_skill_edges(fm)
+    # Explicit composes-with first, then related_skills appended, deduped.
+    assert edges["composes-with"] == ["explicit-z", "legacy-x", "legacy-y"]
+
+
+def test_extract_edges_related_skills_only():
+    fm = {"metadata": {"hermes": {"related_skills": ["x"]}}}
+    edges = extract_skill_edges(fm)
+    assert edges["composes-with"] == ["x"]
+    assert edges["requires"] == []
+
+
+def test_extract_edges_string_and_bracket_forms():
+    # Defensive: malformed YAML can leave strings in place of lists.
+    fm = {"metadata": {"hermes": {"graph": {"requires": "[a, b]"}}}}
+    assert extract_skill_edges(fm)["requires"] == ["a", "b"]
+    fm2 = {"metadata": {"hermes": {"graph": {"requires": "a, b"}}}}
+    assert extract_skill_edges(fm2)["requires"] == ["a", "b"]
+
+
+def test_extract_edges_malformed_metadata_is_tolerated():
+    assert extract_skill_edges({"metadata": "oops"}) == {e: [] for e in EDGE_TYPES}
+    assert extract_skill_edges({"metadata": {"hermes": "oops"}}) == {
+        e: [] for e in EDGE_TYPES
+    }
+    assert extract_skill_edges({"metadata": {"hermes": {"graph": "oops"}}}) == {
+        e: [] for e in EDGE_TYPES
+    }
+
+
+# ── Empty / trivial graphs ──────────────────────────────────────────────────
+
+
+def test_empty_graph_is_valid():
+    g = _graph({})
+    assert len(g) == 0
+    assert g.names() == []
+    v = g.validate()
+    assert v.ok
+    assert v.missing_targets == []
+    assert v.missing_requires == []
+    assert v.missing_warnings == []
+    assert v.requires_cycles == []
+    assert v.conflicts == []
+    assert g.topological_order() == []
+
+
+def test_isolated_nodes_valid():
+    g = _graph({"a": {}, "b": {}})
+    v = g.validate()
+    assert v.ok
+    assert g.closure("a") == ["a"]
+    assert g.blast("a") == {"dependents": [], "conflicts": [], "composes": []}
+
+
+# ── Closure (transitive requires) ───────────────────────────────────────────
+
+
+def test_single_edge_closure():
+    g = _graph({"app": _fm(requires=["lib"]), "lib": {}})
+    # closure includes the skill itself, deps first.
+    assert g.closure("app") == ["lib", "app"]
+    assert g.closure("lib") == ["lib"]
+
+
+def test_multi_hop_closure_is_dependency_first():
+    # app -> mid -> base, plus app -> util
+    g = _graph(
+        {
+            "app": _fm(requires=["mid", "util"]),
+            "mid": _fm(requires=["base"]),
+            "util": {},
+            "base": {},
+        }
+    )
+    order = g.closure("app")
+    assert set(order) == {"app", "mid", "util", "base"}
+    # Every dependency appears before its dependent.
+    assert order.index("base") < order.index("mid")
+    assert order.index("mid") < order.index("app")
+    assert order.index("util") < order.index("app")
+
+
+def test_diamond_closure_no_duplicates():
+    # a -> b, a -> c, b -> d, c -> d  (diamond)
+    g = _graph(
+        {
+            "a": _fm(requires=["b", "c"]),
+            "b": _fm(requires=["d"]),
+            "c": _fm(requires=["d"]),
+            "d": {},
+        }
+    )
+    order = g.closure("a")
+    assert sorted(order) == ["a", "b", "c", "d"]
+    assert len(order) == len(set(order))
+    assert order.index("d") < order.index("b")
+    assert order.index("d") < order.index("c")
+    assert order[-1] == "a"
+
+
+def test_closure_skips_missing_targets():
+    g = _graph({"a": _fm(requires=["ghost"])})
+    # ghost is not in the graph; closure is just {a}, missing reported by validate.
+    assert g.closure("a") == ["a"]
+
+
+def test_closure_unknown_skill_raises_keyerror():
+    g = _graph({"a": {}})
+    with pytest.raises(KeyError):
+        g.closure("nope")
+
+
+def test_closure_tolerates_requires_cycle():
+    g = _graph({"a": _fm(requires=["b"]), "b": _fm(requires=["a"])})
+    assert sorted(g.closure("a")) == ["a", "b"]
+
+
+# ── Cycle detection ─────────────────────────────────────────────────────────
+
+
+def test_requires_cycle_is_hard_error():
+    g = _graph({"a": _fm(requires=["b"]), "b": _fm(requires=["a"])})
+    v = g.validate()
+    assert not v.ok
+    assert len(v.requires_cycles) == 1
+    assert set(v.requires_cycles[0]) == {"a", "b"}
+    # Canonicalised to start at smallest member.
+    assert v.requires_cycles[0][0] == "a"
+
+
+def test_self_requires_cycle_detected():
+    g = _graph({"a": _fm(requires=["a"])})
+    v = g.validate()
+    assert not v.ok
+    assert any(set(c) == {"a"} for c in v.requires_cycles)
+
+
+def test_three_node_cycle():
+    g = _graph(
+        {
+            "a": _fm(requires=["b"]),
+            "b": _fm(requires=["c"]),
+            "c": _fm(requires=["a"]),
+        }
+    )
+    v = g.validate()
+    assert not v.ok
+    assert len(v.requires_cycles) == 1
+    assert set(v.requires_cycles[0]) == {"a", "b", "c"}
+
+
+def test_conflicts_and_composes_cycles_are_not_errors():
+    # Only requires cycles are hard errors; mutual conflicts/composes are fine.
+    g = _graph(
+        {
+            "a": _fm(conflicts_with=["b"], composes_with=["c"]),
+            "b": _fm(conflicts_with=["a"]),
+            "c": _fm(composes_with=["a"]),
+        }
+    )
+    v = g.validate()
+    assert v.requires_cycles == []
+    assert v.ok  # conflicts are warnings, not errors
+
+
+# ── Conflict detection ──────────────────────────────────────────────────────
+
+
+def test_conflict_detection_dedupes_undirected_pairs():
+    g = _graph(
+        {
+            "a": _fm(conflicts_with=["b"]),
+            "b": _fm(conflicts_with=["a"]),  # same pair, declared both ways
+            "c": {},
+        }
+    )
+    v = g.validate()
+    assert v.conflicts == [("a", "b")]
+
+
+def test_conflict_one_directional_still_detected():
+    g = _graph({"a": _fm(conflicts_with=["b"]), "b": {}})
+    v = g.validate()
+    assert v.conflicts == [("a", "b")]
+
+
+# ── Missing edge targets ────────────────────────────────────────────────────
+
+
+def test_missing_requires_target_is_error():
+    g = _graph({"a": _fm(requires=["ghost"])})
+    v = g.validate()
+    assert not v.ok
+    assert ("a", "ghost") in v.missing_requires
+    assert ("a", "requires", "ghost") in v.missing_targets
+
+
+def test_missing_soft_edge_target_is_warning_not_error():
+    # composes-with / conflicts-with / deprecates can point at skills in another
+    # profile or a plugin — a missing target is a warning, the graph stays ok.
+    g = _graph(
+        {
+            "a": _fm(
+                composes_with=["plugin-skill"],
+                conflicts_with=["other-profile-skill"],
+                deprecates=["old-skill"],
+            )
+        }
+    )
+    v = g.validate()
+    assert v.ok  # no missing requires, no cycle
+    assert v.missing_requires == []
+    warned = {(s, e, t) for (s, e, t) in v.missing_warnings}
+    assert ("a", "composes-with", "plugin-skill") in warned
+    assert ("a", "conflicts-with", "other-profile-skill") in warned
+    assert ("a", "deprecates", "old-skill") in warned
+
+
+def test_missing_target_across_edge_types_splits_severity():
+    g = _graph(
+        {
+            "a": _fm(
+                requires=["g1"],
+                conflicts_with=["g2"],
+                composes_with=["g3"],
+                deprecates=["g4"],
+            )
+        }
+    )
+    v = g.validate()
+    assert not v.ok  # the missing requires target g1 is a hard error
+    assert v.missing_requires == [("a", "g1")]
+    warned = {(s, e, t) for (s, e, t) in v.missing_warnings}
+    assert ("a", "conflicts-with", "g2") in warned
+    assert ("a", "composes-with", "g3") in warned
+    assert ("a", "deprecates", "g4") in warned
+    # The merged view still exposes everything.
+    assert ("a", "requires", "g1") in v.missing_targets
+
+
+def test_legacy_related_skills_missing_is_only_a_warning():
+    # related_skills folds into composes-with; a dangling legacy ref must NOT
+    # break validation of a default profile (the 16-dangling-refs case in the
+    # real bundled skills).
+    g = SkillGraph.from_frontmatters(
+        [("a", {"metadata": {"hermes": {"related_skills": ["not-bundled"]}}})]
+    )
+    v = g.validate()
+    assert v.ok
+    assert ("a", "composes-with", "not-bundled") in v.missing_warnings
+
+
+# ── Deprecation chains ──────────────────────────────────────────────────────
+
+
+def test_deprecation_chain_validates():
+    # v3 deprecates v2 deprecates v1 — a governance chain, all valid.
+    g = _graph(
+        {
+            "tool-v3": _fm(deprecates=["tool-v2"]),
+            "tool-v2": _fm(deprecates=["tool-v1"]),
+            "tool-v1": {},
+        }
+    )
+    v = g.validate()
+    assert v.ok
+    assert g.edges_of("tool-v3")["deprecates"] == ["tool-v2"]
+    assert g.edges_of("tool-v2")["deprecates"] == ["tool-v1"]
+
+
+# ── Blast radius ────────────────────────────────────────────────────────────
+
+
+def test_blast_dependents_transitive():
+    # base <- mid <- app  (who depends on base?)
+    g = _graph(
+        {
+            "app": _fm(requires=["mid"]),
+            "mid": _fm(requires=["base"]),
+            "base": {},
+        }
+    )
+    blast = g.blast("base")
+    assert blast["dependents"] == ["app", "mid"]
+    # Changing the leaf affects nobody.
+    assert g.blast("app")["dependents"] == []
+
+
+def test_blast_conflicts_both_directions():
+    g = _graph(
+        {
+            "a": _fm(conflicts_with=["b"]),
+            "b": {},
+            "c": _fm(conflicts_with=["a"]),
+        }
+    )
+    blast = g.blast("a")
+    assert blast["conflicts"] == ["b", "c"]
+
+
+def test_blast_composes_direct_partners():
+    g = _graph({"a": _fm(composes_with=["b", "c"]), "b": {}, "c": {}})
+    assert g.blast("a")["composes"] == ["b", "c"]
+
+
+def test_blast_unknown_skill_raises():
+    g = _graph({"a": {}})
+    with pytest.raises(KeyError):
+        g.blast("nope")
+
+
+# ── Topological order ───────────────────────────────────────────────────────
+
+
+def test_topological_order_full_graph():
+    g = _graph(
+        {
+            "app": _fm(requires=["lib"]),
+            "lib": _fm(requires=["core"]),
+            "core": {},
+            "standalone": {},
+        }
+    )
+    order = g.topological_order()
+    assert set(order) == {"app", "lib", "core", "standalone"}
+    assert order.index("core") < order.index("lib") < order.index("app")
+
+
+def test_topological_order_deterministic():
+    spec = {"a": _fm(requires=["b"]), "b": {}, "c": {}}
+    g1 = _graph(spec)
+    g2 = _graph(spec)
+    assert g1.topological_order() == g2.topological_order()
+
+
+def test_topological_order_complete_even_with_cycle():
+    g = _graph(
+        {
+            "a": _fm(requires=["b"]),
+            "b": _fm(requires=["a"]),
+            "c": {},
+        }
+    )
+    order = g.topological_order()
+    assert sorted(order) == ["a", "b", "c"]
+
+
+# ── DOT rendering ───────────────────────────────────────────────────────────
+
+
+def test_to_dot_contains_nodes_and_edges():
+    g = _graph(
+        {
+            "a": _fm(requires=["b"], conflicts_with=["c"]),
+            "b": {},
+            "c": {},
+        }
+    )
+    dot = g.to_dot()
+    assert dot.startswith("digraph skills {")
+    assert dot.rstrip().endswith("}")
+    assert '"a";' in dot
+    assert '"a" -> "b" [label="requires"];' in dot
+    assert 'conflicts-with' in dot
+
+
+def test_to_dot_conflict_rendered_once():
+    g = _graph({"a": _fm(conflicts_with=["b"]), "b": _fm(conflicts_with=["a"])})
+    dot = g.to_dot()
+    # Undirected conflict pair should appear exactly once.
+    assert dot.count('label="conflicts-with"') == 1
+
+
+# ── from_skills_dirs + skill_relationships wiring ───────────────────────────
+
+
+def _write_skill(skills_dir: Path, category: str, name: str, graph_block: str = ""):
+    d = skills_dir / category / name
+    d.mkdir(parents=True, exist_ok=True)
+    fm_graph = f"\n    graph:\n{graph_block}" if graph_block else ""
+    (d / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: test skill {name}
+metadata:
+  hermes:
+    tags: [test]{fm_graph}
+---
+
+# {name}
+""",
+        encoding="utf-8",
+    )
+    return d
+
+
+def test_from_skills_dirs_scans_and_extracts(tmp_path):
+    skills = tmp_path / "skills"
+    _write_skill(
+        skills,
+        "cat",
+        "app",
+        graph_block="      requires: [lib]\n      conflicts-with: [other]",
+    )
+    _write_skill(skills, "cat", "lib")
+    _write_skill(skills, "cat", "other")
+
+    g = SkillGraph.from_skills_dirs([skills])
+    assert set(g.names()) == {"app", "lib", "other"}
+    assert g.edges_of("app")["requires"] == ["lib"]
+    assert g.edges_of("app")["conflicts-with"] == ["other"]
+    assert g.closure("app") == ["lib", "app"]
+    v = g.validate()
+    assert v.ok
+    assert v.conflicts == [("app", "other")]
+
+
+def test_from_skills_dirs_missing_dir_is_empty():
+    g = SkillGraph.from_skills_dirs([Path("/nonexistent/skills/dir/xyz")])
+    assert len(g) == 0
+    assert g.validate().ok
+
+
+def test_skill_relationships_tool_over_real_dir(tmp_path, monkeypatch):
+    """End-to-end: the tools.skills_tool.skill_relationships agent surface."""
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
+    _write_skill(skills, "cat", "lib")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+
+    import tools.skills_tool as mod
+
+    importlib.reload(mod)
+    # SKILLS_DIR is resolved at import time from HERMES_HOME.
+    monkeypatch.setattr(mod, "SKILLS_DIR", skills)
+
+    # Whole-graph mode.
+    whole = json.loads(mod.skill_relationships())
+    assert whole["success"] is True
+    assert whole["skill_count"] == 2
+    assert whole["validation"]["ok"] is True
+    assert whole["topological_order"].index("lib") < whole[
+        "topological_order"
+    ].index("app")
+
+    # Single-skill mode.
+    one = json.loads(mod.skill_relationships("app"))
+    assert one["success"] is True
+    assert one["skill"] == "app"
+    assert one["edges"]["requires"] == ["lib"]
+    assert one["closure"] == ["lib", "app"]
+    assert one["blast_radius"] == {
+        "dependents": [],
+        "conflicts": [],
+        "composes": [],
+    }
+
+    # Unknown skill mode.
+    miss = json.loads(mod.skill_relationships("ghost"))
+    assert miss["success"] is False
+    assert "not found" in miss["error"]
+
+    # Reload again so other tests get a clean module bound to the real HERMES_HOME.
+    monkeypatch.undo()
+    importlib.reload(mod)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -42,16 +42,30 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     metadata:                     # Optional, arbitrary key-value (agentskills.io)
       hermes:
         tags: [fine-tuning, llm]
-        related_skills: [peft, lora]
+        related_skills: [peft, lora]   # folded into graph.composes-with
+        graph:                         # Optional — Skills-as-Graph (AIP) edges
+          requires: [base-skill]       #   hard prerequisites (loaded transitively)
+          conflicts-with: [other]      #   cannot be co-loaded with these
+          composes-with: [partner]     #   canonical composition partners
+          deprecates: [old-skill]      #   supersedes these (governance)
     ---
 
     # Skill Title
 
     Full instructions and content here...
 
+Skill graph (issue #246): the four typed edges under metadata.hermes.graph form
+a dependency/composition/governance graph over skills. ``requires`` is a hard
+prerequisite (a missing or cyclic ``requires`` is a validation error); the other
+three are advisory/governance edges (a missing target is a warning only, since it
+may reference a skill in another profile or plugin). The legacy ``related_skills``
+list is folded into ``composes-with`` for backward compatibility. Query it via the
+``skill_relationships`` tool or ``agent.skill_graph.SkillGraph``.
+
 Available tools:
 - skills_list: List skills with metadata (progressive disclosure tier 1)
 - skill_view: Load full skill content (progressive disclosure tier 2-3)
+- skill_relationships: Inspect the skill graph — edges, requires-closure, blast radius
 
 Usage:
     from tools.skills_tool import skills_list, skill_view, check_skills_requirements
@@ -796,6 +810,78 @@ def skills_search(query: str, limit: int = 5) -> str:
                 "skills": results,
                 "count": len(results),
                 "hint": "Use skill_view(name) to load full content for a relevant skill",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return tool_error(str(e), success=False)
+
+
+# ── Skill graph (AIP) ──────────────────────────────────────────────────────
+
+
+def _build_skill_graph():
+    """Build a :class:`SkillGraph` over every scanned skills directory.
+
+    Uses the same directory set the registry scans (local ``~/.hermes/skills``
+    first, then configured external dirs) so graph queries see exactly the
+    skills the agent could load.
+    """
+    from agent.skill_graph import SkillGraph
+    from agent.skill_utils import get_external_skills_dirs
+
+    dirs = []
+    if SKILLS_DIR.exists():
+        dirs.append(SKILLS_DIR)
+    dirs.extend(get_external_skills_dirs())
+    return SkillGraph.from_skills_dirs(dirs)
+
+
+def skill_relationships(name: str = None) -> str:
+    """Report the dependency/composition/governance graph around skill(s).
+
+    With *name*: returns that skill's declared edges, its transitive
+    ``requires`` closure (the minimal set to load it), and its blast radius
+    (dependents / conflicts / composition partners).  Without *name*: validates
+    the whole graph (missing edge targets, ``requires`` cycles, conflicts) and
+    returns the dependency-first topological order.
+
+    Returns a JSON string.  This is the agent-facing surface of the
+    Skills-as-Graph layer (issue #246, first increment).
+    """
+    try:
+        graph = _build_skill_graph()
+        validation = graph.validate()
+
+        if name:
+            if name not in graph:
+                suggestions = _suggest_skill_names(name, graph.names())
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"Skill '{name}' not found in the skill graph.",
+                        "suggestions": suggestions,
+                    },
+                    ensure_ascii=False,
+                )
+            return json.dumps(
+                {
+                    "success": True,
+                    "skill": name,
+                    "edges": graph.edges_of(name),
+                    "closure": graph.closure(name),
+                    "blast_radius": graph.blast(name),
+                    "graph_ok": validation.ok,
+                },
+                ensure_ascii=False,
+            )
+
+        return json.dumps(
+            {
+                "success": True,
+                "skill_count": len(graph),
+                "validation": validation.as_dict(),
+                "topological_order": graph.topological_order(),
             },
             ensure_ascii=False,
         )
@@ -1728,6 +1814,21 @@ SKILLS_SEARCH_SCHEMA = {
     },
 }
 
+SKILL_RELATIONSHIPS_SCHEMA = {
+    "name": "skill_relationships",
+    "description": "Inspect the skill dependency/composition graph (AIP). With a skill name: returns its declared edges (requires / conflicts-with / composes-with / deprecates), its transitive 'requires' closure (the minimal set to load it), and its blast radius (dependents, conflicts, composition partners). Without a name: validates the whole graph (missing targets, requires-cycles, conflicts) and returns the dependency-first load order.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "OPTIONAL: skill name to inspect. Omit to validate and order the whole graph.",
+            }
+        },
+        "required": [],
+    },
+}
+
 registry.register(
     name="skills_search",
     toolset="skills",
@@ -1737,4 +1838,12 @@ registry.register(
     ),
     check_fn=check_skills_requirements,
     emoji="🔎",
+)
+registry.register(
+    name="skill_relationships",
+    toolset="skills",
+    schema=SKILL_RELATIONSHIPS_SCHEMA,
+    handler=lambda args, **kw: skill_relationships(name=args.get("name")),
+    check_fn=check_skills_requirements,
+    emoji="🕸️",
 )


### PR DESCRIPTION
First increment of the Skills-as-Graph (AIP) layer described in #246 — a pure-Python typed graph over the existing skill registry, with composition/dependency/governance queries. No new runtime dependencies, no agent behaviour change, fully backward compatible.

## Implemented

- **`agent/skill_graph.py`** — `SkillGraph` built on the existing `agent/skill_utils.py` scanning layer:
  - Models the four AIP edge types from `metadata.hermes.graph`: `requires`, `conflicts-with`, `composes-with`, `deprecates`.
  - Backward-compat: the legacy `metadata.hermes.related_skills` list is folded into `composes-with`, so the graph has real edges across ~40 bundled skills on day one.
  - `from_skills_dirs()` (scans `SKILL.md`) and `from_frontmatters()` (in-memory) constructors.
  - `validate()` — **errors** (drive `ok=False`): missing `requires` target, `requires` cycle. **Warnings** (do not affect `ok`): missing target on a soft edge (`composes-with`/`conflicts-with`/`deprecates`, which may reference a skill in another profile or plugin), and declared `conflicts-with` pairs.
  - `closure(name)` — transitive `requires` closure, dependency-first order.
  - `blast(name)` — every affected skill: transitive `dependents`, `conflicts`, direct `composes` partners.
  - `topological_order()` — full dependency-first load order (cycle-tolerant).
  - `to_dot()` — Graphviz DOT with per-edge-type styling.
- **`tools/skills_tool.py`** — `skill_relationships` tool (registered in the `skills` toolset; the real agent-facing call site) + frontmatter schema docs for `metadata.hermes.graph`.
- **`tests/tools/test_skill_graph.py`** — 37 tests covering empty graph, single/multi-hop closure, diamond dedup, cycle detection (incl. self- and 3-node), conflict detection, deprecation chains, blast radius, missing-target severity split, topo order, DOT rendering, `related_skills` folding, and an end-to-end `skill_relationships` run over a real on-disk skills dir.

## Verification

- `uv run --extra dev python -m pytest tests/tools/test_skill_graph.py -q` → **37 passed**.
- Regression: `tests/tools/test_skill_usage.py tests/tools/test_skill_view_traversal.py tests/test_plugin_skills.py` → **79 passed**.
- `uv run --extra dev ruff check agent/skill_graph.py tools/skills_tool.py tests/tools/test_skill_graph.py` → **All checks passed**.
- Validated against the **81 real bundled skills**: `ok=True`, **zero errors**, 16 dangling legacy soft references surfaced as warnings (they resolve to `optional-skills/` or `plugins/`). This satisfies success criterion #1 ("`graph check` returns zero errors on every existing profile") without papering over the data-quality signal.
- Design decision (severity split by edge type) cross-checked with an independent AI advisor (Gemini via consilium) — confirmed: `requires` is a closed-world binding constraint (error), the other edges are open-world advisories (warning).

## Deferred (not in this increment)

- `hermes skills graph {show,check,closure,blast}` CLI subcommands (the query engine + agent tool are done; the CLI wrapper is the remaining surface).
- Evolution-pipeline hook (run `graph check` / `graph blast` in the `evolution-issues` analysis stage).
- CI/registry "strict" mode that promotes missing soft-edge targets to errors and a `conflicts-with` typo fuzzy-match check (advisor blind-spot note).
- `docs/skills.md` worked-examples page (schema is documented inline in `skills_tool.py`; no such doc file exists yet).

This is a **first increment**, not a full close of #246.
