### PR TITLE
feat(judge): trace replay subsystem — per-step scoring (#304)

### DIFF
--- a/agent/agent_judge.py
+++ b/agent/agent_judge.py
@@ -43,7 +43,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -692,6 +692,25 @@ class AgentJudge:
             session_id, messages, self.rubric, summary=summary
         )
 
+    def score_replay(
+        self,
+        session_id: str,
+        messages: Sequence[Dict[str, Any]],
+        *,
+        task: Optional[str] = None,
+        use_llm: bool = False,
+    ) -> Dict[str, Any]:
+        """Score a trace step-by-step: overall verdict + per-step heuristic.
+
+        Engine-level entry point onto :func:`score_replayed_trace`, so the replay
+        subsystem is reachable from the same object callers already use for
+        whole-trace scoring (a dashboard/CLI consumes this rather than the bare
+        module function).
+        """
+        return score_replayed_trace(
+            session_id, messages, self.rubric, task=task, use_llm=use_llm
+        )
+
     def format_report_terminal(self, verdict: JudgeVerdict) -> str:
         """Return a compact, terminal-ready verdict summary."""
         return format_report_terminal(verdict, self.rubric)
@@ -716,3 +735,133 @@ def format_report_terminal(verdict: JudgeVerdict, rubric: Rubric = DEFAULT_RUBRI
     if verdict.rationale:
         lines.append(f"  {verdict.rationale}")
     return "\n".join(lines)
+
+
+# ── Trace replay subsystem (increment of #304) ───────────────────────────
+
+
+def _replay_content_text(content: Any) -> str:
+    """Best-effort plain text for an assistant message's ``content``.
+
+    Tolerates the three shapes a recorded trace can carry: a plain string, a
+    multimodal block list (text blocks concatenated), or anything else (→ "").
+    Never raises — replay must survive whatever a session log contains.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return " ".join(parts)
+    return ""
+
+
+def replay_trace_steps(
+    messages: Sequence[Dict[str, Any]],
+) -> Iterator[Dict[str, Any]]:
+    """Yield the high-level decision steps in a recorded trace.
+
+    Emits one record per assistant turn that either (a) contains plain text
+    reasoning/answer, or (b) invokes at least one tool.  Tool turns are paired
+    with the immediately following tool result(s) so callers can judge whether
+    each decision was validated by the environment.
+
+    Yields dicts of shape::
+
+        {
+            "step": int,
+            "role": "assistant",
+            "content": str,
+            "tool_calls": List[Dict[str, Any]],
+            "tool_results": List[Dict[str, Any]],
+            "has_final_answer": bool,
+        }
+
+    Pure, deterministic, no LLM — safe to call from dashboards or CI.  Multimodal
+    and malformed content are tolerated (coerced to text), never raising.
+    """
+    step = 0
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "assistant":
+            continue
+        text = _replay_content_text(msg.get("content"))
+        tool_calls = msg.get("tool_calls") or []
+        if not text.strip() and not tool_calls:
+            continue
+        step += 1
+        tool_results: List[Dict[str, Any]] = []
+        if tool_calls:
+            # Collect the next contiguous tool result messages.
+            j = i + 1
+            while j < len(messages):
+                nxt = messages[j]
+                if not isinstance(nxt, dict) or nxt.get("role") != "tool":
+                    break
+                tool_results.append(nxt)
+                j += 1
+        yield {
+            "step": step,
+            "role": "assistant",
+            "content": text,
+            "tool_calls": list(tool_calls),
+            "tool_results": tool_results,
+            "has_final_answer": bool(text.strip() and not tool_calls),
+        }
+
+
+def score_replayed_trace(
+    session_id: str,
+    messages: Sequence[Dict[str, Any]],
+    rubric: Rubric = DEFAULT_RUBRIC,
+    *,
+    task: Optional[str] = None,
+    use_llm: bool = False,
+) -> Dict[str, Any]:
+    """Score a recorded trace step-by-step.
+
+    Returns a dict containing the original ``AgentJudge`` verdict plus a
+    ``steps`` list with per-step summary data.  Each step's score is heuristic
+    only: 1.0 when the step produced a tool result with no failure marker, 0.0
+    when every result looks like a failure, and 0.5 for a pure-reasoning step
+    that produced no tool result.  This is the deterministic, cheap baseline;
+    LLM scoring of individual steps is intentionally deferred (kept small +
+    independently testable).
+    """
+    verdict = AgentJudge(rubric).score(
+        session_id, messages, task=task, use_llm=use_llm
+    )
+    steps: List[Dict[str, Any]] = []
+    for step in replay_trace_steps(messages):
+        failures = sum(
+            1
+            for r in step["tool_results"]
+            if _looks_like_failure(r.get("content") if isinstance(r, dict) else r)
+        )
+        total = len(step["tool_results"])
+        if total == 0:
+            step_score = 0.5
+        elif failures == 0:
+            step_score = 1.0
+        else:
+            step_score = 0.0
+        steps.append(
+            {
+                "step": step["step"],
+                "has_final_answer": step["has_final_answer"],
+                "tool_count": len(step["tool_calls"]),
+                "tool_result_count": total,
+                "tool_failure_count": failures,
+                "score": step_score,
+            }
+        )
+    return {
+        "session_id": session_id,
+        "verdict": verdict.to_dict(),
+        "steps": steps,
+    }

--- a/tests/agent/test_agent_judge_replay.py
+++ b/tests/agent/test_agent_judge_replay.py
@@ -1,0 +1,142 @@
+"""Tests for the Agent-as-Judge trace replay subsystem (issue #304)."""
+
+from agent.agent_judge import (
+    AgentJudge,
+    DEFAULT_RUBRIC,
+    replay_trace_steps,
+    score_replayed_trace,
+)
+
+
+SUCCESS_TRACE = [
+    {"role": "user", "content": "list the files"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "a.py\nb.py"},
+    {"role": "assistant", "content": "There are two files: a.py and b.py."},
+]
+
+FAILING_TRACE = [
+    {"role": "user", "content": "run the build"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "2"}]},
+    {"role": "tool", "content": "error: command not found"},
+    {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "3"}]},
+    {"role": "tool", "content": "error: command not found"},
+]
+
+
+class TestReplayTraceSteps:
+    def test_success_trace_steps(self):
+        steps = list(replay_trace_steps(SUCCESS_TRACE))
+        assert len(steps) == 2
+        assert steps[0]["step"] == 1
+        assert steps[0]["tool_calls"]
+        assert len(steps[0]["tool_results"]) == 1
+        assert steps[1]["has_final_answer"] is True
+        assert steps[1]["tool_calls"] == []
+
+    def test_failing_trace_steps(self):
+        steps = list(replay_trace_steps(FAILING_TRACE))
+        # Three assistant turns, each a terminal call.
+        assert len(steps) == 3
+        for step in steps:
+            assert step["tool_calls"]
+            assert len(step["tool_results"]) == 1
+
+    def test_skips_non_dict_messages(self):
+        mixed = [None, "garbage"] + SUCCESS_TRACE
+        steps = list(replay_trace_steps(mixed))
+        assert len(steps) == 2
+
+    def test_empty_trace(self):
+        assert list(replay_trace_steps([])) == []
+
+
+class TestScoreReplayedTrace:
+    def test_success_trace_scores(self):
+        result = score_replayed_trace("s1", SUCCESS_TRACE, DEFAULT_RUBRIC)
+        assert result["session_id"] == "s1"
+        assert result["verdict"]["method"] == "heuristic"
+        assert result["verdict"]["overall_score"] > 0.7
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["score"] == 1.0
+        assert result["steps"][1]["score"] == 0.5
+
+    def test_failing_trace_scores_low(self):
+        result = score_replayed_trace("s2", FAILING_TRACE, DEFAULT_RUBRIC)
+        assert result["verdict"]["overall_score"] < 0.5
+        assert all(s["score"] == 0.0 for s in result["steps"])
+
+    def test_empty_trace(self):
+        result = score_replayed_trace("s3", [], DEFAULT_RUBRIC)
+        assert result["verdict"]["overall_score"] < 0.5
+        assert result["steps"] == []
+
+    def test_dict_tool_result_content(self):
+        trace = [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}]},
+            {"role": "tool", "content": {"stdout": "ok"}},
+            {"role": "assistant", "content": "Done."},
+        ]
+        steps = list(replay_trace_steps(trace))
+        assert steps[0]["tool_results"][0]["content"] == {"stdout": "ok"}
+        result = score_replayed_trace("s4", trace, DEFAULT_RUBRIC)
+        assert result["steps"][0]["score"] == 1.0
+
+    def test_serializable(self):
+        import json
+
+        result = score_replayed_trace("s5", SUCCESS_TRACE, DEFAULT_RUBRIC)
+        # Should not raise.
+        json.dumps(result)
+
+
+class TestMultimodalAndRobustness:
+    def test_multimodal_content_blocks_are_coerced(self):
+        trace = [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "thinking"}],
+                "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}],
+            },
+            {"role": "tool", "content": "ok"},
+            {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
+        ]
+        steps = list(replay_trace_steps(trace))
+        assert len(steps) == 2
+        assert steps[0]["content"] == "thinking"
+        assert steps[1]["content"] == "Done."
+        assert steps[1]["has_final_answer"] is True
+
+    def test_non_str_content_does_not_crash(self):
+        # The #307 regression: bare `.strip()` on a dict/list content raised.
+        trace = [
+            {
+                "role": "assistant",
+                "content": {"weird": "dict"},
+                "tool_calls": [{"function": {"name": "terminal"}, "id": "1"}],
+            },
+            {"role": "tool", "content": "ok"},
+        ]
+        steps = list(replay_trace_steps(trace))
+        assert len(steps) == 1
+        assert steps[0]["content"] == ""
+
+    def test_assistant_with_dict_content_and_no_tools_is_skipped(self):
+        assert list(replay_trace_steps([{"role": "assistant", "content": {"x": 1}}])) == []
+
+
+class TestAgentJudgeScoreReplay:
+    def test_engine_method_matches_module_function(self):
+        judge = AgentJudge(DEFAULT_RUBRIC)
+        assert judge.score_replay("s", SUCCESS_TRACE) == score_replayed_trace(
+            "s", SUCCESS_TRACE, DEFAULT_RUBRIC
+        )
+
+    def test_engine_method_step_scores(self):
+        result = AgentJudge(DEFAULT_RUBRIC).score_replay("s", SUCCESS_TRACE)
+        assert result["session_id"] == "s"
+        assert result["steps"][0]["score"] == 1.0
+        assert result["steps"][1]["score"] == 0.5


### PR DESCRIPTION
Child of #226 (Agent-as-a-Judge). Re-does the **closed** PR #307 cleanly and unblocks the `needs-work` state.

## Why #307 was closed
Its replay logic was actually sound (its tests pass locally), but it had two real defects:
1. `from typing import Iterator` was a **mid-file import**.
2. `replay_trace_steps` called `.strip()` on raw `content` — a multimodal block-list or a malformed dict would **raise**.

## What ships here
- `replay_trace_steps(messages)` — deterministic per-decision steps; each tool turn paired with its contiguous tool results. New `_replay_content_text()` coerces string / multimodal-block-list / anything-else to text, **never raising**.
- `score_replayed_trace(...)` — overall `AgentJudge` verdict + per-step heuristic score (1.0 result-no-failure / 0.0 all-failed / 0.5 pure-reasoning).
- `AgentJudge.score_replay(...)` — engine-level entry point, so replay is reachable from the same object as whole-trace scoring (addresses the **dead-code** concern that blocked #307).

## Scope boundary
LLM per-step scoring and dashboard/CLI wiring remain deferred (next increment).

## Verification
- `tests/agent/test_agent_judge_replay.py` — 14 tests (incl. multimodal + non-str-content robustness + the engine method); **65 green** with the existing `agent_judge` suite.
- `ruff check .` clean (incl. the blocking gate); module parses.

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)