### PR TITLE
feat(evolution): capability-aware selection — analysis throttles effort budget on LOW_SELECTION_EFFICIENCY

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -180,10 +180,40 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
    0.05) so a genuinely-valid issue that keeps losing the nightly contest still
    climbs over time instead of rotting forever.
 
+5a. **Selection-capability calibration — pick only what you can land (goal 3).**
+    BEFORE the final selection, read the sidecar
+    `~/.hermes/profiles/user1/evolution/evolution-health.txt` (one
+    `[evolution-metrics] …` line, refreshed by the funnel job; missing → treat as
+    signal OK, proceed). This is the longitudinal calibration loop: it reports
+    whether what we SELECTED actually merged. It is INTERNAL plumbing — keep it
+    OUT of any delivered report (same rule as the realized-impact signal in 6c).
+    The flag to act on:
+    - `LOW_SELECTION_EFFICIENCY` (merged/selected over the window is poor — the
+      pipeline picks more than it can land) → **THROTTLE the effort budget**: set
+      this cycle's `max_total_effort` to **1.5** (half the default 3.0), i.e.
+      select roughly half as much work. Spend that smaller budget on the issues
+      with the HIGHEST confidence of landing a merge — prefer lower-`effort`,
+      clearly-scoped issues with an unambiguous plan over high-`effort` or fuzzy
+      ones, even when a fuzzy one scores marginally higher. This is
+      self-capability calibration: a 12% selection_efficiency (e.g. 57 selected,
+      7 merged over the window) means the pipeline is OVER-selecting — choosing
+      work it cannot finish — so the merge funnel, not the score, is the binding
+      constraint. Choose as much as you can actually MERGE, not as much as scores
+      "allow".
+    - no flag / signal OK / missing → proceed with the default budget (3.0).
+
+    The anti-starvation slot (6a) is still honored under the throttled budget: it
+    counts toward `max_total_effort` exactly as before. The scoring formula,
+    weights, and the decomposition/split rules are UNCHANGED — this step only sets
+    the SIZE of the budget the selection in step 6 spends, never how issues score.
+
 6. **Select** the top 8 for implementation (include any `needs-work` issues from
    step 2):
    - Min priority: 0.7
-   - Max total effort: 3.0
+   - Max total effort: the calibrated budget from step 5a — **3.0** by default,
+     **1.5** when `LOW_SELECTION_EFFICIENCY` is flagged. Stop adding issues once
+     their summed `effort_score` reaches this budget; under the throttled 1.5
+     budget, fill it with the highest-land-confidence issues first.
 
 6a. **Anti-starvation slot — guarantee no valid issue rots for days.** Scoring
     alone lets a sound-but-modest issue lose every single night. To prevent that,


### PR DESCRIPTION
## Problem

Prod meta-metrics show **`selection_efficiency` = merged/selected = 12%** over the
measurement window (**selected=57, merged=7**). The implementation stage lands
only **~0.7 merges/cycle**, yet `evolution-analysis` keeps selecting up to
`Max total effort: 3.0` worth of work **blindly** — ignoring the pipeline's real
land-rate. This is exactly the "poor self-capability calibration" the watchdog
flags as **`LOW_SELECTION_EFFICIENCY: picks more than it can land`**
(`scripts/evolution_metrics.py`, fires when merged/selected < 0.34).

## Fix (prompt-level only)

`skills/evolution/evolution-analysis/SKILL.md` gains a step **5a** that, **before**
the final selection, reads the existing sidecar
`~/.hermes/profiles/user1/evolution/evolution-health.txt` (the `[evolution-metrics]`
line). When `LOW_SELECTION_EFFICIENCY` is flagged it **throttles the effort budget
from 3.0 to 1.5** (select ~half as much) and spends that smaller budget on the
issues with the **highest confidence of landing a merge** (lower-effort,
clearly-scoped). Missing file / no flag → default budget 3.0, proceed normally.

Step 6's `Max total effort` now references this calibrated budget.

## Infrastructure already existed (not recreated)

- `scripts/evolution_metrics.py` computes `selection_efficiency` and emits the
  `LOW_SELECTION_EFFICIENCY` flag.
- `scripts/evolution_funnel.py` writes that flag into the `evolution-health.txt`
  sidecar (confirmed on prod, and reproduced E2E here).
- This mirrors the established **read-sidecar-signal** precedent already in the
  fork: `evolution-research` step 0 reads `funnel-summary.txt`, and
  `evolution-analysis` step 6c reads `realized-impact.txt`. No new mechanism.

## What is unchanged

The scoring formula `impact*2*(1-0.4*effort)`, all weight terms, the
anti-starvation slot (6a), the decomposition gate (6b), and the split rule are
**untouched**. Only the *size* of the effort budget becomes adaptive — never how
issues score.

## Testing

- `tests/scripts/test_evolution_skill_integrity.py` (skill-lint dead-wiring gate) — **pass** (the new step reads the sidecar as prose, not a runnable command, so no violation).
- `tests/scripts/test_evolution_metrics.py` — **pass** (code untouched).
- `tests/scripts/test_evolution_funnel.py` — **pass**.
- E2E: simulated a 12%-efficiency window → confirmed the funnel job writes
  `LOW_SELECTION_EFFICIENCY` into `evolution-health.txt` exactly as 5a reads it.

## Honest caveats

- **1.5 is a conservative first step**, not a tuned optimum: at 12% efficiency vs
  ~0.7 merges/cycle, even 1.5 is above true throughput. A proportional budget
  (scale by efficiency/target with a low floor) would track capacity tighter, but
  that is a larger change; this PR keeps the minimal, single-lever correction and
  lets the next cycle's metrics show whether 1.5 is enough.
- The budget is **enforced at the prompt level** (consistent with how the 3.0
  budget, scoring, and anti-starvation already work in this skill). Hard
  enforcement via greedy packing in orchestrator code would be more robust but is
  out of scope here.
