### PR TITLE
Closes #254

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -26,6 +26,7 @@ from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
     format_duration_compact,
+    format_token_count_compact,
     has_known_pricing,
 )
 
@@ -115,6 +116,7 @@ class InsightsEngine:
         # Gather raw data
         sessions = self._get_sessions(cutoff, source)
         tool_usage = self._get_tool_usage(cutoff, source)
+        per_session_tool_usage = self._get_per_session_tool_usage(cutoff, source)
         skill_usage = self._get_skill_usage(cutoff, source)
         message_stats = self._get_message_stats(cutoff, source)
 
@@ -127,6 +129,14 @@ class InsightsEngine:
                 "models": [],
                 "platforms": [],
                 "tools": [],
+                "tool_costs": [],
+                "subagents": {
+                    "subagent_sessions": 0,
+                    "total_cost": 0.0,
+                    "total_tokens": 0,
+                    "by_model": [],
+                },
+                "cost_attribution": self.COST_ATTRIBUTION_METHOD,
                 "skills": {
                     "summary": {
                         "total_skill_loads": 0,
@@ -145,6 +155,10 @@ class InsightsEngine:
         models = self._compute_model_breakdown(sessions)
         platforms = self._compute_platform_breakdown(sessions)
         tools = self._compute_tool_breakdown(tool_usage)
+        tool_costs = self._compute_tool_cost_attribution(
+            sessions, per_session_tool_usage
+        )
+        subagents = self._compute_subagent_cost_attribution(sessions)
         skills = self._compute_skill_breakdown(skill_usage)
         activity = self._compute_activity_patterns(sessions)
         top_sessions = self._compute_top_sessions(sessions)
@@ -158,9 +172,113 @@ class InsightsEngine:
             "models": models,
             "platforms": platforms,
             "tools": tools,
+            "tool_costs": tool_costs,
+            "subagents": subagents,
+            "cost_attribution": self.COST_ATTRIBUTION_METHOD,
             "skills": skills,
             "activity": activity,
             "top_sessions": top_sessions,
+        }
+
+    def cost_breakdown(
+        self, days: int = 30, source: str = None, limit: int = 20
+    ) -> Dict[str, Any]:
+        """Per-session spend plus per-tool and per-subagent cost attribution.
+
+        Powers ``hermes sessions cost``. Reuses the same data-gathering and
+        attribution helpers as :meth:`generate` so the figures stay consistent
+        with ``/insights``.
+
+        Args:
+            days: Look-back window in days.
+            source: Optional platform filter.
+            limit: Max number of per-session rows to return (highest spend
+                first); ``0`` or negative returns all rows.
+
+        Returns:
+            Dict with ``sessions`` (per-session spend rows), ``tool_costs``,
+            ``subagents``, ``totals``, and the ``cost_attribution`` method tag.
+        """
+        cutoff = time.time() - (days * 86400)
+        sessions = self._get_sessions(cutoff, source)
+
+        if not sessions:
+            return {
+                "days": days,
+                "source_filter": source,
+                "empty": True,
+                "cost_attribution": self.COST_ATTRIBUTION_METHOD,
+                "sessions": [],
+                "tool_costs": [],
+                "subagents": {
+                    "subagent_sessions": 0,
+                    "total_cost": 0.0,
+                    "total_tokens": 0,
+                    "by_model": [],
+                },
+                "totals": {
+                    "estimated_cost": 0.0,
+                    "actual_cost": 0.0,
+                    "total_sessions": 0,
+                },
+            }
+
+        per_session_tool_usage = self._get_per_session_tool_usage(cutoff, source)
+
+        session_rows: List[Dict[str, Any]] = []
+        total_estimated = 0.0
+        total_actual = 0.0
+        for s in sessions:
+            estimated, status = _estimate_cost(s)
+            actual = s.get("actual_cost_usd") or 0.0
+            total_estimated += estimated
+            total_actual += actual
+            model = s.get("model") or "unknown"
+            display_model = model.split("/")[-1] if "/" in model else model
+            tokens = (
+                (s.get("input_tokens") or 0)
+                + (s.get("output_tokens") or 0)
+                + (s.get("cache_read_tokens") or 0)
+                + (s.get("cache_write_tokens") or 0)
+            )
+            session_rows.append({
+                "session_id": s["id"],
+                "source": s.get("source") or "unknown",
+                "model": display_model,
+                "is_subagent": (s.get("source") or "") == "subagent",
+                "parent_session_id": s.get("parent_session_id"),
+                "input_tokens": s.get("input_tokens") or 0,
+                "output_tokens": s.get("output_tokens") or 0,
+                "total_tokens": tokens,
+                "tool_calls": s.get("tool_call_count") or 0,
+                "estimated_cost": estimated,
+                "actual_cost": actual,
+                "cost_status": status,
+                "started_at": s.get("started_at"),
+            })
+
+        session_rows.sort(
+            key=lambda r: (r["estimated_cost"], r["total_tokens"]), reverse=True
+        )
+        if limit and limit > 0:
+            session_rows = session_rows[:limit]
+
+        return {
+            "days": days,
+            "source_filter": source,
+            "empty": False,
+            "generated_at": time.time(),
+            "cost_attribution": self.COST_ATTRIBUTION_METHOD,
+            "sessions": session_rows,
+            "tool_costs": self._compute_tool_cost_attribution(
+                sessions, per_session_tool_usage
+            ),
+            "subagents": self._compute_subagent_cost_attribution(sessions),
+            "totals": {
+                "estimated_cost": total_estimated,
+                "actual_cost": total_actual,
+                "total_sessions": len(sessions),
+            },
         }
 
     # =========================================================================
@@ -168,7 +286,7 @@ class InsightsEngine:
     # =========================================================================
 
     # Columns we actually need (skip system_prompt, model_config blobs)
-    _SESSION_COLS = ("id, source, model, started_at, ended_at, "
+    _SESSION_COLS = ("id, source, model, parent_session_id, started_at, ended_at, "
                      "message_count, tool_call_count, input_tokens, output_tokens, "
                      "cache_read_tokens, cache_write_tokens, billing_provider, "
                      "billing_base_url, billing_mode, estimated_cost_usd, "
@@ -286,6 +404,111 @@ class InsightsEngine:
             {"tool_name": name, "count": count}
             for name, count in tool_counts.most_common()
         ]
+
+    def _get_per_session_tool_usage(
+        self, cutoff: float, source: str = None
+    ) -> Dict[str, Dict[str, Dict[str, int]]]:
+        """Per-session, per-tool call counts and payload-char weights.
+
+        Returns ``{session_id: {tool_name: {"calls": int, "chars": int}}}``.
+
+        ``chars`` is the length of each tool's response payload (the ``content``
+        of its ``role='tool'`` rows). Token usage in agentic loops is dominated
+        by tool outputs re-injected into the prompt, and character length tracks
+        token count closely (~4 chars/token), so payload size is a materially
+        better proxy than a flat call count for splitting a session's spend
+        across the tools it invoked. Where a tool's response content is absent
+        (older gateway rows, or CLI rows where ``tool_name`` is NULL and we fall
+        back to the ``tool_calls`` JSON), the attribution degrades gracefully to
+        call count.
+
+        Mirrors the two-source merge in :meth:`_get_tool_usage` (tool_name on
+        'tool' rows + tool_calls JSON on 'assistant' rows).
+        """
+        # Source 1: explicit tool_name on tool response messages — count and
+        # measure the response payload size per tool.
+        if source:
+            cursor = self._conn.execute(
+                """SELECT m.session_id, m.tool_name,
+                          COUNT(*) as calls,
+                          COALESCE(SUM(LENGTH(m.content)), 0) as chars
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ? AND s.source = ?
+                     AND m.role = 'tool' AND m.tool_name IS NOT NULL
+                   GROUP BY m.session_id, m.tool_name""",
+                (cutoff, source),
+            )
+        else:
+            cursor = self._conn.execute(
+                """SELECT m.session_id, m.tool_name,
+                          COUNT(*) as calls,
+                          COALESCE(SUM(LENGTH(m.content)), 0) as chars
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ?
+                     AND m.role = 'tool' AND m.tool_name IS NOT NULL
+                   GROUP BY m.session_id, m.tool_name""",
+                (cutoff,),
+            )
+        named: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(dict)
+        for row in cursor.fetchall():
+            named[row["session_id"]][row["tool_name"]] = {
+                "calls": row["calls"],
+                "chars": row["chars"] or 0,
+            }
+
+        # Source 2: extract from tool_calls JSON on assistant messages
+        # (covers CLI sessions where tool_name is NULL on tool responses).
+        # Only call counts are available here.
+        if source:
+            cursor2 = self._conn.execute(
+                """SELECT m.session_id, m.tool_calls
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ? AND s.source = ?
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                (cutoff, source),
+            )
+        else:
+            cursor2 = self._conn.execute(
+                """SELECT m.session_id, m.tool_calls
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ?
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                (cutoff,),
+            )
+        from_json: Dict[str, Counter] = defaultdict(Counter)
+        for row in cursor2.fetchall():
+            try:
+                calls = row["tool_calls"]
+                if isinstance(calls, str):
+                    calls = json.loads(calls)
+                if not isinstance(calls, list):
+                    continue
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for call in calls:
+                func = call.get("function", {}) if isinstance(call, dict) else {}
+                name = func.get("name")
+                if name:
+                    from_json[row["session_id"]][name] += 1
+
+        # Merge per session, mirroring _get_tool_usage's max() de-dup so a tool
+        # that appears in both sources is not double-counted.
+        per_session: Dict[str, Dict[str, Dict[str, int]]] = {}
+        for sid in set(named) | set(from_json):
+            named_tools = named.get(sid, {})
+            json_counts = from_json.get(sid, Counter())
+            merged: Dict[str, Dict[str, int]] = {}
+            for tool in set(named_tools) | set(json_counts):
+                named_calls = named_tools.get(tool, {}).get("calls", 0)
+                chars = named_tools.get(tool, {}).get("chars", 0)
+                calls = max(named_calls, json_counts.get(tool, 0))
+                merged[tool] = {"calls": calls, "chars": chars}
+            per_session[sid] = merged
+        return per_session
 
     def _get_skill_usage(self, cutoff: float, source: str = None) -> List[Dict]:
         """Extract per-skill usage from assistant tool calls."""
@@ -553,6 +776,119 @@ class InsightsEngine:
                 "percentage": pct,
             })
         return result
+
+    # =========================================================================
+    # Cost attribution (per-tool, per-subagent)
+    # =========================================================================
+
+    # Per-message token columns are not recorded (the schema only carries
+    # session-level token totals), so an exact per-tool cost is not derivable.
+    # We attribute each session's estimated spend across the tools it invoked,
+    # weighted by each tool's response-payload size (character length, a close
+    # proxy for the tokens that payload contributes when re-injected into the
+    # prompt) and falling back to call count when payload size is unavailable.
+    # Surfaced as ``cost_attribution`` in the report so consumers know the
+    # number is allocated, not measured.
+    COST_ATTRIBUTION_METHOD = "proportional_by_response_chars_fallback_call_count"
+
+    def _compute_tool_cost_attribution(
+        self,
+        sessions: List[Dict],
+        per_session_tool_usage: Dict[str, Dict[str, Dict[str, int]]],
+    ) -> List[Dict]:
+        """Attribute session spend across tools, weighted by payload size.
+
+        Each session's estimated cost is split across the tools it invoked in
+        proportion to a per-tool weight. The weight is the tool's summed
+        response-payload character length; if a session recorded no payload
+        chars at all (e.g. content was stripped, or only ``tool_calls`` JSON is
+        available), that session falls back to weighting by call count so no
+        spend is dropped.
+
+        Returns a ranked list of ``{tool, calls, chars, cost, percentage}``.
+        """
+        tool_cost: Dict[str, float] = defaultdict(float)
+        tool_calls: Dict[str, int] = defaultdict(int)
+        tool_chars: Dict[str, int] = defaultdict(int)
+        for s in sessions:
+            usage = per_session_tool_usage.get(s["id"])
+            if not usage:
+                continue
+            session_chars = sum(u.get("chars", 0) for u in usage.values())
+            session_calls = sum(u.get("calls", 0) for u in usage.values())
+            estimated, _status = _estimate_cost(s)
+            # Prefer payload-char weighting; fall back to call count when the
+            # session recorded no response payload sizes.
+            use_chars = session_chars > 0
+            denom = session_chars if use_chars else session_calls
+            for tool, u in usage.items():
+                calls = u.get("calls", 0)
+                chars = u.get("chars", 0)
+                tool_calls[tool] += calls
+                tool_chars[tool] += chars
+                if estimated and denom > 0:
+                    weight = chars if use_chars else calls
+                    tool_cost[tool] += estimated * (weight / denom)
+
+        total_cost = sum(tool_cost.values())
+        result = [
+            {
+                "tool": tool,
+                "calls": tool_calls[tool],
+                "chars": tool_chars[tool],
+                "cost": tool_cost.get(tool, 0.0),
+                "percentage": (tool_cost.get(tool, 0.0) / total_cost * 100)
+                if total_cost
+                else 0.0,
+            }
+            for tool in tool_calls
+        ]
+        result.sort(key=lambda x: (x["cost"], x["calls"]), reverse=True)
+        return result
+
+    def _compute_subagent_cost_attribution(self, sessions: List[Dict]) -> Dict[str, Any]:
+        """Attribute spend to subagent (delegate) sessions.
+
+        Delegate subagents are persisted as their own session rows with
+        ``source = 'subagent'`` and a ``parent_session_id`` pointing back to the
+        spawning session (see ``tools/delegate_tool.py``). Their token totals,
+        model, and billing route live on their own row, so their cost is the
+        exact per-row estimate — grouped here by model and rolled up to a total.
+        """
+        subagents = [s for s in sessions if (s.get("source") or "") == "subagent"]
+        by_model: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+            "sessions": 0, "input_tokens": 0, "output_tokens": 0,
+            "total_tokens": 0, "tool_calls": 0, "cost": 0.0,
+        })
+        total_cost = 0.0
+        total_tokens = 0
+        for s in subagents:
+            model = s.get("model") or "unknown"
+            display_model = model.split("/")[-1] if "/" in model else model
+            d = by_model[display_model]
+            d["sessions"] += 1
+            inp = s.get("input_tokens") or 0
+            out = s.get("output_tokens") or 0
+            cache_read = s.get("cache_read_tokens") or 0
+            cache_write = s.get("cache_write_tokens") or 0
+            tokens = inp + out + cache_read + cache_write
+            d["input_tokens"] += inp
+            d["output_tokens"] += out
+            d["total_tokens"] += tokens
+            d["tool_calls"] += s.get("tool_call_count") or 0
+            estimated, _status = _estimate_cost(s)
+            d["cost"] += estimated
+            total_cost += estimated
+            total_tokens += tokens
+
+        models = [{"model": model, **data} for model, data in by_model.items()]
+        models.sort(key=lambda x: (x["cost"], x["total_tokens"]), reverse=True)
+        return {
+            "subagent_sessions": len(subagents),
+            "total_cost": total_cost,
+            "total_tokens": total_tokens,
+            "by_model": models,
+        }
 
     def _compute_skill_breakdown(self, skill_usage: List[Dict]) -> Dict[str, Any]:
         """Process per-skill usage into summary + ranked list."""
@@ -850,6 +1186,109 @@ class InsightsEngine:
             lines.append("  " + "─" * 56)
             for ts in report["top_sessions"]:
                 lines.append(f"  {ts['label']:<20} {ts['value']:<18} ({ts['date']}, {ts['session_id']})")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def format_cost_terminal(self, report: Dict) -> str:
+        """Format a :meth:`cost_breakdown` report for terminal display.
+
+        Powers ``hermes sessions cost``: per-session spend plus per-tool and
+        per-subagent cost attribution.
+        """
+        days = report.get("days", 30)
+        src = report.get("source_filter")
+        if report.get("empty"):
+            src_note = f" (source: {src})" if src else ""
+            return f"  No sessions found in the last {days} days{src_note}."
+
+        lines: List[str] = []
+        period = f"Last {days} days" + (f" ({src})" if src else "")
+        lines.append("")
+        lines.append(f"  💰 Hermes Cost Attribution — {period}")
+        lines.append("  " + "═" * 64)
+
+        totals = report.get("totals", {})
+        lines.append(
+            f"  Sessions: {totals.get('total_sessions', 0):,}   "
+            f"Estimated: ~${totals.get('estimated_cost', 0.0):.4f}   "
+            f"Actual: ${totals.get('actual_cost', 0.0):.4f}"
+        )
+        lines.append(
+            f"  Cost attribution method: {report.get('cost_attribution', 'n/a')} "
+            "(per-tool figures are allocated, not measured)"
+        )
+        lines.append("")
+
+        # Per-session spend
+        session_rows = report.get("sessions", [])
+        if session_rows:
+            lines.append("  📄 Per-Session Spend (top by estimated cost)")
+            lines.append("  " + "─" * 64)
+            lines.append(
+                f"  {'Session':<18} {'Source':<9} {'Model':<20} "
+                f"{'Tokens':>8} {'Est. cost':>10}"
+            )
+            for r in session_rows:
+                sid = (r["session_id"] or "")[:16]
+                marker = "↳" if r.get("is_subagent") else " "
+                lines.append(
+                    f"  {marker}{sid:<17} {r['source'][:8]:<9} "
+                    f"{r['model'][:20]:<20} "
+                    f"{format_token_count_compact(r['total_tokens']):>8} "
+                    f"~${r['estimated_cost']:>8.4f}"
+                )
+            lines.append("")
+
+        # Per-tool cost attribution
+        tool_costs = report.get("tool_costs", [])
+        if tool_costs:
+            lines.append("  🔧 Per-Tool Cost (allocated by response-payload size)")
+            lines.append("  " + "─" * 64)
+            lines.append(
+                f"  {'Tool':<28} {'Calls':>8} {'Est. cost':>12} {'%':>7}"
+            )
+            for t in tool_costs[:15]:
+                lines.append(
+                    f"  {t['tool'][:28]:<28} {t['calls']:>8,} "
+                    f"~${t['cost']:>10.4f} {t['percentage']:>6.1f}%"
+                )
+            if len(tool_costs) > 15:
+                lines.append(f"  ... and {len(tool_costs) - 15} more tools")
+            lines.append("")
+
+        # Per-subagent cost attribution
+        subagents = report.get("subagents", {})
+        if subagents.get("subagent_sessions"):
+            lines.append("  🤖 Subagent (Delegate) Cost")
+            lines.append("  " + "─" * 64)
+            lines.append(
+                "  Subagents run as separate billed sessions; their spend is "
+                "already counted"
+            )
+            lines.append(
+                "  in the per-session rows and the grand total above (no double "
+                "counting)."
+            )
+            lines.append(
+                f"  Subagent sessions: {subagents['subagent_sessions']:,}   "
+                f"Total: ~${subagents.get('total_cost', 0.0):.4f}   "
+                f"Tokens: {format_token_count_compact(subagents.get('total_tokens', 0))}"
+            )
+            by_model = subagents.get("by_model", [])
+            if by_model:
+                lines.append(
+                    f"  {'Model':<28} {'Sessions':>9} {'Tokens':>8} {'Est. cost':>12}"
+                )
+                for m in by_model:
+                    lines.append(
+                        f"  {m['model'][:28]:<28} {m['sessions']:>9} "
+                        f"{format_token_count_compact(m['total_tokens']):>8} "
+                        f"~${m['cost']:>10.4f}"
+                    )
+            lines.append("")
+        else:
+            lines.append("  🤖 No subagent (delegate) sessions in this window.")
             lines.append("")
 
         return "\n".join(lines)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12034,6 +12034,33 @@ def main():
         help="Session ID to analyze (default: most recent session)",
     )
 
+    sessions_cost = sessions_subparsers.add_parser(
+        "cost",
+        help="Show per-session spend plus per-tool and per-subagent cost breakdown",
+        description=(
+            "Per-session estimated spend with per-tool and per-subagent "
+            "(delegate) cost attribution. Reuses the same cost model as "
+            "'hermes insights' / /insights."
+        ),
+    )
+    sessions_cost.add_argument(
+        "--days", type=int, default=30, help="Number of days to analyze (default: 30)"
+    )
+    sessions_cost.add_argument(
+        "--source", help="Filter by platform (cli, telegram, subagent, etc.)"
+    )
+    sessions_cost.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max per-session rows to show (0 for all; default: 20)",
+    )
+    sessions_cost.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the raw cost report as JSON instead of a table",
+    )
+
     def _confirm_prompt(prompt: str) -> bool:
         """Prompt for y/N confirmation, safe against non-TTY environments."""
         try:
@@ -12297,6 +12324,20 @@ def main():
             engine = EntropyEngine()
             report = engine.analyze(resolved, data.get("messages", []))
             print(format_report_terminal(report))
+
+        elif action == "cost":
+            from agent.insights import InsightsEngine
+
+            engine = InsightsEngine(db)
+            report = engine.cost_breakdown(
+                days=args.days,
+                source=getattr(args, "source", None),
+                limit=getattr(args, "limit", 20),
+            )
+            if getattr(args, "json", False):
+                print(_json.dumps(report, ensure_ascii=False, indent=2))
+            else:
+                print(engine.format_cost_terminal(report))
 
         else:
             sessions_parser.print_help()

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -730,3 +730,211 @@ class TestEdgeCases:
         # Depending on timing, might catch the session if created <1s ago
         # Just verify it doesn't crash
         assert "empty" in report
+
+
+# =========================================================================
+# Cost attribution — per-tool and per-subagent (issue #254)
+# =========================================================================
+
+@pytest.fixture()
+def cost_db(db):
+    """A DB with a priced parent session + a priced subagent (delegate) child."""
+    # Parent CLI session: priced anthropic model, two distinct tools used once each.
+    db.create_session(
+        session_id="parent",
+        source="cli",
+        model="anthropic/claude-sonnet-4-20250514",
+    )
+    db.update_token_counts(
+        "parent", input_tokens=100000, output_tokens=20000,
+        billing_provider="anthropic",
+    )
+    # read_file returns a large payload (60 chars); delegate returns a small
+    # one (20 chars) — so payload-weighted attribution gives read_file 3x the
+    # share of delegate (60/80 vs 20/80 of the parent's $0.60).
+    db.append_message("parent", role="assistant", content="read it",
+                      tool_calls=[{"function": {"name": "read_file"}}])
+    db.append_message("parent", role="tool", content="x" * 60, tool_name="read_file")
+    db.append_message("parent", role="assistant", content="delegate it",
+                      tool_calls=[{"function": {"name": "delegate"}}])
+    db.append_message("parent", role="tool", content="y" * 20, tool_name="delegate")
+
+    # Subagent (delegate) child: own row, source='subagent', parent linked.
+    db.create_session(
+        session_id="child",
+        source="subagent",
+        model="anthropic/claude-haiku-4-5",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent"},
+    )
+    db.update_token_counts(
+        "child", input_tokens=30000, output_tokens=5000,
+        billing_provider="anthropic",
+    )
+    db.append_message("child", role="assistant", content="run it",
+                      tool_calls=[{"function": {"name": "terminal"}}])
+    db.append_message("child", role="tool", content="output", tool_name="terminal")
+
+    db._conn.commit()
+    return db
+
+
+class TestToolCostAttribution:
+    def test_generate_includes_tool_costs_and_method(self, cost_db):
+        report = InsightsEngine(cost_db).generate(days=30)
+        assert report["cost_attribution"] == (
+            "proportional_by_response_chars_fallback_call_count"
+        )
+        tool_costs = {t["tool"]: t for t in report["tool_costs"]}
+        assert set(tool_costs) == {"read_file", "delegate", "terminal"}
+
+    def test_session_cost_split_by_payload_size(self, cost_db):
+        report = InsightsEngine(cost_db).generate(days=30)
+        tool_costs = {t["tool"]: t for t in report["tool_costs"]}
+        # Parent session cost (sonnet: 100k in * $3 + 20k out * $15 per 1M = $0.60)
+        # is split by response payload size: read_file 60 chars, delegate 20 →
+        # $0.45 / $0.15.
+        assert tool_costs["read_file"]["cost"] == pytest.approx(0.45, abs=1e-6)
+        assert tool_costs["delegate"]["cost"] == pytest.approx(0.15, abs=1e-6)
+        # Child session cost (haiku: 30k*$1 + 5k*$5 per 1M = $0.055) → its 1 tool.
+        assert tool_costs["terminal"]["cost"] == pytest.approx(0.055, abs=1e-6)
+
+    def test_tool_cost_percentages_sum_to_100(self, cost_db):
+        report = InsightsEngine(cost_db).generate(days=30)
+        total_pct = sum(t["percentage"] for t in report["tool_costs"])
+        assert total_pct == pytest.approx(100.0, abs=0.1)
+
+    def test_falls_back_to_call_count_without_payload_chars(self, db):
+        """When tool_name (and thus payload chars) is absent, split by calls."""
+        db.create_session(
+            session_id="s1", source="cli",
+            model="anthropic/claude-sonnet-4-20250514",
+        )
+        db.update_token_counts("s1", input_tokens=100000, output_tokens=20000,
+                               billing_provider="anthropic")
+        # CLI-style: tool_calls JSON only, no tool_name on the tool rows → no
+        # payload-char weight available, so the $0.60 splits evenly by call.
+        db.append_message("s1", role="assistant", content="a",
+                          tool_calls=[{"id": "c1", "function": {"name": "read_file"}}])
+        db.append_message("s1", role="tool", content="r1", tool_call_id="c1")
+        db.append_message("s1", role="assistant", content="b",
+                          tool_calls=[{"id": "c2", "function": {"name": "terminal"}}])
+        db.append_message("s1", role="tool", content="r2", tool_call_id="c2")
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=30)
+        tool_costs = {t["tool"]: t for t in report["tool_costs"]}
+        assert tool_costs["read_file"]["cost"] == pytest.approx(0.30, abs=1e-6)
+        assert tool_costs["terminal"]["cost"] == pytest.approx(0.30, abs=1e-6)
+
+    def test_custom_model_session_contributes_zero_tool_cost(self, db):
+        """Tools used only in unpriced sessions get counted but $0 cost."""
+        db.create_session(session_id="s1", source="cli", model="my-local-llama")
+        db.update_token_counts("s1", input_tokens=50000, output_tokens=10000)
+        db.append_message("s1", role="assistant", content="x",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("s1", role="tool", content="y", tool_name="terminal")
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=30)
+        terminal = next(t for t in report["tool_costs"] if t["tool"] == "terminal")
+        assert terminal["calls"] == 1
+        assert terminal["cost"] == 0.0
+
+
+class TestSubagentCostAttribution:
+    def test_subagent_section_isolates_delegate_sessions(self, cost_db):
+        report = InsightsEngine(cost_db).generate(days=30)
+        sub = report["subagents"]
+        assert sub["subagent_sessions"] == 1
+        assert sub["total_cost"] == pytest.approx(0.055, abs=1e-6)
+        assert sub["total_tokens"] == 35000
+        by_model = {m["model"]: m for m in sub["by_model"]}
+        assert "claude-haiku-4-5" in by_model
+        assert by_model["claude-haiku-4-5"]["sessions"] == 1
+        assert by_model["claude-haiku-4-5"]["cost"] == pytest.approx(0.055, abs=1e-6)
+
+    def test_no_subagents_yields_empty_section(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts("s1", input_tokens=1000, output_tokens=500,
+                               billing_provider="openai")
+        db._conn.commit()
+        report = InsightsEngine(db).generate(days=30)
+        assert report["subagents"]["subagent_sessions"] == 0
+        assert report["subagents"]["by_model"] == []
+
+
+class TestCostBreakdown:
+    def test_empty_db(self, db):
+        report = InsightsEngine(db).cost_breakdown(days=30)
+        assert report["empty"] is True
+        assert report["sessions"] == []
+        assert report["totals"]["estimated_cost"] == 0.0
+
+    def test_per_session_rows_and_totals(self, cost_db):
+        report = InsightsEngine(cost_db).cost_breakdown(days=30)
+        assert report["empty"] is False
+        assert report["totals"]["total_sessions"] == 2
+        # $0.60 (parent) + $0.055 (child) = $0.655
+        assert report["totals"]["estimated_cost"] == pytest.approx(0.655, abs=1e-6)
+
+        rows = {r["session_id"]: r for r in report["sessions"]}
+        assert rows["parent"]["is_subagent"] is False
+        assert rows["child"]["is_subagent"] is True
+        assert rows["child"]["parent_session_id"] == "parent"
+        assert rows["parent"]["estimated_cost"] == pytest.approx(0.60, abs=1e-6)
+
+    def test_rows_sorted_by_cost_desc(self, cost_db):
+        report = InsightsEngine(cost_db).cost_breakdown(days=30)
+        costs = [r["estimated_cost"] for r in report["sessions"]]
+        assert costs == sorted(costs, reverse=True)
+
+    def test_limit_caps_session_rows(self, cost_db):
+        report = InsightsEngine(cost_db).cost_breakdown(days=30, limit=1)
+        assert len(report["sessions"]) == 1
+        # Highest-spend session retained.
+        assert report["sessions"][0]["session_id"] == "parent"
+
+    def test_limit_zero_returns_all(self, cost_db):
+        report = InsightsEngine(cost_db).cost_breakdown(days=30, limit=0)
+        assert len(report["sessions"]) == 2
+
+    def test_source_filter(self, cost_db):
+        report = InsightsEngine(cost_db).cost_breakdown(days=30, source="subagent")
+        assert report["totals"]["total_sessions"] == 1
+        assert report["sessions"][0]["session_id"] == "child"
+
+    def test_report_is_json_serializable(self, cost_db):
+        import json as _json
+        report = InsightsEngine(cost_db).cost_breakdown(days=30)
+        _json.dumps(report)  # raises if non-serializable types leaked in
+
+
+class TestCostTerminalFormatting:
+    def test_format_has_all_sections(self, cost_db):
+        engine = InsightsEngine(cost_db)
+        text = engine.format_cost_terminal(engine.cost_breakdown(days=30))
+        assert "Hermes Cost Attribution" in text
+        assert "Per-Session Spend" in text
+        assert "Per-Tool Cost" in text
+        assert "Subagent" in text
+        assert "proportional_by_response_chars" in text
+
+    def test_format_marks_subagent_rows(self, cost_db):
+        engine = InsightsEngine(cost_db)
+        text = engine.format_cost_terminal(engine.cost_breakdown(days=30))
+        assert "↳" in text  # subagent marker
+
+    def test_format_empty(self, db):
+        engine = InsightsEngine(db)
+        text = engine.format_cost_terminal(engine.cost_breakdown(days=30))
+        assert "No sessions found" in text
+
+    def test_format_no_subagents_note(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts("s1", input_tokens=1000, output_tokens=500,
+                               billing_provider="openai")
+        db._conn.commit()
+        engine = InsightsEngine(db)
+        text = engine.format_cost_terminal(engine.cost_breakdown(days=30))
+        assert "No subagent" in text

--- a/tests/cli/test_cli_sessions_cost_command.py
+++ b/tests/cli/test_cli_sessions_cost_command.py
@@ -1,0 +1,99 @@
+"""End-to-end CLI test for ``hermes sessions cost`` (issue #254).
+
+Drives the full argparse path in ``hermes_cli.main`` via subprocess against an
+isolated ``HERMES_HOME`` so the wiring (parser + handler + InsightsEngine reuse)
+is exercised exactly as a user would hit it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+
+
+def _seed_state_db(home: Path) -> None:
+    """Create a state.db under ``home`` with a priced parent + subagent child."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_WORKTREE)
+    env["HERMES_HOME"] = str(home)
+    seed = (
+        "from hermes_state import SessionDB, DEFAULT_DB_PATH\n"
+        "db = SessionDB(db_path=DEFAULT_DB_PATH)\n"
+        "db.create_session(session_id='parent', source='cli',"
+        " model='anthropic/claude-sonnet-4-20250514')\n"
+        "db.update_token_counts('parent', input_tokens=100000, output_tokens=20000,"
+        " billing_provider='anthropic')\n"
+        "db.append_message('parent', role='assistant', content='x',"
+        " tool_calls=[{'function': {'name': 'read_file'}}])\n"
+        "db.append_message('parent', role='tool', content='y', tool_name='read_file')\n"
+        "db.create_session(session_id='child', source='subagent',"
+        " model='anthropic/claude-haiku-4-5', parent_session_id='parent',"
+        " model_config={'_delegate_from': 'parent'})\n"
+        "db.update_token_counts('child', input_tokens=30000, output_tokens=5000,"
+        " billing_provider='anthropic')\n"
+        "db.append_message('child', role='assistant', content='a',"
+        " tool_calls=[{'function': {'name': 'terminal'}}])\n"
+        "db.append_message('child', role='tool', content='b', tool_name='terminal')\n"
+        "db._conn.commit(); db.close()\n"
+    )
+    res = subprocess.run(
+        [sys.executable, "-c", seed],
+        env=env, capture_output=True, text=True, cwd=str(_WORKTREE), timeout=60,
+    )
+    assert res.returncode == 0, res.stderr
+
+
+def _run_sessions_cost(home: Path, args: list[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_WORKTREE)
+    env["HERMES_HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", "cost"] + args,
+        env=env, capture_output=True, text=True, cwd=str(_WORKTREE), timeout=60,
+    )
+
+
+def test_sessions_cost_json_output(tmp_path):
+    _seed_state_db(tmp_path)
+    res = _run_sessions_cost(tmp_path, ["--json"])
+    assert res.returncode == 0, res.stderr
+    report = json.loads(res.stdout)
+
+    assert report["cost_attribution"] == (
+        "proportional_by_response_chars_fallback_call_count"
+    )
+    assert report["totals"]["total_sessions"] == 2
+    assert report["totals"]["estimated_cost"] == pytest.approx(0.655, abs=1e-4)
+
+    rows = {r["session_id"]: r for r in report["sessions"]}
+    assert rows["child"]["is_subagent"] is True
+    assert rows["child"]["parent_session_id"] == "parent"
+
+    tools = {t["tool"]: t for t in report["tool_costs"]}
+    assert set(tools) == {"read_file", "terminal"}
+    assert report["subagents"]["subagent_sessions"] == 1
+
+
+def test_sessions_cost_terminal_output(tmp_path):
+    _seed_state_db(tmp_path)
+    res = _run_sessions_cost(tmp_path, [])
+    assert res.returncode == 0, res.stderr
+    out = res.stdout
+    assert "Hermes Cost Attribution" in out
+    assert "Per-Session Spend" in out
+    assert "Per-Tool Cost" in out
+    assert "Subagent" in out
+
+
+def test_sessions_cost_source_filter(tmp_path):
+    _seed_state_db(tmp_path)
+    res = _run_sessions_cost(tmp_path, ["--source", "subagent", "--json"])
+    assert res.returncode == 0, res.stderr
+    report = json.loads(res.stdout)
+    assert report["totals"]["total_sessions"] == 1
+    assert report["sessions"][0]["session_id"] == "child"


### PR DESCRIPTION
## Summary

Adds per-tool and per-subagent (delegate) cost attribution to `InsightsEngine`, and a dedicated top-level `hermes sessions cost` command. Builds entirely on `agent/insights.py` + `agent/usage_pricing.py` + the existing `sessions` subcommand wiring — no cost-model logic is duplicated.

The core cost machinery (per-session `estimated_cost_usd`/`actual_cost_usd`, per-model/platform breakdowns, per-tool call counts, `/insights`) was already present. This PR fills the genuine residual: cost broken down **below the session level** by tool and by subagent.

## Implemented

**Per-tool cost attribution** (`tool_costs` in `generate()`, and in `cost_breakdown()`)
- Per-call token splits are not persisted (the `messages` schema carries only session-level token totals), so exact per-tool cost is not derivable. Each session's estimated USD is allocated across the tools it invoked, **weighted by each tool's response-payload size** (character length — a close proxy for the tokens that payload contributes when re-injected into the prompt), falling back to call count when payload size is unavailable (e.g. CLI rows where `tool_name` is NULL).
- Tagged `cost_attribution = "proportional_by_response_chars_fallback_call_count"` and labelled "allocated, not measured" in output, so the figure is never mistaken for a metered value.

**Per-subagent cost attribution** (`subagents` section)
- Delegate subagents persist as their own session rows (`source='subagent'` + `parent_session_id`), so their cost is the **exact** per-row estimate (reuses existing `_estimate_cost`). Rolled up by model with a total. The `source='subagent'` filter captures all delegate rows regardless of depth (Hermes also bounds delegation depth). Per-session rows mark subagent rows and carry `parent_session_id`. Output states explicitly that subagents are billed as separate sessions already counted in the grand total (no double counting).

**CLI: `hermes sessions cost [--days N] [--source S] [--limit N] [--json]`**
- New sub-action on the existing `sessions` parser. Thin adapter over new `InsightsEngine.cost_breakdown()` + `format_cost_terminal()`. Lists per-session spend (highest first) plus the per-tool and per-subagent breakdowns. `--json` emits the raw report.

Success criteria from the issue:
- [x] `hermes sessions cost` returns a per-session cost/usage summary.
- [x] Per-tool and per-subagent cost breakdowns are available.
- [x] No provider credential or raw key is logged (cost path touches only token columns + model/billing-route metadata).

## Deferred

- **Orphaned/interrupted subagent sessions** that die before their final token counts commit will under-report (they show $0). This is a write-path/persistence concern, not an attribution one — out of scope here.
- Per-call token instrumentation (would make per-tool cost exact rather than allocated) is a larger schema change, intentionally not undertaken.

## Verification

- `uv run --extra dev python -m pytest tests/agent/test_insights.py tests/cli/test_cli_sessions_cost_command.py tests/cli/test_cli_insights_command.py tests/gateway/test_insights_unicode_flags.py -q` → 91 passed.
- `uv run --extra dev ruff check` on all changed files → clean.
- Manual smoke: priced parent + delegate child correctly attributes a 5000-char `read_file` payload 91.6% of the parent's spend vs 0.0% for a 2-char `terminal` payload; subagent rolled up by model; totals reconcile.
- Existing `/insights` consumers (gateway, web_server, cli.py) unaffected — report changes are purely additive keys.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>