### PR TITLE
feat(evolution): deterministic selection-budget gate — enforce #519's effort-budget contract

### DIFF
--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Deterministic audit of an evolution-analysis cycle's selection output.
+
+The analysis stage is prompt-driven: PR #507/#519 tell it to set this cycle's
+``max_total_effort`` to the budget the metric script prescribes — 3.0 by default,
+1.5 when ``LOW_SELECTION_EFFICIENCY`` is flagged — and to spend no more than that.
+A prompt instruction is NOT enforced: the 2026-06-24 cycle wrote
+``max_total_effort = 2.0`` (neither legal value) and under-throttled. This module
+mechanically catches that class — the budget the agent self-reports must be one
+of the two legal values, and the effort it actually selected must not exceed it.
+
+Read+flag only (the watchdog surfaces it). A bad selection is not catastrophic
+(the analysis stage merges nothing; the next cycle self-corrects), so a morning
+alert to the owner is the right enforcement teeth for THIS stage — the same
+deterministic-verdict pattern as evolution_skill_lint (#190) and the
+realized-impact / regression gates.
+
+Pure functions + explicit IO so it is import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# The two budgets the metric script is allowed to prescribe (#519 contract).
+# Anything else means the agent invented a number instead of copying one.
+LEGAL_BUDGETS: Tuple[float, ...] = (1.5, 3.0)
+_EPS = 1e-9
+
+
+def _num(x: Any) -> Optional[float]:
+    """Coerce to float, but reject bool (True/False are ints in Python)."""
+    if isinstance(x, bool):
+        return None
+    if isinstance(x, (int, float)):
+        return float(x)
+    return None
+
+
+def _selection_constraints(report: Dict[str, Any]) -> Dict[str, Any]:
+    """``max_total_effort`` lives under ``scoring_model.selection_constraints``
+    (observed shape), but tolerate a top-level ``selection_constraints`` too so a
+    future report layout does not silently skip the check."""
+    for container in (report.get("scoring_model"), report):
+        if isinstance(container, dict):
+            sc = container.get("selection_constraints")
+            if isinstance(sc, dict) and "max_total_effort" in sc:
+                return sc
+    return {}
+
+
+def audit_analysis(
+    report: Dict[str, Any], legal_budgets: Sequence[float] = LEGAL_BUDGETS
+) -> List[str]:
+    """Return human-readable violation strings (empty == clean).
+
+    Missing or non-numeric fields are SKIPPED, never flagged — a partial,
+    legacy, or idle report must not raise a false alarm. Only a concrete,
+    clearly-wrong value is reported.
+    """
+    if not isinstance(report, dict):
+        return []
+    out: List[str] = []
+
+    sc = _selection_constraints(report)
+    budget = _num(sc.get("max_total_effort"))
+
+    if budget is not None and not any(abs(budget - b) < _EPS for b in legal_budgets):
+        legal = "/".join(f"{b:g}" for b in legal_budgets)
+        out.append(
+            f"BUDGET_ILLEGAL: max_total_effort={budget:g} is neither legal value "
+            f"({legal}) — the analysis agent invented a budget instead of copying "
+            f"the metric script's prescribed one (PR #519 contract)"
+        )
+
+    spent = _num(report.get("total_effort_selected"))
+    if budget is not None and spent is not None and spent > budget + _EPS:
+        out.append(
+            f"BUDGET_OVERSPENT: total_effort_selected={spent:g} exceeds "
+            f"max_total_effort={budget:g} — the over-selection the throttle exists "
+            f"to prevent"
+        )
+
+    return out
+
+
+def audit_latest(evolution_dir: Path) -> List[str]:
+    """Audit the most recent dated analysis report under ``<dir>/analysis/``.
+
+    Returns prefixed violation strings, or [] when there is no readable dated
+    report. Only ``YYYY-MM-DD.json`` files are considered — the sibling
+    ``issues_*.json`` / ``prs_*.json`` snapshots are skipped.
+    """
+    analysis_dir = evolution_dir / "analysis"
+    try:
+        files = list(analysis_dir.glob("*.json"))
+    except OSError:
+        return []
+    dated = sorted(f for f in files if re.fullmatch(r"\d{4}-\d{2}-\d{2}\.json", f.name))
+    if not dated:
+        return []
+    latest = dated[-1]
+    try:
+        report = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return [f"({latest.stem}) {v}" for v in audit_analysis(report)]
+
+
+def main(argv: List[str]) -> int:
+    import os
+
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    )
+    violations = audit_latest(evolution_dir)
+    for v in violations:
+        print(f"[analysis-audit] {v}")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -334,6 +334,21 @@ def check_realized_impact(evolution_dir: Path) -> List[str]:
     return [f"realized-impact degraded: {line}"]
 
 
+def check_analysis_integrity(evolution_dir: Path) -> List[str]:
+    """Alert when the latest analysis cycle's self-reported selection budget is
+    illegal or overspent — the deterministic teeth behind PR #519's prompt-level
+    effort-budget contract (the analysis agent once wrote max_total_effort=2.0,
+    neither the 1.5 throttle nor the 3.0 default, and over-selected). Silent when
+    clean, when there is no dated analysis report yet, or when the audit module is
+    unavailable (the scheduler installs evolution_*.py alongside this script, so
+    the sibling import resolves at runtime; the guard keeps unit imports safe)."""
+    try:
+        from evolution_analysis_audit import audit_latest
+    except ImportError:
+        return []
+    return [f"analysis selection integrity: {v}" for v in audit_latest(evolution_dir)]
+
+
 def main() -> int:
     hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     evolution_dir = Path(
@@ -363,6 +378,7 @@ def main() -> int:
     alerts += check_upstream_lag()
     alerts += check_health(evolution_dir)
     alerts += check_realized_impact(evolution_dir)
+    alerts += check_analysis_integrity(evolution_dir)
 
     if alerts:
         print("🐶 Evolution watchdog — pipeline anomalies detected:")

--- a/tests/scripts/test_evolution_analysis_audit.py
+++ b/tests/scripts/test_evolution_analysis_audit.py
@@ -1,0 +1,102 @@
+"""Tests for scripts/evolution_analysis_audit.py — deterministic selection-budget
+enforcement (the teeth behind PR #519's prompt-level effort-budget contract)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_analysis_audit import audit_analysis, audit_latest  # noqa: E402
+
+
+def _report(max_total_effort=None, total_effort_selected=None, top_level=False):
+    sc = {"min_priority": 0.7, "max_items": 5}
+    if max_total_effort is not None:
+        sc["max_total_effort"] = max_total_effort
+    report = {"date": "2026-06-24"}
+    if total_effort_selected is not None:
+        report["total_effort_selected"] = total_effort_selected
+    if top_level:
+        report["selection_constraints"] = sc
+    else:
+        report["scoring_model"] = {"base_formula": "...", "selection_constraints": sc}
+    return report
+
+
+class TestAuditAnalysis:
+    def test_legal_default_budget_is_clean(self):
+        assert audit_analysis(_report(3.0, 2.0)) == []
+
+    def test_legal_throttled_budget_is_clean(self):
+        assert audit_analysis(_report(1.5, 1.5)) == []
+
+    def test_illegal_middle_budget_flagged(self):
+        # The exact 2026-06-24 defect: 2.0 is neither 1.5 nor 3.0.
+        v = audit_analysis(_report(2.0, 2.0))
+        assert any("BUDGET_ILLEGAL" in x and "2" in x for x in v)
+
+    def test_overspent_flagged(self):
+        v = audit_analysis(_report(1.5, 2.5))
+        assert any("BUDGET_OVERSPENT" in x for x in v)
+
+    def test_illegal_and_overspent_both_flagged(self):
+        v = audit_analysis(_report(2.0, 2.5))
+        assert any("BUDGET_ILLEGAL" in x for x in v)
+        assert any("BUDGET_OVERSPENT" in x for x in v)
+
+    def test_spent_equal_to_budget_is_clean(self):
+        assert audit_analysis(_report(3.0, 3.0)) == []
+
+    def test_top_level_selection_constraints_fallback(self):
+        assert audit_analysis(_report(2.0, top_level=True))  # still flagged
+        assert audit_analysis(_report(3.0, 3.0, top_level=True)) == []
+
+    def test_missing_budget_is_not_flagged(self):
+        # No max_total_effort at all → skip (no false alarm on a partial report).
+        assert audit_analysis(_report(None, 2.0)) == []
+
+    def test_missing_spent_skips_overspent_only(self):
+        # Illegal budget still flagged; overspent can't be evaluated → not flagged.
+        v = audit_analysis(_report(2.0, None))
+        assert any("BUDGET_ILLEGAL" in x for x in v)
+        assert not any("BUDGET_OVERSPENT" in x for x in v)
+
+    def test_bool_budget_is_ignored(self):
+        # True is an int in Python; must not be read as 1.0 and flagged.
+        assert audit_analysis(_report(True, 1.5)) == []
+
+    def test_non_dict_report_is_safe(self):
+        assert audit_analysis([]) == []  # type: ignore[arg-type]
+        assert audit_analysis("nope") == []  # type: ignore[arg-type]
+
+    def test_custom_legal_budgets(self):
+        assert audit_analysis(_report(2.0, 2.0), legal_budgets=(2.0,)) == []
+
+
+class TestAuditLatest:
+    def _write(self, d, name, report):
+        (d / "analysis").mkdir(parents=True, exist_ok=True)
+        (d / "analysis" / name).write_text(json.dumps(report), encoding="utf-8")
+
+    def test_audits_latest_dated_report(self, tmp_path):
+        self._write(tmp_path, "2026-06-23.json", _report(3.0, 2.0))  # clean, older
+        self._write(tmp_path, "2026-06-24.json", _report(2.0, 2.0))  # illegal, newer
+        out = audit_latest(tmp_path)
+        assert len(out) == 1
+        assert "2026-06-24" in out[0] and "BUDGET_ILLEGAL" in out[0]
+
+    def test_ignores_non_dated_snapshots(self, tmp_path):
+        # issues_*.json / prs_*.json must not be parsed as cycle reports.
+        self._write(tmp_path, "issues_2026-06-24.json", {"junk": True})
+        self._write(tmp_path, "prs_2026-06-24.json", [])
+        self._write(tmp_path, "2026-06-24.json", _report(3.0, 2.0))
+        assert audit_latest(tmp_path) == []
+
+    def test_no_reports_is_silent(self, tmp_path):
+        assert audit_latest(tmp_path) == []
+
+    def test_unreadable_json_is_silent(self, tmp_path):
+        (tmp_path / "analysis").mkdir(parents=True)
+        (tmp_path / "analysis" / "2026-06-24.json").write_text("{not json", encoding="utf-8")
+        assert audit_latest(tmp_path) == []


### PR DESCRIPTION
## Why (gate #1 of the enforcement campaign)
PR #519 made the effort budget deterministic at the **source** (the metric script prescribes `1.5`/`3.0`; `evolution-analysis/SKILL.md` tells the agent to copy it verbatim). But a prompt instruction is **not enforced** — the 2026-06-24 cycle wrote `max_total_effort=2.0` (neither legal value) and under-throttled. This is the deterministic teeth.

## What
- **`scripts/evolution_analysis_audit.py`** — pure `audit_analysis(report)`:
  - `BUDGET_ILLEGAL` when `max_total_effort ∉ {1.5, 3.0}` (catches the `2.0` drift).
  - `BUDGET_OVERSPENT` when `total_effort_selected > max_total_effort`.
  - Missing/non-numeric/bool fields are **skipped** — no false alarm on partial / legacy / idle reports. `audit_latest()` reads the most recent `YYYY-MM-DD.json` under `analysis/` (ignores `issues_*` / `prs_*` snapshots).
- **`evolution_watchdog.py`** — `check_analysis_integrity` wired into the morning run, so a drift surfaces to the owner. Same deterministic-verdict + alert pattern as the realized-impact / regression gates. Silent when clean.

Read+flag only: the analysis stage merges nothing, so a bad selection self-corrects next cycle — an alert is the right enforcement for this stage (the dangerous self-merge step gets a blocking gate in a later PR).

## Verification
- `test_evolution_analysis_audit` (18 cases) + `test_evolution_watchdog` + `test_evolution_skill_integrity` — **62 pass**; `ruff` + `ty` clean.
- **E2E**: run against the real 2026-06-24 report → `BUDGET_ILLEGAL: max_total_effort=2 is neither legal value (1.5/3)` (exit 1).

## Campaign
Next gates (separate PRs): close-validator (fabricated `already-exists` rejections, the #83 class) and a blocking merge-gate (dead code + commit freshness at self-merge).