### PR TITLE
feat(delegate): optional collapsed-summary handoff mode (#319)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5407,6 +5407,14 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # Snapshot the live turn messages so a delegate_task call in THIS batch
+        # can optionally collapse parent history into a child's context
+        # (handoff_mode='collapsed_summary', issue #319). This is a plain
+        # reference, written every turn but read ONLY when collapse-mode is
+        # explicitly requested — the default delegation flow never touches it,
+        # so behavior stays byte-identical when no handoff_mode is passed.
+        self._delegate_handoff_messages = messages
+
         # Plan-and-execute (#290): emit the committed plan once, just before the
         # first tool dispatch of a turn. Inert by default — no-op unless an
         # active plan has been set on session state (nothing in the default loop
@@ -5450,6 +5458,7 @@ class AIAgent:
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
             background=function_args.get("background"),
+            handoff_mode=function_args.get("handoff_mode"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_handoff_collapse.py
+++ b/tests/tools/test_handoff_collapse.py
@@ -1,0 +1,337 @@
+"""Tests for the optional handoff collapse-mode (GitHub issue #319).
+
+Context isolation already shipped: children never receive parent history; they
+only get the explicit ``context`` string (``_build_child_system_prompt`` proves
+this). The genuinely-new piece is an OPTIONAL ``handoff_mode='collapsed_summary'``
+that routes the parent's recent conversation through the EXISTING
+``ContextCompressor`` and prepends the summary to each child's ``context``.
+
+These tests pin three contracts:
+
+  1. Default (no handoff_mode)        -> context passed through unchanged.
+  2. collapsed_summary mode           -> parent history compressed into context
+                                         (compressor mocked, never a real call).
+  3. empty / short / no-snapshot      -> no-op, context unchanged.
+
+The compressor's ``_generate_summary`` is always mocked, so no test makes a
+network call.
+"""
+
+import types
+
+import pytest
+
+import tools.delegate_tool as dt
+from tools.delegate_tool import (
+    HANDOFF_MODE_COLLAPSED_SUMMARY,
+    _HANDOFF_COLLAPSE_HEADER,
+    _apply_handoff_collapse,
+    _build_collapsed_handoff_context,
+    _collapsible_parent_turns,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCompressor:
+    """Stand-in for ContextCompressor exposing only ``_generate_summary``."""
+
+    def __init__(self, summary="SUMMARY-OF-PARENT-HISTORY"):
+        self._summary = summary
+        self.calls = []
+
+    def _generate_summary(self, turns, focus_topic=None):
+        self.calls.append(list(turns))
+        return self._summary
+
+
+_DEFAULT_COMPRESSOR = object()  # sentinel: "give me a fresh _FakeCompressor"
+
+
+def _make_parent(messages=None, compressor=_DEFAULT_COMPRESSOR):
+    """Build a minimal parent_agent stub.
+
+    ``messages`` becomes the ``_delegate_handoff_messages`` snapshot; pass None
+    to omit the attribute entirely (simulating a transport that never stashes
+    it). ``compressor`` defaults to a fresh _FakeCompressor; pass None to
+    simulate an agent without a compressor.
+    """
+    parent = types.SimpleNamespace()
+    if messages is not None:
+        parent._delegate_handoff_messages = messages
+    if compressor is _DEFAULT_COMPRESSOR:
+        compressor = _FakeCompressor()
+    parent.context_compressor = compressor
+    return parent
+
+
+def _sample_history():
+    """A realistic multi-turn parent transcript (system + user + assistant)."""
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Refactor the auth module to use JWT."},
+        {"role": "assistant", "content": "Sure, reading auth.py now."},
+        {"role": "user", "content": "Also add a test for token expiry."},
+        # In-flight assistant turn carrying the delegate_task tool call that
+        # triggered this handoff — must be dropped from the collapse input.
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "delegate_task", "arguments": "{}"}}],
+        },
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# 1. Default behavior unchanged (no handoff_mode)
+# --------------------------------------------------------------------------- #
+
+
+def test_no_mode_leaves_context_identical():
+    """handoff_mode=None must not touch any task's context (byte-identical)."""
+    parent = _make_parent(messages=_sample_history())
+    task_list = [
+        {"goal": "do thing", "context": "original-context"},
+        {"goal": "other", "context": None},
+    ]
+
+    _apply_handoff_collapse(task_list, None, parent)
+
+    assert task_list[0]["context"] == "original-context"
+    assert task_list[1]["context"] is None
+    # Compressor must never be consulted when no mode is requested.
+    assert parent.context_compressor.calls == []
+
+
+def test_unknown_mode_is_ignored_no_op():
+    """An unrecognized handoff_mode degrades to today's behavior, not an error."""
+    parent = _make_parent(messages=_sample_history())
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, "manager_decentralized_galaxy_brain", parent)
+
+    assert task_list[0]["context"] == "ctx"
+    assert parent.context_compressor.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# 2. collapsed_summary mode compresses parent history into context
+# --------------------------------------------------------------------------- #
+
+
+def test_collapsed_summary_prepends_summary_to_existing_context():
+    parent = _make_parent(messages=_sample_history())
+    task_list = [{"goal": "g", "context": "caller-context"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    ctx = task_list[0]["context"]
+    # Header + summary present, caller context preserved AFTER it (background
+    # first, foreground last).
+    assert _HANDOFF_COLLAPSE_HEADER in ctx
+    assert "SUMMARY-OF-PARENT-HISTORY" in ctx
+    assert ctx.endswith("caller-context")
+    assert ctx.index("SUMMARY-OF-PARENT-HISTORY") < ctx.index("caller-context")
+    # Compressor consulted exactly once.
+    assert len(parent.context_compressor.calls) == 1
+
+
+def test_collapsed_summary_sets_context_when_none():
+    parent = _make_parent(messages=_sample_history())
+    task_list = [{"goal": "g", "context": None}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    ctx = task_list[0]["context"]
+    assert ctx is not None
+    assert ctx.startswith(_HANDOFF_COLLAPSE_HEADER)
+    assert "SUMMARY-OF-PARENT-HISTORY" in ctx
+
+
+def test_collapsed_summary_strips_system_and_inflight_delegate_turn():
+    """The collapse input must exclude the system prompt and the delegate call."""
+    parent = _make_parent(messages=_sample_history())
+
+    turns = _collapsible_parent_turns(parent)
+
+    roles = [t["role"] for t in turns]
+    assert "system" not in roles  # system prompt dropped
+    # The trailing assistant turn (delegate_task tool call) is dropped.
+    assert not (turns[-1]["role"] == "assistant" and turns[-1].get("tool_calls"))
+    # The substantive user/assistant turns survive.
+    assert any(t["role"] == "user" for t in turns)
+
+
+def test_collapsed_summary_is_generated_once_for_a_batch():
+    """Batch tasks share one summary — the compressor runs once, not per task."""
+    parent = _make_parent(messages=_sample_history())
+    task_list = [
+        {"goal": "a", "context": "ctx-a"},
+        {"goal": "b", "context": "ctx-b"},
+        {"goal": "c", "context": None},
+    ]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert len(parent.context_compressor.calls) == 1
+    for task in task_list:
+        assert "SUMMARY-OF-PARENT-HISTORY" in task["context"]
+    assert task_list[0]["context"].endswith("ctx-a")
+    assert task_list[1]["context"].endswith("ctx-b")
+    assert task_list[2]["context"].startswith(_HANDOFF_COLLAPSE_HEADER)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Empty / short / missing history -> no-op
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_history_is_noop():
+    parent = _make_parent(messages=[])
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+    assert parent.context_compressor.calls == []
+
+
+def test_short_history_below_min_turns_is_noop():
+    """A single substantive turn is too little to be worth summarizing."""
+    # Only the system prompt + one user turn -> after stripping system, 1 turn.
+    parent = _make_parent(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+    )
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+    assert parent.context_compressor.calls == []
+
+
+def test_missing_snapshot_is_noop():
+    """No _delegate_handoff_messages attribute -> safe no-op."""
+    parent = _make_parent(messages=None)  # attribute omitted entirely
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+
+
+def test_missing_compressor_is_noop():
+    parent = _make_parent(messages=_sample_history(), compressor=None)
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+
+
+def test_summary_returning_none_is_noop():
+    """When the compressor fails/returns None, context is left unchanged."""
+    parent = _make_parent(
+        messages=_sample_history(), compressor=_FakeCompressor(summary=None)
+    )
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+
+
+def test_summary_raising_is_swallowed_as_noop():
+    """A compressor exception must never break delegation."""
+
+    class _BoomCompressor:
+        def _generate_summary(self, turns, focus_topic=None):
+            raise RuntimeError("aux provider down")
+
+    parent = _make_parent(messages=_sample_history(), compressor=_BoomCompressor())
+    task_list = [{"goal": "g", "context": "ctx"}]
+
+    _apply_handoff_collapse(task_list, HANDOFF_MODE_COLLAPSED_SUMMARY, parent)
+
+    assert task_list[0]["context"] == "ctx"
+
+
+# --------------------------------------------------------------------------- #
+# Helper-level direct contract
+# --------------------------------------------------------------------------- #
+
+
+def test_build_collapsed_context_returns_existing_on_noop():
+    parent = _make_parent(messages=[])
+    assert _build_collapsed_handoff_context(parent, "keep-me") == "keep-me"
+    assert _build_collapsed_handoff_context(parent, None) is None
+
+
+# --------------------------------------------------------------------------- #
+# 4. Param threading: delegate_task accepts handoff_mode and the schema/registry
+#    handler forward it (default-safe — single-task flow exercised with a stub).
+# --------------------------------------------------------------------------- #
+
+
+def test_delegate_task_signature_accepts_handoff_mode():
+    import inspect
+
+    sig = inspect.signature(dt.delegate_task)
+    assert "handoff_mode" in sig.parameters
+    assert sig.parameters["handoff_mode"].default is None
+
+
+def test_schema_exposes_handoff_mode_enum():
+    props = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert "handoff_mode" in props
+    assert props["handoff_mode"]["enum"] == ["collapsed_summary"]
+
+
+def test_apply_handoff_collapse_called_in_delegate_task(monkeypatch):
+    """delegate_task must invoke the collapse hook (proving wiring), and the
+    default None mode keeps it a no-op."""
+    seen = {}
+
+    def _spy(task_list, handoff_mode, parent_agent):
+        seen["handoff_mode"] = handoff_mode
+        seen["task_list"] = task_list
+
+    monkeypatch.setattr(dt, "_apply_handoff_collapse", _spy)
+    # Short-circuit the heavy child build/run so we only exercise the wiring up
+    # to the collapse hook. Raising a sentinel after the hook lets us assert it
+    # ran without standing up a full child agent.
+    monkeypatch.setattr(dt, "is_spawn_paused", lambda: False)
+
+    class _Sentinel(Exception):
+        pass
+
+    def _boom(*a, **k):
+        raise _Sentinel
+
+    # _build_child_agent runs AFTER _apply_handoff_collapse; blow up there.
+    monkeypatch.setattr(dt, "_build_child_agent", _boom)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda cfg, pa: {
+        "model": "m", "provider": "", "base_url": "", "api_key": "", "api_mode": "",
+        "command": None, "args": None,
+    })
+
+    parent = _make_parent(messages=_sample_history())
+    # Mirror the attributes delegate_task reads before the child build.
+    parent._delegate_depth = 0
+
+    with pytest.raises(_Sentinel):
+        dt.delegate_task(
+            goal="do the thing",
+            context="ctx",
+            handoff_mode=None,
+            parent_agent=parent,
+        )
+
+    assert seen.get("handoff_mode") is None
+    assert seen["task_list"][0]["goal"] == "do the thing"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -805,6 +805,150 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Handoff collapse-mode (GitHub issue #319)
+# ---------------------------------------------------------------------------
+# Context isolation already ships: children NEVER receive parent history
+# (_build_child_system_prompt passes only goal + the explicit `context` string;
+# the schema even tells the model the subagent "knows nothing about your
+# conversation history"). The genuinely-new piece this adds is an OPTIONAL
+# collapse-mode that routes the parent's recent conversation through the
+# EXISTING ContextCompressor and threads the resulting summary into the child's
+# `context` field — a standardized handoff that condenses prior turns into a
+# single background message instead of forcing the model to hand-author it.
+#
+# Default behavior is byte-identical: handoff_mode=None means the helper below
+# is never called and the `context` string reaches the child exactly as before.
+HANDOFF_MODE_COLLAPSED_SUMMARY = "collapsed_summary"
+_VALID_HANDOFF_MODES = frozenset({HANDOFF_MODE_COLLAPSED_SUMMARY})
+
+# A handoff collapse with fewer than this many parent turns is a no-op: there is
+# nothing worth summarizing, and an LLM round-trip would only add latency/cost
+# while producing a summary thinner than the raw turns it replaces.
+_HANDOFF_MIN_TURNS = 2
+
+# Label that introduces the collapsed summary inside the child's context so the
+# child can tell condensed background apart from caller-authored context.
+_HANDOFF_COLLAPSE_HEADER = (
+    "[COLLAPSED PARENT CONVERSATION — background reference only]"
+)
+
+
+def _collapsible_parent_turns(parent_agent) -> List[Dict[str, Any]]:
+    """Return the parent's recent conversation turns eligible for collapse.
+
+    Reads the live turn snapshot the conversation loop stashes on the parent
+    agent (``_delegate_handoff_messages``). Strips the leading ``system``
+    message (the child gets its own focused system prompt) and the trailing
+    assistant message that carries the in-flight ``delegate_task`` tool call
+    (collapsing the call that triggered this handoff into its own context is
+    circular and useless).
+
+    Returns an empty list when no snapshot is available — keeping collapse-mode
+    a safe no-op for callers (tests, ACP transports, custom embeddings) that
+    never populate the snapshot.
+    """
+    snapshot = getattr(parent_agent, "_delegate_handoff_messages", None)
+    if not isinstance(snapshot, list) or not snapshot:
+        return []
+
+    turns = [m for m in snapshot if isinstance(m, dict)]
+    # Drop the system prompt — the child builds its own.
+    if turns and turns[0].get("role") == "system":
+        turns = turns[1:]
+    # Drop a trailing assistant turn that only exists to carry the
+    # delegate_task tool call that triggered this handoff.
+    if turns and turns[-1].get("role") == "assistant" and turns[-1].get("tool_calls"):
+        turns = turns[:-1]
+    return turns
+
+
+def _build_collapsed_handoff_context(
+    parent_agent,
+    existing_context: Optional[str],
+) -> Optional[str]:
+    """Collapse the parent's recent conversation into the child's ``context``.
+
+    Reuses the parent's existing ``ContextCompressor`` (``_generate_summary``)
+    to condense prior turns into a single structured summary, then merges it
+    with any caller-supplied ``context``. Returns ``existing_context`` unchanged
+    when collapse is impossible or unhelpful, so the caller can assign the
+    return value back unconditionally:
+
+      - no compressor on the parent          -> unchanged
+      - fewer than ``_HANDOFF_MIN_TURNS``    -> unchanged (no-op short history)
+      - summarizer returns nothing / errors  -> unchanged (compressor handles
+        its own failures and returns None)
+
+    The collapsed summary is PREPENDED to the existing context: condensed
+    history is background, the caller's explicit context is the foreground the
+    child should act on.
+    """
+    compressor = getattr(parent_agent, "context_compressor", None)
+    if compressor is None or not hasattr(compressor, "_generate_summary"):
+        return existing_context
+
+    turns = _collapsible_parent_turns(parent_agent)
+    if len(turns) < _HANDOFF_MIN_TURNS:
+        return existing_context
+
+    try:
+        summary = compressor._generate_summary(turns)
+    except Exception as exc:  # defensive: a handoff must never break delegation
+        logger.warning(
+            "delegate_task: collapsed-summary handoff failed (%s); "
+            "falling back to caller-supplied context unchanged.",
+            exc,
+        )
+        return existing_context
+
+    if not summary or not str(summary).strip():
+        return existing_context
+
+    collapsed = f"{_HANDOFF_COLLAPSE_HEADER}\n{str(summary).strip()}"
+    if existing_context and str(existing_context).strip():
+        return f"{collapsed}\n\n{str(existing_context).strip()}"
+    return collapsed
+
+
+def _apply_handoff_collapse(
+    task_list: List[Dict[str, Any]],
+    handoff_mode: Optional[str],
+    parent_agent,
+) -> None:
+    """Mutate ``task_list`` in place, collapsing parent history into each task's
+    ``context`` when ``handoff_mode`` requests it.
+
+    No-op (and therefore byte-identical to the historical flow) unless
+    ``handoff_mode == 'collapsed_summary'``. An unknown mode is logged and
+    ignored rather than raising, so a stale/garbled schema value degrades to
+    today's behavior instead of breaking delegation.
+    """
+    if not handoff_mode:
+        return
+    if handoff_mode not in _VALID_HANDOFF_MODES:
+        logger.debug(
+            "delegate_task: ignoring unknown handoff_mode=%r (valid: %s)",
+            handoff_mode, sorted(_VALID_HANDOFF_MODES),
+        )
+        return
+
+    # Generate the collapsed summary ONCE per delegate_task call — the parent
+    # history is identical for every task in a batch, so re-summarizing per task
+    # would multiply LLM cost with no benefit.
+    collapsed = _build_collapsed_handoff_context(parent_agent, None)
+    if collapsed is None:
+        return  # collapse was a no-op; leave every task's context untouched
+
+    header_block = collapsed  # already carries the header + summary
+    for task in task_list:
+        existing = task.get("context")
+        if existing and str(existing).strip():
+            task["context"] = f"{header_block}\n\n{str(existing).strip()}"
+        else:
+            task["context"] = header_block
+
+
 def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
@@ -2386,6 +2530,7 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    handoff_mode: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2399,6 +2544,15 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The optional 'handoff_mode' parameter controls how parent conversation
+    history is handed to children. Default (None) is unchanged: children
+    receive ONLY the explicit ``context`` string and never see parent history.
+    When set to 'collapsed_summary', the parent's recent conversation is
+    condensed via the existing ContextCompressor and prepended to each task's
+    ``context`` as background reference — a standardized handoff that collapses
+    prior turns into a single message instead of forcing the model to
+    hand-author the relevant background.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2509,6 +2663,13 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Handoff collapse-mode (#319): when requested, condense the parent's
+    # recent conversation into each task's `context` via the existing
+    # ContextCompressor. No-op (byte-identical to the historical flow) when
+    # handoff_mode is None/unset, when the parent exposes no history snapshot,
+    # or when there is too little history to be worth summarizing.
+    _apply_handoff_collapse(task_list, handoff_mode, parent_agent)
 
     overall_start = time.monotonic()
     results = []
@@ -3458,6 +3619,22 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "handoff_mode": {
+                "type": "string",
+                "enum": ["collapsed_summary"],
+                "description": (
+                    "Optional handoff strategy for parent conversation history. "
+                    "Omit (default) and children receive ONLY the explicit "
+                    "'context' you write — they never see your conversation "
+                    "history. Set to 'collapsed_summary' to additionally condense "
+                    "your recent conversation into a single background summary "
+                    "(via the same compressor used for context compaction) and "
+                    "prepend it to each task's 'context'. Use it when the subagent "
+                    "genuinely needs the prior discussion as background and "
+                    "hand-writing that context would be lossy or tedious; skip it "
+                    "for self-contained tasks where a focused 'context' is enough."
+                ),
+            },
         },
         "required": [],
     },
@@ -3481,6 +3658,7 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=args.get("background"),
+        handoff_mode=args.get("handoff_mode"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
Note: the issue premise is **partly false** — context isolation already ships (`delegate_tool.py:744` `_build_child_system_prompt` passes only goal+context, never parent history). So scope is just the optional collapse-mode. `handoff_mode="collapsed_summary"` (default None) summarizes the parent's recent turns once per delegate_task via the existing `ContextCompressor._generate_summary`, prepended to each task's context. **Default byte-identical**: `handoff_mode=None` early-returns before any compressor call. Tests: 16; delegate 143 + compressor 96 green. Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)