### PR TITLE
feat(aux): health ping at session start (Closes #522)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5031,6 +5031,50 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
+def aux_health_ping(task: str = "session_start") -> Optional[str]:
+    """Best-effort health ping for the auxiliary provider layer.
+
+    Resolves the configured provider/model for ``task`` and issues a tiny,
+    cheap chat completion. Returns the resolved ``provider:model`` string on
+    success, or ``None`` if the provider is unreachable. This lets the gateway
+    surface an auxiliary provider problem at session start instead of waiting
+    for the first compression / memory / title-generation call.
+
+    The ping is intentionally small (timeout 10s, max_tokens 1, single user
+    message) and catches only catastrophic misconfiguration or total
+    provider outage. It never raises into the caller.
+    """
+    try:
+        resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
+            task=task)
+        client, final_model = _get_cached_client(
+            resolved_provider,
+            resolved_model or "",
+            base_url=resolved_base_url or "",
+            api_key=resolved_api_key or "",
+            api_mode=resolved_api_mode or "",
+        )
+        if client is None:
+            logger.warning("Auxiliary health ping (%s): no provider configured", task)
+            return None
+
+        kwargs = _build_call_kwargs(
+            resolved_provider,
+            final_model or resolved_model or "",
+            messages=[{"role": "user", "content": "."}],
+            max_tokens=1,
+            timeout=min(_get_task_timeout(task, default=30.0), 10.0),
+        )
+        # Codex / responses adapters need ``messages`` only.
+        client.chat.completions.create(**kwargs)
+        resolved = f"{resolved_provider}:{final_model or resolved_model or 'default'}"
+        logger.info("Auxiliary health ping (%s): ok via %s", task, resolved)
+        return resolved
+    except Exception as e:
+        logger.warning("Auxiliary health ping (%s) failed: %s", task, e)
+        return None
+
+
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
     """Read auxiliary.<task>.extra_body and return a shallow copy when valid."""
     task_config = _get_auxiliary_task_config(task)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1072,6 +1072,15 @@ class SessionStore:
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
+        # Best-effort health ping of the auxiliary provider layer so model-
+        # sidecar problems (compression, memory, title-gen) surface at session
+        # start instead of silently failing later. (#522)
+        try:
+            from agent.auxiliary_client import aux_health_ping
+            aux_health_ping("session_start")
+        except Exception as e:
+            logger.debug("Session health ping failed: %s", e)
+
         return entry
 
     def update_session(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4070,3 +4070,47 @@ class TestAuxiliaryMaxTokensParam:
         ):
             assert auxiliary_max_tokens_param(4096, model="") == {"max_tokens": 4096}
             assert auxiliary_max_tokens_param(4096, model=None) == {"max_tokens": 4096}
+
+
+class TestAuxHealthPing:
+    """Regression: aux_health_ping must probe the auxiliary provider layer at
+    session start and return the resolved provider:model or None on failure."""
+
+    def test_health_ping_returns_provider_model_on_success(self):
+        from agent.auxiliary_client import aux_health_ping
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openrouter", "openai/gpt-4o-mini", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(mock_client, "openai/gpt-4o-mini")),
+            patch("agent.auxiliary_client._build_call_kwargs",
+                  return_value={"messages": [{"role": "user", "content": "."}]}),
+        ):
+            result = aux_health_ping("session_start")
+
+        assert result == "openrouter:openai/gpt-4o-mini"
+        mock_client.chat.completions.create.assert_called_once()
+
+    def test_health_ping_returns_none_when_no_client(self):
+        from agent.auxiliary_client import aux_health_ping
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openrouter", "openai/gpt-4o-mini", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(None, None)),
+        ):
+            assert aux_health_ping("session_start") is None
+
+    def test_health_ping_returns_none_on_exception(self):
+        from agent.auxiliary_client import aux_health_ping
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  side_effect=RuntimeError("config missing")),
+        ):
+            assert aux_health_ping("session_start") is None


### PR DESCRIPTION
Automated evolution PR for issue #522.

Adds aux_health_ping() in agent/auxiliary_client.py and calls it from gateway/session.py when a new session is created. Surfaces auxiliary provider misconfiguration/outage at session start instead of silently failing later during compression / memory / title-generation.