### PR TITLE
fix(evolution): watchdog no longer false-alarms on idle stage cycles

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -72,13 +72,55 @@ def expected_report_date(now: datetime, slot_hour: int, grace_hours: int = GRACE
     return day.isoformat()
 
 
-def check_stage_reports(evolution_dir: Path, now: datetime) -> List[str]:
-    """Alert for every stage whose expected report is missing or trivial."""
+def _load_jobs(jobs_file: Path | None) -> List[dict]:
+    if jobs_file is None:
+        return []
+    try:
+        data = json.loads(jobs_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return data.get("jobs", data if isinstance(data, list) else [])
+
+
+def _stage_ran_clean_for_slot(jobs: List[dict], stage: str, date: str, slot_hour: int) -> bool:
+    """True when the cron job for ``stage`` ran with ``last_status == "ok"`` at or
+    after its slot on ``date``. A MISSING report is only a death if the job did
+    NOT run clean for the slot: when it did, the stage executed and simply had
+    nothing to do (e.g. analysis selected 0 → implementation/integration are
+    legitimately idle and need not emit a report). That is a clean idle cycle,
+    not 'the job died without record'."""
+    name = f"evolution-{stage}"
+    for job in jobs:
+        if str(job.get("name", "")) != name:
+            continue
+        if job.get("last_status") != "ok":
+            return False
+        last_run = _parse_iso(job.get("last_run_at"))
+        if last_run is None:
+            return False
+        try:
+            slot_dt = datetime.fromisoformat(date).replace(hour=slot_hour)
+        except ValueError:
+            return False
+        return last_run >= slot_dt
+    return False
+
+
+def check_stage_reports(
+    evolution_dir: Path, now: datetime, jobs_file: Path | None = None
+) -> List[str]:
+    """Alert for every stage whose expected report is missing or trivial.
+
+    A missing report is suppressed (not a death) when the stage's cron job ran
+    clean for the slot — see ``_stage_ran_clean_for_slot``."""
     alerts: List[str] = []
+    jobs = _load_jobs(jobs_file)
     for stage, (slot_hour, ext) in STAGES.items():
         date = expected_report_date(now, slot_hour)
         report = evolution_dir / stage / f"{date}.{ext}"
         if not report.exists():
+            if _stage_ran_clean_for_slot(jobs, stage, date, slot_hour):
+                continue  # ran clean, nothing to do — idle cycle, not a death
             alerts.append(
                 f"stage '{stage}': expected report {report.name} is MISSING "
                 f"(slot {slot_hour:02d}:00 + {GRACE_HOURS}h grace passed; "
@@ -246,7 +288,7 @@ def main() -> int:
         now = datetime.now()
 
     alerts: List[str] = []
-    alerts += check_stage_reports(evolution_dir, now)
+    alerts += check_stage_reports(evolution_dir, now, jobs_file)
     alerts += check_jobs(jobs_file, now)
     alerts += check_gh()
     alerts += check_health(evolution_dir)

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -40,6 +40,15 @@ gh pr list --repo "$REPO" --state open --limit 50 \
   --json number,title,headRefName,author,mergeable,mergeStateStatus
 ```
 
+1a. **Idle cycle — STILL write a report.** If there are no `evolution/issue-*`
+    candidate PRs (e.g. analysis selected 0 upstream, so implementation opened
+    none), this cycle has nothing to merge. That is NORMAL, not a failure — but
+    you MUST still write the stage report (`"merged": []`, `"skipped": []`, plus
+    a `"note"` like `"idle: no eligible evolution PRs this cycle"`) and then
+    stop. A MISSING report makes the watchdog report the job as died/never-ran.
+    Every run leaves a record — exactly like implementation writes a "No
+    implementation work" report on an idle cycle.
+
 2. **Gate each PR — merge ONLY if EVERY condition holds** (skip otherwise):
    - **Branch** is `evolution/issue-*` (agent-authored). NEVER touch dependabot,
      human, or any other branch.
@@ -247,7 +256,9 @@ echo '{"issue": <#>, "merged_at": "<YYYY-MM-DD>", "predicted_impact": <the issue
 > is not currently open per `gh pr list`, you hallucinated — STOP and redo from
 > the real list.
 
-Save to `~/.hermes/profiles/user1/evolution/integration/YYYY-MM-DD.json`:
+Save to `~/.hermes/profiles/user1/evolution/integration/YYYY-MM-DD.json` on
+**EVERY** run — including idle cycles (`merged: []`, `skipped: []`): a missing
+report is read by the watchdog as a dead job.
 
 ```json
 {
@@ -257,7 +268,8 @@ Save to `~/.hermes/profiles/user1/evolution/integration/YYYY-MM-DD.json`:
   ],
   "skipped": [
     {"pr": "<real PR number>", "reason": "<real failing/pending check or conflict>"}
-  ]
+  ],
+  "note": "<optional — e.g. 'idle: no eligible evolution PRs this cycle'>"
 }
 ```
 

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -70,6 +70,35 @@ class TestStageReports:
         alerts = check_stage_reports(tmp_path, NOW)
         assert len(alerts) == len(STAGES)
 
+    def _jobs_file(self, tmp_path, name, *, status="ok", last_run="2026-06-10T22:01:00"):
+        f = tmp_path / "jobs.json"
+        f.write_text(json.dumps({"jobs": [
+            {"name": name, "enabled": True, "last_status": status, "last_run_at": last_run}
+        ]}))
+        return f
+
+    def test_missing_report_quiet_when_job_ran_clean(self, tmp_path):
+        # implementation report missing, but its cron job ran ok at/after the
+        # 22:00 slot for the expected date (2026-06-10) → idle clean cycle, no alert.
+        self._make_reports(tmp_path, skip=("implementation",))
+        jf = self._jobs_file(tmp_path, "evolution-implementation")
+        assert check_stage_reports(tmp_path, NOW, jf) == []
+
+    def test_missing_report_alerts_when_job_errored(self, tmp_path):
+        # missing report + job FAILED → still a real anomaly.
+        self._make_reports(tmp_path, skip=("implementation",))
+        jf = self._jobs_file(tmp_path, "evolution-implementation", status="error")
+        alerts = check_stage_reports(tmp_path, NOW, jf)
+        assert len(alerts) == 1 and "implementation" in alerts[0]
+
+    def test_missing_report_alerts_when_job_ran_before_slot(self, tmp_path):
+        # job ran ok but BEFORE the slot (stale/previous day) → not this slot's
+        # clean run → still alert.
+        self._make_reports(tmp_path, skip=("integration",))
+        jf = self._jobs_file(tmp_path, "evolution-integration", last_run="2026-06-09T23:00:00")
+        alerts = check_stage_reports(tmp_path, NOW, jf)
+        assert len(alerts) == 1 and "integration" in alerts[0]
+
 
 class TestJobsHealth:
     def _jobs_file(self, tmp_path, jobs):


### PR DESCRIPTION
The 2026-06-17 watchdog flagged integration's 2026-06-16 report MISSING ('job died or never ran'). Root cause: analysis selected 0 (backlog cleared) → implementation + integration were legitimately **idle**. implementation writes an idle report; integration did not, and the watchdog treated any missing report as a death.

**Fixes:**
1. `check_stage_reports` cross-references the cron registry — a missing report is an idle clean cycle (not a death) when the stage's job ran `ok` at/after its slot; an errored/never-run job still alerts. Deterministic, doesn't rely on the agent writing an idle report.
2. `evolution-integration` SKILL writes the report on every run, including idle (mirrors implementation).

3 new tests + 28 watchdog tests pass, ruff clean. The 2nd watchdog signal (LOW_SELECTION_EFFICIENCY) is a true-but-recovering metric over a window distorted by the now-fixed incident-2 + manual merging — intentionally not gamed.