### PR TITLE
feat(plan): plan_mode opt-in flag + model-free eval harness (#292)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -601,6 +601,14 @@ def _run_conversation_impl(
             should_review_memory=_should_review_memory,
         )
 
+    # Plan-and-execute opt-in (#292, final child of #283): when plan mode is
+    # explicitly enabled (HERMES_PLAN_MODE env / plan_mode config — default OFF),
+    # build a plan from this run's task and arm it on ``agent._active_plan``,
+    # which flips the otherwise-inert #290 emission and #291 divergence hooks
+    # live. With the flag off this is a no-op and behavior is byte-identical to
+    # the ReAct baseline. See ``AIAgent._maybe_activate_plan_mode``.
+    agent._maybe_activate_plan_mode(user_message)
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()

--- a/agent/plan_mode.py
+++ b/agent/plan_mode.py
@@ -1,0 +1,221 @@
+"""Plan-and-execute opt-in flag + a model-free planner (issue #292).
+
+This is the **third and final** child of the plan-and-execute decomposition
+(parent #283). The two prior slices shipped *inert* machinery:
+
+* #290 (:mod:`agent.plan_schema`) — the :class:`~agent.plan_schema.Plan` /
+  :class:`~agent.plan_schema.Step` data model and the ``emit_plan`` sink. The
+  agent's ``_emit_plan_before_tool_calls`` hook calls it, but is a no-op until
+  ``self._active_plan`` is set.
+* #291 (:mod:`agent.plan_lookahead`) — ``evaluate_divergence`` / ``PlanProgress``
+  / ``trigger_replan``. The agent's ``_check_step_divergence_after_tool_calls``
+  hook calls it, but likewise self-gates to a no-op while ``self._active_plan``
+  is ``None``.
+
+Both seams exist in ``run_agent.py`` already and do nothing in the default
+loop, because *nothing sets an active plan*. This module is the missing
+opt-in: a flag reader (default **off**) and a deterministic, model-free planner.
+When — and only when — the flag is enabled, the agent builds a plan from the
+user's task and assigns it to ``self._active_plan``, which is what flips the two
+inert hooks live.
+
+Why default-off matters
+------------------------
+Constraint from #292: *default agent behavior is byte-identical unless plan_mode
+is explicitly enabled*. :func:`plan_mode_enabled` returns ``False`` unless the
+operator opts in via the ``HERMES_PLAN_MODE`` env var or the ``plan_mode`` config
+key. With the flag off, ``_maybe_activate_plan_mode`` never assigns
+``_active_plan``, so the emission and divergence hooks stay exactly as inert as
+they were after #290/#291 — no plan is built, no status is emitted, no tool
+selection changes.
+
+Why a model-free planner
+------------------------
+The point of this slice is to *activate the seams* and provide an eval harness
+that compares plan-mode-on against the ReAct baseline **without a live model**.
+:func:`build_stub_plan` derives a small, deterministic :class:`Plan` from the
+task text using only string heuristics — zero tokens, zero latency, fully
+reproducible. It is intentionally simple: a real LLM planner is a strict upgrade
+that can replace it behind the same ``self._active_plan`` assignment. Keeping it
+here (not in ``run_agent.py``) lets the eval harness import and exercise the whole
+plan-mode path with no agent instance and no network.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+from agent.plan_schema import Plan, Step
+from utils import is_truthy_value
+
+# Env var and config key that turn plan mode on. Both default-off: the flag is
+# enabled only when explicitly set to a truthy value.
+PLAN_MODE_ENV_VAR = "HERMES_PLAN_MODE"
+PLAN_MODE_CONFIG_KEY = "plan_mode"
+
+# A config loader: returns the parsed config dict (``hermes_cli.config.load_config``
+# shape). Injectable so the flag reader and its tests never have to touch disk.
+ConfigLoader = Callable[[], Dict[str, Any]]
+
+
+def _default_config_loader() -> Dict[str, Any]:
+    """Load persisted config, swallowing any error to an empty dict.
+
+    Imported lazily (like the other flag readers in ``run_agent.py``) so a config
+    import problem can never break agent startup — a missing/broken config simply
+    means "flag off", the safe default.
+    """
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def plan_mode_enabled(config_loader: Optional[ConfigLoader] = None) -> bool:
+    """Return whether plan-and-execute mode is opted in. **Default: off.**
+
+    Resolution order (first decisive wins), mirroring the established
+    ``_file_mutation_verifier_enabled`` / ``_turn_completion_explainer_enabled``
+    pattern in ``run_agent.py`` — except the safe default is ``False`` here, not
+    ``True``:
+
+    1. ``HERMES_PLAN_MODE`` env var. When present, it decides outright
+       (truthy → on, anything else → off). The env var is the operator's
+       per-process override.
+    2. ``plan_mode`` config key (top level of the persisted config). When the
+       env var is unset but the key is present, its truthiness decides.
+    3. Otherwise **off** — the byte-identical-to-baseline default.
+
+    ``config_loader`` is injected only by tests; production passes ``None`` and
+    gets the lazy disk loader.
+    """
+    env = os.environ.get(PLAN_MODE_ENV_VAR)
+    if env is not None:
+        # An explicit env value is decisive in both directions: "0"/"false"/""
+        # forces off even if config says on.
+        return is_truthy_value(env, default=False)
+
+    loader = config_loader or _default_config_loader
+    try:
+        cfg = loader() or {}
+    except Exception:
+        cfg = {}
+    if isinstance(cfg, dict) and PLAN_MODE_CONFIG_KEY in cfg:
+        return is_truthy_value(cfg.get(PLAN_MODE_CONFIG_KEY), default=False)
+
+    return False  # safe default: plan mode OFF -> seams stay inert
+
+
+# Heuristic task-type detection for the stub planner. Order matters: the first
+# family whose markers hit decides the plan template. Markers are lowercase
+# substrings matched against the task text — deliberately coarse, since the stub
+# only needs to produce a *plausible, deterministic* step skeleton, not a smart
+# one.
+_RESEARCH_MARKERS: tuple[str, ...] = (
+    "research", "investigate", "compare", "summarize", "find out",
+    "look up", "gather", "report on", "survey", "benchmark numbers",
+)
+_REFACTOR_MARKERS: tuple[str, ...] = (
+    "refactor", "rename", "migrate", "extract", "split", "restructure",
+    "move the", "across files", "multi-file", "rework",
+)
+
+
+def _task_family(task: str) -> str:
+    """Classify a task string as ``"research"``, ``"refactor"``, or ``"generic"``."""
+    low = (task or "").lower()
+    if any(marker in low for marker in _REFACTOR_MARKERS):
+        return "refactor"
+    if any(marker in low for marker in _RESEARCH_MARKERS):
+        return "research"
+    return "generic"
+
+
+def _trimmed_goal(task: str, *, limit: int = 120) -> str:
+    """A one-line goal derived from the task's first line, length-capped."""
+    first_line = (task or "").strip().splitlines()[0] if (task or "").strip() else ""
+    if len(first_line) > limit:
+        return first_line[: limit - 1].rstrip() + "…"
+    return first_line
+
+
+def build_stub_plan(task: str) -> Optional[Plan]:
+    """Build a deterministic, model-free :class:`Plan` from a task string.
+
+    Returns ``None`` for an empty/blank task (nothing to plan), so the caller's
+    "no plan" branch — the unchanged-behavior path — is taken. Otherwise returns
+    a small ordered plan whose shape depends on the detected task family
+    (multi-file refactor vs. multi-step research vs. a generic three-step
+    skeleton). Every step carries an ``expected_observation`` so the #291
+    divergence comparator has a yardstick to judge against.
+
+    This is a *stub*: a real LLM planner is a drop-in replacement that produces
+    the same :class:`Plan` type. Keeping the logic pure and deterministic is what
+    lets the eval harness run plan-mode end-to-end with no live model.
+    """
+    if not task or not task.strip():
+        return None
+
+    family = _task_family(task)
+    goal = _trimmed_goal(task)
+
+    if family == "refactor":
+        steps = [
+            Step(
+                tool_call_intent="map the files and symbols the change touches",
+                rationale="a multi-file refactor needs the full blast radius before edits",
+                expected_observation="a list of affected files and the symbols to change",
+            ),
+            Step(
+                tool_call_intent="apply the edits file by file, preserving behavior",
+                rationale="edit each site once the targets are known to avoid backtracking",
+                expected_observation="each target file modified with the renamed/extracted code",
+            ),
+            Step(
+                tool_call_intent="run the test suite to confirm no regression",
+                rationale="prove the refactor preserved behavior before reporting done",
+                expected_observation="the test suite passes with all tests green",
+            ),
+        ]
+    elif family == "research":
+        steps = [
+            Step(
+                tool_call_intent="gather sources relevant to the question",
+                rationale="multi-step research starts by collecting candidate sources",
+                expected_observation="a set of relevant sources or search results",
+            ),
+            Step(
+                tool_call_intent="extract the key facts and figures from the sources",
+                rationale="distill the raw sources into the specific data the task asks for",
+                expected_observation="the extracted facts, numbers, or findings",
+            ),
+            Step(
+                tool_call_intent="synthesize the findings into the requested report",
+                rationale="combine the extracted facts into the deliverable the task wants",
+                expected_observation="a written synthesis answering the research question",
+            ),
+        ]
+    else:
+        steps = [
+            Step(
+                tool_call_intent="understand the task and the current state",
+                rationale="orient before acting so the first action is well-chosen",
+                expected_observation="the relevant context for the task",
+            ),
+            Step(
+                tool_call_intent="carry out the core work of the task",
+                rationale="execute the main action once context is gathered",
+                expected_observation="the task's primary change or output",
+            ),
+            Step(
+                tool_call_intent="verify the result satisfies the task",
+                rationale="confirm success before reporting completion",
+                expected_observation="evidence the task was completed correctly",
+            ),
+        ]
+
+    return Plan(steps=steps, goal=goal, metadata={"source": "stub_planner", "family": family})

--- a/run_agent.py
+++ b/run_agent.py
@@ -5239,6 +5239,65 @@ class AIAgent:
         if emit_plan(plan, emit=self._emit_status):
             self._plan_emitted_for_turn = True
 
+    def _plan_mode_enabled(self) -> bool:
+        """Whether plan-and-execute mode is opted in. **Default: off** (#292).
+
+        The final child of the plan-and-execute decomposition (#283). #290/#291
+        shipped the emission and divergence seams *inert* — they self-gate to a
+        no-op until ``self._active_plan`` is set, and nothing in the default loop
+        sets one. This flag is the opt-in that allows it to be set.
+
+        Resolution lives in :func:`agent.plan_mode.plan_mode_enabled`:
+        ``HERMES_PLAN_MODE`` env var overrides the ``plan_mode`` config key, and
+        the default is ``False`` — so with no opt-in the agent's behavior is
+        byte-identical to the pre-plan-mode baseline. Exposed as a method so
+        tests (and the eval harness) can patch a single seam, mirroring
+        ``_file_mutation_verifier_enabled``.
+        """
+        try:
+            from agent.plan_mode import plan_mode_enabled
+            return plan_mode_enabled()
+        except Exception:
+            # A flag-read failure must never break a turn — fall back to off,
+            # the behavior-preserving default.
+            return False
+
+    def _maybe_activate_plan_mode(self, user_message: str) -> None:
+        """Build and arm an active plan for this run — only when plan mode is on.
+
+        This is the single bridge between the opt-in flag and the otherwise-inert
+        #290/#291 seams. When :meth:`_plan_mode_enabled` is ``False`` (the
+        default) this returns immediately without touching ``self._active_plan``,
+        so the emission and divergence hooks stay no-ops and the agent behaves
+        exactly as it did before plan mode existed.
+
+        When the flag is on, it derives a deterministic, model-free plan from the
+        user's task (:func:`agent.plan_mode.build_stub_plan`) and assigns it to
+        ``self._active_plan`` (re-arming per-run emission). That assignment is
+        what flips ``_emit_plan_before_tool_calls`` and
+        ``_check_step_divergence_after_tool_calls`` live. A real LLM planner is a
+        drop-in replacement behind this same assignment.
+
+        Idempotent per run: if a plan is already active (e.g. a multi-turn
+        conversation, or a replanner already swapped one in) it is left alone.
+        """
+        if not self._plan_mode_enabled():
+            return
+        if getattr(self, "_active_plan", None) is not None:
+            return
+        try:
+            from agent.plan_mode import build_stub_plan
+            plan = build_stub_plan(user_message)
+        except Exception:
+            plan = None
+        if plan is None:
+            return
+        self._active_plan = plan
+        # Re-arm emission so the freshly built plan prints before this run's
+        # first tool dispatch, and reset the progress cursor for the new plan.
+        self._plan_emitted_for_turn = False
+        self._plan_progress = None
+
     def _check_step_divergence_after_tool_calls(self, messages: list) -> None:
         """Lookahead replan check, run once after a turn's tool dispatch (#291).
 

--- a/tests/agent/test_plan_mode_eval.py
+++ b/tests/agent/test_plan_mode_eval.py
@@ -1,0 +1,383 @@
+"""Plan-mode opt-in flag + deterministic eval harness (issue #292).
+
+Final child of the plan-and-execute decomposition (parent #283). Two concerns:
+
+1. **The opt-in flag** (:func:`agent.plan_mode.plan_mode_enabled` and the
+   ``AIAgent._plan_mode_enabled`` / ``_maybe_activate_plan_mode`` wiring). The
+   load-bearing guarantee of this slice is *default-off*: with no explicit
+   opt-in, ``_maybe_activate_plan_mode`` never assigns ``_active_plan``, so the
+   #290 emission hook and the #291 divergence hook stay exactly as inert as they
+   were — the agent's behavior is byte-identical to the ReAct baseline. These
+   tests pin every branch of the flag resolution and the activation gate.
+
+2. **The eval harness** — a small, deterministic suite that compares
+   *plan-mode-on* against the *ReAct baseline* on two representative
+   long-horizon task fixtures (a multi-file refactor and a multi-step research
+   report), using **recorded/synthetic tool trajectories and the model-free stub
+   planner** — NO live model, NO network, NO agent instantiation. It asserts
+   plan mode introduces **no regression** on the deterministic metrics we pick:
+   it must not spuriously flag divergence on an on-plan trajectory, must not cost
+   more observed steps than the baseline, and must fully cover its plan.
+
+Run just this file (full collection breaks on a missing pypy dep):
+
+    python -m pytest tests/agent/test_plan_mode_eval.py -q
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+
+from agent.plan_schema import Plan, Step
+from agent.plan_lookahead import PlanProgress
+from agent.plan_mode import (
+    PLAN_MODE_CONFIG_KEY,
+    PLAN_MODE_ENV_VAR,
+    build_stub_plan,
+    plan_mode_enabled,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 1 — the opt-in flag reader (default OFF)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPlanModeFlagDefaultOff:
+    """plan_mode_enabled() must default to OFF and obey env > config > default."""
+
+    def test_default_is_off_no_env_no_config(self, monkeypatch):
+        monkeypatch.delenv(PLAN_MODE_ENV_VAR, raising=False)
+        # Config loader returns an empty dict -> no opt-in anywhere -> off.
+        assert plan_mode_enabled(config_loader=lambda: {}) is False
+
+    def test_off_when_config_key_absent(self, monkeypatch):
+        monkeypatch.delenv(PLAN_MODE_ENV_VAR, raising=False)
+        assert plan_mode_enabled(config_loader=lambda: {"unrelated": True}) is False
+
+    def test_config_key_truthy_enables(self, monkeypatch):
+        monkeypatch.delenv(PLAN_MODE_ENV_VAR, raising=False)
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: True}) is True
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: "on"}) is True
+
+    def test_config_key_falsey_stays_off(self, monkeypatch):
+        monkeypatch.delenv(PLAN_MODE_ENV_VAR, raising=False)
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: False}) is False
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: "off"}) is False
+
+    def test_env_var_on_overrides_config_off(self, monkeypatch):
+        monkeypatch.setenv(PLAN_MODE_ENV_VAR, "1")
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: False}) is True
+
+    def test_env_var_off_overrides_config_on(self, monkeypatch):
+        # Env is decisive in BOTH directions: explicit "0" forces off even when
+        # config opts in. This is what lets an operator hard-disable per process.
+        monkeypatch.setenv(PLAN_MODE_ENV_VAR, "0")
+        assert plan_mode_enabled(config_loader=lambda: {PLAN_MODE_CONFIG_KEY: True}) is False
+
+    def test_env_var_truthy_values(self, monkeypatch):
+        for val in ("1", "true", "yes", "on", "TRUE", "On"):
+            monkeypatch.setenv(PLAN_MODE_ENV_VAR, val)
+            assert plan_mode_enabled(config_loader=lambda: {}) is True, val
+
+    def test_broken_config_loader_defaults_off(self, monkeypatch):
+        monkeypatch.delenv(PLAN_MODE_ENV_VAR, raising=False)
+
+        def boom():
+            raise RuntimeError("config exploded")
+
+        # A config-read failure must degrade to the safe default, not crash.
+        assert plan_mode_enabled(config_loader=boom) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 2 — the model-free stub planner
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStubPlanner:
+    def test_blank_task_yields_no_plan(self):
+        # No task -> None -> caller's "no plan" (unchanged-behavior) branch.
+        assert build_stub_plan("") is None
+        assert build_stub_plan("   \n ") is None
+
+    def test_refactor_task_classified(self):
+        plan = build_stub_plan("Refactor the auth module across files and rename get_user")
+        assert plan is not None
+        assert plan.metadata["family"] == "refactor"
+        assert len(plan.steps) >= 2
+
+    def test_research_task_classified(self):
+        plan = build_stub_plan("Research and compare FLARE benchmark numbers, then report on them")
+        assert plan is not None
+        assert plan.metadata["family"] == "research"
+
+    def test_generic_task_classified(self):
+        plan = build_stub_plan("Say hello to the user")
+        assert plan is not None
+        assert plan.metadata["family"] == "generic"
+
+    def test_planner_is_deterministic(self):
+        task = "Refactor the storage layer and migrate callers across files"
+        a, b = build_stub_plan(task), build_stub_plan(task)
+        assert a.to_dict() == b.to_dict()
+
+    def test_every_step_has_an_expectation(self):
+        # The #291 divergence comparator needs a yardstick on every step.
+        for task in (
+            "Refactor x across files",
+            "Research the topic and summarize",
+            "Do a generic thing",
+        ):
+            plan = build_stub_plan(task)
+            assert all(s.expected_observation.strip() for s in plan.steps)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 3 — the eval harness: plan-mode-on vs ReAct baseline, no live model
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Bind the real AIAgent seams onto a minimal stand-in so the harness drives the
+# actual divergence/emission code paths with no live model and no AIAgent
+# construction — the same technique the #291 test uses.
+class _HarnessAgent:
+    """Stand-in exposing exactly the seams the plan-mode path touches."""
+
+    def __init__(self):
+        self._status: List[str] = []
+
+    def _emit_status(self, text):
+        self._status.append(text)
+
+    from run_agent import AIAgent  # type: ignore  # noqa: E402
+    _emit_plan_before_tool_calls = AIAgent._emit_plan_before_tool_calls
+    _check_step_divergence_after_tool_calls = AIAgent._check_step_divergence_after_tool_calls
+    _latest_tool_observation = staticmethod(AIAgent._latest_tool_observation)
+
+
+def _tool_msg(text: str) -> dict:
+    return {"role": "tool", "name": "t", "content": text, "tool_call_id": "1"}
+
+
+@dataclass
+class EvalMetrics:
+    """Deterministic, model-free metrics for one task run.
+
+    * ``steps`` — number of tool-observation turns the run consumed.
+    * ``plan_emissions`` — how many times the active plan was printed (0 in
+      baseline; 1 in plan mode for a single run).
+    * ``divergences`` — how many turns the divergence check flagged off-plan.
+    * ``replans`` — how many times a new plan was adopted.
+    * ``plan_covered`` — True if plan mode walked its whole plan (cursor reached
+      the end), or vacuously True for the baseline (no plan to cover).
+    """
+
+    steps: int
+    plan_emissions: int
+    divergences: int
+    replans: int
+    plan_covered: bool
+
+
+@dataclass
+class TaskFixture:
+    """A long-horizon task plus a recorded, on-plan tool trajectory.
+
+    ``trajectory`` is a list of synthetic tool-result strings — the recorded
+    observations a successful run would produce, one per plan step. They are
+    written to overlap the stub plan's ``expected_observation`` keywords so an
+    on-plan run does NOT trip the divergence heuristic (that is the regression
+    signal we assert against).
+    """
+
+    name: str
+    task: str
+    trajectory: List[str]
+
+
+def _run_baseline(fixture: TaskFixture) -> EvalMetrics:
+    """ReAct baseline: plan mode OFF, so no _active_plan is ever set.
+
+    Drives the *same* emission + divergence hooks the live loop calls, but
+    because ``_active_plan`` is never assigned they self-gate to no-ops — exactly
+    the unchanged behavior. This is the control arm.
+    """
+    agent = _HarnessAgent()
+    # No _active_plan attribute at all -> hooks inert (the default-off contract).
+    steps = 0
+    for obs in fixture.trajectory:
+        agent._emit_plan_before_tool_calls()  # inert: nothing to emit
+        agent._check_step_divergence_after_tool_calls([_tool_msg(obs)])  # inert
+        steps += 1
+    return EvalMetrics(
+        steps=steps,
+        plan_emissions=0,
+        divergences=sum(1 for s in agent._status if "diverged" in s),
+        replans=0,
+        plan_covered=True,  # vacuous: no plan to cover
+    )
+
+
+def _run_plan_mode(fixture: TaskFixture) -> EvalMetrics:
+    """Plan-mode-on: build a stub plan, then replay the recorded trajectory.
+
+    Mirrors what ``_maybe_activate_plan_mode`` does (assign ``_active_plan`` from
+    the model-free planner) and then feeds the recorded observations through the
+    very same hooks. No model, no network — fully deterministic.
+    """
+    agent = _HarnessAgent()
+    plan = build_stub_plan(fixture.task)
+    assert plan is not None, f"fixture {fixture.name!r} should produce a plan"
+    agent._active_plan = plan
+    agent._plan_emitted_for_turn = False
+    agent._plan_progress = None
+
+    emissions = 0
+    steps = 0
+    for obs in fixture.trajectory:
+        before = getattr(agent, "_plan_emitted_for_turn", False)
+        agent._emit_plan_before_tool_calls()
+        if not before and getattr(agent, "_plan_emitted_for_turn", False):
+            emissions += 1
+        agent._check_step_divergence_after_tool_calls([_tool_msg(obs)])
+        steps += 1
+
+    progress = getattr(agent, "_plan_progress", None)
+    covered = isinstance(progress, PlanProgress) and progress.is_exhausted()
+    return EvalMetrics(
+        steps=steps,
+        plan_emissions=emissions,
+        divergences=sum(1 for s in agent._status if "diverged" in s),
+        replans=sum(1 for s in agent._status if "diverged" in s and False),  # no replanner wired
+        plan_covered=covered,
+    )
+
+
+# Two representative long-horizon fixtures. Trajectories are authored to be
+# on-plan: each recorded observation echoes the corresponding stub step's
+# expected keywords, so a healthy plan-mode run stays at zero divergences.
+_FIXTURES: List[TaskFixture] = [
+    TaskFixture(
+        name="multi_file_refactor",
+        task="Refactor the storage layer: rename save_blob across files and extract a helper",
+        trajectory=[
+            "mapped affected files and symbols: storage.py, callers.py; symbols save_blob to change",
+            "modified each target file: renamed save_blob and extracted the helper code",
+            "ran the test suite: 42 passed, all tests green, no regression",
+        ],
+    ),
+    TaskFixture(
+        name="multi_step_research",
+        task="Research and compare the FLARE benchmark numbers, then report on the findings",
+        trajectory=[
+            "gathered relevant sources and search results on FLARE",
+            "extracted the key facts and numbers: CWQ 58 to 73.6, WebQSP 78.3 to 90.4",
+            "synthesized the findings into a written report answering the question",
+        ],
+    ),
+]
+
+
+@pytest.fixture(params=_FIXTURES, ids=lambda f: f.name)
+def fixture(request) -> TaskFixture:
+    return request.param
+
+
+class TestEvalHarness:
+    """Regression-compare plan-mode-on against the ReAct baseline per fixture."""
+
+    def test_baseline_is_inert(self, fixture):
+        # The control arm must do literally nothing the agent wouldn't already do:
+        # zero emissions, zero divergences. (Default-off proof at the metric level.)
+        m = _run_baseline(fixture)
+        assert m.plan_emissions == 0
+        assert m.divergences == 0
+        assert m.steps == len(fixture.trajectory)
+
+    def test_plan_mode_emits_once_and_covers_plan(self, fixture):
+        m = _run_plan_mode(fixture)
+        # Plan mode prints its plan exactly once and walks every step.
+        assert m.plan_emissions == 1
+        assert m.plan_covered is True
+
+    def test_no_divergence_regression_on_plan_trajectory(self, fixture):
+        # THE regression assertion: an on-plan trajectory must NOT trip the
+        # divergence heuristic. Plan mode adds zero spurious divergences over
+        # the baseline's zero.
+        baseline = _run_baseline(fixture)
+        plan_mode = _run_plan_mode(fixture)
+        assert plan_mode.divergences <= baseline.divergences
+        assert plan_mode.divergences == 0
+
+    def test_no_step_cost_regression(self, fixture):
+        # Plan mode must not consume more observed steps than the baseline for
+        # the same trajectory — the planner reorganizes work, it doesn't add
+        # round trips. (Latency/token proxy at the deterministic level.)
+        baseline = _run_baseline(fixture)
+        plan_mode = _run_plan_mode(fixture)
+        assert plan_mode.steps == baseline.steps
+
+    def test_plan_mode_detects_a_genuine_divergence(self, fixture):
+        # Sanity that the harness can SEE a regression when one exists: replace
+        # the final on-plan observation with an unanticipated error and confirm
+        # plan mode flags it (so the no-regression assertions above aren't
+        # passing vacuously because the detector is dead).
+        broken = TaskFixture(
+            name=fixture.name + "_broken",
+            task=fixture.task,
+            trajectory=fixture.trajectory[:-1]
+            + ["Error executing tool 'x': no such file or directory"],
+        )
+        m = _run_plan_mode(broken)
+        assert m.divergences >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 4 — the activation gate (_maybe_activate_plan_mode honors the flag)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _GateAgent:
+    """Stand-in for the activation-gate methods, with a patchable flag."""
+
+    def __init__(self, enabled: bool):
+        self._enabled = enabled
+        self._status: List[str] = []
+
+    def _emit_status(self, text):
+        self._status.append(text)
+
+    from run_agent import AIAgent  # type: ignore  # noqa: E402
+    _maybe_activate_plan_mode = AIAgent._maybe_activate_plan_mode
+
+    def _plan_mode_enabled(self) -> bool:  # patch the single seam
+        return self._enabled
+
+
+class TestActivationGate:
+    def test_flag_off_never_sets_active_plan(self):
+        agent = _GateAgent(enabled=False)
+        agent._maybe_activate_plan_mode("Refactor everything across files")
+        # The whole default-off guarantee in one assertion: no plan armed ->
+        # the #290/#291 hooks stay inert -> behavior byte-identical to baseline.
+        assert getattr(agent, "_active_plan", None) is None
+
+    def test_flag_on_arms_a_plan(self):
+        agent = _GateAgent(enabled=True)
+        agent._maybe_activate_plan_mode("Refactor the module across files and rename it")
+        assert isinstance(agent._active_plan, Plan)
+        assert agent._plan_emitted_for_turn is False
+        assert agent._plan_progress is None
+
+    def test_flag_on_blank_task_arms_nothing(self):
+        agent = _GateAgent(enabled=True)
+        agent._maybe_activate_plan_mode("   ")
+        assert getattr(agent, "_active_plan", None) is None
+
+    def test_idempotent_when_plan_already_active(self):
+        agent = _GateAgent(enabled=True)
+        existing = Plan(steps=[Step("keep me", "already active", "stays")])
+        agent._active_plan = existing
+        agent._maybe_activate_plan_mode("Refactor across files")
+        # An already-armed plan (multi-turn / post-replan) is left untouched.
+        assert agent._active_plan is existing


### PR DESCRIPTION
Final child of #283. Turns on the inert #290 emission + #291 divergence hooks.

- `agent/plan_mode.py`: `plan_mode_enabled()` (env `HERMES_PLAN_MODE` → config `plan_mode` → **False**), `build_stub_plan()` (model-free planner).
- `run_agent.py`/`conversation_loop.py`: `_maybe_activate_plan_mode()` sets `_active_plan` ONLY when the flag is on — the single assignment that activates both existing hooks. Hooks reused verbatim.
- **Default-OFF**: with no plan armed, the hooks' `_active_plan is None` guards keep them no-ops → byte-identical to ReAct baseline.
- Eval harness runs **without a live model**: binds the real agent seams onto stand-ins, replays synthetic trajectories vs the stub plan; asserts baseline inert (0 emissions/divergences) and plan-arm no-regression on deterministic metrics; a broken-trajectory test proves the detector still fires.

**Scope:** flag + activation wiring + eval only; no changes to schema/lookahead/hooks.
Tests: `tests/agent/test_plan_mode_eval.py` — 28; 78 green with plan suite. Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)