### PR TITLE
Tool Search progressive disclosure for native tool sets (first increment of #229)

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -82,6 +82,31 @@ class TestConfigParsing:
         assert cfg.max_search_limit == 50
         assert cfg.search_default_limit <= cfg.max_search_limit
 
+    def test_defer_core_toolsets_default_empty(self):
+        from tools.tool_search import ToolSearchConfig
+        assert ToolSearchConfig.from_raw(None).defer_core_toolsets == frozenset()
+        assert ToolSearchConfig.from_raw({"enabled": "on"}).defer_core_toolsets == frozenset()
+
+    def test_defer_core_toolsets_list_form(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({"defer_core_toolsets": ["browser", "tts"]})
+        assert cfg.defer_core_toolsets == frozenset({"browser", "tts"})
+
+    def test_defer_core_toolsets_comma_string_form(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({"defer_core_toolsets": "browser, tts ,"})
+        assert cfg.defer_core_toolsets == frozenset({"browser", "tts"})
+
+    def test_defer_core_toolsets_garbage_is_dropped(self):
+        """A malformed entry must never crash assembly — non-strings are dropped."""
+        from tools.tool_search import ToolSearchConfig, _parse_toolset_list
+        assert _parse_toolset_list(123) == frozenset()
+        assert _parse_toolset_list({"a": 1}) == frozenset()
+        assert _parse_toolset_list([1, "tts", None, ""]) == frozenset({"tts"})
+        # And the full path tolerates it too.
+        cfg = ToolSearchConfig.from_raw({"defer_core_toolsets": 123})
+        assert cfg.defer_core_toolsets == frozenset()
+
 
 # ---------------------------------------------------------------------------
 # Classification — the hard invariant: core tools NEVER defer.
@@ -126,6 +151,178 @@ class TestClassification:
         names = {(td.get("function") or {}).get("name") for td in visible}
         assert "xx_unknown_tool" in names
         assert deferrable == []
+
+
+# ---------------------------------------------------------------------------
+# Config-driven deferral of native (core) tool sets — issue #229 increment.
+#
+# By default core tools never defer. An operator can opt a *native* toolset
+# in to progressive disclosure via tools.tool_search.defer_core_toolsets;
+# those core tools then behave like any other deferrable tool. The hard
+# invariant is that assembly-time classification and dispatch/scope-time
+# validation agree (effective_core_tool_names is the single source of truth),
+# so an opted-in core tool deferred from the visible array is always callable
+# back through the bridge — never a silent dropout.
+# ---------------------------------------------------------------------------
+
+
+class TestCoreToolsetDeferral:
+    # The browser toolset is a representative native tool set: ~10 core
+    # browser_* tools, reliably present in the default tool definitions,
+    # and a real candidate for deferral (a coding/chat session that rarely
+    # browses pays all ~10 schemas every turn).
+    _DEMO_TOOLSET = "browser"
+    _DEMO_TOOL = "browser_click"
+    _PROTECTED_TOOL = "terminal"  # core, in a different toolset — must stay direct.
+
+    @pytest.fixture(autouse=True)
+    def _populate_registry(self):
+        """is_deferrable_tool_name resolves the tool via the live registry, so
+        the tool modules must be imported/registered first — exactly as they
+        are at runtime before any assembly. Importing model_tools and pulling
+        the definitions once triggers registration."""
+        import model_tools
+        model_tools.get_tool_definitions(quiet_mode=True, skip_tool_search_assembly=True)
+
+    def _cfg(self, **over):
+        from tools.tool_search import ToolSearchConfig
+        raw = {"enabled": "on", "defer_core_toolsets": [self._DEMO_TOOLSET]}
+        raw.update(over)
+        return ToolSearchConfig.from_raw(raw)
+
+    def test_effective_core_unchanged_by_default(self):
+        from tools.tool_search import (
+            effective_core_tool_names, _hermes_core_tools, ToolSearchConfig,
+        )
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        assert effective_core_tool_names(cfg) == _hermes_core_tools()
+
+    def test_effective_core_subtracts_opted_in_toolset(self):
+        from tools.tool_search import effective_core_tool_names, _hermes_core_tools
+        raw_core = _hermes_core_tools()
+        # Pre-condition: the demo tool is genuinely a core tool.
+        assert self._DEMO_TOOL in raw_core
+        eff = effective_core_tool_names(self._cfg())
+        assert self._DEMO_TOOL not in eff, (
+            "opted-in core toolset member must drop out of the never-defer set"
+        )
+        # An unrelated core tool stays protected.
+        assert self._PROTECTED_TOOL in eff
+
+    def test_opted_in_core_tool_is_deferrable(self):
+        from tools.tool_search import is_deferrable_tool_name
+        assert is_deferrable_tool_name(self._DEMO_TOOL, self._cfg())
+        # Default config: still never deferrable.
+        from tools.tool_search import ToolSearchConfig
+        assert not is_deferrable_tool_name(
+            self._DEMO_TOOL, ToolSearchConfig.from_raw({"enabled": "on"})
+        )
+
+    def test_protected_core_tool_never_deferrable_even_when_opting_browser(self):
+        from tools.tool_search import is_deferrable_tool_name
+        assert not is_deferrable_tool_name(self._PROTECTED_TOOL, self._cfg())
+
+    def test_classify_defers_opted_in_native_toolset(self):
+        import model_tools
+        from tools.tool_search import classify_tools
+        defs = model_tools.get_tool_definitions(
+            quiet_mode=True, skip_tool_search_assembly=True,
+        ) or []
+        visible, deferrable = classify_tools(defs, self._cfg())
+        deferred_names = {(td.get("function") or {}).get("name") for td in deferrable}
+        visible_names = {(td.get("function") or {}).get("name") for td in visible}
+        browser_deferred = {n for n in deferred_names if n.startswith("browser_")}
+        # The browser toolset registers ~9-12 browser_* tools depending on
+        # which are gated on/off in the environment; the mechanism is proven
+        # by deferring the whole native set, not by an exact count.
+        assert len(browser_deferred) >= 5, (
+            f"expected the native browser toolset deferred, got {sorted(browser_deferred)}"
+        )
+        # Protected core tool stays in the visible array.
+        assert self._PROTECTED_TOOL in visible_names
+
+    def test_assembly_defers_native_toolset_and_reports_savings(self):
+        """assemble_tool_defs both defers the opted-in native tools AND reports
+        the token savings (deferred_tokens) so the win can be measured."""
+        import model_tools
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+        defs = model_tools.get_tool_definitions(
+            quiet_mode=True, skip_tool_search_assembly=True,
+        ) or []
+        baseline = assemble_tool_defs(
+            defs, context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        opted = assemble_tool_defs(defs, context_length=200_000, config=self._cfg())
+        # Opting browser in must add browser_* to the deferred count and
+        # the measured deferred-token total grows accordingly.
+        assert opted.deferred_count > baseline.deferred_count
+        assert opted.deferred_tokens > baseline.deferred_tokens
+        result_names = {(td.get("function") or {}).get("name") for td in opted.tool_defs}
+        # The deferred browser tools are no longer in the model-visible array.
+        assert not any(n.startswith("browser_") for n in result_names)
+        # Protected core tool is still visible.
+        assert self._PROTECTED_TOOL in result_names
+
+    def test_roundtrip_invariant_opted_in_core_tool_is_callable_back(self):
+        """The OpenClaw silent-dropout guard for opted-in core tools: a tool
+        deferred from the visible array MUST be in the scoped deferrable set,
+        resolvable via tool_call, and describable via tool_describe."""
+        import model_tools
+        from tools.tool_search import (
+            scoped_deferrable_names, resolve_underlying_call, dispatch_tool_describe,
+        )
+        cfg = self._cfg()
+        defs = model_tools.get_tool_definitions(
+            quiet_mode=True, skip_tool_search_assembly=True,
+        ) or []
+        scope = scoped_deferrable_names(defs, cfg)
+        assert self._DEMO_TOOL in scope
+        name, _args, err = resolve_underlying_call(
+            {"name": self._DEMO_TOOL, "arguments": {}}, cfg,
+        )
+        assert err is None and name == self._DEMO_TOOL
+        described = json.loads(
+            dispatch_tool_describe(
+                {"name": self._DEMO_TOOL}, current_tool_defs=defs, config=cfg,
+            )
+        )
+        assert "parameters" in described
+
+    def test_default_config_keeps_native_tool_direct(self):
+        """The inverse of the round-trip: with no opt-in, the core tool stays
+        direct and the bridge refuses to resolve it (use it directly)."""
+        from tools.tool_search import ToolSearchConfig, resolve_underlying_call
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        _name, _args, err = resolve_underlying_call(
+            {"name": self._DEMO_TOOL, "arguments": {}}, cfg,
+        )
+        assert err is not None
+        assert "not a deferrable" in err
+
+    def test_naming_non_core_toolset_is_a_noop(self):
+        """Opting in a toolset with no core members changes nothing — those
+        tools were already deferrable (or non-existent)."""
+        from tools.tool_search import effective_core_tool_names, _hermes_core_tools, ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(
+            {"enabled": "on", "defer_core_toolsets": ["xx_no_such_toolset"]}
+        )
+        assert effective_core_tool_names(cfg) == _hermes_core_tools()
+
+    def test_opted_in_core_tool_deferrable_without_registry_entry(self, monkeypatch):
+        """Registry-timing invariant: an opted-in core tool stays deferrable
+        even if the registry has no entry for it at the exact moment of the
+        check. Otherwise a transient registry gap would flip the tool to
+        'not deferrable' at dispatch and make it uncallable through the bridge
+        (silent dropout). The tool's membership in _HERMES_CORE_TOOLS is
+        authoritative — no registry round-trip required."""
+        import tools.tool_search as ts
+        from tools.registry import registry
+        # Force the registry lookup to behave as if the tool isn't registered.
+        monkeypatch.setattr(registry, "get_entry", lambda _name: None)
+        assert ts.is_deferrable_tool_name(self._DEMO_TOOL, self._cfg())
+        # The same gap leaves a non-opted-in core tool firmly NOT deferrable.
+        assert not ts.is_deferrable_tool_name(self._PROTECTED_TOOL, self._cfg())
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -68,6 +68,11 @@ class ToolSearchConfig:
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
     search_default_limit: int
     max_search_limit: int
+    # Native (core) toolsets the operator has opted in to progressive
+    # disclosure. Empty by default — core tools never defer unless their
+    # toolset name appears here. See ``effective_core_tool_names`` for how
+    # this subtracts opted-in core tools from the never-defer set.
+    defer_core_toolsets: frozenset[str] = frozenset()
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -111,7 +116,26 @@ class ToolSearchConfig:
             threshold_pct=threshold_pct,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            defer_core_toolsets=_parse_toolset_list(raw.get("defer_core_toolsets")),
         )
+
+
+def _parse_toolset_list(value: Any) -> frozenset[str]:
+    """Coerce a raw config value into a frozenset of toolset names.
+
+    Accepts a list of strings or a single comma-separated string. Non-string
+    members and blanks are dropped so a malformed entry can't crash assembly.
+    """
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        items = list(value)
+    else:
+        return frozenset()
+    names = {str(item).strip() for item in items if isinstance(item, str) and str(item).strip()}
+    return frozenset(names)
 
 
 def _safe_int(value: Any, fallback: int) -> int:
@@ -147,8 +171,8 @@ def load_config() -> ToolSearchConfig:
 # ---------------------------------------------------------------------------
 
 
-def _core_tool_names() -> frozenset[str]:
-    """Return the set of tool names that must NEVER be deferred.
+def _hermes_core_tools() -> frozenset[str]:
+    """Return the raw ``_HERMES_CORE_TOOLS`` set, unfiltered by config.
 
     Imported lazily because ``toolsets`` imports from ``tools.registry``
     and we don't want a hard cycle.
@@ -160,18 +184,92 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def _core_tools_in_toolsets(toolset_names: frozenset[str]) -> frozenset[str]:
+    """Return the core tools that belong to any of ``toolset_names``.
+
+    A core tool "belongs to" a toolset if the static ``TOOLSETS`` mapping or
+    the live registry places it there. Resolved against both so an operator
+    can name either a static toolset (e.g. ``image_gen``) or a registry
+    toolset. Only names that are actually in ``_HERMES_CORE_TOOLS`` are
+    returned — naming a non-core toolset is a no-op (those tools are already
+    deferrable by default).
+    """
+    if not toolset_names:
+        return frozenset()
+    core = _hermes_core_tools()
+    if not core:
+        return frozenset()
+    members: set[str] = set()
+    try:
+        from toolsets import resolve_toolset
+    except Exception:
+        resolve_toolset = None
+    try:
+        from tools.registry import registry
+    except Exception:
+        registry = None
+    for ts in toolset_names:
+        if resolve_toolset is not None:
+            try:
+                members.update(resolve_toolset(ts))
+            except Exception:
+                pass
+        if registry is not None:
+            try:
+                members.update(registry.get_tool_names_for_toolset(ts))
+            except Exception:
+                pass
+    return frozenset(members & core)
+
+
+def effective_core_tool_names(config: Optional[ToolSearchConfig] = None) -> frozenset[str]:
+    """Return the set of tool names that must NEVER be deferred.
+
+    Starts from ``_HERMES_CORE_TOOLS`` and subtracts any core tool whose
+    toolset the operator opted in to progressive disclosure via
+    ``tools.tool_search.defer_core_toolsets``. This is the single source of
+    truth consulted by ``is_deferrable_tool_name``, so assembly-time
+    classification and dispatch/scope-time validation always agree — a core
+    tool deferred at assembly is callable back via the bridge, and one that
+    is not deferred is rejected by the bridge. Mismatch here is exactly the
+    OpenClaw silent-dropout class of bug.
+    """
+    core = _hermes_core_tools()
+    if config is None:
+        config = load_config()
+    opted_in = _core_tools_in_toolsets(config.defer_core_toolsets)
+    if not opted_in:
+        return core
+    return frozenset(core - opted_in)
+
+
+def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
     A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    OR it is not in the *effective* core set. Core tools are never deferred
+    (this protects against accidental shadowing) unless their toolset is
+    explicitly opted in via ``defer_core_toolsets``.
+
+    ``config`` is resolved from the user config when omitted so the
+    no-config call sites (bridge dispatch, scope validation) stay in sync
+    with assembly-time classification.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
+    if config is None:
+        config = load_config()
+    if name in effective_core_tool_names(config):
         return False
+    # An opted-in core tool is a *known* real tool (it is in
+    # _HERMES_CORE_TOOLS, just excluded from the effective never-defer set).
+    # Treat it as deferrable directly rather than re-resolving it through the
+    # registry: that keeps the assembly/dispatch decision invariant under
+    # transient registry state (a core tool that is unregistered at the exact
+    # moment of a dispatch check would otherwise flip to "not deferrable" and
+    # become uncallable through the bridge — a silent dropout).
+    if name in _hermes_core_tools():
+        return True
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
@@ -186,13 +284,19 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
-    every core tool, plus any tool we can't classify. ``deferrable`` is the
-    candidate set for catalog entry.
+    every effective-core tool, plus any tool we can't classify. ``deferrable``
+    is the candidate set for catalog entry. ``config`` is resolved from the
+    user config when omitted.
     """
+    if config is None:
+        config = load_config()
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
     for td in tool_defs:
@@ -202,7 +306,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, config):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -551,7 +655,7 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(incoming, config)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
@@ -619,7 +723,7 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
@@ -631,19 +735,22 @@ def dispatch_tool_search(args: Dict[str, Any],
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           config: Optional[ToolSearchConfig] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
+    if config is None:
+        config = load_config()
     name = str(args.get("name") or "").strip()
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, config):
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
                 "already, call it directly; otherwise check the spelling against tool_search."
             ),
         }, ensure_ascii=False)
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -657,7 +764,10 @@ def dispatch_tool_describe(args: Dict[str, Any],
     }, ensure_ascii=False)
 
 
-def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
+def scoped_deferrable_names(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> frozenset[str]:
     """Return the set of deferrable tool names present in ``tool_defs``.
 
     ``tool_defs`` is expected to be the *pre-assembly* tool list for the
@@ -668,16 +778,25 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     scoping gate by both the ``model_tools`` bridge dispatch and the
     ``tool_executor`` unwrap so a restricted-toolset session can never invoke
     an out-of-scope tool via the bridge.
+
+    ``config`` is resolved from the user config when omitted so the scope gate
+    sees the same deferred set as assembly (including any opted-in core
+    toolsets).
     """
+    if config is None:
+        config = load_config()
     names: set[str] = set()
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, config):
             names.add(name)
     return frozenset(names)
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any],
+    config: Optional[ToolSearchConfig] = None,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -685,8 +804,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     * the display layer (so the activity feed shows the underlying tool),
     * the trajectory recorder.
 
+    ``config`` is resolved from the user config when omitted so the
+    deferrability check matches assembly-time classification.
+
     On parse error, returns ``(None, {}, error_message)``.
     """
+    if config is None:
+        config = load_config()
     name = str(args.get("name") or "").strip()
     if not name:
         return None, {}, "tool_call requires a 'name' argument"
@@ -702,7 +826,7 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, config):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."
@@ -719,6 +843,7 @@ __all__ = [
     "CatalogEntry",
     "AssemblyResult",
     "load_config",
+    "effective_core_tool_names",
     "is_deferrable_tool_name",
     "classify_tools",
     "estimate_tokens_from_schemas",

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -78,6 +78,7 @@ tools:
     threshold_pct: 10   # percentage of context — only used in auto mode
     search_default_limit: 5
     max_search_limit: 20
+    defer_core_toolsets: []   # native toolsets to also bring under disclosure
 ```
 
 | Key | Default | Meaning |
@@ -86,6 +87,30 @@ tools:
 | `threshold_pct` | `10` | Percentage of context length at which `auto` mode kicks in. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
+| `defer_core_toolsets` | `[]` | Native (core) toolset names to also make eligible for deferral. Empty by default — core tools never defer. See below. |
+
+### Deferring native tool sets
+
+By default only MCP and non-core plugin tools defer; the built-in core set
+is always loaded directly. If a session carries a large native toolset it
+rarely uses on a given turn — for example `browser` (~10 `browser_*` tools)
+in a session that mostly edits code — you can opt that toolset in to
+progressive disclosure:
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto
+    defer_core_toolsets: [browser]
+```
+
+Each named toolset's core tools then behave like any other deferrable tool:
+they leave the model-visible array and are reached through
+`tool_search` → `tool_describe` → `tool_call`, with hooks, guardrails, and
+approvals firing against the real tool name exactly as before. Tools in
+toolsets you do **not** list stay loaded directly. Accepts a YAML list or a
+comma-separated string; naming a toolset that has no core members is a
+no-op.
 
 You can also flip the legacy boolean shape:
 


### PR DESCRIPTION
First increment of #229. Extends the existing Tool Search progressive-disclosure layer (`tools/tool_search.py`) so it can cover **native (core) tool sets**, not just MCP/plugin tools — driven by config, off by default.

## Problem
The always-loaded set was exactly `_HERMES_CORE_TOOLS`; those schemas are paid on every turn regardless of usage. A session carrying a large native toolset it rarely touches (e.g. the ~10 `browser_*` tools in a code-editing session) had no way to defer it. The triage comment scoped the residual as "extend progressive disclosure uniformly to all tool sets + measure token savings — build on `tools/tool_search.py`."

## Implemented
- **New config key** `tools.tool_search.defer_core_toolsets` (list of native toolset names; empty by default). Named toolsets' core tools become eligible for deferral and flow through the existing `tool_search` / `tool_describe` / `tool_call` bridges. Hooks, guardrails, approvals, and the activity-feed unwrap keep firing against the real tool name.
- **`effective_core_tool_names(config)`** is the single source of truth for the never-defer set: `_HERMES_CORE_TOOLS` minus the opted-in core tools. `is_deferrable_tool_name` / `classify_tools` consult it, so assembly-time classification and dispatch/scope-time validation always agree — the OpenClaw silent-dropout invariant holds.
- **Registry-timing hardening:** an opted-in core tool is treated as deferrable directly (it is a known `_HERMES_CORE_TOOLS` member) rather than re-resolved through the live registry, so a transient registry gap can't flip it to "not deferrable" at dispatch and make it uncallable through the bridge. (This fix came out of a peer review of the sync invariant.)
- Config threaded through assemble/dispatch/scope; omitted-config sites fall back to `load_config()` — the same user config assembly reads.
- Docs updated (`website/docs/user-guide/features/tool-search.md`).

## Verification / measuring savings
- `uv run --extra dev python -m pytest tests/tools/test_tool_search.py -q` → **53 passed** (39 pre-existing + 14 new).
- `uv run --extra dev python -m pytest tests/tools/test_tool_search.py tests/test_model_tools.py tests/test_model_tools_async_bridge.py -q` → **91 passed**.
- `uv run --extra dev ruff check tools/tool_search.py tests/tools/test_tool_search.py` → clean.
- **Token savings are measurable** via the existing `AssemblyResult.deferred_tokens` / `deferred_count`. A test (`test_assembly_defers_native_toolset_and_reports_savings`) asserts both grow when a native set is opted in vs the baseline.
- New tests also lock the round-trip callability invariant (a deferred core tool is searchable, describable, and callable back), the registry-timing invariant, and that default behavior is byte-identical (empty list ⇒ effective core == raw core).

## Deferred (intentionally, this is a first increment)
- **No blanket sweep** of every native set under disclosure — that is a UX/quality decision (the model loses sight of its primary toolkit) that warrants its own evaluation. This PR provides the safe, config-driven lever to opt sets in one at a time, plus the measurement hook.
- **Skill instructions** (issue mentions "skills") are not touched — separate surface, separate disclosure mechanism.
- The accuracy success-criterion (synthetic multi-tool selection benchmark) is not added here; this increment proves the mechanism + savings measurement on a representative native toolset (`browser`).

Default-off, additive, self-contained.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>