### PR TITLE
Agent-team shared task list + teammate messaging (first increment of #252)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -740,10 +740,12 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
         config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
     )
 
-    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
-    # _get_platform_tools because it's a non-configurable platform toolset
-    # whose tools live in hermes-cli's universe (see toolsets.py).
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    # Sorted: ["agent_team", "kanban", "memory"]. `kanban` and `agent_team` are
+    # both auto-recovered by _get_platform_tools because they are non-configurable
+    # platform toolsets whose tools live in hermes-cli's universe (see toolsets.py);
+    # their tools stay check_fn-gated (HERMES_KANBAN_TASK / HERMES_TEAM_ID) so they
+    # are inert outside a worker/teammate session.
+    assert server._load_enabled_toolsets() == ["agent_team", "kanban", "memory"]
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
@@ -764,7 +766,7 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
         config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
     )
 
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    assert server._load_enabled_toolsets() == ["agent_team", "kanban", "memory"]
     assert "using configured CLI toolsets" in capsys.readouterr().err
 
 

--- a/tests/tools/test_agent_team.py
+++ b/tests/tools/test_agent_team.py
@@ -1,0 +1,561 @@
+"""Tests for the agent-team coordination primitive (issue #252).
+
+Covers three layers:
+  * TeamStore — the SQLite-backed shared task list + per-teammate mailboxes,
+    including the atomic-claim race and broadcast fan-out.
+  * team_task / team_message — the teammate-facing tools and their env/
+    thread-local gating (hidden from a normal chat session).
+  * delegate_task wiring — a task carrying a ``team`` field becomes a teammate
+    with the agent_team toolset and a bound thread identity.
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from tools.agent_team import (
+    TASK_STATUSES,
+    TEAM_ID_ENV,
+    TEAM_MEMBER_ENV,
+    TeamStore,
+    clear_thread_identity,
+    current_member,
+    current_team_id,
+    is_valid_slug,
+    set_thread_identity,
+    team_db_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def store(tmp_path):
+    s = TeamStore("teamA", db_path=tmp_path / "teamA.db")
+    s.ensure_schema()
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity():
+    """Ensure no thread-local identity bleeds across tests."""
+    clear_thread_identity()
+    yield
+    clear_thread_identity()
+
+
+# ---------------------------------------------------------------------------
+# TeamStore: slugs + path safety
+# ---------------------------------------------------------------------------
+
+def test_valid_slug_accepts_safe_names():
+    assert is_valid_slug("team-1")
+    assert is_valid_slug("alice.bob_2")
+    assert not is_valid_slug("../etc")
+    assert not is_valid_slug("has space")
+    assert not is_valid_slug("")
+    assert not is_valid_slug("x" * 65)
+
+
+def test_invalid_team_id_rejected():
+    with pytest.raises(ValueError):
+        TeamStore("../escape")
+
+
+def test_team_db_path_under_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_TEAM_DB", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = team_db_path("teamX")
+    assert path == tmp_path / "agent_teams" / "teamX.db"
+
+
+def test_team_db_path_env_override(monkeypatch, tmp_path):
+    pinned = tmp_path / "pinned.db"
+    monkeypatch.setenv("HERMES_TEAM_DB", str(pinned))
+    assert team_db_path("anything") == pinned
+
+
+# ---------------------------------------------------------------------------
+# TeamStore: shared task list
+# ---------------------------------------------------------------------------
+
+def test_add_and_list_tasks(store):
+    t1 = store.add_task("research api")
+    t2 = store.add_task("write report", assignee="bob")
+    assert t1["status"] == "open"
+    assert t2["status"] == "claimed" and t2["assignee"] == "bob"
+    tasks = store.list_tasks()
+    assert {t["title"] for t in tasks} == {"research api", "write report"}
+
+
+def test_add_task_requires_title(store):
+    with pytest.raises(ValueError):
+        store.add_task("   ")
+
+
+def test_list_tasks_status_filter(store):
+    store.add_task("a")
+    store.add_task("b", assignee="alice")
+    assert len(store.list_tasks(status="open")) == 1
+    assert len(store.list_tasks(status="claimed")) == 1
+
+
+def test_claim_open_task(store):
+    t = store.add_task("do thing")
+    outcome = store.claim_task(t["id"], "alice")
+    assert outcome["claimed"] is True
+    assert outcome["task"]["assignee"] == "alice"
+    assert outcome["task"]["status"] == "claimed"
+
+
+def test_claim_already_claimed_loses(store):
+    t = store.add_task("do thing")
+    assert store.claim_task(t["id"], "alice")["claimed"] is True
+    second = store.claim_task(t["id"], "bob")
+    assert second["claimed"] is False
+    assert "alice" in second["reason"]
+
+
+def test_reclaim_by_same_member_is_idempotent(store):
+    t = store.add_task("do thing")
+    store.claim_task(t["id"], "alice")
+    again = store.claim_task(t["id"], "alice")
+    assert again["claimed"] is True
+
+
+def test_claim_missing_task(store):
+    outcome = store.claim_task("tt_nonexistent", "alice")
+    assert outcome["claimed"] is False
+    assert outcome["task"] is None
+
+
+def test_concurrent_claim_exactly_one_winner(store):
+    """The atomic UPDATE guarded on status='open' must let exactly one of N
+    concurrent claimers win — this is the shared-task-list correctness core."""
+    t = store.add_task("contested")
+    results = {}
+    barrier = threading.Barrier(8)
+
+    def worker(name):
+        barrier.wait()  # maximise contention
+        results[name] = store.claim_task(t["id"], name)["claimed"]
+
+    threads = [threading.Thread(target=worker, args=(f"m{i}",)) for i in range(8)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    winners = [name for name, won in results.items() if won]
+    assert len(winners) == 1, f"expected exactly one winner, got {winners}"
+    assert store.get_task(t["id"])["assignee"] == winners[0]
+
+
+def test_complete_task_records_result(store):
+    t = store.add_task("compute")
+    store.claim_task(t["id"], "alice")
+    outcome = store.complete_task(t["id"], result="answer=42", member="alice")
+    assert outcome["completed"] is True
+    assert outcome["task"]["status"] == "done"
+    assert outcome["task"]["result"] == "answer=42"
+
+
+# ---------------------------------------------------------------------------
+# TeamStore: direct teammate messaging
+# ---------------------------------------------------------------------------
+
+def test_direct_message_reaches_recipient(store):
+    store.add_member("alice")
+    store.add_member("bob")
+    sent = store.send_message("alice", "need the schema", recipient="bob")
+    assert sent["sent"] is True and sent["broadcast"] is False
+    bob_inbox = store.inbox("bob")
+    assert len(bob_inbox) == 1
+    assert bob_inbox[0]["body"] == "need the schema"
+    assert bob_inbox[0]["sender"] == "alice"
+    # alice did not receive her own direct message
+    assert store.inbox("alice") == []
+
+
+def test_inbox_marks_read(store):
+    store.add_member("bob")
+    store.send_message("alice", "hi", recipient="bob")
+    assert len(store.inbox("bob")) == 1
+    # second poll: unread-only is now empty
+    assert store.inbox("bob") == []
+
+
+def test_broadcast_fans_out_to_all_but_sender(store):
+    for name in ("alice", "bob", "carol"):
+        store.add_member(name)
+    store.send_message("alice", "team sync now")  # no recipient => broadcast
+    assert len(store.inbox("bob")) == 1
+    assert len(store.inbox("carol")) == 1
+    assert store.inbox("alice") == []  # sender excluded
+
+
+def test_send_requires_body(store):
+    with pytest.raises(ValueError):
+        store.send_message("alice", "   ", recipient="bob")
+
+
+def test_message_invalid_recipient_slug(store):
+    with pytest.raises(ValueError):
+        store.send_message("alice", "hi", recipient="../evil")
+
+
+# ---------------------------------------------------------------------------
+# TeamStore: lead-side merge
+# ---------------------------------------------------------------------------
+
+def test_snapshot_aggregates_results(store):
+    store.add_member("alice")
+    store.add_member("bob")
+    t1 = store.add_task("task one")
+    t2 = store.add_task("task two")
+    store.claim_task(t1["id"], "alice")
+    store.complete_task(t1["id"], result="found X", member="alice")
+    store.claim_task(t2["id"], "bob")
+    snap = store.snapshot()
+    assert snap["team_id"] == "teamA"
+    assert snap["done_count"] == 1
+    assert snap["open_count"] == 0  # t2 is claimed, not open
+    assert snap["results"][t1["id"]] == "found X"
+    assert {m["name"] for m in snap["members"]} == {"alice", "bob"}
+
+
+# ---------------------------------------------------------------------------
+# Identity resolution: arg -> thread-local -> env
+# ---------------------------------------------------------------------------
+
+def test_identity_arg_wins(monkeypatch):
+    monkeypatch.setenv(TEAM_ID_ENV, "from-env")
+    set_thread_identity("from-thread", "tmember")
+    assert current_team_id("explicit") == "explicit"
+    assert current_member("explicit-m") == "explicit-m"
+
+
+def test_identity_thread_local_beats_env(monkeypatch):
+    monkeypatch.setenv(TEAM_ID_ENV, "from-env")
+    monkeypatch.setenv(TEAM_MEMBER_ENV, "env-member")
+    set_thread_identity("from-thread", "thread-member")
+    assert current_team_id() == "from-thread"
+    assert current_member() == "thread-member"
+
+
+def test_identity_falls_back_to_env(monkeypatch):
+    clear_thread_identity()
+    monkeypatch.setenv(TEAM_ID_ENV, "env-team")
+    monkeypatch.setenv(TEAM_MEMBER_ENV, "env-member")
+    assert current_team_id() == "env-team"
+    assert current_member() == "env-member"
+
+
+def test_thread_local_is_per_thread():
+    """A thread identity set in one thread must not leak into another."""
+    set_thread_identity("main-team", "main-member")
+    other = {}
+
+    def worker():
+        other["team"] = current_team_id()  # no identity set on this thread
+
+    th = threading.Thread(target=worker)
+    th.start()
+    th.join()
+    assert other["team"] is None
+    assert current_team_id() == "main-team"
+
+
+# ---------------------------------------------------------------------------
+# Tool gating
+# ---------------------------------------------------------------------------
+
+def test_team_tools_hidden_without_identity(monkeypatch, tmp_path):
+    monkeypatch.delenv(TEAM_ID_ENV, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    clear_thread_identity()
+
+    import tools.agent_team_tools  # noqa: F401  ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    team = {n for n in names if n and n.startswith("team_")}
+    assert team == set(), f"team tools leaked into normal chat schema: {team}"
+
+
+def test_team_tools_visible_with_env(monkeypatch, tmp_path):
+    monkeypatch.setenv(TEAM_ID_ENV, "teamA")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import tools.agent_team_tools  # noqa: F401
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    team = {n for n in names if n and n.startswith("team_")}
+    assert team == {"team_task", "team_message"}
+
+
+# ---------------------------------------------------------------------------
+# team_task tool
+# ---------------------------------------------------------------------------
+
+def _setup_team_env(monkeypatch, tmp_path, member="alice"):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv(TEAM_ID_ENV, "teamT")
+    monkeypatch.setenv(TEAM_MEMBER_ENV, member)
+
+
+def test_team_task_no_active_team(monkeypatch, tmp_path):
+    monkeypatch.delenv(TEAM_ID_ENV, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    clear_thread_identity()
+    from tools.agent_team_tools import team_task
+
+    out = json.loads(team_task("list"))
+    assert "error" in out
+
+
+def test_team_task_list_claim_complete_flow(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path, member="alice")
+    from tools.agent_team_tools import team_task
+
+    # Seed a task via the store (the lead's side).
+    s = TeamStore("teamT")
+    s.ensure_schema()
+    task = s.add_task("inspect logs")
+
+    listed = json.loads(team_task("list"))
+    assert listed["team_id"] == "teamT"
+    assert any(t["id"] == task["id"] for t in listed["tasks"])
+
+    claimed = json.loads(team_task("claim", task_id=task["id"]))
+    assert claimed["claimed"] is True
+    assert claimed["task"]["assignee"] == "alice"
+
+    done = json.loads(team_task("complete", task_id=task["id"], result="all clear"))
+    assert done["completed"] is True
+    assert done["task"]["result"] == "all clear"
+
+
+def test_team_task_add_creates_shared_task(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path, member="alice")
+    from tools.agent_team_tools import team_task
+
+    added = json.loads(team_task("add", title="handle the migration"))
+    assert added["added"] is True
+    assert added["task"]["title"] == "handle the migration"
+    assert added["task"]["status"] == "open"
+    # visible to the team
+    listed = json.loads(team_task("list"))
+    assert any(t["title"] == "handle the migration" for t in listed["tasks"])
+
+
+def test_team_task_add_requires_title(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_task
+
+    out = json.loads(team_task("add"))
+    assert "error" in out
+
+
+def test_team_task_claim_requires_task_id(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_task
+
+    out = json.loads(team_task("claim"))
+    assert "error" in out
+
+
+def test_team_task_unknown_action(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_task
+
+    out = json.loads(team_task("frobnicate"))
+    assert "error" in out
+
+
+def test_team_task_bad_status_filter(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_task
+
+    out = json.loads(team_task("list", status="bogus"))
+    assert "error" in out
+    assert sorted(TASK_STATUSES)[0] in out["error"] or "bogus" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# team_message tool
+# ---------------------------------------------------------------------------
+
+def test_team_message_send_and_inbox(monkeypatch, tmp_path):
+    # alice sends to bob
+    _setup_team_env(monkeypatch, tmp_path, member="alice")
+    from tools.agent_team_tools import team_message
+
+    s = TeamStore("teamT")
+    s.ensure_schema()
+    s.add_member("alice")
+    s.add_member("bob")
+
+    sent = json.loads(team_message("send", body="schema ready", to="bob"))
+    assert sent["sent"] is True
+
+    # switch identity to bob and read inbox
+    monkeypatch.setenv(TEAM_MEMBER_ENV, "bob")
+    inbox = json.loads(team_message("inbox"))
+    assert inbox["member"] == "bob"
+    assert len(inbox["messages"]) == 1
+    assert inbox["messages"][0]["body"] == "schema ready"
+
+
+def test_team_message_send_requires_body(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_message
+
+    out = json.loads(team_message("send", to="bob"))
+    assert "error" in out
+
+
+def test_team_message_unknown_action(monkeypatch, tmp_path):
+    _setup_team_env(monkeypatch, tmp_path)
+    from tools.agent_team_tools import team_message
+
+    out = json.loads(team_message("explode"))
+    assert "error" in out
+
+
+# ---------------------------------------------------------------------------
+# delegate_task wiring
+# ---------------------------------------------------------------------------
+
+def test_resolve_team_identity():
+    from tools.delegate_tool import _resolve_team_identity
+
+    assert _resolve_team_identity({"goal": "x"}, 0) is None
+    assert _resolve_team_identity(
+        {"goal": "x", "team": {"team_id": "t1", "member": "alice"}}, 0
+    ) == ("t1", "alice")
+    # missing member => positional fallback
+    assert _resolve_team_identity({"goal": "x", "team": {"team_id": "t1"}}, 3) == (
+        "t1",
+        "teammate-3",
+    )
+    # invalid slug => degrade to plain delegation
+    assert _resolve_team_identity({"goal": "x", "team": {"team_id": "../x"}}, 0) is None
+
+
+def test_ensure_team_toolset_adds_agent_team():
+    from tools.delegate_tool import _ensure_team_toolset
+
+    assert "agent_team" in _ensure_team_toolset(["terminal", "file"], None)
+    # already present => not duplicated
+    result = _ensure_team_toolset(["agent_team"], None)
+    assert result.count("agent_team") == 1
+
+
+def test_team_identity_scope_binds_and_clears():
+    from tools.delegate_tool import _team_identity_scope
+
+    with _team_identity_scope(("t1", "alice")):
+        assert current_team_id() == "t1"
+        assert current_member() == "alice"
+    # cleared on exit
+    assert current_team_id() is None
+
+
+def test_team_identity_scope_noop_for_none():
+    from tools.delegate_tool import _team_identity_scope
+
+    with _team_identity_scope(None):
+        assert current_team_id() is None
+
+
+# ---------------------------------------------------------------------------
+# delegate_task end-to-end: a team task becomes a teammate
+# ---------------------------------------------------------------------------
+
+def _make_mock_parent():
+    """Minimal parent agent with the fields delegate_task reads."""
+    import threading as _t
+    from unittest.mock import MagicMock
+
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = _t.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.enabled_toolsets = ["terminal", "file"]
+    return parent
+
+
+def test_delegate_task_with_team_grants_agent_team_toolset(monkeypatch, tmp_path):
+    """A delegated task carrying a team field must (a) receive the agent_team
+    toolset and (b) get a bound team identity stamped on the child."""
+    from unittest.mock import MagicMock, patch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    parent = _make_mock_parent()
+
+    captured = {}
+
+    def _fake_build(*args, **kwargs):
+        # Capture the toolsets that delegate_task computed for the teammate.
+        captured["toolsets"] = kwargs.get("toolsets")
+        # Confirm the team identity is bound on THIS (build) thread so the
+        # team tools' check_fn would pass during the child's tool resolution.
+        captured["team_id_at_build"] = current_team_id()
+        captured["member_at_build"] = current_member()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "teammate done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_depth = 1
+        child._delegate_role = "leaf"
+        child.session_estimated_cost_usd = 0.0
+        return child
+
+    from tools.delegate_tool import delegate_task
+
+    with patch("tools.delegate_tool._build_child_agent", side_effect=_fake_build):
+        result = json.loads(
+            delegate_task(
+                parent_agent=parent,
+                tasks=[
+                    {
+                        "goal": "research the api",
+                        "team": {"team_id": "teamE", "member": "alice"},
+                    }
+                ],
+            )
+        )
+
+    assert result["results"][0]["status"] == "completed"
+    assert "agent_team" in captured["toolsets"]
+    assert captured["team_id_at_build"] == "teamE"
+    assert captured["member_at_build"] == "alice"

--- a/tools/agent_team.py
+++ b/tools/agent_team.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Agent-team coordination store (GitHub issue #252, first increment).
+
+Hermes already spawns isolated teammate sessions via ``delegate_task``
+(``tools/delegate_tool.py``): each child gets its own fresh context window,
+optional per-task model, and the lead merges their outputs without re-running
+the subtasks in its own context. What delegation does NOT provide is the
+peer-coordination primitive #252 calls for: a *shared task list* that teammates
+can claim and update during execution, and *direct teammate-to-teammate
+messaging* (not just one-way handoffs back to the parent).
+
+This module supplies exactly that residual: a ``team_id``-scoped SQLite store
+holding (a) a shared task list and (b) per-teammate mailboxes. It is the
+coordination backbone; the actual isolated teammate sessions are still spawned
+by the existing delegation machinery, which injects ``HERMES_TEAM_ID`` /
+``HERMES_TEAM_MEMBER`` into each teammate's environment so the teammate-facing
+tools (``team_task``, ``team_message``) bind to the right team and identity.
+
+Storage convention mirrors the kanban board (``tools/kanban_tools.py`` /
+``hermes_cli/kanban_db.py``): a SQLite file under the Hermes home directory,
+one DB per team at ``<hermes_home>/agent_teams/<team_id>.db``.
+
+The store is deliberately small and dependency-free (stdlib ``sqlite3`` only).
+WAL mode + a short busy-timeout make concurrent teammate writers safe; teammate
+sessions run in separate ThreadPoolExecutor worker threads (delegation) or
+separate processes (kanban dispatcher), so cross-connection concurrency is the
+realistic access pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+# Env vars the lead injects into each teammate session. Mirror the kanban
+# dispatcher's ``HERMES_KANBAN_TASK`` convention so the gating + identity
+# resolution is familiar and the two systems never collide.
+TEAM_ID_ENV = "HERMES_TEAM_ID"
+TEAM_MEMBER_ENV = "HERMES_TEAM_MEMBER"
+TEAM_DB_ENV = "HERMES_TEAM_DB"  # defense-in-depth path pin (like HERMES_KANBAN_DB)
+
+# Shared task lifecycle. Kept intentionally flat — this is a coordination
+# list, not a workflow engine (that is what kanban is for).
+TASK_STATUSES = frozenset({"open", "claimed", "done"})
+
+# Identifiers (team id, member name) are embedded in filesystem paths, so
+# constrain them to a safe slug to avoid path traversal.
+_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+_BUSY_TIMEOUT_MS = 5000
+
+
+def is_valid_slug(value: str) -> bool:
+    """Return True when *value* is a safe team-id / member-name slug."""
+    return bool(_SLUG_RE.match(value or ""))
+
+
+def _teams_dir() -> Path:
+    """Directory holding per-team SQLite files."""
+    return get_hermes_home() / "agent_teams"
+
+
+def team_db_path(team_id: str) -> Path:
+    """Resolve the SQLite path for *team_id*.
+
+    ``HERMES_TEAM_DB`` pins the path directly (highest precedence) so the lead
+    can inject an exact path into teammate sessions and make them immune to any
+    home-resolution disagreement — same defense-in-depth the kanban dispatcher
+    uses with ``HERMES_KANBAN_DB``.
+    """
+    override = os.environ.get(TEAM_DB_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    if not is_valid_slug(team_id):
+        raise ValueError(f"invalid team_id slug: {team_id!r}")
+    return _teams_dir() / f"{team_id}.db"
+
+
+class TeamStore:
+    """SQLite-backed shared task list + per-teammate mailboxes for one team.
+
+    A single team is one DB file. Construct with a ``team_id``; call
+    :meth:`ensure_schema` (idempotent) before use. Every method opens a fresh
+    short-lived connection so the store is safe to share across the threads /
+    processes that host the isolated teammate sessions.
+    """
+
+    def __init__(self, team_id: str, db_path: Optional[Path] = None):
+        if not is_valid_slug(team_id):
+            raise ValueError(f"invalid team_id slug: {team_id!r}")
+        self.team_id = team_id
+        self.db_path = Path(db_path) if db_path is not None else team_db_path(team_id)
+
+    # -- connection -----------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path), timeout=_BUSY_TIMEOUT_MS / 1000)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+        return conn
+
+    def ensure_schema(self) -> None:
+        """Create tables if absent. Idempotent."""
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS team_meta (
+                    key   TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS members (
+                    name        TEXT PRIMARY KEY,
+                    role        TEXT NOT NULL DEFAULT '',
+                    model       TEXT NOT NULL DEFAULT '',
+                    created_at  REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id          TEXT PRIMARY KEY,
+                    title       TEXT NOT NULL,
+                    status      TEXT NOT NULL DEFAULT 'open',
+                    assignee    TEXT NOT NULL DEFAULT '',
+                    result      TEXT NOT NULL DEFAULT '',
+                    created_at  REAL NOT NULL,
+                    updated_at  REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS messages (
+                    id          TEXT PRIMARY KEY,
+                    sender      TEXT NOT NULL,
+                    recipient   TEXT NOT NULL DEFAULT '',
+                    body        TEXT NOT NULL,
+                    created_at  REAL NOT NULL,
+                    read_at     REAL
+                );
+                CREATE INDEX IF NOT EXISTS idx_messages_recipient
+                    ON messages(recipient, read_at);
+                """
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO team_meta(key, value) VALUES('team_id', ?)",
+                (self.team_id,),
+            )
+
+    # -- members --------------------------------------------------------
+
+    def add_member(self, name: str, role: str = "", model: str = "") -> Dict[str, Any]:
+        """Register (or update) a teammate. Returns the member row as a dict."""
+        if not is_valid_slug(name):
+            raise ValueError(f"invalid member name slug: {name!r}")
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO members(name, role, model, created_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET role=excluded.role,
+                                                model=excluded.model
+                """,
+                (name, role or "", model or "", now),
+            )
+        return {"name": name, "role": role or "", "model": model or ""}
+
+    def list_members(self) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT name, role, model FROM members ORDER BY created_at"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    # -- shared task list ----------------------------------------------
+
+    def add_task(self, title: str, assignee: str = "") -> Dict[str, Any]:
+        """Append a task to the shared list. Returns the task row."""
+        title = (title or "").strip()
+        if not title:
+            raise ValueError("task title is required")
+        if assignee and not is_valid_slug(assignee):
+            raise ValueError(f"invalid assignee slug: {assignee!r}")
+        task_id = f"tt_{uuid.uuid4().hex[:12]}"
+        now = time.time()
+        status = "claimed" if assignee else "open"
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO tasks(id, title, status, assignee, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?)
+                """,
+                (task_id, title, status, assignee or "", now, now),
+            )
+        return self.get_task(task_id)  # type: ignore[return-value]
+
+    def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def list_tasks(self, status: Optional[str] = None) -> List[Dict[str, Any]]:
+        query = "SELECT * FROM tasks"
+        params: tuple = ()
+        if status:
+            query += " WHERE status = ?"
+            params = (status,)
+        query += " ORDER BY created_at"
+        with self._connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [dict(r) for r in rows]
+
+    def claim_task(self, task_id: str, member: str) -> Dict[str, Any]:
+        """Atomically claim an open task for *member*.
+
+        Returns ``{"claimed": True, "task": {...}}`` on success, or
+        ``{"claimed": False, "reason": ...}`` when the task does not exist or
+        was already claimed by someone else (lost the race).
+        """
+        if not is_valid_slug(member):
+            raise ValueError(f"invalid member slug: {member!r}")
+        now = time.time()
+        with self._connect() as conn:
+            # Single UPDATE guarded on status='open' is the atomic claim — the
+            # SQLite write lock serializes concurrent claimers, so exactly one
+            # wins. Idempotent re-claim by the same member is allowed.
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status='claimed', assignee=?, updated_at=?
+                 WHERE id=?
+                   AND (status='open' OR (status='claimed' AND assignee=?))
+                """,
+                (member, now, task_id, member),
+            )
+            changed = cur.rowcount
+        task = self.get_task(task_id)
+        if task is None:
+            return {"claimed": False, "reason": "no such task", "task": None}
+        if not changed:
+            return {
+                "claimed": False,
+                "reason": f"already claimed by {task['assignee'] or 'someone'}",
+                "task": task,
+            }
+        return {"claimed": True, "task": task}
+
+    def complete_task(
+        self, task_id: str, result: str = "", member: str = ""
+    ) -> Dict[str, Any]:
+        """Mark a task done with an optional result summary.
+
+        ``member`` is accepted for call-site symmetry with :meth:`claim_task`
+        and is not enforced — completion is cooperative within a team, and a
+        teammate that finishes another's work (e.g. picked up a handoff) should
+        not be blocked. Ownership is recorded by ``assignee`` at claim time.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE tasks SET status='done', result=?, updated_at=? WHERE id=?",
+                (result or "", now, task_id),
+            )
+        task = self.get_task(task_id)
+        if task is None:
+            return {"completed": False, "reason": "no such task", "task": None}
+        return {"completed": True, "task": task}
+
+    # -- direct teammate messaging -------------------------------------
+
+    def send_message(
+        self, sender: str, body: str, recipient: str = ""
+    ) -> Dict[str, Any]:
+        """Send a direct message to *recipient*, or broadcast when empty.
+
+        ``recipient=""`` is a broadcast: every member (other than the sender)
+        receives a copy in their inbox. This is the peer-to-peer channel #252
+        asks for — teammates message each other, not only the parent.
+        """
+        if not is_valid_slug(sender):
+            raise ValueError(f"invalid sender slug: {sender!r}")
+        body = (body or "").strip()
+        if not body:
+            raise ValueError("message body is required")
+        if recipient and not is_valid_slug(recipient):
+            raise ValueError(f"invalid recipient slug: {recipient!r}")
+        now = time.time()
+
+        recipients: List[str]
+        if recipient:
+            recipients = [recipient]
+        else:
+            recipients = [
+                m["name"] for m in self.list_members() if m["name"] != sender
+            ]
+            if not recipients:
+                # No registered peers yet: keep the broadcast as an unaddressed
+                # message so it is not silently dropped.
+                recipients = [""]
+
+        created: List[str] = []
+        with self._connect() as conn:
+            for rcpt in recipients:
+                msg_id = f"tm_{uuid.uuid4().hex[:12]}"
+                conn.execute(
+                    """
+                    INSERT INTO messages(id, sender, recipient, body, created_at)
+                    VALUES(?, ?, ?, ?, ?)
+                    """,
+                    (msg_id, sender, rcpt, body, now),
+                )
+                created.append(msg_id)
+        return {
+            "sent": True,
+            "message_ids": created,
+            "recipients": recipients,
+            "broadcast": not recipient,
+        }
+
+    def inbox(
+        self, member: str, unread_only: bool = True, mark_read: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Return messages addressed to *member* (and broadcasts).
+
+        Broadcasts are persisted as per-recipient rows by :meth:`send_message`,
+        so a member's inbox is simply rows where ``recipient == member``. When
+        ``mark_read`` is set, returned unread rows are stamped read so the next
+        poll only surfaces new traffic.
+        """
+        if not is_valid_slug(member):
+            raise ValueError(f"invalid member slug: {member!r}")
+        query = "SELECT * FROM messages WHERE recipient = ?"
+        params: tuple = (member,)
+        if unread_only:
+            query += " AND read_at IS NULL"
+        query += " ORDER BY created_at"
+        with self._connect() as conn:
+            rows = [dict(r) for r in conn.execute(query, params).fetchall()]
+            if mark_read and rows:
+                now = time.time()
+                unread_ids = [r["id"] for r in rows if r["read_at"] is None]
+                if unread_ids:
+                    placeholders = ",".join("?" for _ in unread_ids)
+                    conn.execute(
+                        f"UPDATE messages SET read_at=? WHERE id IN ({placeholders})",
+                        (now, *unread_ids),
+                    )
+        return rows
+
+    # -- lead-side merge ------------------------------------------------
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Full team state for the lead to merge teammate outputs.
+
+        Lets the lead collect every teammate's completed-task results and the
+        message log in one read, instead of re-running subtasks in its own
+        context (success criterion #3).
+        """
+        tasks = self.list_tasks()
+        return {
+            "team_id": self.team_id,
+            "members": self.list_members(),
+            "tasks": tasks,
+            "results": {
+                t["id"]: t["result"]
+                for t in tasks
+                if t["status"] == "done" and t["result"]
+            },
+            "open_count": sum(1 for t in tasks if t["status"] == "open"),
+            "done_count": sum(1 for t in tasks if t["status"] == "done"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Teammate-side identity resolution
+# ---------------------------------------------------------------------------
+#
+# Two teammate-hosting models exist in Hermes, so identity must resolve from
+# both:
+#   * delegate_task spawns children as in-process ThreadPoolExecutor worker
+#     THREADS that all share one ``os.environ`` — env vars cannot distinguish
+#     them, so each thread stamps its identity into a ``threading.local``.
+#   * the kanban dispatcher spawns workers as SUBPROCESSES with their own
+#     environment — those carry identity in ``HERMES_TEAM_ID`` /
+#     ``HERMES_TEAM_MEMBER`` env vars (the same convention kanban uses).
+# Resolution order is therefore: explicit arg → thread-local → env.
+
+_thread_identity = threading.local()
+
+
+def set_thread_identity(team_id: Optional[str], member: Optional[str]) -> None:
+    """Bind this thread's team identity (called at a teammate thread's entry).
+
+    Used by ``delegate_task`` when it runs a teammate in a worker thread so the
+    teammate-facing tools resolve the right team + member without relying on the
+    shared process environment.
+    """
+    _thread_identity.team_id = team_id
+    _thread_identity.member = member
+
+
+def clear_thread_identity() -> None:
+    """Drop this thread's bound team identity (called when the thread exits)."""
+    _thread_identity.team_id = None
+    _thread_identity.member = None
+
+
+def current_team_id(arg: Optional[str] = None) -> Optional[str]:
+    """Resolve the active team id: explicit arg → thread-local → env."""
+    if arg:
+        return arg
+    tl = getattr(_thread_identity, "team_id", None)
+    if tl:
+        return tl
+    val = os.environ.get(TEAM_ID_ENV, "").strip()
+    return val or None
+
+
+def current_member(arg: Optional[str] = None) -> Optional[str]:
+    """Resolve the calling teammate's name: explicit arg → thread-local → env."""
+    if arg:
+        return arg
+    tl = getattr(_thread_identity, "member", None)
+    if tl:
+        return tl
+    val = os.environ.get(TEAM_MEMBER_ENV, "").strip()
+    return val or None

--- a/tools/agent_team_tools.py
+++ b/tools/agent_team_tools.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Teammate-facing agent-team tools (GitHub issue #252, first increment).
+
+Two tools, surfaced only inside a teammate session (env ``HERMES_TEAM_ID``
+set by the lead — same env-gating discipline kanban uses with
+``HERMES_KANBAN_TASK``):
+
+  * ``team_task``    — read / claim / update the shared task list.
+  * ``team_message`` — send a direct message to a named teammate (or broadcast)
+                       and read your own inbox.
+
+These ride on :class:`tools.agent_team.TeamStore`. The lead spawns each
+teammate as an isolated delegation/kanban session with ``HERMES_TEAM_ID`` and
+``HERMES_TEAM_MEMBER`` injected; the tools bind to that team + identity so a
+teammate can coordinate without the lead flattening every interaction into a
+single context.
+
+Why a separate peer-messaging channel rather than reusing kanban comments:
+kanban comments are worker→thread handoffs read by the *next* worker, not a
+direct teammate→teammate channel during concurrent execution. ``team_message``
+is the addressed, mark-read inbox #252 calls for.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from tools.agent_team import (
+    TASK_STATUSES,
+    TEAM_ID_ENV,
+    TEAM_MEMBER_ENV,
+    TeamStore,
+    current_member,
+    current_team_id,
+)
+from tools.registry import registry, tool_error, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+def check_agent_team_requirements() -> bool:
+    """Team tools are available only inside a teammate session.
+
+    A teammate session is one the lead spawned with ``HERMES_TEAM_ID`` in its
+    environment. A normal ``hermes chat`` session (no team id) sees zero
+    team_* tools — identical to how kanban tools stay hidden without
+    ``HERMES_KANBAN_TASK``.
+    """
+    return bool(os.environ.get(TEAM_ID_ENV, "").strip())
+
+
+def _resolve_store(team_id_arg: Optional[str]) -> tuple[Optional[TeamStore], Optional[str]]:
+    """Build a TeamStore for the active team, or return a tool-error string."""
+    team_id = current_team_id(team_id_arg)
+    if not team_id:
+        return None, tool_error(
+            f"no active team — {TEAM_ID_ENV} is not set and no team_id was "
+            "provided. team_* tools run inside a teammate session spawned by "
+            "the lead."
+        )
+    try:
+        store = TeamStore(team_id)
+        store.ensure_schema()
+    except ValueError as exc:
+        return None, tool_error(str(exc))
+    return store, None
+
+
+def _resolve_member(member_arg: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    member = current_member(member_arg)
+    if not member:
+        return None, tool_error(
+            f"no teammate identity — {TEAM_MEMBER_ENV} is not set and no "
+            "member was provided."
+        )
+    return member, None
+
+
+# ---------------------------------------------------------------------------
+# team_task
+# ---------------------------------------------------------------------------
+
+def team_task(
+    action: str,
+    task_id: Optional[str] = None,
+    title: Optional[str] = None,
+    result: Optional[str] = None,
+    status: Optional[str] = None,
+    team_id: Optional[str] = None,
+    member: Optional[str] = None,
+) -> str:
+    """Read / add / claim / complete tasks on the shared team task list."""
+    action = (action or "").strip().lower()
+    store, err = _resolve_store(team_id)
+    if err:
+        return err
+    assert store is not None  # narrowed by err guard
+
+    if action == "list":
+        if status and status not in TASK_STATUSES:
+            return tool_error(
+                f"invalid status {status!r}; expected one of "
+                f"{sorted(TASK_STATUSES)}"
+            )
+        return tool_result(
+            {"team_id": store.team_id, "tasks": store.list_tasks(status or None)}
+        )
+
+    if action == "add":
+        if not title or not title.strip():
+            return tool_error("title is required to add a task")
+        try:
+            task = store.add_task(title)
+        except ValueError as exc:
+            return tool_error(str(exc))
+        return tool_result({"added": True, "task": task})
+
+    if action == "claim":
+        if not task_id:
+            return tool_error("task_id is required to claim a task")
+        member_name, merr = _resolve_member(member)
+        if merr:
+            return merr
+        try:
+            outcome = store.claim_task(task_id, member_name)  # type: ignore[arg-type]
+        except ValueError as exc:
+            return tool_error(str(exc))
+        return tool_result(outcome)
+
+    if action == "complete":
+        if not task_id:
+            return tool_error("task_id is required to complete a task")
+        member_name = current_member(member) or ""
+        outcome = store.complete_task(task_id, result or "", member_name)
+        return tool_result(outcome)
+
+    return tool_error(
+        f"unknown action {action!r}; expected 'list', 'add', 'claim', or "
+        "'complete'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# team_message
+# ---------------------------------------------------------------------------
+
+def team_message(
+    action: str,
+    body: Optional[str] = None,
+    to: Optional[str] = None,
+    team_id: Optional[str] = None,
+    member: Optional[str] = None,
+) -> str:
+    """Send a direct message to a teammate (or broadcast) and read your inbox."""
+    action = (action or "").strip().lower()
+    store, err = _resolve_store(team_id)
+    if err:
+        return err
+    assert store is not None
+
+    member_name, merr = _resolve_member(member)
+    if merr:
+        return merr
+
+    if action == "send":
+        if not body or not body.strip():
+            return tool_error("body is required to send a message")
+        try:
+            outcome = store.send_message(member_name, body, to or "")  # type: ignore[arg-type]
+        except ValueError as exc:
+            return tool_error(str(exc))
+        return tool_result(outcome)
+
+    if action == "inbox":
+        try:
+            messages = store.inbox(member_name)  # type: ignore[arg-type]
+        except ValueError as exc:
+            return tool_error(str(exc))
+        return tool_result({"member": member_name, "messages": messages})
+
+    return tool_error(
+        f"unknown action {action!r}; expected 'send' or 'inbox'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+TEAM_TASK_SCHEMA = {
+    "name": "team_task",
+    "description": (
+        "Coordinate on your agent team's SHARED task list. You are one teammate "
+        "in a lead-spawned team; this list is visible to every teammate.\n\n"
+        "Actions:\n"
+        "- 'list': see all shared tasks (optionally filter by status: open / "
+        "claimed / done). Do this first to find unclaimed work.\n"
+        "- 'add': append a new shared task (title required) for any teammate to "
+        "claim — use this to hand a sub-problem to the team.\n"
+        "- 'claim': atomically take an open task (task_id required). If another "
+        "teammate already claimed it you'll be told — pick a different one.\n"
+        "- 'complete': mark your claimed task done with a result summary "
+        "(task_id required; put your findings in 'result' so the lead can "
+        "merge them without re-running your work)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "add", "claim", "complete"],
+                "description": "What to do with the shared task list.",
+            },
+            "task_id": {
+                "type": "string",
+                "description": "Task id (required for 'claim' and 'complete').",
+            },
+            "title": {
+                "type": "string",
+                "description": "Task title (required for 'add').",
+            },
+            "result": {
+                "type": "string",
+                "description": "Result summary when completing a task.",
+            },
+            "status": {
+                "type": "string",
+                "enum": ["open", "claimed", "done"],
+                "description": "Optional status filter for 'list'.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+TEAM_MESSAGE_SCHEMA = {
+    "name": "team_message",
+    "description": (
+        "Message your teammates directly. Unlike reporting back to the lead, "
+        "this reaches a peer teammate's inbox during execution — use it to "
+        "request a clarification, hand off a sub-problem, or share a finding.\n\n"
+        "Actions:\n"
+        "- 'send': deliver a message. Set 'to' to a teammate's name for a "
+        "direct message, or omit 'to' to broadcast to every teammate.\n"
+        "- 'inbox': read (and mark read) messages addressed to you. Poll this "
+        "when you're waiting on a peer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["send", "inbox"],
+                "description": "Send a message or read your inbox.",
+            },
+            "body": {
+                "type": "string",
+                "description": "Message text (required for 'send').",
+            },
+            "to": {
+                "type": "string",
+                "description": (
+                    "Recipient teammate name for a direct message. Omit to "
+                    "broadcast to all teammates."
+                ),
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="team_task",
+    toolset="agent_team",
+    schema=TEAM_TASK_SCHEMA,
+    handler=lambda args, **kw: team_task(
+        action=args.get("action", ""),
+        task_id=args.get("task_id"),
+        title=args.get("title"),
+        result=args.get("result"),
+        status=args.get("status"),
+    ),
+    check_fn=check_agent_team_requirements,
+    emoji="🧩",
+)
+
+registry.register(
+    name="team_message",
+    toolset="agent_team",
+    schema=TEAM_MESSAGE_SCHEMA,
+    handler=lambda args, **kw: team_message(
+        action=args.get("action", ""),
+        body=args.get("body"),
+        to=args.get("to"),
+    ),
+    check_fn=check_agent_team_requirements,
+    emoji="📨",
+)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -54,6 +54,94 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Agent-team identity (GitHub issue #252)
+# ---------------------------------------------------------------------------
+# A teammate is a delegated child that additionally carries a (team_id, member)
+# identity so it can use the shared task-list + peer-messaging tools in
+# tools/agent_team_tools.py. The lead opts a task into a team by adding a
+# ``team`` field: {"team_id": "<slug>", "member": "<slug>"}.
+import contextlib  # noqa: E402  (grouped with the team helpers below)
+
+
+def _resolve_team_identity(task: Dict[str, Any], task_index: int):
+    """Return a validated ``(team_id, member)`` tuple for *task*, or None.
+
+    The lead opts a task into a team via a ``team`` dict on the task. A missing
+    member name falls back to a positional ``teammate-<index>`` so the lead can
+    leave it implicit. Invalid slugs are dropped (logged) rather than raising,
+    so a malformed team field degrades to a plain delegation instead of failing
+    the whole batch.
+    """
+    team = task.get("team")
+    if not isinstance(team, dict):
+        return None
+    from tools.agent_team import is_valid_slug
+
+    team_id = str(team.get("team_id") or "").strip()
+    if not team_id or not is_valid_slug(team_id):
+        logger.warning(
+            "delegate_task: ignoring team field with invalid team_id %r",
+            team.get("team_id"),
+        )
+        return None
+    member = str(team.get("member") or "").strip() or f"teammate-{task_index}"
+    if not is_valid_slug(member):
+        logger.warning(
+            "delegate_task: ignoring team field with invalid member %r",
+            team.get("member"),
+        )
+        return None
+    return (team_id, member)
+
+
+def _ensure_team_toolset(child_toolsets, parent_agent):
+    """Ensure the ``agent_team`` toolset is present for a teammate child.
+
+    The team tools are gated by check_fn (only visible to teammates), so adding
+    the toolset to a child that the lead designated a teammate is safe even when
+    the parent did not explicitly enable it — capability is granted by team
+    membership, mirroring how role='orchestrator' re-adds 'delegation'.
+    """
+    if child_toolsets is None:
+        # Inherit-from-parent path: start from the parent's enabled toolsets so
+        # we don't accidentally widen the child to all tools.
+        parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+        base = list(parent_enabled) if parent_enabled is not None else list(DEFAULT_TOOLSETS)
+    else:
+        base = list(child_toolsets)
+    if "agent_team" not in base:
+        base.append("agent_team")
+    return base
+
+
+@contextlib.contextmanager
+def _team_identity_scope(team_identity):
+    """Bind the team identity on the current thread for the duration of a block.
+
+    Used around child construction (which resolves the child's tool schema once)
+    so the team tools' check_fn sees an active identity and includes them.
+    """
+    if team_identity is None:
+        yield
+        return
+    from tools.agent_team import (
+        clear_thread_identity,
+        set_thread_identity,
+    )
+    from tools.registry import invalidate_check_fn_cache
+
+    set_thread_identity(team_identity[0], team_identity[1])
+    # The team tools' check_fn is TTL-cached; invalidate so a stale "no team"
+    # result from this (lead) thread does not hide the tools at build time.
+    invalidate_check_fn_cache()
+    try:
+        yield
+    finally:
+        clear_thread_identity()
+        invalidate_check_fn_cache()
+
+
+# ---------------------------------------------------------------------------
 # Subagent approval callbacks
 # ---------------------------------------------------------------------------
 # Subagents run inside a ThreadPoolExecutor worker. The CLI's interactive
@@ -1463,6 +1551,15 @@ def _run_single_child(
     """
     child_start = time.monotonic()
 
+    # Agent-team identity (issue #252): rebind this worker thread's team
+    # identity so the team tools resolve the right team + member when the
+    # teammate calls them. Cleared in the finally block at the end of the run.
+    _team_identity = getattr(child, "_team_identity", None)
+    if _team_identity is not None:
+        from tools.agent_team import set_thread_identity
+
+        set_thread_identity(_team_identity[0], _team_identity[1])
+
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
 
@@ -2011,6 +2108,16 @@ def _run_single_child(
             except Exception as exc:
                 logger.debug("Failed to release credential lease: %s", exc)
 
+        # Drop this worker thread's agent-team identity (issue #252) so a
+        # recycled pool thread does not inherit a stale team binding.
+        if _team_identity is not None:
+            try:
+                from tools.agent_team import clear_thread_identity
+
+                clear_thread_identity()
+            except Exception as exc:
+                logger.debug("Failed to clear team identity: %s", exc)
+
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
@@ -2224,29 +2331,44 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command")
-                or acp_command
-                or creds.get("command"),
-                override_acp_args=(
-                    task_acp_args
-                    if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
-                ),
-                role=effective_role,
-            )
+            # Resolve optional agent-team identity for this teammate (issue
+            # #252). When present, the child becomes a team member with the
+            # shared task-list + peer-messaging tools. Children run as
+            # in-process worker threads sharing os.environ, so identity is
+            # carried via a threading.local set around construction (so the
+            # team tools' check_fn passes and the tools land in agent.tools,
+            # which is resolved once at build time) and re-set at run time.
+            team_identity = _resolve_team_identity(t, i)
+            child_toolsets = t.get("toolsets") or toolsets
+            if team_identity is not None:
+                child_toolsets = _ensure_team_toolset(child_toolsets, parent_agent)
+            with _team_identity_scope(team_identity):
+                child = _build_child_agent(
+                    task_index=i,
+                    goal=t["goal"],
+                    context=t.get("context"),
+                    toolsets=child_toolsets,
+                    model=creds["model"],
+                    max_iterations=effective_max_iter,
+                    task_count=n_tasks,
+                    parent_agent=parent_agent,
+                    override_provider=creds["provider"],
+                    override_base_url=creds["base_url"],
+                    override_api_key=creds["api_key"],
+                    override_api_mode=creds["api_mode"],
+                    override_acp_command=t.get("acp_command")
+                    or acp_command
+                    or creds.get("command"),
+                    override_acp_args=(
+                        task_acp_args
+                        if task_acp_args is not None
+                        else (acp_args if acp_args is not None else creds.get("args"))
+                    ),
+                    role=effective_role,
+                )
+            # Stamp the identity onto the child so _run_single_child can rebind
+            # the threading.local inside the worker thread that runs it.
+            child._team_identity = team_identity
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
@@ -3045,6 +3167,40 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "team": {
+                            "type": "object",
+                            "description": (
+                                "Opt this task into an agent TEAM. Teammates "
+                                "in the same team_id share a task list and can "
+                                "message each other directly via the team_task "
+                                "and team_message tools (granted automatically). "
+                                "Use this when subtasks must self-coordinate "
+                                "(claim shared work, hand off sub-problems) "
+                                "rather than run fully independently. Give every "
+                                "teammate in one delegate_task call the SAME "
+                                "team_id and a DISTINCT member name."
+                            ),
+                            "properties": {
+                                "team_id": {
+                                    "type": "string",
+                                    "description": (
+                                        "Shared team identifier (letters, "
+                                        "digits, '.', '_', '-'; max 64 chars). "
+                                        "All teammates that should coordinate "
+                                        "must use the same value."
+                                    ),
+                                },
+                                "member": {
+                                    "type": "string",
+                                    "description": (
+                                        "This teammate's name within the team "
+                                        "(same charset as team_id). Defaults to "
+                                        "'teammate-<index>' if omitted."
+                                    ),
+                                },
+                            },
+                            "required": ["team_id"],
                         },
                     },
                     "required": ["goal"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -71,6 +71,10 @@ _HERMES_CORE_TOOLS = [
     "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
+    # Agent-team coordination — only in schema inside a teammate session
+    # (HERMES_TEAM_ID env set by the lead). Gated via check_fn in
+    # tools/agent_team_tools.py.
+    "team_task", "team_message",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
 ]
@@ -247,6 +251,19 @@ TOOLSETS = {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
         "includes": []
+    },
+
+    "agent_team": {
+        "description": (
+            "Agent-team coordination — only active inside a teammate session "
+            "spawned by the lead (HERMES_TEAM_ID env set). Gives teammates a "
+            "shared task list (claim/complete) and direct teammate-to-teammate "
+            "messaging, so peers self-coordinate instead of routing everything "
+            "back through the lead. Gated via check_fn in "
+            "tools/agent_team_tools.py."
+        ),
+        "tools": ["team_task", "team_message"],
+        "includes": [],
     },
 
     # "honcho" toolset removed — Honcho is now a memory provider plugin.


### PR DESCRIPTION
## Summary

First increment of #252 "Agent-Team orchestration with independent teammate sessions".

The codebase is mature: `delegate_task` (`tools/delegate_tool.py`) already spawns teammate sessions with **independent context windows** and **per-task model selection**, and the lead already **merges teammate outputs without re-running subtasks** in its own context. So success criteria #2 and #3 were already met by delegation. The genuine residual — and what this PR adds — is the **peer-coordination primitive**: a shared task list teammates can claim/update, and **direct teammate-to-teammate messaging** (success criterion #1).

## Implemented

- **`tools/agent_team.py` — `TeamStore`**: SQLite-backed (WAL + `busy_timeout`) shared task list + per-teammate mailboxes, one DB per team at `<hermes_home>/agent_teams/<team_id>.db` (mirrors the kanban board storage convention).
  - Atomic task claim via a single `status='open'`-guarded `UPDATE` (SQLite serializes writers → exactly one winner under contention).
  - Direct + broadcast messaging; broadcast is fanned out to one row per recipient at send time; `inbox()` marks read.
  - Slug-validated `team_id` / `member` (path-traversal safe).
  - `snapshot()` for lead-side merge of completed-task results.
  - Identity resolves **arg → `threading.local` → env**, so it works for both in-process delegation worker threads (which share `os.environ`) and subprocess teammates (kanban-style, carrying `HERMES_TEAM_ID`).

- **`tools/agent_team_tools.py` — two teammate-facing tools**, gated on `HERMES_TEAM_ID` (same env-gating discipline kanban uses with `HERMES_KANBAN_TASK`; a normal `hermes chat` session sees neither):
  - `team_task` — `list` / `add` / `claim` / `complete` on the shared list.
  - `team_message` — `send` (direct via `to`, or broadcast) / `inbox`.

- **`tools/delegate_tool.py`** — a delegated task carrying a `{"team": {"team_id", "member"}}` field becomes a teammate: the `agent_team` toolset is granted and the team identity is bound on the build thread (so the tools' `check_fn` passes when the child's schema is resolved once at construction) and re-bound in the worker thread at run time, then cleared. New `team` property documented in the `delegate_task` schema.

- **`toolsets.py`** — new `agent_team` toolset + entries in the core tool list.

## Verification

- `uv run --extra dev python -m pytest tests/tools/test_agent_team.py -q` → **40 passed** (store incl. an 8-thread concurrent-claim race proving exactly one winner; tool gating; both tools' happy/error paths; arg/thread-local/env identity; end-to-end `delegate_task` wiring).
- Regression: `test_delegate.py`, `test_delegate_toolset_scope.py`, `test_delegate_composite_toolsets.py`, `test_kanban_tools.py`, `test_registry.py`, `test_toolsets.py`, `test_toolset_distributions.py` → **all green (325 total in the combined run)**.
- `uv run --extra dev ruff check` on all changed files → clean.

## Deferred (future increments of #252)

- Lead-side orchestration tool/skill (the `team` field is the model-facing entry point now; a higher-level "spawn a team" helper + a worked cross-layer-refactor skill demo are future work).
- Per-teammate live message *push* (current model is poll-your-inbox via `team_message inbox`).
- Shared knowledge store beyond task results + messages.

## Scope

First increment — does not fully close #252. Delivers the standalone-valuable coordination backbone (shared task list + direct peer messaging) on top of the existing isolated-session delegation.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>