### PR TITLE
fix(provider): fail fast on non-retryable errors, improve 429 fallback, suppress duplicate dumps (Closes #366, Closes #363, Closes #364, Closes #367)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -23,6 +23,7 @@ Methods covered:
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -33,11 +34,19 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
-from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
+from agent.tool_dispatch_helpers import (
+    _trajectory_normalize_msg,
+    make_tool_result_message,
+)
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
-from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_var_enabled,
+    atomic_json_write,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,33 +54,44 @@ logger = logging.getLogger(__name__)
 def _ra():
     """Lazy ``run_agent`` reference for test-patch routing."""
     import run_agent
+
     return run_agent
 
 
-AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
-)
+AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset({
+    "todo",
+    "session_search",
+    "memory",
+    "clarify",
+    "read_terminal",
+    "delegate_task",
+})
 
 
 def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
     """Return True when an agent-level tool path emits its own post hook."""
     if function_name in AGENT_RUNTIME_POST_HOOK_TOOL_NAMES:
         return True
-    if getattr(agent, "_context_engine_tool_names", None) and function_name in agent._context_engine_tool_names:
+    if (
+        getattr(agent, "_context_engine_tool_names", None)
+        and function_name in agent._context_engine_tool_names
+    ):
         return True
     memory_manager = getattr(agent, "_memory_manager", None)
     return bool(memory_manager and memory_manager.has_tool(function_name))
 
 
-def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+def convert_to_trajectory_format(
+    agent, messages: List[Dict[str, Any]], user_query: str, completed: bool
+) -> List[Dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
-    
+
     Args:
         messages (List[Dict]): Internal message history
         user_query (str): Original user query
         completed (bool): Whether the conversation completed successfully
-        
+
     Returns:
         List[Dict]: Messages in trajectory format
     """
@@ -80,7 +100,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
     # embedding ~1MB base64 blobs into every saved trajectory.
     messages = [_trajectory_normalize_msg(m) for m in messages]
     trajectory = []
-    
+
     # Add system message with tool definitions
     system_msg = (
         "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
@@ -95,71 +115,69 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
         "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
         "Example:\n<tool_call>\n{'name': <function-name>,'arguments': <args-dict>}\n</tool_call>"
     )
-    
-    trajectory.append({
-        "from": "system",
-        "value": system_msg
-    })
-    
+
+    trajectory.append({"from": "system", "value": system_msg})
+
     # Add the actual user prompt (from the dataset) as the first human message
-    trajectory.append({
-        "from": "human",
-        "value": user_query
-    })
-    
+    trajectory.append({"from": "human", "value": user_query})
+
     # Skip the first message (the user query) since we already added it above.
     # Prefill messages are injected at API-call time only (not in the messages
     # list), so no offset adjustment is needed here.
     i = 1
-    
+
     while i < len(messages):
         msg = messages[i]
-        
+
         if msg["role"] == "assistant":
             # Check if this message has tool calls
             if "tool_calls" in msg and msg["tool_calls"]:
                 # Format assistant message with tool calls
                 # Add <think> tags around reasoning for trajectory storage
                 content = ""
-                
+
                 # Prepend reasoning in <think> tags if available (native thinking tokens)
                 if msg.get("reasoning") and msg["reasoning"].strip():
                     content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                
+
                 if msg.get("content") and msg["content"].strip():
                     # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                     # (used when native thinking is disabled and model reasons via XML)
                     content += convert_scratchpad_to_think(msg["content"]) + "\n"
-                
+
                 # Add tool calls wrapped in XML tags
                 for tool_call in msg["tool_calls"]:
-                    if not tool_call or not isinstance(tool_call, dict): continue
+                    if not tool_call or not isinstance(tool_call, dict):
+                        continue
                     # Parse arguments - should always succeed since we validate during conversation
                     # but keep try-except as safety net
                     try:
-                        arguments = json.loads(tool_call["function"]["arguments"]) if isinstance(tool_call["function"]["arguments"], str) else tool_call["function"]["arguments"]
+                        arguments = (
+                            json.loads(tool_call["function"]["arguments"])
+                            if isinstance(tool_call["function"]["arguments"], str)
+                            else tool_call["function"]["arguments"]
+                        )
                     except json.JSONDecodeError:
                         # This shouldn't happen since we validate and retry during conversation,
                         # but if it does, log warning and use empty dict
-                        logger.warning(f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}")
+                        logger.warning(
+                            f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}"
+                        )
                         arguments = {}
-                    
+
                     tool_call_json = {
                         "name": tool_call["function"]["name"],
-                        "arguments": arguments
+                        "arguments": arguments,
                     }
                     content += f"<tool_call>\n{json.dumps(tool_call_json, ensure_ascii=False)}\n</tool_call>\n"
-                
+
                 # Ensure every gpt turn has a <think> block (empty if no reasoning)
                 # so the format is consistent for training data
                 if "<think>" not in content:
                     content = "<think>\n</think>\n" + content
-                
-                trajectory.append({
-                    "from": "gpt",
-                    "value": content.rstrip()
-                })
-                
+
+                trajectory.append({"from": "gpt", "value": content.rstrip()})
+
                 # Collect all subsequent tool responses
                 tool_responses = []
                 j = i + 1
@@ -167,7 +185,7 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                     tool_msg = messages[j]
                     # Format tool response with XML tags
                     tool_response = "<tool_response>\n"
-                    
+
                     # Try to parse tool content as JSON if it looks like JSON
                     tool_content = tool_msg["content"]
                     try:
@@ -175,63 +193,59 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
                             tool_content = json.loads(tool_content)
                     except (json.JSONDecodeError, AttributeError):
                         pass  # Keep as string if not valid JSON
-                    
+
                     tool_index = len(tool_responses)
                     tool_name = (
                         msg["tool_calls"][tool_index]["function"]["name"]
                         if tool_index < len(msg["tool_calls"])
                         else "unknown"
                     )
-                    tool_response += json.dumps({
-                        "tool_call_id": tool_msg.get("tool_call_id", ""),
-                        "name": tool_name,
-                        "content": tool_content
-                    }, ensure_ascii=False)
+                    tool_response += json.dumps(
+                        {
+                            "tool_call_id": tool_msg.get("tool_call_id", ""),
+                            "name": tool_name,
+                            "content": tool_content,
+                        },
+                        ensure_ascii=False,
+                    )
                     tool_response += "\n</tool_response>"
                     tool_responses.append(tool_response)
                     j += 1
-                
+
                 # Add all tool responses as a single message
                 if tool_responses:
                     trajectory.append({
                         "from": "tool",
-                        "value": "\n".join(tool_responses)
+                        "value": "\n".join(tool_responses),
                     })
                     i = j - 1  # Skip the tool messages we just processed
-            
+
             else:
                 # Regular assistant message without tool calls
                 # Add <think> tags around reasoning for trajectory storage
                 content = ""
-                
+
                 # Prepend reasoning in <think> tags if available (native thinking tokens)
                 if msg.get("reasoning") and msg["reasoning"].strip():
                     content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                
+
                 # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                 # (used when native thinking is disabled and model reasons via XML)
                 raw_content = msg["content"] or ""
                 content += convert_scratchpad_to_think(raw_content)
-                
+
                 # Ensure every gpt turn has a <think> block (empty if no reasoning)
                 if "<think>" not in content:
                     content = "<think>\n</think>\n" + content
-                
-                trajectory.append({
-                    "from": "gpt",
-                    "value": content.strip()
-                })
-        
-        elif msg["role"] == "user":
-            trajectory.append({
-                "from": "human",
-                "value": msg["content"]
-            })
-        
-        i += 1
-    
-    return trajectory
 
+                trajectory.append({"from": "gpt", "value": content.strip()})
+
+        elif msg["role"] == "user":
+            trajectory.append({"from": "human", "value": msg["content"]})
+
+        i += 1
+
+    return trajectory
 
 
 def sanitize_tool_call_arguments(
@@ -316,7 +330,10 @@ def sanitize_tool_call_arguments(
                 scan_index = message_index + 1
                 while scan_index < len(messages):
                     candidate = messages[scan_index]
-                    if not isinstance(candidate, dict) or candidate.get("role") != "tool":
+                    if (
+                        not isinstance(candidate, dict)
+                        or candidate.get("role") != "tool"
+                    ):
                         break
                     if candidate.get("tool_call_id") == tool_call_id:
                         existing_tool_msg = candidate
@@ -341,7 +358,6 @@ def sanitize_tool_call_arguments(
         message_index += 1
 
     return repaired
-
 
 
 def repair_message_sequence(agent, messages: List[Dict]) -> int:
@@ -391,7 +407,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
-            for tc in (msg.get("tool_calls") or []):
+            for tc in msg.get("tool_calls") or []:
                 tc_id = tc.get("id") if isinstance(tc, dict) else None
                 if tc_id:
                     known_tool_ids.add(tc_id)
@@ -493,12 +509,9 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
                 1 for m in messages if id(m) in pre_repair_flushed_ids
             )
         else:
-            agent._last_flushed_db_idx = min(
-                agent._last_flushed_db_idx, len(messages)
-            )
+            agent._last_flushed_db_idx = min(agent._last_flushed_db_idx, len(messages))
 
     return repairs
-
 
 
 def strip_think_blocks(agent, content: str) -> str:
@@ -537,19 +550,37 @@ def strip_think_blocks(agent, content: str) -> str:
     # 1. Closed tag pairs — case-insensitive for all variants so
     #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
     #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    content = re.sub(
+        r"<think>.*?</think>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<thinking>.*?</thinking>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<reasoning>.*?</reasoning>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    content = re.sub(
+        r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>",
+        "",
+        content,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    content = re.sub(
+        r"<thought>.*?</thought>", "", content, flags=re.DOTALL | re.IGNORECASE
+    )
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
-    for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                      "function_call", "function_calls"):
+    for _tc_name in (
+        "tool_call",
+        "tool_calls",
+        "tool_result",
+        "function_call",
+        "function_calls",
+    ):
         content = re.sub(
-            rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
-            '',
+            rf"<{_tc_name}\b[^>]*>.*?</{_tc_name}>",
+            "",
             content,
             flags=re.DOTALL | re.IGNORECASE,
         )
@@ -559,10 +590,10 @@ def strip_think_blocks(agent, content: str) -> str:
     #     punctuation) AND carries a name="..." attribute. This keeps
     #     prose mentions like "Use <function> to declare" safe.
     content = re.sub(
-        r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
-        r'<function\b[^>]*\bname\s*=[^>]*>'
-        r'(?:(?:(?!</function>).)*)</function>',
-        '',
+        r"(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*"
+        r"<function\b[^>]*\bname\s*=[^>]*>"
+        r"(?:(?:(?!</function>).)*)</function>",
+        "",
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
@@ -571,15 +602,15 @@ def strip_think_blocks(agent, content: str) -> str:
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
     content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
-        '',
+        r"(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$",
+        "",
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
     content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
-        '',
+        r"</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*",
+        "",
         content,
         flags=re.IGNORECASE,
     )
@@ -588,13 +619,12 @@ def strip_think_blocks(agent, content: str) -> str:
     #     during streaming may still be valuable to the user; matches
     #     OpenClaw's intentional asymmetry.)
     content = re.sub(
-        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
-        '',
+        r"</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*",
+        "",
         content,
         flags=re.IGNORECASE,
     )
     return content
-
 
 
 def recover_with_credential_pool(
@@ -647,6 +677,7 @@ def recover_with_credential_pool(
         if current_provider == "custom" and pool_provider.startswith("custom:"):
             try:
                 from agent.credential_pool import get_custom_provider_pool_key
+
                 _agent_base = (getattr(agent, "base_url", "") or "").strip()
                 _custom_match = bool(_agent_base) and (
                     (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
@@ -658,7 +689,8 @@ def recover_with_credential_pool(
             _ra().logger.warning(
                 "Credential pool provider mismatch: pool=%s, agent=%s — "
                 "skipping pool mutation to avoid cross-provider contamination",
-                pool_provider, current_provider,
+                pool_provider,
+                current_provider,
             )
             return False, has_retried_429
 
@@ -673,7 +705,9 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (billing) — rotated to pool entry %s",
@@ -690,14 +724,18 @@ def recover_with_credential_pool(
         # where has_retried_429 (a local var) gets reset on each new prompt,
         # causing the pool to retry the same exhausted credential forever.
         current_entry = pool.current()
-        current_last_status = getattr(current_entry, "last_status", None) if current_entry else None
+        current_last_status = (
+            getattr(current_entry, "last_status", None) if current_entry else None
+        )
         if current_last_status == STATUS_EXHAUSTED:
             _ra().logger.info(
                 "Credential already exhausted (last_status=%s) — rotating immediately instead of retrying",
                 current_last_status,
             )
             rotate_status = status_code if status_code is not None else 429
-            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=rotate_status, error_context=error_context
+            )
             if next_entry is not None:
                 _ra().logger.info(
                     "Credential %s (rate limit, pre-exhausted) — rotated to pool entry %s",
@@ -721,7 +759,9 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -763,7 +803,8 @@ def recover_with_credential_pool(
         if (
             not is_entitlement
             and status_code == 403
-            and "oauth authentication is currently not allowed for this organization" in _auth_haystack
+            and "oauth authentication is currently not allowed for this organization"
+            in _auth_haystack
         ):
             is_entitlement = True
         if (
@@ -773,7 +814,11 @@ def recover_with_credential_pool(
             and getattr(agent, "api_mode", "") == "anthropic_messages"
         ):
             is_entitlement = True
-        if not is_entitlement and status_code == 403 and (agent.provider or "") == "xai-oauth":
+        if (
+            not is_entitlement
+            and status_code == 403
+            and (agent.provider or "") == "xai-oauth"
+        ):
             _is_xai_auth_failure = (
                 "[wke=unauthenticated:" in _auth_haystack
                 or "oauth2 access token could not be validated" in _auth_haystack
@@ -791,13 +836,17 @@ def recover_with_credential_pool(
             return False, has_retried_429
         refreshed = pool.try_refresh_current()
         if refreshed is not None:
-            _ra().logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
+            _ra().logger.info(
+                f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}"
+            )
             agent._swap_credential(refreshed)
             return True, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status, error_context=error_context
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",
@@ -810,9 +859,12 @@ def recover_with_credential_pool(
     return False, has_retried_429
 
 
-
 def try_recover_primary_transport(
-    agent, api_error: Exception, *, retry_count: int, max_retries: int,
+    agent,
+    api_error: Exception,
+    *,
+    retry_count: int,
+    max_retries: int,
 ) -> bool:
     """Attempt one extra primary-provider recovery cycle for transient transport failures.
 
@@ -846,7 +898,9 @@ def try_recover_primary_transport(
         if getattr(agent, "client", None) is not None:
             try:
                 agent._close_openai_client(
-                    agent.client, reason="primary_recovery", shared=True,
+                    agent.client,
+                    reason="primary_recovery",
+                    shared=True,
                 )
             except Exception:
                 pass
@@ -864,10 +918,12 @@ def try_recover_primary_transport(
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
+
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
+                rt["anthropic_api_key"],
+                rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
@@ -891,8 +947,8 @@ def try_recover_primary_transport(
         logger.warning("Primary transport recovery failed: %s", e)
         return False
 
-# ── End provider fallback ──────────────────────────────────────────────
 
+# ── End provider fallback ──────────────────────────────────────────────
 
 
 def drop_thinking_only_and_merge_users(
@@ -921,7 +977,8 @@ def drop_thinking_only_and_merge_users(
 
     # Pass 1: drop thinking-only assistant turns.
     kept = [
-        m for m in messages
+        m
+        for m in messages
         if not _ra().AIAgent._is_thinking_only_assistant(
             m,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
@@ -936,11 +993,7 @@ def drop_thinking_only_and_merge_users(
     merges = 0
     for m in kept:
         prev = merged[-1] if merged else None
-        if (
-            prev is not None
-            and prev.get("role") == "user"
-            and m.get("role") == "user"
-        ):
+        if prev is not None and prev.get("role") == "user" and m.get("role") == "user":
             prev_content = prev.get("content", "")
             cur_content = m.get("content", "")
             # Work on a copy of ``prev`` so the caller's input dicts are
@@ -988,7 +1041,6 @@ def drop_thinking_only_and_merge_users(
     return merged
 
 
-
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -1019,7 +1071,7 @@ def restore_primary_runtime(agent) -> bool:
         # ── Core runtime state ──
         agent.model = rt["model"]
         agent.provider = rt["provider"]
-        agent.base_url = rt["base_url"]           # setter updates _base_url_lower
+        agent.base_url = rt["base_url"]  # setter updates _base_url_lower
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -1036,10 +1088,12 @@ def restore_primary_runtime(agent) -> bool:
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
+
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
+                rt["anthropic_api_key"],
+                rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
@@ -1068,61 +1122,72 @@ def restore_primary_runtime(agent) -> bool:
 
         logger.info(
             "Primary runtime restored for new turn: %s (%s)",
-            agent.model, agent.provider,
+            agent.model,
+            agent.provider,
         )
         return True
     except Exception as e:
         logger.warning("Failed to restore primary runtime: %s", e)
         return False
 
+
 # Which error types indicate a transient transport failure worth
 # one more attempt with a rebuilt client / connection pool.
 _TRANSIENT_TRANSPORT_ERRORS = frozenset({
-    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
-    "ConnectError", "RemoteProtocolError",
-    "APIConnectionError", "APITimeoutError",
+    "ReadTimeout",
+    "ConnectTimeout",
+    "PoolTimeout",
+    "ConnectError",
+    "RemoteProtocolError",
+    "APIConnectionError",
+    "APITimeoutError",
 })
-
 
 
 def extract_reasoning(agent, assistant_message) -> Optional[str]:
     """
     Extract reasoning/thinking content from an assistant message.
-    
+
     OpenRouter and various providers can return reasoning in multiple formats:
     1. message.reasoning - Direct reasoning field (DeepSeek, Qwen, etc.)
     2. message.reasoning_content - Alternative field (Moonshot AI, Novita, etc.)
     3. message.reasoning_details - Array of {type, summary, ...} objects (OpenRouter unified)
-    
+
     Args:
         assistant_message: The assistant message object from the API response
-        
+
     Returns:
         Combined reasoning text, or None if no reasoning found
     """
     reasoning_parts = []
-    
+
     # Check direct reasoning field
-    if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
+    if hasattr(assistant_message, "reasoning") and assistant_message.reasoning:
         reasoning_parts.append(assistant_message.reasoning)
-    
+
     # Check reasoning_content field (alternative name used by some providers)
-    if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
+    if (
+        hasattr(assistant_message, "reasoning_content")
+        and assistant_message.reasoning_content
+    ):
         # Don't duplicate if same as reasoning
         if assistant_message.reasoning_content not in reasoning_parts:
             reasoning_parts.append(assistant_message.reasoning_content)
-    
+
     # Check reasoning_details array (OpenRouter unified format)
     # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
-    if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+    if (
+        hasattr(assistant_message, "reasoning_details")
+        and assistant_message.reasoning_details
+    ):
         for detail in assistant_message.reasoning_details:
             if isinstance(detail, dict):
                 # Extract summary from reasoning detail object
                 summary = (
-                    detail.get('summary')
-                    or detail.get('thinking')
-                    or detail.get('content')
-                    or detail.get('text')
+                    detail.get("summary")
+                    or detail.get("thinking")
+                    or detail.get("content")
+                    or detail.get("text")
                 )
                 if summary and summary not in reasoning_parts:
                     reasoning_parts.append(summary)
@@ -1158,13 +1223,12 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
                 cleaned = block.strip()
                 if cleaned and cleaned not in reasoning_parts:
                     reasoning_parts.append(cleaned)
-    
+
     # Combine all reasoning parts
     if reasoning_parts:
         return "\n\n".join(reasoning_parts)
-    
-    return None
 
+    return None
 
 
 def dump_api_request_debug(
@@ -1224,10 +1288,14 @@ def dump_api_request_debug(
             response_obj = getattr(error, "response", None)
             if response_obj is not None:
                 try:
-                    error_info["response_status"] = getattr(response_obj, "status_code", None)
+                    error_info["response_status"] = getattr(
+                        response_obj, "status_code", None
+                    )
                     error_info["response_text"] = response_obj.text
                 except Exception as e:
-                    _ra().logger.debug("Could not extract error response details: %s", e)
+                    _ra().logger.debug(
+                        "Could not extract error response details: %s", e
+                    )
 
             # Structured failure category from the shared classifier (#236): so a
             # RuntimeError and a BadRequestError from the same model no longer look
@@ -1249,6 +1317,32 @@ def dump_api_request_debug(
 
             dump_payload["error"] = error_info
 
+            # ── Suppress duplicate dumps of identical failing payloads ─────
+            # Re-dumping the same ~1 MB request on every retry against a
+            # dead endpoint wastes disk I/O and can leak identical secrets
+            # repeatedly.  Cache the last dump per (session, failure category,
+            # request body hash) tuple and skip if the same dump was written
+            # within 60 seconds.
+            _body_for_hash = json.dumps(body, sort_keys=True, default=str)
+            _body_hash = hashlib.sha256(_body_for_hash.encode("utf-8")).hexdigest()[:32]
+            _failure_category = error_info.get("failure_category", "unknown")
+            _dump_cache_key = (agent.session_id, _failure_category, _body_hash)
+            _dump_cache = getattr(agent, "_request_dump_cache", None)
+            if _dump_cache is None:
+                _dump_cache = {}
+                agent._request_dump_cache = _dump_cache
+            _now = time.time()
+            _last_dump_time = _dump_cache.get(_dump_cache_key)
+            if _last_dump_time is not None and (_now - _last_dump_time) < 60:
+                _ra().logger.info(
+                    "Suppressing duplicate request dump for session %s (%s, %s) within 60s",
+                    agent.session_id,
+                    _failure_category,
+                    _body_hash,
+                )
+                return None
+            _dump_cache[_dump_cache_key] = _now
+
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
 
@@ -1260,21 +1354,27 @@ def dump_api_request_debug(
         # output, then hand the resulting payload back to the shared atomic
         # JSON writer so request dumps keep the same write semantics as before.
         from agent.redact import redact_sensitive_text
-        _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
+
+        _serialized = json.dumps(
+            dump_payload, ensure_ascii=False, indent=2, default=str
+        )
         _redacted_payload = json.loads(redact_sensitive_text(_serialized, force=True))
         atomic_json_write(dump_file, _redacted_payload, default=str)
 
-        agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
+        agent._vprint(
+            f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}"
+        )
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):
-            print(json.dumps(_redacted_payload, ensure_ascii=False, indent=2, default=str))
+            print(
+                json.dumps(_redacted_payload, ensure_ascii=False, indent=2, default=str)
+            )
 
         return dump_file
     except Exception as dump_error:
         if agent.verbose_logging:
             logger.warning(f"Failed to dump API request debug payload: {dump_error}")
         return None
-
 
 
 def anthropic_prompt_cache_policy(
@@ -1324,9 +1424,9 @@ def anthropic_prompt_cache_policy(
     # OpenRouter-equivalent endpoint for caching layout purposes.
     is_nous_portal = "nousresearch" in eff_base_url.lower()
     is_anthropic_wire = eff_api_mode == "anthropic_messages"
-    is_native_anthropic = (
-        is_anthropic_wire
-        and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")
+    is_native_anthropic = is_anthropic_wire and (
+        eff_provider == "anthropic"
+        or base_url_hostname(eff_base_url) == "api.anthropic.com"
     )
 
     if is_native_anthropic:
@@ -1357,10 +1457,9 @@ def anthropic_prompt_cache_policy(
     # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
     if is_anthropic_wire:
         is_minimax_provider = provider_lower in {"minimax", "minimax-cn"}
-        is_minimax_host = (
-            base_url_host_matches(eff_base_url, "api.minimax.io")
-            or base_url_host_matches(eff_base_url, "api.minimaxi.com")
-        )
+        is_minimax_host = base_url_host_matches(
+            eff_base_url, "api.minimax.io"
+        ) or base_url_host_matches(eff_base_url, "api.minimaxi.com")
         if is_minimax_provider or is_minimax_host:
             return True, True
 
@@ -1371,7 +1470,10 @@ def anthropic_prompt_cache_policy(
     # through the subscription on every turn.
     model_is_qwen = "qwen" in model_lower
     provider_is_alibaba_family = provider_lower in {
-        "opencode", "opencode-zen", "opencode-go", "alibaba",
+        "opencode",
+        "opencode-zen",
+        "opencode-go",
+        "alibaba",
     }
     if provider_is_alibaba_family and model_is_qwen:
         # Envelope layout (native_anthropic=False): markers on inner
@@ -1382,9 +1484,11 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
-
-def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+def create_openai_client(
+    agent, client_kwargs: dict, *, reason: str, shared: bool
+) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+
     # Treat client_kwargs as read-only. Callers pass agent._client_kwargs (or shallow
     # copies of it) in; any in-place mutation leaks back into the stored dict and is
     # reused on subsequent requests. #10933 hit this by injecting an httpx.Client
@@ -1396,7 +1500,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if agent.provider == "copilot-acp" or str(
+        client_kwargs.get("base_url", "")
+    ).startswith("acp://copilot"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
@@ -1407,12 +1513,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
-    if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
+    if agent.provider == "google-gemini-cli" or str(
+        client_kwargs.get("base_url", "")
+    ).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 
         # Strip OpenAI-specific kwargs the Gemini client doesn't accept
         safe_kwargs = {
-            k: v for k, v in client_kwargs.items()
+            k: v
+            for k, v in client_kwargs.items()
             if k in {"api_key", "base_url", "default_headers", "project_id", "timeout"}
         }
         client = GeminiCloudCodeClient(**safe_kwargs)
@@ -1424,13 +1533,18 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         )
         return client
     if agent.provider == "gemini":
-        from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
+        from agent.gemini_native_adapter import (
+            GeminiNativeClient,
+            is_native_gemini_base_url,
+        )
 
         base_url = str(client_kwargs.get("base_url", "") or "")
         if is_native_gemini_base_url(base_url):
             safe_kwargs = {
-                k: v for k, v in client_kwargs.items()
-                if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
+                k: v
+                for k, v in client_kwargs.items()
+                if k
+                in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
             }
             if "http_client" not in safe_kwargs:
                 keepalive_http = agent._build_keepalive_http_client(base_url)
@@ -1462,7 +1576,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
     if "http_client" not in client_kwargs:
-        keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""))
+        keepalive_http = agent._build_keepalive_http_client(
+            client_kwargs.get("base_url", "")
+        )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
     # Uses the module-level `OpenAI` name, resolved lazily on first
@@ -1477,7 +1593,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(agent, new_model, new_provider, api_key="", base_url="", api_mode=""):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -1575,21 +1691,32 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 resolve_anthropic_token,
                 _is_oauth_token,
             )
+
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
             # API key — falling back would send Anthropic credentials to third-party endpoints.
             _is_native_anthropic = new_provider == "anthropic"
-            effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
+            effective_key = (
+                (api_key or agent.api_key or resolve_anthropic_token() or "")
+                if _is_native_anthropic
+                else (api_key or agent.api_key or "")
+            )
 
             # MiniMax OAuth: swap static string for a per-request callable token
             # provider so the rebuilt client survives 15-min token expiry. See
             # the matching block in agent_init.py for the full rationale.
-            if new_provider == "minimax-oauth" and isinstance(effective_key, str) and effective_key:
+            if (
+                new_provider == "minimax-oauth"
+                and isinstance(effective_key, str)
+                and effective_key
+            ):
                 try:
                     from hermes_cli.auth import build_minimax_oauth_token_provider
+
                     effective_key = build_minimax_oauth_token_provider()
                 except Exception as _mm_exc:  # noqa: BLE001
                     import logging as _logging
+
                     _logging.getLogger(__name__).warning(
                         "MiniMax OAuth: failed to install per-request token provider "
                         "on switch (%s); using static bearer.",
@@ -1598,12 +1725,19 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
-            agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
+            agent._anthropic_base_url = base_url or getattr(
+                agent, "_anthropic_base_url", None
+            )
             agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url,
+                effective_key,
+                agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
-            agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
+            agent._is_anthropic_oauth = (
+                _is_oauth_token(effective_key)
+                if (_is_native_anthropic and isinstance(effective_key, str))
+                else False
+            )
             agent.client = None
             agent._client_kwargs = {}
         else:
@@ -1653,12 +1787,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Update context compressor ──
     if hasattr(agent, "context_compressor") and agent.context_compressor:
         from agent.model_metadata import get_model_context_length
+
         # Re-read custom_providers from live config so per-model
         # context_length overrides are honored when switching to a
         # custom provider mid-session (closes #15779).
         _sm_custom_providers = None
         try:
             from hermes_cli.config import load_config, get_compatible_custom_providers
+
             _sm_cfg = load_config()
             _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
         except Exception:
@@ -1690,7 +1826,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     agent._cached_system_prompt = None
 
     # ── Update _primary_runtime so the change persists across turns ──
-    _cc = agent.context_compressor if hasattr(agent, "context_compressor") and agent.context_compressor else None
+    _cc = (
+        agent.context_compressor
+        if hasattr(agent, "context_compressor") and agent.context_compressor
+        else None
+    )
     agent._primary_runtime = {
         "model": agent.model,
         "provider": agent.provider,
@@ -1701,11 +1841,17 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
-        "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
+        "compressor_base_url": getattr(_cc, "base_url", agent.base_url)
+        if _cc
+        else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
-        "compressor_provider": getattr(_cc, "provider", agent.provider) if _cc else agent.provider,
+        "compressor_provider": getattr(_cc, "provider", agent.provider)
+        if _cc
+        else agent.provider,
         "compressor_context_length": _cc.context_length if _cc else 0,
-        "compressor_api_mode": getattr(_cc, "api_mode", agent.api_mode) if _cc else agent.api_mode,
+        "compressor_api_mode": getattr(_cc, "api_mode", agent.api_mode)
+        if _cc
+        else agent.api_mode,
         "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
     }
     if api_mode == "anthropic_messages":
@@ -1731,7 +1877,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
     if old_norm and new_norm and old_norm != new_norm:
         fallback_chain = [
-            entry for entry in fallback_chain
+            entry
+            for entry in fallback_chain
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
         ]
     agent._fallback_chain = fallback_chain
@@ -1739,16 +1886,24 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",
-        old_model, old_provider, new_model, new_provider,
+        old_model,
+        old_provider,
+        new_model,
+        new_provider,
     )
 
 
-
-def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
-                 tool_call_id: Optional[str] = None, messages: list = None,
-                 pre_tool_block_checked: bool = False,
-                 skip_tool_request_middleware: bool = False,
-                 tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None) -> str:
+def invoke_tool(
+    agent,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: Optional[str] = None,
+    messages: list = None,
+    pre_tool_block_checked: bool = False,
+    skip_tool_request_middleware: bool = False,
+    tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
+) -> str:
     """Invoke a single tool and return the result string. No display logic.
 
     Handles both agent-level tools (todo, memory, etc.) and registry-dispatched
@@ -1782,6 +1937,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     if not pre_tool_block_checked:
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
+
             block_message = get_pre_tool_call_block_message(
                 function_name,
                 function_args,
@@ -1798,6 +1954,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         result = json.dumps({"error": block_message}, ensure_ascii=False)
         try:
             from model_tools import _emit_post_tool_call_hook
+
             _emit_post_tool_call_hook(
                 function_name=function_name,
                 function_args=function_args,
@@ -1819,11 +1976,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     # Check cache first for read-style tools
     cache_hit = False
     cached_result = None
-    
+
     try:
         from tools.tool_cache import get_global_cache
+
         cache = get_global_cache()
-        
+
         # Try to get from cache
         cached_result = cache.get(function_name, function_args, effective_task_id)
         if cached_result is not None:
@@ -1831,6 +1989,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             # Emit post-tool hook for cache hit (with 0 duration)
             try:
                 from model_tools import _emit_post_tool_call_hook
+
                 _emit_post_tool_call_hook(
                     function_name=function_name,
                     function_args=function_args,
@@ -1846,31 +2005,33 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 )
             except Exception:
                 pass
-            
+
             return cached_result
     except Exception:
         # Cache failure should not block tool execution
         pass
-    
+
     tool_start_time = time.monotonic()
 
     def _finish_agent_tool(result: Any, observed_args: Optional[dict] = None) -> Any:
         hook_args = observed_args if isinstance(observed_args, dict) else function_args
-        
+
         # Cache the result if applicable
         try:
             from tools.tool_cache import get_global_cache
+
             cache = get_global_cache()
-            
+
             if not cache_hit:
                 cache.set(function_name, function_args, result, effective_task_id)
                 # Run invalidation for side effects
                 cache.invalidate(function_name, function_args, effective_task_id)
         except Exception:
             pass
-        
+
         try:
             from model_tools import _emit_post_tool_call_hook
+
             _emit_post_tool_call_hook(
                 function_name=function_name,
                 function_args=hook_args,
@@ -1888,8 +2049,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         return result
 
     if function_name == "todo":
+
         def _execute(next_args: dict) -> Any:
             from tools.todo_tool import todo_tool as _todo_tool
+
             return _finish_agent_tool(
                 _todo_tool(
                     todos=next_args.get("todos"),
@@ -1898,13 +2061,23 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+
     elif function_name == "session_search":
+
         def _execute(next_args: dict) -> Any:
             session_db = agent._get_session_db_for_recall()
             if not session_db:
                 from hermes_state import format_session_db_unavailable
-                return _finish_agent_tool(json.dumps({"success": False, "error": format_session_db_unavailable()}), next_args)
+
+                return _finish_agent_tool(
+                    json.dumps({
+                        "success": False,
+                        "error": format_session_db_unavailable(),
+                    }),
+                    next_args,
+                )
             from tools.session_search_tool import session_search as _session_search
+
             return _finish_agent_tool(
                 _session_search(
                     query=next_args.get("query", ""),
@@ -1919,12 +2092,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+
     elif function_name == "memory":
+
         def _execute(next_args: dict) -> Any:
             target = next_args.get("target", "memory")
             operations = next_args.get("operations")
             from tools.memory_tool import memory_tool as _memory_tool
             from tools.memory_tool import DEFAULT_SOURCE_CLASS, DEFAULT_TRUST_TIER
+
             result = _memory_tool(
                 action=next_args.get("action"),
                 target=target,
@@ -1942,13 +2118,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             if agent._memory_manager:
                 if operations:
                     _mem_ops = [
-                        op for op in operations
-                        if isinstance(op, dict) and op.get("action") in {"add", "replace"}
+                        op
+                        for op in operations
+                        if isinstance(op, dict)
+                        and op.get("action") in {"add", "replace"}
                     ]
                 else:
                     _mem_ops = (
-                        [{"action": next_args.get("action"), "content": next_args.get("content")}]
-                        if next_args.get("action") in {"add", "replace"} else []
+                        [
+                            {
+                                "action": next_args.get("action"),
+                                "content": next_args.get("content"),
+                            }
+                        ]
+                        if next_args.get("action") in {"add", "replace"}
+                        else []
                     )
                 for _op in _mem_ops:
                     try:
@@ -1964,12 +2148,20 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     except Exception:
                         pass
             return _finish_agent_tool(result, next_args)
+
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
+
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, next_args), next_args)
+            return _finish_agent_tool(
+                agent._memory_manager.handle_tool_call(function_name, next_args),
+                next_args,
+            )
+
     elif function_name == "clarify":
+
         def _execute(next_args: dict) -> Any:
             from tools.clarify_tool import clarify_tool as _clarify_tool
+
             return _finish_agent_tool(
                 _clarify_tool(
                     question=next_args.get("question", ""),
@@ -1978,9 +2170,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+
     elif function_name == "read_terminal":
+
         def _execute(next_args: dict) -> Any:
-            from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool
+            from tools.read_terminal_tool import (
+                read_terminal_tool as _read_terminal_tool,
+            )
+
             return _finish_agent_tool(
                 _read_terminal_tool(
                     start_line=next_args.get("start_line"),
@@ -1989,18 +2186,28 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+
     elif function_name == "delegate_task":
+
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+            return _finish_agent_tool(
+                agent._dispatch_delegate_task(next_args), next_args
+            )
+
     else:
+
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(
-                function_name, next_args, effective_task_id,
+                function_name,
+                next_args,
+                effective_task_id,
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                enabled_tools=list(agent.valid_tool_names)
+                if agent.valid_tool_names
+                else None,
                 skip_pre_tool_call_hook=True,
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
@@ -2013,7 +2220,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     return run_tool_execution_middleware(
         function_name,
         function_args,
-        lambda next_args: _execute(next_args if isinstance(next_args, dict) else function_args),
+        lambda next_args: _execute(
+            next_args if isinstance(next_args, dict) else function_args
+        ),
         original_args=function_args,
         task_id=effective_task_id or "",
         session_id=getattr(agent, "session_id", "") or "",
@@ -2021,7 +2230,6 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         turn_id=getattr(agent, "_current_turn_id", "") or "",
         api_request_id=getattr(agent, "_current_api_request_id", "") or "",
     )
-
 
 
 def repair_tool_call(agent, tool_name: str) -> str | None:
@@ -2118,7 +2326,6 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     return None
 
 
-
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -2158,8 +2365,11 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     orphaned_results = result_call_ids - surviving_call_ids
     if orphaned_results:
         messages = [
-            m for m in messages
-            if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+            m
+            for m in messages
+            if not (
+                m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results
+            )
         ]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
@@ -2190,7 +2400,6 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     return messages
 
 
-
 def looks_like_codex_intermediate_ack(
     agent,
     user_message: str,
@@ -2208,7 +2417,10 @@ def looks_like_codex_intermediate_ack(
         return False
 
     has_future_ack = bool(
-        re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+        re.search(
+            r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b",
+            assistant_text,
+        )
     )
     if not has_future_ack:
         return False
@@ -2256,13 +2468,15 @@ def looks_like_codex_intermediate_ack(
         or "~/" in user_text
         or "/" in user_text
     )
-    assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
+    assistant_mentions_action = any(
+        marker in assistant_text for marker in action_markers
+    )
     assistant_targets_workspace = any(
         marker in assistant_text for marker in workspace_markers
     )
-    return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
-
-
+    return (
+        user_targets_workspace or assistant_targets_workspace
+    ) and assistant_mentions_action
 
 
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
@@ -2386,9 +2600,7 @@ def _iter_pool_sockets(client: Any):
         if pool is None:
             return
         connections = (
-            getattr(pool, "_connections", None)
-            or getattr(pool, "_pool", None)
-            or []
+            getattr(pool, "_connections", None) or getattr(pool, "_pool", None) or []
         )
     except Exception:
         return
@@ -2400,9 +2612,8 @@ def _iter_pool_sockets(client: Any):
         if inner is not None:
             candidates.append(inner)
         for candidate in candidates:
-            stream = (
-                getattr(candidate, "_network_stream", None)
-                or getattr(candidate, "_stream", None)
+            stream = getattr(candidate, "_network_stream", None) or getattr(
+                candidate, "_stream", None
             )
             if stream is None:
                 continue
@@ -2426,6 +2637,7 @@ def _iter_pool_sockets(client: Any):
                 if callable(extra):
                     try:
                         from anyio.abc import SocketAttribute
+
                         sock = extra(SocketAttribute.raw_socket)
                     except Exception:
                         sock = None
@@ -2455,6 +2667,7 @@ def cleanup_dead_connections(agent) -> bool:
         for sock in _iter_pool_sockets(client):
             # Probe socket health with a non-blocking recv peek
             import socket as _socket
+
             try:
                 sock.setblocking(False)
                 data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)
@@ -2479,7 +2692,6 @@ def cleanup_dead_connections(agent) -> bool:
     except Exception as exc:
         _ra().logger.debug("Dead connection check error: %s", exc)
     return False
-
 
 
 def extract_api_error_context(error: Exception) -> Dict[str, Any]:
@@ -2530,10 +2742,14 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     if "reset_at" not in context:
         message = context.get("message") or ""
         if isinstance(message, str):
-            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
+            delay_match = re.search(
+                r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE
+            )
             if delay_match:
                 value = float(delay_match.group(1))
-                seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+                seconds = (
+                    value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+                )
                 context["reset_at"] = time.time() + seconds
             else:
                 resets_in_match = re.search(
@@ -2548,7 +2764,9 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                     hours = float(resets_in_match.group(1) or 0)
                     minutes = float(resets_in_match.group(2) or 0)
                     seconds = float(resets_in_match.group(3) or 0)
-                    context["reset_at"] = time.time() + (hours * 3600) + (minutes * 60) + seconds
+                    context["reset_at"] = (
+                        time.time() + (hours * 3600) + (minutes * 60) + seconds
+                    )
                 else:
                     sec_match = re.search(
                         r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
@@ -2561,8 +2779,9 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     return context
 
 
-
-def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
+def apply_pending_steer_to_tool_results(
+    agent, messages: list, num_tool_msgs: int
+) -> None:
     """Append any pending /steer text to the last tool result in this turn.
 
     Called at the end of a tool-call batch, before the next API call.
@@ -2603,7 +2822,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
                     agent._pending_steer = steer_text
         else:
             existing = getattr(agent, "_pending_steer", None)
-            agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
+            agent._pending_steer = (
+                (existing + "\n" + steer_text) if existing else steer_text
+            )
         return
     marker = format_steer_marker(steer_text)
     existing_content = messages[target_idx].get("content", "")
@@ -2624,7 +2845,6 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )
-
 
 
 def force_close_tcp_sockets(client: Any) -> int:
@@ -2678,7 +2898,6 @@ def force_close_tcp_sockets(client: Any) -> int:
     except Exception as exc:
         _ra().logger.debug("Force-close TCP sockets sweep error: %s", exc)
     return shutdown_count
-
 
 
 __all__ = [

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
+from agent.retry_utils import extract_retry_after_seconds, jittered_backoff
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -47,6 +48,7 @@ def _ra():
     that target symbols imported into ``run_agent``'s namespace.
     """
     import run_agent
+
     return run_agent
 
 
@@ -106,12 +108,8 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
 def _is_openai_codex_backend(agent) -> bool:
     base_url_lower = str(getattr(agent, "_base_url_lower", "") or "")
     base_url_hostname = str(getattr(agent, "_base_url_hostname", "") or "")
-    return (
-        getattr(agent, "provider", None) == "openai-codex"
-        or (
-            base_url_hostname == "chatgpt.com"
-            and "/backend-api/codex" in base_url_lower
-        )
+    return getattr(agent, "provider", None) == "openai-codex" or (
+        base_url_hostname == "chatgpt.com" and "/backend-api/codex" in base_url_lower
     )
 
 
@@ -217,6 +215,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     is_stale_connection_error,
                     normalize_converse_response,
                 )
+
                 region = api_kwargs.pop("__bedrock_region__", "us-east-1")
                 api_kwargs.pop("__bedrock_converse__", None)
                 client = _get_bedrock_runtime_client(region)
@@ -236,7 +235,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         api_kwargs=api_kwargs,
                     )
                 )
-                result["response"] = request_client.chat.completions.create(**api_kwargs)
+                result["response"] = request_client.chat.completions.create(
+                    **api_kwargs
+                )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
             # handler, the transport error is the expected consequence of our
@@ -309,10 +310,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0)
-        _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
-            "1", "true", "yes", "on"
-        }
+        _ttfb_disable_above = _env_float(
+            "HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0
+        )
+        _ttfb_strict = os.environ.get(
+            "HERMES_CODEX_TTFB_STRICT", ""
+        ).strip().lower() in {"1", "true", "yes", "on"}
         if (
             not _ttfb_strict
             and _ttfb_disable_above > 0
@@ -394,7 +397,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 "(%.0fs > %.0fs, model=%s). Backend accepted the connection "
                 "but sent no stream events. Killing connection so the retry "
                 "loop can reconnect.",
-                _elapsed, _ttfb_timeout, api_kwargs.get("model", "unknown"),
+                _elapsed,
+                _ttfb_timeout,
+                api_kwargs.get("model", "unknown"),
             )
             if _silent_hint:
                 agent._buffer_status(
@@ -483,8 +488,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
             logger.warning(
                 "Non-streaming API call stale for %.0fs (threshold %.0fs). "
                 "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                _elapsed,
+                _stale_timeout,
+                api_kwargs.get("model", "unknown"),
+                f"{_est_ctx:,}",
             )
             if _silent_hint:
                 agent._buffer_status(
@@ -551,7 +558,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
     return result["response"]
 
 
-
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
@@ -595,18 +601,17 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
 
     if agent.api_mode == "codex_responses":
         _ct = agent._get_transport()
-        is_github_responses = (
-            base_url_host_matches(agent.base_url, "models.github.ai")
-            or base_url_host_matches(agent.base_url, "api.githubcopilot.com")
+        is_github_responses = base_url_host_matches(
+            agent.base_url, "models.github.ai"
+        ) or base_url_host_matches(agent.base_url, "api.githubcopilot.com")
+        is_codex_backend = agent.provider == "openai-codex" or (
+            agent._base_url_hostname == "chatgpt.com"
+            and "/backend-api/codex" in agent._base_url_lower
         )
-        is_codex_backend = (
-            agent.provider == "openai-codex"
-            or (
-                agent._base_url_hostname == "chatgpt.com"
-                and "/backend-api/codex" in agent._base_url_lower
-            )
+        is_xai_responses = (
+            agent.provider in {"xai", "xai-oauth"}
+            or agent._base_url_hostname == "api.x.ai"
         )
-        is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -632,13 +637,15 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
                     strip_pattern_and_format,
                     strip_slash_enum,
                 )
+
                 tools_for_api = _copy.deepcopy(tools_for_api)
                 tools_for_api, _ = strip_pattern_and_format(tools_for_api)
                 tools_for_api, _ = strip_slash_enum(tools_for_api)
             except Exception as exc:
                 logger.warning(
                     "%s⚠️ Failed to sanitize tool schemas for xAI: %s",
-                    getattr(agent, "log_prefix", ""), exc,
+                    getattr(agent, "log_prefix", ""),
+                    exc,
                 )
 
         return _ct.build_kwargs(
@@ -653,7 +660,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
-            github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
+            github_reasoning_extra=agent._github_models_reasoning_extra_body()
+            if is_github_responses
+            else None,
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
@@ -665,10 +674,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Provider detection flags
     _is_qwen = agent._is_qwen_portal()
     _is_or = agent._is_openrouter_url()
-    _is_gh = (
-        base_url_host_matches(agent._base_url_lower, "models.github.ai")
-        or base_url_host_matches(agent._base_url_lower, "api.githubcopilot.com")
-    )
+    _is_gh = base_url_host_matches(
+        agent._base_url_lower, "models.github.ai"
+    ) or base_url_host_matches(agent._base_url_lower, "api.githubcopilot.com")
     _is_nous = "nousresearch" in agent._base_url_lower
     _is_nvidia = "integrate.api.nvidia.com" in agent._base_url_lower
     _is_kimi = (
@@ -676,13 +684,19 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         or base_url_host_matches(agent.base_url, "moonshot.ai")
         or base_url_host_matches(agent.base_url, "moonshot.cn")
     )
-    _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
+    _is_tokenhub = base_url_host_matches(
+        agent._base_url_lower, "tokenhub.tencentmaas.com"
+    )
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
     # sentinel (temperature omitted entirely), a numeric override, or None.
     try:
-        from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE
+        from agent.auxiliary_client import (
+            _fixed_temperature_for_model,
+            OMIT_TEMPERATURE,
+        )
+
         _ft = _fixed_temperature_for_model(agent.model, agent.base_url)
         _omit_temp = _ft is OMIT_TEMPERATURE
         _fixed_temp = _ft if not _omit_temp else None
@@ -710,6 +724,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     if (_is_or or _is_nous) and "claude" in (agent.model or "").lower():
         try:
             from agent.anthropic_adapter import _get_anthropic_max_output
+
             _ant_max = _get_anthropic_max_output(agent.model)
         except Exception:
             pass
@@ -727,6 +742,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # found, delegate fully; otherwise fall through to the legacy flag path.
     try:
         from providers import get_provider_profile
+
         _profile = get_provider_profile(agent.provider)
     except Exception:
         _profile = None
@@ -799,17 +815,22 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         provider_preferences=_prefs or None,
         openrouter_min_coding_score=agent.openrouter_min_coding_score,
         qwen_prepare_fn=agent._qwen_prepare_chat_messages if _is_qwen else None,
-        qwen_prepare_inplace_fn=agent._qwen_prepare_chat_messages_inplace if _is_qwen else None,
+        qwen_prepare_inplace_fn=agent._qwen_prepare_chat_messages_inplace
+        if _is_qwen
+        else None,
         qwen_session_metadata=_qwen_meta,
         fixed_temperature=_fixed_temp,
         omit_temperature=_omit_temp,
         supports_reasoning=agent._supports_reasoning_extra_body(),
-        github_reasoning_extra=agent._github_models_reasoning_extra_body() if _is_gh else None,
-        lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
+        github_reasoning_extra=agent._github_models_reasoning_extra_body()
+        if _is_gh
+        else None,
+        lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached()
+        if _is_lmstudio
+        else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
     )
-
 
 
 def build_assistant_message(agent, assistant_message, finish_reason: str) -> dict:
@@ -827,13 +848,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
         content = assistant_message.content or ""
-        think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
+        think_blocks = re.findall(r"<think>(.*?)</think>", content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
             reasoning_text = combined or None
 
     if reasoning_text and agent.verbose_logging:
-        logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
+        logging.debug(
+            f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}"
+        )
 
     if reasoning_text and agent.reasoning_callback:
         # Skip callback when streaming is active — reasoning was already
@@ -880,6 +903,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # when disabled. (#19798)
     if isinstance(_san_content, str) and _san_content:
         from agent.redact import redact_sensitive_text
+
         _san_content = redact_sensitive_text(_san_content)
 
     msg = {
@@ -935,7 +959,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if "reasoning_content" not in msg and reasoning_text:
         msg["reasoning_content"] = reasoning_text
 
-    if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+    if (
+        hasattr(assistant_message, "reasoning_details")
+        and assistant_message.reasoning_details
+    ):
         # Pass reasoning_details back unmodified so providers (OpenRouter,
         # Anthropic, OpenAI) can maintain reasoning continuity across turns.
         # Each provider may include opaque fields (signature, encrypted_content)
@@ -992,7 +1019,9 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                     _fn = getattr(tool_call, "function", None)
                     _fn_name = getattr(_fn, "name", "") if _fn else ""
                     _fn_args = getattr(_fn, "arguments", "{}") if _fn else "{}"
-                    call_id = agent._deterministic_call_id(_fn_name, _fn_args, len(tool_calls))
+                    call_id = agent._deterministic_call_id(
+                        _fn_name, _fn_args, len(tool_calls)
+                    )
             call_id = call_id.strip()
 
             response_item_id = getattr(tool_call, "response_item_id", None)
@@ -1012,7 +1041,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 "type": tool_call.type,
                 "function": {
                     "name": tool_call.function.name,
-                    "arguments": tool_call.function.arguments
+                    "arguments": tool_call.function.arguments,
                 },
             }
             # Defence-in-depth: redact credentials from tool call arguments
@@ -1024,6 +1053,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             # sk-...'")`). (#19798)
             if isinstance(tc_dict["function"]["arguments"], str):
                 from agent.redact import redact_sensitive_text
+
                 tc_dict["function"]["arguments"] = redact_sensitive_text(
                     tc_dict["function"]["arguments"]
                 )
@@ -1041,28 +1071,54 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     return msg
 
 
+def try_activate_fallback(
+    agent,
+    reason: "FailoverReason | None" = None,
+    *,
+    api_error: Optional[Exception] = None,
+) -> bool:
+    """Activate the next fallback provider in the chain, if available.
 
-def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
-    """Switch to the next fallback model/provider in the chain.
-
-    Called when the current model is failing after retries.  Swaps the
-    OpenAI client, model slug, and provider in-place so the retry loop
-    can continue with the new backend.  Advances through the chain on
-    each call; returns False when exhausted.
+    Switches provider, model, client, and base_url to the next configured
+    fallback entry so the conversation can continue with the new backend.
+    Advances through the chain on each call; returns False when exhausted.
 
     Uses the centralized provider router (resolve_provider_client) for
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
+    _current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    _current_model = (getattr(agent, "model", "") or "").strip()
     if reason in {FailoverReason.rate_limit, FailoverReason.billing}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
         # source of the 429 so the cooldown should not be reset/extended.
         fallback_already_active = bool(getattr(agent, "_fallback_activated", False))
-        current_provider = (getattr(agent, "provider", "") or "").strip().lower()
-        primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
-        if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
-            agent._rate_limited_until = time.monotonic() + 60
+        primary_provider = (
+            ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
+        )
+        if (not fallback_already_active) or (
+            primary_provider and _current_provider == primary_provider
+        ):
+            _ra_headers = getattr(getattr(api_error, "response", None), "headers", None)
+            _retry_after_raw = None
+            if _ra_headers and hasattr(_ra_headers, "get"):
+                _retry_after_raw = _ra_headers.get("retry-after") or _ra_headers.get(
+                    "Retry-After"
+                )
+            _cooldown = 60.0
+            if _retry_after_raw:
+                _parsed = extract_retry_after_seconds(_retry_after_raw)
+                if _parsed is not None:
+                    _cooldown = max(1.0, _parsed)
+            _until = time.monotonic() + _cooldown
+            agent._rate_limited_until = _until
+            _provider_cooldowns = getattr(agent, "_rate_limited_providers", None)
+            if _provider_cooldowns is None:
+                _provider_cooldowns = {}
+                agent._rate_limited_providers = _provider_cooldowns
+            if _current_provider:
+                _provider_cooldowns[_current_provider] = _until
     if agent._fallback_index >= len(agent._fallback_chain):
         return False
 
@@ -1071,7 +1127,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
-        return agent._try_activate_fallback()  # skip invalid, try next
+        return agent._try_activate_fallback(
+            reason=reason, api_error=api_error
+        )  # skip invalid, try next
 
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
@@ -1084,9 +1142,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     if fb_provider == current_provider and fb_model == current_model:
         logger.warning(
             "Fallback skip: chain entry %s/%s matches current provider/model",
-            fb_provider, fb_model,
+            fb_provider,
+            fb_model,
         )
-        return agent._try_activate_fallback()
+        return agent._try_activate_fallback(reason=reason, api_error=api_error)
     if (
         fb_base_url_for_dedup
         and current_base_url
@@ -1097,13 +1156,26 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback skip: chain entry base_url %s matches current backend",
             fb_base_url_for_dedup,
         )
-        return agent._try_activate_fallback()
+        return agent._try_activate_fallback(reason=reason, api_error=api_error)
+
+    # Skip fallback providers that are still under a rate-limit cooldown.
+    _provider_cooldowns = getattr(agent, "_rate_limited_providers", None) or {}
+    _fb_cooldown_until = _provider_cooldowns.get(fb_provider)
+    if _fb_cooldown_until and _fb_cooldown_until > time.monotonic():
+        _remaining = max(1, int(_fb_cooldown_until - time.monotonic()))
+        logger.info(
+            "Fallback skip: %s is rate-limit cooled down for %ss",
+            fb_provider,
+            _remaining,
+        )
+        return agent._try_activate_fallback(reason=reason, api_error=api_error)
 
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
     try:
         from agent.auxiliary_client import resolve_provider_client
+
         # Pass base_url and api_key from fallback config so custom
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
@@ -1118,16 +1190,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
-        if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
+        if (
+            fb_base_url_hint
+            and base_url_host_matches(fb_base_url_hint, "ollama.com")
+            and not fb_api_key_hint
+        ):
             fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
         fb_client, _resolved_fb_model = resolve_provider_client(
-            fb_provider, model=fb_model, raw_codex=True,
+            fb_provider,
+            model=fb_model,
+            raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+        )
         if fb_client is None:
             logger.warning(
-                "Fallback to %s failed: provider not configured",
-                fb_provider)
+                "Fallback to %s failed: provider not configured", fb_provider
+            )
             return agent._try_activate_fallback()  # try next in chain
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
@@ -1136,7 +1215,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         except Exception as _norm_err:
             logger.warning(
                 "Could not normalize fallback model %r for provider %r: %s",
-                fb_model, fb_provider, _norm_err,
+                fb_model,
+                fb_provider,
+                _norm_err,
             )
 
         # Determine api_mode from provider / base URL / model
@@ -1145,7 +1226,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
-        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
+        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith(
+            "/anthropic"
+        ):
             fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
@@ -1191,12 +1274,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # entries with different routing) the pool is preserved.
         _existing_pool = getattr(agent, "_credential_pool", None)
         if _existing_pool is not None:
-            _pool_provider = (getattr(_existing_pool, "provider", "") or "").strip().lower()
+            _pool_provider = (
+                (getattr(_existing_pool, "provider", "") or "").strip().lower()
+            )
             if _pool_provider and _pool_provider != fb_provider:
                 logger.info(
                     "Fallback to %s/%s: clearing primary credential pool "
                     "(pool_provider=%s) to prevent cross-provider contamination",
-                    fb_provider, fb_model, _pool_provider,
+                    fb_provider,
+                    fb_model,
+                    _pool_provider,
                 )
                 agent._credential_pool = None
 
@@ -1207,15 +1294,28 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         if fb_api_mode == "anthropic_messages":
             # Build native Anthropic client instead of using OpenAI client
-            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-            effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+            from agent.anthropic_adapter import (
+                build_anthropic_client,
+                resolve_anthropic_token,
+                _is_oauth_token,
+            )
+
+            effective_key = (
+                (fb_client.api_key or resolve_anthropic_token() or "")
+                if fb_provider == "anthropic"
+                else (fb_client.api_key or "")
+            )
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = fb_base_url
             agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                effective_key,
+                agent._anthropic_base_url,
+                timeout=_fb_timeout,
             )
-            agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
+            agent._is_anthropic_oauth = (
+                _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
+            )
             agent.client = None
             agent._client_kwargs = {}
         else:
@@ -1265,16 +1365,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Also pass _config_context_length so the explicit config override
         # (model.context_length in config.yaml) is respected — without this,
         # the fallback activation drops to 128K even when config says 204800.
-        if hasattr(agent, 'context_compressor') and agent.context_compressor:
+        if hasattr(agent, "context_compressor") and agent.context_compressor:
             from agent.model_metadata import get_model_context_length
+
             # ``agent.api_key`` may be callable (Entra ID); the
             # context-length resolver expects a string for live
             # probes. Foundry typically resolves via config/static
             # catalogs anyway, so coerce defensively.
             _fb_ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
             fb_context_length = get_model_context_length(
-                agent.model, base_url=agent.base_url,
-                api_key=_fb_ctx_api_key, provider=agent.provider,
+                agent.model,
+                base_url=agent.base_url,
+                api_key=_fb_ctx_api_key,
+                provider=agent.provider,
                 config_context_length=getattr(agent, "_config_context_length", None),
                 custom_providers=getattr(agent, "_custom_providers", None),
             )
@@ -1293,7 +1396,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         )
         logger.info(
             "Fallback activated: %s → %s (%s)",
-            old_model, fb_model, fb_provider,
+            old_model,
+            fb_model,
+            fb_provider,
         )
         return True
     except Exception as e:
@@ -1301,10 +1406,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return agent._try_activate_fallback()  # try next in chain
 
 
-
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
-    print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
+    print(
+        f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
+    )
 
     summary_request = (
         "You've reached the maximum number of tool-calling iterations allowed. "
@@ -1331,9 +1437,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # bypassing the transport — so mirror that sanitization here:
             # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
             # and every Hermes-internal underscore-prefixed scaffolding key.
-            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+            for schema_foreign in (
+                "tool_name",
+                "codex_reasoning_items",
+                "codex_message_items",
+            ):
                 api_msg.pop(schema_foreign, None)
-            for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+            for internal_key in [
+                k for k in api_msg if isinstance(k, str) and k.startswith("_")
+            ]:
                 api_msg.pop(internal_key, None)
             if _needs_sanitize:
                 agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
@@ -1341,9 +1453,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
         effective_system = agent._cached_system_prompt or ""
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            effective_system = (
+                effective_system + "\n\n" + agent.ephemeral_system_prompt
+            ).strip()
         if effective_system:
-            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            api_messages = [
+                {"role": "system", "content": effective_system}
+            ] + api_messages
         if agent.prefill_messages:
             sys_offset = 1 if effective_system else 0
             for idx, pfm in enumerate(agent.prefill_messages):
@@ -1362,7 +1478,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
         summary_extra_body = {}
         try:
-            from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP
+            from agent.auxiliary_client import (
+                _fixed_temperature_for_model,
+                OMIT_TEMPERATURE as _OMIT_TEMP,
+            )
         except Exception:
             _fixed_temperature_for_model = None
             _OMIT_TEMP = None
@@ -1379,23 +1498,21 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # — which calls chat.completions.create() directly without going
         # through the transport — sends the same shape the transport does.
         _is_lmstudio_summary = (
-            (agent.provider or "").strip().lower() == "lmstudio"
-            and agent._supports_reasoning_extra_body()
-        )
+            agent.provider or ""
+        ).strip().lower() == "lmstudio" and agent._supports_reasoning_extra_body()
         _lm_reasoning_effort: str | None = (
             agent._resolve_lmstudio_summary_reasoning_effort()
-            if _is_lmstudio_summary else None
+            if _is_lmstudio_summary
+            else None
         )
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
             if agent.reasoning_config is not None:
                 summary_extra_body["reasoning"] = agent.reasoning_config
             else:
-                summary_extra_body["reasoning"] = {
-                    "enabled": True,
-                    "effort": "medium"
-                }
+                summary_extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
         if _is_nous:
             from agent.portal_tags import nous_portal_tags as _portal_tags
+
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
@@ -1459,25 +1576,40 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
-                _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                               max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
-                               is_oauth=agent._is_anthropic_oauth,
-                               preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw = _tsum.build_kwargs(
+                    model=agent.model,
+                    messages=api_messages,
+                    tools=None,
+                    max_tokens=agent.max_tokens,
+                    reasoning_config=agent.reasoning_config,
+                    is_oauth=agent._is_anthropic_oauth,
+                    preserve_dots=agent._anthropic_preserve_dots(),
+                )
                 summary_response = agent._anthropic_messages_create(_ant_kw)
-                _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
+                _summary_result = _tsum.normalize_response(
+                    summary_response, strip_tool_prefix=agent._is_anthropic_oauth
+                )
                 final_response = (_summary_result.content or "").strip()
             else:
-                summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
-                _summary_result = agent._get_transport().normalize_response(summary_response)
+                summary_response = agent._ensure_primary_openai_client(
+                    reason="iteration_limit_summary"
+                ).chat.completions.create(**summary_kwargs)
+                _summary_result = agent._get_transport().normalize_response(
+                    summary_response
+                )
                 final_response = (_summary_result.content or "").strip()
 
         if final_response:
             if "<think>" in final_response:
-                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                final_response = re.sub(
+                    r"<think>.*?</think>\s*", "", final_response, flags=re.DOTALL
+                ).strip()
             if final_response:
                 messages.append({"role": "assistant", "content": final_response})
             else:
-                final_response = "I reached the iteration limit and couldn't generate a summary."
+                final_response = (
+                    "I reached the iteration limit and couldn't generate a summary."
+                )
         else:
             # Retry summary generation
             if agent.api_mode == "codex_responses":
@@ -1489,12 +1621,19 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_cnr_retry.content or "").strip()
             elif agent.api_mode == "anthropic_messages":
                 _tretry = agent._get_transport()
-                _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                                is_oauth=agent._is_anthropic_oauth,
-                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
-                                preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw2 = _tretry.build_kwargs(
+                    model=agent.model,
+                    messages=api_messages,
+                    tools=None,
+                    is_oauth=agent._is_anthropic_oauth,
+                    max_tokens=agent.max_tokens,
+                    reasoning_config=agent.reasoning_config,
+                    preserve_dots=agent._anthropic_preserve_dots(),
+                )
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
-                _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
+                _retry_result = _tretry.normalize_response(
+                    retry_response, strip_tool_prefix=agent._is_anthropic_oauth
+                )
                 final_response = (_retry_result.content or "").strip()
             else:
                 summary_kwargs = {
@@ -1510,26 +1649,35 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
-                summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
-                _retry_result = agent._get_transport().normalize_response(summary_response)
+                summary_response = agent._ensure_primary_openai_client(
+                    reason="iteration_limit_summary_retry"
+                ).chat.completions.create(**summary_kwargs)
+                _retry_result = agent._get_transport().normalize_response(
+                    summary_response
+                )
                 final_response = (_retry_result.content or "").strip()
 
             if final_response:
                 if "<think>" in final_response:
-                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                    final_response = re.sub(
+                        r"<think>.*?</think>\s*", "", final_response, flags=re.DOTALL
+                    ).strip()
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:
-                    final_response = "I reached the iteration limit and couldn't generate a summary."
+                    final_response = (
+                        "I reached the iteration limit and couldn't generate a summary."
+                    )
             else:
-                final_response = "I reached the iteration limit and couldn't generate a summary."
+                final_response = (
+                    "I reached the iteration limit and couldn't generate a summary."
+                )
 
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
     return final_response
-
 
 
 def cleanup_task_resources(agent, task_id: str) -> None:
@@ -1560,8 +1708,6 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
-
-
 
 
 def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=None):
@@ -1619,6 +1765,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     normalize_converse_response,
                     stream_converse_with_callbacks,
                 )
+
                 region = api_kwargs.pop("__bedrock_region__", "us-east-1")
                 api_kwargs.pop("__bedrock_converse__", None)
                 client = _get_bedrock_runtime_client(region)
@@ -1671,7 +1818,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     raw_response,
                     on_text_delta=_on_text if agent._has_stream_consumers() else None,
                     on_tool_start=_on_tool,
-                    on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
+                    on_reasoning_delta=_on_reasoning
+                    if agent.reasoning_callback or agent.stream_delta_callback
+                    else None,
                     on_interrupt_check=lambda: agent._interrupt_requested,
                 )
             except Exception as e:
@@ -1755,9 +1904,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _call_chat_completions():
         """Stream a chat completions response."""
         import httpx as _httpx
+
         # Per-provider / per-model request_timeout_seconds (from config.yaml)
         # wins over the HERMES_API_TIMEOUT env default if the user set it.
-        _provider_timeout_cfg = get_provider_request_timeout(agent.provider, agent.model)
+        _provider_timeout_cfg = get_provider_request_timeout(
+            agent.provider, agent.model
+        )
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
@@ -1773,11 +1925,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
             # overrode HERMES_STREAM_READ_TIMEOUT.
-            if _stream_read_timeout == 120.0 and agent.base_url and is_local_endpoint(agent.base_url):
+            if (
+                _stream_read_timeout == 120.0
+                and agent.base_url
+                and is_local_endpoint(agent.base_url)
+            ):
                 _stream_read_timeout = _base_timeout
                 logger.debug(
                     "Local provider detected (%s) — stream read timeout raised to %.0fs",
-                    agent.base_url, _stream_read_timeout,
+                    agent.base_url,
+                    _stream_read_timeout,
                 )
             elif (
                 _stream_read_timeout == 120.0
@@ -1797,11 +1954,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _stream_read_timeout = _stream_stale_timeout
                 logger.debug(
                     "Cloud reasoning stream — read timeout raised to %.0fs to "
-                    "match stale-stream detector", _stream_read_timeout,
+                    "match stale-stream detector",
+                    _stream_read_timeout,
                 )
         # Cap connect/pool at 60s even when provider timeout is higher.
         # connect/pool cover TCP handshake, not model inference.
-        _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
+        _conn_cap = (
+            min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
+        )
         stream_kwargs = {
             **api_kwargs,
             "stream": True,
@@ -1850,7 +2010,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # in a parallel batch, distinguishing them only by id.  Track
         # the last seen id per raw index so we can detect a new tool
         # call starting at the same index and redirect it to a fresh slot.
-        _last_id_at_idx: dict = {}      # raw_index -> last seen non-empty id
+        _last_id_at_idx: dict = {}  # raw_index -> last seen non-empty id
         _active_slot_by_idx: dict = {}  # raw_index -> current slot in tool_calls_acc
         finish_reason = None
         model_name = None
@@ -1895,7 +2055,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 model_name = chunk.model
 
             # Accumulate reasoning content
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(
+                delta, "reasoning", None
+            )
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
                 _fire_first_delta()
@@ -1969,7 +2131,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Vercel AI patterns) is immune to this.
                             entry["function"]["name"] = tc_delta.function.name
                         if tc_delta.function.arguments:
-                            entry["function"]["arguments"] += tc_delta.function.arguments
+                            entry["function"]["arguments"] += (
+                                tc_delta.function.arguments
+                            )
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
                         extra = (tc_delta.model_extra or {}).get("extra_content")
@@ -2027,15 +2191,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True
-                mock_tool_calls.append(SimpleNamespace(
-                    id=tc["id"],
-                    type=tc["type"],
-                    extra_content=tc.get("extra_content"),
-                    function=SimpleNamespace(
-                        name=tc["function"]["name"],
-                        arguments=arguments,
-                    ),
-                ))
+                mock_tool_calls.append(
+                    SimpleNamespace(
+                        id=tc["id"],
+                        type=tc["type"],
+                        extra_content=tc.get("extra_content"),
+                        function=SimpleNamespace(
+                            name=tc["function"]["name"],
+                            arguments=arguments,
+                        ),
+                    )
+                )
 
         # Zero-chunk guard: stream yielded nothing usable — a provider/upstream
         # error or malformed SSE, not a legitimate empty completion. Raise so the
@@ -2146,6 +2312,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # raises a non-retryable TypeError on them, killing the turn. See
         # #31673 / sanitize_anthropic_kwargs().
         from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(agent, "log_prefix", "")
         )
@@ -2255,10 +2422,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         )
                         return
                     _is_timeout = isinstance(
-                        e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
+                        e,
+                        (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout),
                     )
                     _is_conn_err = isinstance(
-                        e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
+                        e,
+                        (
+                            _httpx.ConnectError,
+                            _httpx.RemoteProtocolError,
+                            ConnectionError,
+                        ),
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
 
@@ -2275,13 +2448,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     # tool has executed yet within this API call, so
                     # silent retry is safe wrt side-effects.
                     if deltas_were_sent["yes"]:
-                        _partial_tool_in_flight = bool(
-                            result.get("partial_tool_names")
-                        )
+                        _partial_tool_in_flight = bool(result.get("partial_tool_names"))
                         _is_sse_conn_err_preview = False
                         if not _is_timeout and not _is_conn_err:
                             from openai import APIError as _APIError
-                            if isinstance(e, _APIError) and not getattr(e, "status_code", None):
+
+                            if isinstance(e, _APIError) and not getattr(
+                                e, "status_code", None
+                            ):
                                 _err_lower_preview = str(e).lower()
                                 _SSE_PREVIEW_PHRASES = (
                                     "connection lost",
@@ -2318,7 +2492,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # error isn't transient.  Fall through to the
                             # stub path.
                             logger.warning(
-                                "Streaming failed after partial delivery, not retrying: %s", e
+                                "Streaming failed after partial delivery, not retrying: %s",
+                                e,
                             )
                             result["error"] = e
                             return
@@ -2377,7 +2552,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _is_sse_conn_err = False
                     if not _is_timeout and not _is_conn_err:
                         from openai import APIError as _APIError
-                        if isinstance(e, _APIError) and not getattr(e, "status_code", None):
+
+                        if isinstance(e, _APIError) and not getattr(
+                            e, "status_code", None
+                        ):
                             _err_lower_sse = str(e).lower()
                             _SSE_CONN_PHRASES = (
                                 "connection lost",
@@ -2392,11 +2570,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 "upstream connect error",
                             )
                             _is_sse_conn_err = any(
-                                phrase in _err_lower_sse
-                                for phrase in _SSE_CONN_PHRASES
+                                phrase in _err_lower_sse for phrase in _SSE_CONN_PHRASES
                             )
 
-                    if _is_timeout or _is_conn_err or _is_sse_conn_err or _is_stream_parse_err:
+                    if (
+                        _is_timeout
+                        or _is_conn_err
+                        or _is_sse_conn_err
+                        or _is_stream_parse_err
+                    ):
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
@@ -2437,8 +2619,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             f"{_max_stream_retries + 1} attempts. "
                             "The provider may be experiencing issues — "
                             "try again in a moment."
-                            if _is_stream_parse_err else
-                            "❌ Connection to provider failed after "
+                            if _is_stream_parse_err
+                            else "❌ Connection to provider failed after "
                             f"{_max_stream_retries + 1} attempts. "
                             "The provider may be experiencing issues — "
                             "try again in a moment."
@@ -2446,8 +2628,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     else:
                         _err_lower = str(e).lower()
                         _is_stream_unsupported = (
-                            "stream" in _err_lower
-                            and "not supported" in _err_lower
+                            "stream" in _err_lower and "not supported" in _err_lower
                         )
                         # AWS Bedrock (AnthropicBedrock SDK path): IAM policies
                         # with bedrock:InvokeModel but not
@@ -2467,6 +2648,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             from agent.bedrock_adapter import (
                                 is_streaming_access_denied_error,
                             )
+
                             _is_bedrock_stream_denied = (
                                 is_streaming_access_denied_error(e)
                             )
@@ -2476,8 +2658,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 "\n⚠  AWS IAM denied bedrock:InvokeModelWithResponseStream. "
                                 "Switching to non-streaming.\n"
                                 "   Grant that action to restore streaming output.\n"
-                                if _is_bedrock_stream_denied else
-                                "\n⚠  Streaming is not supported for this "
+                                if _is_bedrock_stream_denied
+                                else "\n⚠  Streaming is not supported for this "
                                 "model/provider. Switching to non-streaming.\n"
                                 "   To avoid this delay, set display.streaming: false "
                                 "in config.yaml\n"
@@ -2508,13 +2690,22 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = float(
+            os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+        )
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
+    if (
+        _stream_stale_timeout_base == 180.0
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
         _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout disabled",
+            agent.base_url,
+        )
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token
@@ -2561,8 +2752,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             logger.warning(
                 "Stream stale for %.0fs (threshold %.0fs) — no chunks received. "
                 "model=%s context=~%s tokens. Killing connection.",
-                _stale_elapsed, _stream_stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                _stale_elapsed,
+                _stream_stale_timeout,
+                api_kwargs.get("model", "unknown"),
+                f"{_est_ctx:,}",
             )
             agent._buffer_status(
                 f"⚠️ No response from provider for {int(_stale_elapsed)}s "
@@ -2638,7 +2831,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 logger.warning(
                     "Partial stream dropped tool call(s) %s after %s chars "
                     "of text; surfaced warning to user: %s",
-                    _partial_names, len(_partial_text or ""), result["error"],
+                    _partial_names,
+                    len(_partial_text or ""),
+                    result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
             else:
@@ -2652,23 +2847,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
             _stub_msg = SimpleNamespace(
-                role="assistant", content=_partial_text, tool_calls=None,
+                role="assistant",
+                content=_partial_text,
+                tool_calls=None,
                 reasoning_content=None,
             )
             return SimpleNamespace(
                 id=PARTIAL_STREAM_STUB_ID,
                 model=getattr(agent, "model", "unknown"),
-                choices=[SimpleNamespace(
-                    index=0, message=_stub_msg, finish_reason=_stub_finish_reason,
-                )],
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        message=_stub_msg,
+                        finish_reason=_stub_finish_reason,
+                    )
+                ],
                 usage=None,
                 _dropped_tool_names=_partial_names or None,
             )
         raise result["error"]
     return result["response"]
 
-# ── Provider fallback ──────────────────────────────────────────────────
 
+# ── Provider fallback ──────────────────────────────────────────────────
 
 
 __all__ = [

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -59,7 +59,7 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.retry_utils import jittered_backoff
+from agent.retry_utils import extract_retry_after_seconds, jittered_backoff
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -72,7 +72,9 @@ logger = logging.getLogger(__name__)
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
-INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
+INTERRUPT_WAITING_FOR_MODEL_PREFIX = (
+    "Operation interrupted: waiting for model response ("
+)
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
@@ -154,6 +156,7 @@ def _ra():
     ``run_agent.OpenAI`` and have those patches reach this code path.
     """
     import run_agent
+
     return run_agent
 
 
@@ -188,10 +191,9 @@ def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     if provider == "nous":
         return True
     base = str(base_url or "")
-    return (
-        base_url_host_matches(base, "inference-api.nousresearch.com")
-        or base_url_host_matches(base, "inference.nousresearch.com")
-    )
+    return base_url_host_matches(
+        base, "inference-api.nousresearch.com"
+    ) or base_url_host_matches(base, "inference.nousresearch.com")
 
 
 def _billing_or_entitlement_message(
@@ -216,7 +218,9 @@ def _billing_or_entitlement_message(
     ]
     if base_url_host_matches(str(base_url or ""), "openrouter.ai"):
         lines.append("OpenRouter credits: https://openrouter.ai/settings/credits")
-    lines.append("You can switch providers temporarily with /model <model> --provider <provider>.")
+    lines.append(
+        "You can switch providers temporarily with /model <model> --provider <provider>."
+    )
     return "\n".join(lines)
 
 
@@ -302,7 +306,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "Session DB get_session failed for system-prompt restore "
                 "(session=%s): %s. Falling back to fresh build — prefix "
                 "cache will miss for this turn.",
-                agent.session_id, exc,
+                agent.session_id,
+                exc,
             )
 
     if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
@@ -330,7 +335,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             "from scratch this turn. Prefix cache will miss until "
             "the rebuild persists. Investigate the previous turn's "
             "update_system_prompt write path.",
-            agent.session_id, stored_state,
+            agent.session_id,
+            stored_state,
         )
 
     # First turn of a new session (or recovering from a broken stored
@@ -342,6 +348,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # to initialise session-scoped state (e.g. warm a memory cache).
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+
         _invoke_hook(
             "on_session_start",
             session_id=agent.session_id,
@@ -370,13 +377,16 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # subsequent turn).
     if agent._session_db:
         try:
-            agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
+            agent._session_db.update_system_prompt(
+                agent.session_id, agent._cached_system_prompt
+            )
         except Exception as exc:
             logger.warning(
                 "Session DB update_system_prompt failed for session %s: "
                 "%s. Subsequent turns will rebuild the system prompt and "
                 "miss the prefix cache.",
-                agent.session_id, exc,
+                agent.session_id,
+                exc,
             )
 
 
@@ -388,7 +398,7 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         value = ""
         for line in prompt.splitlines():
             if line.startswith(prefix):
-                value = line[len(prefix):].strip()
+                value = line[len(prefix) :].strip()
         return value
 
     stored_model = line_value("Model")
@@ -404,7 +414,9 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     return True
 
 
-def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List[str]] = None) -> str:
+def _get_continuation_prompt(
+    is_partial_stub: bool, dropped_tools: Optional[List[str]] = None
+) -> str:
     if is_partial_stub and dropped_tools:
         tool_list = ", ".join(dropped_tools[:3])
         return (
@@ -613,7 +625,9 @@ def _run_conversation_impl(
     # the ReAct baseline. See ``AIAgent._maybe_activate_plan_mode``.
     agent._maybe_activate_plan_mode(user_message)
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while (
+        api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0
+    ) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -624,7 +638,7 @@ def _run_conversation_impl(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
@@ -637,7 +651,9 @@ def _run_conversation_impl(
         elif not agent.iteration_budget.consume():
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
-                agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
+                agent._safe_print(
+                    f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)"
+                )
             break
 
         # Loop guard: if the model is stuck repeating one tool (or repeatedly
@@ -651,7 +667,9 @@ def _run_conversation_impl(
             _lg_sig = _loop_guard.current_run_signature(messages)
             _lg_tool = _lg_sig[0] if _lg_sig else None
             _lg_count = _lg_sig[1] if _lg_sig else 0
-            _lg_prev = getattr(agent, "_loop_guard_nudged", None)  # (tool, count) | None
+            _lg_prev = getattr(
+                agent, "_loop_guard_nudged", None
+            )  # (tool, count) | None
             # Re-nudge when the stuck run is NEW (tool changed/ended) OR it has
             # grown by >=3 calls since the last nudge. Without the growth check a
             # single nudge fired once and then went silent for the next dozen
@@ -659,8 +677,11 @@ def _run_conversation_impl(
             # re-nudges keep pressure on a persistent loop.
             if _lg_tool is None:
                 agent._loop_guard_nudged = None  # run ended — re-arm
-            elif (_lg_prev is None or _lg_prev[0] != _lg_tool
-                  or _lg_count - _lg_prev[1] >= 3):
+            elif (
+                _lg_prev is None
+                or _lg_prev[0] != _lg_tool
+                or _lg_count - _lg_prev[1] >= 3
+            ):
                 _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
                     messages.append({"role": "user", "content": _lg_nudge})
@@ -696,14 +717,15 @@ def _run_conversation_impl(
                         break
                 agent.step_callback(api_call_count, prev_tools)
             except Exception as _step_err:
-                logger.debug("step_callback error (iteration %s): %s", api_call_count, _step_err)
+                logger.debug(
+                    "step_callback error (iteration %s): %s", api_call_count, _step_err
+                )
 
         # Track tool-calling iterations for skill nudge.
         # Counter resets whenever skill_manage is actually used.
-        if (agent._skill_nudge_interval > 0
-                and "skill_manage" in agent.valid_tool_names):
+        if agent._skill_nudge_interval > 0 and "skill_manage" in agent.valid_tool_names:
             agent._iters_since_skill += 1
-        
+
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
         # was thinking), drain it now — before we build api_messages — so
@@ -723,6 +745,7 @@ def _run_conversation_impl(
                 _sm = messages[_si]
                 if isinstance(_sm, dict) and _sm.get("role") == "tool":
                     from agent.prompt_builder import format_steer_marker
+
                     marker = format_steer_marker(_pre_api_steer)
                     existing = _sm.get("content", "")
                     if isinstance(existing, str):
@@ -748,12 +771,18 @@ def _run_conversation_impl(
                 if _lock is not None:
                     with _lock:
                         if agent._pending_steer:
-                            agent._pending_steer = agent._pending_steer + "\n" + _pre_api_steer
+                            agent._pending_steer = (
+                                agent._pending_steer + "\n" + _pre_api_steer
+                            )
                         else:
                             agent._pending_steer = _pre_api_steer
                 else:
                     existing = getattr(agent, "_pending_steer", None)
-                    agent._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
+                    agent._pending_steer = (
+                        (existing + "\n" + _pre_api_steer)
+                        if existing
+                        else _pre_api_steer
+                    )
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages
@@ -784,6 +813,7 @@ def _run_conversation_impl(
         # flush cursor (_last_flushed_db_idx) when repair compacts the list,
         # so the turn-end flush doesn't skip the assistant/tool chain (#44837).
         from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
+
         repaired_seq = repair_message_sequence_with_cursor(agent, messages)
         if repaired_seq > 0:
             request_logger.info(
@@ -854,14 +884,20 @@ def _run_conversation_impl(
         # stay warm.
         effective_system = active_system_prompt or ""
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            effective_system = (
+                effective_system + "\n\n" + agent.ephemeral_system_prompt
+            ).strip()
         if effective_system:
-            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            api_messages = [
+                {"role": "system", "content": effective_system}
+            ] + api_messages
 
         # Inject ephemeral prefill messages right after the system prompt
         # but before conversation history. Same API-call-time-only pattern.
         if agent.prefill_messages:
-            sys_offset = 1 if (api_messages and api_messages[0].get("role") == "system") else 0
+            sys_offset = (
+                1 if (api_messages and api_messages[0].get("role") == "system") else 0
+            )
             for idx, pfm in enumerate(agent.prefill_messages):
                 api_messages.insert(sys_offset + idx, pfm.copy())
 
@@ -915,13 +951,17 @@ def _run_conversation_impl(
                 if isinstance(tc, dict) and "function" in tc:
                     try:
                         args_obj = json.loads(tc["function"]["arguments"])
-                        tc = {**tc, "function": {
-                            **tc["function"],
-                            "arguments": json.dumps(
-                                args_obj, separators=(",", ":"),
-                                sort_keys=True,
-                            ),
-                        }}
+                        tc = {
+                            **tc,
+                            "function": {
+                                **tc["function"],
+                                "arguments": json.dumps(
+                                    args_obj,
+                                    separators=(",", ":"),
+                                    sort_keys=True,
+                                ),
+                            },
+                        }
                     except Exception:
                         tc["function"]["arguments"] = _repair_tool_call_arguments(
                             tc["function"]["arguments"],
@@ -951,7 +991,9 @@ def _run_conversation_impl(
             failed = True
             _turn_exit_reason = "ollama_runtime_context_too_small"
             messages.append({"role": "assistant", "content": final_response})
-            agent._emit_status("❌ Ollama runtime context is too small for Hermes tool use")
+            agent._emit_status(
+                "❌ Ollama runtime context is too small for Hermes tool use"
+            )
             api_call_count -= 1
             agent._api_call_count = api_call_count
             try:
@@ -959,14 +1001,20 @@ def _run_conversation_impl(
             except Exception:
                 pass
             break
-        
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
-        
+
         if not agent.quiet_mode:
-            agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
-            agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
-            agent._vprint(f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}")
+            agent._vprint(
+                f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}..."
+            )
+            agent._vprint(
+                f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)"
+            )
+            agent._vprint(
+                f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}"
+            )
         else:
             # Animated thinking spinner in quiet mode
             face = random.choice(KawaiiSpinner.get_thinking_faces())
@@ -975,19 +1023,36 @@ def _run_conversation_impl(
                 # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                 # (works in both streaming and non-streaming modes)
                 agent.thinking_callback(f"{face} {verb}...")
-            elif not agent._has_stream_consumers() and agent._should_start_quiet_spinner():
+            elif (
+                not agent._has_stream_consumers()
+                and agent._should_start_quiet_spinner()
+            ):
                 # Raw KawaiiSpinner only when no streaming consumers and the
                 # spinner output has a safe sink.
-                spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
-                thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type, print_fn=agent._print_fn)
+                spinner_type = random.choice([
+                    "brain",
+                    "sparkle",
+                    "pulse",
+                    "moon",
+                    "star",
+                ])
+                thinking_spinner = KawaiiSpinner(
+                    f"{face} {verb}...",
+                    spinner_type=spinner_type,
+                    print_fn=agent._print_fn,
+                )
                 thinking_spinner.start()
-        
+
         # Log request details if verbose
         if agent.verbose_logging:
-            logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
-            logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
+            logging.debug(
+                f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}"
+            )
+            logging.debug(
+                f"Last message role: {messages[-1]['role'] if messages else 'none'}"
+            )
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-        
+
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
@@ -1012,15 +1077,14 @@ def _run_conversation_impl(
                         nous_rate_limit_remaining,
                         format_remaining as _fmt_nous_remaining,
                     )
+
                     _nous_remaining = nous_rate_limit_remaining()
                     if _nous_remaining is not None and _nous_remaining > 0:
                         _nous_msg = (
                             f"Nous Portal rate limit active — "
                             f"resets in {_fmt_nous_remaining(_nous_remaining)}."
                         )
-                        agent._buffer_vprint(
-                            f"⏳ {_nous_msg} Trying fallback..."
-                        )
+                        agent._buffer_vprint(f"⏳ {_nous_msg} Trying fallback...")
                         agent._buffer_status(f"⏳ {_nous_msg}")
                         if agent._try_activate_fallback():
                             retry_count = 0
@@ -1049,6 +1113,47 @@ def _run_conversation_impl(
                 except Exception:
                     pass  # Never let rate guard break the agent loop
 
+            # ── Generic provider cooldown guard ───────────────────
+            # If this provider was recently rate-limited (and the cooldown is
+            # still active), skip straight to fallback instead of burning
+            # another request that will likely 429 again.  This complements
+            # the per-provider cooldown recorded by _try_activate_fallback.
+            _provider_cooldowns = getattr(agent, "_rate_limited_providers", None) or {}
+            _current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+            _cooldown_until = (
+                _provider_cooldowns.get(_current_provider)
+                if _current_provider
+                else None
+            )
+            if _cooldown_until and _cooldown_until > time.monotonic():
+                _remaining = max(1, int(_cooldown_until - time.monotonic()))
+                _cooldown_msg = (
+                    f"Provider {_current_provider} is rate-limit cooled down "
+                    f"for {_remaining}s — trying fallback..."
+                )
+                agent._buffer_vprint(f"⏳ {_cooldown_msg}")
+                agent._buffer_status(f"⏳ {_cooldown_msg}")
+                if agent._try_activate_fallback():
+                    retry_count = 0
+                    compression_attempts = 0
+                    _retry.primary_recovery_attempted = False
+                    continue
+                # No fallback — surface the cooldown and bail.
+                agent._flush_status_buffer()
+                agent._persist_session(messages, conversation_history)
+                return {
+                    "final_response": (
+                        f"⏳ {_cooldown_msg}\n\n"
+                        "No fallback provider available. "
+                        "Wait for the cooldown to expire or add a fallback provider."
+                    ),
+                    "messages": messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "failed": True,
+                    "error": _cooldown_msg,
+                }
+
             try:
                 agent._reset_stream_delivery_tracking()
                 # api_messages is built once, before this retry loop, while the
@@ -1063,7 +1168,9 @@ def _run_conversation_impl(
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
-                    api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+                    api_kwargs = agent._get_transport().preflight_kwargs(
+                        api_kwargs, allow_stream=False
+                    )
                 try:
                     from hermes_cli.middleware import apply_llm_request_middleware
 
@@ -1092,6 +1199,7 @@ def _run_conversation_impl(
                         has_hook,
                         invoke_hook as _invoke_hook,
                     )
+
                     if has_hook("pre_api_request"):
                         request_messages = api_kwargs.get("messages")
                         if not isinstance(request_messages, list):
@@ -1114,7 +1222,9 @@ def _run_conversation_impl(
                         # ``api_kwargs`` is the same object passed to the
                         # provider client.  New consumers should read the
                         # sanitised view from ``request["body"]["messages"]``.
-                        _request_payload = agent._api_request_payload_for_hook(api_kwargs)
+                        _request_payload = agent._api_request_payload_for_hook(
+                            api_kwargs
+                        )
                         _invoke_hook(
                             "pre_api_request",
                             task_id=effective_task_id,
@@ -1187,6 +1297,7 @@ def _run_conversation_impl(
                     # health checking, but skip for Mock clients in tests
                     # (mocks return SimpleNamespace, not stream iterators).
                     from unittest.mock import Mock
+
                     if isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
@@ -1215,9 +1326,9 @@ def _run_conversation_impl(
                     api_call_count=api_call_count,
                     middleware_trace=list(_llm_middleware_trace),
                 )
-                
+
                 api_duration = time.time() - api_start_time
-                
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -1225,15 +1336,21 @@ def _run_conversation_impl(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                
+
                 if not agent.quiet_mode:
-                    agent._vprint(f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                
+                    agent._vprint(
+                        f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s"
+                    )
+
                 if agent.verbose_logging:
                     # Log response with provider info if available
-                    resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
-                    logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                
+                    resp_model = (
+                        getattr(response, "model", "N/A") if response else "N/A"
+                    )
+                    logging.debug(
+                        f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}"
+                    )
+
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
@@ -1247,26 +1364,39 @@ def _run_conversation_impl(
                             # Provider returned a terminal failure (e.g. quota exhaustion).
                             # Treat as invalid so the fallback chain is triggered instead of
                             # letting the error bubble up outside the retry/fallback loop.
-                            _codex_resp_status = str(getattr(response, "status", "") or "").strip().lower()
+                            _codex_resp_status = (
+                                str(getattr(response, "status", "") or "")
+                                .strip()
+                                .lower()
+                            )
                             if _codex_resp_status in {"failed", "cancelled"}:
                                 _codex_error_obj = getattr(response, "error", None)
                                 _codex_error_msg = (
-                                    _codex_error_obj.get("message") if isinstance(_codex_error_obj, dict)
-                                    else str(_codex_error_obj) if _codex_error_obj
+                                    _codex_error_obj.get("message")
+                                    if isinstance(_codex_error_obj, dict)
+                                    else str(_codex_error_obj)
+                                    if _codex_error_obj
                                     else f"Responses API returned status '{_codex_resp_status}'"
                                 )
                                 logger.warning(
                                     "Codex response status='%s' (error=%s). Routing to fallback. %s",
-                                    _codex_resp_status, _codex_error_msg,
+                                    _codex_resp_status,
+                                    _codex_error_msg,
                                     agent._client_log_context(),
                                 )
                                 response_invalid = True
-                                error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
+                                error_details.append(
+                                    f"response.status={_codex_resp_status}: {_codex_error_msg}"
+                                )
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
                                 _out_text = getattr(response, "output_text", None)
-                                _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
+                                _out_text_stripped = (
+                                    _out_text.strip()
+                                    if isinstance(_out_text, str)
+                                    else ""
+                                )
                                 if _out_text_stripped:
                                     logger.debug(
                                         "Codex response.output is empty but output_text is present "
@@ -1275,11 +1405,14 @@ def _run_conversation_impl(
                                     )
                                 else:
                                     _resp_status = getattr(response, "status", None)
-                                    _resp_incomplete = getattr(response, "incomplete_details", None)
+                                    _resp_incomplete = getattr(
+                                        response, "incomplete_details", None
+                                    )
                                     logger.warning(
                                         "Codex response.output is empty after stream backfill "
                                         "(status=%s, incomplete_details=%s, model=%s). %s",
-                                        _resp_status, _resp_incomplete,
+                                        _resp_status,
+                                        _resp_incomplete,
                                         getattr(response, "model", None),
                                         f"api_mode={agent.api_mode} provider={agent.provider}",
                                     )
@@ -1292,7 +1425,9 @@ def _run_conversation_impl(
                         if response is None:
                             error_details.append("response is None")
                         else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                            error_details.append(
+                                "response.content invalid (not a non-empty list)"
+                            )
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -1300,14 +1435,16 @@ def _run_conversation_impl(
                         if response is None:
                             error_details.append("response is None")
                         else:
-                            error_details.append("Bedrock response invalid (no output or choices)")
+                            error_details.append(
+                                "Bedrock response invalid (no output or choices)"
+                            )
                 else:
                     _ctv = agent._get_transport()
                     if not _ctv.validate_response(response):
                         response_invalid = True
                         if response is None:
                             error_details.append("response is None")
-                        elif not hasattr(response, 'choices'):
+                        elif not hasattr(response, "choices"):
                             error_details.append("response has no 'choices' attribute")
                         elif response.choices is None:
                             error_details.append("response.choices is None")
@@ -1323,8 +1460,11 @@ def _run_conversation_impl(
                         api_start_time=api_start_time,
                         api_kwargs=api_kwargs,
                         error_type="InvalidAPIResponse",
-                        error_message=", ".join(error_details) or "Invalid API response",
-                        status_code=getattr(getattr(response, "error", None), "code", None),
+                        error_message=", ".join(error_details)
+                        or "Invalid API response",
+                        status_code=getattr(
+                            getattr(response, "error", None), "code", None
+                        ),
                         retry_count=retry_count,
                         max_retries=max_retries,
                         retryable=True,
@@ -1337,16 +1477,18 @@ def _run_conversation_impl(
                         thinking_spinner = None
                     if agent.thinking_callback:
                         agent.thinking_callback("")
-                    
+
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
+                        agent._buffer_status(
+                            "⚠️ Empty/malformed response — switching to fallback..."
+                        )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -1356,31 +1498,47 @@ def _run_conversation_impl(
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
                     provider_name = "Unknown"
-                    if response and hasattr(response, 'error') and response.error:
+                    if response and hasattr(response, "error") and response.error:
                         error_msg = str(response.error)
                         # Try to extract provider from error metadata
-                        if hasattr(response.error, 'metadata') and response.error.metadata:
-                            provider_name = response.error.metadata.get('provider_name', 'Unknown')
-                    elif response and hasattr(response, 'message') and response.message:
+                        if (
+                            hasattr(response.error, "metadata")
+                            and response.error.metadata
+                        ):
+                            provider_name = response.error.metadata.get(
+                                "provider_name", "Unknown"
+                            )
+                    elif response and hasattr(response, "message") and response.message:
                         error_msg = str(response.message)
-                    
+
                     # Try to get provider from model field (OpenRouter often returns actual model used)
-                    if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
+                    if (
+                        provider_name == "Unknown"
+                        and response
+                        and hasattr(response, "model")
+                        and response.model
+                    ):
                         provider_name = f"model={response.model}"
-                    
+
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
-                        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        resp_attrs = {
+                            k: str(v)[:100]
+                            for k, v in vars(response).items()
+                            if not k.startswith("_")
+                        }
                         if agent.verbose_logging:
-                            logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                    
+                            logging.debug(
+                                f"Response attributes for invalid response: {resp_attrs}"
+                            )
+
                     # Extract error code from response for contextual diagnostics
                     _resp_error_code = None
-                    if response and hasattr(response, 'error') and response.error:
-                        _code_raw = getattr(response.error, 'code', None)
+                    if response and hasattr(response, "error") and response.error:
+                        _code_raw = getattr(response.error, "code", None)
                         if _code_raw is None and isinstance(response.error, dict):
-                            _code_raw = response.error.get('code')
+                            _code_raw = response.error.get("code")
                         if _code_raw is not None:
                             try:
                                 _resp_error_code = int(_code_raw)
@@ -1392,32 +1550,44 @@ def _run_conversation_impl(
                     if _resp_error_code == 524:
                         _failure_hint = f"upstream provider timed out (Cloudflare 524, {api_duration:.0f}s)"
                     elif _resp_error_code == 504:
-                        _failure_hint = f"upstream gateway timeout (504, {api_duration:.0f}s)"
+                        _failure_hint = (
+                            f"upstream gateway timeout (504, {api_duration:.0f}s)"
+                        )
                     elif _resp_error_code == 429:
                         _failure_hint = f"rate limited by upstream provider (429)"
                     elif _resp_error_code in {500, 502}:
                         _failure_hint = f"upstream server error ({_resp_error_code}, {api_duration:.0f}s)"
                     elif _resp_error_code in {503, 529}:
-                        _failure_hint = f"upstream provider overloaded ({_resp_error_code})"
+                        _failure_hint = (
+                            f"upstream provider overloaded ({_resp_error_code})"
+                        )
                     elif _resp_error_code is not None:
                         _failure_hint = f"upstream error (code {_resp_error_code}, {api_duration:.0f}s)"
                     elif api_duration < 10:
-                        _failure_hint = f"fast response ({api_duration:.1f}s) — likely rate limited"
+                        _failure_hint = (
+                            f"fast response ({api_duration:.1f}s) — likely rate limited"
+                        )
                     elif api_duration > 60:
                         _failure_hint = f"slow response ({api_duration:.0f}s) — likely upstream timeout"
                     else:
                         _failure_hint = f"response time {api_duration:.1f}s"
 
-                    agent._buffer_vprint(f"⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
+                    agent._buffer_vprint(
+                        f"⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}"
+                    )
                     agent._buffer_vprint(f"   🏢 Provider: {provider_name}")
                     cleaned_provider_error = agent._clean_error_message(error_msg)
-                    agent._buffer_vprint(f"   📝 Provider message: {cleaned_provider_error}")
+                    agent._buffer_vprint(
+                        f"   📝 Provider message: {cleaned_provider_error}"
+                    )
                     agent._buffer_vprint(f"   ⏱️  {_failure_hint}")
-                    
+
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
-                            agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
+                            agent._buffer_status(
+                                f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback..."
+                            )
                         if agent._try_activate_fallback():
                             retry_count = 0
                             compression_attempts = 0
@@ -1425,28 +1595,41 @@ def _run_conversation_impl(
                             continue
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
-                        agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
-                        logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
+                        agent._emit_status(
+                            f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up."
+                        )
+                        logger.error(
+                            f"{agent.log_prefix}Invalid API response after {max_retries} retries."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
                             "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
-                            "failed": True  # Mark as failure for filtering
+                            "failed": True,  # Mark as failure for filtering
                         }
-                    
+
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
-                    wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
-                    agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
-                    logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
-                    
+                    wait_time = jittered_backoff(
+                        retry_count, base_delay=5.0, max_delay=120.0
+                    )
+                    agent._buffer_vprint(
+                        f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})..."
+                    )
+                    logger.warning(
+                        f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}"
+                    )
+
                     # Sleep in small increments to stay responsive to interrupts
                     sleep_end = time.time() + wait_time
                     _backoff_touch_counter = 0
                     while time.time() < sleep_end:
                         if agent._interrupt_requested:
-                            agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                            agent._vprint(
+                                f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.",
+                                force=True,
+                            )
                             agent._persist_session(messages, conversation_history)
                             agent.clear_interrupt()
                             return {
@@ -1476,7 +1659,10 @@ def _run_conversation_impl(
                         incomplete_reason = incomplete_details.get("reason")
                     else:
                         incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                    if status == "incomplete" and incomplete_reason in {
+                        "max_output_tokens",
+                        "length",
+                    }:
                         finish_reason = "length"
                     else:
                         finish_reason = "stop"
@@ -1525,12 +1711,18 @@ def _run_conversation_impl(
                             response, strip_tool_prefix=agent._is_anthropic_oauth
                         )
                     else:
-                        _refusal_result = _refusal_transport.normalize_response(response)
-                    _refusal_text = (getattr(_refusal_result, "content", None) or "").strip()
+                        _refusal_result = _refusal_transport.normalize_response(
+                            response
+                        )
+                    _refusal_text = (
+                        getattr(_refusal_result, "content", None) or ""
+                    ).strip()
                     # Some refusals carry the explanation only in the reasoning
                     # channel; fall back to it so the user sees *something*.
                     if not _refusal_text:
-                        _refusal_text = (agent._extract_reasoning(_refusal_result) or "").strip()
+                        _refusal_text = (
+                            agent._extract_reasoning(_refusal_result) or ""
+                        ).strip()
 
                     agent._invoke_api_request_error_hook(
                         task_id=effective_task_id,
@@ -1540,7 +1732,8 @@ def _run_conversation_impl(
                         api_start_time=api_start_time,
                         api_kwargs=api_kwargs,
                         error_type="ContentPolicyBlocked",
-                        error_message=_refusal_text or "model declined to respond (content_filter)",
+                        error_message=_refusal_text
+                        or "model declined to respond (content_filter)",
                         status_code=None,
                         retry_count=retry_count,
                         max_retries=max_retries,
@@ -1576,7 +1769,9 @@ def _run_conversation_impl(
                     logger.warning(
                         "%sModel declined to respond (finish_reason=content_filter). "
                         "model=%s provider=%s refusal=%s",
-                        agent.log_prefix, agent.model, agent.provider,
+                        agent.log_prefix,
+                        agent.model,
+                        agent.provider,
                         _refusal_log or "(no text)",
                     )
                     agent._emit_status(
@@ -1635,8 +1830,14 @@ def _run_conversation_impl(
                         _trunc_result = _trunc_transport.normalize_response(response)
                     _trunc_msg = _trunc_result
 
-                    _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
-                    _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+                    _trunc_content = (
+                        getattr(_trunc_msg, "content", None) if _trunc_msg else None
+                    )
+                    _trunc_has_tool_calls = (
+                        bool(getattr(_trunc_msg, "tool_calls", None))
+                        if _trunc_msg
+                        else False
+                    )
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning
@@ -1651,8 +1852,9 @@ def _run_conversation_impl(
                     # truncations that deserve continuation retries, not as
                     # thinking-budget exhaustion.
                     _has_think_tags = bool(
-                        _trunc_content and re.search(
-                            r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
+                        _trunc_content
+                        and re.search(
+                            r"<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>",
                             _trunc_content,
                             re.IGNORECASE,
                         )
@@ -1661,7 +1863,12 @@ def _run_conversation_impl(
                         not _trunc_has_tool_calls
                         and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
+                            (
+                                _trunc_content is not None
+                                and not agent._has_content_after_think_block(
+                                    _trunc_content
+                                )
+                            )
                             or _trunc_content is None
                         )
                     )
@@ -1699,18 +1906,27 @@ def _run_conversation_impl(
                             "error": _exhaust_error,
                         }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if agent.api_mode in {
+                        "chat_completions",
+                        "bedrock_converse",
+                        "anthropic_messages",
+                    }:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
-                            interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                            interim_msg = agent._build_assistant_message(
+                                assistant_message, finish_reason
+                            )
                             messages.append(interim_msg)
                             if assistant_message.content:
-                                truncated_response_parts.append(assistant_message.content)
+                                truncated_response_parts.append(
+                                    assistant_message.content
+                                )
 
                             if length_continue_retries < 3:
                                 _is_partial_stream_stub = (
-                                    getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+                                    getattr(response, "id", "")
+                                    == PARTIAL_STREAM_STUB_ID
                                 )
                                 _dropped_tools = getattr(
                                     response, "_dropped_tool_names", None
@@ -1748,7 +1964,9 @@ def _run_conversation_impl(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks(
+                                "".join(truncated_response_parts)
+                            ).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -1760,7 +1978,11 @@ def _run_conversation_impl(
                                 "error": "Response remained truncated after 3 continuation attempts",
                             }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if agent.api_mode in {
+                        "chat_completions",
+                        "bedrock_converse",
+                        "anthropic_messages",
+                    }:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and _trunc_has_tool_calls:
                             _is_stub_stall = (
@@ -1787,13 +2009,23 @@ def _run_conversation_impl(
                                 # network stall doesn't need a bigger budget, but
                                 # a genuine output-cap truncation does, and the
                                 # boost is harmless for the stall case.
-                                _tc_boost_base = agent.max_tokens if agent.max_tokens else 4096
-                                _tc_boost = _tc_boost_base * (truncated_tool_call_retries + 1)
-                                _tc_requested_cap = agent._requested_output_cap_from_api_kwargs(api_kwargs)
+                                _tc_boost_base = (
+                                    agent.max_tokens if agent.max_tokens else 4096
+                                )
+                                _tc_boost = _tc_boost_base * (
+                                    truncated_tool_call_retries + 1
+                                )
+                                _tc_requested_cap = (
+                                    agent._requested_output_cap_from_api_kwargs(
+                                        api_kwargs
+                                    )
+                                )
                                 if _tc_requested_cap is not None:
                                     _tc_boost = max(_tc_boost, _tc_requested_cap)
                                 _tc_boost_cap = max(32768, _tc_requested_cap or 0)
-                                agent._ephemeral_max_output_tokens = min(_tc_boost, _tc_boost_cap)
+                                agent._ephemeral_max_output_tokens = min(
+                                    _tc_boost, _tc_boost_cap
+                                )
                                 # Don't append the broken response to messages;
                                 # just re-run the same API call from the current
                                 # message state, giving the model another chance.
@@ -1827,8 +2059,12 @@ def _run_conversation_impl(
 
                     # If we have prior messages, roll back to last complete state
                     if len(messages) > 1:
-                        agent._vprint(f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn")
-                        rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
+                        agent._vprint(
+                            f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn"
+                        )
+                        rolled_back_messages = agent._get_messages_up_to_last_assistant(
+                            messages
+                        )
 
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
@@ -1839,12 +2075,15 @@ def _run_conversation_impl(
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Response truncated due to output length limit"
+                            "error": "Response truncated due to output length limit",
                         }
                     else:
                         # First message was truncated - mark as failed
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ First response truncated - cannot recover", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ First response truncated - cannot recover",
+                            force=True,
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "final_response": None,
@@ -1852,11 +2091,11 @@ def _run_conversation_impl(
                             "api_calls": api_call_count,
                             "completed": False,
                             "failed": True,
-                            "error": "First response truncated due to output length limit"
+                            "error": "First response truncated due to output length limit",
                         }
-                
+
                 # Track actual token usage from response for context management
-                if hasattr(response, 'usage') and response.usage:
+                if hasattr(response, "usage") and response.usage:
                     canonical_usage = normalize_usage(
                         response.usage,
                         provider=agent.provider,
@@ -1886,9 +2125,15 @@ def _run_conversation_impl(
                     # from the error message), not guessed probe tiers.
                     if getattr(agent.context_compressor, "_context_probed", False):
                         ctx = agent.context_compressor.context_length
-                        if getattr(agent.context_compressor, "_context_probe_persistable", False):
+                        if getattr(
+                            agent.context_compressor,
+                            "_context_probe_persistable",
+                            False,
+                        ):
                             save_context_length(agent.model, agent.base_url, ctx)
-                            agent._safe_print(f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}")
+                            agent._safe_print(
+                                f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}"
+                            )
                         agent.context_compressor._context_probed = False
                         agent.context_compressor._context_probe_persistable = False
 
@@ -1899,18 +2144,25 @@ def _run_conversation_impl(
                     agent.session_input_tokens += canonical_usage.input_tokens
                     agent.session_output_tokens += canonical_usage.output_tokens
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
-                    agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+                    agent.session_cache_write_tokens += (
+                        canonical_usage.cache_write_tokens
+                    )
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""
                     if canonical_usage.cache_read_tokens and prompt_tokens:
-                        _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100*canonical_usage.cache_read_tokens/prompt_tokens:.0f}%)"
+                        _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100 * canonical_usage.cache_read_tokens / prompt_tokens:.0f}%)"
                     logger.info(
                         "API call #%d: model=%s provider=%s in=%d out=%d total=%d latency=%.1fs%s",
-                        agent.session_api_calls, agent.model, agent.provider or "unknown",
-                        prompt_tokens, completion_tokens, total_tokens,
-                        api_duration, _cache_pct,
+                        agent.session_api_calls,
+                        agent.model,
+                        agent.provider or "unknown",
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens,
+                        api_duration,
+                        _cache_pct,
                     )
 
                     cost_result = estimate_usage_cost(
@@ -1921,7 +2173,9 @@ def _run_conversation_impl(
                         api_key=getattr(agent, "api_key", ""),
                     )
                     if cost_result.amount_usd is not None:
-                        agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+                        agent.session_estimated_cost_usd += float(
+                            cost_result.amount_usd
+                        )
                     agent.session_cost_status = cost_result.status
                     agent.session_cost_source = cost_result.source
 
@@ -1950,13 +2204,15 @@ def _run_conversation_impl(
                                 cache_write_tokens=canonical_usage.cache_write_tokens,
                                 reasoning_tokens=canonical_usage.reasoning_tokens,
                                 estimated_cost_usd=float(cost_result.amount_usd)
-                                if cost_result.amount_usd is not None else None,
+                                if cost_result.amount_usd is not None
+                                else None,
                                 cost_status=cost_result.status,
                                 cost_source=cost_result.source,
                                 billing_provider=agent.provider,
                                 billing_base_url=agent.base_url,
                                 billing_mode="subscription_included"
-                                if cost_result.status == "included" else None,
+                                if cost_result.status == "included"
+                                else None,
                                 model=agent.model,
                                 api_call_count=1,
                             )
@@ -1966,12 +2222,16 @@ def _run_conversation_impl(
                             # the root cause of undercounted analytics.
                             logger.debug(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
-                                agent.session_id, total_tokens, e,
+                                agent.session_id,
+                                total_tokens,
+                                e,
                             )
-                    
+
                     if agent.verbose_logging:
-                        logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                    
+                        logging.debug(
+                            f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}"
+                        )
+
                     # Surface cache hit stats for any provider that reports
                     # them — not just those where we inject cache_control
                     # markers.  OpenAI/Kimi/DeepSeek/Qwen all do automatic
@@ -1993,7 +2253,7 @@ def _run_conversation_impl(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
-                
+
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
@@ -2006,6 +2266,7 @@ def _run_conversation_impl(
                 if agent.provider == "nous":
                     try:
                         from agent.nous_rate_guard import clear_nous_rate_limit
+
                         clear_nous_rate_limit()
                     except Exception:
                         pass
@@ -2019,10 +2280,14 @@ def _run_conversation_impl(
                 if agent.thinking_callback:
                     agent.thinking_callback("")
                 api_elapsed = time.time() - api_start_time
-                agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
+                agent._vprint(
+                    f"{agent.log_prefix}⚡ Interrupted during API call.", force=True
+                )
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
-                final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
+                final_response = (
+                    f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
+                )
                 break
 
             except Exception as api_error:
@@ -2045,16 +2310,18 @@ def _run_conversation_impl(
                 # first to strip surrogates, then once more for pure
                 # ASCII-only locale sanitization if needed.
                 # -----------------------------------------------------------
-                if isinstance(api_error, UnicodeEncodeError) and getattr(agent, '_unicode_sanitization_passes', 0) < 2:
+                if (
+                    isinstance(api_error, UnicodeEncodeError)
+                    and getattr(agent, "_unicode_sanitization_passes", 0) < 2
+                ):
                     _err_str = str(api_error).lower()
                     _is_ascii_codec = "'ascii'" in _err_str or "ascii" in _err_str
                     # Detect surrogate errors — utf-8 codec refusing to
                     # encode U+D800..U+DFFF.  The error text is:
                     #   "'utf-8' codec can't encode characters in position
                     #    N-M: surrogates not allowed"
-                    _is_surrogate_error = (
-                        "surrogate" in _err_str
-                        or ("'utf-8'" in _err_str and not _is_ascii_codec)
+                    _is_surrogate_error = "surrogate" in _err_str or (
+                        "'utf-8'" in _err_str and not _is_ascii_codec
                     )
                     # Sanitize surrogates from both the canonical `messages`
                     # list AND `api_messages` (the API-copy, which may carry
@@ -2112,7 +2379,9 @@ def _run_conversation_impl(
                             _sanitize_structure_non_ascii(api_kwargs)
                         _prefill_sanitized = False
                         if isinstance(getattr(agent, "prefill_messages", None), list):
-                            _prefill_sanitized = _sanitize_messages_non_ascii(agent.prefill_messages)
+                            _prefill_sanitized = _sanitize_messages_non_ascii(
+                                agent.prefill_messages
+                            )
 
                         _tools_sanitized = False
                         if isinstance(getattr(agent, "tools", None), list):
@@ -2125,8 +2394,12 @@ def _run_conversation_impl(
                                 active_system_prompt = _sanitized_system
                                 agent._cached_system_prompt = _sanitized_system
                                 _system_sanitized = True
-                        if isinstance(getattr(agent, "ephemeral_system_prompt", None), str):
-                            _sanitized_ephemeral = _strip_non_ascii(agent.ephemeral_system_prompt)
+                        if isinstance(
+                            getattr(agent, "ephemeral_system_prompt", None), str
+                        ):
+                            _sanitized_ephemeral = _strip_non_ascii(
+                                agent.ephemeral_system_prompt
+                            )
                             if _sanitized_ephemeral != agent.ephemeral_system_prompt:
                                 agent.ephemeral_system_prompt = _sanitized_ephemeral
                                 _system_sanitized = True
@@ -2138,7 +2411,9 @@ def _run_conversation_impl(
                             else None
                         )
                         if isinstance(_default_headers, dict):
-                            _headers_sanitized = _sanitize_structure_non_ascii(_default_headers)
+                            _headers_sanitized = _sanitize_structure_non_ascii(
+                                _default_headers
+                            )
 
                         # Sanitize the API key — non-ASCII characters in
                         # credentials (e.g. ʋ instead of v from a bad
@@ -2156,12 +2431,16 @@ def _run_conversation_impl(
                             _clean_key = _strip_non_ascii(_raw_key)
                             if _clean_key != _raw_key:
                                 agent.api_key = _clean_key
-                                if isinstance(getattr(agent, "_client_kwargs", None), dict):
+                                if isinstance(
+                                    getattr(agent, "_client_kwargs", None), dict
+                                ):
                                     agent._client_kwargs["api_key"] = _clean_key
                                 # Also update the live client — it holds its
                                 # own copy of api_key which auth_headers reads
                                 # dynamically on every request.
-                                if getattr(agent, "client", None) is not None and hasattr(agent.client, "api_key"):
+                                if getattr(
+                                    agent, "client", None
+                                ) is not None and hasattr(agent.client, "api_key"):
                                     agent.client.api_key = _clean_key
                                 _credential_sanitized = True
                                 agent._vprint(
@@ -2215,9 +2494,11 @@ def _run_conversation_impl(
                 # provider wordings are observed in the wild.
                 _err_body = ""
                 try:
-                    _err_body = str(getattr(api_error, "body", None) or
-                                    getattr(api_error, "message", None) or
-                                    str(api_error))
+                    _err_body = str(
+                        getattr(api_error, "body", None)
+                        or getattr(api_error, "message", None)
+                        or str(api_error)
+                    )
                 except Exception:
                     pass
                 _err_status = getattr(api_error, "status_code", None)
@@ -2277,7 +2558,11 @@ def _run_conversation_impl(
                     agent._vprint(
                         f"{agent.log_prefix}⚠️  Server rejected image content — "
                         f"switching to text-only mode for this session"
-                        + (". Stripped images from history and retrying." if _imgs_removed else "."),
+                        + (
+                            ". Stripped images from history and retrying."
+                            if _imgs_removed
+                            else "."
+                        ),
                         force=True,
                     )
                     continue
@@ -2287,7 +2572,11 @@ def _run_conversation_impl(
 
                 # ── Classify the error for structured recovery decisions ──
                 _compressor = getattr(agent, "context_compressor", None)
-                _ctx_len = getattr(_compressor, "context_length", 200000) if _compressor else 200000
+                _ctx_len = (
+                    getattr(_compressor, "context_length", 200000)
+                    if _compressor
+                    else 200000
+                )
                 classified = classify_api_error(
                     api_error,
                     provider=getattr(agent, "provider", "") or "",
@@ -2298,9 +2587,12 @@ def _run_conversation_impl(
                 )
                 logger.debug(
                     "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
-                    classified.reason.value, classified.status_code,
-                    classified.retryable, classified.should_compress,
-                    classified.should_rotate_credential, classified.should_fallback,
+                    classified.reason.value,
+                    classified.status_code,
+                    classified.retryable,
+                    classified.should_compress,
+                    classified.should_rotate_credential,
+                    classified.should_fallback,
                 )
                 agent._invoke_api_request_error_hook(
                     task_id=effective_task_id,
@@ -2335,11 +2627,13 @@ def _run_conversation_impl(
                         )
                         continue
 
-                recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
-                    status_code=status_code,
-                    has_retried_429=_retry.has_retried_429,
-                    classified_reason=classified.reason,
-                    error_context=error_context,
+                recovered_with_pool, _retry.has_retried_429 = (
+                    agent._recover_with_credential_pool(
+                        status_code=status_code,
+                        has_retried_429=_retry.has_retried_429,
+                        classified_reason=classified.reason,
+                        error_context=error_context,
+                    )
                 )
                 if recovered_with_pool:
                     continue
@@ -2380,7 +2674,8 @@ def _run_conversation_impl(
                 # of this session so future tool results preemptively
                 # downgrade, and retry once.  See issue #27344.
                 if (
-                    classified.reason == FailoverReason.multimodal_tool_content_unsupported
+                    classified.reason
+                    == FailoverReason.multimodal_tool_content_unsupported
                     and not _retry.multimodal_tool_content_retry_attempted
                 ):
                     _retry.multimodal_tool_content_retry_attempted = True
@@ -2407,7 +2702,8 @@ def _run_conversation_impl(
                 # proposed unconditional omit so capable subscriptions
                 # don't silently lose the capability).
                 if (
-                    classified.reason == FailoverReason.oauth_long_context_beta_forbidden
+                    classified.reason
+                    == FailoverReason.oauth_long_context_beta_forbidden
                     and agent.api_mode == "anthropic_messages"
                     and agent._is_anthropic_oauth
                     and not _retry.oauth_1m_beta_retry_attempted
@@ -2435,8 +2731,12 @@ def _run_conversation_impl(
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
-                        _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        _label = (
+                            "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
+                        )
+                        agent._buffer_vprint(
+                            f"🔐 {_label} auth refreshed after 401. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "chat_completions"
@@ -2446,30 +2746,47 @@ def _run_conversation_impl(
                 ):
                     _retry.nous_auth_retry_attempted = True
                     if agent._try_refresh_nous_client_credentials(force=True):
-                        print(f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                        print(
+                            f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request..."
+                        )
                         continue
                     # Credential refresh didn't help — show diagnostic info.
                     # Most common causes: Portal OAuth expired/revoked,
                     # account out of credits, or agent key blocked.
                     from hermes_constants import display_hermes_home as _dhh_fn
+
                     _dhh = _dhh_fn()
                     _body_text = ""
                     try:
-                        _body = getattr(api_error, "body", None) or getattr(api_error, "response", None)
+                        _body = getattr(api_error, "body", None) or getattr(
+                            api_error, "response", None
+                        )
                         if _body is not None:
                             _body_text = str(_body)[:200]
                     except Exception:
                         pass
-                    print(f"{agent.log_prefix}🔐 Nous 401 — Portal authentication failed.")
+                    print(
+                        f"{agent.log_prefix}🔐 Nous 401 — Portal authentication failed."
+                    )
                     if _body_text:
                         print(f"{agent.log_prefix}   Response: {_body_text}")
                     if not _print_nous_entitlement_guidance(agent, "Nous model access"):
-                        print(f"{agent.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or agent key revoked.")
+                        print(
+                            f"{agent.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or agent key revoked."
+                        )
                     print(f"{agent.log_prefix}   Troubleshooting:")
-                    print(f"{agent.log_prefix}     • Re-authenticate: hermes auth add nous")
-                    print(f"{agent.log_prefix}     • Check credits / billing: https://portal.nousresearch.com")
-                    print(f"{agent.log_prefix}     • Verify stored credentials: {_dhh}/auth.json")
-                    print(f"{agent.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter")
+                    print(
+                        f"{agent.log_prefix}     • Re-authenticate: hermes auth add nous"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Check credits / billing: https://portal.nousresearch.com"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Verify stored credentials: {_dhh}/auth.json"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter"
+                    )
                 if (
                     agent.provider == "copilot"
                     and status_code == 401
@@ -2477,45 +2794,79 @@ def _run_conversation_impl(
                 ):
                     _retry.copilot_auth_retry_attempted = True
                     if agent._try_refresh_copilot_client_credentials():
-                        agent._buffer_vprint(f"🔐 Copilot credentials refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(
+                            f"🔐 Copilot credentials refreshed after 401. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "anthropic_messages"
                     and status_code == 401
-                    and hasattr(agent, '_anthropic_api_key')
+                    and hasattr(agent, "_anthropic_api_key")
                     and not _retry.anthropic_auth_retry_attempted
                 ):
                     _retry.anthropic_auth_retry_attempted = True
                     from agent.anthropic_adapter import _is_oauth_token
                     from agent.azure_identity_adapter import is_token_provider
+
                     if agent._try_refresh_anthropic_client_credentials():
-                        print(f"{agent.log_prefix}🔐 Anthropic credentials refreshed after 401. Retrying request...")
+                        print(
+                            f"{agent.log_prefix}🔐 Anthropic credentials refreshed after 401. Retrying request..."
+                        )
                         continue
                     # Credential refresh didn't help — show diagnostic info
                     key = agent._anthropic_api_key
-                    print(f"{agent.log_prefix}🔐 Anthropic 401 — authentication failed.")
+                    print(
+                        f"{agent.log_prefix}🔐 Anthropic 401 — authentication failed."
+                    )
                     if is_token_provider(key):
                         # Azure Foundry Entra ID — the bearer token is
                         # minted per-request by an httpx event hook on a
                         # custom http_client passed to the SDK. The 401
                         # means Azure rejected the JWT (RBAC role missing,
                         # az login expired, IMDS unreachable, etc.).
-                        print(f"{agent.log_prefix}   Auth method: Microsoft Entra ID (httpx event hook)")
-                        print(f"{agent.log_prefix}   Run `hermes doctor` for credential-chain diagnostics, or")
-                        print(f"{agent.log_prefix}   `az login` if your developer session expired.")
+                        print(
+                            f"{agent.log_prefix}   Auth method: Microsoft Entra ID (httpx event hook)"
+                        )
+                        print(
+                            f"{agent.log_prefix}   Run `hermes doctor` for credential-chain diagnostics, or"
+                        )
+                        print(
+                            f"{agent.log_prefix}   `az login` if your developer session expired."
+                        )
                     else:
-                        auth_method = "Bearer (OAuth/setup-token)" if _is_oauth_token(key) else "x-api-key (API key)"
+                        auth_method = (
+                            "Bearer (OAuth/setup-token)"
+                            if _is_oauth_token(key)
+                            else "x-api-key (API key)"
+                        )
                         print(f"{agent.log_prefix}   Auth method: {auth_method}")
-                        print(f"{agent.log_prefix}   Token prefix: {key[:12]}..." if isinstance(key, str) and len(key) > 12 else f"{agent.log_prefix}   Token: (empty or short)")
+                        print(
+                            f"{agent.log_prefix}   Token prefix: {key[:12]}..."
+                            if isinstance(key, str) and len(key) > 12
+                            else f"{agent.log_prefix}   Token: (empty or short)"
+                        )
                     print(f"{agent.log_prefix}   Troubleshooting:")
                     from hermes_constants import display_hermes_home as _dhh_fn
+
                     _dhh = _dhh_fn()
-                    print(f"{agent.log_prefix}     • Check ANTHROPIC_TOKEN in {_dhh}/.env for Hermes-managed OAuth/setup tokens")
-                    print(f"{agent.log_prefix}     • Check ANTHROPIC_API_KEY in {_dhh}/.env for API keys or legacy token values")
-                    print(f"{agent.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys")
-                    print(f"{agent.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry")
-                    print(f"{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
-                    print(f"{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")
+                    print(
+                        f"{agent.log_prefix}     • Check ANTHROPIC_TOKEN in {_dhh}/.env for Hermes-managed OAuth/setup tokens"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • Check ANTHROPIC_API_KEY in {_dhh}/.env for API keys or legacy token values"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys"
+                    )
+                    print(
+                        f"{agent.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry"
+                    )
+                    print(
+                        f'{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN ""'
+                    )
+                    print(
+                        f'{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY ""'
+                    )
 
                 # Thinking block signature recovery.
                 #
@@ -2564,7 +2915,8 @@ def _run_conversation_impl(
                         "%sThinking block signature recovery: stripped "
                         "reasoning_details from %d api_messages "
                         "(canonical messages unchanged)",
-                        agent.log_prefix, _api_stripped,
+                        agent.log_prefix,
+                        _api_stripped,
                     )
                     continue
 
@@ -2627,11 +2979,13 @@ def _run_conversation_impl(
                     _retry.llama_cpp_grammar_retry_attempted = True
                     try:
                         from tools.schema_sanitizer import strip_pattern_and_format
+
                         _, _stripped = strip_pattern_and_format(agent.tools)
                     except Exception as _strip_exc:  # pragma: no cover — defensive
                         logger.warning(
                             "%sllama.cpp grammar recovery: strip helper failed: %s",
-                            agent.log_prefix, _strip_exc,
+                            agent.log_prefix,
+                            _strip_exc,
                         )
                         _stripped = 0
                     if _stripped:
@@ -2643,7 +2997,8 @@ def _run_conversation_impl(
                         logger.warning(
                             "%sllama.cpp grammar recovery: stripped %d "
                             "pattern/format keyword(s) from tool schemas",
-                            agent.log_prefix, _stripped,
+                            agent.log_prefix,
+                            _stripped,
                         )
                         continue
                     # No keywords found to strip — fall through to normal
@@ -2654,12 +3009,106 @@ def _run_conversation_impl(
                         agent.log_prefix,
                     )
 
+                # ── Fail fast for non-retryable client errors (#366) ─────
+                # The classifier already flags 401/403/404 (and other
+                # deterministic client errors) as retryable=False.  Instead
+                # of incrementing retry_count and waiting through backoff,
+                # try fallback once and, if unavailable, surface a clear
+                # diagnostic and abort immediately.
+                if (
+                    not classified.retryable
+                    and not classified.should_compress
+                    and classified.reason
+                    not in {
+                        FailoverReason.rate_limit,
+                        FailoverReason.overloaded,
+                        FailoverReason.context_overflow,
+                        FailoverReason.payload_too_large,
+                        FailoverReason.long_context_tier,
+                        FailoverReason.thinking_signature,
+                    }
+                    and not _retry.fail_fast_attempted
+                ):
+                    _retry.fail_fast_attempted = True
+                    _nr_provider = (getattr(agent, "provider", "") or "").strip()
+                    _nr_model = (getattr(agent, "model", "") or "").strip()
+                    _nr_base = str(getattr(agent, "base_url", "") or "").rstrip("/")
+                    _nr_status = getattr(api_error, "status_code", None)
+                    _nr_reason_label = classified.reason.value
+                    _nr_summary = agent._summarize_api_error(api_error)
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            f"⚠️ Non-retryable error ({_nr_reason_label}, HTTP {_nr_status}) — trying fallback..."
+                        )
+                    if agent._try_activate_fallback(
+                        reason=classified.reason, api_error=api_error
+                    ):
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        _retry.fail_fast_attempted = False
+                        continue
+                    # No fallback — dump, flush diagnostics, and abort.
+                    if api_kwargs is not None:
+                        agent._dump_api_request_debug(
+                            api_kwargs,
+                            reason="non_retryable_client_error",
+                            error=api_error,
+                        )
+                    agent._flush_status_buffer()
+                    agent._emit_status(
+                        f"❌ Non-retryable error (HTTP {_nr_status}): {_nr_summary}"
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Non-retryable client error (HTTP {_nr_status}). Aborting.",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🔌 Provider: {_nr_provider}  Model: {_nr_model}",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🌐 Endpoint: {_nr_base}", force=True
+                    )
+                    if classified.reason == FailoverReason.model_not_found:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Model '{_nr_model}' was not found. "
+                            "Check the model ID or configure a fallback provider.",
+                            force=True,
+                        )
+                    elif classified.reason in {
+                        FailoverReason.billing,
+                        FailoverReason.auth,
+                    }:
+                        _print_billing_or_entitlement_guidance(
+                            agent,
+                            capability="model access",
+                            provider=_nr_provider,
+                            base_url=_nr_base,
+                            model=_nr_model,
+                        )
+                    else:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.",
+                            force=True,
+                        )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": None,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": str(api_error),
+                        "failure_reason": classified.reason.value,
+                    }
+
                 retry_count += 1
                 elapsed_time = time.time() - api_start_time
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
-                
+
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
@@ -2676,7 +3125,9 @@ def _run_conversation_impl(
                 _base = getattr(agent, "base_url", "unknown")
                 _model = getattr(agent, "model", "unknown")
                 _status_code_str = f" [HTTP {status_code}]" if status_code else ""
-                agent._buffer_vprint(f"⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}")
+                agent._buffer_vprint(
+                    f"⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}"
+                )
                 agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
                 agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
                 agent._buffer_vprint(f"   📝 Error: {_error_summary}")
@@ -2685,16 +3136,15 @@ def _run_conversation_impl(
                     _err_body_str = str(_err_body)[:300] if _err_body else None
                     if _err_body_str:
                         agent._buffer_vprint(f"   📋 Details: {_err_body_str}")
-                agent._buffer_vprint(f"   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
+                agent._buffer_vprint(
+                    f"   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens"
+                )
 
                 # Actionable hint for OpenRouter "no tool endpoints" error.
                 # Buffered like the rest of the retry trace — surfaced only
                 # if every retry+fallback exhausts.  Avoids spamming users
                 # who recover automatically via fallback.
-                if (
-                    agent._is_openrouter_url()
-                    and "support tool use" in error_msg
-                ):
+                if agent._is_openrouter_url() and "support tool use" in error_msg:
                     agent._buffer_vprint(
                         f"   💡 No OpenRouter providers for {_model} support tool calling with your current settings."
                     )
@@ -2711,7 +3161,10 @@ def _run_conversation_impl(
 
                 # Check for interrupt before deciding to retry
                 if agent._interrupt_requested:
-                    agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.",
+                        force=True,
+                    )
                     agent._persist_session(messages, conversation_history)
                     agent.clear_interrupt()
                     return {
@@ -2721,7 +3174,7 @@ def _run_conversation_impl(
                         "completed": False,
                         "interrupted": True,
                     }
-                
+
                 # Check for 413 payload-too-large BEFORE generic 4xx handler.
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
@@ -2748,9 +3201,8 @@ def _run_conversation_impl(
                     FailoverReason.payload_too_large,
                     FailoverReason.context_overflow,
                 }
-                if (
-                    classified.reason in _overflow_reasons
-                    and not getattr(agent, "compression_enabled", True)
+                if classified.reason in _overflow_reasons and not getattr(
+                    agent, "compression_enabled", True
                 ):
                     agent._flush_status_buffer()
                     agent._vprint(
@@ -2821,7 +3273,8 @@ def _run_conversation_impl(
                     if compression_attempts <= max_compression_attempts:
                         original_len = len(messages)
                         messages, active_system_prompt = agent._compress_context(
-                            messages, system_message,
+                            messages,
+                            system_message,
                             approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -2848,7 +3301,9 @@ def _run_conversation_impl(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                if is_rate_limited and agent._fallback_index < len(
+                    agent._fallback_chain
+                ):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
@@ -2864,7 +3319,9 @@ def _run_conversation_impl(
                                 "⚠️ Billing or credits exhausted — switching to fallback provider..."
                             )
                         else:
-                            agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                            agent._buffer_status(
+                                "⚠️ Rate limited — switching to fallback provider..."
+                            )
                         if agent._try_activate_fallback(reason=classified.reason):
                             retry_count = 0
                             compression_attempts = 0
@@ -2903,10 +3360,10 @@ def _run_conversation_impl(
                             is_genuine_nous_rate_limit,
                             record_nous_rate_limit,
                         )
+
                         _err_resp = getattr(api_error, "response", None)
                         _err_hdrs = (
-                            getattr(_err_resp, "headers", None)
-                            if _err_resp else None
+                            getattr(_err_resp, "headers", None) if _err_resp else None
                         )
                         _genuine_nous_rate_limit = is_genuine_nous_rate_limit(
                             headers=_err_hdrs,
@@ -2981,9 +3438,17 @@ def _run_conversation_impl(
                     if compression_attempts > max_compression_attempts:
                         # Terminal — surface the buffered retry trace.
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logger.error(f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logger.error(
+                            f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2994,11 +3459,15 @@ def _run_conversation_impl(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                    agent._buffer_status(
+                        f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}..."
+                    )
 
                     original_len = len(messages)
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message, approx_tokens=approx_tokens,
+                        messages,
+                        system_message,
+                        approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
                     # Compression created a new session — clear history
@@ -3007,7 +3476,9 @@ def _run_conversation_impl(
                     conversation_history = None
 
                     if len(messages) < original_len:
-                        agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                        agent._buffer_status(
+                            f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying..."
+                        )
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
@@ -3015,9 +3486,17 @@ def _run_conversation_impl(
                         # Terminal — surface buffered context so the user
                         # sees what compression attempts were made.
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Payload too large and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logger.error(f"{agent.log_prefix}413 payload too large. Cannot compress further.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Payload too large and cannot compress further.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logger.error(
+                            f"{agent.log_prefix}413 payload too large. Cannot compress further."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -3068,9 +3547,17 @@ def _run_conversation_impl(
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
                             agent._flush_status_buffer()
-                            agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                            agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                            logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                            agent._vprint(
+                                f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                                force=True,
+                            )
+                            logger.error(
+                                f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts."
+                            )
                             agent._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -3092,14 +3579,16 @@ def _run_conversation_impl(
                     # turn a user-configured 1M window into 256K/128K/64K.
                     new_ctx = get_context_length_from_provider_error(error_msg, old_ctx)
                     _provider_lower = (getattr(agent, "provider", "") or "").lower()
-                    _base_lower = (getattr(agent, "base_url", "") or "").rstrip("/").lower()
-                    is_minimax_provider = (
-                        _provider_lower in {"minimax", "minimax-cn"}
-                        or _base_lower.startswith((
-                            "https://api.minimax.io/anthropic",
-                            "https://api.minimaxi.com/anthropic",
-                        ))
+                    _base_lower = (
+                        (getattr(agent, "base_url", "") or "").rstrip("/").lower()
                     )
+                    is_minimax_provider = _provider_lower in {
+                        "minimax",
+                        "minimax-cn",
+                    } or _base_lower.startswith((
+                        "https://api.minimax.io/anthropic",
+                        "https://api.minimaxi.com/anthropic",
+                    ))
                     minimax_delta_only_overflow = (
                         is_minimax_provider
                         and new_ctx is None
@@ -3107,7 +3596,9 @@ def _run_conversation_impl(
                     )
 
                     if new_ctx is not None:
-                        agent._buffer_vprint(f"Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})")
+                        agent._buffer_vprint(
+                            f"Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})"
+                        )
                         compressor.update_model(
                             model=agent.model,
                             context_length=new_ctx,
@@ -3122,7 +3613,9 @@ def _run_conversation_impl(
                         if hasattr(compressor, "_context_probed"):
                             compressor._context_probed = True
                             compressor._context_probe_persistable = True
-                        agent._buffer_vprint(f"⚠️  Context length exceeded — using provider limit: {old_ctx:,} → {new_ctx:,} tokens")
+                        agent._buffer_vprint(
+                            f"⚠️  Context length exceeded — using provider limit: {old_ctx:,} → {new_ctx:,} tokens"
+                        )
                     elif minimax_delta_only_overflow:
                         agent._buffer_vprint(
                             f"Provider reported overflow amount only; "
@@ -3137,9 +3630,17 @@ def _run_conversation_impl(
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                        logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.",
+                            force=True,
+                        )
+                        logger.error(
+                            f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -3150,11 +3651,15 @@ def _run_conversation_impl(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
+                    agent._buffer_status(
+                        f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})..."
+                    )
 
                     original_len = len(messages)
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message, approx_tokens=approx_tokens,
+                        messages,
+                        system_message,
+                        approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
                     # Compression created a new session — clear history
@@ -3164,16 +3669,26 @@ def _run_conversation_impl(
 
                     if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                         if len(messages) < original_len:
-                            agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            agent._buffer_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying..."
+                            )
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
                         # Can't compress further and already at minimum tier
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
-                        logger.error(f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.",
+                            force=True,
+                        )
+                        logger.error(
+                            f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -3245,7 +3760,8 @@ def _run_conversation_impl(
                     or (
                         not classified.retryable
                         and not classified.should_compress
-                        and classified.reason not in {
+                        and classified.reason
+                        not in {
                             FailoverReason.rate_limit,
                             FailoverReason.overloaded,
                             FailoverReason.context_overflow,
@@ -3300,9 +3816,13 @@ def _run_conversation_impl(
                     # abort silently (#35314, #17446).
                     if agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            agent._buffer_status(
+                                "⚠️ Provider safety filter blocked this request — trying fallback..."
+                            )
                         else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                            agent._buffer_status(
+                                f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback..."
+                            )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -3310,7 +3830,9 @@ def _run_conversation_impl(
                         continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
-                            api_kwargs, reason="non_retryable_client_error", error=api_error,
+                            api_kwargs,
+                            reason="non_retryable_client_error",
+                            error=api_error,
                         )
                     # Terminal — flush buffered context so the user sees
                     # what was tried before the abort.
@@ -3325,17 +3847,31 @@ def _run_conversation_impl(
                             f"❌ Non-retryable error (HTTP {status_code}): "
                             f"{agent._summarize_api_error(api_error)}"
                         )
-                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
-                    agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
-                    agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True
+                    )
                     # Actionable guidance for common auth errors
-                    if classified.is_auth or classified.reason == FailoverReason.billing:
-                        if classified.reason == FailoverReason.billing and _print_billing_or_entitlement_guidance(
-                            agent,
-                            capability="model access",
-                            provider=_provider,
-                            base_url=str(_base),
-                            model=_model,
+                    if (
+                        classified.is_auth
+                        or classified.reason == FailoverReason.billing
+                    ):
+                        if (
+                            classified.reason == FailoverReason.billing
+                            and _print_billing_or_entitlement_guidance(
+                                agent,
+                                capability="model access",
+                                provider=_provider,
+                                base_url=str(_base),
+                                model=_model,
+                            )
                         ):
                             pass
                         elif _provider == "nous" and _print_nous_entitlement_guidance(
@@ -3343,34 +3879,91 @@ def _run_conversation_impl(
                             "Nous model access",
                         ):
                             pass
-                        elif _provider in {"openai-codex", "xai-oauth", "nous"} and status_code == 401:
+                        elif (
+                            _provider in {"openai-codex", "xai-oauth", "nous"}
+                            and status_code == 401
+                        ):
                             if _provider == "openai-codex":
-                                agent._vprint(f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been", force=True)
-                                agent._vprint(f"{agent.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:", force=True)
-                                agent._vprint(f"{agent.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.", force=True)
-                                agent._vprint(f"{agent.log_prefix}      2. Then run `hermes auth` to re-authenticate.", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      2. Then run `hermes auth` to re-authenticate.",
+                                    force=True,
+                                )
                             elif _provider == "xai-oauth":
-                                agent._vprint(f"{agent.log_prefix}   💡 xAI OAuth token was rejected (HTTP 401). To fix:", force=True)
-                                agent._vprint(f"{agent.log_prefix}      re-authenticate with xAI Grok OAuth (SuperGrok / Premium+) from `hermes model`.", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}   💡 xAI OAuth token was rejected (HTTP 401). To fix:",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      re-authenticate with xAI Grok OAuth (SuperGrok / Premium+) from `hermes model`.",
+                                    force=True,
+                                )
                             else:  # nous
-                                agent._vprint(f"{agent.log_prefix}   💡 Nous Portal OAuth token was rejected (HTTP 401). Your token may be", force=True)
-                                agent._vprint(f"{agent.log_prefix}      expired, revoked, or your account may be out of credits. To fix:", force=True)
-                                agent._vprint(f"{agent.log_prefix}      1. Re-authenticate: hermes portal", force=True)
-                                agent._vprint(f"{agent.log_prefix}      2. Check your portal account: https://portal.nousresearch.com", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}   💡 Nous Portal OAuth token was rejected (HTTP 401). Your token may be",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      expired, revoked, or your account may be out of credits. To fix:",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      1. Re-authenticate: hermes portal",
+                                    force=True,
+                                )
+                                agent._vprint(
+                                    f"{agent.log_prefix}      2. Check your portal account: https://portal.nousresearch.com",
+                                    force=True,
+                                )
                                 # ``:free`` is OpenRouter slug syntax; Nous Portal will reject
                                 # the model name even after a successful re-auth.
                                 if isinstance(_model, str) and _model.endswith(":free"):
-                                    agent._vprint(f"{agent.log_prefix}      ⚠️  Note: `{_model}` looks like an OpenRouter slug (`:free` suffix).", force=True)
-                                    agent._vprint(f"{agent.log_prefix}         Nous Portal won't recognize that model name. Either switch to a", force=True)
-                                    agent._vprint(f"{agent.log_prefix}         Nous catalog model, or run `/model openrouter:{_model}` to use OpenRouter.", force=True)
+                                    agent._vprint(
+                                        f"{agent.log_prefix}      ⚠️  Note: `{_model}` looks like an OpenRouter slug (`:free` suffix).",
+                                        force=True,
+                                    )
+                                    agent._vprint(
+                                        f"{agent.log_prefix}         Nous Portal won't recognize that model name. Either switch to a",
+                                        force=True,
+                                    )
+                                    agent._vprint(
+                                        f"{agent.log_prefix}         Nous catalog model, or run `/model openrouter:{_model}` to use OpenRouter.",
+                                        force=True,
+                                    )
                         else:
-                            agent._vprint(f"{agent.log_prefix}   💡 Your API key was rejected by the provider. Check:", force=True)
-                            agent._vprint(f"{agent.log_prefix}      • Is the key valid? Run: hermes setup", force=True)
-                            agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Your API key was rejected by the provider. Check:",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}      • Is the key valid? Run: hermes setup",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}      • Does your account have access to {_model}?",
+                                force=True,
+                            )
                             if base_url_host_matches(str(_base), "openrouter.ai"):
-                                agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                                agent._vprint(
+                                    f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits",
+                                    force=True,
+                                )
                     else:
-                        agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.",
+                            force=True,
+                        )
                     # Content-policy blocks deserve their own actionable
                     # guidance — neither "fix your API key" nor "retry won't
                     # help" tells the user what to actually do. The provider
@@ -3393,13 +3986,17 @@ def _run_conversation_impl(
                             f"{agent.log_prefix}        hermes fallback add   (interactive picker — same as `hermes model`)",
                             force=True,
                         )
-                    logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
+                    logger.error(
+                        f"{agent.log_prefix}Non-retryable client error: {api_error}"
+                    )
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the
                     # session even larger, causing the same failure on the
                     # next attempt. (#1630)
-                    if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
+                    if status_code == 400 and (
+                        approx_tokens > 50000 or len(api_messages) > 80
+                    ):
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Skipping session persistence "
                             f"for large failed session to prevent growth loop.",
@@ -3435,15 +4032,22 @@ def _run_conversation_impl(
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once
                     # per API call block.
-                    if not _retry.primary_recovery_attempted and agent._try_recover_primary_transport(
-                        api_error, retry_count=retry_count, max_retries=max_retries,
+                    if (
+                        not _retry.primary_recovery_attempted
+                        and agent._try_recover_primary_transport(
+                            api_error,
+                            retry_count=retry_count,
+                            max_retries=max_retries,
+                        )
                     ):
                         _retry.primary_recovery_attempted = True
                         retry_count = 0
                         continue
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
-                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                        agent._buffer_status(
+                            f"⚠️ Max retries ({max_retries}) exhausted — trying fallback..."
+                        )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -3454,7 +4058,9 @@ def _run_conversation_impl(
                     _final_summary = agent._summarize_api_error(api_error)
                     _billing_guidance = ""
                     if classified.reason == FailoverReason.billing:
-                        agent._emit_status(f"❌ Billing or credits exhausted — {_final_summary}")
+                        agent._emit_status(
+                            f"❌ Billing or credits exhausted — {_final_summary}"
+                        )
                         _billing_guidance = _billing_or_entitlement_message(
                             capability="model access",
                             provider=_provider,
@@ -3469,23 +4075,35 @@ def _run_conversation_impl(
                             model=_model,
                         )
                     elif is_rate_limited:
-                        agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
+                        agent._emit_status(
+                            f"❌ Rate limited after {max_retries} retries — {_final_summary}"
+                        )
                     else:
-                        agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
-                    agent._vprint(f"{agent.log_prefix}   💀 Final error: {_final_summary}", force=True)
+                        agent._emit_status(
+                            f"❌ API failed after {max_retries} retries — {_final_summary}"
+                        )
+                    agent._vprint(
+                        f"{agent.log_prefix}   💀 Final error: {_final_summary}",
+                        force=True,
+                    )
 
                     # Detect SSE stream-drop pattern (e.g. "Network
                     # connection lost") and surface actionable guidance.
                     # This typically happens when the model generates a
                     # very large tool call (write_file with huge content)
                     # and the proxy/CDN drops the stream mid-response.
-                    _is_stream_drop = (
-                        not getattr(api_error, "status_code", None)
-                        and any(p in error_msg for p in (
-                            "connection lost", "connection reset",
-                            "connection closed", "network connection",
-                            "network error", "terminated",
-                        ))
+                    _is_stream_drop = not getattr(
+                        api_error, "status_code", None
+                    ) and any(
+                        p in error_msg
+                        for p in (
+                            "connection lost",
+                            "connection reset",
+                            "connection closed",
+                            "network connection",
+                            "network error",
+                            "terminated",
+                        )
                     )
                     if _is_stream_drop:
                         agent._vprint(
@@ -3505,16 +4123,25 @@ def _run_conversation_impl(
 
                     logger.error(
                         "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
-                        agent.log_prefix, max_retries, _final_summary,
-                        _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                        agent.log_prefix,
+                        max_retries,
+                        _final_summary,
+                        _provider,
+                        _model,
+                        len(api_messages),
+                        f"{approx_tokens:,}",
                     )
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
-                            api_kwargs, reason="max_retries_exhausted", error=api_error,
+                            api_kwargs,
+                            reason="max_retries_exhausted",
+                            error=api_error,
                         )
                     agent._persist_session(messages, conversation_history)
                     if classified.reason == FailoverReason.billing:
-                        _final_response = f"Billing or credits exhausted: {_final_summary}"
+                        _final_response = (
+                            f"Billing or credits exhausted: {_final_summary}"
+                        )
                         if _billing_guidance:
                             _final_response += f"\n\n{_billing_guidance}"
                     else:
@@ -3546,19 +4173,32 @@ def _run_conversation_impl(
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
                 if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                    _resp_headers = getattr(
+                        getattr(api_error, "response", None), "headers", None
+                    )
                     if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get(
+                            "Retry-After"
+                        )
                         if _ra_raw:
-                            try:
-                                _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
-                            except (TypeError, ValueError):
-                                pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
-                if is_rate_limited:
-                    agent._buffer_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
+                            _retry_after = extract_retry_after_seconds(_ra_raw)
+                wait_time = (
+                    _retry_after
+                    if _retry_after
+                    else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                )
+                if is_rate_limited and _retry_after:
+                    agent._buffer_status(
+                        f"⏱️ Rate limited on {getattr(agent, 'provider', 'unknown')}/{getattr(agent, 'model', 'unknown')}. Waiting {wait_time:.1f}s (Retry-After: {_retry_after:.1f}s, attempt {retry_count + 1}/{max_retries})..."
+                    )
+                elif is_rate_limited:
+                    agent._buffer_status(
+                        f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})..."
+                    )
                 else:
-                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    agent._buffer_status(
+                        f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})..."
+                    )
                 logger.warning(
                     "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                     wait_time,
@@ -3573,7 +4213,10 @@ def _run_conversation_impl(
                 _backoff_touch_counter = 0
                 while time.time() < sleep_end:
                     if agent._interrupt_requested:
-                        agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.",
+                            force=True,
+                        )
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
                         return {
@@ -3592,7 +4235,7 @@ def _run_conversation_impl(
                             f"error retry backoff ({retry_count}/{max_retries}), "
                             f"{int(sleep_end - time.time())}s remaining"
                         )
-        
+
         # If the API call was interrupted, skip response processing
         if interrupted:
             _turn_exit_reason = "interrupted_during_api_call"
@@ -3629,7 +4272,9 @@ def _run_conversation_impl(
         # the `response` variable is still None. Break out cleanly.
         if response is None:
             _turn_exit_reason = "all_retries_exhausted_no_response"
-            print(f"{agent.log_prefix}❌ All API retries exhausted with no successful response.")
+            print(
+                f"{agent.log_prefix}❌ All API retries exhausted with no successful response."
+            )
             agent._persist_session(messages, conversation_history)
             break
 
@@ -3641,14 +4286,18 @@ def _run_conversation_impl(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
-            
+
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead
             # of a plain string, which crashes downstream .strip() calls.
-            if assistant_message.content is not None and not isinstance(assistant_message.content, str):
+            if assistant_message.content is not None and not isinstance(
+                assistant_message.content, str
+            ):
                 raw = assistant_message.content
                 if isinstance(raw, dict):
-                    assistant_message.content = raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
+                    assistant_message.content = (
+                        raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
+                    )
                 elif isinstance(raw, list):
                     # Multimodal content list — extract text parts
                     parts = []
@@ -3668,6 +4317,7 @@ def _run_conversation_impl(
                     has_hook,
                     invoke_hook as _invoke_hook,
                 )
+
                 if has_hook("post_api_request"):
                     _assistant_tool_calls = (
                         getattr(assistant_message, "tool_calls", None) or []
@@ -3708,73 +4358,98 @@ def _run_conversation_impl(
             # Handle assistant response
             if assistant_message.content and not agent.quiet_mode:
                 if agent.verbose_logging:
-                    agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content}")
+                    agent._vprint(
+                        f"{agent.log_prefix}🤖 Assistant: {assistant_message.content}"
+                    )
                 else:
-                    agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
+                    agent._vprint(
+                        f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}"
+                    )
 
             # Notify progress callback of model's thinking (used by subagent
             # delegation to relay the child's reasoning to the parent display).
-            if (assistant_message.content and agent.tool_progress_callback):
+            if assistant_message.content and agent.tool_progress_callback:
                 _think_text = assistant_message.content.strip()
                 # Strip reasoning XML tags that shouldn't leak to parent display
                 _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                    r"</?(?:REASONING_SCRATCHPAD|think|reasoning)>", "", _think_text
                 ).strip()
                 # For subagents: relay first line to parent display (existing behaviour).
                 # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+                first_line = _think_text.split("\n")[0][:80] if _think_text else ""
+                if first_line and getattr(agent, "_delegate_depth", 0) > 0:
                     try:
                         agent.tool_progress_callback("_thinking", first_line)
                     except Exception:
                         pass
                 elif _think_text:
                     try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
+                        agent.tool_progress_callback(
+                            "reasoning.available", "_thinking", _think_text[:500], None
+                        )
                     except Exception:
                         pass
-            
+
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
             if has_incomplete_scratchpad(assistant_message.content or ""):
                 agent._incomplete_scratchpad_retries += 1
-                
-                agent._buffer_vprint(f"⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                
+
+                agent._buffer_vprint(
+                    f"⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)"
+                )
+
                 if agent._incomplete_scratchpad_retries <= 2:
-                    agent._buffer_vprint(f"🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)...")
+                    agent._buffer_vprint(
+                        f"🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)..."
+                    )
                     # Don't add the broken message, just retry
                     continue
                 else:
                     # Max retries - discard this turn and save as partial
                     agent._flush_status_buffer()
-                    agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.",
+                        force=True,
+                    )
                     agent._incomplete_scratchpad_retries = 0
-                    
-                    rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
+
+                    rolled_back_messages = agent._get_messages_up_to_last_assistant(
+                        messages
+                    )
                     agent._cleanup_task_resources(effective_task_id)
                     agent._persist_session(messages, conversation_history)
-                    
+
                     return {
                         "final_response": None,
                         "messages": rolled_back_messages,
                         "api_calls": api_call_count,
                         "completed": False,
                         "partial": True,
-                        "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
+                        "error": "Incomplete REASONING_SCRATCHPAD after 2 retries",
                     }
-            
+
             # Reset incomplete scratchpad counter on clean response
             agent._incomplete_scratchpad_retries = 0
 
             if agent.api_mode == "codex_responses" and finish_reason == "incomplete":
                 agent._codex_incomplete_retries += 1
 
-                interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                interim_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
                 interim_has_content = bool((interim_msg.get("content") or "").strip())
-                interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
-                interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
-                interim_has_codex_message_items = bool(interim_msg.get("codex_message_items"))
+                interim_has_reasoning = (
+                    bool(interim_msg.get("reasoning", "").strip())
+                    if isinstance(interim_msg.get("reasoning"), str)
+                    else False
+                )
+                interim_has_codex_reasoning = bool(
+                    interim_msg.get("codex_reasoning_items")
+                )
+                interim_has_codex_message_items = bool(
+                    interim_msg.get("codex_message_items")
+                )
 
                 if (
                     interim_has_content
@@ -3790,16 +4465,26 @@ def _run_conversation_impl(
                     # while visible content/reasoning are unchanged), compare
                     # those opaque payloads too so we don't silently drop the
                     # newer continuation state.
-                    last_codex_items = last_msg.get("codex_reasoning_items") if isinstance(last_msg, dict) else None
+                    last_codex_items = (
+                        last_msg.get("codex_reasoning_items")
+                        if isinstance(last_msg, dict)
+                        else None
+                    )
                     interim_codex_items = interim_msg.get("codex_reasoning_items")
-                    last_codex_message_items = last_msg.get("codex_message_items") if isinstance(last_msg, dict) else None
+                    last_codex_message_items = (
+                        last_msg.get("codex_message_items")
+                        if isinstance(last_msg, dict)
+                        else None
+                    )
                     interim_codex_message_items = interim_msg.get("codex_message_items")
                     duplicate_interim = (
                         isinstance(last_msg, dict)
                         and last_msg.get("role") == "assistant"
                         and last_msg.get("finish_reason") == "incomplete"
-                        and (last_msg.get("content") or "") == (interim_msg.get("content") or "")
-                        and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
+                        and (last_msg.get("content") or "")
+                        == (interim_msg.get("content") or "")
+                        and (last_msg.get("reasoning") or "")
+                        == (interim_msg.get("reasoning") or "")
                         and last_codex_items == interim_codex_items
                         and last_codex_message_items == interim_codex_message_items
                     )
@@ -3809,7 +4494,9 @@ def _run_conversation_impl(
 
                 if agent._codex_incomplete_retries < 3:
                     if not agent.quiet_mode:
-                        agent._vprint(f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)")
+                        agent._vprint(
+                            f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)"
+                        )
                     agent._session_messages = messages
                     continue
 
@@ -3825,26 +4512,33 @@ def _run_conversation_impl(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
-            
+
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:
-                    agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
-                
+                    agent._vprint(
+                        f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)..."
+                    )
+
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
-                        logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
-                
+                        logging.debug(
+                            f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}..."
+                        )
+
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
                     if tc.function.name not in agent.valid_tool_names:
                         repaired = agent._repair_tool_call(tc.function.name)
                         if repaired:
-                            print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
+                            print(
+                                f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'"
+                            )
                             tc.function.name = repaired
                 invalid_tool_calls = [
-                    tc.function.name for tc in assistant_message.tool_calls
+                    tc.function.name
+                    for tc in assistant_message.tool_calls
                     if tc.function.name not in agent.valid_tool_names
                 ]
                 if invalid_tool_calls:
@@ -3854,12 +4548,21 @@ def _run_conversation_impl(
                     # Return helpful error to model — model can agent-correct next turn
                     available = ", ".join(sorted(agent.valid_tool_names))
                     invalid_name = invalid_tool_calls[0]
-                    invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
-                    agent._buffer_vprint(f"⚠️  Unknown tool '{invalid_preview}' — sending error to model for agent-correction ({agent._invalid_tool_retries}/3)")
+                    invalid_preview = (
+                        invalid_name[:80] + "..."
+                        if len(invalid_name) > 80
+                        else invalid_name
+                    )
+                    agent._buffer_vprint(
+                        f"⚠️  Unknown tool '{invalid_preview}' — sending error to model for agent-correction ({agent._invalid_tool_retries}/3)"
+                    )
 
                     if agent._invalid_tool_retries >= 3:
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.", force=True)
+                        agent._vprint(
+                            f"{agent.log_prefix}❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.",
+                            force=True,
+                        )
                         agent._invalid_tool_retries = 0
                         agent._persist_session(messages, conversation_history)
                         return {
@@ -3868,10 +4571,12 @@ def _run_conversation_impl(
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": f"Model generated invalid tool call: {invalid_preview}"
+                            "error": f"Model generated invalid tool call: {invalid_preview}",
                         }
 
-                    assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    assistant_msg = agent._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
                     messages.append(assistant_msg)
                     for tc in assistant_message.tool_calls:
                         _tc_name = tc.function.name
@@ -3909,7 +4614,7 @@ def _run_conversation_impl(
                     continue
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
-                
+
                 # Validate tool call arguments are valid JSON
                 # Handle empty strings as empty objects (common model quirk)
                 invalid_json_args = []
@@ -3929,7 +4634,7 @@ def _run_conversation_impl(
                         json.loads(args)
                     except json.JSONDecodeError as e:
                         invalid_json_args.append((tc.function.name, str(e)))
-                
+
                 if invalid_json_args:
                     # Check if the invalid JSON is due to truncation rather
                     # than a model formatting mistake.  Routers sometimes
@@ -3964,27 +4669,39 @@ def _run_conversation_impl(
                     agent._invalid_json_retries += 1
 
                     tool_name, error_msg = invalid_json_args[0]
-                    agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
+                    agent._buffer_vprint(
+                        f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}"
+                    )
 
                     if agent._invalid_json_retries < 3:
-                        agent._buffer_vprint(f"🔄 Retrying API call ({agent._invalid_json_retries}/3)...")
+                        agent._buffer_vprint(
+                            f"🔄 Retrying API call ({agent._invalid_json_retries}/3)..."
+                        )
                         # Don't add anything to messages, just retry the API call
                         continue
                     else:
                         # Instead of returning partial, inject tool error results so the model can recover.
                         # Using tool results (not user messages) preserves role alternation.
-                        agent._buffer_vprint(f"⚠️  Injecting recovery tool results for invalid JSON...")
+                        agent._buffer_vprint(
+                            f"⚠️  Injecting recovery tool results for invalid JSON..."
+                        )
                         agent._invalid_json_retries = 0  # Reset for next attempt
-                        
+
                         # Append the assistant message with its (broken) tool_calls
-                        recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
+                        recovery_assistant = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
                         messages.append(recovery_assistant)
-                        
+
                         # Respond with tool error results for each tool call
                         invalid_names = {name for name, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
                             if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
+                                err = next(
+                                    e
+                                    for n, e in invalid_json_args
+                                    if n == tc.function.name
+                                )
                                 tool_result = (
                                     f"Error: Invalid JSON arguments. {err}. "
                                     f"For tools with no required parameters, use an empty object: {{}}. "
@@ -3999,7 +4716,7 @@ def _run_conversation_impl(
                                 "content": tool_result,
                             })
                         continue
-                
+
                 # Reset retry counter on successful JSON validation
                 agent._invalid_json_retries = 0
 
@@ -4011,8 +4728,10 @@ def _run_conversation_impl(
                     assistant_message.tool_calls
                 )
 
-                assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                
+                assistant_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
+
                 # If this turn has both content AND tool_calls, capture the content
                 # as a fallback final response. Common pattern: model delivers its
                 # answer and calls memory/skill tools as a side-effect in the same
@@ -4026,7 +4745,10 @@ def _run_conversation_impl(
                     # (search_files, read_file, write_file, terminal, ...),
                     # keep output visible so the user sees progress.
                     _HOUSEKEEPING_TOOLS = frozenset({
-                        "memory", "todo", "skill_manage", "session_search",
+                        "memory",
+                        "todo",
+                        "skill_manage",
+                        "session_search",
                     })
                     _all_housekeeping = all(
                         tc.function.name in _HOUSEKEEPING_TOOLS
@@ -4039,7 +4761,7 @@ def _run_conversation_impl(
                         clean = agent._strip_think_blocks(turn_content).strip()
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
-                
+
                 # Pop thinking-only prefill message(s) before appending
                 # (tool-call path — same rationale as the final-response path).
                 _had_prefill = False
@@ -4081,7 +4803,9 @@ def _run_conversation_impl(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                agent._execute_tool_calls(
+                    assistant_message, messages, effective_task_id, api_call_count
+                )
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
@@ -4125,7 +4849,7 @@ def _run_conversation_impl(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
-                
+
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the
                 # actual context size the provider reported plus the
@@ -4162,10 +4886,13 @@ def _run_conversation_impl(
                         messages, tools=agent.tools or None
                     )
 
-                if agent.compression_enabled and _compressor.should_compress(_real_tokens):
+                if agent.compression_enabled and _compressor.should_compress(
+                    _real_tokens
+                ):
                     agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
+                        messages,
+                        system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,
                         task_id=effective_task_id,
                     )
@@ -4173,24 +4900,24 @@ def _run_conversation_impl(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
-                
+
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages
-                
+
                 # Continue loop for next response
                 continue
-            
+
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a
                 # prior housekeeping tool turn and should not silence the
                 # final response path.
                 agent._mute_post_response = False
-                
+
                 # Check if response only has think block with no actual content after it
                 if not agent._has_content_after_think_block(final_response):
                     # ── Partial stream recovery ─────────────────────
@@ -4203,7 +4930,9 @@ def _run_conversation_impl(
                     )
                     if agent._has_content_after_think_block(_partial_streamed):
                         _turn_exit_reason = "partial_stream_recovery"
-                        _recovered = agent._strip_think_blocks(_partial_streamed).strip()
+                        _recovered = agent._strip_think_blocks(
+                            _partial_streamed
+                        ).strip()
                         logger.info(
                             "Partial stream content delivered (%d chars) "
                             "— using as final response",
@@ -4227,11 +4956,17 @@ def _run_conversation_impl(
                     # likely mid-task narration ("I'll scan the directory...") and
                     # the empty follow-up means the model choked — let the
                     # post-tool nudge below handle that instead of exiting early.
-                    fallback = getattr(agent, '_last_content_with_tools', None)
-                    if fallback and getattr(agent, '_last_content_tools_all_housekeeping', False):
+                    fallback = getattr(agent, "_last_content_with_tools", None)
+                    if fallback and getattr(
+                        agent, "_last_content_tools_all_housekeeping", False
+                    ):
                         _turn_exit_reason = "fallback_prior_turn_content"
-                        logger.info("Empty follow-up after tool calls — using prior turn content as final response")
-                        agent._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
+                        logger.info(
+                            "Empty follow-up after tool calls — using prior turn content as final response"
+                        )
+                        agent._emit_status(
+                            "↻ Empty response after tool calls — using earlier content as final answer"
+                        )
                         agent._last_content_with_tools = None
                         agent._last_content_tools_all_housekeeping = False
                         agent._empty_content_retries = 0
@@ -4267,7 +5002,7 @@ def _run_conversation_impl(
                     # after tool calls route to prefill instead of nudge.
                     _has_inline_thinking = bool(
                         re.search(
-                            r'<think>|<thinking>|<reasoning>',
+                            r"<think>|<thinking>|<reasoning>",
                             final_response or "",
                             re.IGNORECASE,
                         )
@@ -4295,7 +5030,9 @@ def _run_conversation_impl(
                         #   tool(result) → assistant("(empty)") → user(nudge)
                         # Without this, we'd have tool → user which most
                         # APIs reject as an invalid sequence.
-                        _nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                        _nudge_msg = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
                         _nudge_msg["content"] = "(empty)"
                         _nudge_msg["_empty_recovery_synthetic"] = True
                         messages.append(_nudge_msg)
@@ -4353,19 +5090,21 @@ def _run_conversation_impl(
                     # always populate reasoning fields via OpenRouter,
                     # so the old `not _has_structured` guard blocked
                     # retries for every reasoning model after prefill.
-                    _truly_empty = not agent._strip_think_blocks(
-                        final_response
-                    ).strip()
+                    _truly_empty = not agent._strip_think_blocks(final_response).strip()
                     _prefill_exhausted = (
-                        _has_structured
-                        and agent._thinking_prefill_retries >= 2
+                        _has_structured and agent._thinking_prefill_retries >= 2
                     )
-                    if _truly_empty and (not _has_structured or _prefill_exhausted) and agent._empty_content_retries < 3:
+                    if (
+                        _truly_empty
+                        and (not _has_structured or _prefill_exhausted)
+                        and agent._empty_content_retries < 3
+                    ):
                         agent._empty_content_retries += 1
                         logger.warning(
                             "Empty response (no content or reasoning) — "
                             "retry %d/3 (model=%s)",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                         )
                         agent._buffer_status(
                             f"⚠️ Empty response from model — retrying "
@@ -4383,7 +5122,8 @@ def _run_conversation_impl(
                         logger.warning(
                             "Empty response after %d retries — "
                             "attempting fallback (model=%s, provider=%s)",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                             agent.provider,
                         )
                         agent._buffer_status(
@@ -4399,7 +5139,8 @@ def _run_conversation_impl(
                             logger.info(
                                 "Fallback activated after empty responses: "
                                 "now using %s on %s",
-                                agent.model, agent.provider,
+                                agent.model,
+                                agent.provider,
                             )
                             continue
 
@@ -4412,7 +5153,9 @@ def _run_conversation_impl(
                     _turn_exit_reason = "empty_response_exhausted"
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)
-                    assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    assistant_msg = agent._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
                     assistant_msg["content"] = "(empty)"
                     # This is a user-facing failure sentinel for the gateway,
                     # not real assistant content. Persisting it makes later
@@ -4423,11 +5166,16 @@ def _run_conversation_impl(
                     messages.append(assistant_msg)
 
                     if reasoning_text:
-                        reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
+                        reasoning_preview = (
+                            reasoning_text[:500] + "..."
+                            if len(reasoning_text) > 500
+                            else reasoning_text
+                        )
                         logger.warning(
                             "Reasoning-only response (no visible content) "
                             "after exhausting retries and fallback. "
-                            "Reasoning: %s", reasoning_preview,
+                            "Reasoning: %s",
+                            reasoning_preview,
                         )
                         agent._emit_status(
                             "⚠️ Model produced reasoning but no visible "
@@ -4438,18 +5186,22 @@ def _run_conversation_impl(
                             "Empty response (no content or reasoning) "
                             "after %d retries. No fallback available. "
                             "model=%s provider=%s",
-                            agent._empty_content_retries, agent.model,
+                            agent._empty_content_retries,
+                            agent.model,
                             agent.provider,
                         )
                         agent._emit_status(
                             "❌ Model returned no content after all retries"
-                            + (" and fallback attempts." if agent._fallback_chain else
-                               ". No fallback providers configured.")
+                            + (
+                                " and fallback attempts."
+                                if agent._fallback_chain
+                                else ". No fallback providers configured."
+                            )
                         )
 
                     final_response = "(empty)"
                     break
-                
+
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
@@ -4468,7 +5220,9 @@ def _run_conversation_impl(
                     )
                 ):
                     codex_ack_continuations += 1
-                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                    interim_msg = agent._build_assistant_message(
+                        assistant_message, "incomplete"
+                    )
                     messages.append(interim_msg)
                     agent._emit_interim_assistant_message(interim_msg)
 
@@ -4489,10 +5243,12 @@ def _run_conversation_impl(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
-                
+
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
-                final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+
+                final_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending the final response.  These
@@ -4510,14 +5266,18 @@ def _run_conversation_impl(
                     messages.pop()
 
                 messages.append(final_msg)
-                
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
-                    agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
+                    agent._safe_print(
+                        f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)"
+                    )
                 break
-            
+
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            error_msg = (
+                f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            )
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
@@ -4530,7 +5290,7 @@ def _run_conversation_impl(
             # recover the call site.  logger.exception() includes the
             # traceback automatically and emits at ERROR.
             logger.exception("Outer loop error in API call #%d", api_call_count)
-            
+
             # If an assistant message with tool_calls was already appended,
             # the API expects a role="tool" result for every tool_call_id.
             # Fill in error results for any that weren't answered yet.
@@ -4543,11 +5303,12 @@ def _run_conversation_impl(
                 if msg.get("role") == "assistant" and msg.get("tool_calls"):
                     answered_ids = {
                         m["tool_call_id"]
-                        for m in messages[idx + 1:]
+                        for m in messages[idx + 1 :]
                         if isinstance(m, dict) and m.get("role") == "tool"
                     }
                     for tc in msg["tool_calls"]:
-                        if not tc or not isinstance(tc, dict): continue
+                        if not tc or not isinstance(tc, dict):
+                            continue
                         if tc["id"] not in answered_ids:
                             err_msg = {
                                 "role": "tool",
@@ -4557,7 +5318,7 @@ def _run_conversation_impl(
                             }
                             messages.append(err_msg)
                 break
-            
+
             # Non-tool errors don't need a synthetic message injected.
             # The error is already printed to the user (line above), and
             # the retry loop continues.  Injecting a fake user/assistant
@@ -4567,16 +5328,19 @@ def _run_conversation_impl(
             # If we're near the limit, break to avoid infinite loops
             if api_call_count >= agent.max_iterations - 1:
                 _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+                final_response = (
+                    f"I apologize, but I encountered repeated errors: {error_msg}"
+                )
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})
                 break
-    
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
     from agent.turn_finalizer import finalize_turn
+
     return finalize_turn(
         agent,
         final_response=final_response,
@@ -4592,7 +5356,6 @@ def _run_conversation_impl(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
     )
-
 
 
 __all__ = ["run_conversation"]

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -21,50 +21,54 @@ logger = logging.getLogger(__name__)
 
 # ── Error taxonomy ──────────────────────────────────────────────────────
 
+
 class FailoverReason(enum.Enum):
     """Why an API call failed — determines recovery strategy."""
 
     # Authentication / authorization
-    auth = "auth"                        # Transient auth (401/403) — refresh/rotate
-    auth_permanent = "auth_permanent"    # Auth failed after refresh — abort
+    auth = "auth"  # Transient auth (401/403) — refresh/rotate
+    auth_permanent = "auth_permanent"  # Auth failed after refresh — abort
 
     # Billing / quota
-    billing = "billing"                  # 402 or confirmed credit exhaustion — rotate immediately
-    rate_limit = "rate_limit"            # 429 or quota-based throttling — backoff then rotate
+    billing = "billing"  # 402 or confirmed credit exhaustion — rotate immediately
+    rate_limit = "rate_limit"  # 429 or quota-based throttling — backoff then rotate
 
     # Server-side
-    overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
-    server_error = "server_error"        # 500/502 — internal server error, retry
+    overloaded = "overloaded"  # 503/529 — provider overloaded, backoff
+    server_error = "server_error"  # 500/502 — internal server error, retry
 
     # Transport
-    timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    timeout = "timeout"  # Connection/read timeout — rebuild client + retry
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
     payload_too_large = "payload_too_large"  # 413 — compress payload
-    image_too_large = "image_too_large"   # Native image part exceeds provider's per-image limit — shrink and retry
+    image_too_large = "image_too_large"  # Native image part exceeds provider's per-image limit — shrink and retry
 
     # Model / provider policy
-    model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
+    model_not_found = (
+        "model_not_found"  # 404 or invalid model — fallback to different model
+    )
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — deterministic per-request, don't retry unchanged
 
     # Request format
-    format_error = "format_error"        # 400 bad request — abort or strip + retry
+    format_error = "format_error"  # 400 bad request — abort or strip + retry
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
-    long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
+    long_context_tier = "long_context_tier"  # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
 
     # Catch-all
-    unknown = "unknown"                  # Unclassifiable — retry with backoff
+    unknown = "unknown"  # Unclassifiable — retry with backoff
 
 
 # ── Classification result ───────────────────────────────────────────────
+
 
 @dataclass
 class ClassifiedError:
@@ -89,7 +93,6 @@ class ClassifiedError:
         return self.reason in {FailoverReason.auth, FailoverReason.auth_permanent}
 
 
-
 # ── Provider-specific patterns ──────────────────────────────────────────
 
 # Patterns that indicate billing exhaustion (not transient rate limit)
@@ -112,6 +115,14 @@ _BILLING_PATTERNS = [
     "balance_depleted",
     "model_not_supported_on_free_tier",
     "not available on the free tier",
+    "subscription required",
+    "requires a subscription",
+    "requires a paid subscription",
+    "paid subscription",
+    "upgrade your plan",
+    "upgrade to access",
+    "subscription does not include",
+    "active subscription",
 ]
 
 # Patterns that indicate rate limiting (transient, will resolve)
@@ -167,10 +178,10 @@ _PAYLOAD_TOO_LARGE_PATTERNS = [
 # important here (hard 5 MB per image, returned as
 # "messages.N.content.K.image.source.base64: image exceeds 5 MB maximum").
 _IMAGE_TOO_LARGE_PATTERNS = [
-    "image exceeds",        # Anthropic: "image exceeds 5 MB maximum"
-    "image too large",      # generic
-    "image_too_large",      # error_code variant
-    "image size exceeds",   # variant
+    "image exceeds",  # Anthropic: "image exceeds 5 MB maximum"
+    "image too large",  # generic
+    "image_too_large",  # error_code variant
+    "image size exceeds",  # variant
     "image dimensions exceed",  # Anthropic: "image dimensions exceed max allowed size: 8000 pixels"
     "dimensions exceed max allowed size",  # Anthropic dimension-cap (wording variant)
     "max allowed size: 8000",  # Anthropic dimension-cap (explicit pixel ceiling)
@@ -221,14 +232,14 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     # vLLM / local inference server patterns
     "exceeds the max_model_len",
     "max_model_len",
-    "prompt length",             # "engine prompt length X exceeds"
+    "prompt length",  # "engine prompt length X exceeds"
     "input is too long",
     "maximum model length",
     # Ollama patterns
     "context length exceeded",
     "truncating input",
     # llama.cpp / llama-server patterns
-    "slot context",              # "slot context: N tokens, prompt N tokens"
+    "slot context",  # "slot context: N tokens, prompt N tokens"
     "n_ctx_slot",
     # Chinese error messages (some providers return these)
     "超过最大长度",
@@ -268,7 +279,9 @@ def model_id_suffix_variants(model: str) -> list[str]:
     return [f"{model}:cloud", f"{model}:local"]
 
 
-def next_untried_model_variant(base_model: str, tried: "set[str] | frozenset[str]") -> str | None:
+def next_untried_model_variant(
+    base_model: str, tried: "set[str] | frozenset[str]"
+) -> str | None:
     """Next ``model:suffix`` variant of ``base_model`` not present in ``tried``.
 
     Drives the bounded 404 self-correction loop (#348): callers pass the original
@@ -395,11 +408,17 @@ _TIMEOUT_MESSAGE_PATTERNS = [
 
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
-    "ReadTimeout", "ConnectTimeout", "PoolTimeout",
-    "ConnectError", "RemoteProtocolError",
-    "ConnectionError", "ConnectionResetError",
-    "ConnectionAbortedError", "BrokenPipeError",
-    "TimeoutError", "ReadError",
+    "ReadTimeout",
+    "ConnectTimeout",
+    "PoolTimeout",
+    "ConnectError",
+    "RemoteProtocolError",
+    "ConnectionError",
+    "ConnectionResetError",
+    "ConnectionAbortedError",
+    "BrokenPipeError",
+    "TimeoutError",
+    "ReadError",
     "ServerDisconnectedError",
     # SSL/TLS transport errors — transient mid-stream handshake/record
     # failures that should retry rather than surface as a stalled session.
@@ -407,8 +426,12 @@ _TRANSPORT_ERROR_TYPES = frozenset({
     # the type names here so provider-wrapped SSL errors (e.g. when the
     # SDK re-raises without preserving the exception chain) still classify
     # as transport rather than falling through to the unknown bucket.
-    "SSLError", "SSLZeroReturnError", "SSLWantReadError",
-    "SSLWantWriteError", "SSLEOFError", "SSLSyscallError",
+    "SSLError",
+    "SSLZeroReturnError",
+    "SSLWantReadError",
+    "SSLWantWriteError",
+    "SSLEOFError",
+    "SSLSyscallError",
     # OpenAI SDK errors (not subclasses of Python builtins)
     "APIConnectionError",
     "APITimeoutError",
@@ -466,6 +489,7 @@ _SSL_TRANSIENT_PATTERNS = [
 
 
 # ── Classification pipeline ─────────────────────────────────────────────
+
 
 def classify_api_error(
     error: Exception,
@@ -532,11 +556,14 @@ def classify_api_error(
                 if isinstance(_raw_json, str) and _raw_json.strip():
                     try:
                         import json
+
                         _inner = json.loads(_raw_json)
                         if isinstance(_inner, dict):
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
-                                _metadata_msg = str(_inner_err.get("message") or "").lower()
+                                _metadata_msg = str(
+                                    _inner_err.get("message") or ""
+                                ).lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
@@ -545,7 +572,11 @@ def classify_api_error(
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
         parts.append(_body_msg)
-    if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
+    if (
+        _metadata_msg
+        and _metadata_msg not in _raw_msg
+        and _metadata_msg not in _body_msg
+    ):
         parts.append(_metadata_msg)
     error_msg = " ".join(parts)
     provider_lower = (provider or "").strip().lower()
@@ -650,16 +681,10 @@ def classify_api_error(
     # recognizable phrases; on match we strip ``pattern``/``format`` from
     # ``self.tools`` in the retry loop and retry once. Cloud providers are
     # unaffected — they accept these keywords and we never hit this branch.
-    if (
-        status_code == 400
-        and (
-            "error parsing grammar" in error_msg
-            or "json-schema-to-grammar" in error_msg
-            or (
-                "unable to generate parser" in error_msg
-                and "template" in error_msg
-            )
-        )
+    if status_code == 400 and (
+        "error parsing grammar" in error_msg
+        or "json-schema-to-grammar" in error_msg
+        or ("unable to generate parser" in error_msg and "template" in error_msg)
     ):
         return _result(
             FailoverReason.llama_cpp_grammar_pattern,
@@ -686,9 +711,8 @@ def classify_api_error(
     #
     # Both X Premium+ and SuperGrok subscribers hit this path when their
     # subscription tier does not cover the requested model or feature.
-    if (
-        "do not have an active grok subscription" in error_msg
-        or ("out of available resources" in error_msg and "grok" in error_msg)
+    if "do not have an active grok subscription" in error_msg or (
+        "out of available resources" in error_msg and "grok" in error_msg
     ):
         return _result(
             FailoverReason.auth,
@@ -700,9 +724,14 @@ def classify_api_error(
 
     if status_code is not None:
         classified = _classify_by_status(
-            status_code, error_msg, error_code, body,
-            provider=provider_lower, model=model_lower,
-            approx_tokens=approx_tokens, context_length=context_length,
+            status_code,
+            error_msg,
+            error_code,
+            body,
+            provider=provider_lower,
+            model=model_lower,
+            approx_tokens=approx_tokens,
+            context_length=context_length,
             num_messages=num_messages,
             result_fn=_result,
         )
@@ -719,7 +748,8 @@ def classify_api_error(
     # ── 4. Message pattern matching (no status code) ────────────────
 
     classified = _classify_by_message(
-        error_msg, error_type,
+        error_msg,
+        error_type,
         approx_tokens=approx_tokens,
         context_length=context_length,
         result_fn=_result,
@@ -762,7 +792,9 @@ def classify_api_error(
 
     # ── 7. Transport / timeout heuristics ───────────────────────────
 
-    if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
+    if error_type in _TRANSPORT_ERROR_TYPES or isinstance(
+        error, (TimeoutError, ConnectionError, OSError)
+    ):
         return _result(FailoverReason.timeout, retryable=True)
 
     # ── 8. Fallback: unknown ────────────────────────────────────────
@@ -771,6 +803,7 @@ def classify_api_error(
 
 
 # ── Status code classification ──────────────────────────────────────────
+
 
 def _classify_by_status(
     status_code: int,
@@ -882,8 +915,11 @@ def _classify_by_status(
 
     if status_code == 400:
         return _classify_400(
-            error_msg, error_code, body,
-            provider=provider, model=model,
+            error_msg,
+            error_code,
+            body,
+            provider=provider,
+            model=model,
             approx_tokens=approx_tokens,
             context_length=context_length,
             num_messages=num_messages,
@@ -898,11 +934,13 @@ def _classify_by_status(
         # server_error" rule turns one bad request into a retry flood.
         # Detect the unambiguous request-validation signals (in either the
         # message text or the structured error code) and fail fast.
-        if (
-            any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
-            or error_code.lower() in {"invalid_request_error", "unknown_parameter",
-                                      "unsupported_parameter"}
-        ):
+        if any(
+            p in error_msg for p in _REQUEST_VALIDATION_PATTERNS
+        ) or error_code.lower() in {
+            "invalid_request_error",
+            "unknown_parameter",
+            "unsupported_parameter",
+        }:
             return result_fn(
                 FailoverReason.format_error,
                 retryable=False,
@@ -1030,11 +1068,11 @@ def _classify_400(
     # so matching it would mis-route real overflows away from compression. The
     # unambiguous signals are the explicit "unsupported/unknown parameter"
     # message text and the specific parameter-level error codes.
-    if (
-        any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS
-            if p != "invalid_request_error")
-        or error_code_lower in {"unknown_parameter", "unsupported_parameter"}
-    ):
+    if any(
+        p in error_msg
+        for p in _REQUEST_VALIDATION_PATTERNS
+        if p != "invalid_request_error"
+    ) or error_code_lower in {"unknown_parameter", "unsupported_parameter"}:
         return result_fn(
             FailoverReason.format_error,
             retryable=False,
@@ -1115,8 +1153,11 @@ def _classify_400(
 
 # ── Error code classification ───────────────────────────────────────────
 
+
 def _classify_by_error_code(
-    error_code: str, error_msg: str, result_fn,
+    error_code: str,
+    error_msg: str,
+    result_fn,
 ) -> Optional[ClassifiedError]:
     """Classify by structured error codes from the response body."""
     code_lower = error_code.lower()
@@ -1170,6 +1211,7 @@ def _classify_by_error_code(
 
 # ── Message pattern classification ──────────────────────────────────────
 
+
 def _classify_by_message(
     error_msg: str,
     error_type: str,
@@ -1208,7 +1250,9 @@ def _classify_by_message(
     # billing exhaustion.
     has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
     if has_usage_limit:
-        has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+        has_transient_signal = any(
+            p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
+        )
         if has_transient_signal:
             return result_fn(
                 FailoverReason.rate_limit,
@@ -1292,6 +1336,7 @@ def _classify_by_message(
 
 # ── Helpers ─────────────────────────────────────────────────────────────
 
+
 def _extract_status_code(error: Exception) -> Optional[int]:
     """Walk the error and its cause chain to find an HTTP status code."""
     current = error
@@ -1304,7 +1349,9 @@ def _extract_status_code(error: Exception) -> Optional[int]:
         if isinstance(code, int) and 100 <= code < 600:
             return code
         # Walk cause chain
-        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        cause = getattr(current, "__cause__", None) or getattr(
+            current, "__context__", None
+        )
         if cause is None or cause is current:
             break
         current = cause
@@ -1361,6 +1408,7 @@ def _extract_error_code(body: dict) -> str:
         message = error_obj.get("message")
         if isinstance(message, str) and message.strip().startswith("{"):
             import json
+
             try:
                 inner = json.loads(message)
             except (json.JSONDecodeError, TypeError):

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -5,6 +5,8 @@ thundering-herd retry spikes when multiple sessions hit the same
 rate-limited provider concurrently.
 """
 
+import calendar
+import email.utils
 import random
 import threading
 import time
@@ -47,7 +49,7 @@ def jittered_backoff(
     if exponent >= 63 or base_delay <= 0:
         delay = max_delay
     else:
-        delay = min(base_delay * (2 ** exponent), max_delay)
+        delay = min(base_delay * (2**exponent), max_delay)
 
     # Seed from time + counter for decorrelation even with coarse clocks.
     seed = (time.time_ns() ^ (tick * 0x9E3779B9)) & 0xFFFFFFFF
@@ -55,3 +57,35 @@ def jittered_backoff(
     jitter = rng.uniform(0, jitter_ratio * delay)
 
     return delay + jitter
+
+
+def extract_retry_after_seconds(
+    retry_after: str | None, now: float | None = None
+) -> float | None:
+    """Parse a Retry-After value into seconds from now.
+
+    Supports both integer seconds (RFC 7231 §7.1.3) and HTTP-date strings
+    (RFC 7231 §7.1.1.2).  Returns None for malformed/empty values.
+    Caps the result at 300 seconds (5 minutes) so a far-future Retry-After
+    header cannot stall the agent indefinitely.
+    """
+    if not retry_after or not isinstance(retry_after, str):
+        return None
+    retry_after = retry_after.strip()
+    if not retry_after:
+        return None
+
+    # Try integer seconds first.
+    try:
+        return min(float(retry_after), 300.0)
+    except (TypeError, ValueError):
+        pass
+
+    # Try HTTP-date (e.g. "Wed, 21 Oct 2015 07:28:00 GMT").
+    try:
+        parsed = email.utils.parsedate_to_datetime(retry_after)
+        retry_time = calendar.timegm(parsed.utctimetuple())
+        now = now if now is not None else time.time()
+        return max(0.0, min(retry_time - now, 300.0))
+    except Exception:
+        return None

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -58,6 +58,9 @@ class TurnRetryState:
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
 
+    # ── Fail-fast guard for non-retryable client errors ─────────────────
+    fail_fast_attempted: bool = False
+
     # ── Restart signals (read by the outer loop after the attempt) ───────
     restart_with_compressed_messages: bool = False
     restart_with_length_continuation: bool = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -15,7 +15,7 @@ Features:
 
 Usage:
     from run_agent import AIAgent
-    
+
     agent = AIAgent(base_url="http://localhost:30000/v1", model="claude-opus-4-20250514")
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
@@ -37,6 +37,7 @@ import copy
 import hashlib
 import json
 import logging
+
 logger = logging.getLogger(__name__)
 import os
 import re
@@ -46,6 +47,7 @@ import time
 import threading
 import uuid
 from typing import List, Dict, Any, Optional, Callable
+
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
 # that imports the SDK on first call/isinstance check. This preserves:
@@ -110,8 +112,10 @@ from hermes_cli.timeouts import (
 )
 
 _hermes_home = get_hermes_home()
-_project_env = Path(__file__).parent / '.env'
-_loaded_env_paths = load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
+_project_env = Path(__file__).parent / ".env"
+_loaded_env_paths = load_hermes_dotenv(
+    hermes_home=_hermes_home, project_env=_project_env
+)
 if _loaded_env_paths:
     for _env_path in _loaded_env_paths:
         logger.info("Loaded environment variables from %s", _env_path)
@@ -140,6 +144,7 @@ from agent.model_metadata import (
     is_local_endpoint,
 )
 from agent.usage_pricing import normalize_usage
+
 # Re-exported for tests that monkeypatch these symbols on run_agent.
 from agent.context_compressor import ContextCompressor  # noqa: F401
 from agent.retry_utils import jittered_backoff  # noqa: F401
@@ -196,8 +201,13 @@ from agent.tool_dispatch_helpers import (
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname, is_truthy_value, model_forces_max_completion_tokens
-
+from utils import (
+    atomic_json_write,
+    base_url_host_matches,
+    base_url_hostname,
+    is_truthy_value,
+    model_forces_max_completion_tokens,
+)
 
 
 _MAX_TOOL_WORKERS = 8
@@ -260,7 +270,9 @@ def _pool_may_recover_from_rate_limit(
         return False
     # CloudCode / Gemini CLI quotas are account-wide — all pool entries share
     # the same throttle window, so rotation can't recover.  Prefer fallback.
-    if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
+    if provider == "google-gemini-cli" or str(base_url or "").startswith(
+        "cloudcode-pa://"
+    ):
         return False
     return len(pool.entries()) > 1
 
@@ -415,6 +427,7 @@ class AIAgent:
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
+
         init_agent(
             self,
             base_url=base_url,
@@ -528,9 +541,7 @@ class AIAgent:
         except Exception as e:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.
-            logger.warning(
-                "Session DB creation failed (will retry next turn): %s", e
-            )
+            logger.warning("Session DB creation failed (will retry next turn): %s", e)
 
     def _transition_context_engine_session(
         self,
@@ -555,7 +566,11 @@ class AIAgent:
         if not engine:
             return
 
-        if old_session_id and previous_messages is not None and hasattr(engine, "on_session_end"):
+        if (
+            old_session_id
+            and previous_messages is not None
+            and hasattr(engine, "on_session_end")
+        ):
             try:
                 engine.on_session_end(old_session_id, previous_messages)
             except Exception as exc:
@@ -565,7 +580,9 @@ class AIAgent:
             try:
                 engine.on_session_reset()
             except Exception as exc:
-                logger.debug("context engine on_session_reset during transition: %s", exc)
+                logger.debug(
+                    "context engine on_session_reset during transition: %s", exc
+                )
 
         should_start = bool(
             old_session_id
@@ -578,17 +595,22 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
-                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "platform": getattr(self, "platform", None)
+                or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),
             }
             start_context.update(extra_context)
-            start_context = {k: v for k, v in start_context.items() if v not in (None, "")}
+            start_context = {
+                k: v for k, v in start_context.items() if v not in (None, "")
+            }
             try:
                 engine.on_session_start(target_session_id, **start_context)
             except Exception as exc:
-                logger.debug("context engine on_session_start during transition: %s", exc)
+                logger.debug(
+                    "context engine on_session_start during transition: %s", exc
+                )
 
         if (
             carry_over_context
@@ -599,7 +621,10 @@ class AIAgent:
             try:
                 engine.carry_over_new_session_context(old_session_id, target_session_id)
             except Exception as exc:
-                logger.debug("context engine carry_over_new_session_context during transition: %s", exc)
+                logger.debug(
+                    "context engine carry_over_new_session_context during transition: %s",
+                    exc,
+                )
 
     def reset_session_state(
         self,
@@ -608,7 +633,7 @@ class AIAgent:
         carry_over_context: bool = False,
     ):
         """Reset all session-scoped token counters to 0 for a fresh session.
-        
+
         This method encapsulates the reset logic for all session-level metrics
         including:
         - Token usage counters (input, output, total, prompt, completion)
@@ -617,7 +642,7 @@ class AIAgent:
         - Reasoning tokens
         - Estimated cost tracking
         - Context compressor internal counters
-        
+
         The method safely handles optional attributes (e.g., context compressor)
         using ``hasattr`` checks.
 
@@ -640,7 +665,7 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
-        
+
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
@@ -653,7 +678,9 @@ class AIAgent:
             reset_engine=True,
         )
 
-    def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
+    def _ensure_lmstudio_runtime_loaded(
+        self, config_context_length: Optional[int] = None
+    ) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.
         """
@@ -662,11 +689,15 @@ class AIAgent:
         try:
             from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
             from hermes_cli.models import ensure_lmstudio_model_loaded
+
             if config_context_length is None:
                 config_context_length = getattr(self, "_config_context_length", None)
             target_ctx = max(config_context_length or 0, MINIMUM_CONTEXT_LENGTH)
             loaded_ctx = ensure_lmstudio_model_loaded(
-                self.model, self.base_url, getattr(self, "api_key", ""), target_ctx,
+                self.model,
+                self.base_url,
+                getattr(self, "api_key", ""),
+                target_ctx,
             )
             if loaded_ctx:
                 # Push into the live compressor so the status bar reflects the
@@ -686,9 +717,12 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self, new_model, new_provider, api_key="", base_url="", api_mode=""
+    ):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
         from agent.agent_runtime_helpers import switch_model
+
         return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
 
     def _safe_print(self, *args, **kwargs):
@@ -825,7 +859,9 @@ class AIAgent:
             try:
                 self.notice_clear_callback(key)
             except Exception:
-                logger.debug("notice_clear_callback error in _emit_notice_clear", exc_info=True)
+                logger.debug(
+                    "notice_clear_callback error in _emit_notice_clear", exc_info=True
+                )
 
     # ── Buffered retry/fallback status ────────────────────────────────────
     # Retry and fallback chains were flooding the CLI/gateway with status
@@ -945,6 +981,7 @@ class AIAgent:
     def _stream_diag_init() -> Dict[str, Any]:
         """Forwarder — see ``agent.stream_diag.stream_diag_init``."""
         from agent.stream_diag import stream_diag_init
+
         return stream_diag_init()
 
     def _stream_diag_capture_response(
@@ -952,12 +989,14 @@ class AIAgent:
     ) -> None:
         """Forwarder — see ``agent.stream_diag.stream_diag_capture_response``."""
         from agent.stream_diag import stream_diag_capture_response
+
         stream_diag_capture_response(self, diag, http_response)
 
     @staticmethod
     def _flatten_exception_chain(error: BaseException) -> str:
         """Forwarder — see ``agent.stream_diag.flatten_exception_chain``."""
         from agent.stream_diag import flatten_exception_chain
+
         return flatten_exception_chain(error)
 
     def _is_provider_stream_parse_error(self, error: BaseException) -> bool:
@@ -990,9 +1029,15 @@ class AIAgent:
     ) -> None:
         """Forwarder — see ``agent.stream_diag.log_stream_retry``."""
         from agent.stream_diag import log_stream_retry
+
         log_stream_retry(
-            self, kind=kind, error=error, attempt=attempt,
-            max_attempts=max_attempts, mid_tool_call=mid_tool_call, diag=diag,
+            self,
+            kind=kind,
+            error=error,
+            attempt=attempt,
+            max_attempts=max_attempts,
+            mid_tool_call=mid_tool_call,
+            diag=diag,
         )
 
     def _emit_stream_drop(
@@ -1006,9 +1051,14 @@ class AIAgent:
     ) -> None:
         """Forwarder — see ``agent.stream_diag.emit_stream_drop``."""
         from agent.stream_diag import emit_stream_drop
+
         emit_stream_drop(
-            self, error=error, attempt=attempt, max_attempts=max_attempts,
-            mid_tool_call=mid_tool_call, diag=diag,
+            self,
+            error=error,
+            attempt=attempt,
+            max_attempts=max_attempts,
+            mid_tool_call=mid_tool_call,
+            diag=diag,
         )
 
     def _emit_auxiliary_failure(self, task: str, exc: BaseException) -> None:
@@ -1035,11 +1085,13 @@ class AIAgent:
     def _check_compression_model_feasibility(self) -> None:
         """Forwarder — see ``agent.conversation_compression.check_compression_model_feasibility``."""
         from agent.conversation_compression import check_compression_model_feasibility
+
         check_compression_model_feasibility(self)
 
     def _replay_compression_warning(self) -> None:
         """Forwarder — see ``agent.conversation_compression.replay_compression_warning``."""
         from agent.conversation_compression import replay_compression_warning
+
         replay_compression_warning(self)
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
@@ -1140,6 +1192,7 @@ class AIAgent:
             return float("inf")
 
         from agent.chat_completion_helpers import estimate_request_context_tokens
+
         est_tokens = estimate_request_context_tokens(api_payload)
         if est_tokens > 100_000:
             return max(stale_base, 240.0)
@@ -1171,12 +1224,9 @@ class AIAgent:
         """
         if self.api_mode != "codex_responses":
             return None
-        is_codex_backend = (
-            self.provider == "openai-codex"
-            or (
-                getattr(self, "_base_url_hostname", "") == "chatgpt.com"
-                and "/backend-api/codex" in (getattr(self, "_base_url_lower", "") or "")
-            )
+        is_codex_backend = self.provider == "openai-codex" or (
+            getattr(self, "_base_url_hostname", "") == "chatgpt.com"
+            and "/backend-api/codex" in (getattr(self, "_base_url_lower", "") or "")
         )
         if not is_codex_backend:
             return None
@@ -1213,7 +1263,10 @@ class AIAgent:
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.anthropic_prompt_cache_policy``."""
         from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
-        return anthropic_prompt_cache_policy(self, provider=provider, base_url=base_url, api_mode=api_mode, model=model)
+
+        return anthropic_prompt_cache_policy(
+            self, provider=provider, base_url=base_url, api_mode=api_mode, model=model
+        )
 
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
@@ -1245,6 +1298,7 @@ class AIAgent:
         if normalized_provider == "copilot":
             try:
                 from hermes_cli.models import _should_use_copilot_responses_api
+
                 return _should_use_copilot_responses_api(model)
             except Exception:
                 # Fall back to the generic GPT-5 rule if Copilot-specific
@@ -1317,6 +1371,7 @@ class AIAgent:
     def _strip_think_blocks(self, content: str) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.strip_think_blocks``."""
         from agent.agent_runtime_helpers import strip_think_blocks
+
         return strip_think_blocks(self, content)
 
     @staticmethod
@@ -1329,10 +1384,10 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        if stripped.endswith('^'):
+        if stripped.endswith("^"):
             return True
         last = stripped[-1]
-        if last in '.!?:)"\']}。！？：）】」』》^':
+        if last in ".!?:)\"']}。！？：）】」』》^":
             return True
         # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
         if ord(last) >= 0x1F300:
@@ -1388,16 +1443,21 @@ class AIAgent:
     ) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.looks_like_codex_intermediate_ack``."""
         from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
-        return looks_like_codex_intermediate_ack(self, user_message, assistant_content, messages)
+
+        return looks_like_codex_intermediate_ack(
+            self, user_message, assistant_content, messages
+        )
 
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """Forwarder — see ``agent.agent_runtime_helpers.extract_reasoning``."""
         from agent.agent_runtime_helpers import extract_reasoning
+
         return extract_reasoning(self, assistant_message)
 
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Forwarder — see ``agent.chat_completion_helpers.cleanup_task_resources``."""
         from agent.chat_completion_helpers import cleanup_task_resources
+
         return cleanup_task_resources(self, task_id)
 
     # ------------------------------------------------------------------
@@ -1417,6 +1477,7 @@ class AIAgent:
     ) -> List[str]:
         """Forwarder — see ``agent.background_review.summarize_background_review_actions``."""
         from agent.background_review import summarize_background_review_actions
+
         return summarize_background_review_actions(
             review_messages,
             prior_snapshot,
@@ -1438,6 +1499,7 @@ class AIAgent:
         keep working.
         """
         from agent.background_review import spawn_background_review_thread
+
         target, _prompt = spawn_background_review_thread(
             self,
             messages_snapshot,
@@ -1457,6 +1519,7 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.background_review.build_memory_write_metadata``."""
         from agent.background_review import build_memory_write_metadata
+
         return build_memory_write_metadata(
             self,
             write_origin=write_origin,
@@ -1496,7 +1559,9 @@ class AIAgent:
                 if timestamp is not None:
                     msg["timestamp"] = timestamp
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(
+        self, messages: List[Dict], conversation_history: List[Dict] = None
+    ):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -1563,9 +1628,12 @@ class AIAgent:
     def _repair_message_sequence(self, messages: List[Dict]) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_message_sequence``."""
         from agent.agent_runtime_helpers import repair_message_sequence
+
         return repair_message_sequence(self, messages)
 
-    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _flush_messages_to_session_db(
+        self, messages: List[Dict], conversation_history: List[Dict] = None
+    ):
         """Persist any un-flushed messages to the SQLite session store.
 
         Uses per-session message identity tracking so repeated calls (from
@@ -1635,11 +1703,19 @@ class AIAgent:
                     for p in content:
                         if isinstance(p, dict) and p.get("type") == "text":
                             _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
+                        elif isinstance(p, dict) and p.get("type") in {
+                            "image",
+                            "image_url",
+                            "input_image",
+                        }:
                             _txt.append("[screenshot]")
                     content = "\n".join(_txt) if _txt else None
                 tool_calls_data = None
-                if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
+                if (
+                    hasattr(msg, "tool_calls")
+                    and isinstance(msg.tool_calls, list)
+                    and msg.tool_calls
+                ):
                     tool_calls_data = [
                         {"name": tc.function.name, "arguments": tc.function.arguments}
                         for tc in msg.tool_calls
@@ -1655,10 +1731,18 @@ class AIAgent:
                     tool_call_id=msg.get("tool_call_id"),
                     finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    reasoning_content=msg.get("reasoning_content")
+                    if role == "assistant"
+                    else None,
+                    reasoning_details=msg.get("reasoning_details")
+                    if role == "assistant"
+                    else None,
+                    codex_reasoning_items=msg.get("codex_reasoning_items")
+                    if role == "assistant"
+                    else None,
+                    codex_message_items=msg.get("codex_message_items")
+                    if role == "assistant"
+                    else None,
                     timestamp=msg.get("timestamp"),
                 )
                 flushed.append(msg)
@@ -1669,48 +1753,54 @@ class AIAgent:
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
         Get messages up to (but not including) the last assistant turn.
-        
+
         This is used when we need to "roll back" to the last successful point
         in the conversation, typically when the final assistant message is
         incomplete or malformed.
-        
+
         Args:
             messages: Full message list
-            
+
         Returns:
             Messages up to the last complete assistant turn (ending with user/tool message)
         """
         if not messages:
             return []
-        
+
         # Find the index of the last assistant message
         last_assistant_idx = None
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].get("role") == "assistant":
                 last_assistant_idx = i
                 break
-        
+
         if last_assistant_idx is None:
             # No assistant message found, return all messages
             return messages.copy()
-        
+
         # Return everything up to (not including) the last assistant message
         return messages[:last_assistant_idx]
 
     def _format_tools_for_system_message(self) -> str:
         """Forwarder — see ``agent.system_prompt.format_tools_for_system_message``."""
         from agent.system_prompt import format_tools_for_system_message
+
         return format_tools_for_system_message(self)
 
-    def _convert_to_trajectory_format(self, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+    def _convert_to_trajectory_format(
+        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
+    ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.convert_to_trajectory_format``."""
         from agent.agent_runtime_helpers import convert_to_trajectory_format
+
         return convert_to_trajectory_format(self, messages, user_query, completed)
 
-    def _save_trajectory(self, messages: List[Dict[str, Any]], user_query: str, completed: bool):
+    def _save_trajectory(
+        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
+    ):
         """
         Save conversation trajectory to JSONL file.
-        
+
         Args:
             messages (List[Dict]): Complete message history
             user_query (str): Original user query
@@ -1718,7 +1808,7 @@ class AIAgent:
         """
         if not self.save_trajectories:
             return
-        
+
         trajectory = self._convert_to_trajectory_format(messages, user_query, completed)
         _save_trajectory_to_file(trajectory, self.model, completed)
 
@@ -1867,10 +1957,7 @@ class AIAgent:
             except TypeError:
                 return str(value)
         if isinstance(value, (list, tuple)):
-            parts = [
-                AIAgent._coerce_api_error_detail(item)
-                for item in value
-            ]
+            parts = [AIAgent._coerce_api_error_detail(item) for item in value]
             return "; ".join(part for part in parts if part)
         if value is None:
             return ""
@@ -1886,10 +1973,7 @@ class AIAgent:
         """
         raw = str(error)
 
-        if (
-            isinstance(error, ValueError)
-            and "expected ident at line" in raw.lower()
-        ):
+        if isinstance(error, ValueError) and "expected ident at line" in raw.lower():
             return f"Malformed provider streaming response: {raw[:300]}"
 
         # Cloudflare / proxy HTML pages: grab the <title> for a clean summary
@@ -1911,7 +1995,11 @@ class AIAgent:
         # JSON body errors from OpenAI/Anthropic SDKs
         body = getattr(error, "body", None)
         if isinstance(body, dict):
-            msg = body.get("error", {}).get("message") if isinstance(body.get("error"), dict) else body.get("message")
+            msg = (
+                body.get("error", {}).get("message")
+                if isinstance(body.get("error"), dict)
+                else body.get("message")
+            )
             if msg:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""
@@ -1937,36 +2025,39 @@ class AIAgent:
     def _clean_error_message(self, error_msg: str) -> str:
         """
         Clean up error messages for user display, removing HTML content and truncating.
-        
+
         Args:
             error_msg: Raw error message from API or exception
-            
+
         Returns:
             Clean, user-friendly error message
         """
         if not error_msg:
             return "Unknown error"
-            
+
         # Remove HTML content (common with CloudFlare and gateway error pages)
-        if error_msg.strip().startswith('<!DOCTYPE html') or '<html' in error_msg:
+        if error_msg.strip().startswith("<!DOCTYPE html") or "<html" in error_msg:
             return "Service temporarily unavailable (HTML error page returned)"
-            
+
         # Remove newlines and excessive whitespace
-        cleaned = ' '.join(error_msg.split())
-        
+        cleaned = " ".join(error_msg.split())
+
         # Truncate if too long
         if len(cleaned) > 150:
             cleaned = cleaned[:150] + "..."
-            
+
         return cleaned
 
     @staticmethod
     def _extract_api_error_context(error: Exception) -> Dict[str, Any]:
         """Forwarder — see ``agent.agent_runtime_helpers.extract_api_error_context``."""
         from agent.agent_runtime_helpers import extract_api_error_context
+
         return extract_api_error_context(error)
 
-    def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
+    def _usage_summary_for_api_request_hook(
+        self, response: Any
+    ) -> Optional[Dict[str, Any]]:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
         if response is None:
             return None
@@ -2020,7 +2111,10 @@ class AIAgent:
             return value
         if isinstance(value, str):
             if len(value) > max_string:
-                return value[:max_string] + f"...[truncated {len(value) - max_string} chars]"
+                return (
+                    value[:max_string]
+                    + f"...[truncated {len(value) - max_string} chars]"
+                )
             return value
         if isinstance(value, (bytes, bytearray)):
             return f"<{len(value)} bytes>"
@@ -2074,6 +2168,7 @@ class AIAgent:
             pass
         try:
             from dataclasses import asdict, is_dataclass
+
             if is_dataclass(value):
                 return cls._hook_jsonable(
                     asdict(value),
@@ -2095,9 +2190,7 @@ class AIAgent:
         if hasattr(value, "__dict__"):
             try:
                 public_attrs = {
-                    k: v
-                    for k, v in vars(value).items()
-                    if not str(k).startswith("_")
+                    k: v for k, v in vars(value).items() if not str(k).startswith("_")
                 }
                 return cls._hook_jsonable(
                     public_attrs,
@@ -2133,18 +2226,18 @@ class AIAgent:
             "preview": encoded[:limit],
         }
 
-    def _api_request_payload_for_hook(self, api_kwargs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    def _api_request_payload_for_hook(
+        self, api_kwargs: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         body = {
             key: value
             for key, value in (api_kwargs or {}).items()
             if key not in {"timeout", "http_client"}
         }
-        return self._sanitize_hook_payload(
-            {
-                "method": "POST",
-                "body": body,
-            }
-        )
+        return self._sanitize_hook_payload({
+            "method": "POST",
+            "body": body,
+        })
 
     def _api_response_payload_for_hook(
         self,
@@ -2161,18 +2254,16 @@ class AIAgent:
         # the sanitiser MUST preserve that capability or hook subscribers
         # will receive opaque ``str(obj)`` blobs here.
         tool_calls = getattr(assistant_message, "tool_calls", None) or []
-        return self._sanitize_hook_payload(
-            {
-                "model": getattr(response, "model", None),
-                "finish_reason": finish_reason,
-                "assistant_message": {
-                    "role": getattr(assistant_message, "role", "assistant"),
-                    "content": getattr(assistant_message, "content", None),
-                    "tool_calls": tool_calls,
-                },
-                "usage": self._usage_summary_for_api_request_hook(response),
-            }
-        )
+        return self._sanitize_hook_payload({
+            "model": getattr(response, "model", None),
+            "finish_reason": finish_reason,
+            "assistant_message": {
+                "role": getattr(assistant_message, "role", "assistant"),
+                "content": getattr(assistant_message, "content", None),
+                "tool_calls": tool_calls,
+            },
+            "usage": self._usage_summary_for_api_request_hook(response),
+        })
 
     def _invoke_api_request_error_hook(
         self,
@@ -2239,6 +2330,7 @@ class AIAgent:
     ) -> Optional[Path]:
         """Forwarder — see ``agent.agent_runtime_helpers.dump_api_request_debug``."""
         from agent.agent_runtime_helpers import dump_api_request_debug
+
         return dump_api_request_debug(self, api_kwargs, reason=reason, error=error)
 
     @staticmethod
@@ -2247,8 +2339,8 @@ class AIAgent:
         if not content:
             return content
         content = convert_scratchpad_to_think(content)
-        content = re.sub(r'\n+(<think>)', r'\n\1', content)
-        content = re.sub(r'(</think>)\n+', r'\1\n', content)
+        content = re.sub(r"\n+(<think>)", r"\n\1", content)
+        content = re.sub(r"(</think>)\n+", r"\1\n", content)
         return content.strip()
 
     @staticmethod
@@ -2332,11 +2424,14 @@ class AIAgent:
             if log_file.exists():
                 try:
                     existing = json.loads(log_file.read_text(encoding="utf-8"))
-                    existing_count = existing.get("message_count", len(existing.get("messages", [])))
+                    existing_count = existing.get(
+                        "message_count", len(existing.get("messages", []))
+                    )
                     if existing_count > len(cleaned):
                         logging.debug(
                             "Skipping session log overwrite: existing has %d messages, current has %d",
-                            existing_count, len(cleaned),
+                            existing_count,
+                            len(cleaned),
                         )
                         return
                 except Exception:
@@ -2349,7 +2444,9 @@ class AIAgent:
                 "platform": self.platform,
                 "session_start": self.session_start.isoformat(),
                 "last_updated": datetime.now().isoformat(),
-                "system_prompt": redact_sensitive_text(self._cached_system_prompt or ""),
+                "system_prompt": redact_sensitive_text(
+                    self._cached_system_prompt or ""
+                ),
                 "tools": self.tools or [],
                 "message_count": len(cleaned),
                 "messages": cleaned,
@@ -2366,26 +2463,25 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to save session log: {e}")
 
-
     def interrupt(self, message: str = None) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.
-        
+
         Call this from another thread (e.g., input handler, message receiver)
         to gracefully stop the agent and process a new message.
-        
+
         Also signals long-running tool executions (e.g. terminal commands)
         to terminate early, so the agent can respond immediately.
-        
+
         Args:
             message: Optional new message that triggered the interrupt.
                      If provided, the agent will include this in its response context.
-        
+
         Example (CLI):
             # In a separate input thread:
             if user_typed_something:
                 agent.interrupt(user_input)
-        
+
         Example (Messaging):
             # When new message arrives for active session:
             if session_has_running_agent:
@@ -2433,7 +2529,16 @@ class AIAgent:
             except Exception as e:
                 logger.debug("Failed to propagate interrupt to child agent: %s", e)
         if not self.quiet_mode:
-            print("\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
+            print(
+                "\n⚡ Interrupt requested"
+                + (
+                    f": '{message[:40]}...'"
+                    if message and len(message) > 40
+                    else f": '{message}'"
+                    if message
+                    else ""
+                )
+            )
 
     def clear_interrupt(self) -> None:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
@@ -2604,6 +2709,7 @@ class AIAgent:
                 register_default_verifiers,
                 verify_policy_enabled,
             )
+
             if not verify_policy_enabled():
                 return None
             state = getattr(self, "_verify_policy_state", None)
@@ -2624,12 +2730,16 @@ class AIAgent:
             if outcome.status == "error":
                 logger.debug(
                     "verify-policy: verifier %s errored for %s: %s",
-                    outcome.verifier, tool_name, outcome.detail,
+                    outcome.verifier,
+                    tool_name,
+                    outcome.detail,
                 )
                 return None
             if outcome.status == "ok":
                 logger.info(
-                    "verify-policy: %s confirmed %s", outcome.verifier, tool_name,
+                    "verify-policy: %s confirmed %s",
+                    outcome.verifier,
+                    tool_name,
                 )
                 return None
 
@@ -2641,12 +2751,15 @@ class AIAgent:
                 state.retry_attempts[sig] = attempts + 1
                 logger.warning(
                     "verify-policy: %s did not confirm %s (%s) — surfacing for retry",
-                    outcome.verifier, tool_name, outcome.detail,
+                    outcome.verifier,
+                    tool_name,
+                    outcome.detail,
                 )
             elif decision.abort:
                 logger.warning(
                     "verify-policy: %s still did not confirm %s after retry — aborting to user",
-                    outcome.verifier, tool_name,
+                    outcome.verifier,
+                    tool_name,
                 )
             return decision.feedback or None
         except Exception as _vp_err:
@@ -2663,6 +2776,7 @@ class AIAgent:
         """
         try:
             import os as _os
+
             env = _os.environ.get("HERMES_FILE_MUTATION_VERIFIER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
@@ -2670,6 +2784,7 @@ class AIAgent:
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
                 from hermes_cli.config import load_config as _load_config
+
                 _cfg = _load_config() or {}
             except Exception:
                 _cfg = {}
@@ -2710,7 +2825,9 @@ class AIAgent:
         return cls._FOOTER_PATH_RE.sub(lambda m: f"`{m.group(0)}`", text)
 
     @classmethod
-    def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
+    def _format_file_mutation_failure_footer(
+        cls, failed: Dict[str, Dict[str, Any]]
+    ) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.
 
         Displays up to 10 paths with their first error preview, then a
@@ -2760,6 +2877,7 @@ class AIAgent:
         """
         try:
             import os as _os
+
             env = _os.environ.get("HERMES_TURN_COMPLETION_EXPLAINER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
@@ -2767,6 +2885,7 @@ class AIAgent:
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
                 from hermes_cli.config import load_config as _load_config
+
                 _cfg = _load_config() or {}
             except Exception:
                 _cfg = {}
@@ -2804,65 +2923,55 @@ class AIAgent:
         prefix = "⚠️ No reply: "
         if reason == "empty_response_exhausted":
             return (
-                prefix
-                + "the model returned empty content after retries and any "
+                prefix + "the model returned empty content after retries and any "
                 "fallback providers. Try `continue`, switch model/provider, "
                 "or inspect the tool output above."
             )
         if reason == "all_retries_exhausted_no_response":
             return (
-                prefix
-                + "all API retries were exhausted before a response was "
+                prefix + "all API retries were exhausted before a response was "
                 "produced (provider errors / rate limits). Try `continue` "
                 "or switch provider."
             )
         if reason == "partial_stream_recovery":
             return (
-                prefix
-                + "streaming stopped early and only a partial response was "
+                prefix + "streaming stopped early and only a partial response was "
                 "recovered. Send `continue` to resume from where it stopped."
             )
         if reason == "fallback_prior_turn_content":
             return (
-                prefix
-                + "no new content was produced this turn; showing recovered "
+                prefix + "no new content was produced this turn; showing recovered "
                 "prior context. Send `continue` to retry."
             )
         if reason == "interrupted_during_api_call":
             return (
-                prefix
-                + "the request was interrupted mid-call before a reply was "
+                prefix + "the request was interrupted mid-call before a reply was "
                 "received. Send `continue` to retry."
             )
         if reason == "budget_exhausted":
             return (
-                prefix
-                + "the per-turn iteration/cost budget was exhausted before a "
+                prefix + "the per-turn iteration/cost budget was exhausted before a "
                 "final answer. Send `continue` to keep going."
             )
         if reason == "ollama_runtime_context_too_small":
             return (
-                prefix
-                + "the local model's context window was too small to finish. "
+                prefix + "the local model's context window was too small to finish. "
                 "Increase the context size or use a larger model."
             )
         if reason.startswith("max_iterations_reached"):
             return (
-                prefix
-                + "the maximum tool-iteration limit was reached before a "
+                prefix + "the maximum tool-iteration limit was reached before a "
                 "final answer. Send `continue` to keep going, or raise "
                 "`max_iterations`."
             )
         if reason.startswith("error_near_max_iterations"):
             return (
-                prefix
-                + "an error occurred near the iteration limit before a final "
+                prefix + "an error occurred near the iteration limit before a final "
                 "answer. Check the tool output above, then send `continue`."
             )
         if reason == "pending_tool_result":
             return (
-                prefix
-                + "the turn stopped while a tool result was still pending and "
+                prefix + "the turn stopped while a tool result was still pending and "
                 "the model produced no follow-up text. Send `continue` to "
                 "let it summarize."
             )
@@ -2870,9 +2979,12 @@ class AIAgent:
         # which already surfaces its own message) — don't second-guess.
         return ""
 
-    def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
+    def _apply_pending_steer_to_tool_results(
+        self, messages: list, num_tool_msgs: int
+    ) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+
         return apply_pending_steer_to_tool_results(self, messages, num_tool_msgs)
 
     def _touch_activity(self, desc: str) -> None:
@@ -2889,6 +3001,7 @@ class AIAgent:
         if os.environ.get("HERMES_KANBAN_TASK"):
             try:
                 from tools.kanban_tools import heartbeat_current_worker_from_env
+
                 heartbeat_current_worker_from_env()
             except Exception:
                 # Never let the bridge break the agent loop.  The function
@@ -2910,6 +3023,7 @@ class AIAgent:
             return
         try:
             from agent.rate_limit_tracker import parse_rate_limit_headers
+
             state = parse_rate_limit_headers(headers, provider=self.provider)
             if state is not None:
                 self._rate_limit_state = state
@@ -2932,6 +3046,7 @@ class AIAgent:
         # each turn for repeatable testing, bypassing real headers. Throwaway scaffolding.
         try:
             from agent.credits_tracker import dev_fixture_credits_state
+
             _fixture = dev_fixture_credits_state()
         except Exception:
             _fixture = None
@@ -2941,7 +3056,9 @@ class AIAgent:
                 self._credits_session_start_micros = _fixture.remaining_micros
             _latch = getattr(self, "_credits_latch", None)
             if isinstance(_latch, dict):
-                _latch["seen_below_90"] = True  # let warn90 fire without a real crossing
+                _latch["seen_below_90"] = (
+                    True  # let warn90 fire without a real crossing
+                )
             _used = _fixture.used_fraction
             logger.info(
                 "credits ▸ [FIXTURE] remaining=%d (%s) · paid=%s · denom=%s · used=%s "
@@ -2964,6 +3081,7 @@ class AIAgent:
         # ── Parse (fail-open → miss; never overwrite good state with None) ──
         try:
             from agent.credits_tracker import parse_credits_headers
+
             state = parse_credits_headers(headers, provider=self.provider)
         except Exception:
             return  # parse error → treat as a miss, keep last-known
@@ -2994,8 +3112,12 @@ class AIAgent:
                 state.denominator_kind,
                 ("%.0f%%" % (used * 100)) if used is not None else "n/a",
                 ("%.1f¢" % (spent / 10000)) if spent is not None else "n/a",
-                ("%.0fs" % state.age_seconds) if state.age_seconds != float("inf") else "n/a",
-                (" · disabled=%s" % state.disabled_reason) if state.disabled_reason else "",
+                ("%.0fs" % state.age_seconds)
+                if state.age_seconds != float("inf")
+                else "n/a",
+                (" · disabled=%s" % state.disabled_reason)
+                if state.disabled_reason
+                else "",
             )
 
         # Threshold notices — shared with the cold-start seed (see _emit_credits_notices).
@@ -3011,7 +3133,10 @@ class AIAgent:
         swallowing (R1-M2): a depletion-path bug must not vanish silently. Emits clears
         FIRST, then shows (so depleted lands last in a latest-wins slot).
         """
-        if getattr(self, "notice_callback", None) is None and getattr(self, "notice_clear_callback", None) is None:
+        if (
+            getattr(self, "notice_callback", None) is None
+            and getattr(self, "notice_clear_callback", None) is None
+        ):
             return
         if not self._credits_notices_enabled():
             return
@@ -3019,10 +3144,18 @@ class AIAgent:
         if state is None:
             return
         try:
-            from agent.credits_tracker import evaluate_credits_notices, is_free_tier_model
+            from agent.credits_tracker import (
+                evaluate_credits_notices,
+                is_free_tier_model,
+            )
+
             latch = getattr(self, "_credits_latch", None)
             if latch is None:
-                latch = self._credits_latch = {"active": set(), "seen_below_90": False, "usage_band": None}
+                latch = self._credits_latch = {
+                    "active": set(),
+                    "seen_below_90": False,
+                    "usage_band": None,
+                }
             # Free-model gate: a depleted account on a free model can still
             # inference, so the depleted error banner is suppressed. Local-data
             # only (":free" suffix + pricing-cache peek) — never a network call.
@@ -3030,10 +3163,14 @@ class AIAgent:
                 getattr(self, "model", "") or "",
                 getattr(self, "base_url", "") or "",
             )
-            to_show, to_clear = evaluate_credits_notices(state, latch, model_is_free=model_is_free)
-            for key in to_clear:        # clears FIRST …
+            to_show, to_clear = evaluate_credits_notices(
+                state, latch, model_is_free=model_is_free
+            )
+            for key in to_clear:  # clears FIRST …
                 self._emit_notice_clear(key)
-            for notice in to_show:      # … then shows (depleted lands last in a latest-wins slot)
+            for (
+                notice
+            ) in to_show:  # … then shows (depleted lands last in a latest-wins slot)
                 self._emit_notice(notice)
         except Exception:
             logger.warning("credits notice evaluation/emit failed", exc_info=True)
@@ -3052,6 +3189,7 @@ class AIAgent:
         enabled = True
         try:
             from hermes_cli.config import load_config as _load_config
+
             _cfg = _load_config() or {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "credits_notices" in _display:
@@ -3087,7 +3225,9 @@ class AIAgent:
                 return
             if status.upper() == "HIT":
                 self._or_cache_hits += 1
-                logger.info("OpenRouter response cache HIT (total: %d)", self._or_cache_hits)
+                logger.info(
+                    "OpenRouter response cache HIT (total: %d)", self._or_cache_hits
+                )
             else:
                 logger.debug("OpenRouter response cache %s", status.upper())
         except Exception:
@@ -3289,6 +3429,7 @@ class AIAgent:
         # 1. Kill background processes for this task
         try:
             from tools.process_registry import process_registry
+
             process_registry.kill_all(task_id=task_id)
         except Exception:
             pass
@@ -3341,7 +3482,7 @@ class AIAgent:
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.
-        
+
         The gateway creates a fresh AIAgent per message, so the in-memory
         TodoStore is empty. We scan the history for the most recent todo
         tool response and replay it to reconstruct the state.
@@ -3362,12 +3503,14 @@ class AIAgent:
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
-        
+
         if last_todo_response:
             # Replay the items into the store (replace mode)
             self._todo_store.write(last_todo_response, merge=False)
             if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+                self._vprint(
+                    f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history"
+                )
         _set_interrupt(False)
 
     @property
@@ -3375,23 +3518,16 @@ class AIAgent:
         """Check if an interrupt has been requested."""
         return self._interrupt_requested
 
-
-
-
-
-
-
-
-
-
     def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
         """Forwarder — see ``agent.system_prompt.build_system_prompt_parts``."""
         from agent.system_prompt import build_system_prompt_parts
+
         return build_system_prompt_parts(self, system_message=system_message)
 
     def _build_system_prompt(self, system_message: str = None) -> str:
         """Forwarder — see ``agent.system_prompt.build_system_prompt``."""
         from agent.system_prompt import build_system_prompt
+
         return build_system_prompt(self, system_message=system_message)
 
     @staticmethod
@@ -3418,12 +3554,20 @@ class AIAgent:
         fn = getattr(tc, "function", None)
         return getattr(fn, "name", "") or ""
 
-    _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
+    _VALID_API_ROLES = frozenset({
+        "system",
+        "user",
+        "assistant",
+        "tool",
+        "function",
+        "developer",
+    })
 
     @staticmethod
     def _sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.sanitize_api_messages``."""
         from agent.agent_runtime_helpers import sanitize_api_messages
+
         return sanitize_api_messages(messages)
 
     @staticmethod
@@ -3502,6 +3646,7 @@ class AIAgent:
     ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
+
         return drop_thinking_only_and_merge_users(
             messages,
             drop_codex_reasoning_items=drop_codex_reasoning_items,
@@ -3518,8 +3663,11 @@ class AIAgent:
         Returns the original list if no truncation was needed.
         """
         from tools.delegate_tool import _get_max_concurrent_children
+
         max_children = _get_max_concurrent_children()
-        delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
+        delegate_count = sum(
+            1 for tc in tool_calls if tc.function.name == "delegate_task"
+        )
         if delegate_count <= max_children:
             return tool_calls
         kept_delegates = 0
@@ -3534,7 +3682,8 @@ class AIAgent:
         logger.warning(
             "Truncated %d excess delegate_task call(s) to enforce "
             "max_concurrent_children=%d limit",
-            delegate_count - max_children, max_children,
+            delegate_count - max_children,
+            max_children,
         )
         return truncated
 
@@ -3559,11 +3708,13 @@ class AIAgent:
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_tool_call``."""
         from agent.agent_runtime_helpers import repair_tool_call
+
         return repair_tool_call(self, tool_name)
 
     def _invalidate_system_prompt(self):
         """Forwarder — see ``agent.system_prompt.invalidate_system_prompt``."""
         from agent.system_prompt import invalidate_system_prompt
+
         invalidate_system_prompt(self)
 
     @staticmethod
@@ -3664,15 +3815,19 @@ class AIAgent:
         except Exception:
             return None
 
-    def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+    def _create_openai_client(
+        self, client_kwargs: dict, *, reason: str, shared: bool
+    ) -> Any:
         """Forwarder — see ``agent.agent_runtime_helpers.create_openai_client``."""
         from agent.agent_runtime_helpers import create_openai_client
+
         return create_openai_client(self, client_kwargs, reason=reason, shared=shared)
 
     @staticmethod
     def _force_close_tcp_sockets(client: Any) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.force_close_tcp_sockets``."""
         from agent.agent_runtime_helpers import force_close_tcp_sockets
+
         return force_close_tcp_sockets(client)
 
     def _close_openai_client(self, client: Any, *, reason: str, shared: bool) -> None:
@@ -3703,7 +3858,9 @@ class AIAgent:
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
-                new_client = self._create_openai_client(self._client_kwargs, reason=reason, shared=True)
+                new_client = self._create_openai_client(
+                    self._client_kwargs, reason=reason, shared=True
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to rebuild shared OpenAI client (%s) %s error=%s",
@@ -3735,6 +3892,7 @@ class AIAgent:
     def _cleanup_dead_connections(self) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.cleanup_dead_connections``."""
         from agent.agent_runtime_helpers import cleanup_dead_connections
+
         return cleanup_dead_connections(self)
 
     @staticmethod
@@ -3769,7 +3927,9 @@ class AIAgent:
 
         return copilot_request_headers(is_agent_turn=True, is_vision=is_vision)
 
-    def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
+    def _create_request_openai_client(
+        self, *, reason: str, api_kwargs: Optional[dict] = None
+    ) -> Any:
         from unittest.mock import Mock
 
         primary_client = self._ensure_primary_openai_client(reason=reason)
@@ -3788,11 +3948,12 @@ class AIAgent:
         # Shared/primary clients and Anthropic / Bedrock paths are
         # unaffected (they don't go through here).
         request_kwargs["max_retries"] = 0
-        if (
-            base_url_host_matches(str(request_kwargs.get("base_url", "")), "api.githubcopilot.com")
-            and self._api_kwargs_have_image_parts(api_kwargs or {})
-        ):
-            request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
+        if base_url_host_matches(
+            str(request_kwargs.get("base_url", "")), "api.githubcopilot.com"
+        ) and self._api_kwargs_have_image_parts(api_kwargs or {}):
+            request_kwargs["default_headers"] = self._copilot_headers_for_request(
+                is_vision=True
+            )
         return self._create_openai_client(request_kwargs, reason=reason, shared=False)
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
@@ -3831,18 +3992,25 @@ class AIAgent:
                 exc,
             )
 
-    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
+    def _run_codex_stream(
+        self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None
+    ):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream
+
         return run_codex_stream(self, api_kwargs, client, on_first_delta)
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_create_stream_fallback``."""
         from agent.codex_runtime import run_codex_create_stream_fallback
+
         return run_codex_create_stream_fallback(self, api_kwargs, client)
 
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
-        if self.api_mode != "codex_responses" or self.provider not in {"openai-codex", "xai-oauth"}:
+        if self.api_mode != "codex_responses" or self.provider not in {
+            "openai-codex",
+            "xai-oauth",
+        }:
             return False
 
         # Guard against silent account swap.
@@ -3910,7 +4078,9 @@ class AIAgent:
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
 
-        if not self._replace_primary_openai_client(reason=f"{self.provider}_credential_refresh"):
+        if not self._replace_primary_openai_client(
+            reason=f"{self.provider}_credential_refresh"
+        ):
             return False
 
         return True
@@ -3989,7 +4159,9 @@ class AIAgent:
         return True
 
     def _try_refresh_anthropic_client_credentials(self) -> bool:
-        if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
+        if self.api_mode != "anthropic_messages" or not hasattr(
+            self, "_anthropic_api_key"
+        ):
             return False
         # Only refresh credentials for the native Anthropic provider.
         # Other anthropic_messages providers (MiniMax, Alibaba, etc.) use their own keys.
@@ -4002,7 +4174,10 @@ class AIAgent:
             return False
 
         try:
-            from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
+            from agent.anthropic_adapter import (
+                resolve_anthropic_token,
+                build_anthropic_client,
+            )
 
             new_token = resolve_anthropic_token()
         except Exception as exc:
@@ -4027,7 +4202,9 @@ class AIAgent:
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
         except Exception as exc:
-            logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
+            logger.warning(
+                "Failed to rebuild Anthropic client after credential refresh: %s", exc
+            )
             return False
 
         self._anthropic_api_key = new_token
@@ -4036,7 +4213,10 @@ class AIAgent:
         # the Anthropic protocol must not trip OAuth paths (#1739 & third-party
         # identity-injection guard).
         from agent.anthropic_adapter import _is_oauth_token
-        self._is_anthropic_oauth = _is_oauth_token(new_token) if self.provider == "anthropic" else False
+
+        self._is_anthropic_oauth = (
+            _is_oauth_token(new_token) if self.provider == "anthropic" else False
+        )
         return True
 
     def _apply_client_headers_for_base_url(self, base_url: str) -> None:
@@ -4061,6 +4241,7 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):
             from agent.auxiliary_client import _codex_cloudflare_headers
+
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
                 self._client_kwargs.get("api_key", "")
             )
@@ -4069,6 +4250,7 @@ class AIAgent:
             _ph_headers = None
             try:
                 from providers import get_provider_profile as _gpf2
+
                 _ph2 = _gpf2(self.provider)
                 if _ph2 and _ph2.default_headers:
                     _ph_headers = dict(_ph2.default_headers)
@@ -4110,13 +4292,20 @@ class AIAgent:
         from agent.auxiliary_client import (
             _apply_user_default_headers as _merge_user_headers,
         )
+
         merged = _merge_user_headers(self._client_kwargs.get("default_headers"))
         if merged:
             self._client_kwargs["default_headers"] = merged
 
     def _swap_credential(self, entry) -> None:
-        runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
-        runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        runtime_key = getattr(entry, "runtime_api_key", None) or getattr(
+            entry, "access_token", ""
+        )
+        runtime_base = (
+            getattr(entry, "runtime_base_url", None)
+            or getattr(entry, "base_url", None)
+            or self.base_url
+        )
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
@@ -4129,16 +4318,21 @@ class AIAgent:
             self._anthropic_api_key = runtime_key
             self._anthropic_base_url = runtime_base
             self._anthropic_client = build_anthropic_client(
-                runtime_key, runtime_base,
+                runtime_key,
+                runtime_base,
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
-            self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
+            self._is_anthropic_oauth = (
+                _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
+            )
             self.api_key = runtime_key
             self.base_url = runtime_base
             return
 
         self.api_key = runtime_key
-        self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
+        self.base_url = (
+            runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
+        )
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
         self._apply_client_headers_for_base_url(self.base_url)
@@ -4154,17 +4348,23 @@ class AIAgent:
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.recover_with_credential_pool``."""
         from agent.agent_runtime_helpers import recover_with_credential_pool
-        return recover_with_credential_pool(self, status_code=status_code, has_retried_429=has_retried_429, classified_reason=classified_reason, error_context=error_context)
+
+        return recover_with_credential_pool(
+            self,
+            status_code=status_code,
+            has_retried_429=has_retried_429,
+            classified_reason=classified_reason,
+            error_context=error_context,
+        )
 
     def _credential_pool_may_recover_rate_limit(self) -> bool:
         """Whether a rate-limit retry should wait for same-provider credentials."""
         pool = self._credential_pool
         if pool is None:
             return False
-        if (
-            self.provider == "google-gemini-cli"
-            or str(getattr(self, "base_url", "")).startswith("cloudcode-pa://")
-        ):
+        if self.provider == "google-gemini-cli" or str(
+            getattr(self, "base_url", "")
+        ).startswith("cloudcode-pa://"):
             # CloudCode/Gemini quota windows are usually account-level throttles.
             # Prefer the configured fallback immediately instead of waiting out
             # Retry-After while a pooled OAuth credential may still appear usable.
@@ -4178,6 +4378,7 @@ class AIAgent:
         # api_mode-flip race (the Anthropic SDK raises a non-retryable
         # TypeError on them). See #31673.
         from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(self, "log_prefix", "")
         )
@@ -4198,10 +4399,12 @@ class AIAgent:
         _drop_1m = bool(getattr(self, "_oauth_1m_beta_disabled", False))
         if getattr(self, "provider", None) == "bedrock":
             from agent.anthropic_adapter import build_anthropic_bedrock_client
+
             region = getattr(self, "_bedrock_region", "us-east-1") or "us-east-1"
             self._anthropic_client = build_anthropic_bedrock_client(region)
         else:
             from agent.anthropic_adapter import build_anthropic_client
+
             self._anthropic_client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
@@ -4212,6 +4415,7 @@ class AIAgent:
     def _interruptible_api_call(self, api_kwargs: dict):
         """Forwarder — see ``agent.chat_completion_helpers.interruptible_api_call``."""
         from agent.chat_completion_helpers import interruptible_api_call
+
         return interruptible_api_call(self, api_kwargs)
 
     # ── Unified streaming API call ─────────────────────────────────────────
@@ -4234,7 +4438,11 @@ class AIAgent:
                 if ctx_scrubber is not None:
                     think_tail = ctx_scrubber.feed(think_tail)
                 if think_tail:
-                    callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
+                    callbacks = [
+                        cb
+                        for cb in (self.stream_delta_callback, self._stream_callback)
+                        if cb is not None
+                    ]
                     for cb in callbacks:
                         try:
                             cb(think_tail)
@@ -4248,7 +4456,11 @@ class AIAgent:
         if scrubber is not None:
             tail = scrubber.flush()
             if tail:
-                callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
+                callbacks = [
+                    cb
+                    for cb in (self.stream_delta_callback, self._stream_callback)
+                    if cb is not None
+                ]
                 for cb in callbacks:
                     try:
                         cb(tail)
@@ -4277,7 +4489,9 @@ class AIAgent:
         if not visible_content:
             return False
         streamed = self._normalize_interim_visible_text(
-            self._strip_think_blocks(getattr(self, "_current_streamed_assistant_text", "") or "")
+            self._strip_think_blocks(
+                getattr(self, "_current_streamed_assistant_text", "") or ""
+            )
         )
         return bool(streamed) and streamed == visible_content
 
@@ -4338,7 +4552,11 @@ class AIAgent:
                 text = text.lstrip("\n")
         if not text:
             return
-        callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
+        callbacks = [
+            cb
+            for cb in (self.stream_delta_callback, self._stream_callback)
+            if cb is not None
+        ]
         delivered = False
         for cb in callbacks:
             try:
@@ -4385,12 +4603,21 @@ class AIAgent:
     ):
         """Forwarder — see ``agent.chat_completion_helpers.interruptible_streaming_api_call``."""
         from agent.chat_completion_helpers import interruptible_streaming_api_call
-        return interruptible_streaming_api_call(self, api_kwargs, on_first_delta=on_first_delta)
 
-    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+        return interruptible_streaming_api_call(
+            self, api_kwargs, on_first_delta=on_first_delta
+        )
+
+    def _try_activate_fallback(
+        self,
+        reason: "FailoverReason | None" = None,
+        *,
+        api_error: Optional[Exception] = None,
+    ) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
-        return try_activate_fallback(self, reason)
+
+        return try_activate_fallback(self, reason, api_error=api_error)
 
     def _has_pending_fallback(self) -> bool:
         """Whether a fallback provider is actually available to switch to.
@@ -4409,21 +4636,32 @@ class AIAgent:
     def _restore_primary_runtime(self) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.restore_primary_runtime``."""
         from agent.agent_runtime_helpers import restore_primary_runtime
+
         return restore_primary_runtime(self)
 
     def _try_recover_primary_transport(
-        self, api_error: Exception, *, retry_count: int, max_retries: int,
+        self,
+        api_error: Exception,
+        *,
+        retry_count: int,
+        max_retries: int,
     ) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.try_recover_primary_transport``."""
         from agent.agent_runtime_helpers import try_recover_primary_transport
-        return try_recover_primary_transport(self, api_error, retry_count=retry_count, max_retries=max_retries)
+
+        return try_recover_primary_transport(
+            self, api_error, retry_count=retry_count, max_retries=max_retries
+        )
 
     @staticmethod
     def _content_has_image_parts(content: Any) -> bool:
         if not isinstance(content, list):
             return False
         for part in content:
-            if isinstance(part, dict) and part.get("type") in {"image_url", "input_image"}:
+            if isinstance(part, dict) and part.get("type") in {
+                "image_url",
+                "input_image",
+            }:
                 return True
         return False
 
@@ -4432,7 +4670,7 @@ class AIAgent:
         header, _, data = str(image_url or "").partition(",")
         mime = "image/jpeg"
         if header.startswith("data:"):
-            mime_part = header[len("data:"):].split(";", 1)[0].strip()
+            mime_part = header[len("data:") :].split(";", 1)[0].strip()
             if mime_part.startswith("image/"):
                 mime = mime_part
         suffix = {
@@ -4442,7 +4680,9 @@ class AIAgent:
             "image/jpeg": ".jpg",
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
-        tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
+        tmp = tempfile.NamedTemporaryFile(
+            prefix="anthropic_image_", suffix=suffix, delete=False
+        )
         try:
             with tmp:
                 tmp.write(base64.b64decode(data))
@@ -4476,14 +4716,18 @@ class AIAgent:
         vision_source = str(image_url or "")
         cleanup_path: Optional[Path] = None
         if vision_source.startswith("data:"):
-            vision_source, cleanup_path = self._materialize_data_url_for_vision(vision_source)
+            vision_source, cleanup_path = self._materialize_data_url_for_vision(
+                vision_source
+            )
 
         description = ""
         try:
             from tools.vision_tools import vision_analyze_tool
 
             result_json = asyncio.run(
-                vision_analyze_tool(image_url=vision_source, user_prompt=analysis_prompt)
+                vision_analyze_tool(
+                    image_url=vision_source, user_prompt=analysis_prompt
+                )
             )
             result = json.loads(result_json) if isinstance(result_json, str) else {}
             description = (result.get("analysis") or "").strip()
@@ -4501,9 +4745,7 @@ class AIAgent:
 
         note = f"[The {role_label} attached an image. Here's what it contains:\n{description}]"
         if vision_source and not str(image_url or "").startswith("data:"):
-            note += (
-                f"\n[If you need a closer look, use vision_analyze with image_url: {vision_source}]"
-            )
+            note += f"\n[If you need a closer look, use vision_analyze with image_url: {vision_source}]"
 
         self._anthropic_image_fallback_cache[cache_key] = note
         return note
@@ -4525,6 +4767,7 @@ class AIAgent:
         try:
             from hermes_cli.config import load_config
             from agent.image_routing import _lookup_supports_vision
+
             cfg = load_config()
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
@@ -4541,6 +4784,7 @@ class AIAgent:
         """
         try:
             from providers import get_provider_profile
+
             provider = (getattr(self, "provider", "") or "").strip()
             profile = get_provider_profile(provider)
             if profile is not None:
@@ -4572,11 +4816,19 @@ class AIAgent:
 
             if ptype in {"image_url", "input_image"}:
                 image_data = part.get("image_url", {})
-                image_url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data or "")
+                image_url = (
+                    image_data.get("url", "")
+                    if isinstance(image_data, dict)
+                    else str(image_data or "")
+                )
                 if image_url:
-                    image_notes.append(self._describe_image_for_anthropic_fallback(image_url, role))
+                    image_notes.append(
+                        self._describe_image_for_anthropic_fallback(image_url, role)
+                    )
                 else:
-                    image_notes.append("[An image was attached but no image source was available.]")
+                    image_notes.append(
+                        "[An image was attached but no image source was available.]"
+                    )
                 continue
 
             text = str(part.get("text", "") or "").strip()
@@ -4591,7 +4843,9 @@ class AIAgent:
             return prefix
         if suffix:
             return suffix
-        return "[A multimodal message was converted to text for Anthropic compatibility.]"
+        return (
+            "[A multimodal message was converted to text for Anthropic compatibility.]"
+        )
 
     def _get_transport(self, api_mode: str = None):
         """Return the cached transport for the given (or current) api_mode.
@@ -4607,6 +4861,7 @@ class AIAgent:
         t = cache.get(mode)
         if t is None:
             from agent.transports import get_transport
+
             t = get_transport(mode)
             cache[mode] = t
         return t
@@ -4696,7 +4951,8 @@ class AIAgent:
                 logger.debug(
                     "Tool %s: provider %s does not accept list-type tool "
                     "content — sending text summary",
-                    tool_name, getattr(self, "provider", ""),
+                    tool_name,
+                    getattr(self, "provider", ""),
                 )
                 return _multimodal_text_summary(result)
             key = (
@@ -4708,7 +4964,9 @@ class AIAgent:
                 logger.debug(
                     "Tool %s: model %s/%s known to reject list-type tool "
                     "content this session — sending text summary",
-                    tool_name, key[0], key[1],
+                    tool_name,
+                    key[0],
+                    key[1],
                 )
                 return _multimodal_text_summary(result)
             return content
@@ -4742,6 +5000,7 @@ class AIAgent:
     ) -> bool:
         """Forwarder — see ``agent.conversation_compression.try_shrink_image_parts_in_messages``."""
         from agent.conversation_compression import try_shrink_image_parts_in_messages
+
         return try_shrink_image_parts_in_messages(
             api_messages,
             max_dimension=max_dimension,
@@ -4836,9 +5095,13 @@ class AIAgent:
         Regression for #11976; mirrors the opencode-go fix for #5211
         (commit f77be22c), which extended this same allowlist."""
         if (getattr(self, "provider", "") or "").lower() in {
-            "alibaba", "minimax", "minimax-cn",
-            "opencode-go", "opencode-zen",
-            "zai", "bedrock",
+            "alibaba",
+            "minimax",
+            "minimax-cn",
+            "opencode-go",
+            "opencode-zen",
+            "zai",
+            "bedrock",
             "xiaomi",
         }:
             return True
@@ -4886,7 +5149,11 @@ class AIAgent:
         for msg in prepared:
             if isinstance(msg, dict) and msg.get("role") == "system":
                 content = msg.get("content")
-                if isinstance(content, list) and content and isinstance(content[-1], dict):
+                if (
+                    isinstance(content, list)
+                    and content
+                    and isinstance(content[-1], dict)
+                ):
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
@@ -4916,13 +5183,18 @@ class AIAgent:
         for msg in messages:
             if isinstance(msg, dict) and msg.get("role") == "system":
                 content = msg.get("content")
-                if isinstance(content, list) and content and isinstance(content[-1], dict):
+                if (
+                    isinstance(content, list)
+                    and content
+                    and isinstance(content[-1], dict)
+                ):
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Forwarder — see ``agent.chat_completion_helpers.build_api_kwargs``."""
         from agent.chat_completion_helpers import build_api_kwargs
+
         return build_api_kwargs(self, api_messages)
 
     def _supports_reasoning_extra_body(self) -> bool:
@@ -4934,10 +5206,9 @@ class AIAgent:
         """
         if base_url_host_matches(self._base_url_lower, "nousresearch.com"):
             return True
-        if (
-            base_url_host_matches(self._base_url_lower, "models.github.ai")
-            or base_url_host_matches(self._base_url_lower, "api.githubcopilot.com")
-        ):
+        if base_url_host_matches(
+            self._base_url_lower, "models.github.ai"
+        ) or base_url_host_matches(self._base_url_lower, "api.githubcopilot.com"):
             try:
                 from hermes_cli.models import github_model_reasoning_efforts
 
@@ -4993,8 +5264,11 @@ class AIAgent:
                 return opts
         try:
             from hermes_cli.models import lmstudio_model_reasoning_options
+
             opts = lmstudio_model_reasoning_options(
-                self.model, self.base_url, getattr(self, "api_key", ""),
+                self.model,
+                self.base_url,
+                getattr(self, "api_key", ""),
             )
         except Exception:
             opts = []
@@ -5009,6 +5283,7 @@ class AIAgent:
         can't drift on effort resolution and clamping.
         """
         from agent.lmstudio_reasoning import resolve_lmstudio_effort
+
         return resolve_lmstudio_effort(
             self.reasoning_config,
             self._lmstudio_reasoning_options_cached(),
@@ -5028,9 +5303,9 @@ class AIAgent:
         if self.reasoning_config and isinstance(self.reasoning_config, dict):
             if self.reasoning_config.get("enabled") is False:
                 return None
-            requested_effort = str(
-                self.reasoning_config.get("effort", "medium")
-            ).strip().lower()
+            requested_effort = (
+                str(self.reasoning_config.get("effort", "medium")).strip().lower()
+            )
         else:
             requested_effort = "medium"
 
@@ -5049,6 +5324,7 @@ class AIAgent:
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Forwarder — see ``agent.chat_completion_helpers.build_assistant_message``."""
         from agent.chat_completion_helpers import build_assistant_message
+
         return build_assistant_message(self, assistant_message, finish_reason)
 
     def _needs_thinking_reasoning_pad(self) -> bool:
@@ -5066,7 +5342,11 @@ class AIAgent:
         ``urlparse``) calls under it. Caching drops the per-turn cost from
         ~5us × 16 = ~80us to <1us.
         """
-        key = (self.provider, self.model, getattr(self, "_base_url_lower", self.base_url))
+        key = (
+            self.provider,
+            self.model,
+            getattr(self, "_base_url_lower", self.base_url),
+        )
         cached = getattr(self, "_thinking_pad_cache", None)
         if cached is not None and cached[0] == key:
             return cached[1]
@@ -5132,15 +5412,19 @@ class AIAgent:
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api
+
         return copy_reasoning_content_for_api(self, source_msg, api_msg)
 
     def _reapply_reasoning_echo_for_provider(self, api_messages: list) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.reapply_reasoning_echo_for_provider``."""
         from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
         return reapply_reasoning_echo_for_provider(self, api_messages)
 
     @staticmethod
-    def _sanitize_tool_calls_for_strict_api(api_msg: dict, model: "str | None" = None) -> dict:
+    def _sanitize_tool_calls_for_strict_api(
+        api_msg: dict, model: "str | None" = None
+    ) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.
 
         Providers like Mistral, Fireworks, and other strict OpenAI-compatible APIs
@@ -5166,12 +5450,14 @@ class AIAgent:
         if not isinstance(tool_calls, list):
             return api_msg
         from agent.transports.chat_completions import _model_consumes_thought_signature
+
         _STRIP_KEYS = {"call_id", "response_item_id"}
         if not _model_consumes_thought_signature(model):
             _STRIP_KEYS = _STRIP_KEYS | {"extra_content"}
         api_msg["tool_calls"] = [
             {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
-            if isinstance(tc, dict) else tc
+            if isinstance(tc, dict)
+            else tc
             for tc in tool_calls
         ]
         return api_msg
@@ -5185,7 +5471,10 @@ class AIAgent:
     ) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.sanitize_tool_call_arguments``."""
         from agent.agent_runtime_helpers import sanitize_tool_call_arguments
-        return sanitize_tool_call_arguments(messages, logger=logger, session_id=session_id)
+
+        return sanitize_tool_call_arguments(
+            messages, logger=logger, session_id=session_id
+        )
 
     def _should_sanitize_tool_calls(self) -> bool:
         """Determine if tool_calls need sanitization for strict APIs.
@@ -5200,7 +5489,16 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False) -> tuple:
+    def _compress_context(
+        self,
+        messages: list,
+        system_message: str,
+        *,
+        approx_tokens: int = None,
+        task_id: str = "default",
+        focus_topic: str = None,
+        force: bool = False,
+    ) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
 
         ``force=True`` is passed by the manual ``/compress`` slash command
@@ -5209,9 +5507,14 @@ class AIAgent:
         ``force=False``.
         """
         from agent.conversation_compression import compress_context
+
         return compress_context(
-            self, messages, system_message,
-            approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
+            self,
+            messages,
+            system_message,
+            approx_tokens=approx_tokens,
+            task_id=task_id,
+            focus_topic=focus_topic,
             force=force,
         )
 
@@ -5220,7 +5523,9 @@ class AIAgent:
         if decision.should_halt and self._tool_guardrail_halt_decision is None:
             self._tool_guardrail_halt_decision = decision
 
-    def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
+    def _toolguard_controlled_halt_response(
+        self, decision: ToolGuardrailDecision
+    ) -> str:
         tool = decision.tool_name or "a tool"
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
@@ -5274,6 +5579,7 @@ class AIAgent:
         if getattr(self, "_plan_emitted_for_turn", False):
             return
         from agent.plan_schema import emit_plan
+
         if emit_plan(plan, emit=self._emit_status):
             self._plan_emitted_for_turn = True
 
@@ -5294,6 +5600,7 @@ class AIAgent:
         """
         try:
             from agent.plan_mode import plan_mode_enabled
+
             return plan_mode_enabled()
         except Exception:
             # A flag-read failure must never break a turn — fall back to off,
@@ -5325,6 +5632,7 @@ class AIAgent:
             return
         try:
             from agent.plan_mode import build_stub_plan
+
             plan = build_stub_plan(user_message)
         except Exception:
             plan = None
@@ -5380,9 +5688,7 @@ class AIAgent:
         result = evaluate_divergence(observed, step)
         if result.diverged:
             try:
-                self._emit_status(
-                    f"↪ plan step {step.index} diverged: {result.reason}"
-                )
+                self._emit_status(f"↪ plan step {step.index} diverged: {result.reason}")
             except Exception:
                 pass
             new_plan = trigger_replan(
@@ -5436,7 +5742,13 @@ class AIAgent:
         # ``reversed`` collected newest-first; restore chronological order.
         return "\n".join(reversed(texts))
 
-    def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
         Dispatches to concurrent execution only for batches that look
@@ -5486,6 +5798,7 @@ class AIAgent:
         invocation paths (concurrent, sequential, inline).
         """
         from tools.delegate_tool import delegate_task as _delegate_task
+
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
@@ -5500,13 +5813,20 @@ class AIAgent:
             parent_agent=self,
         )
 
-    def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
-                     tool_call_id: Optional[str] = None, messages: list = None,
-                     pre_tool_block_checked: bool = False,
-                     skip_tool_request_middleware: bool = False,
-                     tool_request_middleware_trace: Optional[list[dict[str, Any]]] = None) -> str:
+    def _invoke_tool(
+        self,
+        function_name: str,
+        function_args: dict,
+        effective_task_id: str,
+        tool_call_id: Optional[str] = None,
+        messages: list = None,
+        pre_tool_block_checked: bool = False,
+        skip_tool_request_middleware: bool = False,
+        tool_request_middleware_trace: Optional[list[dict[str, Any]]] = None,
+    ) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.invoke_tool``."""
         from agent.agent_runtime_helpers import invoke_tool
+
         return invoke_tool(
             self,
             function_name,
@@ -5530,6 +5850,7 @@ class AIAgent:
         """
         import shutil as _shutil
         import textwrap as _tw
+
         cols = _shutil.get_terminal_size((120, 24)).columns
         wrap_width = max(40, cols - len(indent))
         out_lines: list[str] = []
@@ -5537,26 +5858,48 @@ class AIAgent:
             if len(raw_line) <= wrap_width:
                 out_lines.append(raw_line)
             else:
-                wrapped = _tw.wrap(raw_line, width=wrap_width,
-                                   break_long_words=True,
-                                   break_on_hyphens=False)
+                wrapped = _tw.wrap(
+                    raw_line,
+                    width=wrap_width,
+                    break_long_words=True,
+                    break_on_hyphens=False,
+                )
                 out_lines.extend(wrapped or [raw_line])
         body = ("\n" + indent).join(out_lines)
         return f"{indent}{label}{body}"
 
-    def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls_concurrent(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_concurrent``."""
         from agent.tool_executor import execute_tool_calls_concurrent
-        return execute_tool_calls_concurrent(self, assistant_message, messages, effective_task_id, api_call_count)
 
-    def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+        return execute_tool_calls_concurrent(
+            self, assistant_message, messages, effective_task_id, api_call_count
+        )
+
+    def _execute_tool_calls_sequential(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_sequential``."""
         from agent.tool_executor import execute_tool_calls_sequential
-        return execute_tool_calls_sequential(self, assistant_message, messages, effective_task_id, api_call_count)
+
+        return execute_tool_calls_sequential(
+            self, assistant_message, messages, effective_task_id, api_call_count
+        )
 
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations
+
         return handle_max_iterations(self, messages, api_call_count)
 
     def run_conversation(
@@ -5571,6 +5914,7 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
+
         return run_conversation(
             self,
             user_message,
@@ -5607,7 +5951,16 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+        )
+
 
 def main(
     query: str = None,
@@ -5621,7 +5974,7 @@ def main(
     save_trajectories: bool = False,
     save_sample: bool = False,
     verbose: bool = False,
-    log_prefix_chars: int = 20
+    log_prefix_chars: int = 20,
 ):
     """
     Main function for running the agent directly.
@@ -5647,58 +6000,65 @@ def main(
     """
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
-    
+
     # Handle tool listing
     if list_tools:
         from model_tools import get_all_tool_names, get_available_toolsets
         from toolsets import get_all_toolsets, get_toolset_info
-        
+
         print("📋 Available Tools & Toolsets:")
         print("-" * 50)
-        
+
         # Show new toolsets system
         print("\n🎯 Predefined Toolsets (New System):")
         print("-" * 40)
         all_toolsets = get_all_toolsets()
-        
+
         # Group by category
         basic_toolsets = []
         composite_toolsets = []
         scenario_toolsets = []
-        
+
         for name, toolset in all_toolsets.items():
             info = get_toolset_info(name)
             if info:
                 entry = (name, info)
                 if name in {"web", "terminal", "vision", "creative", "reasoning"}:
                     basic_toolsets.append(entry)
-                elif name in {"research", "development", "analysis", "content_creation", "full_stack"}:
+                elif name in {
+                    "research",
+                    "development",
+                    "analysis",
+                    "content_creation",
+                    "full_stack",
+                }:
                     composite_toolsets.append(entry)
                 else:
                     scenario_toolsets.append(entry)
-        
+
         # Print basic toolsets
         print("\n📌 Basic Toolsets:")
         for name, info in basic_toolsets:
-            tools_str = ', '.join(info['resolved_tools']) if info['resolved_tools'] else 'none'
+            tools_str = (
+                ", ".join(info["resolved_tools"]) if info["resolved_tools"] else "none"
+            )
             print(f"  • {name:15} - {info['description']}")
             print(f"    Tools: {tools_str}")
-        
+
         # Print composite toolsets
         print("\n📂 Composite Toolsets (built from other toolsets):")
         for name, info in composite_toolsets:
-            includes_str = ', '.join(info['includes']) if info['includes'] else 'none'
+            includes_str = ", ".join(info["includes"]) if info["includes"] else "none"
             print(f"  • {name:15} - {info['description']}")
             print(f"    Includes: {includes_str}")
             print(f"    Total tools: {info['tool_count']}")
-        
+
         # Print scenario-specific toolsets
         print("\n🎭 Scenario-Specific Toolsets:")
         for name, info in scenario_toolsets:
             print(f"  • {name:20} - {info['description']}")
             print(f"    Total tools: {info['tool_count']}")
-        
-        
+
         # Show legacy toolset compatibility
         print("\n📦 Legacy Toolsets (for backward compatibility):")
         legacy_toolsets = get_available_toolsets()
@@ -5707,47 +6067,57 @@ def main(
             print(f"  {status} {name}: {info['description']}")
             if not info["available"]:
                 print(f"    Requirements: {', '.join(info['requirements'])}")
-        
+
         # Show individual tools
         all_tools = get_all_tool_names()
         print(f"\n🔧 Individual Tools ({len(all_tools)} available):")
         for tool_name in sorted(all_tools):
             toolset = get_toolset_for_tool(tool_name)
             print(f"  📌 {tool_name} (from {toolset})")
-        
+
         print("\n💡 Usage Examples:")
         print("  # Use predefined toolsets")
-        print("  python run_agent.py --enabled_toolsets=research --query='search for Python news'")
-        print("  python run_agent.py --enabled_toolsets=development --query='debug this code'")
-        print("  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'")
+        print(
+            "  python run_agent.py --enabled_toolsets=research --query='search for Python news'"
+        )
+        print(
+            "  python run_agent.py --enabled_toolsets=development --query='debug this code'"
+        )
+        print(
+            "  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'"
+        )
         print("  ")
         print("  # Combine multiple toolsets")
-        print("  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'")
+        print(
+            "  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'"
+        )
         print("  ")
         print("  # Disable toolsets")
-        print("  python run_agent.py --disabled_toolsets=terminal --query='no command execution'")
+        print(
+            "  python run_agent.py --disabled_toolsets=terminal --query='no command execution'"
+        )
         print("  ")
         print("  # Run with trajectory saving enabled")
         print("  python run_agent.py --save_trajectories --query='your question here'")
         return
-    
+
     # Parse toolset selection arguments
     enabled_toolsets_list = None
     disabled_toolsets_list = None
-    
+
     if enabled_toolsets:
         enabled_toolsets_list = [t.strip() for t in enabled_toolsets.split(",")]
         print(f"🎯 Enabled toolsets: {enabled_toolsets_list}")
-    
+
     if disabled_toolsets:
         disabled_toolsets_list = [t.strip() for t in disabled_toolsets.split(",")]
         print(f"🚫 Disabled toolsets: {disabled_toolsets_list}")
-    
+
     if save_trajectories:
         print("💾 Trajectory saving: ENABLED")
         print("   - Successful conversations → trajectory_samples.jsonl")
         print("   - Failed conversations → failed_trajectories.jsonl")
-    
+
     # Initialize agent with provided parameters
     try:
         agent = AIAgent(
@@ -5759,12 +6129,12 @@ def main(
             disabled_toolsets=disabled_toolsets_list,
             save_trajectories=save_trajectories,
             verbose_logging=verbose,
-            log_prefix_chars=log_prefix_chars
+            log_prefix_chars=log_prefix_chars,
         )
     except RuntimeError as e:
         print(f"❌ Failed to initialize agent: {e}")
         return
-    
+
     # Use provided query or default to Python 3.13 example
     if query is None:
         user_query = (
@@ -5773,45 +6143,43 @@ def main(
         )
     else:
         user_query = query
-    
+
     print(f"\n📝 User Query: {user_query}")
     print("\n" + "=" * 50)
-    
+
     # Run conversation
     result = agent.run_conversation(user_query)
-    
+
     print("\n" + "=" * 50)
     print("📋 CONVERSATION SUMMARY")
     print("=" * 50)
     print(f"✅ Completed: {result['completed']}")
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
-    
-    if result['final_response']:
+
+    if result["final_response"]:
         print("\n🎯 FINAL RESPONSE:")
         print("-" * 30)
-        print(result['final_response'])
-    
+        print(result["final_response"])
+
     # Save sample trajectory to UUID-named file if requested
     if save_sample:
         sample_id = str(uuid.uuid4())[:8]
         sample_filename = f"sample_{sample_id}.json"
-        
+
         # Convert messages to trajectory format (same as batch_runner)
         trajectory = agent._convert_to_trajectory_format(
-            result['messages'], 
-            user_query, 
-            result['completed']
+            result["messages"], user_query, result["completed"]
         )
-        
+
         entry = {
             "conversations": trajectory,
             "timestamp": datetime.now().isoformat(),
             "model": model,
-            "completed": result['completed'],
-            "query": user_query
+            "completed": result["completed"],
+            "query": user_query,
         }
-        
+
         try:
             with open(sample_filename, "w", encoding="utf-8") as f:
                 # Pretty-print JSON with indent for readability
@@ -5819,10 +6187,11 @@ def main(
             print(f"\n💾 Sample trajectory saved to: {sample_filename}")
         except Exception as e:
             print(f"\n⚠️ Failed to save sample: {e}")
-    
+
     print("\n👋 Agent execution completed!")
 
 
 if __name__ == "__main__":
     import fire
+
     fire.Fire(main)

--- a/tests/agent/test_dump_duplicate_suppression.py
+++ b/tests/agent/test_dump_duplicate_suppression.py
@@ -1,0 +1,126 @@
+"""Tests for duplicate API request dump suppression (issue #367)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.agent_runtime_helpers import dump_api_request_debug
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(tmp_path: Path) -> AIAgent:
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://my-llm.example.com/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.api_key = "sk-test"
+        agent.logs_dir = tmp_path
+        return agent
+
+
+def test_duplicate_dump_suppressed_within_window(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    err = ValueError("boom")
+    err.status_code = 401  # type: ignore[attr-defined]
+
+    first = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+    assert first is not None
+    assert first.exists()
+
+    second = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+    assert second is None
+
+
+def test_duplicate_dump_allowed_after_window(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+    err = ValueError("boom")
+    err.status_code = 401  # type: ignore[attr-defined]
+
+    first = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+    assert first is not None
+
+    # Simulate cache entry aging out by poking the cache directly.
+    cache = agent._request_dump_cache
+    assert cache is not None
+    key = next(iter(cache.keys()))
+    cache[key] = time.time() - 61
+
+    second = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+    assert second is not None
+    assert second.exists()
+
+
+def test_different_failure_category_not_suppressed(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    err1 = ValueError("boom")
+    err1.status_code = 401  # type: ignore[attr-defined]
+    err2 = ValueError("boom2")
+    err2.status_code = 429  # type: ignore[attr-defined]
+
+    first = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err1)
+    assert first is not None
+
+    second = dump_api_request_debug(agent, api_kwargs, reason="rate_limit", error=err2)
+    assert second is not None
+
+
+def test_preflight_dump_not_suppressed_against_error_dump(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    pre = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+    assert pre is not None
+
+    err = ValueError("boom")
+    err.status_code = 401  # type: ignore[attr-defined]
+    post = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+    assert post is not None
+
+
+def test_dump_payload_includes_failure_category(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+    err = ValueError("paid subscription required")
+    err.status_code = 403  # type: ignore[attr-defined]
+
+    dump_file = dump_api_request_debug(agent, api_kwargs, reason="billing", error=err)
+    assert dump_file is not None
+    data = json.loads(dump_file.read_text())
+    assert data["error"]["failure_category"] == "billing"
+    assert data["error"]["retryable"] is False

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -16,8 +16,10 @@ from agent.error_classifier import (
 
 # ── Helper: mock API errors ────────────────────────────────────────────
 
+
 class MockAPIError(Exception):
     """Simulates an OpenAI SDK APIStatusError."""
+
     def __init__(self, message, status_code=None, body=None):
         super().__init__(message)
         self.status_code = status_code
@@ -26,6 +28,7 @@ class MockAPIError(Exception):
 
 class MockTransportError(Exception):
     """Simulates a transport-level error with a specific type name."""
+
     pass
 
 
@@ -47,6 +50,7 @@ class ServerDisconnectedError(MockTransportError):
 
 # ── Test: FailoverReason enum ──────────────────────────────────────────
 
+
 class TestFailoverReason:
     def test_all_reasons_have_string_values(self):
         for reason in FailoverReason:
@@ -54,15 +58,24 @@ class TestFailoverReason:
 
     def test_enum_members_exist(self):
         expected = {
-            "auth", "auth_permanent", "billing", "rate_limit",
-            "overloaded", "server_error", "timeout",
-            "context_overflow", "payload_too_large", "image_too_large",
-            "model_not_found", "format_error",
+            "auth",
+            "auth_permanent",
+            "billing",
+            "rate_limit",
+            "overloaded",
+            "server_error",
+            "timeout",
+            "context_overflow",
+            "payload_too_large",
+            "image_too_large",
+            "model_not_found",
+            "format_error",
             "invalid_encrypted_content",
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
-            "thinking_signature", "long_context_tier",
+            "thinking_signature",
+            "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
             "unknown",
@@ -72,6 +85,7 @@ class TestFailoverReason:
 
 
 # ── Test: ClassifiedError ──────────────────────────────────────────────
+
 
 class TestClassifiedError:
     def test_is_auth_property(self):
@@ -96,6 +110,7 @@ class TestClassifiedError:
 
 # ── Test: Status code extraction ───────────────────────────────────────
 
+
 class TestExtractStatusCode:
     def test_from_status_code_attr(self):
         e = MockAPIError("fail", status_code=429)
@@ -104,6 +119,7 @@ class TestExtractStatusCode:
     def test_from_status_attr(self):
         class ErrWithStatus(Exception):
             status = 503
+
         assert _extract_status_code(ErrWithStatus()) == 503
 
     def test_from_cause_chain(self):
@@ -117,12 +133,15 @@ class TestExtractStatusCode:
 
     def test_rejects_non_http_status(self):
         """Integers outside 100-599 on .status should be ignored."""
+
         class ErrWeirdStatus(Exception):
             status = 42
+
         assert _extract_status_code(ErrWeirdStatus()) is None
 
 
 # ── Test: Error body extraction ────────────────────────────────────────
+
 
 class TestExtractErrorBody:
     def test_from_body_attr(self):
@@ -134,6 +153,7 @@ class TestExtractErrorBody:
 
 
 # ── Test: Error code extraction ────────────────────────────────────────
+
 
 class TestExtractErrorCode:
     def test_from_nested_error_code(self):
@@ -167,6 +187,7 @@ class TestExtractErrorCode:
 
 
 # ── Test: 402 disambiguation ───────────────────────────────────────────
+
 
 class TestClassify402:
     """The critical 402 billing vs rate_limit disambiguation."""
@@ -214,6 +235,7 @@ class TestClassify402:
 
 
 # ── Test: Full classification pipeline ─────────────────────────────────
+
 
 class TestClassifyApiError:
     """End-to-end classification tests."""
@@ -280,10 +302,23 @@ class TestClassifyApiError:
         assert result.retryable is True
 
     def test_403_plan_entitlement_billing(self):
-        e = MockAPIError("This plan does not include the requested model", status_code=403)
+        e = MockAPIError(
+            "This plan does not include the requested model", status_code=403
+        )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
+
+    def test_403_paid_subscription_billing(self):
+        """403 with 'requires a paid subscription' is classified as billing."""
+        e = MockAPIError(
+            "Forbidden: this model requires a paid subscription",
+            status_code=403,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_fallback is True
 
     def test_404_free_tier_model_block_is_billing(self):
         e = MockAPIError(
@@ -569,12 +604,17 @@ class TestClassifyApiError:
         assert result.should_compress is True
 
     def test_400_too_many_tokens(self):
-        e = MockAPIError("This model's maximum context is 128000 tokens, too many tokens", status_code=400)
+        e = MockAPIError(
+            "This model's maximum context is 128000 tokens, too many tokens",
+            status_code=400,
+        )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
 
     def test_400_prompt_too_long(self):
-        e = MockAPIError("prompt is too long: 300000 tokens > 200000 maximum", status_code=400)
+        e = MockAPIError(
+            "prompt is too long: 300000 tokens > 200000 maximum", status_code=400
+        )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.context_overflow
 
@@ -598,7 +638,9 @@ class TestClassifyApiError:
         result = classify_api_error(e, approx_tokens=1000, context_length=200000)
         assert result.reason == FailoverReason.format_error
 
-    def test_400_generic_many_messages_below_large_context_pressure_is_format_error(self):
+    def test_400_generic_many_messages_below_large_context_pressure_is_format_error(
+        self,
+    ):
         """Large-context sessions should not overflow solely due to message count."""
         e = MockAPIError(
             "Error",
@@ -694,7 +736,8 @@ class TestClassifyApiError:
         """A 400 'cannot be modified' that has nothing to do with thinking
         blocks must NOT be swept into thinking_signature recovery."""
         e = MockAPIError(
-            "this field cannot be modified after creation", status_code=400,
+            "this field cannot be modified after creation",
+            status_code=400,
         )
         result = classify_api_error(e, provider="anthropic", approx_tokens=0)
         assert result.reason != FailoverReason.thinking_signature
@@ -720,7 +763,9 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
-    def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(self):
+    def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(
+        self,
+    ):
         message = "Encrypted content could not be decrypted or parsed."
         e = MockAPIError(
             message,
@@ -732,8 +777,12 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_fallback is True
 
-    @pytest.mark.parametrize("error_code", ["Invalid_Encrypted_Content", "INVALID_ENCRYPTED_CONTENT"])
-    def test_invalid_encrypted_content_code_is_case_insensitive_for_400(self, error_code):
+    @pytest.mark.parametrize(
+        "error_code", ["Invalid_Encrypted_Content", "INVALID_ENCRYPTED_CONTENT"]
+    )
+    def test_invalid_encrypted_content_code_is_case_insensitive_for_400(
+        self, error_code
+    ):
         e = MockAPIError(
             "Error code: 400 - bad request",
             status_code=400,
@@ -882,7 +931,9 @@ class TestClassifyApiError:
     def test_error_code_resource_exhausted(self):
         e = MockAPIError(
             "Resource exhausted",
-            body={"error": {"code": "resource_exhausted", "message": "Too many requests"}},
+            body={
+                "error": {"code": "resource_exhausted", "message": "Too many requests"}
+            },
         )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
@@ -996,7 +1047,11 @@ class TestClassifyApiError:
         e = MockAPIError(
             "Invalid value for parameter 'temperature': must be between 0 and 2",
             status_code=400,
-            body={"error": {"message": "Invalid value for parameter 'temperature': must be between 0 and 2"}},
+            body={
+                "error": {
+                    "message": "Invalid value for parameter 'temperature': must be between 0 and 2"
+                }
+            },
         )
         result = classify_api_error(e, approx_tokens=1000)
         assert result.reason == FailoverReason.format_error
@@ -1009,17 +1064,25 @@ class TestClassifyApiError:
         request-validation guard it was routed into the compression loop,
         re-sent with the same bad param, and ended in "Cannot compress
         further". Regression for gpt-5-context-overflow-misclassification."""
-        msg = ("Unsupported parameter: 'max_tokens' is not supported with this "
-               "model. Use 'max_completion_tokens' instead.")
+        msg = (
+            "Unsupported parameter: 'max_tokens' is not supported with this "
+            "model. Use 'max_completion_tokens' instead."
+        )
         e = MockAPIError(
             msg,
             status_code=400,
-            body={"error": {"message": msg, "type": "invalid_request_error",
-                            "code": "unsupported_parameter"}},
+            body={
+                "error": {
+                    "message": msg,
+                    "type": "invalid_request_error",
+                    "code": "unsupported_parameter",
+                }
+            },
         )
         # Tiny context against a huge window — definitely not a real overflow.
-        result = classify_api_error(e, model="gpt-5.4",
-                                    approx_tokens=6962, context_length=1050000)
+        result = classify_api_error(
+            e, model="gpt-5.4", approx_tokens=6962, context_length=1050000
+        )
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
         assert result.should_compress is False
@@ -1030,8 +1093,12 @@ class TestClassifyApiError:
         e = MockAPIError(
             "Unknown parameter: 'foo'.",
             status_code=400,
-            body={"error": {"message": "Unknown parameter: 'foo'.",
-                            "code": "unknown_parameter"}},
+            body={
+                "error": {
+                    "message": "Unknown parameter: 'foo'.",
+                    "code": "unknown_parameter",
+                }
+            },
         )
         result = classify_api_error(e, approx_tokens=1000)
         assert result.reason == FailoverReason.format_error
@@ -1041,15 +1108,18 @@ class TestClassifyApiError:
         """Guard the guard: OpenAI stamps genuine context-overflow 400s with
         the generic 'invalid_request_error' code. The request-validation guard
         must NOT key off that code, or real overflows stop compressing."""
-        msg = ("This model's maximum context length is 128000 tokens, however "
-               "you requested 150000 tokens.")
+        msg = (
+            "This model's maximum context length is 128000 tokens, however "
+            "you requested 150000 tokens."
+        )
         e = MockAPIError(
             msg,
             status_code=400,
             body={"error": {"message": msg, "type": "invalid_request_error"}},
         )
-        result = classify_api_error(e, model="gpt-5.4",
-                                    approx_tokens=150000, context_length=128000)
+        result = classify_api_error(
+            e, model="gpt-5.4", approx_tokens=150000, context_length=128000
+        )
         assert result.reason == FailoverReason.context_overflow
         assert result.should_compress is True
 
@@ -1070,10 +1140,14 @@ class TestClassifyApiError:
         e = MockAPIError(
             "Invalid 'input[index].name': string does not match pattern.",
             status_code=400,
-            body={"message": "Invalid 'input[index].name': string does not match pattern.",
-                  "type": "invalid_request_error"},
+            body={
+                "message": "Invalid 'input[index].name': string does not match pattern.",
+                "type": "invalid_request_error",
+            },
         )
-        result = classify_api_error(e, approx_tokens=200000, context_length=400000, num_messages=500)
+        result = classify_api_error(
+            e, approx_tokens=200000, context_length=400000, num_messages=500
+        )
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
 
@@ -1168,6 +1242,7 @@ class TestClassifyApiError:
 
 # ── Test: Adversarial / edge cases (from live testing) ─────────────────
 
+
 class TestAdversarialEdgeCases:
     """Edge cases discovered during live testing with real SDK objects."""
 
@@ -1183,9 +1258,11 @@ class TestAdversarialEdgeCases:
 
     def test_non_dict_body(self):
         """Some providers return strings instead of JSON."""
+
         class StringBodyError(Exception):
             status_code = 400
             body = "just a string"
+
         result = classify_api_error(StringBodyError("bad"))
         assert result.reason == FailoverReason.format_error
 
@@ -1193,6 +1270,7 @@ class TestAdversarialEdgeCases:
         class ListBodyError(Exception):
             status_code = 500
             body = [{"error": "something"}]
+
         result = classify_api_error(ListBodyError("server error"))
         assert result.reason == FailoverReason.server_error
 
@@ -1235,9 +1313,11 @@ class TestAdversarialEdgeCases:
 
     def test_200_with_error_body(self):
         """200 status with error in body — should be unknown, not crash."""
+
         class WeirdSuccess(Exception):
             status_code = 200
             body = {"error": {"message": "loading"}}
+
         result = classify_api_error(WeirdSuccess("model loading"))
         assert result.reason == FailoverReason.unknown
 
@@ -1269,8 +1349,10 @@ class TestAdversarialEdgeCases:
 
     def test_disconnect_pattern_ordering(self):
         """Disconnect + large session must beat generic transport catch."""
+
         class FakeRemoteProtocol(Exception):
             pass
+
         # Type name isn't in _TRANSPORT_ERROR_TYPES but message has disconnect pattern
         e = Exception("peer closed connection without sending complete message")
         result = classify_api_error(e, approx_tokens=150000, context_length=200000)
@@ -1304,7 +1386,7 @@ class TestAdversarialEdgeCases:
                     "code": 400,
                     "metadata": {
                         "raw": '{"error":{"message":"context length exceeded: 50000 > 32768"}}'
-                    }
+                    },
                 }
             },
         )
@@ -1321,7 +1403,7 @@ class TestAdversarialEdgeCases:
                     "message": "Provider returned error",
                     "metadata": {
                         "raw": '{"error":{"message":"Rate limit exceeded. Please retry after 30s."}}'
-                    }
+                    },
                 }
             },
         )
@@ -1335,7 +1417,9 @@ class TestAdversarialEdgeCases:
             status_code=400,
         )
         # provider is openrouter, not anthropic — old code missed this
-        result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
+        result = classify_api_error(
+            e, provider="openrouter", model="anthropic/claude-sonnet-4"
+        )
         assert result.reason == FailoverReason.thinking_signature
 
     def test_generic_400_large_by_message_count(self):
@@ -1347,7 +1431,10 @@ class TestAdversarialEdgeCases:
         )
         # Low token count but high message count
         result = classify_api_error(
-            e, approx_tokens=5000, context_length=200000, num_messages=100,
+            e,
+            approx_tokens=5000,
+            context_length=200000,
+            num_messages=100,
         )
         assert result.reason == FailoverReason.context_overflow
 
@@ -1355,7 +1442,10 @@ class TestAdversarialEdgeCases:
         """Server disconnect with 200+ messages should trigger context overflow."""
         e = Exception("server disconnected without sending complete message")
         result = classify_api_error(
-            e, approx_tokens=5000, context_length=200000, num_messages=250,
+            e,
+            approx_tokens=5000,
+            context_length=200000,
+            num_messages=250,
         )
         assert result.reason == FailoverReason.context_overflow
 
@@ -1368,7 +1458,7 @@ class TestAdversarialEdgeCases:
                     "message": "Provider returned error",
                     "metadata": {
                         "raw": '{"error":{"message":"The model gpt-99 does not exist"}}'
-                    }
+                    },
                 }
             },
         )
@@ -1417,9 +1507,7 @@ class TestAdversarialEdgeCases:
             body={
                 "error": {
                     "message": {
-                        "detail": [
-                            {"type": "missing", "loc": ["body", "required"]}
-                        ]
+                        "detail": [{"type": "missing", "loc": ["body", "required"]}]
                     }
                 }
             },
@@ -1438,7 +1526,7 @@ class TestAdversarialEdgeCases:
                     "message": "Provider error",
                     "metadata": {
                         "raw": '{"error":{"message":{"detail":[{"type":"invalid"}]}}}'
-                    }
+                    },
                 }
             },
         )
@@ -1471,6 +1559,7 @@ class TestAdversarialEdgeCases:
 
 
 # ── Test: SSL/TLS transient errors ─────────────────────────────────────
+
 
 class TestSSLTransientPatterns:
     """SSL/TLS alerts mid-stream should retry as timeout, not unknown, and
@@ -1515,7 +1604,9 @@ class TestSSLTransientPatterns:
 
     def test_ssl_prefix_classifies_as_timeout(self):
         """Python's generic '[SSL: XYZ]' prefix from the ssl module."""
-        e = Exception("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+        e = Exception(
+            "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"
+        )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
@@ -1529,7 +1620,7 @@ class TestSSLTransientPatterns:
         e = Exception("[SSL: BAD_RECORD_MAC] sslv3 alert bad record mac")
         result = classify_api_error(
             e,
-            approx_tokens=180000,      # 90% of a 200k-context window
+            approx_tokens=180000,  # 90% of a 200k-context window
             context_length=200000,
             num_messages=300,
         )
@@ -1555,12 +1646,15 @@ class TestSSLTransientPatterns:
         """Real ssl.SSLError instance — the type name alone (not message)
         should route to the transport bucket."""
         import ssl
+
         e = ssl.SSLError("arbitrary ssl error")
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
 
+
 # ── Test: RateLimitError without status_code (Copilot/GitHub Models) ──────────
+
 
 class TestRateLimitErrorWithoutStatusCode:
     """Regression tests for the Copilot/GitHub Models edge case where the
@@ -1595,8 +1689,8 @@ class TestRateLimitErrorWithoutStatusCode:
         assert result.reason != FailoverReason.rate_limit
 
 
-
 # ── Test: multimodal_tool_content_unsupported pattern ───────────────────
+
 
 class TestMultimodalToolContentUnsupported:
     """Issue #27344 — providers that reject list-type tool message content
@@ -1654,11 +1748,14 @@ class TestMultimodalToolContentUnsupported:
     def test_unrelated_400_is_not_misclassified(self):
         """Make sure the patterns don't false-positive on normal 400s."""
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
-        result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
+        result = classify_api_error(
+            e, provider="openrouter", model="anthropic/claude-sonnet-4"
+        )
         assert result.reason != FailoverReason.multimodal_tool_content_unsupported
 
 
 # ── Model 404 suffix-variant self-correction (#348) ────────────────────
+
 
 class TestModelSuffixVariants:
     def test_bare_id_yields_cloud_then_local(self):
@@ -1674,7 +1771,10 @@ class TestModelSuffixVariants:
         assert model_id_suffix_variants("   ") == []
 
     def test_whitespace_is_trimmed(self):
-        assert model_id_suffix_variants("  kimi-k2  ") == ["kimi-k2:cloud", "kimi-k2:local"]
+        assert model_id_suffix_variants("  kimi-k2  ") == [
+            "kimi-k2:cloud",
+            "kimi-k2:local",
+        ]
 
 
 class TestNextUntriedModelVariant:
@@ -1682,7 +1782,10 @@ class TestNextUntriedModelVariant:
         assert next_untried_model_variant("glm-4", {"glm-4"}) == "glm-4:cloud"
 
     def test_skips_already_tried(self):
-        assert next_untried_model_variant("glm-4", {"glm-4", "glm-4:cloud"}) == "glm-4:local"
+        assert (
+            next_untried_model_variant("glm-4", {"glm-4", "glm-4:cloud"})
+            == "glm-4:local"
+        )
 
     def test_exhausted_returns_none(self):
         tried = {"glm-4", "glm-4:cloud", "glm-4:local"}
@@ -1700,4 +1803,3 @@ class TestNextUntriedModelVariant:
             seq.append(v)
             tried.add(v)
         assert seq == ["qwen3:cloud", "qwen3:local"]
-

--- a/tests/agent/test_retry_utils.py
+++ b/tests/agent/test_retry_utils.py
@@ -1,0 +1,52 @@
+"""Tests for Retry-After parsing in agent.retry_utils."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agent.retry_utils import extract_retry_after_seconds, jittered_backoff
+
+
+def test_extract_retry_after_seconds_integer():
+    assert extract_retry_after_seconds("42") == 42.0
+
+
+def test_extract_retry_after_seconds_integer_with_whitespace():
+    assert extract_retry_after_seconds("  7  ") == 7.0
+
+
+def test_extract_retry_after_seconds_http_date():
+    # 10 seconds in the future
+    future = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(time.time() + 10))
+    parsed = extract_retry_after_seconds(future)
+    assert parsed is not None
+    assert 9.0 <= parsed <= 10.0
+
+
+def test_extract_retry_after_seconds_http_date_past():
+    past = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(time.time() - 5))
+    assert extract_retry_after_seconds(past) == 0.0
+
+
+def test_extract_retry_after_seconds_caps_at_300():
+    parsed = extract_retry_after_seconds("600")
+    assert parsed is not None
+    assert parsed == 300.0
+
+
+def test_extract_retry_after_seconds_invalid_returns_none():
+    assert extract_retry_after_seconds("not-a-number-or-date") is None
+    assert extract_retry_after_seconds("") is None
+    assert extract_retry_after_seconds(None) is None
+
+
+def test_jittered_backoff_increases_with_attempt():
+    base = jittered_backoff(1, base_delay=1.0, max_delay=120.0)
+    later = jittered_backoff(5, base_delay=1.0, max_delay=120.0)
+    assert base < later
+
+
+def test_jittered_backoff_respects_max_delay():
+    assert jittered_backoff(100, base_delay=1.0, max_delay=30.0) <= 45.0

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -27,6 +27,7 @@ EXPECTED_FIELDS = {
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
     "has_retried_429",
+    "fail_fast_attempted",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",
 }

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,10 +30,14 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
-        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -62,6 +66,7 @@ def _mock_resolve(base_url="https://openrouter.ai/api/v1", api_key="fallback-key
 # _primary_runtime snapshot
 # =============================================================================
 
+
 class TestPrimaryRuntimeSnapshot:
     def test_snapshot_created_at_init(self):
         agent = _make_agent()
@@ -86,10 +91,16 @@ class TestPrimaryRuntimeSnapshot:
     def test_snapshot_includes_anthropic_state_when_applicable(self):
         """Anthropic-mode agents should snapshot Anthropic-specific state."""
         with (
-            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
             patch("run_agent.check_toolset_requirements", return_value={}),
             patch("run_agent.OpenAI"),
-            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ),
         ):
             agent = AIAgent(
                 api_key="sk-ant-test-12345678",
@@ -115,6 +126,7 @@ class TestPrimaryRuntimeSnapshot:
 # _restore_primary_runtime()
 # =============================================================================
 
+
 class TestRestorePrimaryRuntime:
     def test_noop_when_not_fallback(self):
         agent = _make_agent()
@@ -123,14 +135,20 @@ class TestRestorePrimaryRuntime:
 
     def test_restores_model_and_provider(self):
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
         )
         original_model = agent.model
         original_provider = agent.provider
 
         # Simulate fallback activation
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback()
 
         assert agent._fallback_activated is True
@@ -156,7 +174,10 @@ class TestRestorePrimaryRuntime:
         )
         # Advance through the chain
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback()
 
         assert agent._fallback_index == 1  # consumed one entry
@@ -168,14 +189,20 @@ class TestRestorePrimaryRuntime:
 
     def test_restores_compressor_state(self):
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
         )
         original_ctx_len = agent.context_compressor.context_length
         original_threshold = agent.context_compressor.threshold_tokens
 
         # Simulate fallback modifying compressor
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback()
 
         # Manually simulate compressor being changed (as _try_activate_fallback does)
@@ -216,6 +243,7 @@ class TestRestorePrimaryRuntime:
 # _try_recover_primary_transport()
 # =============================================================================
 
+
 def _make_transport_error(error_type="ReadTimeout"):
     """Create an exception whose type().__name__ matches the given name."""
     cls = type(error_type, (Exception,), {})
@@ -223,15 +251,15 @@ def _make_transport_error(error_type="ReadTimeout"):
 
 
 class TestTryRecoverPrimaryTransport:
-
     def test_recovers_on_read_timeout(self):
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ReadTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -240,10 +268,11 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ConnectTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -252,10 +281,11 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="zai")
         error = _make_transport_error("PoolTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -264,10 +294,11 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("APIConnectionError")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -276,10 +307,11 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("APITimeoutError")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -290,7 +322,9 @@ class TestTryRecoverPrimaryTransport:
         error = _make_transport_error("ReadTimeout")
 
         result = agent._try_recover_primary_transport(
-            error, retry_count=3, max_retries=3,
+            error,
+            retry_count=3,
+            max_retries=3,
         )
         assert result is False
 
@@ -300,25 +334,35 @@ class TestTryRecoverPrimaryTransport:
         error = ValueError("invalid model")
 
         result = agent._try_recover_primary_transport(
-            error, retry_count=3, max_retries=3,
+            error,
+            retry_count=3,
+            max_retries=3,
         )
         assert result is False
 
     def test_skipped_for_openrouter(self):
-        agent = _make_agent(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+        agent = _make_agent(
+            provider="openrouter", base_url="https://openrouter.ai/api/v1"
+        )
         error = _make_transport_error("ReadTimeout")
 
         result = agent._try_recover_primary_transport(
-            error, retry_count=3, max_retries=3,
+            error,
+            retry_count=3,
+            max_retries=3,
         )
         assert result is False
 
     def test_skipped_for_nous_provider(self):
-        agent = _make_agent(provider="nous", base_url="https://inference.nous.nousresearch.com/v1")
+        agent = _make_agent(
+            provider="nous", base_url="https://inference.nous.nousresearch.com/v1"
+        )
         error = _make_transport_error("ReadTimeout")
 
         result = agent._try_recover_primary_transport(
-            error, retry_count=3, max_retries=3,
+            error,
+            retry_count=3,
+            max_retries=3,
         )
         assert result is False
 
@@ -328,10 +372,11 @@ class TestTryRecoverPrimaryTransport:
         # For non-anthropic_messages api_mode, it will use OpenAI client
         error = _make_transport_error("ConnectError")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -340,10 +385,11 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="ollama", base_url="http://localhost:11434/v1")
         error = _make_transport_error("ConnectTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with patch("run_agent.OpenAI", return_value=MagicMock()), patch("time.sleep"):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is True
@@ -352,10 +398,14 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ReadTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep") as mock_sleep:
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("time.sleep") as mock_sleep,
+        ):
             agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
             # wait_time = min(3 + retry_count, 8) = min(6, 8) = 6
             mock_sleep.assert_called_once_with(6)
@@ -364,10 +414,14 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ReadTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep") as mock_sleep:
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("time.sleep") as mock_sleep,
+        ):
             agent._try_recover_primary_transport(
-                error, retry_count=10, max_retries=3,
+                error,
+                retry_count=10,
+                max_retries=3,
             )
             # wait_time = min(3 + 10, 8) = 8
             mock_sleep.assert_called_once_with(8)
@@ -377,14 +431,20 @@ class TestTryRecoverPrimaryTransport:
         old_client = agent.client
         error = _make_transport_error("ReadTimeout")
 
-        with patch("run_agent.OpenAI", return_value=MagicMock()), \
-             patch("time.sleep"), \
-             patch.object(agent, "_close_openai_client") as mock_close:
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("time.sleep"),
+            patch.object(agent, "_close_openai_client") as mock_close,
+        ):
             agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
             mock_close.assert_called_once_with(
-                old_client, reason="primary_recovery", shared=True,
+                old_client,
+                reason="primary_recovery",
+                shared=True,
             )
 
     def test_survives_rebuild_failure(self):
@@ -392,10 +452,14 @@ class TestTryRecoverPrimaryTransport:
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ReadTimeout")
 
-        with patch("run_agent.OpenAI", side_effect=Exception("socket error")), \
-             patch("time.sleep"):
+        with (
+            patch("run_agent.OpenAI", side_effect=Exception("socket error")),
+            patch("time.sleep"),
+        ):
             result = agent._try_recover_primary_transport(
-                error, retry_count=3, max_retries=3,
+                error,
+                retry_count=3,
+                max_retries=3,
             )
 
         assert result is False
@@ -405,6 +469,7 @@ class TestTryRecoverPrimaryTransport:
 # Integration: restore_primary_runtime called from run_conversation
 # =============================================================================
 
+
 class TestRestoreInRunConversation:
     """Verify the hook in run_conversation() calls _restore_primary_runtime."""
 
@@ -412,8 +477,12 @@ class TestRestoreInRunConversation:
         agent = _make_agent()
         agent._fallback_activated = True
 
-        with patch.object(agent, "_restore_primary_runtime", return_value=True) as mock_restore, \
-             patch.object(agent, "run_conversation", wraps=None) as _:
+        with (
+            patch.object(
+                agent, "_restore_primary_runtime", return_value=True
+            ) as mock_restore,
+            patch.object(agent, "run_conversation", wraps=None) as _,
+        ):
             # We can't easily run the full conversation, but we can verify
             # the method exists and is callable
             agent._restore_primary_runtime()
@@ -422,13 +491,19 @@ class TestRestoreInRunConversation:
     def test_full_cycle_fallback_then_restore(self):
         """Simulate: turn 1 activates fallback, turn 2 restores primary."""
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
             provider="custom",
         )
 
         # Turn 1: activate fallback
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             assert agent._try_activate_fallback() is True
 
         assert agent._fallback_activated is True
@@ -450,16 +525,23 @@ class TestRestoreInRunConversation:
 # Rate-limit cooldown gate
 # =============================================================================
 
+
 class TestRateLimitCooldown:
     """Verify _restore_primary_runtime() respects the 60s rate-limit cooldown."""
 
     def test_restore_blocked_during_cooldown(self):
         """While _rate_limited_until is in the future, restore returns False."""
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
         )
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback()
 
         assert agent._fallback_activated is True
@@ -474,10 +556,16 @@ class TestRateLimitCooldown:
     def test_restore_allowed_after_cooldown_expires(self):
         """Once the cooldown window passes, restore proceeds normally."""
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
         )
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback()
 
         assert agent._fallback_activated is True
@@ -494,20 +582,84 @@ class TestRateLimitCooldown:
     def test_cooldown_set_on_rate_limit_reason(self):
         """_try_activate_fallback with rate_limit reason sets _rate_limited_until."""
         from run_agent import FailoverReason
+
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
         )
         before = time.monotonic()
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
 
         assert hasattr(agent, "_rate_limited_until")
         assert agent._rate_limited_until > before + 50  # ~60s from now
 
+    def test_cooldown_uses_retry_after_header(self):
+        """_try_activate_fallback with a 429 response uses Retry-After seconds."""
+        from run_agent import FailoverReason
+
+        class _Resp:
+            headers = {"retry-after": "42"}
+
+        class _Err(Exception):
+            response = _Resp()
+
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        )
+        before = time.monotonic()
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            agent._try_activate_fallback(
+                reason=FailoverReason.rate_limit, api_error=_Err()
+            )
+
+        assert agent._rate_limited_until > before + 40
+        assert agent._rate_limited_until <= before + 300
+
+    def test_rate_limited_provider_skipped_in_fallback_chain(self):
+        """A provider under cooldown is skipped when scanning the fallback chain."""
+        from run_agent import FailoverReason
+
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+                {"provider": "anthropic", "model": "claude-sonnet-4"},
+            ],
+        )
+        # Put openrouter under cooldown.
+        agent._rate_limited_providers = {"openrouter": time.monotonic() + 60}
+        mock_client = _mock_resolve()
+        resolved: list[tuple[str, str]] = []
+
+        def _resolve(provider, model=None, **kw):
+            resolved.append((provider, model or ""))
+            return (mock_client, None)
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client", side_effect=_resolve
+        ):
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+
+        # openrouter was skipped, anthropic was tried.
+        assert resolved == [("anthropic", "claude-sonnet-4")]
+
     def test_cooldown_not_set_when_already_on_fallback(self):
         """Chain-switching while already on fallback must not reset cooldown."""
         from run_agent import FailoverReason
+
         agent = _make_agent(
             fallback_model=[
                 {"provider": "openrouter", "model": "model-a"},
@@ -515,7 +667,10 @@ class TestRateLimitCooldown:
             ],
         )
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             # First call: leaving primary → cooldown should be set
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
             first_cooldown = getattr(agent, "_rate_limited_until", 0)


### PR DESCRIPTION
Automated evolution PR for issues #366, #363, #364, and #367.

What changed:
- Non-retryable API client errors (401/403/404 and other retryable=False classifications) now try fallback once and abort immediately with a clear diagnostic instead of burning the max_retries budget.
- 429 Retry-After headers are parsed (integer seconds or HTTP-date) and honored as the cooldown floor; fallback entries still under a per-provider cooldown are skipped.
- 403 responses mentioning paid subscriptions / upgrades are classified as billing and routed through the fallback + user-facing guidance path.
- Duplicate request debug dumps for the same session + failure category + request body within 60 seconds are suppressed to avoid wasting disk/API budget on dead endpoints.

Local validation: ruff check + ruff format --check passed; pytest for touched modules passed.

Closes #366
Closes #363
Closes #364
Closes #367