### PR TITLE
feat: Agent-as-Judge trace replay subsystem (increment 1 of #304)

### DIFF
--- a/agent/agent_judge.py
+++ b/agent/agent_judge.py
@@ -716,3 +716,106 @@ def format_report_terminal(verdict: JudgeVerdict, rubric: Rubric = DEFAULT_RUBRI
     if verdict.rationale:
         lines.append(f"  {verdict.rationale}")
     return "\n".join(lines)
+
+
+# ── Trace replay subsystem (increment of #304) ───────────────────────────
+
+from typing import Iterator
+
+
+def replay_trace_steps(
+    messages: Sequence[Dict[str, Any]],
+) -> Iterator[Dict[str, Any]]:
+    """Yield the high-level decision steps in a recorded trace.
+
+    Emits one record per assistant turn that either (a) contains plain text
+    reasoning/answer, or (b) invokes at least one tool.  Tool turns are paired
+    with the immediately following tool result(s) so callers can judge whether
+    each decision was validated by the environment.
+
+    Yields dicts of shape::
+
+        {
+            "step": int,
+            "role": "assistant",
+            "content": str,
+            "tool_calls": List[Dict[str, Any]],
+            "tool_results": List[Dict[str, Any]],
+            "has_final_answer": bool,
+        }
+
+    Pure, deterministic, no LLM — safe to call from dashboards or CI.
+    """
+    step = 0
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "")
+        if role != "assistant":
+            continue
+        content = msg.get("content") or ""
+        tool_calls = msg.get("tool_calls") or []
+        if not content.strip() and not tool_calls:
+            continue
+        step += 1
+        tool_results = []
+        if tool_calls:
+            # Collect the next contiguous tool result messages.
+            j = i + 1
+            while j < len(messages):
+                nxt = messages[j]
+                if not isinstance(nxt, dict) or nxt.get("role") != "tool":
+                    break
+                tool_results.append(nxt)
+                j += 1
+        yield {
+            "step": step,
+            "role": "assistant",
+            "content": content if isinstance(content, str) else "",
+            "tool_calls": list(tool_calls),
+            "tool_results": tool_results,
+            "has_final_answer": bool(content.strip() and not tool_calls),
+        }
+
+
+def score_replayed_trace(
+    session_id: str,
+    messages: Sequence[Dict[str, Any]],
+    rubric: Rubric = DEFAULT_RUBRIC,
+    *,
+    task: Optional[str] = None,
+    use_llm: bool = False,
+) -> Dict[str, Any]:
+    """Score a recorded trace step-by-step.
+
+    Returns a dict containing the original ``AgentJudge`` verdict plus a
+    ``steps`` list with per-step summary data.  The step scores are heuristic
+    only (binary: 1 if the step has a tool result and no failure marker, 0
+    otherwise).  This is the deterministic, cheap baseline; LLM scoring of
+    individual steps is intentionally deferred to keep the increment small
+    and independently testable.
+    """
+    verdict = AgentJudge(rubric).score(
+        session_id, messages, task=task, use_llm=use_llm
+    )
+    steps = []
+    for step in replay_trace_steps(messages):
+        failures = sum(
+            1 for r in step["tool_results"]
+            if _looks_like_failure(r.get("content") if isinstance(r, dict) else r)
+        )
+        total = len(step["tool_results"])
+        step_score = 1.0 if total > 0 and failures == 0 else (0.5 if total == 0 else 0.0)
+        steps.append({
+            "step": step["step"],
+            "has_final_answer": step["has_final_answer"],
+            "tool_count": len(step["tool_calls"]),
+            "tool_result_count": total,
+            "tool_failure_count": failures,
+            "score": step_score,
+        })
+    return {
+        "session_id": session_id,
+        "verdict": verdict.to_dict(),
+        "steps": steps,
+    }

--- a/tests/agent/test_agent_judge_replay.py
+++ b/tests/agent/test_agent_judge_replay.py
@@ -1,0 +1,94 @@
+"""Tests for the Agent-as-Judge trace replay subsystem (issue #304)."""
+
+import pytest
+
+from agent.agent_judge import (
+    DEFAULT_RUBRIC,
+    replay_trace_steps,
+    score_replayed_trace,
+)
+
+
+SUCCESS_TRACE = [
+    {"role": "user", "content": "list the files"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "a.py\nb.py"},
+    {"role": "assistant", "content": "There are two files: a.py and b.py."},
+]
+
+FAILING_TRACE = [
+    {"role": "user", "content": "run the build"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "2"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "3"}]},
+    {"role": "tool", "content": "error: command not found"},
+]
+
+
+class TestReplayTraceSteps:
+    def test_success_trace_steps(self):
+        steps = list(replay_trace_steps(SUCCESS_TRACE))
+        assert len(steps) == 2
+        assert steps[0]["step"] == 1
+        assert steps[0]["tool_calls"]
+        assert len(steps[0]["tool_results"]) == 1
+        assert steps[1]["has_final_answer"] is True
+        assert steps[1]["tool_calls"] == []
+
+    def test_failing_trace_steps(self):
+        steps = list(replay_trace_steps(FAILING_TRACE))
+        # Three assistant turns, each a terminal call.
+        assert len(steps) == 3
+        for step in steps:
+            assert step["tool_calls"]
+            assert len(step["tool_results"]) == 1
+
+    def test_skips_non_dict_messages(self):
+        mixed = [None, "garbage"] + SUCCESS_TRACE
+        steps = list(replay_trace_steps(mixed))
+        assert len(steps) == 2
+
+    def test_empty_trace(self):
+        assert list(replay_trace_steps([])) == []
+
+
+class TestScoreReplayedTrace:
+    def test_success_trace_scores(self):
+        result = score_replayed_trace("s1", SUCCESS_TRACE, DEFAULT_RUBRIC)
+        assert result["session_id"] == "s1"
+        assert result["verdict"]["method"] == "heuristic"
+        assert result["verdict"]["overall_score"] > 0.7
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["score"] == 1.0
+        assert result["steps"][1]["score"] == 0.5
+
+    def test_failing_trace_scores_low(self):
+        result = score_replayed_trace("s2", FAILING_TRACE, DEFAULT_RUBRIC)
+        assert result["verdict"]["overall_score"] < 0.5
+        assert all(s["score"] == 0.0 for s in result["steps"])
+
+    def test_empty_trace(self):
+        result = score_replayed_trace("s3", [], DEFAULT_RUBRIC)
+        assert result["verdict"]["overall_score"] < 0.5
+        assert result["steps"] == []
+
+    def test_dict_tool_result_content(self):
+        trace = [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+            {"role": "tool", "content": {"stdout": "ok"}},
+            {"role": "assistant", "content": "Done."},
+        ]
+        steps = list(replay_trace_steps(trace))
+        assert steps[0]["tool_results"][0]["content"] == {"stdout": "ok"}
+        result = score_replayed_trace("s4", trace, DEFAULT_RUBRIC)
+        assert result["steps"][0]["score"] == 1.0
+
+    def test_serializable(self):
+        import json
+
+        result = score_replayed_trace("s5", SUCCESS_TRACE, DEFAULT_RUBRIC)
+        # Should not raise.
+        json.dumps(result)


### PR DESCRIPTION
Automated evolution PR for issue #304.

- Adds deterministic `replay_trace_steps()` that yields assistant decision steps paired with contiguous tool results.
- Adds `score_replayed_trace()` that returns the existing AgentJudge verdict plus a per-step heuristic score list.
- Keeps LLM-per-step scoring and dashboard/CLI wiring deferred so the increment is small and independently testable.

Deferred (next increment):
- Wire `score_replayed_trace()` into the session-store dashboard path.
- Add CLI command (e.g. `/judge --replay <session-id>`).
- Optional LLM scoring of individual replay steps.