### PR TITLE
feat(delegate): bounded auto-retry on shallow delegations (#323)

### DIFF
--- a/tests/tools/test_delegate_shallow_retry.py
+++ b/tests/tools/test_delegate_shallow_retry.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+Tests for bounded auto-retry on shallow delegations (issue #323).
+
+When a delegated subagent returns narrative text WITHOUT executing any
+tools, `_run_single_child` flags it as ``shallow_result``.  Historically
+the parent was only ADVISED to re-delegate; the round-trip was already
+wasted.  Issue #323 adds a bounded automatic re-delegation with an
+escalated goal: on a shallow result the same child is re-run (budget 1,
+hard ceiling 2) with a prefix that references the failure.  The retry
+result replaces the shallow one when the retry actually calls tools.
+
+Invariants under test:
+  - shallow -> one retry -> success (tools called): retry result wins,
+    shallow_result flag cleared, escalated goal handed to the child.
+  - shallow -> retry STILL shallow: give up at budget, keep the
+    shallow_result flag, never loop past the budget.
+  - non-shallow first attempt: NO retry (run_conversation called once).
+  - budget is never exceeded (run_conversation call count bounded).
+  - budget=0 disables the retry entirely (back to advise-only behaviour).
+
+Run with:  python -m pytest tests/tools/test_delegate_shallow_retry.py -q
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    _SHALLOW_RETRY_BUDGET_MAX,
+    _get_shallow_retry_budget,
+    delegate_task,
+)
+
+
+def _make_mock_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _shallow_result(text="I'll call web_search with query 'foo'..."):
+    """A completed run with NO tool calls — the shallow failure mode."""
+    return {
+        "final_response": text,
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 1,
+        "messages": [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": text},
+        ],
+    }
+
+
+def _tool_using_result(text="Found 3 results.", tool="web_search"):
+    """A completed run that actually executed a tool."""
+    return {
+        "final_response": text,
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 2,
+        "messages": [
+            {"role": "user", "content": "do something"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "function": {
+                            "name": tool,
+                            "arguments": '{"query": "foo"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": '{"results": [1,2,3]}'},
+            {"role": "assistant", "content": text},
+        ],
+    }
+
+
+class TestShallowRetryBudgetConfig(unittest.TestCase):
+    def test_default_budget_is_one(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertEqual(_get_shallow_retry_budget(), 1)
+
+    def test_budget_clamped_to_ceiling(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"shallow_retry_max": 99},
+        ):
+            self.assertEqual(_get_shallow_retry_budget(), _SHALLOW_RETRY_BUDGET_MAX)
+
+    def test_budget_zero_disables(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"shallow_retry_max": 0},
+        ):
+            self.assertEqual(_get_shallow_retry_budget(), 0)
+
+    def test_negative_clamped_to_zero(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"shallow_retry_max": -5},
+        ):
+            self.assertEqual(_get_shallow_retry_budget(), 0)
+
+    def test_garbage_falls_back_to_default(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"shallow_retry_max": "not-a-number"},
+        ):
+            self.assertEqual(_get_shallow_retry_budget(), 1)
+
+    def test_ceiling_is_two(self):
+        self.assertEqual(_SHALLOW_RETRY_BUDGET_MAX, 2)
+
+
+class TestShallowRetryBehaviour(unittest.TestCase):
+    def test_shallow_then_retry_success(self):
+        """shallow -> one retry that calls a tool -> retry result wins."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=1
+        ):
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.side_effect = [
+                _shallow_result(),
+                _tool_using_result(text="Found 3 results."),
+            ]
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web for foo", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            # Retried exactly once (2 total runs).
+            self.assertEqual(mock_child.run_conversation.call_count, 2)
+            # Retry succeeded -> the shallow flag must be gone and the
+            # winning summary is the tool-using one, not the narrative.
+            self.assertNotEqual(entry.get("shallow_result"), True)
+            self.assertIn("Found 3 results.", entry["summary"])
+            self.assertTrue(len(entry["tool_trace"]) >= 1)
+            self.assertEqual(entry["tool_trace"][0]["tool"], "web_search")
+            # Bookkeeping: a retry happened.
+            self.assertEqual(entry.get("shallow_retries"), 1)
+
+    def test_escalated_goal_references_failure(self):
+        """The retry goal must be escalated (reference the failure + demand a tool call)."""
+        parent = _make_mock_parent(depth=0)
+        seen_goals = []
+
+        def _capture(*args, **kwargs):
+            seen_goals.append(kwargs.get("user_message"))
+            # First call shallow, second call tool-using.
+            return _shallow_result() if len(seen_goals) == 1 else _tool_using_result()
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=1
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.side_effect = _capture
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Search the web for foo", parent_agent=parent)
+
+            self.assertEqual(len(seen_goals), 2)
+            first, second = seen_goals
+            self.assertEqual(first, "Search the web for foo")
+            # Escalated prompt must reference the no-tool failure and the
+            # original goal, and must be different from the first goal.
+            self.assertNotEqual(second, first)
+            self.assertIn("Search the web for foo", second)
+            lowered = second.lower()
+            self.assertTrue("tool" in lowered)
+            self.assertTrue(
+                "no tool" in lowered
+                or "did not" in lowered
+                or "without" in lowered
+                or "previous" in lowered
+            )
+
+    def test_shallow_then_still_shallow_gives_up_at_budget(self):
+        """shallow -> retry still shallow -> stop at budget, keep the flag."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=1
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            # Always shallow.
+            mock_child.run_conversation.side_effect = [
+                _shallow_result("narrative one"),
+                _shallow_result("narrative two"),
+            ]
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            # Budget 1 -> exactly one retry -> 2 total runs, never more.
+            self.assertEqual(mock_child.run_conversation.call_count, 2)
+            # Still shallow -> flag retained, parent still warned.
+            self.assertEqual(entry.get("shallow_result"), True)
+            self.assertIn("SHALLOW DELEGATION", entry["summary"])
+            self.assertEqual(entry.get("shallow_retries"), 1)
+
+    def test_non_shallow_first_attempt_no_retry(self):
+        """A first attempt that calls tools must NOT trigger any retry."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=1
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = _tool_using_result()
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            # Exactly one run — no retry for a healthy delegation.
+            self.assertEqual(mock_child.run_conversation.call_count, 1)
+            self.assertNotEqual(entry.get("shallow_result"), True)
+            self.assertNotIn("shallow_retries", entry)
+
+    def test_budget_never_exceeded_ceiling(self):
+        """Even with budget at the ceiling, the run count is bounded (1 + budget)."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget",
+            return_value=_SHALLOW_RETRY_BUDGET_MAX,
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            # Always shallow — force the loop to exhaust the budget.
+            mock_child.run_conversation.side_effect = [
+                _shallow_result(f"narrative {i}") for i in range(10)
+            ]
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            # 1 initial + at most _SHALLOW_RETRY_BUDGET_MAX retries.
+            self.assertEqual(
+                mock_child.run_conversation.call_count,
+                1 + _SHALLOW_RETRY_BUDGET_MAX,
+            )
+            self.assertEqual(entry.get("shallow_result"), True)
+            self.assertEqual(entry.get("shallow_retries"), _SHALLOW_RETRY_BUDGET_MAX)
+
+    def test_budget_zero_disables_retry(self):
+        """budget=0 -> advise-only legacy behaviour, no extra run."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=0
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = _shallow_result()
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            # No retry at all.
+            self.assertEqual(mock_child.run_conversation.call_count, 1)
+            self.assertEqual(entry.get("shallow_result"), True)
+            self.assertIn("SHALLOW DELEGATION", entry["summary"])
+            self.assertNotIn("shallow_retries", entry)
+
+    def test_orchestrator_no_tool_calls_not_retried(self):
+        """An orchestrator whose work is sub-delegation looks tool-less but is
+        NOT shallow — re-running it would re-fire its child delegations. It
+        must never be auto-retried (no double-execution of side-effecting work).
+        """
+        parent = _make_mock_parent(depth=0)
+        # max_spawn_depth>=2 so role="orchestrator" survives _build_child_agent
+        # (otherwise it degrades to leaf and _delegate_role is overwritten).
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget", return_value=2
+        ), patch(
+            "tools.delegate_tool._load_config",
+            return_value={"max_spawn_depth": 2},
+        ):
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "orchestrated 2 workers",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Coordinate two research streams",
+                    role="orchestrator",
+                    parent_agent=parent,
+                )
+            )
+            entry = result["results"][0]
+
+            # Ran exactly once — no retry despite the empty tool_trace.
+            self.assertEqual(mock_child.run_conversation.call_count, 1)
+            self.assertNotIn("shallow_retries", entry)
+
+    def test_retry_recovers_after_first_retry_still_shallow(self):
+        """budget 2: shallow -> shallow -> tool-using succeeds; flag cleared."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegate_tool._get_shallow_retry_budget",
+            return_value=2,
+        ):
+            mock_child = MagicMock()
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.side_effect = [
+                _shallow_result("narrative one"),
+                _shallow_result("narrative two"),
+                _tool_using_result(text="Recovered on second retry."),
+            ]
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Search the web", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            self.assertEqual(mock_child.run_conversation.call_count, 3)
+            self.assertNotEqual(entry.get("shallow_result"), True)
+            self.assertIn("Recovered on second retry.", entry["summary"])
+            self.assertEqual(entry.get("shallow_retries"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -621,6 +621,59 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_shallow_retry_budget() -> int:
+    """Read delegation.shallow_retry_max — bounded auto-retry budget (issue #323).
+
+    Number of times a *shallow* delegation (child completed with ZERO tool
+    calls) is automatically re-run with an escalated goal before giving up
+    and surfacing the shallow result to the parent. Default 1 (one retry);
+    0 disables auto-retry entirely (legacy advise-only behaviour); clamped
+    to ``_SHALLOW_RETRY_BUDGET_MAX`` so a misconfigured value can never make
+    delegation loop unbounded. Also honours the env override
+    ``DELEGATION_SHALLOW_RETRY_MAX`` for ops without a config file.
+
+    This budget only ever applies on an already-detected shallow result, so
+    a healthy first-try (tool-using) delegation is never slowed by it.
+    """
+    cfg = _load_config()
+    val = cfg.get("shallow_retry_max")
+    if val is None:
+        env_val = os.getenv("DELEGATION_SHALLOW_RETRY_MAX")
+        val = env_val if env_val not in (None, "") else None
+    if val is None:
+        return _DEFAULT_SHALLOW_RETRY_BUDGET
+    try:
+        ival = int(val)
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.shallow_retry_max=%r is not a valid integer; using default %d",
+            val,
+            _DEFAULT_SHALLOW_RETRY_BUDGET,
+        )
+        return _DEFAULT_SHALLOW_RETRY_BUDGET
+    return max(0, min(_SHALLOW_RETRY_BUDGET_MAX, ival))
+
+
+def _escalate_shallow_goal(original_goal: str, attempt: int) -> str:
+    """Build an escalated re-delegation goal referencing the no-tool failure.
+
+    Prepends a hard, unambiguous instruction that the child's previous attempt
+    produced narrative text without executing any tool, and that its FIRST
+    action this time must be a tool call. The original goal is preserved
+    verbatim below the escalation so the child still knows what to do.
+    """
+    return (
+        "RETRY (escalated): your PREVIOUS attempt at this task FAILED — you "
+        "returned narrative text and did NOT execute any tool. Describing a "
+        "tool call is not the same as making one. This time your FIRST action "
+        "MUST be a real tool call; do not output any prose before it. Do the "
+        "actual work with your tools and report the concrete artifacts "
+        f"(file contents, search results, command output).\n\n"
+        f"(retry {attempt}/{_SHALLOW_RETRY_BUDGET_MAX})\n\n"
+        f"ORIGINAL TASK:\n{original_goal}"
+    )
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -697,6 +750,17 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+
+# Shallow-delegation auto-retry (issue #323). When a child completes WITHOUT
+# making any tool call (the "narrative text instead of tool execution" failure
+# mode), the round-trip is already wasted — re-delegating once with an
+# escalated goal recovers it without spending the parent's reasoning budget on
+# a manual re-delegate. Strictly bounded: at most _SHALLOW_RETRY_BUDGET_MAX
+# extra runs, and only ever on an already-detected shallow result (a healthy,
+# tool-using delegation never enters this path). Operators tune it via
+# delegation.shallow_retry_max (0 disables; clamped to the ceiling).
+_SHALLOW_RETRY_BUDGET_MAX = 2  # hard ceiling on auto-retries per child
+_DEFAULT_SHALLOW_RETRY_BUDGET = 1  # default: one escalated retry
 
 
 # ---------------------------------------------------------------------------
@@ -1547,6 +1611,84 @@ def _dump_subagent_timeout_diagnostic(
         return None
 
 
+def _derive_child_outcome(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive status, summary, and tool_trace from a child run_conversation result.
+
+    Pure function (no agent/IO) so it can be applied to BOTH the initial run
+    and any shallow-retry re-run (issue #323) without duplicating the parsing
+    logic. Returns a dict with: summary, completed, interrupted, api_calls,
+    status, tool_trace, exit_reason.
+    """
+    summary = result.get("final_response") or ""
+    completed = result.get("completed", False)
+    interrupted = result.get("interrupted", False)
+    api_calls = result.get("api_calls", 0)
+
+    if interrupted:
+        status = "interrupted"
+    elif summary:
+        # A summary means the subagent produced usable output. exit_reason
+        # ("completed" vs "max_iterations") already tells the parent *how*
+        # the task ended.
+        status = "completed"
+    else:
+        status = "failed"
+
+    # Build tool trace from conversation messages (already in memory).
+    # Uses tool_call_id to correctly pair parallel tool calls with results.
+    tool_trace: list[Dict[str, Any]] = []
+    trace_by_id: Dict[str, Dict[str, Any]] = {}
+    messages = result.get("messages") or []
+    if isinstance(messages, list):
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    fn = tc.get("function", {})
+                    entry_t = {
+                        "tool": fn.get("name", "unknown"),
+                        "args_bytes": len(fn.get("arguments", "")),
+                    }
+                    tool_trace.append(entry_t)
+                    tc_id = tc.get("id")
+                    if tc_id:
+                        trace_by_id[tc_id] = entry_t
+            elif msg.get("role") == "tool":
+                content = _stringify_tool_content(msg.get("content", ""))
+                is_error = _looks_like_error_output(content)
+                result_meta = {
+                    "result_bytes": len(content),
+                    "status": "error" if is_error else "ok",
+                }
+                # Match by tool_call_id for parallel calls
+                tc_id = msg.get("tool_call_id")
+                target = trace_by_id.get(tc_id) if tc_id else None
+                if target is not None:
+                    target.update(result_meta)
+                elif tool_trace:
+                    # Fallback for messages without tool_call_id
+                    tool_trace[-1].update(result_meta)
+
+    # Determine exit reason
+    if interrupted:
+        exit_reason = "interrupted"
+    elif completed:
+        exit_reason = "completed"
+    else:
+        exit_reason = "max_iterations"
+
+    return {
+        "summary": summary,
+        "completed": completed,
+        "interrupted": interrupted,
+        "api_calls": api_calls,
+        "status": status,
+        "tool_trace": tool_trace,
+        "exit_reason": exit_reason,
+    }
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -1870,64 +2012,89 @@ def _run_single_child(
 
         duration = round(time.monotonic() - child_start, 2)
 
-        summary = result.get("final_response") or ""
-        completed = result.get("completed", False)
-        interrupted = result.get("interrupted", False)
-        api_calls = result.get("api_calls", 0)
+        _outcome = _derive_child_outcome(result)
+        summary = _outcome["summary"]
+        completed = _outcome["completed"]
+        interrupted = _outcome["interrupted"]
+        api_calls = _outcome["api_calls"]
+        status = _outcome["status"]
+        tool_trace = _outcome["tool_trace"]
+        exit_reason = _outcome["exit_reason"]
 
-        if interrupted:
-            status = "interrupted"
-        elif summary:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
-            status = "completed"
-        else:
-            status = "failed"
-
-        # Build tool trace from conversation messages (already in memory).
-        # Uses tool_call_id to correctly pair parallel tool calls with results.
-        tool_trace: list[Dict[str, Any]] = []
-        trace_by_id: Dict[str, Dict[str, Any]] = {}
-        messages = result.get("messages") or []
-        if isinstance(messages, list):
-            for msg in messages:
-                if not isinstance(msg, dict):
-                    continue
-                if msg.get("role") == "assistant":
-                    for tc in msg.get("tool_calls") or []:
-                        fn = tc.get("function", {})
-                        entry_t = {
-                            "tool": fn.get("name", "unknown"),
-                            "args_bytes": len(fn.get("arguments", "")),
-                        }
-                        tool_trace.append(entry_t)
-                        tc_id = tc.get("id")
-                        if tc_id:
-                            trace_by_id[tc_id] = entry_t
-                elif msg.get("role") == "tool":
-                    content = _stringify_tool_content(msg.get("content", ""))
-                    is_error = _looks_like_error_output(content)
-                    result_meta = {
-                        "result_bytes": len(content),
-                        "status": "error" if is_error else "ok",
-                    }
-                    # Match by tool_call_id for parallel calls
-                    tc_id = msg.get("tool_call_id")
-                    target = trace_by_id.get(tc_id) if tc_id else None
-                    if target is not None:
-                        target.update(result_meta)
-                    elif tool_trace:
-                        # Fallback for messages without tool_call_id
-                        tool_trace[-1].update(result_meta)
-
-        # Determine exit reason
-        if interrupted:
-            exit_reason = "interrupted"
-        elif completed:
-            exit_reason = "completed"
-        else:
-            exit_reason = "max_iterations"
+        # Bounded shallow-delegation auto-retry (issue #323). A child that
+        # COMPLETED but made ZERO tool calls returned narrative text instead
+        # of executing tools — the round-trip is already wasted. Re-run the
+        # SAME child with an escalated goal that references the failure and
+        # demands a tool call first. Strictly additive and bounded:
+        #   - only ever fires on an already-shallow, completed result, so a
+        #     healthy tool-using first attempt is never re-run (hot-path safe);
+        #   - capped at _get_shallow_retry_budget() (<= _SHALLOW_RETRY_BUDGET_MAX)
+        #     retries — the loop can never run unbounded;
+        #   - the first attempt to actually call a tool wins and replaces the
+        #     shallow outcome; if every retry is still shallow we keep the
+        #     original shallow result and fall through to the warning below.
+        # No double-execution risk beyond what a manual re-delegate would
+        # incur: the parent was already told to re-delegate this exact goal.
+        #
+        # Orchestrators are EXCLUDED: their real work is sub-delegation, which
+        # never shows up as a tool_trace, so a delegating orchestrator looks
+        # "shallow" but isn't — and re-running one would re-fire its child
+        # delegations (duplicate side-effecting work). Only leaf children,
+        # whose job is to actually call tools, are eligible for auto-retry.
+        shallow_retries = 0
+        _child_is_orchestrator = (
+            getattr(child, "_delegate_role", None) == "orchestrator"
+        )
+        if status == "completed" and not tool_trace and not _child_is_orchestrator:
+            retry_budget = _get_shallow_retry_budget()
+            while shallow_retries < retry_budget and not tool_trace:
+                shallow_retries += 1
+                escalated_goal = _escalate_shallow_goal(goal, shallow_retries)
+                logger.info(
+                    "Subagent %d shallow result (no tool calls); auto-retry "
+                    "%d/%d with escalated goal",
+                    task_index,
+                    shallow_retries,
+                    retry_budget,
+                )
+                try:
+                    retry_result = child.run_conversation(
+                        user_message=escalated_goal,
+                        task_id=child_task_id,
+                        stream_callback=_relay_child_text,
+                    )
+                except Exception as _retry_exc:
+                    # A retry failure must never break the delegation — fall
+                    # back to the original shallow result and stop retrying.
+                    logger.warning(
+                        "Subagent %d shallow auto-retry %d raised %s; keeping "
+                        "original shallow result",
+                        task_index,
+                        shallow_retries,
+                        type(_retry_exc).__name__,
+                    )
+                    break
+                _retry_outcome = _derive_child_outcome(retry_result)
+                # Only adopt the retry if it actually produced tool calls —
+                # an interrupted/failed/still-shallow retry must not clobber
+                # the (at least completed) original summary.
+                if _retry_outcome["tool_trace"]:
+                    result = retry_result
+                    summary = _retry_outcome["summary"]
+                    completed = _retry_outcome["completed"]
+                    interrupted = _retry_outcome["interrupted"]
+                    api_calls = _retry_outcome["api_calls"]
+                    status = _retry_outcome["status"]
+                    tool_trace = _retry_outcome["tool_trace"]
+                    exit_reason = _retry_outcome["exit_reason"]
+                    logger.info(
+                        "Subagent %d recovered on shallow auto-retry %d "
+                        "(%d tool call(s))",
+                        task_index,
+                        shallow_retries,
+                        len(tool_trace),
+                    )
+                # else: still shallow — loop again until budget exhausted.
 
         # Extract token counts (safe for mock objects)
         _input_tokens = getattr(child, "session_prompt_tokens", 0)
@@ -1972,20 +2139,35 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        # Surface the bounded auto-retry count (issue #323) so callers and
+        # trace-mining (#248) can see recovery happened. Absent (not 0) when
+        # no retry was attempted, to avoid noise on the healthy path.
+        if shallow_retries:
+            entry["shallow_retries"] = shallow_retries
+
         # Shallow-delegation detector (issue 102): a child that made ZERO
         # tool calls answered from its own head. For the dominant delegation
         # use case (read/filter/compute on real data) that narrative is a
         # non-result — flag it loudly IN the summary so the parent model
         # cannot miss it, plus a structured field for programmatic callers.
+        # Issue #323: by this point the bounded auto-retry above has already
+        # tried (and failed) to recover, so this only fires when retries were
+        # exhausted or disabled — the warning still tells the parent to act.
         if status == "completed" and not tool_trace:
             entry["shallow_result"] = True
+            _retry_note = (
+                f" Auto-retry exhausted ({shallow_retries} attempt(s)) and the "
+                "subagent still made no tool calls."
+                if shallow_retries
+                else ""
+            )
             entry["summary"] = (
                 "⚠️ SHALLOW DELEGATION: this subagent made NO tool calls — "
                 "the text below is narrative from model memory, not "
                 "extracted data. If you asked for file contents, search "
                 "results, or computed values, treat this as a failure and "
                 "either re-delegate with explicit tool instructions or do "
-                "the work inline.\n\n" + summary
+                "the work inline." + _retry_note + "\n\n" + summary
             )
 
         # Cross-agent file-state reminder.  If this subagent wrote any


### PR DESCRIPTION
On a `shallow_result` (child completed with zero tool calls), re-delegate ONCE with an escalated tool-first goal instead of only advising. `tools/delegate_tool.py`: budget `min(2, config delegation.shallow_retry_max, default 1)`, gated on `status==completed and not tool_trace` (`:2055`) so healthy delegations are byte-identical; orchestrators excluded (no double sub-delegation); `=0` restores legacy advise-only. Tests: 14; delegate suites 177 green. Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)