### PR TITLE
feat(plan): lookahead divergence-detect + replan trigger (#291)

### DIFF
--- a/agent/plan_lookahead.py
+++ b/agent/plan_lookahead.py
@@ -1,0 +1,292 @@
+"""Lookahead re-planning — divergence detection after each step (issue #291).
+
+Child #1 (#290) shipped the explicit plan data model (:mod:`agent.plan_schema`):
+an ordered, immutable :class:`~agent.plan_schema.Plan` of declarative
+:class:`~agent.plan_schema.Step` s, each carrying an ``expected_observation``
+— the prediction of what the agent should see if the step goes as planned.
+
+This module is child #2's *minimal* slice: the seam that, after a step's tool
+call completes, compares the **observed** result against that step's
+``expected_observation`` and decides whether reality *diverged* from the plan.
+When it diverges, a replan is *triggered* — but triggering is all this slice
+owns. The actual "ask an LLM for a fresh plan" call is sibling #292's job and
+stays behind a default-off seam here (a stub / overridable hook), so nothing in
+this module reaches a model or mutates agent behavior on its own.
+
+What's here
+-----------
+* :class:`DivergenceResult` — a frozen verdict: ``diverged`` (bool), a plain
+  ``reason``, and the ``signal`` that fired (an enum-ish string). Pure value.
+* :func:`evaluate_divergence` — the pure heuristic comparator. Given an observed
+  result string and a :class:`~agent.plan_schema.Step`, returns a
+  :class:`DivergenceResult`. No I/O, no LLM, deterministic. This is the
+  load-bearing piece other slices and the eval harness (#292) build on.
+* :class:`PlanProgress` — a tiny cursor over a plan's steps so the agent loop
+  can ask "which step did this tool call belong to?" and advance. Default-off
+  by construction: with no active plan there is no progress object.
+* :func:`should_replan` / :func:`trigger_replan` — the replan-trigger seam.
+  ``should_replan`` is pure policy over a :class:`DivergenceResult`;
+  ``trigger_replan`` invokes an optional, caller-supplied ``replanner`` callable
+  and is a no-op (returns ``None``) when none is wired — exactly mirroring how
+  ``emit_plan`` stays inert when there is no active plan.
+
+Why a heuristic, not a model
+----------------------------
+``expected_observation`` is free text written by whatever produced the plan, and
+the observed tool result is free text too. A cheap, transparent, deterministic
+comparator (error-signal detection + keyword overlap) is enough to *flag* a
+divergence for a replanner to act on, and it costs zero tokens and zero latency
+— which matters because this runs after *every* step. Sharper, model-based
+adjudication is a strict upgrade #292 can layer on top of the same seam.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from agent.plan_schema import Plan, Step
+
+# A replanner: given the diverged step, its observed result, and the divergence
+# verdict, optionally produce a fresh :class:`Plan`. Returning ``None`` means
+# "keep the current plan". This module never supplies one — the agent (or #292's
+# harness) wires it in. Kept as a type alias so the seam's contract is explicit.
+Replanner = Callable[["Plan", "Step", str, "DivergenceResult"], Optional[Plan]]
+
+# Substrings that mark a tool result as a failure/error observation. Matched
+# case-insensitively against the observed result. Intentionally small and
+# conservative — these are the high-signal markers the runtime itself emits
+# (see ``agent.tool_diagnostics`` / guardrail synthetic results) plus the
+# obvious ones. A replanner can be far smarter; this only needs to catch the
+# "the step clearly failed" case the expected_observation didn't anticipate.
+_ERROR_MARKERS: tuple[str, ...] = (
+    "error executing tool",
+    "traceback (most recent call last)",
+    "exception:",
+    "failed:",
+    "[tool execution cancelled",
+    "permission denied",
+    "no such file or directory",
+    "command not found",
+    "fatal:",
+)
+
+# Words too common to count as meaningful overlap between an expectation and an
+# observation. Keeps keyword matching from passing on filler alone.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the", "a", "an", "and", "or", "of", "to", "in", "on", "at", "for",
+        "with", "is", "are", "be", "it", "its", "this", "that", "as", "by",
+        "from", "should", "will", "would", "we", "i", "you", "they", "see",
+        "show", "shows", "showing", "result", "results", "output", "back",
+    }
+)
+
+# Signal labels carried on a DivergenceResult, so consumers (and #292's harness)
+# can branch on *why* without re-parsing the reason text.
+SIGNAL_OK = "ok"  # observed matched / no yardstick to judge against
+SIGNAL_NO_EXPECTATION = "no_expectation"  # step predicted nothing — never diverges
+SIGNAL_EMPTY_OBSERVATION = "empty_observation"  # expected something, saw nothing
+SIGNAL_ERROR = "error"  # observed carries a failure marker the step didn't predict
+SIGNAL_MISMATCH = "mismatch"  # expected keywords absent from observed
+
+
+@dataclass(frozen=True)
+class DivergenceResult:
+    """A frozen verdict on whether an observation diverged from a step.
+
+    ``diverged`` is the boolean the replan-trigger seam keys off.
+    ``reason`` is a one-line, human-readable explanation (for status output /
+    transcripts). ``signal`` is a stable label from the ``SIGNAL_*`` constants so
+    programmatic consumers branch without parsing prose. ``overlap`` is the
+    fraction (0..1) of the expectation's meaningful keywords found in the
+    observation — recorded for the same reason ``Plan.metadata`` is: downstream
+    policy (#292) may want a knob, and a verdict that hides its evidence is
+    harder to tune.
+    """
+
+    diverged: bool
+    reason: str
+    signal: str
+    overlap: float = 0.0
+
+
+def _keywords(text: str) -> List[str]:
+    """Lowercased, de-stopworded word tokens of ``text`` (length >= 3)."""
+    tokens = re.findall(r"[a-z0-9_]+", text.lower())
+    return [t for t in tokens if len(t) >= 3 and t not in _STOPWORDS]
+
+
+def _has_error_marker(observed_lower: str) -> bool:
+    return any(marker in observed_lower for marker in _ERROR_MARKERS)
+
+
+def evaluate_divergence(
+    observed: Optional[str],
+    step: Step,
+    *,
+    overlap_threshold: float = 0.34,
+) -> DivergenceResult:
+    """Compare an observed tool result against ``step.expected_observation``.
+
+    Pure and deterministic — no I/O, no model call. The policy, in order:
+
+    1. **No yardstick.** If the step predicted nothing
+       (``expected_observation`` blank), there is nothing to diverge from →
+       ``diverged=False`` (``SIGNAL_NO_EXPECTATION``). This is what keeps a plan
+       whose steps omit predictions from ever tripping a replan.
+    2. **Empty observation.** The step expected *something* but the tool gave
+       back nothing → diverged (``SIGNAL_EMPTY_OBSERVATION``).
+    3. **Unanticipated error.** The observation carries a failure marker that the
+       expectation did not itself describe (so a step that *predicts* an error
+       isn't flagged for getting one) → diverged (``SIGNAL_ERROR``).
+    4. **Keyword mismatch.** Otherwise, measure how many of the expectation's
+       meaningful keywords appear in the observation. Below ``overlap_threshold``
+       → diverged (``SIGNAL_MISMATCH``); at or above → on-plan (``SIGNAL_OK``).
+
+    ``overlap_threshold`` is the one tunable knob; the default (~a third of the
+    expectation's keywords must surface) is deliberately lenient so only clear
+    drift trips it. Tightening it is a #292 concern.
+    """
+    expectation = (step.expected_observation or "").strip()
+    if not expectation:
+        return DivergenceResult(
+            diverged=False,
+            reason="step predicted no observation; nothing to compare against",
+            signal=SIGNAL_NO_EXPECTATION,
+        )
+
+    observed_text = observed or ""
+    observed_lower = observed_text.lower()
+
+    if not observed_text.strip():
+        return DivergenceResult(
+            diverged=True,
+            reason="expected an observation but the step produced no output",
+            signal=SIGNAL_EMPTY_OBSERVATION,
+        )
+
+    # An error counts as divergence only if the step did not itself anticipate
+    # one — otherwise a step whose whole point is "expect a failure" would be
+    # falsely flagged.
+    if _has_error_marker(observed_lower) and not _has_error_marker(expectation.lower()):
+        return DivergenceResult(
+            diverged=True,
+            reason="observed result reports an error the step did not anticipate",
+            signal=SIGNAL_ERROR,
+        )
+
+    expected_keywords = _keywords(expectation)
+    if not expected_keywords:
+        # Expectation was all filler/stopwords — no testable content. Treat as
+        # "no yardstick" rather than inventing a mismatch.
+        return DivergenceResult(
+            diverged=False,
+            reason="expectation has no testable keywords; treated as on-plan",
+            signal=SIGNAL_NO_EXPECTATION,
+        )
+
+    observed_keywords = set(_keywords(observed_text))
+    hits = sum(1 for kw in expected_keywords if kw in observed_keywords)
+    overlap = hits / len(expected_keywords)
+
+    if overlap < overlap_threshold:
+        return DivergenceResult(
+            diverged=True,
+            reason=(
+                f"observation matched {hits}/{len(expected_keywords)} expected "
+                f"keywords ({overlap:.0%}), below the {overlap_threshold:.0%} threshold"
+            ),
+            signal=SIGNAL_MISMATCH,
+            overlap=overlap,
+        )
+
+    return DivergenceResult(
+        diverged=False,
+        reason=(
+            f"observation matched {hits}/{len(expected_keywords)} expected "
+            f"keywords ({overlap:.0%}); on plan"
+        ),
+        signal=SIGNAL_OK,
+        overlap=overlap,
+    )
+
+
+@dataclass
+class PlanProgress:
+    """A mutable cursor over a plan's steps for the execute loop.
+
+    The agent advances this as each step's tool call completes, so the loop can
+    answer "which step does this observation belong to?" via :meth:`current` and
+    move on via :meth:`advance`. Deliberately *not* frozen — it is per-turn
+    mutable execution state, the counterpart to the immutable :class:`Plan`
+    artifact it points into.
+
+    Default-off by construction: a :class:`PlanProgress` only exists when an
+    active plan is set, so the loop's "no progress object" branch is the
+    unchanged-behavior path.
+    """
+
+    plan: Plan
+    cursor: int = 0  # 0-based index of the *next* step to be observed
+
+    def current(self) -> Optional[Step]:
+        """The step the next observation is judged against, or ``None`` if done."""
+        if 0 <= self.cursor < len(self.plan.steps):
+            return self.plan.steps[self.cursor]
+        return None
+
+    def advance(self) -> None:
+        """Move the cursor past the current step (clamped at the end)."""
+        if self.cursor < len(self.plan.steps):
+            self.cursor += 1
+
+    def is_exhausted(self) -> bool:
+        """True once every step has been observed."""
+        return self.cursor >= len(self.plan.steps)
+
+    def adopt(self, plan: Plan) -> None:
+        """Replace the plan and reset the cursor — what a replan installs."""
+        self.plan = plan
+        self.cursor = 0
+
+
+def should_replan(result: DivergenceResult) -> bool:
+    """Pure policy: does this divergence verdict warrant a replan?
+
+    Trivial today (any divergence → replan), but isolated as its own seam so
+    #292 can make it selective (e.g. only ``SIGNAL_ERROR``, or only after N
+    consecutive mismatches) without touching the comparator or the agent loop.
+    """
+    return result.diverged
+
+
+def trigger_replan(
+    plan: Plan,
+    step: Step,
+    observed: str,
+    result: DivergenceResult,
+    *,
+    replanner: Optional[Replanner] = None,
+) -> Optional[Plan]:
+    """Fire the replan seam. Inert (returns ``None``) when no replanner is wired.
+
+    This is the #291/#292 boundary made explicit. #291 owns *detecting*
+    divergence and *deciding to* replan; actually producing a new plan is a
+    model call #292 supplies as ``replanner``. With no replanner — the default —
+    this returns ``None`` and the current plan stands, so the trigger is a no-op
+    exactly like ``emit_plan(None, ...)`` is.
+
+    A misbehaving replanner must never break a turn, so its exceptions are
+    swallowed (mirroring ``emit_plan``'s broken-sink contract).
+    """
+    if replanner is None:
+        return None
+    try:
+        new_plan = replanner(plan, step, observed, result)
+    except Exception:
+        return None
+    if isinstance(new_plan, Plan):
+        return new_plan
+    return None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -149,6 +149,11 @@ def build_turn_context(
     # an active plan (if any) is re-emitted at the start of each turn. Inert
     # unless ``agent._active_plan`` is set — see ``_emit_plan_before_tool_calls``.
     agent._plan_emitted_for_turn = False
+    # Plan-and-execute lookahead (#291): clear the per-turn step-progress cursor
+    # so divergence checking starts fresh each turn. Inert unless an active plan
+    # is set — see ``_check_step_divergence_after_tool_calls``. Rebuilt lazily on
+    # first use against the current ``agent._active_plan``.
+    agent._plan_progress = None
 
     # Pre-turn connection health check: clean up dead TCP connections.
     if agent.api_mode != "anthropic_messages":

--- a/run_agent.py
+++ b/run_agent.py
@@ -5145,6 +5145,106 @@ class AIAgent:
         if emit_plan(plan, emit=self._emit_status):
             self._plan_emitted_for_turn = True
 
+    def _check_step_divergence_after_tool_calls(self, messages: list) -> None:
+        """Lookahead replan check, run once after a turn's tool dispatch (#291).
+
+        Plan-and-execute child #2. When an active plan is set, the agent tracks a
+        per-turn :class:`agent.plan_lookahead.PlanProgress` cursor over its steps.
+        After the turn's tool calls complete, this compares the freshly observed
+        tool result against the current step's ``expected_observation`` via the
+        pure :func:`agent.plan_lookahead.evaluate_divergence`. If they diverged,
+        it fires the replan-trigger seam — which only does anything when a
+        ``replanner`` callable has been wired (sibling #292); otherwise it is a
+        no-op and the current plan stands. Either way the cursor advances.
+
+        Default-off by construction, mirroring ``_emit_plan_before_tool_calls``:
+        with no ``self._active_plan`` this returns immediately, so the agent's
+        observable behavior is unchanged until a future slice opts in by building
+        and assigning a plan. This neither selects tools nor mutates ``messages``.
+        """
+        plan = getattr(self, "_active_plan", None)
+        if plan is None:
+            return
+
+        from agent.plan_lookahead import (
+            PlanProgress,
+            evaluate_divergence,
+            should_replan,
+            trigger_replan,
+        )
+
+        # Lazily create / re-sync the per-turn progress cursor against the active
+        # plan. A replan that swaps ``_active_plan`` invalidates an old cursor, so
+        # rebuild whenever the tracked plan identity drifts.
+        progress = getattr(self, "_plan_progress", None)
+        if not isinstance(progress, PlanProgress) or progress.plan is not plan:
+            progress = PlanProgress(plan)
+            self._plan_progress = progress
+
+        step = progress.current()
+        if step is None:
+            return  # plan already exhausted — nothing left to judge
+
+        observed = self._latest_tool_observation(messages)
+        result = evaluate_divergence(observed, step)
+        if result.diverged:
+            try:
+                self._emit_status(
+                    f"↪ plan step {step.index} diverged: {result.reason}"
+                )
+            except Exception:
+                pass
+            new_plan = trigger_replan(
+                plan,
+                step,
+                observed or "",
+                result,
+                replanner=getattr(self, "_replanner", None),
+            )
+            if new_plan is not None:
+                # A replanner produced a fresh plan: adopt it, re-arm emission so
+                # the new plan prints next turn, and reset the cursor.
+                self._active_plan = new_plan
+                self._plan_emitted_for_turn = False
+                progress.adopt(new_plan)
+                return
+        # No replan (or none wired): treat the current step as observed and move
+        # the cursor forward so the next turn judges the next step.
+        if not should_replan(result):
+            progress.advance()
+        else:
+            # Diverged but nothing replanned — still advance so a stuck step
+            # can't wedge the cursor and re-fire forever on the same observation.
+            progress.advance()
+
+    @staticmethod
+    def _latest_tool_observation(messages: list) -> Optional[str]:
+        """Extract the most recent tool-result text from ``messages``.
+
+        Reads the trailing ``role == "tool"`` message(s) appended by this turn's
+        dispatch and returns their textual content, or ``None`` if the last
+        message isn't a tool result (e.g. an assistant message with no calls).
+        Multimodal (list) content is reduced to its text parts; non-text is
+        ignored. Pure read — never mutates ``messages``.
+        """
+        if not messages:
+            return None
+        texts: List[str] = []
+        for msg in reversed(messages):
+            if not isinstance(msg, dict) or msg.get("role") != "tool":
+                break
+            content = msg.get("content")
+            if isinstance(content, str):
+                texts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        texts.append(part["text"])
+        if not texts:
+            return None
+        # ``reversed`` collected newest-first; restore chronological order.
+        return "\n".join(reversed(texts))
+
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
@@ -5173,6 +5273,12 @@ class AIAgent:
             )
         finally:
             self._executing_tools = False
+            # Plan-and-execute (#291): after this turn's tool results land, check
+            # whether the observation diverged from the active plan's current
+            # step and trigger a replan if so. Inert by default — no-op unless an
+            # active plan has been set (nothing in the default loop sets one).
+            # See ``_check_step_divergence_after_tool_calls``.
+            self._check_step_divergence_after_tool_calls(messages)
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:
         """Single call site for delegate_task dispatch.

--- a/tests/agent/test_plan_lookahead.py
+++ b/tests/agent/test_plan_lookahead.py
@@ -1,0 +1,286 @@
+"""Tests for agent.plan_lookahead — divergence detection + replan trigger (#291).
+
+Covers child #2 of the plan-and-execute decomposition (parent #283):
+
+* the pure :func:`evaluate_divergence` comparator and its signal taxonomy,
+* the :class:`PlanProgress` cursor,
+* the default-off :func:`should_replan` / :func:`trigger_replan` seam
+  (inert unless a ``replanner`` is wired — sibling #292 wires it),
+* and the run_agent.py integration: the seam self-gates to a no-op until an
+  active plan is set, mirroring the #290 emission hook.
+"""
+
+import pytest
+
+from agent.plan_schema import Plan, Step
+from agent.plan_lookahead import (
+    DivergenceResult,
+    PlanProgress,
+    Replanner,
+    evaluate_divergence,
+    should_replan,
+    trigger_replan,
+    SIGNAL_OK,
+    SIGNAL_NO_EXPECTATION,
+    SIGNAL_EMPTY_OBSERVATION,
+    SIGNAL_ERROR,
+    SIGNAL_MISMATCH,
+)
+
+
+def _step(intent="run pytest", rationale="prove green", expect="all tests pass"):
+    return Step(
+        tool_call_intent=intent,
+        rationale=rationale,
+        expected_observation=expect,
+    )
+
+
+# ── evaluate_divergence (the pure comparator) ────────────────────────────────
+
+class TestEvaluateDivergence:
+    def test_no_expectation_never_diverges(self):
+        # A step that predicts nothing has no yardstick — can't diverge.
+        step = _step(expect="")
+        result = evaluate_divergence("anything at all here", step)
+        assert result.diverged is False
+        assert result.signal == SIGNAL_NO_EXPECTATION
+
+    def test_whitespace_only_expectation_never_diverges(self):
+        result = evaluate_divergence("anything", _step(expect="   \n  "))
+        assert result.diverged is False
+        assert result.signal == SIGNAL_NO_EXPECTATION
+
+    def test_empty_observation_when_something_expected_diverges(self):
+        result = evaluate_divergence("", _step(expect="the test suite passes"))
+        assert result.diverged is True
+        assert result.signal == SIGNAL_EMPTY_OBSERVATION
+
+    def test_none_observation_treated_as_empty(self):
+        result = evaluate_divergence(None, _step(expect="some output expected"))
+        assert result.diverged is True
+        assert result.signal == SIGNAL_EMPTY_OBSERVATION
+
+    def test_unanticipated_error_diverges(self):
+        step = _step(expect="the file contents of plan_schema.py")
+        observed = "Error executing tool 'read_file': no such file or directory"
+        result = evaluate_divergence(observed, step)
+        assert result.diverged is True
+        assert result.signal == SIGNAL_ERROR
+
+    def test_anticipated_error_does_not_diverge_on_error(self):
+        # A step whose expectation itself describes an error must not be flagged
+        # just for observing one — it falls through to keyword matching.
+        step = _step(expect="a traceback (most recent call last) from the failing import")
+        observed = "Traceback (most recent call last):\n  import boom\nImportError"
+        result = evaluate_divergence(observed, step)
+        # Error marker present in BOTH expectation and observation -> not an
+        # error-signal divergence; keyword overlap (traceback/import) keeps it on-plan.
+        assert result.signal != SIGNAL_ERROR
+        assert result.diverged is False
+
+    def test_matching_keywords_on_plan(self):
+        step = _step(expect="the pytest suite passes with all green")
+        observed = "collected 12 items ... 12 passed. pytest suite green."
+        result = evaluate_divergence(observed, step)
+        assert result.diverged is False
+        assert result.signal == SIGNAL_OK
+        assert result.overlap > 0.0
+
+    def test_keyword_mismatch_diverges(self):
+        step = _step(expect="a JSON list of three FLARE benchmark numbers")
+        observed = "the weather in Paris is sunny and warm today"
+        result = evaluate_divergence(observed, step)
+        assert result.diverged is True
+        assert result.signal == SIGNAL_MISMATCH
+        assert 0.0 <= result.overlap < 0.34
+
+    def test_threshold_is_tunable(self):
+        step = _step(expect="alpha beta gamma delta")  # 4 keywords
+        observed = "alpha only"  # 1/4 = 0.25 overlap
+        # Default threshold (0.34) -> diverged.
+        assert evaluate_divergence(observed, step).diverged is True
+        # Lenient threshold below the overlap -> on plan.
+        assert evaluate_divergence(observed, step, overlap_threshold=0.2).diverged is False
+
+    def test_expectation_all_stopwords_is_not_testable(self):
+        # No meaningful keywords -> treated as on-plan, not a false mismatch.
+        result = evaluate_divergence("zzz qqq", _step(expect="the it is to be"))
+        assert result.diverged is False
+        assert result.signal == SIGNAL_NO_EXPECTATION
+
+    def test_result_is_frozen(self):
+        result = evaluate_divergence("x", _step(expect=""))
+        with pytest.raises((AttributeError, TypeError)):
+            result.diverged = True  # type: ignore[misc]
+
+
+# ── PlanProgress (the execution cursor) ──────────────────────────────────────
+
+class TestPlanProgress:
+    def _plan(self, n=3):
+        return Plan(steps=[_step(intent=f"s{i}") for i in range(n)])
+
+    def test_current_points_at_first_step_initially(self):
+        prog = PlanProgress(self._plan())
+        assert prog.current().index == 1
+
+    def test_advance_walks_steps_then_exhausts(self):
+        plan = self._plan(2)
+        prog = PlanProgress(plan)
+        assert prog.current().index == 1
+        prog.advance()
+        assert prog.current().index == 2
+        prog.advance()
+        assert prog.current() is None
+        assert prog.is_exhausted() is True
+
+    def test_advance_clamps_past_end(self):
+        prog = PlanProgress(self._plan(1))
+        prog.advance()
+        prog.advance()  # extra advance must not run the cursor away
+        assert prog.cursor == 1
+        assert prog.is_exhausted() is True
+
+    def test_adopt_swaps_plan_and_resets_cursor(self):
+        prog = PlanProgress(self._plan(2))
+        prog.advance()
+        assert prog.cursor == 1
+        new_plan = self._plan(3)
+        prog.adopt(new_plan)
+        assert prog.plan is new_plan
+        assert prog.cursor == 0
+        assert prog.current().index == 1
+
+
+# ── should_replan / trigger_replan (the default-off seam) ────────────────────
+
+class TestReplanSeam:
+    def test_should_replan_tracks_divergence(self):
+        assert should_replan(DivergenceResult(True, "r", SIGNAL_MISMATCH)) is True
+        assert should_replan(DivergenceResult(False, "r", SIGNAL_OK)) is False
+
+    def test_trigger_replan_inert_without_replanner(self):
+        # Default-off: no replanner wired -> no new plan, current plan stands.
+        plan = Plan(steps=[_step()])
+        result = DivergenceResult(True, "diverged", SIGNAL_MISMATCH)
+        assert trigger_replan(plan, plan.steps[0], "obs", result) is None
+
+    def test_trigger_replan_invokes_wired_replanner(self):
+        plan = Plan(steps=[_step(intent="old")])
+        fresh = Plan(steps=[_step(intent="new")])
+        seen = {}
+
+        def replanner(p, s, observed, res):
+            seen["args"] = (p, s, observed, res)
+            return fresh
+
+        out = trigger_replan(plan, plan.steps[0], "obs-text", DivergenceResult(True, "r", SIGNAL_ERROR), replanner=replanner)
+        assert out is fresh
+        assert seen["args"][0] is plan
+        assert seen["args"][2] == "obs-text"
+
+    def test_trigger_replan_swallows_replanner_exception(self):
+        def boom(*_args):
+            raise RuntimeError("replanner exploded")
+
+        plan = Plan(steps=[_step()])
+        # A misbehaving replanner must never break a turn.
+        out = trigger_replan(plan, plan.steps[0], "o", DivergenceResult(True, "r", SIGNAL_ERROR), replanner=boom)
+        assert out is None
+
+    def test_trigger_replan_ignores_non_plan_return(self):
+        def bad(*_args):
+            return "not a plan"
+
+        plan = Plan(steps=[_step()])
+        assert trigger_replan(plan, plan.steps[0], "o", DivergenceResult(True, "r", SIGNAL_ERROR), replanner=bad) is None
+
+    def test_replanner_alias_is_exported(self):
+        # The type alias is part of the seam's public contract (#292 imports it).
+        assert Replanner is not None
+
+
+# ── run_agent.py integration (self-gating default-off) ───────────────────────
+
+class _FakeAgent:
+    """Minimal stand-in exposing just the methods the seam touches."""
+
+    def __init__(self):
+        self._status: list[str] = []
+
+    def _emit_status(self, text):
+        self._status.append(text)
+
+    # Bind the real implementations under test. ``_latest_tool_observation`` is
+    # a @staticmethod on AIAgent; re-wrap it so the descriptor survives binding
+    # onto this stand-in class (a bare function assignment would turn it into an
+    # instance method and inject ``self``).
+    from run_agent import AIAgent  # type: ignore  # noqa: E402
+    _check_step_divergence_after_tool_calls = AIAgent._check_step_divergence_after_tool_calls
+    _latest_tool_observation = staticmethod(AIAgent._latest_tool_observation)
+
+
+def _tool_msg(text):
+    return {"role": "tool", "name": "t", "content": text, "tool_call_id": "1"}
+
+
+class TestRunAgentSeam:
+    def test_no_active_plan_is_inert(self):
+        agent = _FakeAgent()
+        # No _active_plan attribute at all -> must no-op without raising.
+        agent._check_step_divergence_after_tool_calls([_tool_msg("anything")])
+        assert agent._status == []
+        assert getattr(agent, "_plan_progress", None) is None
+
+    def test_active_plan_on_plan_advances_quietly(self):
+        agent = _FakeAgent()
+        agent._active_plan = Plan(steps=[_step(expect="all tests pass")])
+        agent._plan_progress = None
+        agent._check_step_divergence_after_tool_calls([_tool_msg("12 passed, all tests pass, green")])
+        # On-plan: no divergence status emitted, cursor advanced.
+        assert agent._status == []
+        assert agent._plan_progress.cursor == 1
+
+    def test_divergence_emits_status_and_advances_without_replanner(self):
+        agent = _FakeAgent()
+        agent._active_plan = Plan(steps=[_step(expect="a sorted list of user records")])
+        agent._plan_progress = None
+        agent._check_step_divergence_after_tool_calls([_tool_msg("Error executing tool 'x': boom")])
+        assert any("diverged" in s for s in agent._status)
+        # No replanner wired -> plan unchanged, cursor still advances.
+        assert agent._plan_progress.cursor == 1
+        assert len(agent._active_plan.steps) == 1
+
+    def test_divergence_with_replanner_adopts_new_plan(self):
+        agent = _FakeAgent()
+        original = Plan(steps=[_step(intent="old", expect="a sorted list of user records")])
+        replacement = Plan(steps=[_step(intent="new-a"), _step(intent="new-b")])
+        agent._active_plan = original
+        agent._plan_progress = None
+        agent._replanner = lambda p, s, observed, res: replacement
+        agent._plan_emitted_for_turn = True  # pretend already emitted this turn
+        agent._check_step_divergence_after_tool_calls([_tool_msg("Error executing tool: nope")])
+        # Replanner fired -> new plan adopted, emission re-armed, cursor reset.
+        assert agent._active_plan is replacement
+        assert agent._plan_emitted_for_turn is False
+        assert agent._plan_progress.plan is replacement
+        assert agent._plan_progress.cursor == 0
+
+    def test_latest_tool_observation_reads_trailing_tool_messages(self):
+        msgs = [
+            {"role": "assistant", "content": "calling"},
+            _tool_msg("first result"),
+            _tool_msg("second result"),
+        ]
+        obs = _FakeAgent._latest_tool_observation(msgs)
+        assert "first result" in obs and "second result" in obs
+
+    def test_latest_tool_observation_none_when_no_trailing_tool(self):
+        msgs = [{"role": "assistant", "content": "no tools here"}]
+        assert _FakeAgent._latest_tool_observation(msgs) is None
+
+    def test_latest_tool_observation_handles_multimodal_content(self):
+        msgs = [{"role": "tool", "name": "t", "tool_call_id": "1",
+                 "content": [{"type": "text", "text": "vision text"}, {"type": "image_url"}]}]
+        assert _FakeAgent._latest_tool_observation(msgs) == "vision text"


### PR DESCRIPTION
Child of #283. Builds on the merged plan schema (#290) + emit hook.

- `agent/plan_lookahead.py`: `evaluate_divergence(observed, step)` → `DivergenceResult` (pure heuristic), `PlanProgress` step cursor, `should_replan`/`trigger_replan(replanner=None)` seam.
- `run_agent.py`: `_check_step_divergence_after_tool_calls` in `_execute_tool_calls` `finally` — **default-off**, no-op unless `_active_plan` set; `trigger_replan` returns None without a wired replanner.

**Scope boundary:** no opt-in flag, no LLM replanner, no eval — sibling #292. Additive & inert by default.
Tests: `tests/agent/test_plan_lookahead.py` — 28; existing plan/turn_context green. Closes #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)