### PR TITLE
feat(agent): per-provider request timeout default 60s (Closes #520)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -97,13 +97,15 @@ model:
 # HERMES_API_TIMEOUT env var (which still applies when no config is set).
 # ``stale_timeout_seconds`` controls the non-streaming stale-call detector and
 # wins over the legacy HERMES_API_CALL_STALE_TIMEOUT env var. Leaving these
-# unset keeps the legacy defaults (HERMES_API_TIMEOUT=1800s,
-# HERMES_API_CALL_STALE_TIMEOUT=90s, native Anthropic 900s). The
+# unset keeps the legacy defaults (HERMES_API_TIMEOUT=60s,
+# HERMES_API_CALL_STALE_TIMEOUT=90s, native Anthropic 900s).  The
 # implicit non-stream stale detector is auto-disabled for local endpoints
 # and can scale upward for very large contexts.
 #
 # Not currently wired for AWS Bedrock (bedrock_converse + AnthropicBedrock
 # SDK paths) — those use boto3 with its own timeout configuration.
+#
+# Default request timeout is 60s (was 1800s). Override per provider/model below.
 #
 # providers:
 #   ollama-local:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1150,10 +1150,10 @@ class AIAgent:
           1. ``providers.<id>.models.<model>.timeout_seconds`` (per-model override)
           2. ``providers.<id>.request_timeout_seconds`` (provider-wide)
           3. ``HERMES_API_TIMEOUT`` env var (legacy escape hatch)
-          4. 1800.0s default
+          4. 60.0s default
 
         Used by OpenAI-wire chat completions (streaming and non-streaming) so
-        the per-provider config knob wins over the 1800s default.  Without this
+        the per-provider config knob wins over the 60s default.  Without this
         helper, the hardcoded ``HERMES_API_TIMEOUT`` fallback would always be
         passed as a per-call ``timeout=`` kwarg, overriding the client-level
         timeout the AIAgent.__init__ path configured.
@@ -1161,7 +1161,7 @@ class AIAgent:
         cfg = get_provider_request_timeout(self.provider, self.model)
         if cfg is not None:
             return cfg
-        return env_float("HERMES_API_TIMEOUT", 1800.0)
+        return env_float("HERMES_API_TIMEOUT", 60.0)
 
     def _resolved_api_call_stale_timeout_base(self) -> tuple[float, bool]:
         """Resolve the base non-stream stale timeout and whether it is implicit.

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -207,9 +207,30 @@ def test_resolved_api_call_timeout_priority(monkeypatch, tmp_path):
     )
     assert agent2._resolved_api_call_timeout() == 999.0
 
-    # Case C: no config, no env → 1800.0 default
+    # Case C: no config, no env → 60.0 default
     monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
-    assert agent2._resolved_api_call_timeout() == 1800.0
+    assert agent2._resolved_api_call_timeout() == 60.0
+
+
+def test_resolved_api_call_timeout_default_is_60s(monkeypatch, tmp_path):
+    """When no config or env var is set, the implicit default is 60s."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    from run_agent import AIAgent
+    agent = AIAgent(
+        model="gpt-4o",
+        provider="openrouter",
+        api_key="sk-dummy",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    assert agent._resolved_api_call_timeout() == 60.0
 
 
 def test_resolved_api_call_stale_timeout_priority(monkeypatch, tmp_path):


### PR DESCRIPTION
Automated evolution PR for issue #520.

Lower the implicit request timeout fallback from 1800s to 60s so a hung provider cannot block a turn indefinitely. Config knobs still win:

- providers.<id>.models.<model>.timeout_seconds
- providers.<id>.request_timeout_seconds
- HERMES_API_TIMEOUT env var

Updates cli-config.yaml.example and adds regression tests for the new default.