### PR TITLE
feat(evolution): deterministic effort budget — metric script owns 1.5/3.0, analysis copies verbatim

### DIFF
--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -91,6 +91,15 @@ def compute_health(records: List[Dict[str, Any]], last: int = 30) -> Dict[str, A
                 "(poor self-capability calibration)"
             )
 
+    # Deterministic effort budget for the NEXT selection cycle. The analysis
+    # stage copies this verbatim instead of deriving "1.5 vs 3.0" from the flag
+    # itself — a prompt-level decision that drifted to arbitrary middles like 2.0
+    # (observed 2026-06-24, under-throttling while the watchdog kept firing). The
+    # ONLY two legal values are the throttled budget and the default; the script
+    # owns the choice, the agent owns nothing but the copy.
+    low_selection = any(f.startswith("LOW_SELECTION_EFFICIENCY") for f in flags)
+    effort_budget = 1.5 if low_selection else 3.0
+
     return {
         "cycles_total": len(window),
         "cycles_active": len(active),
@@ -102,6 +111,7 @@ def compute_health(records: List[Dict[str, Any]], last: int = 30) -> Dict[str, A
         "selection_efficiency": round(selection_efficiency, 3) if selection_efficiency is not None else None,
         "reject_rate": round(reject_rate, 3) if reject_rate is not None else None,
         "merged_trend": _trend([_int(r, "merged") for r in active]),
+        "effort_budget": effort_budget,
         "flags": flags,
     }
 
@@ -112,12 +122,16 @@ def _pct(x: Optional[float]) -> str:
 
 def format_health(h: Dict[str, Any]) -> str:
     tail = " | ".join(h["flags"]) if h["flags"] else "healthy"
+    # NOTE: effort_budget rides in the BODY, never the tail. evolution_watchdog
+    # keys on `.endswith("| healthy")` / `| <FLAG>`, so the flags must stay the
+    # last segment after the final `|`.
     return (
         f"[evolution-metrics] {h['cycles_active']}/{h['cycles_total']} active cycles: "
         f"success={_pct(h['cycle_success_rate'])} "
         f"selection_efficiency={_pct(h['selection_efficiency'])} "
         f"reject_rate={_pct(h['reject_rate'])} merged_trend={h['merged_trend']} "
-        f"(created={h['issues_created']} selected={h['selected']} merged={h['merged']}) | {tail}"
+        f"(created={h['issues_created']} selected={h['selected']} merged={h['merged']}) "
+        f"effort_budget={h['effort_budget']:.1f} | {tail}"
     )
 
 

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -187,20 +187,22 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
     signal OK, proceed). This is the longitudinal calibration loop: it reports
     whether what we SELECTED actually merged. It is INTERNAL plumbing — keep it
     OUT of any delivered report (same rule as the realized-impact signal in 6c).
-    The flag to act on:
-    - `LOW_SELECTION_EFFICIENCY` (merged/selected over the window is poor — the
-      pipeline picks more than it can land) → **THROTTLE the effort budget**: set
-      this cycle's `max_total_effort` to **1.5** (half the default 3.0), i.e.
-      select roughly half as much work. Spend that smaller budget on the issues
-      with the HIGHEST confidence of landing a merge — prefer lower-`effort`,
-      clearly-scoped issues with an unambiguous plan over high-`effort` or fuzzy
-      ones, even when a fuzzy one scores marginally higher. This is
-      self-capability calibration: a 12% selection_efficiency (e.g. 57 selected,
-      7 merged over the window) means the pipeline is OVER-selecting — choosing
-      work it cannot finish — so the merge funnel, not the score, is the binding
-      constraint. Choose as much as you can actually MERGE, not as much as scores
-      "allow".
-    - no flag / signal OK / missing → proceed with the default budget (3.0).
+
+    The line carries an explicit, pre-computed `effort_budget=X` token. **`X` is
+    the metric script's decision, not yours** — it is `1.5` when the window trips
+    `LOW_SELECTION_EFFICIENCY`, else `3.0`; those are the ONLY two legal values.
+    Set this cycle's `max_total_effort` to **exactly `X`, copied verbatim** — never
+    derive your own number, never land on a middle value like `2.0`. If the sidecar
+    is missing or has no `effort_budget=` token, default to `3.0`.
+
+    When `X` is `1.5` the pipeline is OVER-selecting — a 12% selection_efficiency
+    (e.g. 57 selected, 7 merged over the window) means it picks more work than it
+    can finish — so spend that smaller budget on the issues with the HIGHEST
+    confidence of landing a merge: prefer lower-`effort`, clearly-scoped issues with
+    an unambiguous plan over high-`effort` or fuzzy ones, even when a fuzzy one
+    scores marginally higher. The merge funnel, not the score, is the binding
+    constraint: choose as much as you can actually MERGE, not as much as scores
+    "allow".
 
     The anti-starvation slot (6a) is still honored under the throttled budget: it
     counts toward `max_total_effort` exactly as before. The scoring formula,
@@ -210,10 +212,10 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
 6. **Select** the top 8 for implementation (include any `needs-work` issues from
    step 2):
    - Min priority: 0.7
-   - Max total effort: the calibrated budget from step 5a — **3.0** by default,
-     **1.5** when `LOW_SELECTION_EFFICIENCY` is flagged. Stop adding issues once
-     their summed `effort_score` reaches this budget; under the throttled 1.5
-     budget, fill it with the highest-land-confidence issues first.
+   - Max total effort: the `effort_budget` value copied verbatim from the sidecar
+     in step 5a — **3.0** by default, **1.5** when throttled; never a middle value.
+     Stop adding issues once their summed `effort_score` reaches this budget; under
+     the throttled 1.5 budget, fill it with the highest-land-confidence issues first.
 
 6a. **Anti-starvation slot — guarantee no valid issue rots for days.** Scoring
     alone lets a sound-but-modest issue lose every single night. To prevent that,

--- a/tests/scripts/test_evolution_metrics.py
+++ b/tests/scripts/test_evolution_metrics.py
@@ -69,3 +69,34 @@ class TestComputeHealth:
     def test_window_last_n(self):
         recs = [_rec(f"d{i}", selected=1, merged=1) for i in range(40)]
         assert compute_health(recs, last=10)["cycles_total"] == 10
+
+    def test_effort_budget_throttles_only_when_flagged(self):
+        # Healthy window → default budget 3.0 (no throttle).
+        healthy = [_rec(f"d{i}", selected=4, merged=3, rejected=1) for i in range(5)]
+        assert compute_health(healthy)["effort_budget"] == 3.0
+        # LOW_SELECTION_EFFICIENCY flagged → throttled budget 1.5, never a middle.
+        starved = [_rec(f"d{i}", selected=10, merged=0) for i in range(4)]
+        h = compute_health(starved)
+        assert any("LOW_SELECTION_EFFICIENCY" in f for f in h["flags"])
+        assert h["effort_budget"] == 1.5
+
+    def test_effort_budget_default_when_insufficient_signal(self):
+        # < 3 active cycles → no flags → default budget; never throttle blindly.
+        few = [_rec("d1", selected=10, merged=0), _rec("d2", selected=10, merged=0)]
+        assert compute_health(few)["effort_budget"] == 3.0
+
+    def test_format_health_carries_budget_without_breaking_watchdog_tail(self):
+        # The budget token must sit in the body, NOT the tail: evolution_watchdog
+        # keys on `.endswith("| healthy")` and treats everything after the last
+        # `|` as the flags. A budget in the tail would silence/garble the alert.
+        healthy = format_health(
+            compute_health([_rec(f"d{i}", selected=4, merged=3, rejected=1) for i in range(5)])
+        )
+        assert "effort_budget=3.0" in healthy
+        assert healthy.endswith("| healthy")
+        flagged = format_health(
+            compute_health([_rec(f"d{i}", selected=10, merged=0) for i in range(4)])
+        )
+        assert "effort_budget=1.5" in flagged
+        assert not flagged.endswith("| healthy")
+        assert "LOW_SELECTION_EFFICIENCY" in flagged


### PR DESCRIPTION
## Problem
The watchdog re-fires `LOW_SELECTION_EFFICIENCY` (selection_efficiency = merged/selected = 12%, window selected=60 merged=7) the morning after #507's prompt-level throttle landed.

Root cause — the **2026-06-24 analysis cycle set `max_total_effort=2.0`**, neither the 3.0 default nor the 1.5 throttle #507 prescribed. A prompt-level "you decide 1.5 vs 3.0 from the flag" instruction is unenforced, so the LLM drifted to an arbitrary middle, under-throttling and keeping the funnel over-selected.

## Fix
Move the 1.5-vs-3.0 decision **out of the prompt into the deterministic metric script**.

- `evolution_metrics.compute_health()` emits `effort_budget` (1.5 when `LOW_SELECTION_EFFICIENCY` flagged, else 3.0 — the only two legal values).
- `format_health()` renders `effort_budget=X` in the **body** of the one-line sidecar, before the final `| <tail>`, so `evolution_watchdog`'s `.endswith("| healthy")` flag parsing is untouched.
- `evolution-analysis/SKILL.md` steps 5a/6 now **copy `effort_budget=X` verbatim** as `max_total_effort`; middle values like 2.0 are explicitly illegal. Scoring formula, weights, decomposition/split rules, and the anti-starvation slot are UNCHANGED.

## Verification
- `test_evolution_metrics` (+3 cases: throttle-only-when-flagged, default-on-insufficient-signal, budget-in-body-not-watchdog-tail), `test_evolution_watchdog`, `test_evolution_funnel`, `test_evolution_skill_integrity` — **73 pass**.
- `ruff` + `ty` clean.
- E2E: rendered a prod-shaped flagged line → watchdog still alerts; healthy line stays silent.

## Independent review (Gemini via consilium)
Confirmed: (1) fixes decision-drift, (2) watchdog body/tail invariant robust, (3) `1.5` correctly calibrated for ~0.7 merges/cycle (`2.0` judged "too weak").

## Follow-up (separate, not in this PR)
This makes the budget deterministic at source but still relies on prompt compliance. A hard gate — reject an analysis cycle whose `max_total_effort` ∉ {1.5, 3.0} or `total_effort_selected > effort_budget` — would make it *enforced*.