### PR TITLE
feat(skills): opt-in topological skills loader v2 (#298)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1361,9 +1361,20 @@ def build_skills_system_prompt(
             for k, v in (snapshot.get("category_descriptions") or {}).items()
         }
     else:
-        # Cold path: full filesystem scan + write snapshot for next time
+        # Cold path: full filesystem scan + write snapshot for next time.
+        #
+        # Skill file order: by default this is the flat directory order from
+        # iter_skill_index_files (unchanged, byte-identical to pre-#298). When
+        # the opt-in v2 loader is enabled (skills.skills_loader_v2 /
+        # HERMES_SKILLS_LOADER_V2, default OFF) the SKILL.md files are returned
+        # in topological (dependency-first) order instead, with the flat order
+        # used as a fallback for un-graphed/legacy skills and on requires
+        # cycles. iter_skill_files_for_load delegates to the exact same flat
+        # scan when the flag is off, so nothing changes for existing profiles.
+        from agent.skills_loader_v2 import iter_skill_files_for_load
+
         skill_entries: list[dict] = []
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+        for skill_file in iter_skill_files_for_load(skills_dir):
             is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
             entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
             skill_entries.append(entry)

--- a/agent/skills_loader_v2.py
+++ b/agent/skills_loader_v2.py
@@ -1,0 +1,235 @@
+"""Skills loader v2 — graph-ordered (topological) skill loading (issue #298).
+
+The long-standing skills loader (``agent/prompt_builder.build_skills_system_prompt``
+cold path) scans ``SKILL.md`` files in **directory order** — a flat listing with
+no notion of dependencies between skills.  Issue #246 (Skills-as-Graph / AIP)
+added :mod:`agent.skill_graph`, which models typed ``requires`` /
+``conflicts-with`` / ``composes-with`` / ``deprecates`` edges and can compute a
+dependency-first :meth:`~agent.skill_graph.SkillGraph.topological_order`.
+
+This module is the **opt-in** bridge between the two: given the same skills
+directories the flat loader scans, it builds the graph at startup, computes the
+topological load order (dependencies before dependents), and returns the
+``SKILL.md`` paths in that order so the existing per-skill loading logic can run
+unchanged.  It is wired behind a **default-OFF** flag
+(``skills.skills_loader_v2`` in config.yaml, or ``HERMES_SKILLS_LOADER_V2`` in
+the environment).  When the flag is off, the loader is never invoked and skill
+loading is byte-identical to today.
+
+Design constraints (this changes how skills load for EVERY profile):
+
+* **Never drop a skill.**  A ``SKILL.md`` that the graph cannot place (a skill
+  with no graph frontmatter, a legacy manifest, a file whose name the graph
+  didn't register) is emitted in its original flat (directory) order *after*
+  every graph-ordered file.  The set of returned files is always exactly the
+  set the flat scan would have produced.
+* **Reuse, don't reimplement.**  All graph logic lives in
+  :mod:`agent.skill_graph`; this module only maps skill *names* back to their
+  ``SKILL.md`` *paths* and orders the file list.  The caller still does the
+  actual reading/parsing/indexing via the existing flat code path.
+* **Fail clear on cycles.**  A ``requires`` cycle has no valid load order;
+  :func:`ordered_skill_files` raises :class:`SkillRequiresCycleError` naming the
+  cycle so the caller can log it and fall back to the flat loader rather than
+  silently loading in an arbitrary order.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from agent.skill_graph import SkillGraph
+from agent.skill_utils import iter_skill_index_files, parse_frontmatter
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+_FALSY = ("0", "false", "no", "off")
+
+# Env var name and config key for the opt-in flag (kept in sync with the docs
+# in this module's docstring and the call site in agent/prompt_builder.py).
+ENV_FLAG = "HERMES_SKILLS_LOADER_V2"
+CONFIG_KEY = "skills_loader_v2"
+
+
+class SkillRequiresCycleError(Exception):
+    """Raised when the skill graph has a ``requires`` cycle (no load order).
+
+    A ``requires`` cycle means "A needs B which (transitively) needs A": there
+    is no order in which every skill loads after its prerequisites.  The error
+    message names every detected cycle so the operator can fix the offending
+    ``requires`` edges.  The caller is expected to catch this and fall back to
+    the flat loader so skill loading never silently breaks.
+    """
+
+    def __init__(self, cycles: List[List[str]]):
+        self.cycles = cycles
+        rendered = "; ".join(" -> ".join(c + [c[0]]) for c in cycles if c)
+        super().__init__(
+            f"skill graph has {len(cycles)} requires cycle(s): {rendered}"
+        )
+
+
+def v2_enabled() -> bool:
+    """Return True when the v2 ordered loader is opted in.
+
+    Resolution order (first decisive wins):
+
+    1. ``HERMES_SKILLS_LOADER_V2`` env var — an explicit truthy/falsy value
+       overrides config (handy for tests and one-off runs).
+    2. ``skills.skills_loader_v2`` in config.yaml.
+    3. Default **False** — flat loading, byte-identical to pre-#298 behavior.
+
+    Any read failure falls back to False (never enable the new path by
+    accident).
+    """
+    raw_env = os.getenv(ENV_FLAG)
+    if raw_env is not None:
+        val = raw_env.strip().lower()
+        if val in _TRUTHY:
+            return True
+        if val in _FALSY:
+            return False
+        # Unrecognized env value: ignore it and consult config.
+
+    try:
+        from agent.skill_preprocessing import load_skills_config
+
+        cfg = load_skills_config()
+        return bool(cfg.get(CONFIG_KEY, False))
+    except Exception:  # noqa: BLE001 - config read must never break startup
+        logger.debug("skills_loader_v2: could not read config flag", exc_info=True)
+        return False
+
+
+def _name_for_skill_file(skill_file: Path, skills_dir: Path) -> str:
+    """Resolve the graph node name for a ``SKILL.md`` path.
+
+    Mirrors :meth:`SkillGraph.from_skills_dirs`: the node name is the
+    frontmatter ``name`` if present, else the skill's directory name.  Parse
+    failures fall back to the directory name — the file is still returned by
+    :func:`ordered_skill_files`, just ordered as an un-graphed leaf.
+    """
+    try:
+        frontmatter, _ = parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        name = str(frontmatter.get("name") or skill_file.parent.name).strip()
+        return name or skill_file.parent.name
+    except Exception:  # noqa: BLE001 - one bad file is non-fatal
+        return skill_file.parent.name
+
+
+def ordered_skill_files(skills_dir: Path) -> List[Path]:
+    """Return *skills_dir*'s ``SKILL.md`` paths in topological load order.
+
+    Builds a :class:`~agent.skill_graph.SkillGraph` over *skills_dir*, validates
+    it, and orders the discovered ``SKILL.md`` files so that every skill loads
+    after the skills it ``requires``.
+
+    Fallback / safety guarantees:
+
+    * The returned list contains **exactly** the same files
+      :func:`agent.skill_utils.iter_skill_index_files` would yield — never more,
+      never fewer.  Skills the graph cannot place (no graph frontmatter, legacy
+      manifest, name collision) are appended in their original flat order after
+      the graph-ordered files, so nothing is ever dropped.
+    * On a ``requires`` cycle the function raises
+      :class:`SkillRequiresCycleError` (named cycle) — it does **not** silently
+      pick an arbitrary order.  Callers fall back to the flat scan.
+
+    Raises:
+        SkillRequiresCycleError: the graph has at least one ``requires`` cycle.
+    """
+    # The authoritative file list — flat, directory order. This is the set the
+    # legacy loader walks; we only ever reorder it, never add/remove.
+    flat_files: List[Path] = list(iter_skill_index_files(skills_dir, "SKILL.md"))
+    if not flat_files:
+        return flat_files
+
+    graph = SkillGraph.from_skills_dirs([skills_dir])
+
+    # Hard error: a requires cycle has no valid load order. Surface it clearly
+    # rather than emitting an arbitrary order.
+    validation = graph.validate()
+    if validation.requires_cycles:
+        raise SkillRequiresCycleError(validation.requires_cycles)
+
+    # Map each discovered file to its graph node name. A name may map to several
+    # files if two skill dirs share a frontmatter name; the graph keeps only the
+    # first (local-dir precedence), so later duplicates are treated as un-graphed
+    # and preserved in flat order — never dropped.
+    name_to_files: Dict[str, List[Path]] = {}
+    file_names: Dict[Path, str] = {}
+    for f in flat_files:
+        name = _name_for_skill_file(f, skills_dir)
+        file_names[f] = name
+        name_to_files.setdefault(name, []).append(f)
+
+    topo_names = graph.topological_order()
+
+    ordered: List[Path] = []
+    placed: set = set()
+
+    # 1) Emit files in topological (dependency-first) order. For a name that the
+    #    graph registered, emit its first matching file once.
+    for name in topo_names:
+        files = name_to_files.get(name)
+        if not files:
+            continue
+        first = files[0]
+        if first in placed:
+            continue
+        ordered.append(first)
+        placed.add(first)
+
+    # 2) Append every remaining file (un-graphed skills, duplicate-name files,
+    #    legacy manifests) in their original flat order. This is the fallback
+    #    that guarantees no skill is ever lost.
+    for f in flat_files:
+        if f not in placed:
+            ordered.append(f)
+            placed.add(f)
+
+    return ordered
+
+
+def ordered_skill_files_or_flat(skills_dir: Path) -> List[Path]:
+    """Topological order when the graph allows it, else the flat order.
+
+    Convenience wrapper used at the call site: returns
+    :func:`ordered_skill_files` but, on a :class:`SkillRequiresCycleError`,
+    logs the named cycle and returns the plain flat scan so skill loading still
+    succeeds.  Any other unexpected failure also falls back to flat — the v2
+    loader must never be able to break skill loading for a profile.
+    """
+    try:
+        return ordered_skill_files(skills_dir)
+    except SkillRequiresCycleError as exc:
+        logger.error(
+            "skills_loader_v2: %s — falling back to flat (directory-order) "
+            "skill loading for %s",
+            exc,
+            skills_dir,
+        )
+    except Exception:  # noqa: BLE001 - defensive: never break loading
+        logger.warning(
+            "skills_loader_v2: unexpected error ordering skills in %s; "
+            "falling back to flat loading",
+            skills_dir,
+            exc_info=True,
+        )
+    return list(iter_skill_index_files(skills_dir, "SKILL.md"))
+
+
+def iter_skill_files_for_load(skills_dir: Path) -> List[Path]:
+    """The single entry point the flat loader calls to get skill files.
+
+    * Flag OFF (default): identical to ``list(iter_skill_index_files(skills_dir,
+      "SKILL.md"))`` — byte-identical to the pre-#298 loader.
+    * Flag ON: graph-ordered (topological) load order, with the flat fallback
+      for un-graphed skills and on cycle errors.
+    """
+    if not v2_enabled():
+        return list(iter_skill_index_files(skills_dir, "SKILL.md"))
+    return ordered_skill_files_or_flat(skills_dir)

--- a/tests/agent/test_skills_loader_v2.py
+++ b/tests/agent/test_skills_loader_v2.py
@@ -1,0 +1,253 @@
+"""Tests for agent/skills_loader_v2.py — the opt-in graph-ordered loader (#298).
+
+Covers the four behaviours the issue calls out:
+
+  * topological ordering — dependencies (``requires`` targets) load before
+    their dependents;
+  * clear cycle error — a ``requires`` cycle raises a named
+    :class:`SkillRequiresCycleError` rather than silently picking an order;
+  * legacy / un-graphed skills fall back — a skill with no graph frontmatter is
+    never dropped, it is appended in flat order;
+  * flag OFF == flat behaviour — with the flag off, the load order is exactly
+    the legacy ``iter_skill_index_files`` order (byte-identical).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from agent.skill_utils import iter_skill_index_files
+from agent.skills_loader_v2 import (
+    CONFIG_KEY,
+    ENV_FLAG,
+    SkillRequiresCycleError,
+    iter_skill_files_for_load,
+    ordered_skill_files,
+    ordered_skill_files_or_flat,
+    v2_enabled,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _write_skill(
+    skills_dir: Path, category: str, name: str, graph_block: str = ""
+) -> Path:
+    """Write a minimal SKILL.md and return the directory it lives in."""
+    d = skills_dir / category / name
+    d.mkdir(parents=True, exist_ok=True)
+    fm_graph = f"\n    graph:\n{graph_block}" if graph_block else ""
+    (d / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: test skill {name}
+metadata:
+  hermes:
+    tags: [test]{fm_graph}
+---
+
+# {name}
+""",
+        encoding="utf-8",
+    )
+    return d
+
+
+def _names(files, skills_dir: Path):
+    """Map a list of SKILL.md paths back to their skill (directory) names."""
+    return [Path(f).parent.name for f in files]
+
+
+@pytest.fixture(autouse=True)
+def _flag_off(monkeypatch):
+    """Default every test to the v2 loader being OFF unless it opts in.
+
+    Pins the env var so a developer's ambient HERMES_SKILLS_LOADER_V2 can't
+    flip a 'flag off' assertion, and neutralises config so v2_enabled() is
+    deterministic.
+    """
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+    monkeypatch.setattr(
+        "agent.skill_preprocessing.load_skills_config", lambda: {}, raising=True
+    )
+
+
+# ── flag resolution ──────────────────────────────────────────────────────────
+
+
+def test_v2_disabled_by_default():
+    assert v2_enabled() is False
+
+
+def test_v2_enabled_via_env(monkeypatch):
+    monkeypatch.setenv(ENV_FLAG, "1")
+    assert v2_enabled() is True
+
+
+def test_v2_enabled_via_config(monkeypatch):
+    monkeypatch.setattr(
+        "agent.skill_preprocessing.load_skills_config",
+        lambda: {CONFIG_KEY: True},
+        raising=True,
+    )
+    assert v2_enabled() is True
+
+
+def test_env_falsy_overrides_truthy_config(monkeypatch):
+    """An explicit falsy env var wins over a truthy config value."""
+    monkeypatch.setenv(ENV_FLAG, "0")
+    monkeypatch.setattr(
+        "agent.skill_preprocessing.load_skills_config",
+        lambda: {CONFIG_KEY: True},
+        raising=True,
+    )
+    assert v2_enabled() is False
+
+
+# ── topological ordering ─────────────────────────────────────────────────────
+
+
+def test_topological_order_deps_before_dependents(tmp_path):
+    skills = tmp_path / "skills"
+    # app requires lib; lib requires base. Load order must be base, lib, app.
+    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
+    _write_skill(skills, "cat", "lib", graph_block="      requires: [base]")
+    _write_skill(skills, "cat", "base")
+
+    ordered = ordered_skill_files(skills)
+    names = _names(ordered, skills)
+
+    assert set(names) == {"app", "lib", "base"}
+    assert names.index("base") < names.index("lib") < names.index("app")
+
+
+def test_diamond_dependency_orders_root_first(tmp_path):
+    skills = tmp_path / "skills"
+    # top requires {left, right}; both require base. base must be first, top last.
+    _write_skill(
+        skills, "cat", "top", graph_block="      requires: [left, right]"
+    )
+    _write_skill(skills, "cat", "left", graph_block="      requires: [base]")
+    _write_skill(skills, "cat", "right", graph_block="      requires: [base]")
+    _write_skill(skills, "cat", "base")
+
+    names = _names(ordered_skill_files(skills), skills)
+    assert names[0] == "base"
+    assert names[-1] == "top"
+    assert names.index("base") < names.index("left")
+    assert names.index("base") < names.index("right")
+    assert names.index("left") < names.index("top")
+    assert names.index("right") < names.index("top")
+
+
+# ── clear cycle error ────────────────────────────────────────────────────────
+
+
+def test_requires_cycle_raises_named_error(tmp_path):
+    skills = tmp_path / "skills"
+    _write_skill(skills, "cat", "a", graph_block="      requires: [b]")
+    _write_skill(skills, "cat", "b", graph_block="      requires: [a]")
+
+    with pytest.raises(SkillRequiresCycleError) as exc_info:
+        ordered_skill_files(skills)
+
+    err = exc_info.value
+    # The cycle members are named in the error so an operator can fix it.
+    assert err.cycles, "cycle list must be populated"
+    cycle_members = {n for cycle in err.cycles for n in cycle}
+    assert {"a", "b"} <= cycle_members
+    assert "a" in str(err) and "b" in str(err)
+
+
+def test_or_flat_falls_back_on_cycle(tmp_path):
+    """The convenience wrapper degrades to flat order on a cycle, never raising."""
+    skills = tmp_path / "skills"
+    _write_skill(skills, "cat", "a", graph_block="      requires: [b]")
+    _write_skill(skills, "cat", "b", graph_block="      requires: [a]")
+    _write_skill(skills, "cat", "lonely")
+
+    ordered = ordered_skill_files_or_flat(skills)
+    flat = list(iter_skill_index_files(skills, "SKILL.md"))
+    # Cycle -> no reordering attempted; we get exactly the flat scan.
+    assert ordered == flat
+
+
+# ── legacy / un-graphed fallback ─────────────────────────────────────────────
+
+
+def test_ungraphed_skill_is_never_dropped(tmp_path):
+    skills = tmp_path / "skills"
+    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
+    _write_skill(skills, "cat", "lib")
+    # legacy: a skill with NO graph frontmatter at all.
+    _write_skill(skills, "cat", "legacy")
+
+    ordered = ordered_skill_files(skills)
+    names = _names(ordered, skills)
+
+    # Same set of files as the flat scan — nothing added, nothing dropped.
+    assert set(names) == {"app", "lib", "legacy"}
+    assert len(ordered) == len(set(ordered)) == 3
+    # Graph constraint still honoured among graphed skills.
+    assert names.index("lib") < names.index("app")
+    # The un-graphed skill is still present.
+    assert "legacy" in names
+
+
+def test_returned_set_equals_flat_set(tmp_path):
+    """ordered_skill_files is a pure permutation of the flat scan."""
+    skills = tmp_path / "skills"
+    _write_skill(skills, "a", "one", graph_block="      requires: [two]")
+    _write_skill(skills, "a", "two")
+    _write_skill(skills, "b", "three")
+    _write_skill(skills, "b", "four", graph_block="      composes-with: [three]")
+
+    ordered = set(ordered_skill_files(skills))
+    flat = set(iter_skill_index_files(skills, "SKILL.md"))
+    assert ordered == flat
+
+
+def test_empty_dir_returns_empty(tmp_path):
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    assert ordered_skill_files(skills) == []
+    assert ordered_skill_files_or_flat(skills) == []
+
+
+# ── flag OFF == flat behaviour (byte-identical) ──────────────────────────────
+
+
+def test_flag_off_is_flat_order(tmp_path):
+    skills = tmp_path / "skills"
+    # Deliberately set up edges that WOULD reorder under v2, to prove the flag
+    # off path ignores the graph entirely.
+    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
+    _write_skill(skills, "cat", "lib")
+
+    flat = list(iter_skill_index_files(skills, "SKILL.md"))
+    # Flag is off (autouse fixture) -> identical to the legacy scan.
+    assert iter_skill_files_for_load(skills) == flat
+
+
+def test_flag_on_reorders(tmp_path, monkeypatch):
+    skills = tmp_path / "skills"
+    _write_skill(skills, "cat", "app", graph_block="      requires: [lib]")
+    _write_skill(skills, "cat", "lib")
+
+    monkeypatch.setenv(ENV_FLAG, "1")
+    loaded = iter_skill_files_for_load(skills)
+    names = _names(loaded, skills)
+    # Under v2 the dependency loads first.
+    assert names.index("lib") < names.index("app")
+
+
+def test_flag_on_cycle_falls_back_to_flat(tmp_path, monkeypatch):
+    """End-to-end: flag on + cycle -> entry point still returns flat, no raise."""
+    skills = tmp_path / "skills"
+    _write_skill(skills, "cat", "a", graph_block="      requires: [b]")
+    _write_skill(skills, "cat", "b", graph_block="      requires: [a]")
+
+    monkeypatch.setenv(ENV_FLAG, "1")
+    flat = list(iter_skill_index_files(skills, "SKILL.md"))
+    assert iter_skill_files_for_load(skills) == flat


### PR DESCRIPTION
Child of #246. Builds on the merged skill_graph (#309) topo/cycle API. **Hot-path-conservative**: opt-in, default-off, fallback-safe.

- `agent/skills_loader_v2.py`: `v2_enabled()` (config `skills.skills_loader_v2` / env `HERMES_SKILLS_LOADER_V2`, **default OFF**), `ordered_skill_files()` (loads in `SkillGraph.topological_order()`, deps first), `SkillRequiresCycleError` (names the cycle), `iter_skill_files_for_load()` entry point.
- **Byte-identical when off**: `iter_skill_files_for_load` returns exactly `list(iter_skill_index_files(...))` — same paths/order as today. Single call site in `prompt_builder.build_skills_system_prompt`.
- **Never drops a skill**: ordered set is a pure permutation of the flat scan; un-graphed/legacy skills appended in original order; on a `requires` cycle, logs the named cycle and falls back to the flat scan.
- All graph logic reused from skill_graph.py — not reimplemented.

**Scope:** ordered loader only; CLI `graph` subcommands + analysis-stage hook remain epic #246 follow-ups.
Tests: `tests/agent/test_skills_loader_v2.py` — 14; skill_graph + skill_* 146 green; prompt_builder/caching/system_prompt 160 green. Closes #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)