### PR TITLE
feat(evolution): close-validator gate — catch fabricated already-exists rejections (#83 class)

### DIFF
--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -31,6 +31,13 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 LEGAL_BUDGETS: Tuple[float, ...] = (1.5, 3.0)
 _EPS = 1e-9
 
+# A repo-relative file path cited in prose: at least one "/" and a file
+# extension, so "i.e." / "1.2" / bare words never match. The token stops at
+# whitespace/punctuation, so "tools/x.py (lines 5-6)" yields "tools/x.py".
+_CITED_PATH_RE = re.compile(
+    r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+\.[A-Za-z][A-Za-z0-9]{0,5})"
+)
+
 
 def _num(x: Any) -> Optional[float]:
     """Coerce to float, but reject bool (True/False are ints in Python)."""
@@ -88,12 +95,47 @@ def audit_analysis(
     return out
 
 
-def audit_latest(evolution_dir: Path) -> List[str]:
+def audit_rejections(report: Dict[str, Any], repo_root: Optional[Path]) -> List[str]:
+    """Catch FABRICATED ``already-exists`` rejections — the #83 class, where the
+    analysis agent CLOSED an issue claiming the feature already exists and cited a
+    repo path that does not exist (the real #83 cited ``scripts/evolution_watchdog.sh``;
+    the actual script is ``.py``). Only flags when an ``already-exists`` rejection
+    cites one or more concrete paths and NONE of them exist — a single missing
+    path among existing ones is treated as a typo / secondary reference, not
+    fabrication. Needs the repo to verify; silent without it (cannot prove
+    absence) or when there are no rejections."""
+    if not isinstance(report, dict) or repo_root is None:
+        return []
+    repo = Path(repo_root)
+    try:
+        if not repo.is_dir():
+            return []
+    except OSError:
+        return []
+    out: List[str] = []
+    for rej in report.get("rejected") or []:
+        if not isinstance(rej, dict):
+            continue
+        if str(rej.get("reason_code") or "").strip().lower() != "already-exists":
+            continue
+        cited = _CITED_PATH_RE.findall(str(rej.get("reason") or ""))
+        if cited and not any((repo / p).exists() for p in cited):
+            issue = rej.get("issue_number")
+            out.append(
+                f"FABRICATED_REJECTION: issue #{issue} closed as already-exists "
+                f"citing {', '.join(cited[:3])} — none exist in the repo"
+            )
+    return out
+
+
+def audit_latest(evolution_dir: Path, repo_root: Optional[Path] = None) -> List[str]:
     """Audit the most recent dated analysis report under ``<dir>/analysis/``.
 
-    Returns prefixed violation strings, or [] when there is no readable dated
-    report. Only ``YYYY-MM-DD.json`` files are considered — the sibling
-    ``issues_*.json`` / ``prs_*.json`` snapshots are skipped.
+    Runs the budget checks (``audit_analysis``) plus — when ``repo_root`` is given
+    — the fabricated-rejection check (``audit_rejections``). Returns prefixed
+    violation strings, or [] when there is no readable dated report. Only
+    ``YYYY-MM-DD.json`` files are considered — the sibling ``issues_*.json`` /
+    ``prs_*.json`` snapshots are skipped.
     """
     analysis_dir = evolution_dir / "analysis"
     try:
@@ -108,7 +150,8 @@ def audit_latest(evolution_dir: Path) -> List[str]:
         report = json.loads(latest.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return []
-    return [f"({latest.stem}) {v}" for v in audit_analysis(report)]
+    violations = audit_analysis(report) + audit_rejections(report, repo_root)
+    return [f"({latest.stem}) {v}" for v in violations]
 
 
 def main(argv: List[str]) -> int:
@@ -120,7 +163,9 @@ def main(argv: List[str]) -> int:
             str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
         )
     )
-    violations = audit_latest(evolution_dir)
+    repo_env = os.environ.get("EVOLUTION_REPO_DIR")
+    repo_root = Path(repo_env) if repo_env else None
+    violations = audit_latest(evolution_dir, repo_root)
     for v in violations:
         print(f"[analysis-audit] {v}")
     return 1 if violations else 0

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -336,17 +336,21 @@ def check_realized_impact(evolution_dir: Path) -> List[str]:
 
 def check_analysis_integrity(evolution_dir: Path) -> List[str]:
     """Alert when the latest analysis cycle's self-reported selection budget is
-    illegal or overspent — the deterministic teeth behind PR #519's prompt-level
-    effort-budget contract (the analysis agent once wrote max_total_effort=2.0,
-    neither the 1.5 throttle nor the 3.0 default, and over-selected). Silent when
-    clean, when there is no dated analysis report yet, or when the audit module is
-    unavailable (the scheduler installs evolution_*.py alongside this script, so
-    the sibling import resolves at runtime; the guard keeps unit imports safe)."""
+    illegal or overspent (PR #519's effort-budget contract — the agent once wrote
+    max_total_effort=2.0, neither 1.5 nor 3.0), OR when an ``already-exists``
+    rejection cited repo paths that do not exist (the #83 fabricated-close class —
+    needs the repo, resolved via _resolve_repo_dir). Silent when clean, when there
+    is no dated analysis report yet, or when the audit module is unavailable (the
+    scheduler installs evolution_*.py alongside this script, so the sibling import
+    resolves at runtime; the guard keeps unit imports safe)."""
     try:
         from evolution_analysis_audit import audit_latest
     except ImportError:
         return []
-    return [f"analysis selection integrity: {v}" for v in audit_latest(evolution_dir)]
+    return [
+        f"analysis selection integrity: {v}"
+        for v in audit_latest(evolution_dir, _resolve_repo_dir())
+    ]
 
 
 def main() -> int:

--- a/tests/scripts/test_evolution_analysis_audit.py
+++ b/tests/scripts/test_evolution_analysis_audit.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from evolution_analysis_audit import audit_analysis, audit_latest  # noqa: E402
+from evolution_analysis_audit import (  # noqa: E402
+    audit_analysis,
+    audit_latest,
+    audit_rejections,
+)
 
 
 def _report(max_total_effort=None, total_effort_selected=None, top_level=False):
@@ -100,3 +104,131 @@ class TestAuditLatest:
         (tmp_path / "analysis").mkdir(parents=True)
         (tmp_path / "analysis" / "2026-06-24.json").write_text("{not json", encoding="utf-8")
         assert audit_latest(tmp_path) == []
+
+    def test_audit_latest_runs_rejection_check_with_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write(
+            tmp_path,
+            "2026-06-24.json",
+            {
+                "scoring_model": {"selection_constraints": {"max_total_effort": 3.0}},
+                "total_effort_selected": 2.0,
+                "rejected": [
+                    {
+                        "issue_number": 83,
+                        "reason_code": "already-exists",
+                        "reason": "already done in scripts/ghost.sh",
+                        "closed": True,
+                    }
+                ],
+            },
+        )
+        out = audit_latest(tmp_path, repo)
+        assert any("FABRICATED_REJECTION" in x and "#83" in x for x in out)
+
+    def test_audit_latest_without_repo_skips_rejection_check(self, tmp_path):
+        self._write(
+            tmp_path,
+            "2026-06-24.json",
+            {
+                "scoring_model": {"selection_constraints": {"max_total_effort": 3.0}},
+                "total_effort_selected": 2.0,
+                "rejected": [
+                    {
+                        "issue_number": 83,
+                        "reason_code": "already-exists",
+                        "reason": "already done in scripts/ghost.sh",
+                        "closed": True,
+                    }
+                ],
+            },
+        )
+        assert audit_latest(tmp_path) == []  # no repo_root → no fabrication check
+
+
+class TestAuditRejections:
+    def _rep(self, rejected):
+        return {"date": "2026-06-24", "rejected": rejected}
+
+    def test_already_exists_with_real_path_is_clean(self, tmp_path):
+        (tmp_path / "agent").mkdir()
+        (tmp_path / "agent" / "real.py").write_text("x")
+        rej = [
+            {
+                "issue_number": 1,
+                "reason_code": "already-exists",
+                "reason": "already implemented in agent/real.py",
+                "closed": True,
+            }
+        ]
+        assert audit_rejections(self._rep(rej), tmp_path) == []
+
+    def test_fabricated_path_flagged(self, tmp_path):
+        # The real #83: cited scripts/evolution_watchdog.sh (the actual one is .py).
+        rej = [
+            {
+                "issue_number": 83,
+                "reason_code": "already-exists",
+                "reason": "already done in scripts/evolution_watchdog.sh and skills/x/SKILL.md",
+                "closed": True,
+            }
+        ]
+        v = audit_rejections(self._rep(rej), tmp_path)
+        assert any("FABRICATED_REJECTION" in x and "#83" in x for x in v)
+
+    def test_mixed_real_and_missing_is_not_flagged(self, tmp_path):
+        (tmp_path / "agent").mkdir()
+        (tmp_path / "agent" / "real.py").write_text("x")
+        rej = [
+            {
+                "issue_number": 5,
+                "reason_code": "already-exists",
+                "reason": "see agent/real.py and agent/typoed_missing.py",
+                "closed": True,
+            }
+        ]
+        assert audit_rejections(self._rep(rej), tmp_path) == []
+
+    def test_other_reason_codes_ignored(self, tmp_path):
+        rej = [
+            {
+                "issue_number": 7,
+                "reason_code": "harmful",
+                "reason": "mentions nonexistent/path.py but is not an already-exists claim",
+                "closed": True,
+            }
+        ]
+        assert audit_rejections(self._rep(rej), tmp_path) == []
+
+    def test_no_concrete_path_is_not_flagged(self, tmp_path):
+        rej = [
+            {
+                "issue_number": 9,
+                "reason_code": "already-exists",
+                "reason": "this capability already exists in the codebase",
+                "closed": True,
+            }
+        ]
+        assert audit_rejections(self._rep(rej), tmp_path) == []
+
+    def test_path_with_line_numbers_extracts_cleanly(self, tmp_path):
+        rej = [
+            {
+                "issue_number": 11,
+                "reason_code": "already-exists",
+                "reason": "implemented in tools/missing_tool.py (lines 53-54, 682+)",
+                "closed": True,
+            }
+        ]
+        v = audit_rejections(self._rep(rej), tmp_path)
+        assert any("tools/missing_tool.py" in x for x in v)
+
+    def test_no_repo_root_is_silent(self):
+        rej = [{"issue_number": 1, "reason_code": "already-exists", "reason": "x/y.py"}]
+        assert audit_rejections(self._rep(rej), None) == []
+
+    def test_empty_or_missing_rejections_clean(self, tmp_path):
+        assert audit_rejections({"rejected": []}, tmp_path) == []
+        assert audit_rejections({}, tmp_path) == []
+


### PR DESCRIPTION
## Why (gate #2 of the enforcement campaign)
The analysis stage can CLOSE an issue as `already-exists`, citing a repo path as evidence — but the "cite an exact path you verified" rule is prompt-level and unenforced. The real **#83** was closed citing `scripts/evolution_watchdog.sh`; the actual script is `.py`, so a wanted idea was permanently killed on **fabricated evidence**.

## What
- **`audit_rejections(report, repo_root)`** — for each `already-exists` rejection, extract cited repo paths from the prose `reason` and flag `FABRICATED_REJECTION` when it cites concrete paths and **none exist**. A single missing path among existing ones → treated as a typo / secondary ref (not fabrication), so legitimate rejections never false-positive.
- `audit_latest` runs the rejection check when given a `repo_root`.
- `evolution_watchdog.check_analysis_integrity` passes `_resolve_repo_dir()` (the same resolver `check_upstream_lag` uses) so the morning run verifies the latest cycle's closes against the actual checkout.

Read+flag only — the close already happened; the value is surfacing the pattern so the owner can re-open. (The blocking gate lives at the self-merge step — gate #3.)

## Verification
- `test_evolution_analysis_audit` (+8 rejection cases) + `test_evolution_watchdog` — **61 pass**; `ruff` + `ty` clean.
- **E2E on real prod data**: 5 real `already-exists` rejections (citing `hermes_cli/skills_hub.py`, `agent/prompt_builder.py`, `plugins/memory/mem0/__init__.py`, `tools/skills_tool.py`, …) → **0 false positives**; a fabricated `scripts/evolution_watchdog.sh` → flagged.