### PR TITLE
feat(plan): explicit Plan/Step schema + inert pre-tool-call emission (#290)

### DIFF
--- a/agent/plan_schema.py
+++ b/agent/plan_schema.py
@@ -1,0 +1,222 @@
+"""Explicit plan data model — the artifact behind plan-and-execute (issue #290).
+
+Hermes' loop is reactive ReAct today: observe, think, act, one tool call at a
+time. The plan-and-execute upgrade (parent #283) replaces that greedy posture
+with an *explicit, ordered plan* the agent commits to before it starts calling
+tools. This module ships only the **data model** for that plan plus a safe,
+inert emission seam — no lookahead (sibling #291), no replanning (sibling #292).
+
+What's here
+-----------
+* :class:`Step` — one ordered unit of intended work. Three fields, matching the
+  issue spec: ``tool_call_intent`` (what tool/action the agent means to run),
+  ``rationale`` (why this step, in plain language), and
+  ``expected_observation`` (what the agent expects to see back). All three are
+  declarative *intent* — a Step is never the tool call itself, so building a
+  plan has no side effects and dispatches nothing.
+* :class:`Plan` — an ordered, immutable sequence of ``Step`` s with an optional
+  one-line ``goal``. Steps are 1-indexed for humans via :attr:`Step.index`.
+* :func:`emit_plan` — render a plan to a human-readable block and hand it to an
+  ``emit`` sink (a ``print``-like callable). Pure I/O on a sink the caller
+  supplies; it computes nothing about tool dispatch.
+
+Why frozen dataclasses
+----------------------
+The codebase models declarative "this is the resolved shape of X" objects as
+``@dataclass(frozen=True)`` (see ``agent.coding_context.ContextProfile`` /
+``RuntimeMode``). A plan is exactly that kind of object: built once, read by
+many, never mutated in place. Freezing makes accidental mid-flight edits a hard
+error and keeps the artifact safe to stash on session state and share.
+
+Default-off by construction
+---------------------------
+Nothing in this module reaches into the agent loop, and nothing in the loop
+constructs a :class:`Plan` on its own. The emission hook on the agent
+(``_emit_plan_before_tool_calls``) is a no-op until something sets an active
+plan, so the agent behaves identically when the feature is unused. Wiring an
+opt-in flag and an eval harness on top of this is #292's job, not this slice's.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+# A plan-emission sink: any ``print``-like callable taking a single string.
+EmitFn = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class Step:
+    """One ordered, declarative step of an execution plan.
+
+    A ``Step`` describes *intended* work — it is never the tool call itself, so
+    constructing one runs nothing and has no side effects. The three content
+    fields are the issue-#290 contract:
+
+    ``tool_call_intent``     — the tool or action the agent means to take next,
+                               e.g. ``"read_file(agent/plan_schema.py)"`` or
+                               ``"search the web for FLARE benchmark numbers"``.
+                               Free text by design: this is a stated intent, not
+                               a validated/dispatchable tool invocation.
+    ``rationale``            — why this step exists, in plain language. The
+                               reasoning that justifies the intent.
+    ``expected_observation`` — what the agent expects to observe back if the
+                               step goes as planned. The yardstick a later
+                               replanning pass (#292) will compare reality
+                               against; unused here beyond being recorded.
+
+    ``index`` is an optional 1-based position used only for human-readable
+    rendering. :meth:`Plan.__post_init__` assigns it when steps are collected
+    into a plan, so callers normally leave it ``None``.
+    """
+
+    tool_call_intent: str
+    rationale: str
+    expected_observation: str
+    index: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        # Intent and rationale are the load-bearing fields; an empty intent is a
+        # programming error (a step that intends nothing). Validate at the
+        # source rather than letting a blank step slip into the artifact.
+        if not self.tool_call_intent or not self.tool_call_intent.strip():
+            raise ValueError("Step.tool_call_intent must be a non-empty string")
+        if not self.rationale or not self.rationale.strip():
+            raise ValueError("Step.rationale must be a non-empty string")
+
+    def with_index(self, index: int) -> "Step":
+        """Return a copy of this step pinned to a 1-based ``index``.
+
+        Frozen dataclasses can't be mutated, so plan assembly rebuilds each step
+        with its position rather than writing the field in place.
+        """
+        return Step(
+            tool_call_intent=self.tool_call_intent,
+            rationale=self.rationale,
+            expected_observation=self.expected_observation,
+            index=index,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict (session-state / transcript friendly)."""
+        return {
+            "tool_call_intent": self.tool_call_intent,
+            "rationale": self.rationale,
+            "expected_observation": self.expected_observation,
+            "index": self.index,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Step":
+        """Rebuild a :class:`Step` from :meth:`to_dict` output.
+
+        Tolerant of a missing ``expected_observation`` / ``index`` (older or
+        hand-authored payloads), strict on the two required fields via
+        :meth:`__post_init__`.
+        """
+        return cls(
+            tool_call_intent=str(data.get("tool_call_intent", "")),
+            rationale=str(data.get("rationale", "")),
+            expected_observation=str(data.get("expected_observation", "")),
+            index=data.get("index"),
+        )
+
+    def render(self) -> str:
+        """One human-readable block for this step (used by :func:`emit_plan`)."""
+        head = f"{self.index}. " if self.index is not None else "- "
+        lines = [f"{head}{self.tool_call_intent}"]
+        lines.append(f"   why: {self.rationale}")
+        if self.expected_observation and self.expected_observation.strip():
+            lines.append(f"   expect: {self.expected_observation}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class Plan:
+    """An ordered, immutable plan: a ``goal`` plus 1-indexed :class:`Step` s.
+
+    Built once and read by many. The constructor assigns each step its 1-based
+    :attr:`Step.index` so callers pass steps without worrying about numbering.
+    A plan with zero steps is rejected — an empty plan is not an artifact, and
+    the inert emission hook treats "no plan" and "empty plan" the same anyway
+    (it emits nothing), so forbidding it keeps the type honest.
+    """
+
+    steps: Sequence[Step]
+    goal: str = ""
+    # Free-form provenance/labels for downstream consumers (#292's harness).
+    # Never read by this module; carried verbatim.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.steps:
+            raise ValueError("Plan must contain at least one Step")
+        # Re-pin indices 1..N so the artifact's numbering is always canonical,
+        # regardless of any index the caller set on individual steps. Frozen, so
+        # assign through object.__setattr__ (the dataclass-documented escape
+        # hatch for normalizing fields in __post_init__).
+        indexed = tuple(
+            step.with_index(position)
+            for position, step in enumerate(self.steps, start=1)
+        )
+        object.__setattr__(self, "steps", indexed)
+
+    def __len__(self) -> int:
+        return len(self.steps)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict for session state or transcripts."""
+        return {
+            "goal": self.goal,
+            "steps": [step.to_dict() for step in self.steps],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Plan":
+        """Rebuild a :class:`Plan` from :meth:`to_dict` output."""
+        raw_steps = data.get("steps") or []
+        steps = [Step.from_dict(item) for item in raw_steps]
+        metadata = data.get("metadata")
+        return cls(
+            steps=steps,
+            goal=str(data.get("goal", "")),
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+        )
+
+    def render(self) -> str:
+        """Render the whole plan as a human-readable text block.
+
+        Stable, terminal-friendly output suitable for printing before tool
+        calls or stashing in a transcript. No ANSI, no side effects.
+        """
+        lines: List[str] = []
+        header = "Plan"
+        if self.goal and self.goal.strip():
+            header = f"Plan — {self.goal.strip()}"
+        lines.append(header)
+        for step in self.steps:
+            lines.append(step.render())
+        return "\n".join(lines)
+
+
+def emit_plan(plan: Optional[Plan], *, emit: EmitFn) -> bool:
+    """Render ``plan`` and push it to the ``emit`` sink. Inert when no plan.
+
+    The single shared emission primitive. Returns ``True`` if a plan was
+    emitted, ``False`` when ``plan`` is ``None`` (the default-off case) — so the
+    agent's pre-tool-call hook can call this unconditionally and stay a no-op
+    until an active plan is set.
+
+    ``emit`` is any ``print``-like callable; the agent passes its own status
+    sink. Never raises on a misbehaving sink — emission must not break a turn.
+    """
+    if plan is None:
+        return False
+    try:
+        emit(plan.render())
+    except Exception:
+        # A broken sink must never interrupt tool dispatch.
+        return False
+    return True

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -145,6 +145,10 @@ def build_turn_context(
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
     agent._vision_supported = True
+    # Plan-and-execute (#290): re-arm the once-per-turn plan emission guard so
+    # an active plan (if any) is re-emitted at the start of each turn. Inert
+    # unless ``agent._active_plan`` is set — see ``_emit_plan_before_tool_calls``.
+    agent._plan_emitted_for_turn = False
 
     # Pre-turn connection health check: clean up dead TCP connections.
     if agent.api_mode != "anthropic_messages":

--- a/run_agent.py
+++ b/run_agent.py
@@ -5121,6 +5121,30 @@ class AIAgent:
         self._set_tool_guardrail_halt(decision)
         return toolguard_synthetic_result(decision)
 
+    def _emit_plan_before_tool_calls(self) -> None:
+        """Emit the active plan once, just before this turn's tool dispatch.
+
+        Plan-and-execute slice (#290): a safe, inert emission seam. The agent
+        keeps an optional active plan on session state (``self._active_plan``,
+        ``None`` by default). When set to a :class:`agent.plan_schema.Plan`,
+        this renders it through ``_emit_status`` exactly once per turn (guarded
+        by ``self._plan_emitted_for_turn`` so a multi-iteration turn doesn't
+        reprint it). When unset — the default — this is a no-op, so the agent's
+        observable behavior is unchanged until a future slice (#292) opts in by
+        building and assigning a plan.
+
+        Deliberately scope-bounded: this neither builds a plan, reads one back,
+        nor influences tool selection. It is store-and-show only.
+        """
+        plan = getattr(self, "_active_plan", None)
+        if plan is None:
+            return
+        if getattr(self, "_plan_emitted_for_turn", False):
+            return
+        from agent.plan_schema import emit_plan
+        if emit_plan(plan, emit=self._emit_status):
+            self._plan_emitted_for_turn = True
+
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
@@ -5129,6 +5153,12 @@ class AIAgent:
         file reads/writes may do so only when their target paths do not overlap.
         """
         tool_calls = assistant_message.tool_calls
+
+        # Plan-and-execute (#290): emit the committed plan once, just before the
+        # first tool dispatch of a turn. Inert by default — no-op unless an
+        # active plan has been set on session state (nothing in the default loop
+        # sets one). See ``_emit_plan_before_tool_calls``.
+        self._emit_plan_before_tool_calls()
 
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True

--- a/tests/agent/test_plan_schema.py
+++ b/tests/agent/test_plan_schema.py
@@ -1,0 +1,167 @@
+"""Tests for agent.plan_schema — Step/Plan data model and inert emission seam.
+
+Covers the issue-#290 contract: the three Step fields, ordered/immutable Plan
+assembly with 1-based indexing, round-trip serialization, human-readable
+rendering, and ``emit_plan`` being inert (no-op) when no plan is set — the
+property that keeps the run_agent.py hook default-off.
+"""
+
+import pytest
+
+from agent.plan_schema import Plan, Step, emit_plan
+
+
+# ── Step ────────────────────────────────────────────────────────────────────
+
+class TestStep:
+    def test_holds_the_three_required_fields(self):
+        step = Step(
+            tool_call_intent="read_file(agent/plan_schema.py)",
+            rationale="understand the current schema before editing",
+            expected_observation="the module source with Step and Plan defs",
+        )
+        assert step.tool_call_intent == "read_file(agent/plan_schema.py)"
+        assert step.rationale == "understand the current schema before editing"
+        assert step.expected_observation == "the module source with Step and Plan defs"
+        assert step.index is None
+
+    def test_is_frozen(self):
+        step = Step(tool_call_intent="x", rationale="y", expected_observation="z")
+        with pytest.raises((AttributeError, TypeError)):
+            step.tool_call_intent = "mutated"  # type: ignore[misc]
+
+    def test_empty_intent_rejected_at_source(self):
+        with pytest.raises(ValueError):
+            Step(tool_call_intent="   ", rationale="y", expected_observation="z")
+
+    def test_empty_rationale_rejected_at_source(self):
+        with pytest.raises(ValueError):
+            Step(tool_call_intent="x", rationale="", expected_observation="z")
+
+    def test_empty_expected_observation_allowed(self):
+        # expected_observation is the replanning yardstick (#292); a step may
+        # legitimately not predict an observation yet.
+        step = Step(tool_call_intent="x", rationale="y", expected_observation="")
+        assert step.expected_observation == ""
+
+    def test_with_index_returns_pinned_copy(self):
+        step = Step(tool_call_intent="x", rationale="y", expected_observation="z")
+        pinned = step.with_index(3)
+        assert pinned.index == 3
+        assert step.index is None  # original untouched (frozen copy semantics)
+        assert pinned.tool_call_intent == "x"
+
+    def test_round_trip_dict(self):
+        step = Step(
+            tool_call_intent="search the web for FLARE numbers",
+            rationale="cite the benchmark improvement",
+            expected_observation="CWQ 58% -> 73.6%",
+            index=2,
+        )
+        restored = Step.from_dict(step.to_dict())
+        assert restored == step
+
+    def test_from_dict_tolerates_missing_optional_fields(self):
+        step = Step.from_dict({"tool_call_intent": "x", "rationale": "y"})
+        assert step.expected_observation == ""
+        assert step.index is None
+
+    def test_render_includes_intent_rationale_and_expectation(self):
+        step = Step(
+            tool_call_intent="run pytest",
+            rationale="prove the change is green",
+            expected_observation="all tests pass",
+            index=1,
+        )
+        rendered = step.render()
+        assert "1. run pytest" in rendered
+        assert "why: prove the change is green" in rendered
+        assert "expect: all tests pass" in rendered
+
+    def test_render_omits_expectation_line_when_blank(self):
+        step = Step(
+            tool_call_intent="run pytest", rationale="prove green",
+            expected_observation="", index=1,
+        )
+        assert "expect:" not in step.render()
+
+
+# ── Plan ────────────────────────────────────────────────────────────────────
+
+def _step(intent: str) -> Step:
+    return Step(tool_call_intent=intent, rationale="r-" + intent, expected_observation="o-" + intent)
+
+
+class TestPlan:
+    def test_assigns_one_based_indices_in_order(self):
+        plan = Plan(steps=[_step("a"), _step("b"), _step("c")], goal="demo")
+        assert [s.index for s in plan.steps] == [1, 2, 3]
+        assert [s.tool_call_intent for s in plan.steps] == ["a", "b", "c"]
+
+    def test_reindexes_regardless_of_caller_supplied_index(self):
+        # Caller-set indices are normalized to canonical 1..N.
+        messy = [_step("a").with_index(99), _step("b").with_index(5)]
+        plan = Plan(steps=messy)
+        assert [s.index for s in plan.steps] == [1, 2]
+
+    def test_is_frozen(self):
+        plan = Plan(steps=[_step("a")])
+        with pytest.raises((AttributeError, TypeError)):
+            plan.goal = "mutated"  # type: ignore[misc]
+
+    def test_empty_plan_rejected(self):
+        with pytest.raises(ValueError):
+            Plan(steps=[])
+
+    def test_len_reflects_step_count(self):
+        assert len(Plan(steps=[_step("a"), _step("b")])) == 2
+
+    def test_metadata_carried_verbatim(self):
+        plan = Plan(steps=[_step("a")], metadata={"source": "test", "k": 1})
+        assert plan.metadata == {"source": "test", "k": 1}
+
+    def test_round_trip_dict(self):
+        plan = Plan(
+            steps=[_step("a"), _step("b")],
+            goal="ship the schema",
+            metadata={"origin": "#290"},
+        )
+        restored = Plan.from_dict(plan.to_dict())
+        assert restored == plan
+
+    def test_render_has_goal_header_and_every_step(self):
+        plan = Plan(steps=[_step("alpha"), _step("beta")], goal="do the thing")
+        rendered = plan.render()
+        assert "Plan — do the thing" in rendered
+        assert "1. alpha" in rendered
+        assert "2. beta" in rendered
+
+    def test_render_without_goal_uses_bare_header(self):
+        rendered = Plan(steps=[_step("only")]).render()
+        assert rendered.splitlines()[0] == "Plan"
+
+
+# ── emit_plan (the inert seam) ───────────────────────────────────────────────
+
+class TestEmitPlan:
+    def test_none_plan_is_inert(self):
+        sink: list[str] = []
+        emitted = emit_plan(None, emit=sink.append)
+        assert emitted is False
+        assert sink == []  # default-off: nothing rendered, nothing emitted
+
+    def test_emits_rendered_plan_once(self):
+        sink: list[str] = []
+        plan = Plan(steps=[_step("a")], goal="g")
+        emitted = emit_plan(plan, emit=sink.append)
+        assert emitted is True
+        assert len(sink) == 1
+        assert "Plan — g" in sink[0]
+        assert "1. a" in sink[0]
+
+    def test_broken_sink_does_not_raise(self):
+        def boom(_text: str) -> None:
+            raise RuntimeError("sink exploded")
+
+        # Emission must never break a turn — a misbehaving sink is swallowed.
+        assert emit_plan(Plan(steps=[_step("a")]), emit=boom) is False


### PR DESCRIPTION
Child of #283 (plan-and-execute). Ships the **plan data model** only.

- `agent/plan_schema.py`: frozen `Step` (`tool_call_intent`, `rationale`, `expected_observation`) + ordered `Plan` (1..N indices, dict round-trip, render). Source-level validation, no `cast`.
- `run_agent.py`: `_emit_plan_before_tool_calls` at the top of `_execute_tool_calls` — **default-off**, no-op unless `_active_plan` is set, at-most-once per turn. Byte-identical default behavior.

**Scope boundary:** no lookahead (#291), no replanning/opt-in flag/eval (#292), no plan construction — store-and-show seam only.
Tests: `tests/agent/test_plan_schema.py` — 22 passed. Note: touches `run_agent.py`/`turn_context.py` (shared with #293) — second merge may need a trivial conflict resolution.

Closes #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)