### PR TITLE
fix(evolution): wake-gate requires WRITE access, not just reachability

### DIFF
--- a/scripts/evolution_access_gate.sh
+++ b/scripts/evolution_access_gate.sh
@@ -1,43 +1,64 @@
 #!/bin/bash
-# Evolution wake-gate: only wake the LLM agent if GitHub is actually reachable.
+# Evolution wake-gate: only wake the LLM agent if the authenticated GitHub
+# account has WRITE (push) access to the evolution repo.
 #
 # WHY: the whole evolution cycle (research -> issues -> analysis ->
-# implementation -> integration) only has value if the agent can POST to GitHub
-# (open issues / PRs, merge). With no GitHub access the agent can produce nothing
-# durable — so running research/issues/etc would just BURN LLM tokens and
-# web-search quota for nothing. In that case the user simply runs plain Hermes
-# from our repo and receives our updates; the agent should NOT spend money trying
-# to self-evolve without an outlet.
+# implementation -> integration) only has value if the agent can PUSH to GitHub
+# (open issues / PRs, merge). Reachability alone is NOT enough: a read-only
+# account passes `gh api user`, so it would wake the agent, let it spend tokens
+# on research/issues/analysis, and only fail at the implementation push — with
+# nothing durable to show. (This actually happened: a read-only account woke
+# the agent, ran every stage, then could not push a single branch or PR, leaving
+# a trail of "push:false" blocked-implementation comments.) Without WRITE the
+# user simply runs plain Hermes from our repo and receives our updates; the
+# agent should NOT burn LLM tokens / web-search quota trying to self-evolve with
+# no outlet.
 #
 # HOW: Hermes cron treats the LAST stdout line as a wake gate. Printing
 # `{"wakeAgent": false}` skips the agent entirely — no LLM run, no delivery.
-# This check is cheap (one gh/REST call), so it costs ~nothing to gate the
-# expensive agent run behind it.
+# The repo-permission check is one cheap REST call, so it costs ~nothing to gate
+# the expensive agent run behind it. The repo is GITHUB_EVOLUTION_REPO (same
+# default as scripts/setup_evolution_bot.sh); write is push|maintain|admin.
 set +e
 
 ENVF="${HERMES_HOME:-$HOME/.hermes}/.env"
 [ -f "$ENVF" ] && { set -a; . "$ENVF" 2>/dev/null; set +a; }
 
+REPO="${GITHUB_EVOLUTION_REPO:-Lexus2016/hermes-agent-evolution}"
+
+# A repo's `permissions` object is only populated for the AUTHENTICATED viewer,
+# so `"push":true` there means the current token can push to REPO. push,
+# maintain and admin all imply push access.
+_has_write() {
+    case "$1" in
+        *'"push":true'*|*'"maintain":true'*|*'"admin":true'*) return 0 ;;
+        *'"push": true'*|*'"maintain": true'*|*'"admin": true'*) return 0 ;;
+    esac
+    return 1
+}
+
 ok=0
 # 1) persistent gh auth (~/.config/gh) — the canonical path on a configured server
 if command -v gh >/dev/null 2>&1 && gh api user --jq .login >/dev/null 2>&1; then
-    ok=1
+    perms="$(gh api "repos/$REPO" --jq '.permissions // {}' 2>/dev/null || echo '{}')"
+    _has_write "$perms" && ok=1
 fi
 # 2) fall back to a raw token from the env file
 if [ "$ok" = "0" ] && [ -n "${GITHUB_PRIVATE_TOKEN:-}${GITHUB_TOKEN:-}" ]; then
     _tok="${GITHUB_PRIVATE_TOKEN:-$GITHUB_TOKEN}"
     if command -v curl >/dev/null 2>&1; then
-        curl -fsS -H "Authorization: Bearer ${_tok}" \
+        perms="$(curl -fsS -H "Authorization: Bearer ${_tok}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/user >/dev/null 2>&1 && ok=1
+            "https://api.github.com/repos/$REPO" 2>/dev/null)"
+        _has_write "$perms" && ok=1
     fi
     unset _tok
 fi
 
 if [ "$ok" = "1" ]; then
-    echo "evolution access-gate: GitHub reachable — waking agent."
+    echo "evolution access-gate: write access to $REPO confirmed — waking agent."
     echo '{"wakeAgent": true}'
 else
-    echo "evolution access-gate: no GitHub access — skipping agent to avoid burning LLM tokens / web-search quota. Add a GitHub token to ${ENVF} (and run 'gh auth login') to enable self-evolution."
+    echo "evolution access-gate: no WRITE access to $REPO — skipping agent to avoid burning LLM tokens / web-search quota on work that cannot be pushed (a reachable read-only account still cannot open branches/PRs). Grant the authenticated account push access on $REPO (or run as a writer), then 'gh auth login'."
     echo '{"wakeAgent": false}'
 fi

--- a/tests/scripts/test_evolution_access_gate.py
+++ b/tests/scripts/test_evolution_access_gate.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/evolution_access_gate.sh.
+
+The wake-gate must wake the agent ONLY when the authenticated GitHub account has
+WRITE (push|maintain|admin) access to the evolution repo — not merely when
+GitHub is reachable. A read-only account passes `gh api user` but cannot push a
+branch or open a PR, so waking it just burns LLM tokens.
+
+We exercise the gate with a fake `gh` on PATH that returns a configurable
+`permissions` object, and assert the final stdout line (the wake gate Hermes
+cron reads).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE = REPO_ROOT / "scripts" / "evolution_access_gate.sh"
+# Resolve bash from the real environment; the gate is then run with an isolated
+# PATH so only our fake `gh` (and no real gh/curl) is reachable from inside it.
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _write_fake_gh(bin_dir: Path, *, perms: str | None, authed: bool = True) -> None:
+    """Install a fake `gh` that answers `api user` and `api repos/...`.
+
+    `gh api repos/<repo> --jq '.permissions // {}'` is emulated by echoing the
+    already-jq-extracted permissions object (what real gh would print).
+    """
+    if perms is None:
+        perms = "{}"
+    user_branch = 'echo "tester"\n  exit 0' if authed else "exit 1"
+    script = f"""#!/bin/bash
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  {user_branch}
+fi
+if [ "$1" = "api" ]; then
+  case "$2" in
+    repos/*) printf '%s' '{perms}'; exit 0 ;;
+  esac
+fi
+exit 1
+"""
+    gh = bin_dir / "gh"
+    gh.write_text(script)
+    gh.chmod(gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run_gate(tmp_path: Path, bin_dir: Path) -> str:
+    """Run the gate with an isolated PATH/HERMES_HOME; return the last stdout line."""
+    home = tmp_path / "hermes_home"
+    home.mkdir(exist_ok=True)
+    env = {
+        "PATH": str(bin_dir),  # only our fakes are reachable
+        "HERMES_HOME": str(home),  # empty .env → no stray real token
+        "GITHUB_EVOLUTION_REPO": "Owner/repo",
+    }
+    # Ensure no inherited tokens leak in.
+    for k in ("GITHUB_TOKEN", "GITHUB_PRIVATE_TOKEN"):
+        env.pop(k, None)
+    proc = subprocess.run(
+        [BASH, str(GATE)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip().splitlines()[-1]
+
+
+def _wakes(line: str) -> bool:
+    return json.loads(line) == {"wakeAgent": True}
+
+
+def test_push_access_wakes_agent(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms='{"admin":false,"maintain":false,"push":true,"pull":true}')
+    assert _wakes(_run_gate(tmp_path, bin_dir))
+
+
+def test_admin_access_wakes_agent(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms='{"admin":true,"maintain":true,"push":true,"pull":true}')
+    assert _wakes(_run_gate(tmp_path, bin_dir))
+
+
+def test_read_only_account_does_not_wake(tmp_path: Path) -> None:
+    """The exact failure mode that prompted this fix: reachable but push:false."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms='{"admin":false,"maintain":false,"push":false,"pull":true}')
+    assert not _wakes(_run_gate(tmp_path, bin_dir))
+
+
+def test_spaced_json_push_true_wakes(tmp_path: Path) -> None:
+    """Tolerate a pretty-printed permissions object (`"push": true`)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms='{ "push": true, "pull": true }')
+    assert _wakes(_run_gate(tmp_path, bin_dir))
+
+
+def test_unauthenticated_does_not_wake(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms="{}", authed=False)
+    assert not _wakes(_run_gate(tmp_path, bin_dir))
+
+
+def test_no_gh_no_token_does_not_wake(tmp_path: Path) -> None:
+    """No gh on PATH and no env token → cannot confirm write → skip."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()  # deliberately empty: no gh, no curl
+    assert not _wakes(_run_gate(tmp_path, bin_dir))


### PR DESCRIPTION
## Problem

`scripts/evolution_access_gate.sh` woke the evolution agent whenever GitHub was *reachable* — `gh api user` succeeds for a **read-only** token. A read-only account therefore woke the agent, ran research → issues → analysis, and only failed at the implementation **push**, burning LLM tokens / web-search quota with nothing durable to show. This is exactly what produced the trail of identical `push:false` *blocked-implementation* comments on the #246/#248/#282/#283 decomposition children (account `acipat`, read-only on this repo).

## Fix

The gate now confirms **write** access (`push` | `maintain` | `admin`) on `GITHUB_EVOLUTION_REPO` — the same repo default and write semantics already used by `scripts/setup_evolution_bot.sh:63` — before emitting `wakeAgent:true`. A reachable-but-read-only account now yields `wakeAgent:false` with an actionable message. Both the persistent-`gh` path and the raw-token `curl` fallback are covered.

## Tests

`tests/scripts/test_evolution_access_gate.py` runs the gate with a fake `gh` on an isolated PATH and asserts the wake decision: push→wake, admin→wake, read-only→skip, pretty-printed JSON→wake, unauthenticated→skip, no-gh/no-token→skip. 6/6 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)