### PR TITLE
fix(evolution): register_evolution_cron crash on agent jobs without skills — unblocks self-update

### DIFF
--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -351,9 +351,17 @@ def main(argv: list[str]) -> int:
             if not no_agent:
                 if str(prompt) != (cur.get("prompt") or ""):
                     changes["prompt"] = str(prompt)
-                if list(skills) != list(cur.get("skills") or []):
+                # skills/toolsets are None when the YAML omits them — that means
+                # "leave the registered value as-is", NOT "clear it". Only
+                # reconcile when the YAML explicitly specifies a value, and never
+                # call list() on None: that TypeError silently aborted EVERY
+                # re-register (and thus every integration self-update) once the
+                # jobs already existed, freezing HERMES_HOME script/skill sync.
+                if skills is not None and list(skills) != list(cur.get("skills") or []):
                     changes["skills"] = skills
-                if list(toolsets) != list(cur.get("enabled_toolsets") or []):
+                if toolsets is not None and list(toolsets) != list(
+                    cur.get("enabled_toolsets") or []
+                ):
                     changes["enabled_toolsets"] = toolsets
                 # Detect script changes (e.g. Hydra replacing access gate)
                 cur_script = str(cur.get("script") or "").strip()

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -256,6 +256,40 @@ class TestReconcileExistingJob:
         assert rc == 0
         assert calls == {}  # no update_job call — nothing changed
 
+    def _write_agent_yaml_no_skills(self, src_dir, schedule):
+        # An agent job whose YAML omits skills:/toolsets: entirely — the
+        # _normalize_skills(None) -> None case that used to crash reconcile.
+        (src_dir / "upstream-sync.yaml").write_text(
+            "name: evolution-upstream-sync\n"
+            f'schedule: "{schedule}"\n'
+            "enabled: true\n"
+            'prompt: "sync upstream"\n'
+        )
+
+    def test_existing_agent_job_without_skills_does_not_crash(self, tmp_path, monkeypatch):
+        """Regression: _normalize_skills(None) returns None; reconcile must not
+        call list(None) — that TypeError silently aborted EVERY re-register (and
+        thus every integration self-update) once the jobs already existed,
+        freezing HERMES_HOME script/skill sync. A YAML that omits skills means
+        'leave the registered skills as-is', never 'clear them'."""
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        # changed schedule (so update_job IS called), but no skills:/toolsets:
+        self._write_agent_yaml_no_skills(src_dir, "0 8 * * 1,3,5")
+        existing = self._existing(mod, jobs_mod, "0 8 * * 0")  # old schedule, HAS skills
+        calls = self._wire(mod, jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0  # did NOT crash on list(None)
+        # Only the schedule reconciles; the registered skills/toolsets must be
+        # preserved (not clobbered to []) when the YAML omits them.
+        assert calls["updates"] == {"schedule": "0 8 * * 1,3,5"}
+
+
 
 class TestFindVenvPython:
     """The registrar self-locates the install venv interpreter so it runs with


### PR DESCRIPTION
## Root cause (the real deploy-machinery bug)
`_normalize_skills` / `_normalize_toolsets` return **`None`** (not `[]`) when a stage YAML omits `skills:` / `toolsets:`. The reconcile path for an **already-registered** job ran `list(skills)` / `list(toolsets)` unconditionally:

```
TypeError: 'NoneType' object is not iterable   # register_evolution_cron.py:354
```

This branch only runs for jobs that **already exist**, so the *first* registration succeeds but **every subsequent `register_evolution_cron` run crashes**. Since the registrar IS the integration stage's self-update step (refresh HERMES_HOME no_agent scripts + sync skills), this **silently froze script/skill deployment on prod** — e.g. PR #519's funnel-side `effort_budget` never reached `HERMES_HOME/scripts` until the registrar was run by hand. Verified live on osoba: a manual run copied the helper scripts (which happens *before* reconcile) then died on this exact TypeError.

## Fix
Only reconcile `skills`/`toolsets` when the YAML **explicitly specifies** them (`is not None`). A `None` means "leave the registered value as-is", **not** "clear it" — so this also stops a no-skills YAML from clobbering a job's registered skills to `[]`.

## Verification
- New regression test: an existing agent job whose YAML omits `skills:` reconciles its schedule **without crashing** and without clobbering skills.
- `test_register_evolution_cron` — **23 pass** (`uv run`); `ruff` + `ty` clean.

## Impact
Unblocks the autonomous integration self-update so no_agent script + skill changes (like #519) actually deploy each cycle instead of freezing.