### PR TITLE
fix(nix): resync npmDepsHash after upstream merge (#352)

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -21,7 +21,7 @@ let
 
   # Single npm deps fetch from the workspace root lockfile.
   # All workspace packages share this derivation.
-  npmDepsHash = "sha256-kbjJksq7limRIYqP3DwI+GNgCXkG96tXcsQqmuEedxo=";
+  npmDepsHash = "sha256-rcZA9b/e02qQOvurztSkpQWrGyS2QL8pn0Jc8wuGs2c=";
 
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;


### PR DESCRIPTION
Mechanical follow-up to PR #352. The upstream sync changed `package-lock.json`, leaving the pinned `npmDepsHash` in `nix/lib.nix` stale → the `nix` flake-check failed (advisory, but the nix build on main is broken until this lands).

Bumped `nix/lib.nix:24` to the hash `fetchNpmDeps` actually computes for the merged lockfile: `sha256-rcZA9b/e02qQOvurztSkpQWrGyS2QL8pn0Jc8wuGs2c=` (the authoritative `got:` from CI — `fix-lockfiles` itself overrides the `prefetch-npm-deps` guess with this). No `package-lock.json` change. The `nix` check on this PR is the verification oracle.