### PR TITLE
feat(skills): provides/capability layer + governance surface (#297, #299)

### DIFF
--- a/agent/skill_graph.py
+++ b/agent/skill_graph.py
@@ -116,17 +116,46 @@ def extract_skill_edges(frontmatter: Dict[str, Any]) -> Dict[str, List[str]]:
     return edges
 
 
+def extract_skill_provides(frontmatter: Dict[str, Any]) -> List[str]:
+    """Extract the capabilities a skill declares it ``provides`` (issue #297).
+
+    Reads ``metadata.hermes.graph.provides`` — a flat list of capability names.
+    A capability is an *abstract ability* (e.g. ``web-search``, ``pdf-export``),
+    NOT a skill name: several skills may provide the same capability, and a
+    ``requires`` edge may name either a concrete skill or a capability. Capability
+    ``requires`` are satisfied when some skill in the graph provides that
+    capability (see :meth:`SkillGraph.validate`). Malformed structures yield an
+    empty list rather than raising, mirroring :func:`extract_skill_edges`.
+    """
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    hermes = metadata.get("hermes")
+    if not isinstance(hermes, dict):
+        return []
+    graph = hermes.get("graph")
+    if not isinstance(graph, dict):
+        return []
+    return _normalize_edge_targets(graph.get("provides"))
+
+
 @dataclass
 class SkillNode:
-    """A single skill in the graph and its declared outbound edges."""
+    """A single skill in the graph: its declared outbound edges and the
+    capabilities it ``provides``."""
 
     name: str
     category: Optional[str] = None
     path: Optional[str] = None
     edges: Dict[str, List[str]] = field(default_factory=dict)
+    provides: List[str] = field(default_factory=list)
 
     def targets(self, edge_type: str) -> List[str]:
         return list(self.edges.get(edge_type, []))
+
+    def provided(self) -> List[str]:
+        """Capabilities this skill declares it provides."""
+        return list(self.provides)
 
 
 @dataclass
@@ -148,6 +177,11 @@ class GraphValidation:
     ``conflicts`` are reported as facts — two skills declaring
     ``conflicts-with`` each other is something the agent must avoid co-loading,
     but it does not make the graph invalid.
+
+    ``capability_conflicts`` (issue #299) report capabilities that more than one
+    skill ``provides``. That is a load-time *warning*, not an error: overlapping
+    providers are often legitimate (interchangeable implementations), but the
+    agent should know that resolving such a capability is ambiguous.
     """
 
     ok: bool
@@ -157,6 +191,7 @@ class GraphValidation:
     # Warnings (do NOT drive ok):
     missing_warnings: List[Tuple[str, str, str]]  # (source, edge_type, missing_target)
     conflicts: List[Tuple[str, str]]  # sorted (a, b) pairs
+    capability_conflicts: List[Tuple[str, List[str]]]  # (capability, sorted providers)
 
     @property
     def missing_targets(self) -> List[Tuple[str, str, str]]:
@@ -178,6 +213,10 @@ class GraphValidation:
                 for (s, e, t) in self.missing_warnings
             ],
             "conflicts": [{"a": a, "b": b} for (a, b) in self.conflicts],
+            "capability_conflicts": [
+                {"capability": cap, "providers": providers}
+                for (cap, providers) in self.capability_conflicts
+            ],
         }
 
 
@@ -219,6 +258,7 @@ class SkillGraph:
                 category=categories.get(name),
                 path=paths.get(name),
                 edges=extract_skill_edges(frontmatter or {}),
+                provides=extract_skill_provides(frontmatter or {}),
             )
         return cls(nodes)
 
@@ -255,6 +295,7 @@ class SkillGraph:
                     category=category,
                     path=rel,
                     edges=extract_skill_edges(frontmatter),
+                    provides=extract_skill_provides(frontmatter),
                 )
         return cls(nodes)
 
@@ -293,8 +334,17 @@ class SkillGraph:
           * a ``composes-with`` / ``conflicts-with`` / ``deprecates`` edge points
             at a skill not in the graph — these are advisory/governance edges
             that may legitimately reference skills in another profile or plugin;
-          * declared ``conflicts-with`` pairs.
+          * declared ``conflicts-with`` pairs;
+          * a capability ``provided`` by more than one skill (ambiguous resolution).
+
+        A ``requires`` target is satisfied (issue #297) when it names either a
+        skill in the graph OR a capability some skill ``provides``; only a target
+        that is neither is a missing-requires error. (Capability ``requires`` are
+        resolved for validation/reject here; expanding them into the load
+        ``closure``/topological order — where the provider choice may be
+        ambiguous — is deferred to the topological-loader increment, #298.)
         """
+        caps = self._capabilities()
         missing_requires: List[Tuple[str, str]] = []
         missing_warnings: List[Tuple[str, str, str]] = []
         for node in self._nodes.values():
@@ -303,12 +353,15 @@ class SkillGraph:
                     if target in self._nodes:
                         continue
                     if etype == "requires":
+                        if target in caps:
+                            continue  # satisfied by a capability provider
                         missing_requires.append((node.name, target))
                     else:
                         missing_warnings.append((node.name, etype, target))
 
         cycles = self._find_requires_cycles()
         conflicts = self._collect_conflicts()
+        capability_conflicts = self._collect_capability_conflicts()
 
         ok = not missing_requires and not cycles
         # Sort for deterministic output.
@@ -321,6 +374,7 @@ class SkillGraph:
             requires_cycles=cycles,
             missing_warnings=missing_warnings,
             conflicts=conflicts,
+            capability_conflicts=capability_conflicts,
         )
 
     def _requires_targets(self, name: str) -> List[str]:
@@ -391,6 +445,38 @@ class SkillGraph:
                 pair = tuple(sorted((node.name, target)))
                 pairs.add(pair)  # type: ignore[arg-type]
         return list(pairs)
+
+    def _collect_capability_conflicts(self) -> List[Tuple[str, List[str]]]:
+        """Capabilities provided by more than one skill (issue #299 warning)."""
+        return [
+            (cap, providers)
+            for cap, providers in self.capability_surface().items()
+            if len(providers) > 1
+        ]
+
+    # ── Capabilities (governance surface, issue #299) ─────────────────────
+
+    def _capabilities(self) -> Set[str]:
+        """Every capability provided by any skill in the graph."""
+        caps: Set[str] = set()
+        for node in self._nodes.values():
+            caps.update(node.provided())
+        return caps
+
+    def capability_surface(self) -> Dict[str, List[str]]:
+        """The resolved "what can I do?" surface: capability -> providing skills.
+
+        A capability is an abstract ability declared via ``provides``; one or
+        more skills may provide it.  Returns a dict keyed by capability name
+        (sorted) with deterministically sorted provider-skill lists.  Capabilities
+        with two or more providers are also surfaced by :meth:`validate` as
+        ``capability_conflicts`` (ambiguous resolution is a load-time warning).
+        """
+        surface: Dict[str, Set[str]] = {}
+        for node in self._nodes.values():
+            for cap in node.provided():
+                surface.setdefault(cap, set()).add(node.name)
+        return {cap: sorted(skills) for cap, skills in sorted(surface.items())}
 
     # ── Queries ───────────────────────────────────────────────────────────
 

--- a/tests/tools/test_skill_graph.py
+++ b/tests/tools/test_skill_graph.py
@@ -24,6 +24,7 @@ from agent.skill_graph import (
     EDGE_TYPES,
     SkillGraph,
     extract_skill_edges,
+    extract_skill_provides,
 )
 
 
@@ -447,6 +448,106 @@ def test_to_dot_conflict_rendered_once():
     assert dot.count('label="conflicts-with"') == 1
 
 
+# ── provides / capabilities (issue #297 + #299) ─────────────────────────────
+
+
+def test_extract_provides_empty_and_malformed():
+    assert extract_skill_provides({}) == []
+    assert extract_skill_provides({"metadata": "oops"}) == []
+    assert extract_skill_provides({"metadata": {"hermes": {"graph": "oops"}}}) == []
+
+
+def test_extract_provides_list_and_string_forms():
+    fm = _fm(provides=["web-search", "pdf-export"])
+    assert extract_skill_provides(fm) == ["web-search", "pdf-export"]
+    fm2 = {"metadata": {"hermes": {"graph": {"provides": "a, b"}}}}
+    assert extract_skill_provides(fm2) == ["a", "b"]
+
+
+def test_node_carries_provides():
+    g = _graph({"searcher": _fm(provides=["web-search"]), "plain": {}})
+    assert g.node("searcher").provided() == ["web-search"]
+    assert g.node("plain").provided() == []
+
+
+def test_capability_surface_maps_capability_to_providers():
+    g = _graph(
+        {
+            "brave": _fm(provides=["web-search"]),
+            "google": _fm(provides=["web-search"]),
+            "pdfkit": _fm(provides=["pdf-export"]),
+            "plain": {},
+        }
+    )
+    surface = g.capability_surface()
+    assert surface == {
+        "pdf-export": ["pdfkit"],
+        "web-search": ["brave", "google"],  # sorted providers
+    }
+
+
+def test_requires_satisfied_by_capability_provider():
+    # `report` requires the `web-search` capability, provided by `brave`.
+    g = _graph(
+        {
+            "report": _fm(requires=["web-search"]),
+            "brave": _fm(provides=["web-search"]),
+        }
+    )
+    v = g.validate()
+    assert v.ok  # capability requirement is satisfied, not a missing target
+    assert v.missing_requires == []
+
+
+def test_requires_capability_with_no_provider_is_missing():
+    g = _graph({"report": _fm(requires=["web-search"])})
+    v = g.validate()
+    assert not v.ok
+    assert ("report", "web-search") in v.missing_requires
+
+
+def test_capability_provided_twice_is_a_warning_not_error():
+    g = _graph(
+        {
+            "brave": _fm(provides=["web-search"]),
+            "google": _fm(provides=["web-search"]),
+        }
+    )
+    v = g.validate()
+    assert v.ok  # ambiguous provider is a warning, graph stays valid
+    assert ("web-search", ["brave", "google"]) in v.capability_conflicts
+
+
+def test_single_provider_is_not_a_capability_conflict():
+    g = _graph({"brave": _fm(provides=["web-search"]), "other": {}})
+    v = g.validate()
+    assert v.capability_conflicts == []
+
+
+def test_validation_as_dict_includes_capability_conflicts():
+    g = _graph(
+        {"a": _fm(provides=["cap"]), "b": _fm(provides=["cap"])}
+    )
+    d = g.validate().as_dict()
+    assert d["capability_conflicts"] == [
+        {"capability": "cap", "providers": ["a", "b"]}
+    ]
+
+
+def test_capability_requires_does_not_pollute_skill_closure():
+    # closure stays skill-name based; a capability requirement is validated but
+    # not auto-expanded into the load closure (deferred to #298).
+    g = _graph(
+        {
+            "report": _fm(requires=["web-search", "lib"]),
+            "lib": {},
+            "brave": _fm(provides=["web-search"]),
+        }
+    )
+    assert g.validate().ok
+    assert g.closure("report") == ["lib", "report"]
+
+
 # ── from_skills_dirs + skill_relationships wiring ───────────────────────────
 
 
@@ -501,8 +602,13 @@ def test_skill_relationships_tool_over_real_dir(tmp_path, monkeypatch):
     """End-to-end: the tools.skills_tool.skill_relationships agent surface."""
     home = tmp_path / ".hermes"
     skills = home / "skills"
-    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
-    _write_skill(skills, "cat", "lib")
+    _write_skill(
+        skills,
+        "cat",
+        "app",
+        graph_block="      requires: [lib]\n      provides: [report-gen]",
+    )
+    _write_skill(skills, "cat", "lib", graph_block="      provides: [data-access]")
 
     monkeypatch.setenv("HERMES_HOME", str(home))
     import importlib
@@ -521,12 +627,19 @@ def test_skill_relationships_tool_over_real_dir(tmp_path, monkeypatch):
     assert whole["topological_order"].index("lib") < whole[
         "topological_order"
     ].index("app")
+    # Capability surface ("what can I do?") is exposed.
+    assert whole["capability_surface"] == {
+        "data-access": ["lib"],
+        "report-gen": ["app"],
+    }
+    assert whole["validation"]["capability_conflicts"] == []
 
     # Single-skill mode.
     one = json.loads(mod.skill_relationships("app"))
     assert one["success"] is True
     assert one["skill"] == "app"
     assert one["edges"]["requires"] == ["lib"]
+    assert one["provides"] == ["report-gen"]
     assert one["closure"] == ["lib", "app"]
     assert one["blast_radius"] == {
         "dependents": [],

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -843,14 +843,16 @@ def _build_skill_graph():
 def skill_relationships(name: str = None) -> str:
     """Report the dependency/composition/governance graph around skill(s).
 
-    With *name*: returns that skill's declared edges, its transitive
-    ``requires`` closure (the minimal set to load it), and its blast radius
-    (dependents / conflicts / composition partners).  Without *name*: validates
-    the whole graph (missing edge targets, ``requires`` cycles, conflicts) and
-    returns the dependency-first topological order.
+    With *name*: returns that skill's declared edges, the capabilities it
+    ``provides``, its transitive ``requires`` closure (the minimal set to load
+    it), and its blast radius (dependents / conflicts / composition partners).
+    Without *name*: validates the whole graph (missing edge targets, ``requires``
+    cycles, conflicts, capability conflicts), returns the dependency-first
+    topological order, and the resolved capability surface (``what can I do?`` —
+    capability -> providing skills).
 
     Returns a JSON string.  This is the agent-facing surface of the
-    Skills-as-Graph layer (issue #246, first increment).
+    Skills-as-Graph layer (issue #246; capability/governance increment #297+#299).
     """
     try:
         graph = _build_skill_graph()
@@ -867,11 +869,13 @@ def skill_relationships(name: str = None) -> str:
                     },
                     ensure_ascii=False,
                 )
+            node = graph.node(name)
             return json.dumps(
                 {
                     "success": True,
                     "skill": name,
                     "edges": graph.edges_of(name),
+                    "provides": node.provided() if node else [],
                     "closure": graph.closure(name),
                     "blast_radius": graph.blast(name),
                     "graph_ok": validation.ok,
@@ -885,6 +889,7 @@ def skill_relationships(name: str = None) -> str:
                 "skill_count": len(graph),
                 "validation": validation.as_dict(),
                 "topological_order": graph.topological_order(),
+                "capability_surface": graph.capability_surface(),
             },
             ensure_ascii=False,
         )


### PR DESCRIPTION
Builds on the Skills-as-Graph first increment (PR #269, `agent/skill_graph.py`). Implements the capability half of the #246 decomposition.

## #297 — data model: `provides` + requires-resolution
- Skills declare `metadata.hermes.graph.provides`: a flat list of **capability** names (abstract abilities like `web-search`, not skill names).
- A `requires` edge may now name **either a skill or a capability**. A capability requirement is satisfied when some skill `provides` it, so `validate()` rejects only genuinely unresolved requires (the 'loader rejects manifests with unresolved requires' behaviour, validation-driven).
- Scope boundary: expanding capability-requires into the load **closure**/topological order (where the provider choice can be ambiguous) is deferred to the topological-loader increment **#298** — documented in `validate()`.

## #299 — governance: capability surface + conflict warnings
- `SkillGraph.capability_surface()` → the resolved **'what can I do?'** map (capability → providing skills).
- `validate()` now reports `capability_conflicts`: a capability provided by 2+ skills is a load-time **warning** (ambiguous resolution), never an error.
- Exposed through the `skill_relationships` agent tool: `capability_surface` on the whole-graph view, `provides` on the single-skill view.

## Why not #298 here
#298 refactors the real flat skills **loader** into `skills_loader_v2.py` — a hot-path change affecting startup loading for every profile. It deserves its own careful PR rather than riding along in this additive data-model increment; left as `needs-work`.

## Tests
Pure additive layer: existing 37 `skill_graph` tests unchanged; **+10** new (provides parsing, capability surface, requires-via-capability resolution, capability-conflict warnings, closure isolation, tool wiring). 47 green in the file; 456 green across all `skills_tool` tests.

Closes #297. Partially addresses #299 (capability surface + conflict warnings shipped; per-profile resolution wiring follows #298).

🤖 Generated with [Claude Code](https://claude.com/claude-code)