### PR TITLE
feat(cron): structured timeout failure summary (Closes #521)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1509,6 +1509,10 @@ def save_job_failure(
     output: str = "",
     exit_code: Optional[int] = None,
     traceback_text: Optional[str] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    failure_category: Optional[str] = None,
+    retry_count: Optional[int] = None,
     max_output_chars: int = 4000,
 ) -> Path:
     """Persist a per-job failure record under ``FAILURE_DIR``.
@@ -1518,6 +1522,10 @@ def save_job_failure(
     Records are keyed by job id and timestamp; the most recent file per job
     is the canonical "latest failure". Failures are written even when the
     job later recovers, so the record reflects the *most recent* run status.
+
+    When ``failure_category`` is provided (e.g. ``timeout``) it is included
+    in the record so cron failures can be aggregated and alerted on by
+    failure class.
 
     Returns the path of the written record.
     """
@@ -1543,6 +1551,10 @@ def save_job_failure(
         "timestamp": now.isoformat(),
         "success": bool(success),
         "exit_code": exit_code,
+        "provider": provider,
+        "model": model,
+        "failure_category": failure_category,
+        "retry_count": retry_count,
         "error": error,
         "traceback": traceback_text,
         "last_output": trimmed_output,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -48,7 +48,9 @@ from hermes_time import now as _hermes_now
 logger = logging.getLogger(__name__)
 
 
-def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
+def _summarize_cron_failure_for_delivery(
+    job: dict, error: str | None, failure_category: str | None = None
+) -> str:
     """Return a compact one-line failure message for chat delivery.
 
     Full details stay in the cron output directory and the logs. Chat should
@@ -58,6 +60,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+    category_tag = f" [{failure_category}]" if failure_category else ""
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -67,14 +70,14 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
         elif "quota" in lower:
             reason = "quota limit"
         return (
-            f"⚠️ Cron '{job_name}' failed: provider {reason}. "
+            f"⚠️ Cron '{job_name}' failed: provider {reason}{category_tag}. "
             "Fallback chain was exhausted or unavailable. "
             "Full details saved in cron output / cron/failures."
         )
 
     if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
         return (
-            f"⚠️ Cron '{job_name}' failed: provider timeout. "
+            f"⚠️ Cron '{job_name}' failed: provider timeout{category_tag}. "
             "Fallback chain was exhausted or unavailable. "
             "Full details saved in cron output / cron/failures."
         )
@@ -2661,6 +2664,40 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         mark_job_started(job["id"])
         success, output, final_response, error = run_job(job)
 
+        # Classify provider-layer failures so the cron failure record and any
+        # delivery summary can include a stable failure_category (e.g. timeout).
+        failure_category: Optional[str] = None
+        if not success and error:
+            try:
+                from agent.error_classifier import classify_api_error
+                classified = classify_api_error(RuntimeError(error))
+                if classified is not None:
+                    failure_category = classified.reason.value
+            except Exception:
+                failure_category = None
+
+        # Best-effort retry count from the agent's final error text when the
+        # retry loop surfaced it (e.g. "max retries (3) exceeded").
+        retry_count: Optional[int] = None
+        if not success and error:
+            match = re.search(r"(?:retry|retries)\s*\(?\s*(\d+)\s*\)?", error, re.IGNORECASE)
+            if match:
+                retry_count = int(match.group(1))
+
+        # Determine the provider/model that ran the job from the job record or
+        # the active process model env. Cron jobs store a per-job model override;
+        # resolving provider from model follows the ordinary HERMES_MODEL path.
+        cron_provider: Optional[str] = None
+        cron_model: Optional[str] = None
+        if not success:
+            cron_model = job.get("model") or os.getenv("HERMES_MODEL") or None
+            if cron_model:
+                try:
+                    from hermes_cli.models import parse_model_input
+                    cron_provider, cron_model = parse_model_input(cron_model, "")
+                except Exception:
+                    cron_provider = None
+
         output_file = save_job_output(job["id"], output)
         if verbose:
             logger.info("Output saved to: %s", output_file)
@@ -2678,6 +2715,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     error=error,
                     output=output,
                     traceback_text=tb,
+                    provider=cron_provider,
+                    model=cron_model,
+                    failure_category=failure_category,
+                    retry_count=retry_count,
                 )
                 logger.warning(
                     "Job '%s' failure record saved to cron/failures",
@@ -2697,7 +2738,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         deliver_content = (
             strip_reasoning_for_delivery(final_response)
             if success
-            else _summarize_cron_failure_for_delivery(job, error)
+            else _summarize_cron_failure_for_delivery(job, error, failure_category)
         )
         # Treat whitespace-only final responses the same as empty
         # responses: do not deliver a blank message, and let the

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3488,3 +3488,64 @@ class TestHomeTargetEnvVarRegistry:
         from cron.scheduler import _HOME_TARGET_ENV_VARS
 
         assert _HOME_TARGET_ENV_VARS.get("whatsapp") == "WHATSAPP_HOME_CHANNEL"
+
+
+class TestCronTimeoutFailureSummary:
+    """Regression: cron jobs must write a structured failure summary when the
+    provider layer times out, including provider, model, failure_category, and
+    retry count."""
+
+    def test_timeout_failure_record_includes_category_and_model(self, tmp_path, monkeypatch):
+        from cron.scheduler import run_one_job
+        from cron.jobs import get_latest_failure
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Minimal Hermes home layout required by save_job_failure
+        (tmp_path / "cron").mkdir()
+        (tmp_path / "cron" / "output").mkdir(parents=True)
+        (tmp_path / "cron" / "failures").mkdir(parents=True)
+
+        job = {
+            "id": "test-timeout-summary",
+            "name": "Timeout summary test",
+            "model": "openrouter:openai/gpt-4o",
+            "prompt": "ping",
+            "deliver": "",
+        }
+
+        # Patch run_job to simulate a provider timeout after retries.
+        def _fake_run_job(_job):
+            return (
+                False,
+                "Agent output before death",
+                "",
+                "ReadError: request timed out after 60s (retries 3 exhausted)",
+            )
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "run_job", _fake_run_job)
+        monkeypatch.setattr(sched_mod, "mark_job_started", lambda _jid: None)
+        monkeypatch.setattr(sched_mod, "save_job_output", lambda _jid, _output: None)
+        monkeypatch.setattr(sched_mod, "_deliver_result", lambda _job, _content, **kw: None)
+
+        run_one_job(job, verbose=False)
+
+        record = get_latest_failure("test-timeout-summary")
+        assert record is not None
+        assert record["success"] is False
+        assert record["failure_category"] == "timeout"
+        assert record["provider"] == "openrouter"
+        assert record["model"] == "openai/gpt-4o"
+        assert record["retry_count"] == 3
+        assert "timed out" in record["error"].lower()
+
+    def test_delivery_summary_includes_failure_category(self):
+        from cron.scheduler import _summarize_cron_failure_for_delivery
+
+        job = {"id": "j1", "name": "Job one"}
+        msg = _summarize_cron_failure_for_delivery(
+            job, "ReadError: request timed out after 60s", "timeout"
+        )
+        assert "provider timeout" in msg
+        assert "[timeout]" in msg
+        assert "Job one" in msg


### PR DESCRIPTION
Automated evolution PR for issue #521.

Cron failure records now include provider, model, failure_category (via agent.error_classifier.classify_api_error), and retry_count. The delivery summary appends the category so operators see e.g. "provider timeout [timeout]".

Includes regression tests in tests/cron/test_scheduler.py.