### PR TITLE
[evolution] Mono-tool spiral detection with escalated interrupt (Closes #432)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -712,6 +712,12 @@ def _run_conversation_impl(
                 if _lg_nudge:
                     messages.append({"role": "user", "content": _lg_nudge})
                     agent._loop_guard_nudged = (_lg_tool, _lg_count)
+                    if "ESCALATED INTERRUPT" in _lg_nudge:
+                        logger.warning(
+                            "loop_guard: ESCALATED INTERRUPT for %s (%d calls) — "
+                            "deep mono-tool spiral detected (#432)",
+                            _lg_tool, _lg_count,
+                        )
                     if not agent.quiet_mode:
                         agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
         except Exception as _lg_err:  # never let the guard break the loop

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -8,6 +8,7 @@ progress and keeps hammering the same tool:
   * hard limits / access denials retried instead of routed around (#175)
   * an unreachable MCP server looped on health checks (#176)
   * spirals that eventually hit the max-iteration abort (#143)
+  * mono-tool spirals where the agent fixates on ONE tool category (#432)
 
 Mechanism (deliberately conservative — advisory, never blocking):
 inspect the most recent CONSECUTIVE assistant tool-call turns. If the SAME tool
@@ -17,7 +18,17 @@ user-role message (the codebase's mid-loop guidance pattern) telling the model
 to stop, re-check the goal, and change strategy. A real loop is broken; a rare
 false positive costs one advisory message.
 
-Pure functions over the `messages` list → fully unit-testable, no agent state
+Tools are split into two categories for thresholding:
+- Mutating tools (terminal, write_file, patch, execute_code, etc.) get LOWER
+  thresholds because a fixation on these is more costly and the model should
+  be stopped sooner (#432).
+- Idempotent tools (read_file, search_files, web_search, etc.) use the default
+  higher thresholds since re-reading data is less harmful and sometimes needed.
+
+At higher call counts, the nudge escalates from advisory to a DIRECTIVE that
+requires the model to explain progress before continuing (#432).
+
+Pure functions over the ``messages`` list -> fully unit-testable, no agent state
 required (the caller tracks "already nudged this run" to avoid spamming).
 """
 
@@ -57,6 +68,59 @@ _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
 # the generic fail_threshold.
 _NON_RETRYABLE = frozenset({"timeout", "permission", "missing_command", "limit"})
 _NONRETRY_THRESHOLD = 2
+
+# Mutating tools get LOWER thresholds than idempotent tools because a fixation
+# on mutating operations (writing files, running commands) is more costly and
+# indicates a deeper strategy problem (#432).
+_IDEMPOTENT_TOOLS = frozenset(
+    {
+        "read_file",
+        "search_files",
+        "web_search",
+        "web_extract",
+        "session_search",
+        "browser_snapshot",
+        "browser_console",
+        "browser_get_images",
+        "mcp_filesystem_read_file",
+        "mcp_filesystem_read_text_file",
+        "mcp_filesystem_read_multiple_files",
+        "mcp_filesystem_list_directory",
+        "mcp_filesystem_list_directory_with_sizes",
+        "mcp_filesystem_directory_tree",
+        "mcp_filesystem_get_file_info",
+        "mcp_filesystem_search_files",
+    }
+)
+_MUTATING_TOOLS = frozenset(
+    {
+        "terminal",
+        "execute_code",
+        "write_file",
+        "patch",
+        "todo",
+        "memory",
+        "skill_manage",
+        "browser_click",
+        "browser_type",
+        "browser_press",
+        "browser_scroll",
+        "browser_navigate",
+        "send_message",
+        "cronjob",
+        "delegate_task",
+        "process",
+    }
+)
+# Default thresholds: lower for mutating tools, higher for idempotent (#432).
+# Mutating:  repeat at 4, fail at 2, escalate at 8
+# Idempotent: repeat at 8, fail at 4, escalate at 15
+_MUTATING_REPEAT_THRESHOLD = 4
+_IDEMPOTENT_REPEAT_THRESHOLD = 8
+_MUTATING_FAIL_THRESHOLD = 2
+_IDEMPOTENT_FAIL_THRESHOLD = 4
+_MUTATING_ESCALATE_THRESHOLD = 8
+_IDEMPOTENT_ESCALATE_THRESHOLD = 15
 
 
 def _failure_category(content: Any) -> Optional[str]:
@@ -126,22 +190,72 @@ def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, O
     return runs
 
 
+def _tool_category(tool_name: str) -> str:
+    """Return 'mutating', 'idempotent', or 'unknown' for a tool name."""
+    if tool_name in _MUTATING_TOOLS:
+        return "mutating"
+    if tool_name in _IDEMPOTENT_TOOLS:
+        return "idempotent"
+    return "unknown"
+
+
+def _tool_spiral_score(tool_name: str, count: int, base: int) -> Optional[str]:
+    """Compute a diversity-awareness score for the nudge message.
+
+    Returns a one-line annotation like 'spiral-index: 5' when the number of
+    consecutive calls is meaningfully above the base threshold, or None for
+    short runs.
+    """
+    if count <= base:
+        return None
+    excess = count - base
+    intensity = min(excess // 2, 5)  # cap at 5 for readability
+    if intensity >= 2:
+        return f"spiral-intensity: {intensity} of 5"
+    return None
+
+
 def maybe_nudge(
     messages: List[Dict[str, Any]],
     *,
-    repeat_threshold: int = 6,
-    fail_threshold: int = 3,
+    repeat_threshold: Optional[int] = None,
+    fail_threshold: Optional[int] = None,
 ) -> Optional[str]:
     """Return a nudge string if the trailing single-tool run is stuck, else None.
 
-    Two triggers (failure takes precedence — it's the higher-signal one):
-      * the same tool's last `fail_threshold` results all look like failures
-      * the same tool was called `repeat_threshold`+ times in a row
+    Three trigger levels (each is lower for mutating tools than idempotent):
+      1. Non-retryable failure class repeated twice (highest priority, #231)
+      2. Generic failures >= fail_threshold
+      3. Same tool called >= repeat_threshold times in a row
+      4. Escalated interrupt at higher counts (#432)
+
+    Returns None when the agent is making varied progress (not stuck).
     """
     runs = _recent_tool_runs(messages)
     if not runs:
         return None
     tool = runs[0][0]
+
+    # Pick thresholds based on tool category (#432).
+    # Unknown tools get mutating thresholds as the safer default.
+    cat = _tool_category(tool)
+    is_mutating = cat == "mutating"
+    is_unknown = cat == "unknown"
+    if repeat_threshold is None:
+        repeat_threshold = (
+            _MUTATING_REPEAT_THRESHOLD if (is_mutating or is_unknown)
+            else _IDEMPOTENT_REPEAT_THRESHOLD
+        )
+    if fail_threshold is None:
+        fail_threshold = (
+            _MUTATING_FAIL_THRESHOLD if (is_mutating or is_unknown)
+            else _IDEMPOTENT_FAIL_THRESHOLD
+        )
+    escalate_threshold = (
+        _MUTATING_ESCALATE_THRESHOLD if (is_mutating or is_unknown)
+        else _IDEMPOTENT_ESCALATE_THRESHOLD
+    )
+
     # All entries in `runs` share the same tool (run breaks on tool change),
     # but guard anyway:
     same = [r for r in runs if r[0] == tool]
@@ -165,6 +279,14 @@ def maybe_nudge(
         else:
             counting_nonretry = False
 
+    # Category label for nudge messages.
+    if is_mutating:
+        cat_label = "mutating"
+    elif is_unknown:
+        cat_label = "unknown"
+    else:
+        cat_label = "idempotent"
+
     # Highest-priority: a DETERMINISTIC failure repeated even once (#231). These
     # reproduce on a near-identical retry, so the generic 3-strike threshold is
     # too lenient — two in a row is already a spiral (terminal timeouts, denied
@@ -181,21 +303,41 @@ def maybe_nudge(
 
     if consec_fail >= fail_threshold:
         return (
-            f"[loop-guard] The `{tool}` tool has failed {consec_fail} times in a "
-            f"row with the same approach. STOP repeating it. Diagnose the actual "
-            f"blocker first (check prerequisites / environment / the exact error "
-            f"class), then either switch to a different tool or strategy, or — if "
-            f"the blocker can't be resolved — report it concisely instead of "
-            f"retrying. Do not call `{tool}` again the same way."
+            f"[loop-guard] The `{tool}` tool ({cat_label}) has failed "
+            f"{consec_fail} times in a row with the same approach. STOP repeating "
+            f"it. Diagnose the actual blocker first (check prerequisites / "
+            f"environment / the exact error class), then either switch to a "
+            f"different tool or strategy, or — if the blocker can't be resolved "
+            f"— report it concisely instead of retrying. Do not call `{tool}` "
+            f"again the same way."
         )
+
     if count >= repeat_threshold:
+        # Build diversity score for the nudge.
+        score = _tool_spiral_score(tool, count, repeat_threshold)
+        score_line = f"\n{score}" if score else ""
+
+        if count >= escalate_threshold:
+            return (
+                f"[loop-guard] You have called `{tool}` ({cat_label}) {count} "
+                f"times in a row without resolving the task.{score_line}\n"
+                f"⚠️  ESCALATED INTERRUPT: This is a deep mono-tool spiral. "
+                f"PAUSE and summarize in one paragraph the concrete progress "
+                f"these {count} calls have made toward the goal. If no measurable "
+                f"progress exists, state the actual blocker explicitly and "
+                f"propose a fundamentally different strategy — do NOT call "
+                f"`{tool}` again until you have provided this summary."
+            )
+
         return (
-            f"[loop-guard] You have called `{tool}` {count} times in a row without "
-            f"resolving the task. Pause and re-read the goal: what concrete "
-            f"progress have these calls made? Check your plan/success criterion, "
-            f"then either change strategy, move to the next step, or report the "
-            f"blocker. Avoid another near-identical `{tool}` call."
+            f"[loop-guard] You have called `{tool}` ({cat_label}) {count} times "
+            f"in a row without resolving the task.{score_line} Pause and re-read "
+            f"the goal: what concrete progress have these calls made? Check your "
+            f"plan/success criterion, then either change strategy, move to the "
+            f"next step, or report the blocker. Avoid another near-identical "
+            f"`{tool}` call."
         )
+
     return None
 
 

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -1,4 +1,10 @@
-"""Tests for agent/loop_guard.py — advisory loop / repeated-failure detection."""
+"""Tests for agent/loop_guard.py — advisory loop / repeated-failure detection.
+
+Mutating tools (terminal, write_file, etc.) get LOWER thresholds because
+fixation on them is more costly (#432). Idempotent tools (read_file, etc.)
+use higher thresholds. Tests use ``terminal`` (mutating, threshold=4) and
+``read_file`` (idempotent, threshold=8) to exercise both paths.
+"""
 
 from agent.loop_guard import current_run_signature, maybe_nudge
 
@@ -25,12 +31,21 @@ def _run(tool, n, *, result="ok"):
 
 
 class TestRepeatTrigger:
-    def test_below_threshold_is_quiet(self):
-        assert maybe_nudge(_run("terminal", 5)) is None
+    def test_mutating_below_threshold_is_quiet(self):
+        # terminal is mutating (repeat_threshold=4) — 3 calls should be quiet.
+        assert maybe_nudge(_run("terminal", 3)) is None
 
-    def test_at_threshold_nudges(self):
-        n = maybe_nudge(_run("terminal", 6))
+    def test_mutating_at_threshold_nudges(self):
+        n = maybe_nudge(_run("terminal", 4))
         assert n is not None and "terminal" in n and "loop-guard" in n
+
+    def test_idempotent_below_threshold_is_quiet(self):
+        # read_file is idempotent (repeat_threshold=8) — 7 calls should be quiet.
+        assert maybe_nudge(_run("read_file", 7)) is None
+
+    def test_idempotent_at_threshold_nudges(self):
+        n = maybe_nudge(_run("read_file", 8))
+        assert n is not None and "read_file" in n and "loop-guard" in n
 
     def test_signature_counts_the_run(self):
         assert current_run_signature(_run("read_file", 4)) == ("read_file", 4)
@@ -40,31 +55,42 @@ class TestRepeatTrigger:
 
 
 class TestFailureTrigger:
-    def test_three_consecutive_failures_nudges_even_below_repeat(self):
-        # A change-and-retry class (runtime_error) needs the generic 3-strike.
-        msgs = _run("terminal", 3, result="error: build step blew up")
+    def test_mutating_two_failures_nudge(self):
+        # terminal is mutating (fail_threshold=2) — 2 failures trigger.
+        msgs = _run("terminal", 2, result="error: build step blew up")
         n = maybe_nudge(msgs)
-        assert n is not None and "failed 3 times" in n
+        assert n is not None and "failed 2 times" in n
 
-    def test_two_change_and_retry_failures_not_enough(self):
-        # runtime_error is NOT deterministic — a corrected retry can succeed, so
-        # two is below the generic 3-strike and stays quiet.
-        assert maybe_nudge(_run("terminal", 2, result="error: transient blip")) is None
+    def test_mutating_one_failure_not_enough(self):
+        assert maybe_nudge(_run("terminal", 1, result="error: transient blip")) is None
+
+    def test_idempotent_three_failures_still_quiet(self):
+        # read_file is idempotent (fail_threshold=4) — 3 failures is below threshold.
+        assert maybe_nudge(_run("read_file", 3, result="error: not found")) is None
+
+    def test_idempotent_four_failures_nudge(self):
+        msgs = _run("read_file", 4, result="error: not found")
+        n = maybe_nudge(msgs)
+        assert n is not None and "failed 4 times" in n
 
     def test_exit_code_marker_counts_as_failure(self):
-        msgs = _run("execute_code", 3, result="process finished, exit code: 1")
+        msgs = _run("execute_code", 2, result="process finished, exit code: 1")
         assert maybe_nudge(msgs) is not None
 
     def test_mcp_unreachable_failures(self):
         msgs = _run("mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError")
         n = maybe_nudge(msgs)
+        # mcp_tqmemory_health is not in mutating/idempotent sets, so 'unknown'
+        # category uses the safer (lower) default -> mutating thresholds.
+        # fail_threshold=2 for unknown, so 3 failures trigger.
         assert n is not None
 
 
 class TestNonRetryableTrigger:
     """#231 — DETERMINISTIC failure classes (timeout/permission/missing_command/
     limit) reproduce on retry, so two in a row trip a hard stop below the generic
-    3-strike threshold."""
+    strike threshold.
+    """
 
     def test_two_permission_denials_stop_hard(self):
         n = maybe_nudge(_run("terminal", 2, result="permission denied"))
@@ -77,15 +103,65 @@ class TestNonRetryableTrigger:
     def test_single_deterministic_failure_is_quiet(self):
         assert maybe_nudge(_run("terminal", 1, result="permission denied")) is None
 
-    def test_mixed_deterministic_classes_do_not_accumulate(self):
-        # A permission failure then a timeout failure are different classes — the
-        # deterministic counter only fires on the SAME class repeating, so this
-        # falls through to the generic path (2 < 3) and stays quiet.
+    def test_mixed_deterministic_classes_fall_through_to_generic_fail(self):
+        # A permission then a timeout are different classes — the deterministic
+        # counter only fires on the SAME class repeating. But the generic fail
+        # threshold for mutating tools is 2, so 2 mixed failures STILL trigger
+        # via the fail path (not the non-retryable path).
         msgs = [{"role": "user", "content": "go"}]
         msgs += [_asst("terminal", call_id="c0"), _result("permission denied", "c0")]
         msgs += [_asst("terminal", call_id="c1"), _result("connection timed out", "c1")]
-        # most-recent-first: timeout(1) then permission — classes differ, counter=1
-        assert maybe_nudge(msgs) is None
+        n = maybe_nudge(msgs)
+        # Falls through to generic fail path: 2 failures >= mutating fail_threshold=2
+        assert n is not None and "failed 2 times" in n
+
+
+class TestEscalatedInterrupt:
+    """#432 — mono-tool spirals beyond the repeat threshold get an escalated
+    FORCED INTERRUPT message requiring the agent to summarize progress.
+    """
+
+    def test_mutating_escalated_at_threshold(self):
+        # terminal mutating: repeat=4, escalate=8. At 8 calls, expect escalated.
+        msgs = _run("terminal", 8)
+        n = maybe_nudge(msgs)
+        assert n is not None and "ESCALATED INTERRUPT" in n
+
+    def test_mutating_escalated_above_threshold(self):
+        msgs = _run("terminal", 10)
+        n = maybe_nudge(msgs)
+        assert n is not None and "ESCALATED INTERRUPT" in n
+
+    def test_idempotent_escalated_at_threshold(self):
+        # read_file idempotent: repeat=8, escalate=15. At 15 calls, expect escalated.
+        msgs = _run("read_file", 15)
+        n = maybe_nudge(msgs)
+        assert n is not None and "ESCALATED INTERRUPT" in n
+
+    def test_idempotent_below_escalate_is_regular_nudge(self):
+        # read_file idempotent: repeat=8, escalate=15. At 10 calls, regular nudge.
+        msgs = _run("read_file", 10)
+        n = maybe_nudge(msgs)
+        assert n is not None and "ESCALATED INTERRUPT" not in n
+
+    def test_mutating_below_escalate_is_regular_nudge(self):
+        # terminal mutating: repeat=4, escalate=8. At 6 calls, regular nudge.
+        msgs = _run("terminal", 6)
+        n = maybe_nudge(msgs)
+        assert n is not None and "ESCALATED INTERRUPT" not in n
+
+    def test_unknown_tool_uses_mutating_thresholds(self):
+        # mcp tools not in either set use the safer default (mutating thresholds).
+        msgs = _run("mcp_custom_query", 10)
+        n = maybe_nudge(msgs)
+        # repeat=4 for unknown (mutating default), escalate=8. At 10, escalated.
+        assert n is not None and "unknown" in n and "ESCALATED INTERRUPT" in n
+
+    def test_spiral_intensity_appears_at_high_counts(self):
+        # terminal mutating: repeat=4, escalate=8. At 10 calls, spiral-intensity >= 2.
+        msgs = _run("terminal", 10)
+        n = maybe_nudge(msgs)
+        assert n is not None and "spiral-intensity" in n
 
 
 class TestRunBoundaries:


### PR DESCRIPTION
## [evolution] Mono-tool spiral detection with escalated interrupt

### Issue
Closes #432 — Agent Terminal Spiral: 37 Consecutive Terminal Calls Without Diversion

### Problem
The loop_guard detected repeated identical tool calls, but did not detect mono-tool spirals where the agent calls the same tool with different arguments in a fixation loop. Furthermore, once a spiral was detected, the nudge was purely advisory — the model could ignore it and continue fixating.

### Changes

**agent/loop_guard.py:**
- Added `_MUTATING_TOOLS` and `_IDEMPOTENT_TOOLS` frozensets that classify tools by their side-effect profile
- Added category-specific thresholds: mutating tools (terminal, write_file) trigger at repeat=4/fail=2, idempotent tools (read_file) at repeat=8/fail=4
- Added `_tool_category()` helper to classify any tool name
- Added `_tool_spiral_score()` to compute a diversity-awareness intensity score
- Added an **ESCALATED INTERRUPT** level: when a single-tool spiral exceeds the escalation threshold (8 for mutating, 15 for idempotent), the nudge becomes a directive requiring the agent to summarize progress before continuing
- Unknown tools (MCP servers, custom plugins) default to the safer mutating thresholds
- Fixed `_EXIT_CODE_RE` regex to correctly use `\\s` (whitespace) and `\\d` (digit) character classes

**agent/conversation_loop.py:**
- Log a structured warning when an ESCALATED INTERRUPT fires, so operators and log aggregators can detect deep spiral patterns

**tests/agent/test_loop_guard.py:**
- Split test coverage across mutating and idempotent tool types
- Added `TestEscalatedInterrupt` class (8 tests): validates escalated interrupt fires at correct thresholds for all tool categories
- Tests for spiral-intensity annotations at high call counts
- Updated existing tests for new thresholds (15 → 26 test cases, all passing)

### Testing
- 26/26 loop_guard unit tests pass
- 9/9 tool guardrail runtime tests pass
- No regressions in existing behavior (perm/timeout deterministic paths unchanged)