### PR TITLE
feat(evolution): deterministic merge-gate — policy + atomic self-merge (gate #3)

### DIFF
--- a/scripts/evolution_merge_gate.py
+++ b/scripts/evolution_merge_gate.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Deterministic policy gate for the autonomous evolution self-merge step.
+
+The integration stage self-merges its OWN ``evolution/issue-*`` PRs into main and
+then auto-deploys — a bad self-merge lands on every install. Branch protection
+already requires green CI; this adds the OPERATIONAL-SAFETY policy the agent
+cannot be trusted to enforce on itself, plus an ATOMIC merge that closes the
+check-then-merge (TOCTOU) race the prompt-level branch-integrity check has.
+
+Blocking policy (all deterministic, zero-false-positive — a violation means the
+change genuinely needs a human, not that the heuristic guessed):
+
+* ``DIFF_TOO_LARGE`` — total changed lines exceed the cap. A large autonomous
+  change is the agent spiraling or a major refactor that warrants human review.
+* ``HIGH_RISK_PATH`` — the PR touches infrastructure the agent must never rewrite
+  unattended: CI/CD workflows, dependency lockfiles + manifests (supply-chain),
+  container/infra definitions, secrets, or its OWN enforcement machinery (the
+  approval policy, this gate, the cron registrar).
+
+When the policy passes, the ``--merge`` mode merges ATOMICALLY: the GitHub merge
+API is handed the reviewed head SHA, so a push that lands between check and merge
+returns 409 and aborts instead of merging unreviewed code.
+
+Pure ``check_merge_policy`` + explicit IO so the policy is import-safe and
+unit-testable; the gh/network calls live only in the CLI shell.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+# Default cap on total changed lines (additions + deletions) for an unattended
+# self-merge. Overridable via EVOLUTION_MERGE_MAX_LINES.
+DEFAULT_MAX_LINES = 200
+
+# Globs (matched against the repo-relative path, case-insensitive) the agent must
+# not modify in a self-merged PR. Kept conservative and specific so a normal
+# code/test/docs PR never trips it.
+HIGH_RISK_GLOBS: Tuple[str, ...] = (
+    # CI/CD — never let the agent rewrite the runners that gate it.
+    ".github/workflows/*",
+    ".github/actions/*",
+    # Dependency manifests + lockfiles — supply-chain / no unattended upgrades.
+    "pyproject.toml",
+    "uv.lock",
+    "poetry.lock",
+    "requirements*.txt",
+    "constraints*.txt",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+    "flake.nix",
+    "flake.lock",
+    # Container / infra definitions.
+    "Dockerfile*",
+    "docker-compose*.yml",
+    # Secrets / credentials — must never appear in an autonomous PR.
+    ".env*",
+    "**/.env*",
+    "*.pem",
+    "*.key",
+    # The agent's OWN enforcement + deploy machinery.
+    "tools/approval.py",
+    "scripts/evolution_merge_gate.py",
+    "scripts/register_evolution_cron.py",
+)
+
+
+def _norm(path: Any) -> str:
+    p = str(path or "").strip()
+    if p.startswith("./"):  # only the relative-path marker — keep .github/.env dots
+        p = p[2:]
+    return p.lower()
+
+
+def check_merge_policy(
+    files: Sequence[Dict[str, Any]],
+    max_lines: int = DEFAULT_MAX_LINES,
+    high_risk_globs: Sequence[str] = HIGH_RISK_GLOBS,
+) -> List[str]:
+    """Return blocking-violation strings (empty == may self-merge).
+
+    ``files`` is the ``gh pr view --json files`` shape:
+    ``[{"path": str, "additions": int, "deletions": int}, ...]``.
+    """
+    if not isinstance(files, (list, tuple)):
+        return []
+    out: List[str] = []
+
+    total = 0
+    risky: List[str] = []
+    globs = [g.lower() for g in high_risk_globs]
+    for f in files:
+        if not isinstance(f, dict):
+            continue
+        try:
+            total += int(f.get("additions") or 0) + int(f.get("deletions") or 0)
+        except (TypeError, ValueError):
+            pass
+        path = _norm(f.get("path"))
+        if not path:
+            continue
+        base = path.rsplit("/", 1)[-1]
+        for g in globs:
+            # Match against the full path AND the basename so a glob like
+            # "uv.lock" catches it at any depth, while ".github/workflows/*"
+            # matches the rooted path.
+            if fnmatch.fnmatch(path, g) or fnmatch.fnmatch(base, g):
+                risky.append(path)
+                break
+
+    if max_lines and total > max_lines:
+        out.append(
+            f"DIFF_TOO_LARGE: {total} changed lines exceed the {max_lines}-line "
+            f"self-merge cap — a change this size needs human review"
+        )
+    if risky:
+        shown = ", ".join(sorted(set(risky))[:5])
+        out.append(
+            f"HIGH_RISK_PATH: touches infrastructure the agent must not self-merge "
+            f"unattended ({shown}) — needs human review"
+        )
+    return out
+
+
+def _run(cmd: List[str]) -> Tuple[int, str, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def _pr_files(pr: int, repo: Optional[str], runner: Callable[[List[str]], Tuple[int, str, str]]) -> Optional[List[Dict[str, Any]]]:
+    cmd = ["gh", "pr", "view", str(pr), "--json", "files"]
+    if repo:
+        cmd += ["--repo", repo]
+    code, out, _ = runner(cmd)
+    if code != 0:
+        return None
+    try:
+        return json.loads(out).get("files") or []
+    except ValueError:
+        return None
+
+
+def _pr_head_sha(pr: int, repo: Optional[str], runner: Callable[[List[str]], Tuple[int, str, str]]) -> Optional[str]:
+    cmd = ["gh", "pr", "view", str(pr), "--json", "headRefOid"]
+    if repo:
+        cmd += ["--repo", repo]
+    code, out, _ = runner(cmd)
+    if code != 0:
+        return None
+    try:
+        return json.loads(out).get("headRefOid")
+    except ValueError:
+        return None
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    if "--pr" not in args:
+        print("usage: evolution_merge_gate.py --pr N [--merge] [--method squash] [--repo O/R]")
+        return 2
+    pr = int(args[args.index("--pr") + 1])
+    repo = args[args.index("--repo") + 1] if "--repo" in args else os.environ.get("EVOLUTION_REPO_SLUG")
+    method = args[args.index("--method") + 1] if "--method" in args else "squash"
+    do_merge = "--merge" in args
+    try:
+        max_lines = int(os.environ.get("EVOLUTION_MERGE_MAX_LINES", DEFAULT_MAX_LINES))
+    except ValueError:
+        max_lines = DEFAULT_MAX_LINES
+
+    runner = _run
+    files = _pr_files(pr, repo, runner)
+    if files is None:
+        print(f"[merge-gate] could not read PR #{pr} files (gh error) — refusing to merge")
+        return 1
+
+    violations = check_merge_policy(files, max_lines=max_lines)
+    if violations:
+        print(f"[merge-gate] PR #{pr} BLOCKED from autonomous self-merge:")
+        for v in violations:
+            print(f"  • {v}")
+        return 1
+
+    print(f"[merge-gate] PR #{pr} policy OK ({len(files)} files)")
+    if not do_merge:
+        return 0
+
+    head = _pr_head_sha(pr, repo, runner)
+    if not head:
+        print(f"[merge-gate] could not resolve PR #{pr} head SHA — refusing to merge")
+        return 1
+    # Atomic merge: pass the reviewed head SHA so a concurrent push between the
+    # policy check and the merge fails with 409 instead of landing unreviewed.
+    slug = repo or os.environ.get("EVOLUTION_REPO_SLUG", "")
+    api = f"repos/{slug}/pulls/{pr}/merge"
+    code, out, err = runner(
+        ["gh", "api", "--method", "PUT", api, "-f", f"sha={head}", "-f", f"merge_method={method}"]
+    )
+    if code != 0:
+        print(f"[merge-gate] atomic merge of PR #{pr} FAILED (head moved or merge error): {err.strip().splitlines()[0] if err.strip() else 'see gh output'}")
+        return 1
+    print(f"[merge-gate] PR #{pr} merged atomically at {head[:9]} ({method})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -194,21 +194,26 @@ gh pr list --repo "$REPO" --state open --limit 50 \
 4. **Merge** (squash). `--admin` is required because branch protection mandates
    review; the owner token authorizes it.
 
-   **FIRST — branch-integrity check (you review a PR, then merge whatever its
-   branch HEAD is NOW; those can differ).** Another agent or a shared checkout
-   can push commits onto the branch between your review (2a) and this merge, and
-   `gh pr merge` lands the branch HEAD — so an un-reviewed commit rides in under
-   your approval. Before merging, confirm the commit set you reviewed is still
-   the whole PR:
+   **Merge via the deterministic gate — it enforces the self-merge policy AND
+   closes the review→merge race.** `gh pr merge` lands the branch HEAD, so a
+   commit pushed onto the branch between your 2a review and this merge would ride
+   in unreviewed; and a raw merge cannot refuse an oversized or infrastructure-
+   touching autonomous change. `scripts/evolution_merge_gate.py` does both
+   deterministically: it re-checks the PR against the policy (a diff-size cap;
+   never self-merge a PR that touches CI workflows, dependency lockfiles/manifests,
+   secrets, or the pipeline's own approval / merge-gate / cron-registrar
+   machinery), then merges ATOMICALLY by passing the reviewed head SHA — so a push
+   that landed since 2a returns 409 and aborts instead of merging unreviewed code.
 ```bash
-gh pr view <N> --repo "$REPO" --json commits --jq '.commits[].oid'
+python3 scripts/evolution_merge_gate.py --pr <N> --repo "$REPO" --merge --method squash
 ```
-   If a commit appeared that was NOT in your 2a review → do NOT merge blind:
-   re-run the code review (2a) + dead-code grep against the FULL current diff. If
-   it passes, merge; if not, send back. Only then:
-```bash
-gh pr merge <N> --repo "$REPO" --squash --admin
-```
+   Non-zero exit = BLOCKED (policy violation, or the head moved since review). Do
+   NOT merge blind. If the head moved, re-run the 2a code review + dead-code grep
+   against the FULL current diff and retry; if the policy blocked it (oversized /
+   infra / dependency change), leave it for human review and record why in the
+   report. Only fall back to `gh pr merge <N> --repo "$REPO" --squash --admin` for
+   a PR the gate has already cleared but could not merge for an unrelated gh
+   reason.
 
 4a. **Continue or close — keep multi-phase `roadmap` issues moving (don't let them
     stall at slice 1).** A PR that carries `Closes #NN` auto-closes its issue on

--- a/tests/scripts/test_evolution_merge_gate.py
+++ b/tests/scripts/test_evolution_merge_gate.py
@@ -1,0 +1,82 @@
+"""Tests for scripts/evolution_merge_gate.py — the deterministic self-merge policy
+(diff-size cap + high-risk path blocklist; the atomic-merge IO is exercised only
+via the pure policy here)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_merge_gate import check_merge_policy  # noqa: E402
+
+
+def _f(path, additions=1, deletions=0):
+    return {"path": path, "additions": additions, "deletions": deletions}
+
+
+class TestCheckMergePolicy:
+    def test_small_code_change_is_clean(self):
+        files = [_f("scripts/foo.py", 30, 5), _f("tests/scripts/test_foo.py", 40, 0)]
+        assert check_merge_policy(files) == []
+
+    def test_diff_too_large_flagged(self):
+        files = [_f("agent/big.py", 150, 120)]  # 270 > 200
+        v = check_merge_policy(files)
+        assert any("DIFF_TOO_LARGE" in x for x in v)
+
+    def test_diff_at_cap_is_clean(self):
+        files = [_f("agent/x.py", 120, 80)]  # exactly 200
+        assert not any("DIFF_TOO_LARGE" in x for x in check_merge_policy(files))
+
+    def test_custom_max_lines(self):
+        files = [_f("a.py", 30, 0)]
+        assert any("DIFF_TOO_LARGE" in x for x in check_merge_policy(files, max_lines=10))
+
+    def test_workflow_path_is_high_risk(self):
+        v = check_merge_policy([_f(".github/workflows/tests.yml", 2, 1)])
+        assert any("HIGH_RISK_PATH" in x for x in v)
+
+    def test_lockfiles_and_manifests_are_high_risk(self):
+        for p in ("uv.lock", "package-lock.json", "pyproject.toml", "requirements.txt", "flake.lock"):
+            v = check_merge_policy([_f(p, 3, 1)])
+            assert any("HIGH_RISK_PATH" in x for x in v), p
+
+    def test_nested_lockfile_matched_by_basename(self):
+        v = check_merge_policy([_f("web/uv.lock", 3, 1)])
+        assert any("HIGH_RISK_PATH" in x for x in v)
+
+    def test_own_enforcement_machinery_is_high_risk(self):
+        for p in ("tools/approval.py", "scripts/evolution_merge_gate.py", "scripts/register_evolution_cron.py"):
+            v = check_merge_policy([_f(p, 3, 1)])
+            assert any("HIGH_RISK_PATH" in x for x in v), p
+
+    def test_secrets_and_env_are_high_risk(self):
+        for p in (".env", ".env.production", "config/secret.key", "tls/server.pem"):
+            v = check_merge_policy([_f(p, 1, 0)])
+            assert any("HIGH_RISK_PATH" in x for x in v), p
+
+    def test_dockerfile_is_high_risk(self):
+        v = check_merge_policy([_f("Dockerfile", 2, 0)])
+        assert any("HIGH_RISK_PATH" in x for x in v)
+
+    def test_large_and_risky_reports_both(self):
+        files = [_f(".github/workflows/x.yml", 1, 0), _f("a.py", 150, 120)]
+        v = check_merge_policy(files)
+        assert any("DIFF_TOO_LARGE" in x for x in v)
+        assert any("HIGH_RISK_PATH" in x for x in v)
+
+    def test_empty_or_non_list_is_safe(self):
+        assert check_merge_policy([]) == []
+        assert check_merge_policy(None) == []  # type: ignore[arg-type]
+
+    def test_malformed_file_entries_skipped(self):
+        files = ["nope", {"path": None}, _f("ok/small.py", 1, 0)]
+        assert check_merge_policy(files) == []
+
+    def test_ordinary_docs_and_skill_md_are_clean(self):
+        files = [
+            _f("skills/evolution/evolution-analysis/SKILL.md", 20, 4),
+            _f("docs/note.md", 10, 0),
+            _f("agent/feature.py", 60, 10),
+        ]
+        assert check_merge_policy(files) == []


### PR DESCRIPTION
## Why (gate #3, the dangerous self-merge step)
The integration stage self-merges its own `evolution/issue-*` PRs and auto-deploys to every install. Branch protection requires green CI, but the branch-integrity + dead-code checks are prompt-level (unenforced). This adds the deterministic operational-safety gate. **Designed with a cross-AI review (Gemini)** which reshaped it away from a brittle blocking dead-code AST toward zero-false-positive operational gates + an atomic merge.

## What
- **`scripts/evolution_merge_gate.py`** — pure `check_merge_policy(files, max_lines)`:
  - `DIFF_TOO_LARGE`: > 200 changed lines (`EVOLUTION_MERGE_MAX_LINES`) — a large autonomous change is the agent spiraling / a refactor that needs a human.
  - `HIGH_RISK_PATH`: never self-merge a PR touching CI workflows, dependency lockfiles/manifests (supply-chain), container/infra, secrets, or the pipeline's **own** approval / merge-gate / cron-registrar machinery.
  - `--merge` mode merges **atomically** via `gh api PUT .../merge -f sha=<reviewed_head>` → a push between review and merge returns **409 and aborts** (closes the TOCTOU race the prompt-level check had).
- **`evolution-integration/SKILL.md`**: the merge step now goes through the gate instead of a manual commit-set check + raw `gh pr merge`.

Only ever evaluates autonomous `evolution/issue-*` PRs (the only ones integration merges); human PRs are unaffected. Dead-code is deliberately **not** a blocking gate (AST across Python/JS false-positives on reflection/decorators/route registries → would stall the pipeline) — a future detect+alert.

## Verification
- `test_evolution_merge_gate` (14 policy cases) + `test_evolution_skill_integrity` — **25 pass**; `ruff` + `ty` clean.
- E2E: typical small PR → OK; `uv.lock` → `HIGH_RISK_PATH`; 520-line → `DIFF_TOO_LARGE`.