### PR TITLE
feat(evolution): pre-submission dedup gate — shift triage left (#336)

### DIFF
--- a/scripts/evolution_pre_submit_triage.py
+++ b/scripts/evolution_pre_submit_triage.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Pre-submission triage gate for the evolution `issues` stage (#336).
+
+WHY THIS EXISTS — shift triage LEFT. The evolution pipeline historically opened
+GitHub issues FIRST and triaged SECOND (the `analysis` stage labels `rejected`
+and closes). Because `research` optimizes for coverage and every fork runs its
+own research cycle against the shared origin, GitHub fills with duplicate /
+already-covered proposals that a human or the analysis stage must clear
+afterward. This gate moves the duplicate check BEFORE `gh issue create`: for a
+DRAFT proposal it decides CREATE vs SKIP-duplicate against the currently-OPEN
+issues, so only non-duplicate proposals are ever filed.
+
+CONSERVATISM IS THE WHOLE POINT (anti-fabrication guard). The project has a
+documented, expensive failure mode: triage FABRICATED a rejection and wrongly
+CLOSED a real issue (#83, the #101 class). The lesson is asymmetric-cost: a
+wrongful SKIP suppresses a genuine proposal (silent, hard to notice); a
+needless CREATE merely adds one issue that later triage can still close. So we
+SKIP **only** on a HIGH-confidence title/signature overlap (Dice >= a high
+threshold) and DEFAULT TO CREATE on any doubt — empty open-issues, a weak or
+ambiguous overlap, a missing draft title. Never skip on a weak match.
+
+SCOPE (this slice): deterministic dedup against OPEN issues only. The
+coverage/LLM-confidence check and per-fork isolation are explicit follow-ups
+(see #336), NOT implemented here. Closed/rejected-issue handling stays in
+skills/evolution/evolution-issues/SKILL.md.
+
+The similarity idiom is REUSED from scripts/evolution_dedup.py
+(`normalize_title`): same tag-stripping + lowercase + punctuation-collapse, so
+this gate and the local dedup cache canonicalize titles identically. We extend
+it from an exact-key hash to a graded token overlap so a HIGH threshold can be
+applied.
+
+The open-issues fetch is behind an INJECTABLE SEAM (`fetch_open_issues`) so the
+pure `decide()` runs fully offline in tests; only the CLI touches the network
+via `gh issue list`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+# Reuse the EXACT normalization idiom from the local dedup cache so both stages
+# canonicalize titles identically (tag-strip + lowercase + punctuation-collapse).
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent))
+from evolution_dedup import normalize_title  # noqa: E402
+
+# HIGH by design: skip ONLY a near-exact title overlap. Lowering this re-opens
+# the fabricated-rejection failure mode (#83/#101) — keep the bar high.
+DEFAULT_THRESHOLD = 0.85
+
+
+def _tokens(title: str) -> List[str]:
+    """Normalized, de-duplicated word tokens of a title (order-independent)."""
+    norm = normalize_title(title)
+    # normalize_title already lowercases and reduces non-word runs to single
+    # spaces, so a plain split yields the canonical token set.
+    return sorted(set(norm.split()))
+
+
+def similarity(a: str, b: str) -> float:
+    """Graded title overlap in [0.0, 1.0] via the Sørensen–Dice coefficient on
+    normalized token SETS: ``2 * |A ∩ B| / (|A| + |B|)``.
+
+    Deterministic, symmetric, pure. 1.0 = identical canonical token sets (e.g.
+    cosmetic ``[TAG]``/case/punctuation variants), 0.0 = disjoint or empty. We
+    use token sets (not sequences) so word-order differences don't mask a true
+    duplicate, and Dice (not raw intersection) so adding a couple of words to an
+    otherwise-identical title still scores high but a single shared generic word
+    ("metrics") scores low — exactly the gradient the conservative threshold
+    relies on.
+    """
+    ta, tb = set(_tokens(a)), set(_tokens(b))
+    if not ta or not tb:
+        return 0.0
+    inter = len(ta & tb)
+    return (2.0 * inter) / (len(ta) + len(tb))
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Structured gate object: {decision, matched_issue, score, reason}.
+
+    ``decision`` is ``"create"`` or ``"skip_duplicate"``. ``matched_issue`` is
+    the OPEN issue number a skip is justified by (``None`` on create).
+    ``score`` is the best similarity observed (for auditability — present even
+    on create). ``reason`` is a human-readable justification for the report/log.
+    """
+
+    decision: str
+    score: float
+    reason: str
+    matched_issue: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "matched_issue": self.matched_issue,
+            "score": round(self.score, 4),
+            "reason": self.reason,
+        }
+
+
+def _best_open_match(
+    draft_title: str, open_issues: Sequence[Dict[str, Any]]
+) -> tuple[float, Optional[Dict[str, Any]]]:
+    """Best (score, issue) over OPEN issues only. Closed issues are out of scope
+    for this gate (handled in SKILL.md), so they never produce a skip signal."""
+    best_score = 0.0
+    best_issue: Optional[Dict[str, Any]] = None
+    for issue in open_issues:
+        state = str(issue.get("state", "open")).lower()
+        if state != "open":
+            continue
+        title = issue.get("title")
+        if not title:
+            continue
+        score = similarity(draft_title, str(title))
+        if score > best_score:
+            best_score = score
+            best_issue = issue
+    return best_score, best_issue
+
+
+def decide(
+    draft: Dict[str, Any],
+    open_issues: Sequence[Dict[str, Any]],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> GateDecision:
+    """Decide CREATE vs SKIP-duplicate for ``draft`` against the OPEN issues.
+
+    CONSERVATIVE: returns ``skip_duplicate`` ONLY when the best OPEN-issue title
+    overlap is ``>= threshold`` (a HIGH, near-exact bar). Every other outcome —
+    no draft title, empty open-issues, a weak or merely-partial overlap — returns
+    ``create``. This create-on-doubt default is the anti-fabrication guard: a
+    wrongful skip silently suppresses a real proposal (the #83/#101 failure
+    mode), whereas a needless create is cheaply closed by later triage. We never
+    skip on a weak match.
+
+    Pure: ``open_issues`` is injected by the caller (the CLI fetches it via
+    ``gh``); this function performs no IO and is fully offline-testable.
+    """
+    draft_title = str(draft.get("title") or "").strip()
+    if not draft_title:
+        return GateDecision(
+            decision="create",
+            score=0.0,
+            reason="draft has no usable title; cannot prove a duplicate — create",
+            matched_issue=None,
+        )
+
+    best_score, best_issue = _best_open_match(draft_title, open_issues)
+
+    if best_issue is not None and best_score >= threshold:
+        return GateDecision(
+            decision="skip_duplicate",
+            score=best_score,
+            reason=(
+                f"high-confidence duplicate of OPEN issue "
+                f"#{best_issue.get('number')} (score {best_score:.3f} "
+                f">= threshold {threshold:.3f})"
+            ),
+            matched_issue=_as_int(best_issue.get("number")),
+        )
+
+    # Create-on-doubt. Surface the near-miss for auditability without acting on it.
+    if best_issue is not None:
+        reason = (
+            f"best OPEN match #{best_issue.get('number')} score {best_score:.3f} "
+            f"< threshold {threshold:.3f} — too weak to skip, defaulting to create"
+        )
+    else:
+        reason = "no overlapping OPEN issue — create"
+    return GateDecision(
+        decision="create", score=best_score, reason=reason, matched_issue=None
+    )
+
+
+def _as_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── IO boundary (injectable seam) ───────────────────────────────────────────────
+def fetch_open_issues(
+    repo: str, *, limit: int = 300, runner: Optional[Callable[[List[str]], str]] = None
+) -> List[Dict[str, Any]]:
+    """Fetch currently-OPEN issues via ``gh`` (the only networked path).
+
+    ``runner`` is injectable so tests can supply canned JSON without a real
+    ``gh``; production passes the default subprocess runner. Returns a list of
+    ``{number, title, state}`` dicts. On any failure returns ``[]`` — and an
+    empty open-issues list makes ``decide`` return CREATE, i.e. a fetch failure
+    fails OPEN (never a wrongful skip), consistent with the conservative rule.
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,state",
+    ]
+    run = runner or _default_runner
+    try:
+        raw = run(cmd)
+        data = json.loads(raw) if raw else []
+    except Exception:
+        return []
+    if not isinstance(data, list):
+        return []
+    issues: List[Dict[str, Any]] = []
+    for item in data:
+        if isinstance(item, dict) and item.get("title"):
+            issues.append(
+                {
+                    "number": item.get("number"),
+                    "title": item.get("title"),
+                    "state": item.get("state", "open"),
+                }
+            )
+    return issues
+
+
+def _default_runner(cmd: List[str]) -> str:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return proc.stdout
+
+
+def main(argv: List[str]) -> int:
+    """CLI for the SKILL.md hook:
+
+        evolution_pre_submit_triage.py decide "<draft title>" [--repo R] [--threshold T]
+
+    Prints the gate object as one JSON line and sets the exit code so the skill
+    can branch from the terminal:  exit 0 = CREATE, exit 10 = SKIP-duplicate,
+    exit 2 = usage error. The non-zero SKIP code is deliberately distinct from a
+    generic failure so a crashed gate (any other non-zero) is NOT mistaken for a
+    skip — fail-open toward CREATE.
+    """
+    args = list(argv[1:])
+    if not args or args[0] != "decide":
+        print('usage: evolution_pre_submit_triage.py decide "<title>" '
+              "[--repo OWNER/REPO] [--threshold T]", file=sys.stderr)
+        return 2
+    rest = args[1:]
+    title: Optional[str] = None
+    repo = "Lexus2016/hermes-agent-evolution"
+    threshold = DEFAULT_THRESHOLD
+    i = 0
+    while i < len(rest):
+        tok = rest[i]
+        if tok == "--repo" and i + 1 < len(rest):
+            repo = rest[i + 1]
+            i += 2
+        elif tok == "--threshold" and i + 1 < len(rest):
+            try:
+                threshold = float(rest[i + 1])
+            except ValueError:
+                print(f"invalid --threshold: {rest[i + 1]}", file=sys.stderr)
+                return 2
+            i += 2
+        elif title is None:
+            title = tok
+            i += 1
+        else:
+            i += 1
+    if not title:
+        print("missing draft title", file=sys.stderr)
+        return 2
+
+    open_issues = fetch_open_issues(repo)
+    decision = decide({"title": title}, open_issues, threshold=threshold)
+    print(json.dumps(decision.to_dict()))
+    return 10 if decision.decision == "skip_duplicate" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -86,6 +86,31 @@ Create GitHub issues and pull requests based on research.
     or deliberately dropped even when no issue exists for it. Skip silently if the
     tools are absent; never depend on them.
 
+2c. **Deterministic pre-submission gate — shift triage LEFT (#336).** The
+    by-meaning comparison in 2b is a judgement call made in-context; back it with
+    a DETERMINISTIC gate so the CREATE / SKIP-duplicate decision is reproducible
+    and auditable. For EACH surviving proposal, consult the gate BEFORE
+    `gh issue create`. It fetches the currently-OPEN issues itself (via `gh issue
+    list`, behind an injectable seam) and scores the draft title against them:
+    ```bash
+    python scripts/evolution_pre_submit_triage.py decide "<proposal title>" \
+      --repo Lexus2016/hermes-agent-evolution
+    # prints one JSON line: {"decision","matched_issue","score","reason"}
+    # exit 0  = CREATE (proceed to step 3)
+    # exit 10 = SKIP-duplicate (do NOT create; record as considered)
+    ```
+    **CONSERVATIVE RULE — create on doubt (anti-fabrication guard).** The gate
+    SKIPS only on a HIGH-confidence title overlap (Dice >= 0.85) against an
+    **OPEN** issue; every weaker or ambiguous match returns CREATE. This is
+    deliberate: the project's documented failure mode is triage FABRICATING a
+    rejection and wrongly closing a real issue (#83/#101). A wrongful SKIP
+    silently suppresses a genuine proposal; a needless CREATE is cheaply closed
+    by later analysis. So NEVER skip on a weak match — when in doubt, file.
+    On a SKIP, record it as a considered duplicate (step after creation, below)
+    and move on; on CREATE, continue to step 3. (Scope of this gate is dedup
+    against OPEN issues only; coverage/LLM-confidence and per-fork isolation are
+    follow-ups, not part of it.)
+
 3. **Create issues** (only for proposals that survived BOTH 2a and 2b) via the
    `gh` CLI (terminal tool). `gh` is already authorized via persistent `gh auth login`.
 
@@ -229,6 +254,7 @@ the raw text of research sources. Before creating an issue:
 
 Check before creating:
 - [ ] A similar idea has not already been proposed
+- [ ] The deterministic pre-submission gate returned CREATE (exit 0), not SKIP (exit 10)
 - [ ] The issue does not already exist
 - [ ] There is research evidence
 - [ ] There is an implementation plan

--- a/tests/scripts/test_evolution_pre_submit_triage.py
+++ b/tests/scripts/test_evolution_pre_submit_triage.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/evolution_pre_submit_triage.py — shift-left dedup gate (#336).
+
+The gate decides CREATE / SKIP-duplicate for a DRAFT proposal BEFORE
+`gh issue create`, comparing it against the currently-OPEN issues. The
+CRITICAL invariant under test is CONSERVATISM: skip ONLY on a high-confidence
+title overlap; default to CREATE on any doubt. This is the anti-fabrication
+guard — the project's documented past failure mode (#83/#101) was triage
+FABRICATING a rejection and wrongly closing a real issue. A weak/ambiguous
+match must therefore yield CREATE, never SKIP.
+
+Pure + offline: the open-issues list is INJECTED (no network), so these tests
+run with no `gh`.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_pre_submit_triage import (  # noqa: E402
+    DEFAULT_THRESHOLD,
+    GateDecision,
+    decide,
+    similarity,
+)
+
+
+def _issue(number, title, state="open"):
+    return {"number": number, "title": title, "state": state}
+
+
+class TestSimilarity:
+    def test_identical_titles_score_one(self):
+        # Cosmetic-only variants (tag, case, punctuation) normalize to the SAME
+        # canonical token set -> 1.0. Note: stripping "[FIX]" is NOT the same as
+        # the word "fix" surviving, so the tag form and a literal "fix ..." form
+        # are deliberately < 1.0 (see test_tag_strip_is_not_word_fix).
+        assert similarity("[FIX] Web Scraping 403!", "[fix]  web scraping 403.") == 1.0
+
+    def test_tag_strip_is_not_word_fix(self):
+        # Guard the normalization contract: a stripped [TAG] != the bare word.
+        s = similarity("[FIX] web scraping 403", "fix web scraping 403")
+        assert 0.0 < s < 1.0
+
+    def test_disjoint_titles_score_zero(self):
+        assert similarity("add memory cache", "rewrite the cron scheduler") == 0.0
+
+    def test_partial_overlap_between_zero_and_one(self):
+        s = similarity("add LRU memory cache", "add memory cache eviction")
+        assert 0.0 < s < 1.0
+
+    def test_symmetric(self):
+        a = similarity("alpha beta gamma", "beta gamma delta")
+        b = similarity("beta gamma delta", "alpha beta gamma")
+        assert a == b
+
+    def test_empty_titles_are_safe_zero(self):
+        # No tokens -> no evidence of duplication -> 0.0 (never a skip signal).
+        assert similarity("", "anything") == 0.0
+        assert similarity("[TAG]", "") == 0.0
+
+
+class TestDecideSkipOnHighConfidence:
+    def test_exact_duplicate_skips(self):
+        draft = {"title": "[IMPROVEMENT] Per-cycle funnel metrics"}
+        open_issues = [_issue(42, "per-cycle funnel metrics")]
+        d = decide(draft, open_issues)
+        assert isinstance(d, GateDecision)
+        assert d.decision == "skip_duplicate"
+        assert d.matched_issue == 42
+        assert d.score == 1.0
+
+    def test_near_duplicate_above_threshold_skips(self):
+        # Cosmetic word added but the signature is overwhelmingly shared.
+        draft = {"title": "[FEATURE] add hierarchical memory cache with LRU eviction"}
+        open_issues = [_issue(7, "add hierarchical memory cache with LRU eviction now")]
+        d = decide(draft, open_issues)
+        assert d.decision == "skip_duplicate"
+        assert d.matched_issue == 7
+        assert d.score >= DEFAULT_THRESHOLD
+
+    def test_skip_picks_best_of_several(self):
+        draft = {"title": "Add per-cycle funnel metrics dashboard"}
+        open_issues = [
+            _issue(1, "rewrite the cron scheduler"),
+            _issue(2, "add per-cycle funnel metrics dashboard"),  # exact
+            _issue(3, "add some metrics"),
+        ]
+        d = decide(draft, open_issues)
+        assert d.decision == "skip_duplicate"
+        assert d.matched_issue == 2
+
+
+class TestDecideCreateOnDoubt:
+    """The anti-fabrication guard: anything short of a HIGH-confidence overlap
+    must default to CREATE. Never skip on a weak match (#83/#101 lesson)."""
+
+    def test_weak_match_creates_not_skips(self):
+        # Shares only the generic word "metrics" — a weak, ambiguous overlap.
+        draft = {"title": "[FEATURE] Realtime GPU utilization metrics"}
+        open_issues = [_issue(9, "Add per-cycle funnel metrics")]
+        d = decide(draft, open_issues)
+        assert d.decision == "create"
+        assert d.matched_issue is None
+        assert d.score < DEFAULT_THRESHOLD
+
+    def test_ambiguous_partial_overlap_creates(self):
+        # Real, related, but clearly a DIFFERENT proposal — must not be skipped.
+        draft = {"title": "Add retry backoff to provider error handling"}
+        open_issues = [_issue(11, "Add circuit breaker to provider error handling")]
+        d = decide(draft, open_issues)
+        assert d.decision == "create"
+
+    def test_empty_open_issues_creates(self):
+        d = decide({"title": "anything at all"}, [])
+        assert d.decision == "create"
+        assert d.matched_issue is None
+        assert d.score == 0.0
+
+    def test_only_open_issues_considered_for_skip(self):
+        # A CLOSED issue with an exact title must NOT trigger a skip here:
+        # the OPEN-issue dedup scope is the only thing this gate owns; closed/
+        # rejected handling stays in the SKILL.md (and re-filing a closed-as-
+        # rejected idea is a separate, already-covered concern). Default CREATE.
+        draft = {"title": "Exactly the same title"}
+        open_issues = [_issue(5, "exactly the same title", state="closed")]
+        d = decide(draft, open_issues)
+        assert d.decision == "create"
+        assert d.matched_issue is None
+
+    def test_just_below_threshold_creates(self):
+        # Construct a match strictly below threshold -> CREATE (boundary is safe).
+        draft = {"title": "alpha beta gamma delta"}
+        open_issues = [_issue(3, "alpha beta gamma epsilon zeta")]
+        s = similarity(draft["title"], open_issues[0]["title"])
+        assert s < DEFAULT_THRESHOLD, "fixture must sit below threshold"
+        d = decide(draft, open_issues)
+        assert d.decision == "create"
+
+
+class TestDecideThresholdConfigurable:
+    def test_threshold_is_injectable(self):
+        draft = {"title": "alpha beta gamma delta"}
+        open_issues = [_issue(3, "alpha beta gamma epsilon zeta")]
+        s = similarity(draft["title"], open_issues[0]["title"])
+        # With a permissive threshold at/below the score, the SAME pair skips.
+        d = decide(draft, open_issues, threshold=s)
+        assert d.decision == "skip_duplicate"
+        assert d.matched_issue == 3
+
+    def test_default_threshold_is_high(self):
+        # Conservatism is a design constant, not an accident: keep the bar high.
+        assert DEFAULT_THRESHOLD >= 0.8
+
+
+class TestGateDecisionShape:
+    def test_decision_is_serializable_object(self):
+        d = decide({"title": "x y z"}, [])
+        # Structured gate object {decision, matched_issue, score, reason}.
+        as_dict = d.to_dict()
+        assert set(as_dict) == {"decision", "matched_issue", "score", "reason"}
+        assert as_dict["decision"] == "create"
+        assert isinstance(as_dict["reason"], str) and as_dict["reason"]
+
+    def test_draft_title_missing_is_create(self):
+        # A draft with no usable title can't be proven a duplicate -> CREATE.
+        d = decide({}, [_issue(1, "some open issue")])
+        assert d.decision == "create"


### PR DESCRIPTION
Fixes the root cause of GitHub clutter (owner-raised): verify proposals BEFORE `gh issue create`, not after. `scripts/evolution_pre_submit_triage.py`: `decide(draft, open_issues, threshold=0.85)` → CREATE / SKIP-duplicate, reusing `evolution_dedup.normalize_title` (graded Sørensen–Dice on open-issue titles); `fetch_open_issues` behind an injectable runner (offline tests, fails OPEN). Hooked into `evolution-issues/SKILL.md` step 2c. **Create-on-doubt guard**: skips ONLY on ≥0.85 overlap; weak/ambiguous/empty → CREATE — the explicit guard against the past fabricated-rejection failure (#83/#101). Scope: dedup-vs-open only; coverage-check + per-fork isolation are follow-ups. Tests: 18 + dedup/integrity 19 green; ruff+ty clean. Closes #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)