### PR TITLE
feat(honcho): circuit breaker for dialectic queries (Closes #463)

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -152,6 +152,16 @@ class HonchoSessionManager:
             )
             self._async_thread.start()
 
+        # Circuit-breaker state for Honcho dialectic queries.  Consecutive
+        # hard failures (transport/5xx/SDK-level errors) trip the breaker
+        # so a backend outage stops burning API credits on every turn.
+        self._consecutive_dialectic_failures: int = 0
+        self._dialectic_failure_window_start: float = 0.0
+        self._dialectic_tripped_at: float | None = None
+        # Count only recent consecutive failures; a single success resets.
+        self._CIRCUIT_BREAKER_THRESHOLD: int = 5
+        self._CIRCUIT_BREAKER_COOLDOWN_SECONDS: float = 120.0
+
     @property
     def honcho(self) -> Honcho:
         """Get the Honcho client, refreshing a near-expiry OAuth token in place.
@@ -625,6 +635,11 @@ class HonchoSessionManager:
         if not session:
             return ""
 
+        # Circuit-breaker gate. When open, skip the backend call entirely so
+        # a failing Honcho backend can't burn credits every turn.
+        if not self.dialectic_query_available():
+            return ""
+
         target_peer_id = self._resolve_peer_id(session, peer)
         if target_peer_id is None:
             return ""
@@ -658,10 +673,74 @@ class HonchoSessionManager:
             # Apply Hermes-side char cap before caching
             if result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:
                 result = result[:self._dialectic_max_chars].rsplit(" ", 1)[0] + " …"
+
+            # A non-empty result resets the failure window.  Empty but
+            # exception-free results may indicate a sparse profile, not a
+            # backend outage, so do NOT increment the breaker counter here.
+            if result and result.strip():
+                self._reset_dialectic_failure_window()
             return result
         except Exception as e:
-            logger.warning("Honcho dialectic query failed: %s", e)
+            self._record_dialectic_failure()
+            # Full traceback once per failure window for observability.
+            logger.exception(
+                "Honcho dialectic query failed for session '%s' (failure %d/%d): %s",
+                session_key,
+                self._consecutive_dialectic_failures,
+                self._CIRCUIT_BREAKER_THRESHOLD,
+                e,
+            )
             return ""
+
+    def _reset_dialectic_failure_window(self) -> None:
+        """Clear dialectic failure tracking after a healthy result."""
+        self._consecutive_dialectic_failures = 0
+        self._dialectic_failure_window_start = 0.0
+        self._dialectic_tripped_at = None
+
+    def _record_dialectic_failure(self) -> None:
+        """Increment consecutive failure count and trip the breaker if needed."""
+        import time
+
+        now = time.monotonic()
+        if self._consecutive_dialectic_failures == 0:
+            self._dialectic_failure_window_start = now
+        self._consecutive_dialectic_failures += 1
+        if self._consecutive_dialectic_failures >= self._CIRCUIT_BREAKER_THRESHOLD:
+            # Refresh trip timestamp on every failure once the breaker is open
+            # so half-open probes that fail stay blocked.
+            self._dialectic_tripped_at = now
+            logger.error(
+                "Honcho dialectic circuit breaker tripped after %d consecutive failures; "
+                "cooling down for %.0f seconds",
+                self._consecutive_dialectic_failures,
+                self._CIRCUIT_BREAKER_COOLDOWN_SECONDS,
+            )
+
+    def dialectic_query_available(self) -> bool:
+        """Return False while the dialectic circuit breaker is open.
+
+        A tripped breaker stays open for ``_CIRCUIT_BREAKER_COOLDOWN_SECONDS``.
+        After that it moves to half-open: the next call is allowed to probe
+        the backend, and the breaker either resets on success or re-trips
+        immediately on another failure.
+        """
+        import time
+
+        if self._dialectic_tripped_at is None:
+            return True
+        now = time.monotonic()
+        elapsed = now - self._dialectic_tripped_at
+        if elapsed >= self._CIRCUIT_BREAKER_COOLDOWN_SECONDS:
+            # Half-open: allow exactly one probe through.  The call site
+            # will record success/failure and reset or re-trip.
+            return True
+        logger.warning(
+            "Honcho dialectic circuit breaker OPEN (%.1f/%.0fs remaining); skipping query",
+            self._CIRCUIT_BREAKER_COOLDOWN_SECONDS - elapsed,
+            self._CIRCUIT_BREAKER_COOLDOWN_SECONDS,
+        )
+        return False
 
     def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:
         """

--- a/tests/honcho_plugin/test_dialectic_circuit_breaker.py
+++ b/tests/honcho_plugin/test_dialectic_circuit_breaker.py
@@ -1,0 +1,140 @@
+"""Tests for the Honcho dialectic circuit breaker."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class TestDialecticCircuitBreaker:
+    """Circuit breaker prevents burning Honcho API credits during outages."""
+
+    @staticmethod
+    def _make_manager() -> HonchoSessionManager:
+        cfg = MagicMock()
+        cfg.write_frequency = "async"
+        cfg.dialectic_reasoning_level = "low"
+        cfg.dialectic_dynamic = True
+        cfg.dialectic_max_chars = 600
+        cfg.dialectic_max_input_chars = 10000
+        cfg.user_observe_me = True
+        cfg.user_observe_others = True
+        cfg.ai_observe_me = True
+        cfg.ai_observe_others = True
+        cfg.message_max_chars = 25000
+        mgr = HonchoSessionManager(config=cfg)
+        # Fast thresholds for tests
+        mgr._CIRCUIT_BREAKER_THRESHOLD = 3
+        mgr._CIRCUIT_BREAKER_COOLDOWN_SECONDS = 10.0
+        return mgr
+
+    @staticmethod
+    def _make_session(mgr: HonchoSessionManager, key: str = "test") -> HonchoSession:
+        session = HonchoSession(
+            key=key,
+            user_peer_id="user-peer",
+            assistant_peer_id="ai-peer",
+            honcho_session_id="session-id",
+        )
+        mgr._cache[key] = session
+        return session
+
+    def test_available_by_default(self):
+        mgr = self._make_manager()
+        assert mgr.dialectic_query_available() is True
+
+    def test_failure_increments_counter(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=Exception("Honcho backend unreachable")
+        )
+        for _ in range(2):
+            assert mgr.dialectic_query("test", "hello") == ""
+        assert mgr._consecutive_dialectic_failures == 2
+        assert mgr.dialectic_query_available() is True
+
+    def test_breaker_trips_after_threshold(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=Exception("Honcho backend unreachable")
+        )
+        for _ in range(3):
+            mgr.dialectic_query("test", "hello")
+        assert mgr._consecutive_dialectic_failures == 3
+        assert mgr._dialectic_tripped_at is not None
+        assert mgr.dialectic_query_available() is False
+
+    def test_breaker_blocks_calls_while_open(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        mgr._consecutive_dialectic_failures = 3
+        mgr._dialectic_tripped_at = time.monotonic()
+        peer_mock = MagicMock()
+        peer_mock.chat.return_value = "should not run"
+        mgr._get_or_create_peer = MagicMock(return_value=peer_mock)
+
+        result = mgr.dialectic_query("test", "hello")
+        assert result == ""
+        peer_mock.chat.assert_not_called()
+
+    def test_success_after_failure_resets_window(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        peer_mock = MagicMock()
+        peer_mock.chat.return_value = "healthy result"
+        mgr._get_or_create_peer = MagicMock(return_value=peer_mock)
+
+        # Simulate prior failure state
+        mgr._consecutive_dialectic_failures = 2
+        mgr.dialectic_query("test", "hello")
+        assert mgr._consecutive_dialectic_failures == 0
+        assert mgr._dialectic_tripped_at is None
+
+    def test_half_open_probe_resets_on_success(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        peer_mock = MagicMock()
+        peer_mock.chat.return_value = "probe succeeded"
+        mgr._get_or_create_peer = MagicMock(return_value=peer_mock)
+
+        mgr._consecutive_dialectic_failures = 3
+        mgr._dialectic_tripped_at = time.monotonic() - 15.0
+        assert mgr.dialectic_query_available() is True  # half-open
+
+        result = mgr.dialectic_query("test", "hello")
+        assert result == "probe succeeded"
+        assert mgr._consecutive_dialectic_failures == 0
+        assert mgr._dialectic_tripped_at is None
+
+    def test_half_open_probe_re_trips_on_failure(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        mgr._get_or_create_peer = MagicMock(side_effect=Exception("still down"))
+
+        mgr._consecutive_dialectic_failures = 3
+        old_tripped = time.monotonic() - 15.0
+        mgr._dialectic_tripped_at = old_tripped
+        assert mgr.dialectic_query_available() is True  # half-open
+
+        mgr.dialectic_query("test", "hello")
+        # A new failure should keep the breaker open and refresh the trip timestamp.
+        assert mgr._consecutive_dialectic_failures >= 3
+        assert mgr._dialectic_tripped_at is not None
+        assert mgr._dialectic_tripped_at >= old_tripped
+        assert mgr.dialectic_query_available() is False
+
+    def test_empty_result_does_not_increment_failure(self):
+        mgr = self._make_manager()
+        self._make_session(mgr)
+        peer_mock = MagicMock()
+        peer_mock.chat.return_value = ""
+        mgr._get_or_create_peer = MagicMock(return_value=peer_mock)
+
+        for _ in range(5):
+            mgr.dialectic_query("test", "hello")
+        assert mgr._consecutive_dialectic_failures == 0
+        assert mgr.dialectic_query_available() is True


### PR DESCRIPTION
Adds a per-session circuit breaker around Honcho dialectic queries so a failing backend stops burning API credits after 5 consecutive failures.\n\n- Trip after 5 consecutive exceptions from the Honcho SDK/backend.\n- 120s cooldown; half-open probe resets on success or re-trips on failure.\n- Empty (but exception-free) results do NOT increment the failure counter, so sparse profiles don't disable memory.\n- Replaces the silent logger.warning with logger.exception so failures are observable in logs.\n\nCloses #463