### PR TITLE
test(repo_map): fix file-toolset assertion after #320 added repo_map

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -34,14 +34,15 @@ class TestToolResolution:
     """Verify get_tool_definitions returns all expected tools for eval."""
 
     def test_terminal_and_file_toolsets_resolve_all_tools(self):
-        """enabled_toolsets=['terminal', 'file'] should produce 6 tools."""
+        """enabled_toolsets=['terminal', 'file'] should produce 7 tools."""
         from model_tools import get_tool_definitions
         tools = get_tool_definitions(
             enabled_toolsets=["terminal", "file"],
             quiet_mode=True,
         )
         names = {t["function"]["name"] for t in tools}
-        expected = {"terminal", "process", "read_file", "write_file", "search_files", "patch"}
+        # repo_map joined the `file` toolset in #320 (Python-ast repo overview).
+        expected = {"terminal", "process", "read_file", "write_file", "search_files", "patch", "repo_map"}
         assert expected == names, f"Expected {expected}, got {names}"
 
     def test_terminal_tool_present(self):


### PR DESCRIPTION
#320/PR #335 registered `repo_map` in the `file` toolset, so `get_tool_definitions(['terminal','file'])` now returns 7 tools. `test_modal_sandbox_fixes.py:44` hardcoded the old 6-tool set → regression. Updated. Test-only; 19 passed locally. (This failure was wrongly admin-merged past as a flake when #335 landed — fixing the root.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)