### PR TITLE
feat(verify): VerifyPolicy registry + advisory consult for mutating calls (#293)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -684,6 +684,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
+                # Gather-Act-Verify advisory consult (#293). Opt-in, default
+                # off; runs a registered verifier against a *successful*
+                # mutating call and records the outcome. Never retries/blocks
+                # — that is #294. The helper is fully self-gating.
+                try:
+                    agent._consult_verify_policy(
+                        function_name, function_args, function_result, is_error,
+                    )
+                except Exception as _vp_err:
+                    logging.debug("verify-policy consult failed: %s", _vp_err)
+
             if not blocked and agent.tool_progress_callback:
                 try:
                     agent.tool_progress_callback(
@@ -1333,6 +1344,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
+            # Gather-Act-Verify advisory consult (#293) — see the concurrent
+            # path for rationale. Opt-in, default off; verify-after-success,
+            # never retries/blocks (#294). Both dispatch paths feed the same
+            # advisory seam.
+            try:
+                agent._consult_verify_policy(
+                    function_name, function_args, function_result, _is_error_result,
+                )
+            except Exception as _vp_err:
+                logging.debug("verify-policy consult failed: %s", _vp_err)
 
         if not _execution_blocked and agent.tool_progress_callback:
             try:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -351,6 +351,16 @@ def build_turn_context(
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
 
+    # Gather-Act-Verify (#293): lazily-built verify-policy registry + per-turn
+    # advisory-outcome ledger. The registry persists across turns (verifiers are
+    # registered once by skills/config); only the per-turn outcome list resets.
+    _vp_state = getattr(agent, "_verify_policy_state", None)
+    if _vp_state is None:
+        from agent.verify_policy import _AgentVerifyState
+        agent._verify_policy_state = _AgentVerifyState()
+    else:
+        _vp_state.outcomes.clear()
+
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.
     agent._execution_thread_id = threading.current_thread().ident

--- a/agent/verify_policy.py
+++ b/agent/verify_policy.py
@@ -1,0 +1,372 @@
+"""Gather-Act-Verify — the verify-hook registry for mutating tool calls.
+
+Issue #293 (child of #282). After a mutating tool call *succeeds*, the agent
+may consult a registry of verifiers that re-check the claimed outcome: a write
+that returned ``bytes_written`` actually landed on disk, a ``terminal`` command
+that exited 0 actually produced the artifact it promised, and so on. Mutating
+calls can succeed silently while producing the wrong outcome — this registry is
+the seam where a verifier confirms (or contradicts) that.
+
+Scope (deliberately minimal — see the constraints on #293):
+
+* This module is the **registry + policy** only. It defines what a verifier is,
+  how mutating tools register one, and a :func:`VerifyPolicy.consult` entrypoint
+  that returns a structured :class:`VerifyOutcome`.
+* The *default* verifiers (file-exists + content for writes, exit-code + output
+  for terminal) and **retry-on-mismatch** are the sibling issue #294. Nothing
+  here retries, blocks, or rewrites a call.
+* Consultation is **advisory**. ``consult`` is a pure read: it runs the
+  registered verifier and reports ``ok`` / ``mismatch`` / ``error`` /
+  ``skipped``. It never raises out of a verifier, never mutates the call, and
+  never touches the conversation. The caller decides what (if anything) to do
+  with the outcome — by default, log it.
+
+Design mirrors :mod:`agent.tool_guardrails` / :mod:`agent.policy_interceptors`
+intentionally: frozen dataclasses, pure verifiers, a config-shaped registry.
+This is verify-**after-success** and **opt-in** — distinct from the existing
+turn-end file-mutation *failure* footer (``turn_finalizer.py`` ~L189), which
+surfaces writes that FAILED. The two never collide: that footer reads failures,
+this registry reads successes.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+# Canonical names of the mutating tools that MUST be verifiable. Mirrors the
+# tools called out in #293. Kept local (not imported from tool_guardrails'
+# broader MUTATING_TOOL_NAMES) because the verify contract is about tools whose
+# success is checkable against an external artifact — writes, patches, and
+# shell mutations — not every state-touching tool (todo/memory/etc.).
+MUTATING_TOOL_NAMES: frozenset[str] = frozenset(
+    {"write_file", "patch", "terminal", "write_to_file"}
+)
+
+
+@dataclass(frozen=True)
+class VerifyCall:
+    """Immutable view of the mutating call being verified.
+
+    ``tool_name`` and ``args`` describe what the model asked for; ``result`` is
+    the (successful) tool result string the dispatch path observed. A verifier
+    inspects these to decide whether the claimed mutation really happened.
+    """
+
+    tool_name: str
+    args: Mapping[str, Any]
+    result: Any = None
+
+
+@dataclass(frozen=True)
+class VerifyOutcome:
+    """Structured result of consulting the registry for one mutating call.
+
+    ``status`` is one of:
+
+    * ``ok``       — a verifier ran and confirmed the mutation.
+    * ``mismatch`` — a verifier ran and the mutation did NOT hold (the silent
+      failure #282 is about). Advisory: the caller logs it; #294 will retry.
+    * ``error``    — the verifier itself raised / could not run. Never fatal.
+    * ``skipped``  — no verifier registered for this tool, or the feature is off.
+
+    ``verifier`` names which verifier produced the outcome (empty when skipped).
+    ``detail`` is a short human-readable explanation for logs.
+    """
+
+    status: str  # ok | mismatch | error | skipped
+    tool_name: str
+    verifier: str = ""
+    detail: str = ""
+
+    @property
+    def confirmed(self) -> bool:
+        """True only when a verifier ran and the mutation held."""
+        return self.status == "ok"
+
+    @property
+    def ran(self) -> bool:
+        """True when a verifier actually executed (ok, mismatch, or error)."""
+        return self.status in {"ok", "mismatch", "error"}
+
+    @classmethod
+    def ok(cls, tool_name: str, verifier: str, detail: str = "") -> "VerifyOutcome":
+        return cls(status="ok", tool_name=tool_name, verifier=verifier, detail=detail)
+
+    @classmethod
+    def mismatch(cls, tool_name: str, verifier: str, detail: str = "") -> "VerifyOutcome":
+        return cls(status="mismatch", tool_name=tool_name, verifier=verifier, detail=detail)
+
+    @classmethod
+    def error(cls, tool_name: str, verifier: str, detail: str = "") -> "VerifyOutcome":
+        return cls(status="error", tool_name=tool_name, verifier=verifier, detail=detail)
+
+    @classmethod
+    def skipped(cls, tool_name: str, detail: str = "") -> "VerifyOutcome":
+        return cls(status="skipped", tool_name=tool_name, detail=detail)
+
+
+# A verifier is a pure predicate: given the call, return True when the mutation
+# is confirmed and False when it is not. Raising is tolerated by ``consult`` and
+# surfaced as a ``VerifyOutcome.error`` — a verifier never crashes a turn.
+Verifier = Callable[[VerifyCall], bool]
+
+
+@dataclass(frozen=True)
+class RegisteredVerifier:
+    """A verifier bound to a human-readable name for log attribution."""
+
+    name: str
+    verifier: Verifier
+
+
+# ── Verifier factories ───────────────────────────────────────────────────────
+# Three kinds, matching #293: command, file-existence, symbolic predicate.
+
+
+def make_file_exists_verifier(
+    path_resolver: Callable[[VerifyCall], list[str]] | None = None,
+) -> Verifier:
+    """File-existence verifier: confirm the call's target path(s) now exist.
+
+    ``path_resolver`` maps a call to the list of paths that should exist after
+    it. Defaults to reading ``args["path"]`` (the common write_file/patch shape)
+    plus ``args["file"]`` for ``write_to_file``. A mutation is confirmed only
+    when *every* resolved path exists on disk; an empty resolution is treated as
+    "nothing to check" → confirmed (the call mutated something unaddressable
+    here, e.g. an in-place terminal command — not this verifier's job).
+    """
+
+    def _default_resolver(call: VerifyCall) -> list[str]:
+        paths: list[str] = []
+        for key in ("path", "file"):
+            val = call.args.get(key)
+            if isinstance(val, str) and val:
+                paths.append(val)
+        return paths
+
+    resolve = path_resolver or _default_resolver
+
+    def _verify(call: VerifyCall) -> bool:
+        paths = resolve(call)
+        if not paths:
+            return True
+        return all(os.path.exists(p) for p in paths)
+
+    return _verify
+
+
+def make_command_verifier(
+    command: str | list[str],
+    *,
+    cwd_resolver: Callable[[VerifyCall], str | None] | None = None,
+    timeout: float = 30.0,
+) -> Verifier:
+    """Command verifier: confirm by running a shell command, exit 0 == verified.
+
+    ``command`` is a string (run via the shell) or an argv list (run directly,
+    no shell). The mutation is confirmed iff the command exits 0. ``timeout``
+    bounds the run; a timeout or spawn failure raises, which ``consult`` reports
+    as a verify *error* (not a mismatch) — we don't claim the mutation failed
+    just because the checker couldn't run.
+
+    Note: the command is supplied by the *registrant* (a skill / config), never
+    by the model — this is not a path for the LLM to run arbitrary shell.
+    """
+    use_shell = isinstance(command, str)
+
+    def _verify(call: VerifyCall) -> bool:
+        cwd = cwd_resolver(call) if cwd_resolver else None
+        completed = subprocess.run(
+            command if use_shell else list(command),
+            shell=use_shell,
+            cwd=cwd,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return completed.returncode == 0
+
+    return _verify
+
+
+def make_predicate_verifier(predicate: Verifier) -> Verifier:
+    """Symbolic-predicate verifier: wrap an arbitrary pure ``VerifyCall`` check.
+
+    The escape hatch for skills that verify against in-memory or domain state
+    (a parsed AST, a config object, a service health flag) rather than the
+    filesystem or a subprocess. Thin by design — it exists so callers express
+    intent (``make_predicate_verifier(...)``) symmetrically with the other two
+    factories rather than passing a bare lambda to ``register``.
+    """
+    return predicate
+
+
+# Convenience parser for the command-verifier string form, so a config layer
+# can register ``"pytest -q"`` without importing shlex itself.
+def split_command(command: str) -> list[str]:
+    """Split a shell-style command string into an argv list."""
+    return shlex.split(command)
+
+
+class VerifyPolicy:
+    """Registry mapping mutating tool names to their verifiers.
+
+    The contract #293 asks for: mutating tools MUST be *registerable* with a
+    verifier, the run agent can *look one up*, and *consult* it after a mutating
+    call. Consultation is advisory and never raises.
+
+    A tool may register more than one verifier (e.g. file-exists AND a content
+    command); :func:`consult` runs them in registration order and returns the
+    first non-confirming outcome (``mismatch`` or ``error``), else ``ok``. This
+    makes the common single-verifier case a straight pass/fail while still
+    letting a registrant layer cheap and expensive checks.
+    """
+
+    def __init__(self) -> None:
+        self._verifiers: dict[str, list[RegisteredVerifier]] = {}
+
+    # ── registration / lookup ────────────────────────────────────────────
+    def register(self, tool_name: str, verifier: Verifier, *, name: str = "") -> None:
+        """Register ``verifier`` for ``tool_name``.
+
+        ``tool_name`` SHOULD be one of :data:`MUTATING_TOOL_NAMES` — that is the
+        set #293 says must be verifiable — but registration is not restricted to
+        it, so a skill can attach a verifier to a custom mutating tool. ``name``
+        is used for log attribution; it defaults to the callable's ``__name__``.
+        """
+        if not tool_name:
+            raise ValueError("tool_name must be a non-empty string")
+        if not callable(verifier):
+            raise TypeError("verifier must be callable")
+        label = name or getattr(verifier, "__name__", "") or "verifier"
+        self._verifiers.setdefault(tool_name, []).append(
+            RegisteredVerifier(name=label, verifier=verifier)
+        )
+
+    def unregister(self, tool_name: str) -> None:
+        """Drop all verifiers for ``tool_name`` (no-op if none registered)."""
+        self._verifiers.pop(tool_name, None)
+
+    def lookup(self, tool_name: str) -> tuple[RegisteredVerifier, ...]:
+        """Return the verifiers registered for ``tool_name`` (possibly empty)."""
+        return tuple(self._verifiers.get(tool_name, ()))
+
+    def has_verifier(self, tool_name: str) -> bool:
+        """True when at least one verifier is registered for ``tool_name``."""
+        return bool(self._verifiers.get(tool_name))
+
+    @property
+    def registered_tools(self) -> frozenset[str]:
+        """The set of tool names with at least one verifier."""
+        return frozenset(self._verifiers)
+
+    def missing_verifier_tools(
+        self, mutating_tools: frozenset[str] = MUTATING_TOOL_NAMES
+    ) -> frozenset[str]:
+        """Mutating tools that have no verifier yet — the #293 policy gap.
+
+        Reporting helper: the policy is that every mutating tool MUST register a
+        verifier. This names the ones that haven't, so a config/bootstrap layer
+        (or a test) can assert coverage without enforcing it at dispatch time.
+        """
+        return frozenset(t for t in mutating_tools if not self.has_verifier(t))
+
+    # ── consultation ─────────────────────────────────────────────────────
+    def consult(self, tool_name: str, args: Mapping[str, Any], result: Any = None) -> VerifyOutcome:
+        """Run the registered verifier(s) for ``tool_name`` against the call.
+
+        Returns a :class:`VerifyOutcome`. Pure and advisory:
+
+        * no verifier registered → ``skipped``;
+        * all verifiers confirm   → ``ok``;
+        * a verifier returns False → ``mismatch`` (first one wins);
+        * a verifier raises        → ``error`` (first one wins), caught here so a
+          buggy verifier can never crash the turn.
+
+        This never executes the tool, mutates ``args``, or touches the
+        conversation — it only reports.
+        """
+        verifiers = self._verifiers.get(tool_name)
+        if not verifiers:
+            return VerifyOutcome.skipped(tool_name, "no verifier registered")
+        call = VerifyCall(tool_name=tool_name, args=dict(args), result=result)
+        for rv in verifiers:
+            try:
+                confirmed = rv.verifier(call)
+            except Exception as exc:  # a verifier must never break the turn
+                return VerifyOutcome.error(
+                    tool_name, rv.name, f"{type(exc).__name__}: {exc}"
+                )
+            if not confirmed:
+                return VerifyOutcome.mismatch(
+                    tool_name, rv.name, "verifier did not confirm the mutation"
+                )
+        return VerifyOutcome.ok(
+            tool_name,
+            verifiers[-1].name,
+            f"{len(verifiers)} verifier(s) confirmed",
+        )
+
+
+# ── advisory consult gate ────────────────────────────────────────────────────
+# The wiring point in the dispatch path is opt-in: the agent behaves identically
+# unless this is explicitly turned on. Default OFF so #293 ships without
+# altering any turn. #294 (default verifiers + retry) flips the behavioral side.
+
+_VERIFY_POLICY_ENV = "HERMES_VERIFY_POLICY"
+
+
+def verify_policy_enabled() -> bool:
+    """Whether the advisory verify-after-mutation consult is enabled.
+
+    Default **OFF**. Enabled by setting ``HERMES_VERIFY_POLICY`` to a truthy
+    value (``1``/``true``/``yes``/``on``), or via the ``verify_policy.enabled``
+    key in ``config.yaml``. Reads the env var first so a session can flip it
+    without editing config. Any failure resolving config → OFF (safe default).
+    """
+    env = os.environ.get(_VERIFY_POLICY_ENV)
+    if env is not None:
+        return env.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config() or {}
+    except Exception:
+        return False
+    section = cfg.get("verify_policy") if isinstance(cfg, dict) else None
+    if isinstance(section, dict) and "enabled" in section:
+        return bool(section.get("enabled"))
+    return False
+
+
+@dataclass
+class _AgentVerifyState:
+    """Per-agent lazily-built registry + the per-turn outcome ledger.
+
+    Held off the agent as a single attribute so the dispatch path touches one
+    optional seam. ``outcomes`` accumulates this turn's advisory results purely
+    for logging / introspection; it is reset each turn alongside the existing
+    ``_turn_failed_file_mutations`` state.
+    """
+
+    registry: VerifyPolicy = field(default_factory=VerifyPolicy)
+    outcomes: list[VerifyOutcome] = field(default_factory=list)
+
+
+__all__ = [
+    "MUTATING_TOOL_NAMES",
+    "VerifyCall",
+    "VerifyOutcome",
+    "Verifier",
+    "RegisteredVerifier",
+    "VerifyPolicy",
+    "make_file_exists_verifier",
+    "make_command_verifier",
+    "make_predicate_verifier",
+    "split_command",
+    "verify_policy_enabled",
+]

--- a/run_agent.py
+++ b/run_agent.py
@@ -2521,6 +2521,56 @@ class AIAgent:
             for path in targets:
                 state.pop(path, None)
 
+    def _consult_verify_policy(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        result: Any,
+        is_error: bool,
+    ) -> None:
+        """Advisory Gather-Act-Verify consult after a *successful* mutating call.
+
+        Issue #293. Opt-in and side-effect free: when the verify-policy feature
+        is enabled (default OFF) and a verifier is registered for ``tool_name``,
+        run it and record/log the structured :class:`VerifyOutcome`. This NEVER
+        retries, blocks, or rewrites the call — retry-on-mismatch is the sibling
+        #294. Distinct from the turn-end file-mutation *failure* footer: that
+        surfaces writes that FAILED; this verifies writes that SUCCEEDED.
+
+        Gated so the agent behaves identically when the feature is off OR no
+        verifier is registered. Any error is swallowed — a verifier can never
+        affect the turn.
+        """
+        if is_error:
+            return  # only verify calls the tool reported as successful
+        try:
+            from agent.verify_policy import verify_policy_enabled
+            if not verify_policy_enabled():
+                return
+            state = getattr(self, "_verify_policy_state", None)
+            if state is None or not state.registry.has_verifier(tool_name):
+                return
+            outcome = state.registry.consult(tool_name, args, result)
+            if outcome.status == "skipped":
+                return
+            state.outcomes.append(outcome)
+            if outcome.status == "mismatch":
+                logger.warning(
+                    "verify-policy: %s did not confirm %s (%s)",
+                    outcome.verifier, tool_name, outcome.detail,
+                )
+            elif outcome.status == "error":
+                logger.debug(
+                    "verify-policy: verifier %s errored for %s: %s",
+                    outcome.verifier, tool_name, outcome.detail,
+                )
+            else:
+                logger.info(
+                    "verify-policy: %s confirmed %s", outcome.verifier, tool_name,
+                )
+        except Exception as _vp_err:
+            logger.debug("verify-policy consult failed: %s", _vp_err)
+
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
 

--- a/tests/agent/test_verify_policy.py
+++ b/tests/agent/test_verify_policy.py
@@ -1,0 +1,363 @@
+"""Tests for the Gather-Act-Verify verify-hook registry (#293).
+
+Covers the registry contract (register / lookup / consult), the three verifier
+kinds (command, file-existence, symbolic predicate), the advisory ``consult``
+outcomes, the opt-in enable gate, and the #293 policy assertion that every
+mutating tool can register a verifier — without any retry/blocking (that is the
+sibling #294).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent.verify_policy import (
+    MUTATING_TOOL_NAMES,
+    RegisteredVerifier,
+    VerifyCall,
+    VerifyOutcome,
+    VerifyPolicy,
+    make_command_verifier,
+    make_file_exists_verifier,
+    make_predicate_verifier,
+    split_command,
+    verify_policy_enabled,
+)
+
+
+# ── VerifyOutcome primitives ─────────────────────────────────────────────────
+
+
+def test_verify_outcome_constructors_set_status_and_flags():
+    ok = VerifyOutcome.ok("write_file", "exists", "landed")
+    assert ok.status == "ok"
+    assert ok.confirmed is True
+    assert ok.ran is True
+    assert ok.verifier == "exists"
+    assert ok.detail == "landed"
+
+    mismatch = VerifyOutcome.mismatch("patch", "exists")
+    assert mismatch.status == "mismatch"
+    assert mismatch.confirmed is False
+    assert mismatch.ran is True
+
+    err = VerifyOutcome.error("terminal", "cmd", "boom")
+    assert err.status == "error"
+    assert err.confirmed is False
+    assert err.ran is True
+
+    skipped = VerifyOutcome.skipped("memory")
+    assert skipped.status == "skipped"
+    assert skipped.confirmed is False
+    assert skipped.ran is False
+
+
+def test_verify_outcome_is_frozen():
+    outcome = VerifyOutcome.ok("write_file", "exists")
+    with pytest.raises(Exception):
+        outcome.status = "mismatch"  # type: ignore[misc]
+
+
+# ── registry: register / lookup ──────────────────────────────────────────────
+
+
+def test_register_and_lookup_roundtrip():
+    policy = VerifyPolicy()
+    assert policy.has_verifier("write_file") is False
+    assert policy.lookup("write_file") == ()
+
+    policy.register("write_file", lambda call: True, name="always")
+    assert policy.has_verifier("write_file") is True
+    registered = policy.lookup("write_file")
+    assert len(registered) == 1
+    assert isinstance(registered[0], RegisteredVerifier)
+    assert registered[0].name == "always"
+    assert policy.registered_tools == frozenset({"write_file"})
+
+
+def test_register_defaults_name_from_callable():
+    policy = VerifyPolicy()
+
+    def my_checker(call: VerifyCall) -> bool:
+        return True
+
+    policy.register("patch", my_checker)
+    assert policy.lookup("patch")[0].name == "my_checker"
+
+
+def test_register_rejects_empty_tool_name_and_non_callable():
+    policy = VerifyPolicy()
+    with pytest.raises(ValueError):
+        policy.register("", lambda call: True)
+    with pytest.raises(TypeError):
+        policy.register("write_file", "not callable")  # type: ignore[arg-type]
+
+
+def test_unregister_removes_all_verifiers_for_tool():
+    policy = VerifyPolicy()
+    policy.register("write_file", lambda call: True)
+    policy.register("write_file", lambda call: True)
+    assert len(policy.lookup("write_file")) == 2
+    policy.unregister("write_file")
+    assert policy.has_verifier("write_file") is False
+    # idempotent
+    policy.unregister("write_file")
+
+
+# ── #293 policy: mutating tools MUST be verifiable ───────────────────────────
+
+
+def test_canonical_mutating_tool_names():
+    assert MUTATING_TOOL_NAMES == frozenset(
+        {"write_file", "patch", "terminal", "write_to_file"}
+    )
+
+
+def test_missing_verifier_tools_reports_uncovered_mutating_tools():
+    policy = VerifyPolicy()
+    # Nothing registered → every mutating tool is uncovered.
+    assert policy.missing_verifier_tools() == MUTATING_TOOL_NAMES
+
+    for tool in MUTATING_TOOL_NAMES:
+        policy.register(tool, lambda call: True)
+    # Full coverage → no gaps.
+    assert policy.missing_verifier_tools() == frozenset()
+
+
+# ── consult: advisory outcomes ───────────────────────────────────────────────
+
+
+def test_consult_skips_when_no_verifier_registered():
+    policy = VerifyPolicy()
+    outcome = policy.consult("write_file", {"path": "/tmp/x"})
+    assert outcome.status == "skipped"
+    assert outcome.tool_name == "write_file"
+    assert outcome.ran is False
+
+
+def test_consult_ok_when_verifier_confirms():
+    policy = VerifyPolicy()
+    policy.register("write_file", lambda call: True, name="ok-checker")
+    outcome = policy.consult("write_file", {"path": "/tmp/x"}, result="{}")
+    assert outcome.status == "ok"
+    assert outcome.confirmed is True
+    assert outcome.verifier == "ok-checker"
+
+
+def test_consult_mismatch_when_verifier_denies():
+    policy = VerifyPolicy()
+    policy.register("patch", lambda call: False, name="denier")
+    outcome = policy.consult("patch", {"path": "/tmp/x"})
+    assert outcome.status == "mismatch"
+    assert outcome.confirmed is False
+    assert outcome.verifier == "denier"
+
+
+def test_consult_error_when_verifier_raises_and_does_not_propagate():
+    policy = VerifyPolicy()
+
+    def boom(call: VerifyCall) -> bool:
+        raise RuntimeError("kaboom")
+
+    policy.register("terminal", boom, name="exploder")
+    # Must NOT raise — a buggy verifier can never crash the turn.
+    outcome = policy.consult("terminal", {"command": "true"})
+    assert outcome.status == "error"
+    assert outcome.verifier == "exploder"
+    assert "kaboom" in outcome.detail
+
+
+def test_consult_runs_verifiers_in_order_first_failure_wins():
+    policy = VerifyPolicy()
+    calls: list[str] = []
+
+    def first(call: VerifyCall) -> bool:
+        calls.append("first")
+        return True
+
+    def second(call: VerifyCall) -> bool:
+        calls.append("second")
+        return False
+
+    def third(call: VerifyCall) -> bool:  # should never run
+        calls.append("third")
+        return True
+
+    policy.register("write_file", first, name="first")
+    policy.register("write_file", second, name="second")
+    policy.register("write_file", third, name="third")
+    outcome = policy.consult("write_file", {"path": "/tmp/x"})
+    assert outcome.status == "mismatch"
+    assert outcome.verifier == "second"
+    assert calls == ["first", "second"]  # short-circuits before third
+
+
+def test_consult_passes_call_view_to_verifier():
+    policy = VerifyPolicy()
+    seen: dict[str, object] = {}
+
+    def capture(call: VerifyCall) -> bool:
+        seen["tool"] = call.tool_name
+        seen["args"] = dict(call.args)
+        seen["result"] = call.result
+        return True
+
+    policy.register("write_file", capture)
+    policy.consult("write_file", {"path": "/tmp/x"}, result="done")
+    assert seen == {
+        "tool": "write_file",
+        "args": {"path": "/tmp/x"},
+        "result": "done",
+    }
+
+
+# ── file-existence verifier ──────────────────────────────────────────────────
+
+
+def test_file_exists_verifier_confirms_existing_path(tmp_path):
+    f = tmp_path / "created.txt"
+    f.write_text("hi")
+    policy = VerifyPolicy()
+    policy.register("write_file", make_file_exists_verifier(), name="exists")
+    outcome = policy.consult("write_file", {"path": str(f)})
+    assert outcome.status == "ok"
+
+
+def test_file_exists_verifier_mismatch_on_missing_path(tmp_path):
+    missing = tmp_path / "nope.txt"
+    policy = VerifyPolicy()
+    policy.register("write_file", make_file_exists_verifier(), name="exists")
+    outcome = policy.consult("write_file", {"path": str(missing)})
+    assert outcome.status == "mismatch"
+
+
+def test_file_exists_verifier_reads_write_to_file_arg(tmp_path):
+    f = tmp_path / "wtf.txt"
+    f.write_text("x")
+    verify = make_file_exists_verifier()
+    assert verify(VerifyCall("write_to_file", {"file": str(f)})) is True
+    assert verify(VerifyCall("write_to_file", {"file": str(tmp_path / "absent")})) is False
+
+
+def test_file_exists_verifier_no_path_is_treated_as_nothing_to_check():
+    verify = make_file_exists_verifier()
+    # terminal-style call: no path arg → not this verifier's job → confirmed
+    assert verify(VerifyCall("terminal", {"command": "ls"})) is True
+
+
+def test_file_exists_verifier_custom_resolver(tmp_path):
+    a = tmp_path / "a"
+    a.write_text("1")
+    b = tmp_path / "b"  # missing
+    verify = make_file_exists_verifier(
+        path_resolver=lambda call: [str(a), str(b)]
+    )
+    assert verify(VerifyCall("patch", {})) is False
+    b.write_text("2")
+    assert verify(VerifyCall("patch", {})) is True
+
+
+# ── command verifier ─────────────────────────────────────────────────────────
+
+
+def test_command_verifier_shell_string_exit_zero_confirms():
+    policy = VerifyPolicy()
+    policy.register("terminal", make_command_verifier("true"), name="cmd")
+    assert policy.consult("terminal", {"command": "x"}).status == "ok"
+
+
+def test_command_verifier_shell_string_nonzero_mismatch():
+    policy = VerifyPolicy()
+    policy.register("terminal", make_command_verifier("false"), name="cmd")
+    assert policy.consult("terminal", {"command": "x"}).status == "mismatch"
+
+
+def test_command_verifier_argv_list_form(tmp_path):
+    target = tmp_path / "artifact"
+    target.write_text("ok")
+    verify = make_command_verifier(["test", "-f", str(target)])
+    assert verify(VerifyCall("terminal", {})) is True
+    target.unlink()
+    assert verify(VerifyCall("terminal", {})) is False
+
+
+def test_command_verifier_timeout_surfaces_as_error_not_mismatch():
+    policy = VerifyPolicy()
+    policy.register(
+        "terminal", make_command_verifier("sleep 5", timeout=0.05), name="slow"
+    )
+    outcome = policy.consult("terminal", {"command": "x"})
+    # A checker that can't finish is an *error*, not proof the mutation failed.
+    assert outcome.status == "error"
+
+
+def test_command_verifier_uses_cwd_resolver(tmp_path):
+    (tmp_path / "marker").write_text("1")
+    verify = make_command_verifier(
+        ["test", "-f", "marker"],
+        cwd_resolver=lambda call: str(tmp_path),
+    )
+    assert verify(VerifyCall("terminal", {})) is True
+
+
+def test_split_command_helper():
+    assert split_command("pytest -q tests/") == ["pytest", "-q", "tests/"]
+
+
+# ── symbolic predicate verifier ──────────────────────────────────────────────
+
+
+def test_predicate_verifier_wraps_arbitrary_check():
+    verify = make_predicate_verifier(
+        lambda call: call.args.get("mode") == "replace"
+    )
+    policy = VerifyPolicy()
+    policy.register("patch", verify, name="mode-check")
+    assert policy.consult("patch", {"mode": "replace"}).status == "ok"
+    assert policy.consult("patch", {"mode": "patch"}).status == "mismatch"
+
+
+def test_predicate_verifier_can_inspect_result_payload():
+    verify = make_predicate_verifier(
+        lambda call: isinstance(call.result, str) and "bytes_written" in call.result
+    )
+    policy = VerifyPolicy()
+    policy.register("write_file", verify)
+    assert policy.consult("write_file", {}, result='{"bytes_written": 5}').status == "ok"
+    assert policy.consult("write_file", {}, result='{"error": "x"}').status == "mismatch"
+
+
+# ── enable gate (opt-in, default OFF) ────────────────────────────────────────
+
+
+def test_verify_policy_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("HERMES_VERIFY_POLICY", raising=False)
+    # Force config resolution to fail/return nothing → default OFF.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
+    )
+    assert verify_policy_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_verify_policy_env_enables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_VERIFY_POLICY", val)
+    assert verify_policy_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+def test_verify_policy_env_disables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_VERIFY_POLICY", val)
+    assert verify_policy_enabled() is False
+
+
+def test_verify_policy_config_enables_when_env_absent(monkeypatch):
+    monkeypatch.delenv("HERMES_VERIFY_POLICY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {"verify_policy": {"enabled": True}},
+        raising=False,
+    )
+    assert verify_policy_enabled() is True


### PR DESCRIPTION
Child of #282 (Gather→Act→Verify). Ships the **registry + policy**, advisory and opt-in.

- `agent/verify_policy.py`: `VerifyPolicy.register/lookup/consult`; `VerifyOutcome` (ok/mismatch/error/skipped); verifier factories (command / file-exists / predicate); `MUTATING_TOOL_NAMES`={write_file,patch,terminal,write_to_file}; `verify_policy_enabled()` **default OFF**.
- `run_agent.py` + `agent/tool_executor.py`: consult seam after mutating-success in both dispatch paths — only when enabled AND a verifier is registered; never blocks/retries/raises. Distinct from the upstream turn-end *failure* footer.

**Scope boundary:** no default verifiers, no retry-on-mismatch (#294). Registry ships empty → `skipped` until a layer registers one.
Tests: `tests/agent/test_verify_policy.py` — 39 passed. Note: touches `run_agent.py`/`turn_context.py` (shared with #290).

Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)