### PR TITLE
fix(evolution): multi-phase roadmap issues stall at increment 1 (next-increment continuation)

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -70,19 +70,28 @@ gh issue view <N> --repo Lexus2016/hermes-agent-evolution --json body,comments
    a false positive here silently kills the whole day's cycle, so judge
    by SLOTS, not by dates.
 
-2. **Rework first — `needs-work` issues are PRIORITY, not rejects.** An issue
-   labelled `needs-work` was ALREADY judged worth doing and attempted; a PR
-   failed code review and was sent back with a rework brief (in the issue
-   comments). Do NOT reject it as "already exists / already tried" — that throws
-   away a wanted idea. Instead SELECT it for implementation (give it priority, it
-   has momentum) so implementation can read the brief and finish it properly (or
-   consciously drop it). Only skip a `needs-work` issue if it is now genuinely
-   harmful or obsolete — and then close it with a reason AND the `rejected` label
-   (see step 3), don't just ignore it.
+2. **Momentum first — `needs-work` AND `next-increment` issues are PRIORITY, not
+   rejects.** Two non-terminal labels mark issues already judged worth doing and
+   already in motion. SELECT both for implementation (give them priority — they
+   have momentum) and read the brief in the issue comments. Do NOT reject either
+   as "already exists / already tried" — that throws away wanted, in-progress work:
+   - **`needs-work`** — a previous PR failed code review and was sent back with a
+     rework brief. Implementation reworks it (or consciously drops it).
+   - **`next-increment`** — a previous increment of a multi-phase `roadmap` issue
+     was MERGED, and a continuation brief (in the issue comments) lists what
+     REMAINS. The capability PARTIALLY exists on `main`; the issue tracks the
+     deferred slices. Implementation builds the next coherent slice from current
+     `main`. ⚠️ CRITICAL: do NOT let the "already-exists" triage (step 3) reject
+     it just because increment-1's code is now present — the brief says what is
+     still MISSING, and that remaining work is the entire point. This is the gate
+     that keeps multi-phase features advancing instead of stalling at slice 1.
+   Only skip such an issue if it is now genuinely harmful or obsolete — then close
+   it with a reason AND the `rejected` label (see step 3), don't just ignore it.
 
 3. **Viability triage — REJECT before you rank.** Implementing the wrong thing
    costs far more than skipping it. For EACH remaining open issue (NOT already
-   handled as `needs-work` above), first decide whether it should exist at all.
+   handled as `needs-work` / `next-increment` above), first decide whether it
+   should exist at all.
    REJECT it (do not rank, do not implement) if ANY holds:
    - **Already implemented** — the capability already exists. You MUST check the
      codebase before assuming it's new, e.g.:
@@ -270,12 +279,21 @@ owner can see, straight from the GitHub issue list, what happened to each idea
 | `accepted` | green `0e8a16` | Sent to a PR / implemented | evolution-implementation (when the PR is opened) |
 | `rejected` | red `b60205` | Turned down — see closing comment | analysis triage, or implementation final re-check / conscious drop |
 | `needs-work` | orange `d93f0b` | A PR was bounced back; rework in progress | evolution-integration (code-review gate) |
+| `next-increment` | blue `1d76db` | A roadmap increment merged; more deferred — re-queued | evolution-integration (post-merge, partial increment) |
 
-`accepted` and `rejected` are terminal. `needs-work` is transient: it becomes
-`accepted` once a reworked PR is opened, or `rejected` if implementation drops
-it. **This skill only ever sets `rejected`** (on triage rejects). Do NOT mark an
-issue `accepted` here — selection is a recommendation; `accepted` means the code
-actually went to a PR, which only implementation can confirm.
+`accepted` and `rejected` are terminal. `needs-work` and `next-increment` are
+TRANSIENT — they cycle back into selection (step 2):
+- `needs-work` becomes `accepted` once a reworked PR is opened, or `rejected` if
+  implementation drops it.
+- `next-increment` becomes `accepted` again when the next increment's PR opens,
+  and is finally CLOSED (by integration) when an increment's PR carries `Closes
+  #N` — i.e. when the multi-phase feature is fully delivered. Without this label
+  a `roadmap` issue stalls forever at slice 1 (`accepted` is terminal, and its
+  partial code trips the already-exists triage).
+**This skill only ever sets `rejected`** (on triage rejects). Do NOT mark an
+issue `accepted` / `next-increment` here — selection is a recommendation; those
+states mean the code actually went to / came back from a PR, which only
+implementation and integration can confirm.
 
 ## Output format
 

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -26,6 +26,17 @@ Implement selected issues, create versions, and self-update.
     with `"skipped": "stale analysis input (<date>) — upstream stage failed"`
     and STOP. Acting on outdated decisions is worse than skipping a cycle.
 
+1a0. **`next-increment` issues — CONTINUE a multi-phase roadmap feature.** If a
+    selected issue is labelled `next-increment`, a PRIOR increment already MERGED
+    and integration left a continuation brief in the comments listing what REMAINS
+    (`gh issue view <N> --repo Lexus2016/hermes-agent-evolution --comments`). The
+    capability PARTIALLY exists on `main` already — do NOT re-implement it and do
+    NOT treat the existing code as "already done". Branch FRESH from current `main`
+    (the prior increment is already there), read the brief, and implement the NEXT
+    coherent, independently-mergeable slice. In the PR, declare scope honestly
+    (see "Create a PR" below): `Closes #N` only if THIS slice finishes the issue;
+    otherwise list a `Deferred (next increment)` block so integration re-queues it.
+
 1a. **`needs-work` issues — YOUR call: rework or consciously drop.** If a selected
     issue is labelled `needs-work`, a previous PR failed code review and was sent
     back. FIRST read the rework brief in the issue comments
@@ -167,10 +178,22 @@ gh auth setup-git    # makes git https push/pull use gh's stored credentials
 ```
 
 ### Commit
+
+**Declare scope honestly — `Closes` ONLY if this slice fully delivers the issue.**
+A GitHub closing keyword (`Closes #123`) auto-closes the issue on squash-merge.
+Use it ONLY when THIS PR satisfies the issue's success criteria end-to-end. For a
+multi-phase / `roadmap` issue where you land just one coherent slice and defer the
+rest, do NOT write `Closes` (that would close it with ~75% of the work undone);
+instead, in the PR body, add a `Deferred (next increment):` block naming exactly
+what remains — integration reads it post-merge and re-queues the issue as
+`next-increment` so the pipeline finishes it later (see "Create a PR").
+
 ```bash
 git add .
 git commit -m "feat: implement feature name
 
+# Final slice → 'Closes #123'.  Partial roadmap slice → OMIT Closes (the PR body's
+# 'Deferred (next increment)' block re-queues it instead).
 Closes #123
 
 Co-Authored-By: Hermes Evolution <evolution@hermes.ai>"
@@ -186,19 +209,29 @@ git push origin evolution/issue-123-feature-name
 ⛔ Direct merge into `main` is FORBIDDEN. Create a PR and STOP there:
 
 ```bash
+# FINAL slice (fully delivers the issue):
 gh pr create --base main --head evolution/issue-123-feature-name \
   --title "feat: <feature name> (Closes #123)" \
   --body "Automated evolution PR for issue #123."
+
+# PARTIAL slice of a multi-phase / roadmap issue — OMIT Closes from title AND body,
+# and list what remains so integration re-queues it as next-increment:
+#   gh pr create --base main --head evolution/issue-123-feature-name \
+#     --title "feat: <feature name> — increment 1 of #123" \
+#     --body $'First coherent slice of #123.\n\nDeferred (next increment):\n- step 2 ...\n- step 3 ...'
 ```
 
-Once the PR is open, flip the issue to the terminal `accepted` status so the
-owner sees — straight from the issue list — that this idea actually went to a
-PR. If it was a `needs-work` rework, drop that transient label now:
+Once the PR is open, flip the issue to `accepted` so the owner sees — straight
+from the issue list — that this idea actually went to a PR. Drop any transient
+label it carried (`needs-work` rework OR `next-increment` continuation) now —
+the issue is back "in a PR". If this PR is a PARTIAL roadmap slice, integration
+will flip it BACK to `next-increment` post-merge (it can't be decided until the
+merge lands); if it `Closes #N`, it closes on merge. Either way, set `accepted` here:
 ```bash
 gh label create accepted --color 0e8a16 \
   --description "Accepted by evolution — sent to a PR" 2>/dev/null || true
 gh issue edit <issue#> --repo Lexus2016/hermes-agent-evolution \
-  --add-label accepted --remove-label needs-work 2>/dev/null || true
+  --add-label accepted --remove-label needs-work --remove-label next-increment 2>/dev/null || true
 ```
 
 Merging happens ONLY after green CI tests

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -208,6 +208,47 @@ gh pr view <N> --repo "$REPO" --json commits --jq '.commits[].oid'
 gh pr merge <N> --repo "$REPO" --squash --admin
 ```
 
+4a. **Continue or close — keep multi-phase `roadmap` issues moving (don't let them
+    stall at slice 1).** A PR that carries `Closes #NN` auto-closes its issue on
+    merge — done, nothing to do here. But a PARTIAL increment of a multi-phase
+    issue intentionally OMITS `Closes` and lists a `Deferred (next increment):`
+    block, so after merge its issue is **still open** and still labelled
+    `accepted` (terminal) — which would freeze it forever (analysis never
+    re-selects `accepted`, and the now-merged slice trips its already-exists
+    triage). Fix that here, right after the merge:
+```bash
+# Did the merge close the issue? (PR had Closes #NN → GitHub closed it)
+ISTATE=$(gh issue view <issue#> --repo "$REPO" --json state --jq .state 2>/dev/null)
+if [ "$ISTATE" = "OPEN" ]; then
+  # Partial increment of a roadmap issue. Pull the Deferred block from the PR body.
+  REMAIN=$(gh pr view <N> --repo "$REPO" --json body --jq .body \
+    | sed -n '/[Dd]eferred (next increment)/,$p')
+  INC=$(( $(gh issue view <issue#> --repo "$REPO" --json comments --jq \
+    '[.comments[]|select(.body|test("increment [0-9]+ of roadmap"))]|length') + 1 ))
+  if [ -z "$REMAIN" ] || [ "$INC" -ge 5 ]; then
+    # Nothing meaningful left (Closes was just forgotten), OR we hit the loop cap:
+    # close it. If real work still remains at the cap, also open ONE fresh issue
+    # for the remainder so it re-enters scoring honestly instead of cycling forever.
+    gh issue close <issue#> --repo "$REPO" \
+      --comment "Roadmap delivered across $INC increment(s); final slice in PR #<N>. Closing. (If scope remains, it was re-filed as a fresh issue.)"
+  else
+    # Re-queue for the next increment: non-terminal label + continuation brief.
+    gh label create next-increment --color 1d76db \
+      --description "Roadmap increment merged; more deferred — re-queued" 2>/dev/null || true
+    gh issue edit <issue#> --repo "$REPO" \
+      --add-label next-increment --remove-label accepted 2>/dev/null || true
+    gh issue comment <issue#> --repo "$REPO" --body \
+      "Increment $INC of roadmap landed in PR #<N> (merged). Remaining for next increment:
+$REMAIN
+
+Re-queued — evolution-analysis will pick this up (priority, like \`needs-work\`) and build the next slice from current \`main\`."
+  fi
+fi
+```
+    The loop terminates naturally: each increment shrinks the Deferred list until
+    one PR finally carries `Closes #NN`. The `INC >= 5` cap is a backstop against
+    a feature that never converges — close it and re-file the genuine remainder.
+
 5. **Self-update onto the merged code** (this is what makes evolution real). Use
    the OFFICIAL updater — it has snapshot + automatic rollback on failure:
 ```bash


### PR DESCRIPTION
## Problem
Issues older than 24h that look 'unprocessed' were actually fully processed: each was selected, implemented, and had its first-increment PR **merged** (#226→#265, #229→#270, #230→#267, #246→#269, #248→#261). They stay open because they are multi-phase `roadmap` features whose PR intentionally omitted `Closes #N` (the rest deferred).

They then **freeze at ~25% done**, invisible to every selection gate:
- `accepted` is a TERMINAL label → analysis never re-selects.
- the merged first slice trips the 'already-exists' triage rejection.
- the anti-starvation slot explicitly excludes `accepted`.
Nothing owns 'continue the next increment' or 'close when done'.

## Fix (instruction-only; reuses the `needs-work` momentum machinery)
- New non-terminal label **`next-increment`** (blue `1d76db`).
- **integration** step 4a (post-merge): issue still OPEN (no `Closes`) → read the PR's `Deferred (next increment)` block → re-tag `accepted`→`next-increment` + continuation-brief comment, OR close if nothing remains. Loop-guard: cap at 5 increments → close + re-file remainder.
- **implementation**: handle `next-increment` (fresh branch from `main`, read brief, next slice); `Closes #N` only for the final slice, else a `Deferred (next increment)` block.
- **analysis**: route `next-increment` through the `needs-work` PRIORITY path (select, skip already-exists triage); label table + transient note.

## Termination
Each increment shrinks the Deferred list until one PR carries `Closes #N` and integration closes the issue. The 5-increment cap backstops non-convergence.

Skill-only change (3 .md files). The 5 currently-stalled issues are backfilled separately to re-enter the pipeline.