### PR TITLE
feat(evolution): self-harness LLM proposal generator (human-gated) (#295)

### DIFF
--- a/scripts/evolution_harness_proposer.py
+++ b/scripts/evolution_harness_proposer.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Self-Harness harness-proposal generator (#295, child of #248).
+
+``evolution_trace_miner.py`` (the shipped first increment) turns the agent's own
+execution traces into structured **weakness records** — anonymized counts +
+classes + labels for clusters that recur >= ``min_count`` times. This module is
+the next layer of the Self-Harness loop (arXiv 2606.09498): it feeds those
+weakness records to an LLM that emits a **harness proposal** — a single
+structured object describing a targeted, constrained change to the agent's
+*harness* (the system-prompt, retry policy, or tool guards around the model),
+NOT to the task at hand.
+
+Each proposal has a ``type`` in:
+
+  * ``system_prompt_delta``  — text to ADD to the system prompt (a constraint /
+    reminder / checklist item the recurring failure shows the model needs).
+  * ``retry_policy_change``  — a change to how a tool/provider call is retried
+    (e.g. cap consecutive retries, add a backoff, mark a class non-retryable).
+  * ``tool_guard``           — a precondition / postcondition guard to wrap a
+    tool with (validate args, sanity-check the result, refuse on a bad shape).
+
+The proposal is a structured object the ``evolution-issues`` stage ingests
+alongside research-generated proposals (same shape contract: a title + body it
+can file as a GitHub issue, with evidence). It is NOT free-form text into the
+pipeline — the type is constrained and the evidence is carried explicitly.
+
+CRITICAL SAFETY INVARIANT — HUMAN-GATED, NEVER AUTO-APPLIED
+-----------------------------------------------------------
+This module is a *generator of proposals*, full stop. It NEVER applies a change:
+it does not rewrite a prompt, edit a wrapper, or touch any config. There is no
+"apply" code path in this file by design. Every emitted proposal carries
+``status="proposed"`` and ``requires_human_review=True``; the regression GATE
+that decides whether an accepted proposal is safe to land is the SIBLING issue
+#296 and lives elsewhere. A human (or the issues stage's triage) reviews and
+vetoes. This mirrors the project decision that the evolution loop proposes, and
+only a human disposes.
+
+Design mirrors the other ``scripts/evolution_*.py`` helpers: pure, typed,
+import-safe functions + a thin CLI, with the LLM call isolated behind an
+INJECTABLE seam (a ``Callable``) so every test runs without a network — exactly
+the ``runner`` seam idiom from ``evolution_watchdog.py``.
+
+CLI (reads weakness records from the trace miner's sidecar / stdin):
+
+    evolution_harness_proposer.py weaknesses-latest.json
+    cat weaknesses-latest.json | evolution_harness_proposer.py
+
+It prints one JSON object ``{"proposals": [...], "count": N, ...}`` to stdout and
+exits 0. WITHOUT an LLM seam configured the CLI is deterministic-only: it still
+emits a proposal *envelope* per weakness (type + evidence + a templated body)
+but with no LLM-authored delta, so the script is useful and testable offline and
+NEVER silently makes a network call.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# A weakness ``kind`` (from the trace miner) maps to exactly one harness
+# proposal ``type``. This is the constrained vocabulary the issues stage relies
+# on — anything outside it is dropped rather than passed through as free-form.
+PROPOSAL_TYPES = ("system_prompt_delta", "retry_policy_change", "tool_guard")
+
+KIND_TO_TYPE: Dict[str, str] = {
+    # A tool whose results keep looking like failures wants a wrapper guard
+    # (validate preconditions / sanity-check the result shape).
+    "tool_failure": "tool_guard",
+    # A recurring provider-layer error class is a retry/fallback-policy concern.
+    "provider_error": "retry_policy_change",
+    # A retry spiral (same tool many times in a row) is also a retry-policy
+    # concern: cap consecutive retries / add a non-retryable diagnostic.
+    "retry_spiral": "retry_policy_change",
+}
+
+# The signature an injected LLM function must satisfy. It receives the weakness
+# record and the chosen proposal type and returns the model-authored fields
+# (e.g. ``title``, ``delta``, ``rationale``). It is the ONLY place a network
+# call may happen, and it is injected so tests pass a stub. The default is
+# ``None`` (offline): no seam -> no LLM-authored delta, never a hidden call.
+LLMFn = Callable[[Dict[str, Any], str], Dict[str, Any]]
+
+
+def proposal_type_for(weakness: Dict[str, Any]) -> Optional[str]:
+    """Map a weakness record's ``kind`` to its constrained proposal ``type``.
+
+    Returns ``None`` for an unknown / malformed kind so the caller DROPS it
+    rather than inventing a free-form proposal type. Pure + deterministic."""
+    if not isinstance(weakness, dict):
+        return None
+    kind = weakness.get("kind")
+    if not isinstance(kind, str):
+        return None
+    return KIND_TO_TYPE.get(kind)
+
+
+def _evidence_of(weakness: Dict[str, Any]) -> Dict[str, Any]:
+    """Carry the trace evidence forward VERBATIM from the weakness record.
+
+    Only the anonymized fields the miner already emits (counts / classes /
+    labels / tool names) — never raw trace content, because the miner never had
+    any. Subset is whitelisted so nothing unexpected leaks into a filed issue."""
+    allowed = (
+        "kind", "tool", "signature", "occurrences", "severity", "label",
+        "max_consecutive", "sessions",
+    )
+    return {k: weakness[k] for k in allowed if k in weakness}
+
+
+def _default_title(weakness: Dict[str, Any], ptype: str) -> str:
+    """Deterministic fallback title used when no LLM seam authors one.
+
+    Concrete and de-dup-friendly (names the subject + the proposal type) so the
+    issues stage's exact-title idempotency guard behaves predictably."""
+    subject = weakness.get("tool") or weakness.get("signature") or "agent harness"
+    label = {
+        "system_prompt_delta": "system-prompt guard",
+        "retry_policy_change": "retry-policy change",
+        "tool_guard": "tool guard",
+    }[ptype]
+    return f"[HARNESS] {label} for `{subject}`"
+
+
+def _coerce_str(value: Any) -> str:
+    """Best-effort string coercion for an LLM-authored scalar field; never
+    raises (a malformed model reply must not crash the generator)."""
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return str(value)
+
+
+def build_proposal(
+    weakness: Dict[str, Any],
+    *,
+    llm: Optional[LLMFn] = None,
+) -> Optional[Dict[str, Any]]:
+    """Turn ONE weakness record into ONE structured harness proposal.
+
+    Returns ``None`` if the weakness's kind has no constrained proposal type
+    (it is dropped, not passed through as free-form). The proposal is inert
+    DATA describing a change — it is never applied here.
+
+    The LLM seam (``llm``), when provided, authors the human-readable fields
+    (``title``, ``delta``, ``rationale``). When absent the proposal is a
+    deterministic ENVELOPE: correct type + evidence + a templated body, with
+    ``llm_authored=False`` so a reviewer can see it needs fleshing out. Either
+    way the proposal carries the hard human-gating fields.
+    """
+    if not isinstance(weakness, dict):
+        return None
+    ptype = proposal_type_for(weakness)
+    if ptype is None:
+        return None
+
+    evidence = _evidence_of(weakness)
+    proposal: Dict[str, Any] = {
+        "type": ptype,
+        "source": "self-harness",  # distinguishes from research-generated proposals
+        "evidence": evidence,
+        # --- HARD human-gating invariant: inert, never auto-applied. ---
+        "status": "proposed",
+        "requires_human_review": True,
+        "auto_apply": False,
+    }
+
+    if llm is not None:
+        # The injected seam is the ONLY place a network call may occur. Anything
+        # it returns is treated as untrusted scalar text and coerced safely; the
+        # ``type`` it cannot change (we picked it deterministically above).
+        try:
+            authored = llm(dict(weakness), ptype)
+        except Exception as exc:  # pragma: no cover - exercised via stub in tests
+            # A failing LLM must degrade to the deterministic envelope, never
+            # crash the whole batch.
+            authored = {}
+            proposal["llm_error"] = _coerce_str(exc)
+        if not isinstance(authored, dict):
+            authored = {}
+        title = _coerce_str(authored.get("title")) or _default_title(weakness, ptype)
+        proposal["title"] = title
+        proposal["delta"] = _coerce_str(authored.get("delta"))
+        proposal["rationale"] = _coerce_str(authored.get("rationale"))
+        proposal["llm_authored"] = bool(authored)
+    else:
+        proposal["title"] = _default_title(weakness, ptype)
+        proposal["delta"] = ""
+        proposal["rationale"] = _coerce_str(weakness.get("label"))
+        proposal["llm_authored"] = False
+
+    return proposal
+
+
+def generate_proposals(
+    weaknesses: List[Dict[str, Any]],
+    *,
+    llm: Optional[LLMFn] = None,
+) -> List[Dict[str, Any]]:
+    """Map a list of weakness records to harness proposals (best-first).
+
+    Malformed records and records whose kind has no constrained proposal type
+    are dropped silently. Order follows the input (the miner already sorts
+    weaknesses by severity desc), so the worst cluster yields the first
+    proposal. Pure aside from the injected ``llm`` seam."""
+    proposals: List[Dict[str, Any]] = []
+    for w in weaknesses:
+        p = build_proposal(w, llm=llm)
+        if p is not None:
+            proposals.append(p)
+    return proposals
+
+
+def load_weaknesses(payload: Any) -> List[Dict[str, Any]]:
+    """Extract the weakness records list from a trace-miner payload.
+
+    Accepts either the miner's full sidecar object
+    (``{"weaknesses": [...], ...}``) or a bare JSON list of records. Non-dict
+    entries are dropped. Never raises on a shape it does not recognize — returns
+    an empty list so the generator degrades to 'no proposals'."""
+    if isinstance(payload, dict):
+        records = payload.get("weaknesses", [])
+    else:
+        records = payload
+    if not isinstance(records, list):
+        return []
+    return [r for r in records if isinstance(r, dict)]
+
+
+def _parse_args(argv: List[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Tiny hand-rolled arg parse (matches the other evolution_* CLIs).
+
+    Returns ``(path, error)``. ``path`` is the positional weakness-records file
+    (absent -> read stdin). There are intentionally no flags that could trigger
+    an LLM call from the CLI: the offline/deterministic path is the only CLI
+    behavior, so the script never makes a hidden network call."""
+    path: Optional[str] = None
+    for arg in argv[1:]:
+        if arg.startswith("-"):
+            return None, f"unknown flag: {arg}"
+        path = arg
+    return path, None
+
+
+def main(argv: List[str]) -> int:
+    path, err = _parse_args(argv)
+    if err:
+        print(f"[evolution-harness-proposer] {err}", file=sys.stderr)
+        return 2
+    try:
+        raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    except OSError as exc:
+        print(f"[evolution-harness-proposer] cannot read input: {exc}", file=sys.stderr)
+        return 2
+    try:
+        payload = json.loads(raw)
+    except ValueError as exc:
+        print(f"[evolution-harness-proposer] input is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    weaknesses = load_weaknesses(payload)
+    # CLI is deterministic-only: no LLM seam is wired here, so no network call is
+    # ever made from the command line. A caller that wants LLM-authored deltas
+    # imports ``generate_proposals`` and injects its own ``llm``.
+    proposals = generate_proposals(weaknesses, llm=None)
+
+    out = {
+        "source": "self-harness",
+        "count": len(proposals),
+        "human_gated": True,  # echo the invariant for any downstream consumer
+        "proposals": proposals,
+    }
+    print(json.dumps(out, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_harness_proposer.py
+++ b/tests/scripts/test_evolution_harness_proposer.py
@@ -1,0 +1,278 @@
+"""Tests for scripts/evolution_harness_proposer.py (#295, child of #248).
+
+The harness proposer turns trace-miner weakness records into structured,
+human-gated harness proposals. The LLM call is behind an injectable seam, so
+every test here runs offline with a stub (or no seam at all).
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_harness_proposer import (  # noqa: E402
+    KIND_TO_TYPE,
+    PROPOSAL_TYPES,
+    build_proposal,
+    generate_proposals,
+    load_weaknesses,
+    main,
+    proposal_type_for,
+)
+
+
+# --- fixtures -------------------------------------------------------------
+
+def _tool_failure(tool="terminal", n=9):
+    return {
+        "kind": "tool_failure",
+        "tool": tool,
+        "occurrences": n,
+        "severity": n,
+        "label": f"`{tool}` results look like failures {n}x — harden the wrapper.",
+    }
+
+
+def _provider_error(sig="429:rate_limit", n=60):
+    return {
+        "kind": "provider_error",
+        "signature": sig,
+        "occurrences": n,
+        "severity": n,
+        "label": f"provider error `{sig}` recurs {n}x — check fallback chain.",
+    }
+
+
+def _retry_spiral(tool="browser_navigate", runs=15, sessions=3):
+    return {
+        "kind": "retry_spiral",
+        "tool": tool,
+        "max_consecutive": runs,
+        "sessions": sessions,
+        "severity": runs,
+        "label": f"`{tool}` retry spiral up to {runs} consecutive — add a fallback.",
+    }
+
+
+def _stub_llm(calls):
+    """An injectable LLM seam that records its calls and returns canned fields.
+    Proves the generator works WITHOUT a network and that the seam is the only
+    place model output enters."""
+
+    def _fn(weakness, ptype):
+        calls.append((weakness, ptype))
+        return {
+            "title": f"[HARNESS] stub for {weakness.get('kind')}",
+            "delta": "ADD: stub harness delta authored by the (mocked) LLM.",
+            "rationale": "stub rationale",
+        }
+
+    return _fn
+
+
+# --- type mapping ---------------------------------------------------------
+
+class TestProposalTypeFor:
+    def test_known_kinds_map_to_constrained_types(self):
+        assert proposal_type_for(_tool_failure()) == "tool_guard"
+        assert proposal_type_for(_provider_error()) == "retry_policy_change"
+        assert proposal_type_for(_retry_spiral()) == "retry_policy_change"
+
+    def test_every_mapped_type_is_in_the_constrained_vocabulary(self):
+        for t in KIND_TO_TYPE.values():
+            assert t in PROPOSAL_TYPES
+
+    def test_unknown_kind_returns_none(self):
+        assert proposal_type_for({"kind": "totally_new_kind"}) is None
+
+    def test_non_dict_and_missing_kind_return_none(self):
+        assert proposal_type_for("not-a-dict") is None
+        assert proposal_type_for({"no": "kind"}) is None
+        assert proposal_type_for({"kind": 123}) is None
+
+
+# --- single proposal build ------------------------------------------------
+
+class TestBuildProposal:
+    def test_offline_envelope_without_llm(self):
+        p = build_proposal(_tool_failure())
+        assert p is not None
+        assert p["type"] == "tool_guard"
+        assert p["llm_authored"] is False
+        assert p["delta"] == ""  # no model -> no authored delta
+        assert p["title"].startswith("[HARNESS]")
+        # rationale falls back to the miner's label (no model).
+        assert "harden" in p["rationale"]
+
+    def test_llm_seam_authors_fields_and_is_called(self):
+        calls = []
+        p = build_proposal(_provider_error(), llm=_stub_llm(calls))
+        assert p is not None
+        assert len(calls) == 1
+        weakness, ptype = calls[0]
+        assert ptype == "retry_policy_change"
+        assert weakness["signature"] == "429:rate_limit"
+        assert p["llm_authored"] is True
+        assert p["delta"].startswith("ADD:")
+        assert p["title"] == "[HARNESS] stub for provider_error"
+
+    def test_unknown_kind_is_dropped(self):
+        assert build_proposal({"kind": "mystery", "severity": 99}) is None
+
+    def test_non_dict_weakness_is_dropped(self):
+        assert build_proposal("nope") is None
+
+    def test_evidence_carries_only_anonymized_fields(self):
+        # Even if a (malformed) record sneaks an unexpected key, evidence keeps
+        # only the whitelisted anonymized fields — never raw content.
+        w = dict(_tool_failure())
+        w["raw_trace"] = "secret user prompt that must NOT leak"
+        p = build_proposal(w)
+        assert p is not None
+        assert "raw_trace" not in p["evidence"]
+        assert "raw_trace" not in json.dumps(p)
+        assert p["evidence"]["tool"] == "terminal"
+        assert p["evidence"]["occurrences"] == 9
+
+    def test_llm_returning_garbage_degrades_to_envelope(self):
+        # A model reply that is not a dict must not crash; fall back to defaults.
+        def _bad_llm(_w, _t):
+            return ["not", "a", "dict"]
+
+        p = build_proposal(_retry_spiral(), llm=_bad_llm)
+        assert p is not None
+        assert p["llm_authored"] is False
+        assert p["delta"] == ""
+        assert p["title"].startswith("[HARNESS]")
+
+    def test_llm_raising_is_caught_and_recorded(self):
+        def _boom(_w, _t):
+            raise RuntimeError("network down")
+
+        p = build_proposal(_tool_failure(), llm=_boom)
+        assert p is not None
+        assert p["llm_error"] == "network down"
+        assert p["llm_authored"] is False  # degraded, not crashed
+
+
+# --- HARD safety invariant: human-gated, never auto-applied ---------------
+
+class TestHumanGatingInvariant:
+    def test_every_proposal_is_inert_and_human_gated(self):
+        weaknesses = [_tool_failure(), _provider_error(), _retry_spiral()]
+        for p in generate_proposals(weaknesses, llm=_stub_llm([])):
+            assert p["status"] == "proposed"
+            assert p["requires_human_review"] is True
+            assert p["auto_apply"] is False
+
+    def test_module_exposes_no_apply_path(self):
+        # The generator MUST NOT ship any function that applies/mutates harness
+        # state. Guard against a future regression that adds one.
+        import evolution_harness_proposer as mod
+
+        forbidden = ("apply", "write_prompt", "mutate", "patch_config",
+                     "install", "rewrite", "commit")
+        names = [n for n in dir(mod) if not n.startswith("_")]
+        for n in names:
+            low = n.lower()
+            for bad in forbidden:
+                assert bad not in low, f"forbidden apply-like symbol exported: {n}"
+
+    def test_cli_output_echoes_human_gated_flag(self, tmp_path, capsys):
+        sidecar = {"weaknesses": [_tool_failure()]}
+        p = tmp_path / "weaknesses-latest.json"
+        p.write_text(json.dumps(sidecar), encoding="utf-8")
+        rc = main(["evolution_harness_proposer.py", str(p)])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["human_gated"] is True
+        assert all(pr["auto_apply"] is False for pr in out["proposals"])
+
+
+# --- batch generation -----------------------------------------------------
+
+class TestGenerateProposals:
+    def test_one_proposal_per_valid_weakness_order_preserved(self):
+        weaknesses = [_provider_error(n=60), _retry_spiral(), _tool_failure()]
+        props = generate_proposals(weaknesses)
+        assert len(props) == 3
+        # Order follows input (miner already sorts by severity desc).
+        assert props[0]["type"] == "retry_policy_change"
+        assert props[0]["evidence"]["signature"] == "429:rate_limit"
+        assert props[2]["type"] == "tool_guard"
+
+    def test_malformed_and_unknown_records_dropped(self):
+        weaknesses = [_tool_failure(), {"kind": "unknown"}, "not-a-dict", {}]
+        props = generate_proposals(weaknesses)
+        assert len(props) == 1
+        assert props[0]["type"] == "tool_guard"
+
+    def test_empty_input_yields_no_proposals(self):
+        assert generate_proposals([]) == []
+
+
+# --- loader ---------------------------------------------------------------
+
+class TestLoadWeaknesses:
+    def test_accepts_full_sidecar_object(self):
+        payload = {"window_days": 7, "weaknesses": [_tool_failure(), _provider_error()]}
+        recs = load_weaknesses(payload)
+        assert len(recs) == 2
+
+    def test_accepts_bare_list(self):
+        recs = load_weaknesses([_tool_failure()])
+        assert len(recs) == 1
+
+    def test_non_dict_entries_dropped(self):
+        recs = load_weaknesses([_tool_failure(), "x", 5, None])
+        assert len(recs) == 1
+
+    def test_unrecognized_shape_yields_empty(self):
+        assert load_weaknesses(42) == []
+        assert load_weaknesses({"weaknesses": "not-a-list"}) == []
+
+
+# --- CLI ------------------------------------------------------------------
+
+class TestMainCLI:
+    def test_file_input_emits_proposals(self, tmp_path, capsys):
+        sidecar = {"weaknesses": [_tool_failure(), _provider_error()]}
+        p = tmp_path / "w.json"
+        p.write_text(json.dumps(sidecar), encoding="utf-8")
+        rc = main(["evolution_harness_proposer.py", str(p)])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["count"] == 2
+        assert out["source"] == "self-harness"
+
+    def test_stdin_input(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps([_tool_failure()])))
+        rc = main(["evolution_harness_proposer.py"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0 and out["count"] == 1
+
+    def test_bad_json_exit_2(self, tmp_path, capsys):
+        p = tmp_path / "bad.json"
+        p.write_text("{not json", encoding="utf-8")
+        rc = main(["evolution_harness_proposer.py", str(p)])
+        assert rc == 2
+        assert "not valid JSON" in capsys.readouterr().err
+
+    def test_unknown_flag_exit_2(self, capsys):
+        rc = main(["evolution_harness_proposer.py", "--bogus"])
+        assert rc == 2
+        assert "unknown flag" in capsys.readouterr().err
+
+    def test_missing_file_exit_2(self, tmp_path, capsys):
+        rc = main(["evolution_harness_proposer.py", str(tmp_path / "nope.json")])
+        assert rc == 2
+        assert "cannot read input" in capsys.readouterr().err
+
+    def test_empty_weaknesses_yields_zero_proposals(self, tmp_path, capsys):
+        p = tmp_path / "empty.json"
+        p.write_text(json.dumps({"weaknesses": []}), encoding="utf-8")
+        rc = main(["evolution_harness_proposer.py", str(p)])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0 and out["count"] == 0 and out["proposals"] == []


### PR DESCRIPTION
Child of #248 (Self-Harness). Builds on `evolution_trace_miner.py`.

- `scripts/evolution_harness_proposer.py`: load weakness records (`weaknesses-latest.json` or bare list) → injectable LLM seam → structured `HarnessProposal` objects (type ∈ {system_prompt_delta, retry_policy_change, tool_guard}) for the issues stage.
- **Human-gated structurally**: every proposal carries `status=proposed`, `requires_human_review=True`, `auto_apply=False`; module exposes **no apply/mutate path** (a test fails if an apply-like symbol is ever added). Offline CLI; evidence whitelisted (no raw-trace leak, tested).

**Scope boundary:** no regression gate (#296). Emits proposals only.
Tests: `tests/scripts/test_evolution_harness_proposer.py` — 27 passed.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)