### PR TITLE
feat(judge): category-aware pass-rate aggregation (#318)

### DIFF
--- a/agent/judge_categories.py
+++ b/agent/judge_categories.py
@@ -1,0 +1,184 @@
+"""Category-aware aggregation over Agent-as-a-Judge verdicts (issue #318).
+
+A small, additive layer on top of ``agent.agent_judge``.  Headline judge
+success rates are averages, and persistent blind spots (business-logic flaws,
+race conditions, vulnerability recognition) are hidden inside them.  This module
+takes a batch of already-computed :class:`~agent.agent_judge.JudgeVerdict`s —
+each carrying a benchmark-task ``category`` label — and groups them into
+per-category pass rates, then surfaces the weakest categories as targets for the
+evolution loop's next skill/prompt mutation.
+
+Design (deliberately minimal):
+
+* **Stats** (:class:`CategoryStats`) — an immutable per-category roll-up
+  (``n`` scored, ``passed`` count, derived ``pass_rate``) with a JSON-friendly
+  :meth:`CategoryStats.to_dict` for the evolution report.
+* **Aggregation** (:func:`aggregate_by_category`) — a pure function grouping
+  ``(category, verdict)`` pairs into ``{category: CategoryStats}``.  Pass/fail
+  uses :meth:`JudgeVerdict.passed` so the threshold semantics are identical to
+  every other consumer of a verdict.
+* **Targeting** (:func:`weakest_categories`) — a pure function ranking
+  categories worst-pass-rate-first; a zero-pass category is always a target.
+* **Report** (:func:`build_category_report`) — the JSON-serialisable shape the
+  evolution report embeds (``per_category`` + ``weakest_categories``).
+
+SAFETY / ADDITIVITY
+-------------------
+Nothing here is wired into ``AgentJudge.score``; whole-trace scoring is
+byte-for-byte unchanged.  This module only *reads* verdicts a caller already
+produced — it never re-scores, calls an LLM, or touches the rubric.  The
+``category`` label lives on the caller's benchmark-task record, not inside the
+verdict, so labels are stable across re-runs of the same benchmark.
+
+Reference
+---------
+* Agent-as-a-Judge, ICML 2025 — https://proceedings.mlr.press/v267/zhuge25a.html
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+from agent.agent_judge import JudgeVerdict
+
+# Default pass/fail threshold, matching ``JudgeVerdict.passed``'s own default so
+# category pass rates agree with every other verdict consumer out of the box.
+DEFAULT_THRESHOLD = 0.7
+
+# A labelled verdict: the benchmark-task category and the verdict scored for it.
+VerdictWithCategory = Tuple[str, JudgeVerdict]
+
+
+@dataclass(frozen=True)
+class CategoryStats:
+    """Per-category roll-up of pass/fail outcomes.
+
+    Attributes:
+        category: The benchmark-task category label (whitespace-normalised).
+        n: Number of verdicts scored in this category.
+        passed: How many of those verdicts cleared the pass threshold.
+    """
+
+    category: str
+    n: int
+    passed: int
+
+    @property
+    def pass_rate(self) -> float:
+        """Fraction of verdicts that passed; 0.0 for an empty category."""
+        return self.passed / self.n if self.n else 0.0
+
+    def to_dict(self) -> Dict[str, float]:
+        """JSON-serialisable form for the evolution report."""
+        return {
+            "pass_rate": round(self.pass_rate, 4),
+            "n": self.n,
+            "passed": self.passed,
+        }
+
+
+def aggregate_by_category(
+    verdicts_with_category: Sequence[VerdictWithCategory],
+    threshold: float = DEFAULT_THRESHOLD,
+) -> Dict[str, CategoryStats]:
+    """Group labelled verdicts into per-category pass rates.
+
+    Pure and deterministic — no LLM, no I/O.  Each ``(category, verdict)`` pair
+    contributes one trial to its category; the verdict passes when
+    ``verdict.passed(threshold)`` is true (identical >= semantics to every other
+    verdict consumer).  Category labels are whitespace-normalised so a stray
+    space does not fork a category across benchmark re-runs.
+
+    Args:
+        verdicts_with_category: ``(category, verdict)`` pairs to aggregate.
+        threshold: Pass/fail cutoff handed to :meth:`JudgeVerdict.passed`.
+
+    Returns:
+        ``{category: CategoryStats}`` for every category seen (empty if the
+        batch is empty).
+
+    Raises:
+        ValueError: if a category label is empty after whitespace stripping.
+    """
+    counts: Dict[str, List[int]] = {}  # category -> [n, passed]
+    for category, verdict in verdicts_with_category:
+        label = category.strip()
+        if not label:
+            raise ValueError("category label must be a non-empty string")
+        bucket = counts.setdefault(label, [0, 0])
+        bucket[0] += 1
+        if verdict.passed(threshold):
+            bucket[1] += 1
+    return {
+        label: CategoryStats(category=label, n=n, passed=passed)
+        for label, (n, passed) in counts.items()
+    }
+
+
+def weakest_categories(
+    aggregated: Dict[str, CategoryStats],
+    *,
+    max_pass_rate: float = 1.0,
+    limit: int = 0,
+) -> List[CategoryStats]:
+    """Rank categories worst-pass-rate-first as evolution targets.
+
+    Pure and deterministic.  Ties on pass rate break by category name so the
+    ordering — and therefore the chosen mutation target — is stable across
+    re-runs of the same benchmark.
+
+    Args:
+        aggregated: Output of :func:`aggregate_by_category`.
+        max_pass_rate: Keep only categories at or below this pass rate (default
+            1.0 keeps all).  ``0.0`` surfaces only zero-pass categories.
+        limit: Cap the number of targets returned; ``0`` (default) means no cap.
+
+    Returns:
+        :class:`CategoryStats` ordered weakest-first, filtered and capped.
+    """
+    targets = [
+        stats
+        for stats in aggregated.values()
+        if stats.pass_rate <= max_pass_rate
+    ]
+    targets.sort(key=lambda s: (s.pass_rate, s.category))
+    if limit > 0:
+        targets = targets[:limit]
+    return targets
+
+
+def build_category_report(
+    verdicts_with_category: Sequence[VerdictWithCategory],
+    threshold: float = DEFAULT_THRESHOLD,
+    *,
+    max_pass_rate: float = 0.5,
+    limit: int = 0,
+) -> Dict[str, object]:
+    """Build the JSON-serialisable category breakdown for the evolution report.
+
+    Combines :func:`aggregate_by_category` and :func:`weakest_categories` into
+    the shape the evolution report embeds: a full per-category breakdown plus an
+    ordered list of weakest-category labels (the mutation targets).
+
+    Args:
+        verdicts_with_category: ``(category, verdict)`` pairs to report on.
+        threshold: Pass/fail cutoff for aggregation.
+        max_pass_rate: Weakest-category cutoff (default 0.5 — categories passing
+            at most half the time are targets; a zero-pass category always
+            qualifies).
+        limit: Cap on the number of weakest-category targets (``0`` = no cap).
+
+    Returns:
+        ``{"per_category": {cat: stats_dict}, "weakest_categories": [cat, ...]}``.
+    """
+    aggregated = aggregate_by_category(verdicts_with_category, threshold)
+    weakest = weakest_categories(
+        aggregated, max_pass_rate=max_pass_rate, limit=limit
+    )
+    return {
+        "per_category": {
+            cat: stats.to_dict() for cat, stats in aggregated.items()
+        },
+        "weakest_categories": [stats.category for stats in weakest],
+    }

--- a/tests/agent/test_judge_categories.py
+++ b/tests/agent/test_judge_categories.py
@@ -1,0 +1,176 @@
+"""Tests for the category-aware judge aggregator (issue #318).
+
+A pure, additive layer over ``agent.agent_judge``: it groups a list of
+``JudgeVerdict``s by a benchmark-task ``category`` label into per-category pass
+rates and surfaces the weakest categories as evolution targets.  No LLM, no
+rubric change, no mutation of ``AgentJudge.score`` behaviour.
+"""
+
+import json
+
+import pytest
+
+from agent.agent_judge import JudgeVerdict, TraceSummary
+from agent.judge_categories import (
+    CategoryStats,
+    aggregate_by_category,
+    weakest_categories,
+)
+
+
+def _verdict(session_id: str, overall: float) -> JudgeVerdict:
+    """A minimal verdict at a chosen overall score (rest is irrelevant here)."""
+    return JudgeVerdict(
+        session_id=session_id,
+        overall_score=overall,
+        dimension_scores={},
+        rationale="",
+        method="heuristic",
+        trace_summary=TraceSummary(),
+    )
+
+
+# A small labelled batch spanning three categories with mixed outcomes.
+#   recognition:    2 pass, 0 fail  -> 1.00
+#   business-logic: 1 pass, 1 fail  -> 0.50
+#   race:           0 pass, 2 fail  -> 0.00  (a zero-pass category)
+SAMPLE_BATCH = [
+    ("recognition", _verdict("r1", 0.90)),
+    ("recognition", _verdict("r2", 0.75)),
+    ("business-logic", _verdict("b1", 0.80)),
+    ("business-logic", _verdict("b2", 0.40)),
+    ("race", _verdict("c1", 0.30)),
+    ("race", _verdict("c2", 0.10)),
+]
+
+
+class TestAggregateByCategory:
+    def test_empty_batch_yields_empty_mapping(self):
+        assert aggregate_by_category([]) == {}
+
+    def test_groups_and_computes_pass_rate(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        assert set(agg) == {"recognition", "business-logic", "race"}
+        assert agg["recognition"].pass_rate == 1.0
+        assert agg["recognition"].n == 2
+        assert agg["recognition"].passed == 2
+        assert agg["business-logic"].pass_rate == 0.5
+        assert agg["business-logic"].passed == 1
+        assert agg["race"].pass_rate == 0.0
+        assert agg["race"].passed == 0
+        assert agg["race"].n == 2
+
+    def test_threshold_is_respected(self):
+        # At a 0.85 threshold only the 0.90 verdict passes recognition.
+        agg = aggregate_by_category(SAMPLE_BATCH, threshold=0.85)
+        assert agg["recognition"].passed == 1
+        assert agg["recognition"].pass_rate == 0.5
+        # business-logic and race now have zero passes.
+        assert agg["business-logic"].passed == 0
+        assert agg["race"].passed == 0
+
+    def test_uses_verdict_passed_semantics(self):
+        # A verdict exactly at the threshold passes (>= in JudgeVerdict.passed).
+        batch = [("edge", _verdict("e1", 0.7))]
+        agg = aggregate_by_category(batch, threshold=0.7)
+        assert agg["edge"].passed == 1
+        assert agg["edge"].pass_rate == 1.0
+
+    def test_single_category(self):
+        batch = [("solo", _verdict("s1", 0.9)), ("solo", _verdict("s2", 0.2))]
+        agg = aggregate_by_category(batch)
+        assert list(agg) == ["solo"]
+        assert agg["solo"].n == 2
+        assert agg["solo"].passed == 1
+        assert agg["solo"].pass_rate == 0.5
+
+    def test_category_label_whitespace_normalised(self):
+        # Leading/trailing whitespace in a label should not fork a category.
+        batch = [("race", _verdict("c1", 0.1)), ("  race  ", _verdict("c2", 0.2))]
+        agg = aggregate_by_category(batch)
+        assert set(agg) == {"race"}
+        assert agg["race"].n == 2
+
+    def test_missing_category_label_rejected(self):
+        with pytest.raises(ValueError):
+            aggregate_by_category([("", _verdict("x", 0.5))])
+
+    def test_stats_to_dict_is_json_serialisable(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        payload = {cat: stats.to_dict() for cat, stats in agg.items()}
+        # Must round-trip through JSON for the evolution report.
+        json.dumps(payload)
+        rec = payload["recognition"]
+        assert rec == {"pass_rate": 1.0, "n": 2, "passed": 2}
+
+
+class TestCategoryStats:
+    def test_pass_rate_derived_from_passed_and_n(self):
+        stats = CategoryStats(category="x", n=4, passed=1)
+        assert stats.pass_rate == 0.25
+
+    def test_zero_n_pass_rate_is_zero_not_division_error(self):
+        stats = CategoryStats(category="x", n=0, passed=0)
+        assert stats.pass_rate == 0.0
+
+
+class TestWeakestCategories:
+    def test_returns_lowest_pass_rates_first(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        weakest = weakest_categories(agg)
+        cats = [w.category for w in weakest]
+        # race (0.0) before business-logic (0.5) before recognition (1.0).
+        assert cats[0] == "race"
+        assert cats.index("business-logic") < cats.index("recognition")
+
+    def test_max_pass_rate_filter_surfaces_only_weak(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        # Only categories at or below 0.5 pass rate are evolution targets.
+        weak = weakest_categories(agg, max_pass_rate=0.5)
+        cats = {w.category for w in weak}
+        assert cats == {"race", "business-logic"}
+        assert "recognition" not in cats
+
+    def test_zero_pass_category_always_surfaced(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        weak = weakest_categories(agg, max_pass_rate=0.0)
+        # Success criterion: a category with zero passes triggers a target.
+        assert [w.category for w in weak] == ["race"]
+
+    def test_limit_caps_result_count(self):
+        agg = aggregate_by_category(SAMPLE_BATCH)
+        weak = weakest_categories(agg, limit=1)
+        assert len(weak) == 1
+        assert weak[0].category == "race"
+
+    def test_empty_aggregate_yields_no_targets(self):
+        assert weakest_categories({}) == []
+
+    def test_deterministic_tie_break_by_category_name(self):
+        # Two categories with identical pass rate sort by name (stable re-runs).
+        batch = [
+            ("zeta", _verdict("z1", 0.1)),
+            ("alpha", _verdict("a1", 0.1)),
+        ]
+        agg = aggregate_by_category(batch)
+        weak = weakest_categories(agg)
+        assert [w.category for w in weak] == ["alpha", "zeta"]
+
+
+class TestEvolutionReportShape:
+    def test_report_dict_has_per_category_and_weakest(self):
+        from agent.judge_categories import build_category_report
+
+        report = build_category_report(SAMPLE_BATCH, threshold=0.7)
+        json.dumps(report)  # JSON-serialisable for the evolution report
+        assert "per_category" in report
+        assert "weakest_categories" in report
+        assert report["per_category"]["race"]["pass_rate"] == 0.0
+        # The zero-pass category is an evolution target.
+        assert "race" in report["weakest_categories"]
+
+    def test_empty_report(self):
+        from agent.judge_categories import build_category_report
+
+        report = build_category_report([])
+        assert report == {"per_category": {}, "weakest_categories": []}


### PR DESCRIPTION
Extends Agent-as-a-Judge (#226) with per-category breakdown. `agent/judge_categories.py`: pure `aggregate_by_category(verdicts, threshold)` → {category: pass_rate} + `weakest_categories()` + `build_category_report()` JSON for the evolution mutation selector. Reuses `JudgeVerdict.passed()`; no new judge/LLM/rubric change, `AgentJudge.score` untouched. Tests: 18; judge suite 51 green. Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)