### PR TITLE
feat(skills): schema-tier progressive disclosure via skill_view(schema_only) (#303)

### DIFF
--- a/tests/tools/test_skill_schema_progressive.py
+++ b/tests/tools/test_skill_schema_progressive.py
@@ -1,0 +1,233 @@
+"""Tests for skill-schema progressive disclosure (issue #303, child of #229).
+
+The skills system already had two tiers:
+  * ``skills_list``                     -> name + description (tier 1)
+  * ``skill_view(name)``                -> full SKILL.md body (tier 3)
+
+This adds the cheap middle tier:
+  * ``skill_view(name, schema_only=True)`` -> name + description + structured
+    schema (inputs / outputs / examples / required env), WITHOUT the body.
+
+These tests cover the new ``extract_skill_schema`` helper, the ``schema_only``
+short-circuit in ``skill_view``, the additive ``schema`` field on full loads,
+and that all the existing security/disabled/platform gates still fire.
+"""
+
+import json
+from unittest.mock import patch
+
+from tools.skills_tool import (
+    extract_skill_schema,
+    skill_view,
+)
+
+
+def _make_skill(skills_dir, name, frontmatter_extra="", body="Step 1: Do the thing."):
+    """Create a minimal skill directory (mirrors test_skills_tool helper)."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = f"""\
+---
+name: {name}
+description: Description for {name}.
+{frontmatter_extra}---
+
+# {name}
+
+{body}
+"""
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+# A SKILL.md frontmatter block declaring a full schema (inputs/outputs/examples).
+_SCHEMA_FRONTMATTER = (
+    "inputs:\n"
+    "  - name: dataset_path\n"
+    "    description: Path to the training data.\n"
+    "outputs:\n"
+    "  - name: model_dir\n"
+    "    description: Directory of the fine-tuned model.\n"
+    "examples:\n"
+    "  - \"skill_view('demo')\"\n"
+    "  - description: Train on a CSV\n"
+    "    command: run --data foo.csv\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_skill_schema
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSkillSchema:
+    def test_extracts_inputs_outputs_examples(self):
+        frontmatter, _ = _parse(_SCHEMA_FRONTMATTER)
+        schema = extract_skill_schema(frontmatter)
+        assert schema["inputs"][0]["name"] == "dataset_path"
+        assert schema["outputs"][0]["name"] == "model_dir"
+        # str and dict examples both survive, in order
+        assert schema["examples"][0] == "skill_view('demo')"
+        assert schema["examples"][1]["command"] == "run --data foo.csv"
+
+    def test_empty_when_no_schema_fields(self):
+        frontmatter, _ = _parse("")
+        assert extract_skill_schema(frontmatter) == {}
+
+    def test_required_env_folded_into_schema(self):
+        fm = {
+            "required_environment_variables": [
+                {"name": "API_KEY", "prompt": "Enter API key"}
+            ]
+        }
+        schema = extract_skill_schema(fm)
+        assert schema["required_environment_variables"][0]["name"] == "API_KEY"
+
+    def test_blank_and_bad_examples_dropped(self):
+        fm = {"examples": ["good", "", "  ", 42, {"x": 1}]}
+        schema = extract_skill_schema(fm)
+        assert schema["examples"] == ["good", {"x": 1}]
+
+    def test_single_example_coerced_to_list(self):
+        fm = {"examples": "only-one"}
+        assert extract_skill_schema(fm)["examples"] == ["only-one"]
+
+
+def _parse(frontmatter_body):
+    """Build full SKILL.md content from a frontmatter body and parse it."""
+    from tools.skills_tool import _parse_frontmatter
+
+    content = f"---\nname: x\ndescription: d.\n{frontmatter_body}---\n\n# x\n\nBody.\n"
+    return _parse_frontmatter(content)
+
+
+# ---------------------------------------------------------------------------
+# skill_view(schema_only=True)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaOnlyLoad:
+    def test_schema_only_returns_schema_without_body(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "schema-skill",
+                frontmatter_extra=_SCHEMA_FRONTMATTER,
+                body="SECRET BODY MARKER should not be loaded.",
+            )
+            raw = skill_view("schema-skill", schema_only=True)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["schema_only"] is True
+        assert result["name"] == "schema-skill"
+        assert result["description"] == "Description for schema-skill."
+        # The cheap tier must NOT carry the full body.
+        assert "content" not in result
+        assert "SECRET BODY MARKER" not in raw
+        # But it MUST carry the structured schema.
+        assert result["schema"]["inputs"][0]["name"] == "dataset_path"
+        assert result["schema"]["outputs"][0]["name"] == "model_dir"
+
+    def test_schema_only_empty_schema_when_none_declared(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "bare-skill")
+            raw = skill_view("bare-skill", schema_only=True)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["schema"] == {}
+        assert "content" not in result
+
+    def test_schema_only_respects_disabled_gate(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skills_tool._is_skill_disabled", return_value=True),
+        ):
+            _make_skill(tmp_path, "hidden", frontmatter_extra=_SCHEMA_FRONTMATTER)
+            raw = skill_view("hidden", schema_only=True)
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "disabled" in result["error"].lower()
+
+    def test_schema_only_nonexistent_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            raw = skill_view("nope", schema_only=True)
+        result = json.loads(raw)
+        assert result["success"] is False
+
+    def test_schema_only_ignored_when_file_path_given(self, tmp_path):
+        """file_path is already a scoped load; schema_only must not hijack it."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "with-ref")
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "guide.md").write_text("REF FILE CONTENT")
+            raw = skill_view(
+                "with-ref", file_path="references/guide.md", schema_only=True
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        # We got the linked file, not the schema preview.
+        assert result["content"] == "REF FILE CONTENT"
+        assert "schema_only" not in result
+
+
+# ---------------------------------------------------------------------------
+# Full skill_view still carries schema (additive, non-regressive)
+# ---------------------------------------------------------------------------
+
+
+class TestFullViewSchemaField:
+    def test_full_view_includes_schema_when_declared(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path, "full-schema", frontmatter_extra=_SCHEMA_FRONTMATTER
+            )
+            raw = skill_view("full-schema")
+        result = json.loads(raw)
+        assert result["success"] is True
+        # Full body is present (tier 3) ...
+        assert "Step 1" in result["content"]
+        # ... and the schema is surfaced alongside it (same shape as tier 2).
+        assert result["schema"]["inputs"][0]["name"] == "dataset_path"
+
+    def test_full_view_omits_schema_when_absent(self, tmp_path):
+        """Skills with no schema keep the lean legacy response (no empty key)."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "no-schema")
+            raw = skill_view("no-schema")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "schema" not in result
+
+
+# ---------------------------------------------------------------------------
+# Registry handler: schema_only is a browse (view), not a use
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerUsageBump:
+    def test_schema_only_bumps_view_not_use(self, tmp_path):
+        from tools.skills_tool import _skill_view_with_bump
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "browsed", frontmatter_extra=_SCHEMA_FRONTMATTER)
+            with (
+                patch("tools.skill_usage.bump_view") as mock_view,
+                patch("tools.skill_usage.bump_use") as mock_use,
+            ):
+                _skill_view_with_bump({"name": "browsed", "schema_only": True})
+        mock_view.assert_called_once_with("browsed")
+        mock_use.assert_not_called()
+
+    def test_full_view_bumps_both_view_and_use(self, tmp_path):
+        from tools.skills_tool import _skill_view_with_bump
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "loaded")
+            with (
+                patch("tools.skill_usage.bump_view") as mock_view,
+                patch("tools.skill_usage.bump_use") as mock_use,
+            ):
+                _skill_view_with_bump({"name": "loaded"})
+        mock_view.assert_called_once_with("loaded")
+        mock_use.assert_called_once_with("loaded")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -8,6 +8,9 @@ and optional supporting files like references, templates, and examples.
 
 Inspired by Anthropic's Claude Skills system with progressive disclosure architecture:
 - Metadata (name ≤64 chars, description ≤1024 chars) - shown in skills_list
+- Schema (inputs / outputs / examples / required env) - loaded via
+  skill_view(name, schema_only=True) — a cheap middle tier between the
+  name+description listing and the full body (issue #303)
 - Full Instructions - loaded via skill_view when needed
 - Linked Files (references, templates) - loaded on demand
 
@@ -30,6 +33,14 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     name: skill-name              # Required, max 64 chars
     description: Brief description # Required, max 1024 chars
     version: 1.0.0                # Optional
+    inputs:                       # Optional — schema tier (issue #303)
+      - name: dataset_path        #   What the skill consumes. Free-form;
+        description: Path to data  #   surfaced verbatim by schema_only loads.
+    outputs:                      # Optional — what the skill produces
+      - name: report
+        description: Markdown summary
+    examples:                     # Optional — short usage examples (str or dict)
+      - "skill_view('my-skill')"
     license: MIT                  # Optional (agentskills.io)
     platforms: [macos]            # Optional — restrict to specific OS platforms
                                   #   Valid: macos, linux, windows
@@ -562,6 +573,60 @@ def _parse_tags(tags_value) -> List[str]:
     return [t.strip().strip("\"'") for t in tags_value.split(",") if t.strip()]
 
 
+def _normalize_schema_examples(value: Any) -> List[Any]:
+    """Coerce a raw frontmatter ``examples`` value into a clean list.
+
+    Accepts a single example (str/dict) or a list of them. Blank strings and
+    non-str/dict members are dropped so a malformed entry can't bloat the
+    schema tier. Order is preserved.
+    """
+    if not value:
+        return []
+    items = value if isinstance(value, list) else [value]
+    examples: List[Any] = []
+    for item in items:
+        if isinstance(item, dict):
+            examples.append(item)
+        elif isinstance(item, str) and item.strip():
+            examples.append(item.strip())
+    return examples
+
+
+def extract_skill_schema(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the structured invocation schema declared in skill frontmatter.
+
+    This is the middle progressive-disclosure tier (issue #303, child of #229):
+    ``skills_list`` exposes name+description (tier 1) and ``skill_view`` loads the
+    full SKILL.md body (tier 3). The schema is the cheap-to-load contract — what
+    the skill takes (``inputs``), what it produces (``outputs``), the credentials
+    it needs (``required_environment_variables``, surfaced here read-only), and a
+    few usage ``examples`` — without paying for the whole instruction body.
+
+    Fields are read verbatim from frontmatter (the YAML loader already gives us
+    lists/dicts). Absent fields are simply omitted, so a skill that declares no
+    schema yields an empty dict. The required-env list reuses the same
+    normalization as ``skill_view`` so the two never disagree.
+    """
+    schema: Dict[str, Any] = {}
+
+    inputs = frontmatter.get("inputs")
+    if inputs:
+        schema["inputs"] = inputs
+
+    outputs = frontmatter.get("outputs")
+    if outputs:
+        schema["outputs"] = outputs
+
+    examples = _normalize_schema_examples(frontmatter.get("examples"))
+    if examples:
+        schema["examples"] = examples
+
+    required_env_vars = _get_required_environment_variables(frontmatter)
+    if required_env_vars:
+        schema["required_environment_variables"] = required_env_vars
+
+    return schema
+
 
 def _get_disabled_skill_names() -> Set[str]:
     """Load disabled skill names from config.
@@ -1033,6 +1098,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    schema_only: bool = False,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -1045,6 +1111,16 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        schema_only: Progressive-disclosure middle tier (issue #303). When True,
+            resolve the skill (all security/platform/disabled gates still run) and
+            return only its name, description, and structured ``schema`` (inputs /
+            outputs / examples / required env), WITHOUT loading the full SKILL.md
+            body, preprocessing it, or triggering env-capture side effects. This is
+            the cheap "what does this skill take and produce?" load that sits
+            between ``skills_list`` (name+description) and a full ``skill_view``.
+            Ignored when ``file_path`` is given (a linked-file read is already
+            scoped). Plugin-provided skills currently fall through to the full
+            load.
 
     Returns:
         JSON string with skill content or error message
@@ -1363,6 +1439,27 @@ def skill_view(
                 ensure_ascii=False,
             )
 
+        # Progressive-disclosure middle tier (issue #303): return just the
+        # structured schema (inputs/outputs/examples/required-env) without the
+        # full body, preprocessing, or env-capture side effects. A file_path
+        # read is already a scoped load, so schema_only does not apply there.
+        if schema_only and not file_path:
+            schema_name = parsed_frontmatter.get("name", resolved_name)
+            return json.dumps(
+                {
+                    "success": True,
+                    "name": schema_name,
+                    "description": parsed_frontmatter.get("description", ""),
+                    "schema": extract_skill_schema(parsed_frontmatter),
+                    "schema_only": True,
+                    "hint": (
+                        "Schema only. Call skill_view(name) without schema_only "
+                        "to load the full instructions."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:
             from tools.path_security import validate_within_dir, has_traversal_component
@@ -1649,6 +1746,14 @@ def skill_view(
             else SkillReadinessStatus.AVAILABLE.value,
         }
 
+        # Surface the structured schema (inputs/outputs/examples/required-env)
+        # alongside the full content too — same tier-2 contract a schema_only
+        # load returns, so callers see one consistent ``schema`` shape. Omitted
+        # when the skill declares no schema, keeping the response lean.
+        skill_schema = extract_skill_schema(frontmatter)
+        if skill_schema:
+            result["schema"] = skill_schema
+
         setup_help = next((e["help"] for e in required_env_vars if e.get("help")), None)
         if setup_help:
             result["setup_help"] = setup_help
@@ -1762,6 +1867,10 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+            "schema_only": {
+                "type": "boolean",
+                "description": "OPTIONAL: When true, return only the skill's name, description, and structured schema (inputs/outputs/examples/required env) WITHOUT loading the full SKILL.md body — a cheap 'what does this skill take and produce?' preview between skills_list and a full load. Ignored if file_path is set.",
+            },
         },
         "required": ["name"],
     },
@@ -1781,8 +1890,12 @@ def _skill_view_with_bump(args, **kw):
     """Invoke skill_view, then bump view_count on success. Best-effort: a
     telemetry failure never breaks the tool call."""
     name = args.get("name", "")
+    schema_only = bool(args.get("schema_only"))
     result = skill_view(
-        name, file_path=args.get("file_path"), task_id=kw.get("task_id")
+        name,
+        file_path=args.get("file_path"),
+        task_id=kw.get("task_id"),
+        schema_only=schema_only,
     )
     try:
         parsed = json.loads(result)
@@ -1793,10 +1906,13 @@ def _skill_view_with_bump(args, **kw):
             if resolved:
                 from tools.skill_usage import bump_use, bump_view
                 bump_view(str(resolved))
-                # A skill_view tool call is the agent actively loading the skill
-                # to act on it — that counts as use, not just a browse/view.
-                # Curator's stale timer keys off last_used_at (see agent/curator.py).
-                bump_use(str(resolved))
+                # A full skill_view tool call is the agent actively loading the
+                # skill to act on it — that counts as use, not just a browse.
+                # A schema_only load is a cheap preview (tier 2), so it bumps
+                # view but NOT use — it must not reset the Curator stale timer,
+                # which keys off last_used_at (see agent/curator.py).
+                if not schema_only:
+                    bump_use(str(resolved))
     except Exception:
         pass
     return result


### PR DESCRIPTION
Child of #229 (Tool Search progressive disclosure). Adds the missing **middle tier** to skill disclosure.

- `tools/skills_tool.py`: `extract_skill_schema()` (inputs/outputs/examples + required env from frontmatter); `skill_view(..., schema_only=True)` returns name+description+schema with **no body/preprocessing/env-capture**, after all security/platform gates; full loads also gain the `schema` field (omitted when empty). Registry exposes `schema_only`; schema-only browse skips `bump_use` (not a use).
- **Extend over new**: reuses `skill_view`'s security stack (path-traversal, platform/disabled gates) instead of a parallel `skill_load` tool — zero new tool-schema tokens (one boolean param).

**Scope boundary:** plugin skills fall through to full load this slice; no frontmatter-authoring enforcement.
Tests: `tests/tools/test_skill_schema_progressive.py` (16) + existing — 103 passed; adjacent skill suites 97 passed/1 skipped.

Closes #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)