### PR TITLE
test(tui-gateway): de-flake test_session_create_no_race_keeps_worker_alive

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5273,13 +5273,20 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
         built = session["agent_ready"].wait(timeout=10.0)
         assert built, "agent build did not complete within timeout"
 
-        # Build finished without a close race — nothing should have been
-        # cleaned up by the orphan check.
+        # Build finished without a close race — this build thread must not have
+        # cleaned up ITS OWN worker/notify. Scope the assertions to this session's
+        # key: the approval hooks are patched globally, so concurrent daemon build
+        # threads from sibling session.create tests in the same shard append THEIR
+        # keys to these lists (this test clearing _sessions even nudges a late
+        # sibling's build thread into its own replaced-cleanup). Comparing to ``[]``
+        # made the test fail on that sibling noise; the own-key check stays immune
+        # while still catching this thread over-cleaning its own session.
+        my_key = session["session_key"]
         assert (
-            closed_workers == []
+            my_key not in closed_workers
         ), f"build thread closed its own worker despite no race: {closed_workers}"
         assert (
-            unregistered_keys == []
+            my_key not in unregistered_keys
         ), f"build thread unregistered its own notify despite no race: {unregistered_keys}"
 
         # Session should have the live worker installed.


### PR DESCRIPTION
## Problem
`test_session_create_no_race_keeps_worker_alive` fails intermittently and has blocked unrelated PRs (#534 shard 3, #536 shard 1), each needing a flaky-rerun. With `evolution-integration`'s `require_all_checks_green`, it also randomly blocks the **autonomous pipeline's own merges** — direct drag on merge throughput.

## Root cause
The approval hooks (`register/unregister_gateway_notify`) are monkeypatched **globally**. Concurrent daemon build threads from sibling `session.create` tests in the same xdist shard append THEIR session keys to `closed_workers` / `unregistered_keys`. This test also clears `server._sessions`, which nudges a late sibling's build thread into its own replaced-cleanup. Comparing the lists to `[]` then fails on that sibling noise — the observed failing key `20260625_..._955d26` is a **sibling** session, not this test's.

## Fix
Scope the assertions to THIS session's own key (`session["session_key"]`) instead of asserting the global lists are empty. The own-key check is immune to sibling noise while still catching this build thread over-cleaning its own session — the regression the test guards. **Test-only change** (the production build-thread logic is correct).

## Verification
`-k "session_create or no_race or worker"` (18 tests incl. target + siblings) pass; `ruff` clean. (The race only reproduces under full-shard xdist concurrency; the fix is immune by construction.)