### PR TITLE
feat: loop-guard arg-level detection + search provider_dead diagnostic and fallback chain (Closes #544, #467)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -34,6 +34,7 @@ required (the caller tracks "already nudged this run" to avoid spamming).
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -57,6 +58,8 @@ _FAILURE_MARKERS = (
     "exit status",
     "is not recognized",
     "could not be found",
+    "no results",
+    "no results found",
 )
 
 _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
@@ -69,49 +72,52 @@ _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
 _NON_RETRYABLE = frozenset({"timeout", "permission", "missing_command", "limit"})
 _NONRETRY_THRESHOLD = 2
 
+# Idempotent tools that are especially prone to content-free repetition and that
+# the issue evidence shows spiraling with no progress even when individual calls
+# return "success". Count these as non-progress after a shorter run so the model
+# is nudged toward a different query / tool / strategy.
+_SHORT_CIRCUIT_IDEMPOTENT = frozenset({"search_files", "web_search", "web_extract"})
+_SHORT_CIRCUIT_REPEAT_THRESHOLD = 4
+
 # Mutating tools get LOWER thresholds than idempotent tools because a fixation
 # on mutating operations (writing files, running commands) is more costly and
 # indicates a deeper strategy problem (#432).
-_IDEMPOTENT_TOOLS = frozenset(
-    {
-        "read_file",
-        "search_files",
-        "web_search",
-        "web_extract",
-        "session_search",
-        "browser_snapshot",
-        "browser_console",
-        "browser_get_images",
-        "mcp_filesystem_read_file",
-        "mcp_filesystem_read_text_file",
-        "mcp_filesystem_read_multiple_files",
-        "mcp_filesystem_list_directory",
-        "mcp_filesystem_list_directory_with_sizes",
-        "mcp_filesystem_directory_tree",
-        "mcp_filesystem_get_file_info",
-        "mcp_filesystem_search_files",
-    }
-)
-_MUTATING_TOOLS = frozenset(
-    {
-        "terminal",
-        "execute_code",
-        "write_file",
-        "patch",
-        "todo",
-        "memory",
-        "skill_manage",
-        "browser_click",
-        "browser_type",
-        "browser_press",
-        "browser_scroll",
-        "browser_navigate",
-        "send_message",
-        "cronjob",
-        "delegate_task",
-        "process",
-    }
-)
+_IDEMPOTENT_TOOLS = frozenset({
+    "read_file",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "session_search",
+    "browser_snapshot",
+    "browser_console",
+    "browser_get_images",
+    "mcp_filesystem_read_file",
+    "mcp_filesystem_read_text_file",
+    "mcp_filesystem_read_multiple_files",
+    "mcp_filesystem_list_directory",
+    "mcp_filesystem_list_directory_with_sizes",
+    "mcp_filesystem_directory_tree",
+    "mcp_filesystem_get_file_info",
+    "mcp_filesystem_search_files",
+})
+_MUTATING_TOOLS = frozenset({
+    "terminal",
+    "execute_code",
+    "write_file",
+    "patch",
+    "todo",
+    "memory",
+    "skill_manage",
+    "browser_click",
+    "browser_type",
+    "browser_press",
+    "browser_scroll",
+    "browser_navigate",
+    "send_message",
+    "cronjob",
+    "delegate_task",
+    "process",
+})
 # Default thresholds: lower for mutating tools, higher for idempotent (#432).
 # Mutating:  repeat at 4, fail at 2, escalate at 8
 # Idempotent: repeat at 8, fail at 4, escalate at 15
@@ -143,17 +149,41 @@ def _looks_like_failure(content: Any) -> bool:
     return bool(_EXIT_CODE_RE.search(content))
 
 
-def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, Optional[str]]]:
-    """Most-recent-first list of (single_tool_name, result_failed, failure_class)
+def _tool_result_arg_hash(content: Any) -> Optional[str]:
+    """Return a canonical JSON key of the tool-call arguments embedded in a
+    tool result, or None if no arguments can be parsed. Used to detect
+    identical-query repetition for tools like web_search where the same
+    arguments produce the same empty result and drive a spiral (#467).
+    """
+    if not isinstance(content, str) or not content:
+        return None
+    try:
+        parsed = json.loads(content)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    args = parsed.get("parameters") or parsed.get("args") or parsed.get("arguments")
+    if not isinstance(args, dict):
+        return None
+    return json.dumps(args, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _recent_tool_runs(
+    messages: List[Dict[str, Any]],
+) -> List[Tuple[str, bool, Optional[str], Optional[str]]]:
+    """Most-recent-first list of
+    (single_tool_name, result_failed, failure_class, arg_hash)
     for the trailing run of assistant turns that each called EXACTLY ONE tool.
     ``failure_class`` is the tool_diagnostics category of the failing result (or
-    None when the turn did not fail).
+    None when the turn did not fail). ``arg_hash`` is a canonical JSON of the
+    parsed arguments when they can be recovered from the tool result.
 
     Stops at the first assistant turn that is not a single-tool call (a text
     reply, or a multi-tool turn) — that breaks the "stuck on one tool" run.
     Multi-tool turns are normal varied work, not a single-tool spiral.
     """
-    runs: List[Tuple[str, bool, Optional[str]]] = []
+    runs: List[Tuple[str, bool, Optional[str], Optional[str]]] = []
     i = len(messages) - 1
     # Collect tool results by id as we walk back so we can mark failures.
     while i >= 0:
@@ -161,9 +191,7 @@ def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, O
         if msg.get("role") == "assistant" and msg.get("tool_calls"):
             tcs = [tc for tc in msg["tool_calls"] if isinstance(tc, dict)]
             names = [
-                tc.get("function", {}).get("name")
-                for tc in tcs
-                if tc.get("function")
+                tc.get("function", {}).get("name") for tc in tcs if tc.get("function")
             ]
             names = [n for n in names if n]
             if len(set(names)) != 1:
@@ -174,14 +202,17 @@ def _recent_tool_runs(messages: List[Dict[str, Any]]) -> List[Tuple[str, bool, O
             # Results for this turn are the "tool" messages that follow it.
             failed = False
             category: Optional[str] = None
+            arg_hash: Optional[str] = None
             for j in range(i + 1, len(messages)):
                 tm = messages[j]
                 if tm.get("role") != "tool":
                     break
-                if _looks_like_failure(tm.get("content")):
+                content = tm.get("content")
+                if _looks_like_failure(content):
                     failed = True
-                    category = _failure_category(tm.get("content")) or category
-            runs.append((tool, failed, category))
+                    category = _failure_category(content) or category
+                arg_hash = _tool_result_arg_hash(content) or arg_hash
+            runs.append((tool, failed, category, arg_hash))
             i -= 1
         elif msg.get("role") == "tool":
             i -= 1  # skip result messages; handled with their assistant turn
@@ -223,11 +254,13 @@ def maybe_nudge(
 ) -> Optional[str]:
     """Return a nudge string if the trailing single-tool run is stuck, else None.
 
-    Three trigger levels (each is lower for mutating tools than idempotent):
+    Trigger levels (each is lower for mutating tools than idempotent):
       1. Non-retryable failure class repeated twice (highest priority, #231)
       2. Generic failures >= fail_threshold
       3. Same tool called >= repeat_threshold times in a row
       4. Escalated interrupt at higher counts (#432)
+      5. Same *arguments* repeated for short-circuit idempotent tools
+         (search_files / web_search / web_extract) >= 4 times (#467)
 
     Returns None when the agent is making varied progress (not stuck).
     """
@@ -243,17 +276,29 @@ def maybe_nudge(
     is_unknown = cat == "unknown"
     if repeat_threshold is None:
         repeat_threshold = (
-            _MUTATING_REPEAT_THRESHOLD if (is_mutating or is_unknown)
+            _MUTATING_REPEAT_THRESHOLD
+            if (is_mutating or is_unknown)
             else _IDEMPOTENT_REPEAT_THRESHOLD
         )
     if fail_threshold is None:
         fail_threshold = (
-            _MUTATING_FAIL_THRESHOLD if (is_mutating or is_unknown)
+            _MUTATING_FAIL_THRESHOLD
+            if (is_mutating or is_unknown)
             else _IDEMPOTENT_FAIL_THRESHOLD
         )
     escalate_threshold = (
-        _MUTATING_ESCALATE_THRESHOLD if (is_mutating or is_unknown)
+        _MUTATING_ESCALATE_THRESHOLD
+        if (is_mutating or is_unknown)
         else _IDEMPOTENT_ESCALATE_THRESHOLD
+    )
+    short_circuit_threshold = (
+        _MUTATING_REPEAT_THRESHOLD
+        if (is_mutating or is_unknown)
+        else (
+            _SHORT_CIRCUIT_REPEAT_THRESHOLD
+            if tool in _SHORT_CIRCUIT_IDEMPOTENT
+            else repeat_threshold
+        )
     )
 
     # All entries in `runs` share the same tool (run breaks on tool change),
@@ -264,7 +309,7 @@ def maybe_nudge(
     consec_nonretry = 0
     nonretry_class: Optional[str] = None
     counting_nonretry = True
-    for _t, failed, category in same:
+    for _t, failed, category, _arg_hash in same:
         if failed:
             consec_fail += 1
         else:
@@ -311,6 +356,23 @@ def maybe_nudge(
             f"— report it concisely instead of retrying. Do not call `{tool}` "
             f"again the same way."
         )
+
+    # Same-argument repetition for known spiral-prone idempotent tools (#467).
+    # This catches web_search returning "no results" / search_files returning
+    # nothing, where each individual call technically "succeeded" but repeating
+    # the exact same query is still a loop.
+    if tool in _SHORT_CIRCUIT_IDEMPOTENT and count >= short_circuit_threshold:
+        arg_hashes = [r[3] for r in same if r[3] is not None]
+        if arg_hashes and len(set(arg_hashes)) == 1:
+            score = _tool_spiral_score(tool, count, short_circuit_threshold)
+            score_line = f"\n{score}" if score else ""
+            return (
+                f"[loop-guard] You have called `{tool}` {count} times with the "
+                f"SAME arguments and the result is not making progress.{score_line} "
+                f"Do NOT repeat `{tool}` with those identical arguments. Rephrase "
+                f"the query, broaden or narrow it, switch to a different information "
+                f"source, or state the blocker if no relevant results are available."
+            )
 
     if count >= repeat_threshold:
         # Build diversity score for the nudge.

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -19,30 +19,71 @@ from typing import Any, Optional, Tuple
 
 # Ordered most-specific first; first match wins. (regex, category, hint).
 _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
-    (re.compile(r"command not found|not recognized as|: No such file or directory.*\b(sh|bash|exec)\b|executable file not found", re.I),
-     "missing_command",
-     "A required binary/command is missing. Check prerequisites first "
-     "(`which <cmd>` / install it), or use a different tool — do NOT repeat the same command."),
-    (re.compile(r"permission denied|access denied|not permitted|forbidden|refusing to write|operation not permitted|EACCES", re.I),
-     "permission",
-     "Access is denied and the agent can't elevate. Do NOT retry the same path — "
-     "use an allowed path/tool, or report exactly what access is needed."),
-    (re.compile(r"timed out|timeout|deadline exceeded|ClosedResourceError|unreachable|connection refused|ETIMEDOUT", re.I),
-     "timeout",
-     "The operation timed out / the resource is unreachable. Set it aside, route to a "
-     "fallback if one exists, and do NOT loop on health checks or retry blindly."),
-    (re.compile(r"\b(char(acter)?s?|byte)s?\b.*\b(limit|exceed|too (long|large|big)|maximum)\b|exceeds the maximum|max(imum)? (length|size)|too many tokens|context length", re.I),
-     "limit",
-     "A size/length limit was hit. Don't resend as-is — chunk the work, summarize, "
-     "or raise the relevant config limit; a near-identical retry will fail the same way."),
-    (re.compile(r"no such file or directory|not found|does not exist|cannot find|no matches found|0 results|no results", re.I),
-     "not_found",
-     "The target wasn't found. Re-check the path/name (it may be dynamic), broaden the "
-     "search, or create the prerequisite first — don't repeat the same lookup."),
-    (re.compile(r"traceback \(most recent call|exit code[:\s]+[1-9]|exit status [1-9]|non-zero exit|error:|exception|failed", re.I),
-     "runtime_error",
-     "The call errored. Read the message, fix the root cause, and CHANGE the call — "
-     "retrying the same arguments will reproduce it."),
+    (
+        re.compile(
+            r"command not found|not recognized as|: No such file or directory.*\b(sh|bash|exec)\b|executable file not found",
+            re.I,
+        ),
+        "missing_command",
+        "A required binary/command is missing. Check prerequisites first "
+        "(`which <cmd>` / install it), or use a different tool — do NOT repeat the same command.",
+    ),
+    (
+        re.compile(
+            r"permission denied|access denied|not permitted|forbidden|refusing to write|operation not permitted|EACCES",
+            re.I,
+        ),
+        "permission",
+        "Access is denied and the agent can't elevate. Do NOT retry the same path — "
+        "use an allowed path/tool, or report exactly what access is needed.",
+    ),
+    (
+        re.compile(
+            r"timed out|timeout|deadline exceeded|ClosedResourceError|unreachable|connection refused|ETIMEDOUT",
+            re.I,
+        ),
+        "timeout",
+        "The operation timed out / the resource is unreachable. Set it aside, route to a "
+        "fallback if one exists, and do NOT loop on health checks or retry blindly.",
+    ),
+    (
+        re.compile(
+            r"\b(char(acter)?s?|byte)s?\b.*\b(limit|exceed|too (long|large|big)|maximum)\b|exceeds the maximum|max(imum)? (length|size)|too many tokens|context length",
+            re.I,
+        ),
+        "limit",
+        "A size/length limit was hit. Don't resend as-is — chunk the work, summarize, "
+        "or raise the relevant config limit; a near-identical retry will fail the same way.",
+    ),
+    (
+        re.compile(
+            r"\bno results\b|\bno results found\b|duckduckgo search failed|brave search returned http|could not reach .* search|searxng returned http",
+            re.I,
+        ),
+        "provider_dead",
+        "The active search provider is not returning results. Switch to a different "
+        "search_backend in config.yaml or via hermes tools, or report the blocker "
+        "if no alternative provider is configured. Do not retry the same query with "
+        "the same provider.",
+    ),
+    (
+        re.compile(
+            r"no such file or directory|not found|does not exist|cannot find|no matches found|0 results|no results",
+            re.I,
+        ),
+        "not_found",
+        "The target wasn't found. Re-check the path/name (it may be dynamic), broaden the "
+        "search, or create the prerequisite first — don't repeat the same lookup.",
+    ),
+    (
+        re.compile(
+            r"traceback \(most recent call|exit code[:\s]+[1-9]|exit status [1-9]|non-zero exit|error:|exception|failed",
+            re.I,
+        ),
+        "runtime_error",
+        "The call errored. Read the message, fix the root cause, and CHANGE the call — "
+        "retrying the same arguments will reproduce it.",
+    ),
 )
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -137,6 +137,7 @@ def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
     except Exception:
         pass
 
+
 _IS_WINDOWS = platform.system() == "Windows"
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -180,22 +181,43 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # planting them.
 _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # Loader / linker
-    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG",
-    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
-    "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FALLBACK_FRAMEWORK_PATH",
     # Python
-    "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
-    "PYTHONEXECUTABLE", "PYTHONNOUSERSITE",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE",
+    "PYTHONNOUSERSITE",
     # Node
-    "NODE_OPTIONS", "NODE_PATH",
+    "NODE_OPTIONS",
+    "NODE_PATH",
     # General
-    "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+    "PATH",
+    "SHELL",
+    "BROWSER",
+    "EDITOR",
+    "VISUAL",
+    "PAGER",
     # Git
-    "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+    "GIT_SSH_COMMAND",
+    "GIT_EXEC_PATH",
+    "GIT_SHELL",
     # Hermes runtime location — never via dashboard env writer.
     # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
-    "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+    "HERMES_CONFIG",
+    "HERMES_ENV",
 })
 
 
@@ -214,6 +236,7 @@ def _reject_denylisted_env_var(key: str) -> None:
             "the env writer. If you really need this, edit "
             "~/.hermes/.env directly."
         )
+
 
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
@@ -242,46 +265,104 @@ _CONFIG_LOCK = threading.RLock()
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
-    "OPENAI_API_KEY", "OPENAI_BASE_URL",
-    "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
-    "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME",
-    "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME",
-    "SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME",
-    "SIGNAL_ACCOUNT", "SIGNAL_HTTP_URL",
-    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
-    "SIGNAL_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL_NAME",
-    "SMS_HOME_CHANNEL", "SMS_HOME_CHANNEL_NAME",
-    "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
-    "DINGTALK_HOME_CHANNEL", "DINGTALK_HOME_CHANNEL_NAME",
-    "FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_ENCRYPT_KEY", "FEISHU_VERIFICATION_TOKEN",
-    "FEISHU_HOME_CHANNEL", "FEISHU_HOME_CHANNEL_NAME",
-    "YUANBAO_HOME_CHANNEL", "YUANBAO_HOME_CHANNEL_NAME",
-    "WECOM_BOT_ID", "WECOM_SECRET",
-    "WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET", "WECOM_CALLBACK_AGENT_ID",
-    "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_ENCODING_AES_KEY",
-    "WECOM_CALLBACK_HOST", "WECOM_CALLBACK_PORT",
-    "WECOM_HOME_CHANNEL", "WECOM_HOME_CHANNEL_NAME",
-    "WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN", "WEIXIN_BASE_URL", "WEIXIN_CDN_BASE_URL",
-    "WEIXIN_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL_NAME", "WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY",
-    "WEIXIN_ALLOWED_USERS", "WEIXIN_GROUP_ALLOWED_USERS", "WEIXIN_ALLOW_ALL_USERS",
-    "BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD",
-    "BLUEBUBBLES_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL_NAME",
-    "QQ_APP_ID", "QQ_CLIENT_SECRET", "QQBOT_HOME_CHANNEL", "QQBOT_HOME_CHANNEL_NAME",
-    "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
-    "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
-    "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
-    "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
-    "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
-    "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SMS_HOME_CHANNEL",
+    "SMS_HOME_CHANNEL_NAME",
+    "DINGTALK_CLIENT_ID",
+    "DINGTALK_CLIENT_SECRET",
+    "DINGTALK_HOME_CHANNEL",
+    "DINGTALK_HOME_CHANNEL_NAME",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_HOME_CHANNEL",
+    "FEISHU_HOME_CHANNEL_NAME",
+    "YUANBAO_HOME_CHANNEL",
+    "YUANBAO_HOME_CHANNEL_NAME",
+    "WECOM_BOT_ID",
+    "WECOM_SECRET",
+    "WECOM_CALLBACK_CORP_ID",
+    "WECOM_CALLBACK_CORP_SECRET",
+    "WECOM_CALLBACK_AGENT_ID",
+    "WECOM_CALLBACK_TOKEN",
+    "WECOM_CALLBACK_ENCODING_AES_KEY",
+    "WECOM_CALLBACK_HOST",
+    "WECOM_CALLBACK_PORT",
+    "WECOM_HOME_CHANNEL",
+    "WECOM_HOME_CHANNEL_NAME",
+    "WEIXIN_ACCOUNT_ID",
+    "WEIXIN_TOKEN",
+    "WEIXIN_BASE_URL",
+    "WEIXIN_CDN_BASE_URL",
+    "WEIXIN_HOME_CHANNEL",
+    "WEIXIN_HOME_CHANNEL_NAME",
+    "WEIXIN_DM_POLICY",
+    "WEIXIN_GROUP_POLICY",
+    "WEIXIN_ALLOWED_USERS",
+    "WEIXIN_GROUP_ALLOWED_USERS",
+    "WEIXIN_ALLOW_ALL_USERS",
+    "BLUEBUBBLES_SERVER_URL",
+    "BLUEBUBBLES_PASSWORD",
+    "BLUEBUBBLES_HOME_CHANNEL",
+    "BLUEBUBBLES_HOME_CHANNEL_NAME",
+    "QQ_APP_ID",
+    "QQ_CLIENT_SECRET",
+    "QQBOT_HOME_CHANNEL",
+    "QQBOT_HOME_CHANNEL_NAME",
+    "QQ_HOME_CHANNEL",
+    "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
+    "QQ_ALLOWED_USERS",
+    "QQ_GROUP_ALLOWED_USERS",
+    "QQ_ALLOW_ALL_USERS",
+    "QQ_MARKDOWN_SUPPORT",
+    "QQ_STT_API_KEY",
+    "QQ_STT_BASE_URL",
+    "QQ_STT_MODEL",
+    "IRC_SERVER",
+    "IRC_PORT",
+    "IRC_NICKNAME",
+    "IRC_CHANNEL",
+    "IRC_USE_TLS",
+    "IRC_SERVER_PASSWORD",
+    "IRC_NICKSERV_PASSWORD",
+    "TERMINAL_ENV",
+    "TERMINAL_SSH_KEY",
+    "TERMINAL_SSH_PORT",
     # Deprecated tool-progress env vars — replaced by display.tool_progress in
     # config.yaml. Kept known here so .env sanitization/reload still handle
     # them for existing users (gateway reads them as a back-compat fallback),
     # without surfacing them in user-facing OPTIONAL_ENV_VARS listings.
-    "HERMES_TOOL_PROGRESS", "HERMES_TOOL_PROGRESS_MODE",
-    "WHATSAPP_MODE", "WHATSAPP_ENABLED",
-    "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
-    "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
-    "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
+    "HERMES_TOOL_PROGRESS",
+    "HERMES_TOOL_PROGRESS_MODE",
+    "WHATSAPP_MODE",
+    "WHATSAPP_ENABLED",
+    "MATTERMOST_HOME_CHANNEL",
+    "MATTERMOST_HOME_CHANNEL_NAME",
+    "MATTERMOST_REPLY_MODE",
+    "MATRIX_PASSWORD",
+    "MATRIX_ENCRYPTION",
+    "MATRIX_DEVICE_ID",
+    "MATRIX_HOME_ROOM",
+    "MATRIX_REQUIRE_MENTION",
+    "MATRIX_FREE_RESPONSE_ROOMS",
+    "MATRIX_AUTO_THREAD",
+    "MATRIX_DM_AUTO_THREAD",
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable
@@ -492,6 +573,7 @@ def is_uv_tool_install() -> bool:
     ``hermes update`` to upgrade the wrong copy. It would also block on a
     subprocess call (~seconds) just to compute a recommendation string.
     """
+
     def _has_uv_tool_marker(path: str) -> bool:
         norm = os.path.normpath(path).replace(os.sep, "/").lower()
         return "/uv/tools/hermes-agent/" in norm + "/"
@@ -515,6 +597,7 @@ def recommended_update_command_for_method(method: str) -> str:
         if is_uv_tool_install():
             return "uv tool upgrade hermes-agent"
         import shutil
+
         if shutil.which("uv"):
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
@@ -610,6 +693,7 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
         "Use your package manager to upgrade or reinstall Hermes."
     )
 
+
 def managed_error(action: str = "modify configuration"):
     """Print user-friendly error for managed mode."""
     print(format_managed_message(action), file=sys.stderr)
@@ -618,6 +702,7 @@ def managed_error(action: str = "modify configuration"):
 # =============================================================================
 # Container-aware CLI (NixOS container mode)
 # =============================================================================
+
 
 def get_container_exec_info() -> Optional[dict]:
     """Read container mode metadata from HERMES_HOME/.container-mode.
@@ -634,6 +719,7 @@ def get_container_exec_info() -> Optional[dict]:
         return None
 
     from hermes_constants import is_container
+
     if is_container():
         return None
 
@@ -672,17 +758,21 @@ def get_container_exec_info() -> Optional[dict]:
 from hermes_constants import get_hermes_home  # noqa: F811,E402
 from utils import atomic_replace
 
+
 def get_config_path() -> Path:
     """Get the main config file path."""
     return get_hermes_home() / "config.yaml"
+
 
 def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""
     return get_hermes_home() / ".env"
 
+
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
 
 def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
     """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.
@@ -793,7 +883,11 @@ def _is_container() -> bool:
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup_content = f.read()
-        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
+        if (
+            "docker" in cgroup_content
+            or "lxc" in cgroup_content
+            or "kubepods" in cgroup_content
+        ):
             return True
     except (OSError, IOError):
         pass
@@ -845,8 +939,16 @@ def ensure_hermes_home():
         home.mkdir(parents=True, exist_ok=True)
         _secure_dir(home)
         for subdir in (
-            "cron", "sessions", "logs", "logs/curator", "memories",
-            "pairing", "hooks", "image_cache", "audio_cache", "skills",
+            "cron",
+            "sessions",
+            "logs",
+            "logs/curator",
+            "memories",
+            "pairing",
+            "hooks",
+            "image_cache",
+            "audio_cache",
+            "skills",
         ):
             d = home / subdir
             d.mkdir(parents=True, exist_ok=True)
@@ -858,15 +960,13 @@ def _ensure_hermes_home_managed(home: Path):
     """Managed-mode variant: verify dirs exist (activation creates them), seed SOUL.md."""
     if not home.is_dir():
         raise RuntimeError(
-            f"HERMES_HOME {home} does not exist. "
-            "Run 'sudo nixos-rebuild switch' first."
+            f"HERMES_HOME {home} does not exist. Run 'sudo nixos-rebuild switch' first."
         )
     for subdir in ("cron", "sessions", "logs", "memories"):
         d = home / subdir
         if not d.is_dir():
             raise RuntimeError(
-                f"{d} does not exist. "
-                "Run 'sudo nixos-rebuild switch' first."
+                f"{d} does not exist. Run 'sudo nixos-rebuild switch' first."
             )
     # Curator reports dir is a sub-path of logs/; create it if missing.
     # In managed mode the activation script may not know about this subdir,
@@ -1015,7 +1115,6 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
     },
-    
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",
@@ -1077,9 +1176,9 @@ DEFAULT_CONFIG = {
         "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         # Container resource limits (docker, singularity, modal, daytona — ignored for local/ssh)
         "container_cpu": 1,
-        "container_memory": 5120,       # MB (default 5GB)
-        "container_disk": 51200,        # MB (default 50GB)
-        "container_persistent": True,   # Persist filesystem across sessions
+        "container_memory": 5120,  # MB (default 5GB)
+        "container_disk": 51200,  # MB (default 50GB)
+        "container_persistent": True,  # Persist filesystem across sessions
         # Docker volume mounts — share host directories with the container.
         # Each entry is "host_path:container_path" (standard Docker -v syntax).
         # Example:
@@ -1091,7 +1190,7 @@ DEFAULT_CONFIG = {
         # Explicit opt-in: mount the host cwd into /workspace for Docker sessions.
         # Default off because passing host directories into a sandbox weakens isolation.
         "docker_mount_cwd_to_workspace": False,
-        "docker_extra_args": [],        # Extra flags passed verbatim to docker run
+        "docker_extra_args": [],  # Extra flags passed verbatim to docker run
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)
@@ -1109,13 +1208,12 @@ DEFAULT_CONFIG = {
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
     },
-
     "web": {
-        "backend": "",           # shared fallback — applies to both search and extract
-        "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
-        "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "backend": "",  # shared fallback — applies to both search and extract
+        "search_backend": "",  # per-capability override for web_search (e.g. "searxng")
+        "extract_backend": "",  # per-capability override for web_extract (e.g. "native")
+        "search_backend_fallback_chain": "",
     },
-
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
@@ -1154,7 +1252,6 @@ DEFAULT_CONFIG = {
             "loopback_host_alias": "host.docker.internal",
         },
     },
-
     # Filesystem checkpoints — automatic snapshots before destructive file ops.
     # When enabled, the agent takes a snapshot of the working directory once
     # per conversation turn (on first write_file/patch call).  Use /rollback
@@ -1193,7 +1290,6 @@ DEFAULT_CONFIG = {
         "delete_orphans": True,
         "min_interval_hours": 24,
     },
-
     # Hard cap (chars) for a single automatic context file such as SOUL.md,
     # AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Hermes applies
     # head/tail truncation. ``null`` (the default) lets the cap scale with the
@@ -1201,12 +1297,10 @@ DEFAULT_CONFIG = {
     # rarely truncate a project doc. Set a positive integer to pin a fixed cap
     # and override the dynamic behavior. Separate from read_file tool limits.
     "context_file_max_chars": None,
-
     # Maximum characters returned by a single read_file call.  Reads that
     # exceed this are rejected with guidance to use offset+limit.
     # 100K chars ≈ 25–35K tokens across typical tokenisers.
     "file_read_max_chars": 100_000,
-
     # Seconds to wait at agent-build time for in-flight MCP server discovery
     # to finish before the agent snapshots its tool list.  MCP discovery runs
     # in a background thread so a slow/dead server can't freeze startup; this
@@ -1221,7 +1315,6 @@ DEFAULT_CONFIG = {
     # (see agent/turn_context.py), so correctness never depends on it.  Keep it
     # small so a slow/dead server adds little to first-response latency.
     "mcp_discovery_timeout": 1.5,
-
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the
     # payload sent to the model (keeping head + tail for terminal,
@@ -1241,7 +1334,6 @@ DEFAULT_CONFIG = {
         "max_lines": 2000,
         "max_line_length": 2000,
     },
-
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
@@ -1259,7 +1351,6 @@ DEFAULT_CONFIG = {
             "idempotent_no_progress": 5,
         },
     },
-
     # Pluggable, deterministic per-policy interceptors that run before tool
     # execution, alongside the loop guardrails above. Each named policy can
     # allow / deny / rewrite a tool call. Disabled by default (opt-in); a
@@ -1273,58 +1364,56 @@ DEFAULT_CONFIG = {
             # {"policy": "deny_tools", "options": {"tools": []}},
         ],
     },
-
     "compression": {
         "enabled": True,
-        "threshold": 0.50,            # compress when context usage exceeds this ratio
-        "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
-        "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "threshold": 0.50,  # compress when context usage exceeds this ratio
+        "target_ratio": 0.20,  # fraction of threshold to preserve as recent tail
+        "protect_last_n": 20,  # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
-        "protect_first_n": 3,         # non-system head messages always preserved
-                                      # verbatim, in ADDITION to the system prompt
-                                      # (which is always implicitly protected). Set to
-                                      # 0 for long-running rolling-compaction sessions
-                                      # where you want nothing pinned except the
-                                      # system prompt + rolling summary + recent tail.
+        "protect_first_n": 3,  # non-system head messages always preserved
+        # verbatim, in ADDITION to the system prompt
+        # (which is always implicitly protected). Set to
+        # 0 for long-running rolling-compaction sessions
+        # where you want nothing pinned except the
+        # system prompt + rolling summary + recent tail.
         "abort_on_summary_failure": False,  # When True, auto-compression that fails
-                                      # to generate a summary (aux LLM errored / returned
-                                      # non-JSON / timed out) aborts entirely instead of
-                                      # dropping the middle window with a static
-                                      # "summary unavailable" placeholder.  Messages are
-                                      # preserved unchanged and the session "freezes" at
-                                      # its current size until the user runs /compress
-                                      # (which bypasses the failure cooldown) or /new.
-                                      # Default False matches historical behavior; set to
-                                      # True if you'd rather pause than silently lose
-                                      # context turns when your aux model is flaky.
+        # to generate a summary (aux LLM errored / returned
+        # non-JSON / timed out) aborts entirely instead of
+        # dropping the middle window with a static
+        # "summary unavailable" placeholder.  Messages are
+        # preserved unchanged and the session "freezes" at
+        # its current size until the user runs /compress
+        # (which bypasses the failure cooldown) or /new.
+        # Default False matches historical behavior; set to
+        # True if you'd rather pause than silently lose
+        # context turns when your aux model is flaky.
         "codex_gpt55_autoraise": True,  # When True, gpt-5.5 on the ChatGPT Codex OAuth
-                                      # route raises its compaction trigger to 85% (vs the
-                                      # global `threshold` above). Codex hard-caps gpt-5.5
-                                      # at a 272K window, so the default 50% would compact
-                                      # at ~136K and waste half the usable context. Set to
-                                      # False to opt back down to the global threshold
-                                      # (e.g. 0.50) for Codex gpt-5.5 sessions. Only this
-                                      # exact route is affected — gpt-5.5 on OpenAI's
-                                      # direct API, OpenRouter, and Copilot keep the
-                                      # global threshold regardless.
-        "in_place": False,            # When True, compaction rewrites the message
-                                      # list and rebuilds the system prompt WITHOUT
-                                      # rotating the session id — the conversation
-                                      # keeps one durable id for its whole life
-                                      # (no parent_session_id chain, no `name #N`
-                                      # renumbering). Eliminates the session-rotation
-                                      # bug cluster (#33618 /goal loss, #14238 lost
-                                      # response, #33907 orphans, #45117 search gaps,
-                                      # #42228 null cwd) — see #38763. Non-destructive:
-                                      # the live context is compacted (lossy for what
-                                      # the model reloads), but the pre-compaction
-                                      # turns are soft-archived under the same id
-                                      # (active=0, compacted=1) — still searchable via
-                                      # session_search and recoverable, not deleted.
-                                      # Default False during rollout; will flip on
-                                      # after live validation.
+        # route raises its compaction trigger to 85% (vs the
+        # global `threshold` above). Codex hard-caps gpt-5.5
+        # at a 272K window, so the default 50% would compact
+        # at ~136K and waste half the usable context. Set to
+        # False to opt back down to the global threshold
+        # (e.g. 0.50) for Codex gpt-5.5 sessions. Only this
+        # exact route is affected — gpt-5.5 on OpenAI's
+        # direct API, OpenRouter, and Copilot keep the
+        # global threshold regardless.
+        "in_place": False,  # When True, compaction rewrites the message
+        # list and rebuilds the system prompt WITHOUT
+        # rotating the session id — the conversation
+        # keeps one durable id for its whole life
+        # (no parent_session_id chain, no `name #N`
+        # renumbering). Eliminates the session-rotation
+        # bug cluster (#33618 /goal loss, #14238 lost
+        # response, #33907 orphans, #45117 search gaps,
+        # #42228 null cwd) — see #38763. Non-destructive:
+        # the live context is compacted (lossy for what
+        # the model reloads), but the pre-compaction
+        # turns are soft-archived under the same id
+        # (active=0, compacted=1) — still searchable via
+        # session_search and recoverable, not deleted.
+        # Default False during rollout; will flip on
+        # after live validation.
     },
-
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).
     # See tools/kanban_tools.py and hermes_cli/kanban_db.py for the actual
     # implementations. Per-platform notification opt-out is handled by the
@@ -1339,13 +1428,11 @@ DEFAULT_CONFIG = {
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
     },
-
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
         "cache_ttl": "5m",
     },
-
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).
@@ -1366,14 +1453,13 @@ DEFAULT_CONFIG = {
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
     },
-
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {
         "region": "",  # AWS region for Bedrock API calls (empty = AWS_REGION env var → us-east-1)
         "discovery": {
-            "enabled": True,           # Auto-discover models via ListFoundationModels
-            "provider_filter": [],     # Only show models from these providers (e.g. ["anthropic", "amazon"])
+            "enabled": True,  # Auto-discover models via ListFoundationModels
+            "provider_filter": [],  # Only show models from these providers (e.g. ["anthropic", "amazon"])
             "refresh_interval": 3600,  # Cache discovery results for this many seconds
         },
         "guardrail": {
@@ -1381,12 +1467,11 @@ DEFAULT_CONFIG = {
             # Create a guardrail in the Bedrock console, then set the ID and version here.
             # See: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
             "guardrail_identifier": "",  # e.g. "abc123def456"
-            "guardrail_version": "",     # e.g. "1" or "DRAFT"
+            "guardrail_version": "",  # e.g. "1" or "DRAFT"
             "stream_processing_mode": "async",  # "sync" or "async"
-            "trace": "disabled",         # "enabled", "disabled", or "enabled_full"
+            "trace": "disabled",  # "enabled", "disabled", or "enabled_full"
         },
     },
-
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
@@ -1415,12 +1500,12 @@ DEFAULT_CONFIG = {
     # openrouter.min_coding_score do NOT propagate to aux calls by design.
     "auxiliary": {
         "vision": {
-            "provider": "auto",    # auto | openrouter | nous | codex | custom
-            "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
-            "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
-            "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
-            "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
-            "extra_body": {},      # OpenAI-compatible provider-specific request fields
+            "provider": "auto",  # auto | openrouter | nous | codex | custom
+            "model": "",  # e.g. "google/gemini-2.5-flash", "gpt-4o"
+            "base_url": "",  # direct OpenAI-compatible endpoint (takes precedence over provider)
+            "api_key": "",  # API key for base_url (falls back to OPENAI_API_KEY)
+            "timeout": 120,  # seconds — LLM API call timeout; vision payloads need generous timeout
+            "extra_body": {},  # OpenAI-compatible provider-specific request fields
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
         "web_extract": {
@@ -1428,7 +1513,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
+            "timeout": 360,  # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
             "extra_body": {},
         },
         "compression": {
@@ -1436,7 +1521,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 120,  # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —
@@ -1453,7 +1538,7 @@ DEFAULT_CONFIG = {
         },
         "approval": {
             "provider": "auto",
-            "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)
+            "model": "",  # fast/cheap model recommended (e.g. gemini-flash, haiku)
             "base_url": "",
             "api_key": "",
             "timeout": 30,
@@ -1569,7 +1654,6 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
     },
-    
     "display": {
         "compact": False,
         "personality": "",
@@ -1577,10 +1661,10 @@ DEFAULT_CONFIG = {
         # Recap tuning for /resume and startup resume. The defaults match the
         # historical hardcoded values; expose them as config so power users can
         # widen or tighten the snapshot to taste.
-        "resume_exchanges": 10,            # max user+assistant pairs to show
-        "resume_max_user_chars": 300,      # truncate user message text
-        "resume_max_assistant_chars": 200, # truncate non-last assistant text
-        "resume_max_assistant_lines": 3,   # truncate non-last assistant lines
+        "resume_exchanges": 10,  # max user+assistant pairs to show
+        "resume_max_user_chars": 300,  # truncate user message text
+        "resume_max_assistant_chars": 200,  # truncate non-last assistant text
+        "resume_max_assistant_lines": 3,  # truncate non-last assistant lines
         # When True (default), assistant entries that are *only* tool calls
         # (no visible text) are skipped in the recap. This prevents the recap
         # from being dominated by `[2 tool calls: terminal, read_file]` lines
@@ -1617,7 +1701,7 @@ DEFAULT_CONFIG = {
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
         "streaming": False,
-        "timestamps": False,      # Show [HH:MM] on user and assistant labels
+        "timestamps": False,  # Show [HH:MM] on user and assistant labels
         "final_response_markdown": "strip",  # render | strip | raw
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator
@@ -1628,7 +1712,7 @@ DEFAULT_CONFIG = {
         # clarify) into scrollback so the question and decision survive the
         # panel repaint. Set false to keep scrollback untouched.
         "persist_prompts": True,
-        "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        "inline_diffs": True,  # Show inline diff previews for write actions (write_file, patch, skill_manage)
         # File-mutation verifier footer.  When true (default), the agent
         # appends a one-line advisory to its final response whenever a
         # write_file / patch call failed during the turn and was never
@@ -1649,7 +1733,7 @@ DEFAULT_CONFIG = {
         # iteration/budget limit.  Replaces the bare "(empty)" sentinel so the
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
-        "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "show_cost": False,  # Show $ cost in the status bar (off by default)
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
@@ -1726,7 +1810,6 @@ DEFAULT_CONFIG = {
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
-
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
@@ -1812,12 +1895,10 @@ DEFAULT_CONFIG = {
         # the login flow.
         "public_url": "",
     },
-
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
-    
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
@@ -1863,7 +1944,7 @@ DEFAULT_CONFIG = {
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
-            "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
+            "ref_text": "",  # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
         },
@@ -1881,7 +1962,6 @@ DEFAULT_CONFIG = {
             # "normalize_audio": True,
         },
     },
-    
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
@@ -1902,22 +1982,19 @@ DEFAULT_CONFIG = {
             "diarize": False,
         },
     },
-
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
-        "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
-        "silence_threshold": 200,     # RMS below this = silence (0-32767)
-        "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "beep_enabled": True,  # Play record start/stop beeps in CLI voice mode
+        "silence_threshold": 200,  # RMS below this = silence (0-32767)
+        "silence_duration": 3.0,  # Seconds of silence before auto-stop
     },
-    
     "human_delay": {
         "mode": "off",
         "min_ms": 800,
         "max_ms": 2500,
     },
-    
     # Context engine -- controls how the context window is managed when
     # approaching the model's token limit.
     # "compressor" = built-in lossy summarization (default).
@@ -1927,7 +2004,6 @@ DEFAULT_CONFIG = {
     "context": {
         "engine": "compressor",
     },
-
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,
@@ -1945,8 +2021,8 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 2200,  # ~800 tokens at 2.75 chars/token
+        "user_char_limit": 1375,  # ~500 tokens at 2.75 chars/token
         # Allow per-apply_batch memory_char_limit overrides when explicitly
         # enabled (issue #517). Default False so dynamic limit changes cannot
         # silently alter the configured budget or invalidate the per-conversation
@@ -1976,20 +2052,19 @@ DEFAULT_CONFIG = {
         # Only ONE external provider is allowed at a time.
         "provider": "",
     },
-
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
     "delegation": {
-        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
-        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
-        "base_url": "",    # direct OpenAI-compatible endpoint for subagents
-        "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
-        "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",
-                           # "codex_responses", or "anthropic_messages". Empty = auto-detect
-                           # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
-                           # explicitly for non-standard endpoints the heuristic can't detect.
+        "model": "",  # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
+        "provider": "",  # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "base_url": "",  # direct OpenAI-compatible endpoint for subagents
+        "api_key": "",  # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "api_mode": "",  # wire protocol for delegation.base_url: "chat_completions",
+        # "codex_responses", or "anthropic_messages". Empty = auto-detect
+        # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
+        # explicitly for non-standard endpoints the heuristic can't detect.
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these
@@ -1997,20 +2072,20 @@ DEFAULT_CONFIG = {
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
-                               # independent of the parent's max_iterations)
+        # independent of the parent's max_iterations)
         "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
-                                     # = no timeout: children fail only from real errors
-                                     # (API, tools, iteration budget), never a delegation
-                                     # stopwatch. Set a positive number of seconds
-                                     # (floor 30s) to enforce a hard cap.
+        # = no timeout: children fail only from real errors
+        # (API, tools, iteration budget), never a delegation
+        # stopwatch. Set a positive number of seconds
+        # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
-                                 # "low", "minimal", "none" (empty = inherit parent's level)
+        # "low", "minimal", "none" (empty = inherit parent's level)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         "max_async_children": 3,  # max concurrent background (background=true) subagents; new dispatches rejected at capacity
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.
-        "max_spawn_depth": 1,        # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
+        "max_spawn_depth": 1,  # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
         "orchestrator_enabled": True,  # kill switch for role="orchestrator"
         # When a subagent hits a dangerous-command approval prompt, the parent's
         # prompt_toolkit TUI owns stdin — a thread-local input() call from the
@@ -2022,12 +2097,10 @@ DEFAULT_CONFIG = {
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
     },
-
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
     "prefill_messages_file": "",
-
     # Goals — persistent cross-turn goals (Ralph-style loop).
     # After every turn, a lightweight judge call asks the auxiliary model
     # whether the active /goal is satisfied by the assistant's last
@@ -2043,12 +2116,11 @@ DEFAULT_CONFIG = {
         # unbounded model spend on fuzzy / unachievable goals.
         "max_turns": 20,
     },
-
     # Skills — external skill directories for sharing skills across tools/agents.
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
     # always goes to ~/.hermes/skills/.
     "skills": {
-        "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "external_dirs": [],  # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
@@ -2087,7 +2159,6 @@ DEFAULT_CONFIG = {
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
     },
-
     # Curator — background skill maintenance.
     #
     # Periodically reviews AGENT-CREATED skills (never bundled or
@@ -2137,35 +2208,31 @@ DEFAULT_CONFIG = {
             "keep": 5,  # retain last N regular snapshots
         },
     },
-
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
     # This section is only needed for hermes-specific overrides; everything else
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
     "honcho": {},
-
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.
     "timezone": "",
-
     # Slack platform settings (gateway mode)
     "slack": {
-        "require_mention": True,       # Require @mention to respond in channels
+        "require_mention": True,  # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},  # Per-channel ephemeral system prompts
     },
-
     # Discord platform settings (gateway mode)
     "discord": {
-        "require_mention": True,       # Require @mention to respond in server channels
+        "require_mention": True,  # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "auto_thread": True,  # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
-        "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
-        "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
-        "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "history_backfill": True,  # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
+        "history_backfill_limit": 50,  # Max number of recent messages to scan when assembling the backfill block
+        "reactions": True,  # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},  # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
@@ -2198,14 +2265,14 @@ DEFAULT_CONFIG = {
         # stop-and-swap — the Grok-voice-mode feel. discord.py ships no mixer;
         # this is implemented in plugins/platforms/discord/voice_mixer.py.
         "voice_fx": {
-            "enabled": False,         # master switch for the mixer subsystem
+            "enabled": False,  # master switch for the mixer subsystem
             "ambient_enabled": True,  # play the idle "thinking" bed while tools run
-            "ambient_path": "",       # custom loop audio file; "" = synthesised pad
-            "ambient_gain": 0.18,     # idle bed loudness, 0.0–1.0
-            "duck_gain": 0.06,        # ambient loudness while speech plays
-            "speech_gain": 1.0,       # TTS / ack loudness, 0.0–1.0
-            "ack_enabled": True,      # speak a short phrase before the first tool call
-            "ack_phrases": [          # picked at random; set [] to disable phrases
+            "ambient_path": "",  # custom loop audio file; "" = synthesised pad
+            "ambient_gain": 0.18,  # idle bed loudness, 0.0–1.0
+            "duck_gain": 0.06,  # ambient loudness while speech plays
+            "speech_gain": 1.0,  # TTS / ack loudness, 0.0–1.0
+            "ack_enabled": True,  # speak a short phrase before the first tool call
+            "ack_phrases": [  # picked at random; set [] to disable phrases
                 "Let me look into that.",
                 "One moment.",
                 "Checking on that now.",
@@ -2214,7 +2281,6 @@ DEFAULT_CONFIG = {
             ],
         },
     },
-
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.
@@ -2222,32 +2288,28 @@ DEFAULT_CONFIG = {
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
     },
-
     # Telegram platform settings (gateway mode)
     "telegram": {
-        "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
-        "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
-        "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "reactions": False,  # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},  # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "allowed_chats": "",  # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
-            "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
+            "rich_messages": False,  # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
         },
     },
-
     # Mattermost platform settings (gateway mode)
     "mattermost": {
-        "require_mention": True,       # Require @mention to respond in channels
+        "require_mention": True,  # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},  # Per-channel ephemeral system prompts
     },
-
     # Matrix platform settings (gateway mode)
     "matrix": {
-        "require_mention": True,       # Require @mention to respond in rooms
-        "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
-        "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        "require_mention": True,  # Require @mention to respond in rooms
+        "free_response_rooms": "",  # Comma-separated room IDs where bot responds without mention
+        "allowed_rooms": "",  # If set, bot ONLY responds in these room IDs (whitelist)
     },
-
     # Approval mode for dangerous commands:
     #   manual — always prompt the user (default)
     #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
@@ -2278,12 +2340,10 @@ DEFAULT_CONFIG = {
         # opt out there).
         "destructive_slash_confirm": True,
     },
-
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
-
     # Per-platform system-prompt hint overrides. Lets an admin append to or
     # replace Hermes' built-in platform hint for a single messaging platform
     # (WhatsApp, Slack, Telegram, ...) without affecting other platforms.
@@ -2299,7 +2359,6 @@ DEFAULT_CONFIG = {
     #         When tabular output would be useful, invoke the
     #         table_formatting skill instead of emitting a Markdown table.
     "platform_hints": {},
-
     # Shell-script hooks — declarative bridge that invokes shell scripts
     # on plugin-hook events (pre_tool_call, post_tool_call, pre_llm_call,
     # subagent_stop, etc.).  Each entry maps an event name to a list of
@@ -2308,7 +2367,6 @@ DEFAULT_CONFIG = {
     # stored approval from ~/.hermes/shell-hooks-allowlist.json.
     # See `website/docs/user-guide/features/hooks.md` for schema + examples.
     "hooks": {},
-
     # Auto-accept shell-hook registrations without a TTY prompt.  Also
     # toggleable per-invocation via --accept-hooks or HERMES_ACCEPT_HOOKS=1.
     # Gateway / cron / non-interactive runs need this (or one of the other
@@ -2318,7 +2376,6 @@ DEFAULT_CONFIG = {
     # Supports string format: {"name": "system prompt"}
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
     "personalities": {},
-
     # Pre-exec security scanning via tirith
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
@@ -2348,7 +2405,6 @@ DEFAULT_CONFIG = {
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
     },
-
     "cron": {
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
@@ -2391,7 +2447,6 @@ DEFAULT_CONFIG = {
         # messages. No env var — config.yaml is the canonical UI.
         "failure_digest": False,
     },
-
     # Kanban multi-agent coordination — controls the dispatcher loop that
     # spawns workers for ready tasks. The dispatcher ticks every N seconds
     # (default 60), reclaims stale claims, promotes dependency-satisfied
@@ -2452,7 +2507,6 @@ DEFAULT_CONFIG = {
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
     },
-
     # execute_code settings — controls the tool used for programmatic tool calls.
     "code_execution": {
         # Execution mode:
@@ -2466,7 +2520,6 @@ DEFAULT_CONFIG = {
         # tool whitelist apply identically in both modes.
         "mode": "project",
     },
-
     # Tool Search (progressive disclosure for large tool surfaces).
     # When the model is connected to many MCP servers or non-core plugin
     # tools, their JSON schemas can consume a substantial fraction of the
@@ -2498,15 +2551,13 @@ DEFAULT_CONFIG = {
             "max_search_limit": 20,
         },
     },
-
     # Logging — controls file logging to ~/.hermes/logs/.
     # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
     "logging": {
-        "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
-        "max_size_mb": 5,      # Max size per log file before rotation
-        "backup_count": 3,     # Number of rotated backup files to keep
+        "level": "INFO",  # Minimum level for agent.log: DEBUG, INFO, WARNING
+        "max_size_mb": 5,  # Max size per log file before rotation
+        "backup_count": 3,  # Number of rotated backup files to keep
     },
-
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches
     # curated model lists for OpenRouter and Nous Portal from this URL,
     # falling back to the in-repo snapshot on network failure.  Lets us
@@ -2527,7 +2578,6 @@ DEFAULT_CONFIG = {
         #       url: https://example.com/my-curation.json
         "providers": {},
     },
-
     # Network settings — workarounds for connectivity issues.
     "network": {
         # Force IPv4 connections.  On servers with broken or unreachable IPv6,
@@ -2535,7 +2585,6 @@ DEFAULT_CONFIG = {
         # before falling back to IPv4.  Set to true to skip IPv6 entirely.
         "force_ipv4": False,
     },
-
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
@@ -2549,7 +2598,6 @@ DEFAULT_CONFIG = {
         "message_timestamps": {
             "enabled": False,
         },
-
         # Maximum bytes for an inbound image / audio / video payload the
         # gateway will buffer into memory and cache to disk. Inbound media is
         # read fully into RAM before being written, so an unbounded upload
@@ -2559,7 +2607,6 @@ DEFAULT_CONFIG = {
         # (gateway/platforms/base.py), so the cap holds across every platform
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
-
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,
@@ -2597,7 +2644,6 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
-
         # OpenAI-compatible API server platform
         # (gateway/platforms/api_server.py).
         "api_server": {
@@ -2610,7 +2656,6 @@ DEFAULT_CONFIG = {
             "max_concurrent_runs": 10,
         },
     },
-
     # Real-time token streaming to messaging platforms (Telegram, Discord,
     # Slack, etc.). Read at the top level by the gateway; absent this block the
     # gateway falls back to these same defaults, so adding it here only makes
@@ -2649,7 +2694,6 @@ DEFAULT_CONFIG = {
         # completion time. Telegram only; other platforms ignore it.
         "fresh_final_after_seconds": 0.0,
     },
-
     # Session storage — controls automatic cleanup of ~/.hermes/state.db.
     # state.db accumulates every session, message, tool call, and FTS5 index
     # entry forever.  Without auto-pruning, a heavy user (gateway + cron)
@@ -2686,7 +2730,6 @@ DEFAULT_CONFIG = {
         # tool that consumes the JSON files directly.
         "write_json_snapshots": False,
     },
-
     # Contextual first-touch onboarding hints (see agent/onboarding.py).
     # Each hint is shown once per install and then latched here so it
     # never fires again.  Users can wipe the section to re-see all hints.
@@ -2699,7 +2742,6 @@ DEFAULT_CONFIG = {
         # The offer fires at most once (latched under onboarding.seen).
         "profile_build": "ask",
     },
-
     # ``hermes update`` behaviour.
     "updates": {
         # Run a full ``hermes backup``-style zip of HERMES_HOME before every
@@ -2735,7 +2777,6 @@ DEFAULT_CONFIG = {
         #               are never touched.
         "non_interactive_local_changes": "stash",
     },
-
     # Language Server Protocol — semantic diagnostics from real
     # language servers (pyright, gopls, rust-analyzer, etc.) wired
     # into the post-write lint check used by ``write_file`` and
@@ -2752,21 +2793,18 @@ DEFAULT_CONFIG = {
         # subsystem — no servers spawn, no background event loop, no
         # cost.
         "enabled": True,
-
         # Diagnostic-wait mode for the post-write check.
         # ``"document"`` waits up to ``wait_timeout`` seconds for the
         # current file's diagnostics; ``"full"`` additionally requests
         # workspace-wide diagnostics (slower).
         "wait_mode": "document",
         "wait_timeout": 5.0,
-
         # How to handle missing server binaries.
         # ``"auto"`` — try to install via npm/go/pip into
         #              ``<HERMES_HOME>/lsp/bin/`` on first use.
         # ``"manual"`` — only use binaries already on PATH.
         # ``"off"`` — alias for ``manual``.
         "install_strategy": "auto",
-
         # Per-server overrides.  Each key is a server_id from the
         # registry (``pyright``, ``typescript``, ``gopls``,
         # ``rust-analyzer``, etc.) and accepts:
@@ -2782,8 +2820,6 @@ DEFAULT_CONFIG = {
         # setups.
         "servers": {},
     },
-
-
     # X (Twitter) Search via xAI's built-in x_search Responses tool.
     # The tool registers when xAI credentials are available (SuperGrok
     # OAuth or XAI_API_KEY) AND the x_search toolset is enabled in
@@ -2800,7 +2836,6 @@ DEFAULT_CONFIG = {
         # Each retry backs off (1.5x attempt seconds, capped at 5s).
         "retries": 2,
     },
-
     # =========================================================================
     # External secret sources
     # =========================================================================
@@ -2839,7 +2874,6 @@ DEFAULT_CONFIG = {
             "server_url": "",
         },
     },
-
     # Paste collapse thresholds (TUI + CLI).
     #
     # paste_collapse_threshold (default 5)
@@ -2860,7 +2894,6 @@ DEFAULT_CONFIG = {
     "paste_collapse_threshold": 5,
     "paste_collapse_threshold_fallback": 5,
     "paste_collapse_char_threshold": 2000,
-
     # Computer Use (cua-driver) toolset settings.
     "computer_use": {
         # cua-driver ships with anonymous usage telemetry (PostHog) ENABLED
@@ -2871,8 +2904,6 @@ DEFAULT_CONFIG = {
         # to let cua-driver use its own default (telemetry on).
         "cua_telemetry": False,
     },
-
-
     # Config schema version - bump this when adding new required fields
     "_config_version": 30,
 }
@@ -2884,10 +2915,21 @@ DEFAULT_CONFIG = {
 # Track which env vars were introduced in each config version.
 # Migration only mentions vars new since the user's previous version.
 ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
-    3: ["FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID", "FAL_KEY"],
+    3: [
+        "FIRECRAWL_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "FAL_KEY",
+    ],
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
-    5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
-        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    5: [
+        "WHATSAPP_ENABLED",
+        "WHATSAPP_MODE",
+        "WHATSAPP_ALLOWED_USERS",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_ALLOWED_USERS",
+    ],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
 }
@@ -3272,7 +3314,6 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
-
     # ── Tool API keys ──
     "EXA_API_KEY": {
         "description": "Exa API key for AI-native web search and contents",
@@ -3397,7 +3438,12 @@ OPTIONAL_ENV_VARS = {
         "description": "Browser engine for local mode: auto (default Chrome), lightpanda (faster, no screenshots), chrome",
         "prompt": "Browser engine (auto/lightpanda/chrome)",
         "url": "https://github.com/vercel-labs/agent-browser",
-        "tools": ["browser_navigate", "browser_snapshot", "browser_click", "browser_vision"],
+        "tools": [
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_vision",
+        ],
         "password": False,
         "category": "tool",
         "advanced": True,
@@ -3456,7 +3502,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-
     # ── Bundled skills (opt-in: only needed if the user uses that skill) ──
     # These use category="skill" (distinct from "tool") so the sandbox
     # env blocklist in tools/environments/local.py does NOT rewrite them —
@@ -3494,7 +3539,6 @@ OPTIONAL_ENV_VARS = {
         "category": "skill",
         "advanced": True,
     },
-
     # ── Honcho ──
     "HONCHO_API_KEY": {
         "description": "Honcho API key for AI-native persistent memory",
@@ -3509,7 +3553,6 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
     },
-
     # ── Langfuse observability ──
     "HERMES_LANGFUSE_PUBLIC_KEY": {
         "description": "Langfuse project public key (pk-lf-...)",
@@ -3533,7 +3576,6 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
-
     # ── Messaging platforms ──
     "TELEGRAM_BOT_TOKEN": {
         "description": "Telegram bot token from @BotFather",
@@ -3578,8 +3620,8 @@ OPTIONAL_ENV_VARS = {
     },
     "SLACK_BOT_TOKEN": {
         "description": "Slack bot token (xoxb-). Get from OAuth & Permissions after installing your app. "
-                       "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
-                       "im:history, im:read, im:write, users:read, files:read, files:write",
+        "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
+        "im:history, im:read, im:write, users:read, files:read, files:write",
         "prompt": "Slack Bot Token (xoxb-...)",
         "help": "In your Slack app, add the required bot scopes, install the app to the workspace, then copy OAuth & Permissions > Bot User OAuth Token.",
         "url": "https://api.slack.com/apps",
@@ -3588,8 +3630,8 @@ OPTIONAL_ENV_VARS = {
     },
     "SLACK_APP_TOKEN": {
         "description": "Slack app-level token (xapp-) for Socket Mode. Get from Basic Information → "
-                       "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
-                       "message.channels, message.groups, app_mention",
+        "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
+        "message.channels, message.groups, app_mention",
         "prompt": "Slack App Token (xapp-...)",
         "help": "In your Slack app, enable Socket Mode, then create Basic Information > App-Level Tokens with the connections:write scope.",
         "url": "https://api.slack.com/apps",
@@ -3905,7 +3947,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "messaging",
     },
-
     # ── Agent settings ──
     # NOTE: MESSAGING_CWD was removed here — use terminal.cwd in config.yaml
     # instead.  The gateway reads TERMINAL_CWD (bridged from terminal.cwd).
@@ -3946,22 +3987,22 @@ OPTIONAL_ENV_VARS = {
 def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     """
     Check which environment variables are missing.
-    
+
     Returns list of dicts with var info for missing variables.
     """
     missing = []
-    
+
     # Check required vars
     for var_name, info in REQUIRED_ENV_VARS.items():
         if not get_env_value(var_name):
             missing.append({"name": var_name, **info, "is_required": True})
-    
+
     # Check optional vars (if not required_only)
     if not required_only:
         for var_name, info in OPTIONAL_ENV_VARS.items():
             if not get_env_value(var_name):
                 missing.append({"name": var_name, **info, "is_required": False})
-    
+
     return missing
 
 
@@ -4043,7 +4084,7 @@ def clear_model_endpoint_credentials(
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
-    
+
     Walks the DEFAULT_CONFIG tree at arbitrary depth and reports any keys
     present in defaults but absent from the user's loaded config.
     """
@@ -4052,7 +4093,7 @@ def get_missing_config_fields() -> List[Dict[str, Any]]:
 
     def _check(defaults: dict, current: dict, prefix: str = ""):
         for key, default_value in defaults.items():
-            if key.startswith('_'):
+            if key.startswith("_"):
                 continue
             full_key = key if not prefix else f"{prefix}.{key}"
             if key not in current:
@@ -4076,7 +4117,10 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     config.yaml.  Returns a list of dicts suitable for prompting.
     """
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, SKILL_CONFIG_PREFIX
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            SKILL_CONFIG_PREFIX,
+        )
     except Exception:
         return []
 
@@ -4087,6 +4131,7 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
         # should never break `hermes update`.  Skill-config prompting is a
         # post-migration nicety, not a blocker.
         import logging
+
         logging.getLogger(__name__).debug(
             "discover_all_skill_config_vars failed: %s", e
         )
@@ -4141,26 +4186,42 @@ def _normalize_custom_provider_entry(
     if "api_key_env" in entry and "key_env" not in entry:
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
+        "name",
+        "api",
+        "url",
+        "base_url",
+        "api_key",
+        "key_env",
+        "api_key_env",
+        "api_mode",
+        "transport",
+        "model",
+        "default_model",
+        "models",
+        "context_length",
+        "rate_limit_delay",
+        "request_timeout_seconds",
+        "stale_timeout_seconds",
         "circuit_breaker",
-        "discover_models", "extra_body",
+        "discover_models",
+        "extra_body",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
             logger.warning(
                 "providers.%s: camelCase key '%s' auto-mapped to '%s' "
                 "(use snake_case to avoid this warning)",
-                provider_key or "?", camel, snake,
+                provider_key or "?",
+                camel,
+                snake,
             )
             entry[snake] = entry[camel]
     unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
     if unknown:
         logger.warning(
             "providers.%s: unknown config keys ignored: %s",
-            provider_key or "?", ", ".join(sorted(unknown)),
+            provider_key or "?",
+            ", ".join(sorted(unknown)),
         )
 
     from urllib.parse import urlparse
@@ -4178,7 +4239,9 @@ def _normalize_custom_provider_entry(
                 logger.warning(
                     "providers.%s: '%s' value '%s' is not a valid URL "
                     "(no scheme or host) — skipped",
-                    provider_key or "?", url_key, candidate,
+                    provider_key or "?",
+                    url_key,
+                    candidate,
                 )
     if not base_url:
         return None
@@ -4462,17 +4525,40 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+    "_config_version",
+    "model",
+    "providers",
+    "fallback_model",
+    "fallback_providers",
+    "credential_pool_strategies",
+    "toolsets",
+    "agent",
+    "terminal",
+    "display",
+    "compression",
+    "delegation",
+    "auxiliary",
+    "custom_providers",
+    "context",
+    "memory",
+    "gateway",
+    "sessions",
+    "streaming",
+    "updates",
+    "mcp_servers",
 }
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "name",
+    "base_url",
+    "api_key",
+    "api_mode",
+    "model",
+    "models",
+    "context_length",
+    "rate_limit_delay",
+    "extra_body",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
@@ -4491,7 +4577,9 @@ class ConfigIssue:
     hint: str
 
 
-def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+def validate_config_structure(
+    config: Optional[Dict[str, Any]] = None,
+) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
     Catches common YAML formatting mistakes that produce confusing runtime
@@ -4503,7 +4591,13 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         try:
             config = load_config()
         except Exception:
-            return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
+            return [
+                ConfigIssue(
+                    "error",
+                    "Could not load config.yaml",
+                    "Run 'hermes setup' to create a valid config",
+                )
+            ]
 
     issues: List[ConfigIssue] = []
 
@@ -4511,46 +4605,56 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     cp = config.get("custom_providers")
     if cp is not None:
         if isinstance(cp, dict):
-            issues.append(ConfigIssue(
-                "error",
-                "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
-                "Change to:\n"
-                "  custom_providers:\n"
-                "    - name: my-provider\n"
-                "      base_url: https://...\n"
-                "      api_key: ...",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
+                    "Change to:\n"
+                    "  custom_providers:\n"
+                    "    - name: my-provider\n"
+                    "      base_url: https://...\n"
+                    "      api_key: ...",
+                )
+            )
             # Check if dict keys look like they should be list-entry fields
             cp_keys = set(cp.keys()) if isinstance(cp, dict) else set()
             suspicious = cp_keys & _CUSTOM_PROVIDER_LIKE_FIELDS
             if suspicious:
-                issues.append(ConfigIssue(
-                    "warning",
-                    f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
-                    "These should be indented under a '- name: ...' list entry, not at root level",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
+                        "These should be indented under a '- name: ...' list entry, not at root level",
+                    )
+                )
         elif isinstance(cp, list):
             # Validate each entry in the list
             for i, entry in enumerate(cp):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
-                        "Each entry should have at minimum: name, base_url",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
+                            "Each entry should have at minimum: name, base_url",
+                        )
+                    )
                     continue
                 if not entry.get("name"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'name' field",
-                        "Add a name, e.g.: name: my-provider",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'name' field",
+                            "Add a name, e.g.: name: my-provider",
+                        )
+                    )
                 if not entry.get("base_url"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'base_url' field",
-                        "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'base_url' field",
+                            "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
+                        )
+                    )
 
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
@@ -4559,78 +4663,100 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             # Chain fallback — validate each entry
             for i, entry in enumerate(fb):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "error",
-                        f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
-                        "Each entry needs provider + model",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "error",
+                            f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
+                            "Each entry needs provider + model",
+                        )
+                    )
                 else:
                     if not entry.get("provider"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'provider' field",
-                            "Add: provider: openrouter (or another provider)",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'provider' field",
+                                "Add: provider: openrouter (or another provider)",
+                            )
+                        )
                     if not entry.get("model"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'model' field",
-                            "Add: model: <model-name>",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'model' field",
+                                "Add: model: <model-name>",
+                            )
+                        )
         elif not isinstance(fb, dict):
-            issues.append(ConfigIssue(
-                "error",
-                f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
-                "Change to:\n"
-                "  fallback_model:\n"
-                "    provider: openrouter\n"
-                "    model: anthropic/claude-sonnet-4",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
+                    "Change to:\n"
+                    "  fallback_model:\n"
+                    "    provider: openrouter\n"
+                    "    model: anthropic/claude-sonnet-4",
+                )
+            )
         elif fb:
             if not fb.get("provider"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'provider' field — fallback will be disabled",
-                    "Add: provider: openrouter (or another provider)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'provider' field — fallback will be disabled",
+                        "Add: provider: openrouter (or another provider)",
+                    )
+                )
             if not fb.get("model"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'model' field — fallback will be disabled",
-                    "Add: model: anthropic/claude-sonnet-4 (or another model)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'model' field — fallback will be disabled",
+                        "Add: model: anthropic/claude-sonnet-4 (or another model)",
+                    )
+                )
 
     # ── Check for fallback_model accidentally nested inside custom_providers ──
-    if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
-        issues.append(ConfigIssue(
-            "error",
-            "fallback_model appears inside custom_providers instead of at root level",
-            "Move fallback_model to the top level of config.yaml (no indentation)",
-        ))
+    if (
+        isinstance(cp, dict)
+        and "fallback_model" not in config
+        and "fallback_model" in (cp or {})
+    ):
+        issues.append(
+            ConfigIssue(
+                "error",
+                "fallback_model appears inside custom_providers instead of at root level",
+                "Move fallback_model to the top level of config.yaml (no indentation)",
+            )
+        )
 
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")
     if cp and not model_cfg:
-        issues.append(ConfigIssue(
-            "warning",
-            "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
-            "Add a model section:\n"
-            "  model:\n"
-            "    provider: custom\n"
-            "    default: your-model-name\n"
-            "    base_url: https://...",
-        ))
+        issues.append(
+            ConfigIssue(
+                "warning",
+                "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
+                "Add a model section:\n"
+                "  model:\n"
+                "    provider: custom\n"
+                "    default: your-model-name\n"
+                "    base_url: https://...",
+            )
+        )
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
         if key.startswith("_"):
             continue
         if key not in _KNOWN_ROOT_KEYS and key in _CUSTOM_PROVIDER_LIKE_FIELDS:
-            issues.append(ConfigIssue(
-                "warning",
-                f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
-                f"Move '{key}' under the appropriate section",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "warning",
+                    f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
+                    f"Move '{key}' under the appropriate section",
+                )
+            )
 
     return issues
 
@@ -4705,11 +4831,11 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
-    
+
     Args:
         interactive: If True, prompt user for missing values
         quiet: If True, suppress output
-        
+
     Returns:
         Dict with migration results: {"env_added": [...], "config_added": [...], "warnings": [...]}
     """
@@ -4725,7 +4851,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check config version
     current_ver, latest_ver = check_config_version()
-    
+
     # ── Version 3 → 4: migrate tool progress from .env to config.yaml ──
     if current_ver < 4:
         config = load_config()
@@ -4737,18 +4863,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             old_mode = get_env_value("HERMES_TOOL_PROGRESS_MODE")
             if old_enabled and old_enabled.lower() in {"false", "0", "no"}:
                 display["tool_progress"] = "off"
-                results["config_added"].append("display.tool_progress=off (from HERMES_TOOL_PROGRESS=false)")
+                results["config_added"].append(
+                    "display.tool_progress=off (from HERMES_TOOL_PROGRESS=false)"
+                )
             elif old_mode and old_mode.lower() in {"new", "all"}:
                 display["tool_progress"] = old_mode.lower()
-                results["config_added"].append(f"display.tool_progress={old_mode.lower()} (from HERMES_TOOL_PROGRESS_MODE)")
+                results["config_added"].append(
+                    f"display.tool_progress={old_mode.lower()} (from HERMES_TOOL_PROGRESS_MODE)"
+                )
             else:
                 display["tool_progress"] = "all"
                 results["config_added"].append("display.tool_progress=all (default)")
             config["display"] = display
             save_config(config)
             if not quiet:
-                print(f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}")
-    
+                print(
+                    f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}"
+                )
+
     # ── Version 4 → 5: add timezone field ──
     if current_ver < 5:
         config = load_config()
@@ -4756,7 +4888,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             old_tz = os.getenv("HERMES_TIMEZONE", "")
             if old_tz and old_tz.strip():
                 config["timezone"] = old_tz.strip()
-                results["config_added"].append(f"timezone={old_tz.strip()} (from HERMES_TIMEZONE)")
+                results["config_added"].append(
+                    f"timezone={old_tz.strip()} (from HERMES_TIMEZONE)"
+                )
             else:
                 config["timezone"] = ""
                 results["config_added"].append("timezone= (empty, uses server-local)")
@@ -4790,12 +4924,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if not isinstance(entry, dict):
                     continue
                 old_name = entry.get("name", "")
-                old_url = entry.get("base_url", "") or entry.get("url", "") or entry.get("api", "") or ""
+                old_url = (
+                    entry.get("base_url", "")
+                    or entry.get("url", "")
+                    or entry.get("api", "")
+                    or ""
+                )
                 if not old_url:
                     continue  # skip entries with no URL
 
                 # Generate a kebab-case key from the display name
-                key = old_name.strip().lower().replace(" ", "-").replace("(", "").replace(")", "")
+                key = (
+                    old_name
+                    .strip()
+                    .lower()
+                    .replace(" ", "-")
+                    .replace("(", "")
+                    .replace(")", "")
+                )
                 # Remove consecutive hyphens and trailing hyphens
                 while "--" in key:
                     key = key.replace("--", "-")
@@ -4804,6 +4950,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     # Fallback: derive from URL hostname
                     try:
                         from urllib.parse import urlparse
+
                         parsed = urlparse(old_url)
                         key = (parsed.hostname or "endpoint").replace(".", "-")
                     except Exception:
@@ -4836,7 +4983,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 config.pop("custom_providers", None)
                 save_config(config)
                 if not quiet:
-                    print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
+                    print(
+                        f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section"
+                    )
                     for key in list(providers_dict.keys())[-migrated_count:]:
                         ep = providers_dict[key]
                         print(f"    → {key}: {ep.get('api', '')}")
@@ -4852,7 +5001,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if old_val:
                     save_env_value(dead_var, "")
                     if not quiet:
-                        print(f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)")
+                        print(
+                            f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)"
+                        )
             except Exception:
                 pass
 
@@ -4879,11 +5030,25 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             if provider in {"local", "local_command"}:
                 # Don't migrate an OpenAI model name into the local section
                 _local_models = {
-                    "tiny.en", "tiny", "base.en", "base", "small.en", "small",
-                    "medium.en", "medium", "large-v1", "large-v2", "large-v3",
-                    "large", "distil-large-v2", "distil-medium.en",
-                    "distil-small.en", "distil-large-v3", "distil-large-v3.5",
-                    "large-v3-turbo", "turbo",
+                    "tiny.en",
+                    "tiny",
+                    "base.en",
+                    "base",
+                    "small.en",
+                    "small",
+                    "medium.en",
+                    "medium",
+                    "large-v1",
+                    "large-v2",
+                    "large-v3",
+                    "large",
+                    "distil-large-v2",
+                    "distil-medium.en",
+                    "distil-small.en",
+                    "distil-large-v3",
+                    "distil-large-v3.5",
+                    "large-v3-turbo",
+                    "turbo",
                 }
                 if legacy_model in _local_models:
                     # Check raw config — only set if user didn't already
@@ -4915,7 +5080,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         if "interim_assistant_messages" not in display:
             display["interim_assistant_messages"] = True
             config["display"] = display
-            results["config_added"].append("display.interim_assistant_messages=true (default)")
+            results["config_added"].append(
+                "display.interim_assistant_messages=true (default)"
+            )
             save_config(config)
             if not quiet:
                 print("  ✓ Added display.interim_assistant_messages=true")
@@ -4941,8 +5108,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             save_config(config)
             if not quiet:
                 migrated = ", ".join(f"{p}={m}" for p, m in old_overrides.items())
-                print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
-            results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
+                print(
+                    f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}"
+                )
+            results["config_added"].append(
+                "display.platforms (migrated from tool_progress_overrides)"
+            )
 
     # ── Version 16 → 17: remove legacy compression.summary_* keys ──
     if current_ver < 17:
@@ -4972,12 +5143,19 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if not aux_comp.get("base_url"):
                     aux_comp["base_url"] = str(s_base_url).strip()
                     migrated_keys.append(f"base_url={s_base_url}")
-            if migrated_keys or s_model is not None or s_provider is not None or s_base_url is not None:
+            if (
+                migrated_keys
+                or s_model is not None
+                or s_provider is not None
+                or s_base_url is not None
+            ):
                 config["compression"] = comp
                 save_config(config)
                 if not quiet:
                     if migrated_keys:
-                        print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
+                        print(
+                            f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}"
+                        )
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 
@@ -5090,9 +5268,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             touched = True
 
         # (2) auxiliary.curator task slot
-        _aux_curator_defaults = (
-            DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
-        )
+        _aux_curator_defaults = DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
         raw_aux = config.get("auxiliary")
         if not isinstance(raw_aux, dict):
             raw_aux = {}
@@ -5144,7 +5320,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             save_config(config)
             results["config_added"].append("model_catalog.ttl_hours 24→1")
             if not quiet:
-                print("  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)")
+                print(
+                    "  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)"
+                )
 
     # ── Version 28 → 29: rename memory/skills write_mode → write_approval ──
     # The tri-state write_mode (on|off|approve) was replaced by a clear boolean
@@ -5163,7 +5341,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 continue
             old = sub.pop("write_mode")
             old_norm = old.strip().lower() if isinstance(old, str) else old
-            sub["write_approval"] = (old_norm == "approve")
+            sub["write_approval"] = old_norm == "approve"
             config[subsystem] = sub
             touched = True
             results["config_added"].append(
@@ -5205,7 +5383,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     raw_mcp_servers = config.get("mcp_servers")
     if isinstance(raw_mcp_servers, dict):
         try:
-            from hermes_cli.mcp_security import validate_mcp_server_entry as _validate_mcp_server_entry
+            from hermes_cli.mcp_security import (
+                validate_mcp_server_entry as _validate_mcp_server_entry,
+            )
         except Exception:
             _validate_mcp_server_entry = None
         if _validate_mcp_server_entry:
@@ -5231,43 +5411,46 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")
-    
+
     # Check for missing required env vars
     missing_env = get_missing_env_vars(required_only=True)
-    
+
     if missing_env and not quiet:
         print("\n⚠️  Missing required environment variables:")
         for var in missing_env:
             print(f"   • {var['name']}: {var['description']}")
-    
+
     if interactive and missing_env:
         print("\nLet's configure them now:\n")
         for var in missing_env:
             if var.get("url"):
                 print(f"  Get your key at: {var['url']}")
-            
+
             if var.get("password"):
                 value = masked_secret_prompt(f"  {var['prompt']}: ")
             else:
                 value = input(f"  {var['prompt']}: ").strip()
-            
+
             if value:
                 save_env_value(var["name"], value)
                 results["env_added"].append(var["name"])
                 print(f"  ✓ Saved {var['name']}")
             else:
-                results["warnings"].append(f"Skipped {var['name']} - some features may not work")
+                results["warnings"].append(
+                    f"Skipped {var['name']} - some features may not work"
+                )
             print()
-    
+
     # Check for missing optional env vars and offer to configure interactively
     # Skip "advanced" vars (like OPENAI_BASE_URL) -- those are for power users
     missing_optional = get_missing_env_vars(required_only=False)
     required_names = {v["name"] for v in missing_env} if missing_env else set()
     missing_optional = [
-        v for v in missing_optional
+        v
+        for v in missing_optional
         if v["name"] not in required_names and not v.get("advanced")
     ]
-    
+
     # Only offer to configure env vars that are NEW since the user's previous version
     new_var_names = set()
     for ver in range(current_ver + 1, latest_ver + 1):
@@ -5302,7 +5485,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                             f"  {info.get('prompt', name)} (Enter to skip): "
                         )
                     else:
-                        value = input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
+                        value = input(
+                            f"  {info.get('prompt', name)} (Enter to skip): "
+                        ).strip()
                     if value:
                         save_env_value(name, value)
                         results["env_added"].append(name)
@@ -5310,22 +5495,22 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     print()
             else:
                 print("  Set later with: hermes config set <key> <value>")
-    
+
     # Check for missing config fields
     missing_config = get_missing_config_fields()
-    
+
     if missing_config:
         config = load_config()
-        
+
         for field in missing_config:
             key = field["key"]
             default = field["default"]
-            
+
             _set_nested(config, key, default)
             results["config_added"].append(key)
             if not quiet:
                 print(f"  ✓ Added {key} = {default}")
-        
+
         # Update version and save
         config["_config_version"] = latest_ver
         save_config(config)
@@ -5344,7 +5529,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         print(f"\n  {len(missing_skill_config)} skill setting(s) not configured:")
         for var in missing_skill_config:
             skill_name = var.get("skill", "unknown")
-            print(f"    • {var['key']} — {var['description']} (from skill: {skill_name})")
+            print(
+                f"    • {var['key']} — {var['description']} (from skill: {skill_name})"
+            )
         print()
         try:
             answer = input("  Configure skill settings? [y/N]: ").strip().lower()
@@ -5390,11 +5577,7 @@ def _deep_merge(base: dict, override: dict) -> dict:
     """
     result = base.copy()
     for key, value in override.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             result[key] = _deep_merge(result[key], value)
         else:
             result[key] = value
@@ -5473,7 +5656,11 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
     rotation between load and save while still treating mixed literal/template
     string edits as caller-owned once their rendered value diverges.
     """
-    if isinstance(current, str) and isinstance(raw, str) and re.search(r"\${[^}]+}", raw):
+    if (
+        isinstance(current, str)
+        and isinstance(raw, str)
+        and re.search(r"\${[^}]+}", raw)
+    ):
         if current == raw:
             return raw
         if isinstance(loaded_expanded, str) and current == loaded_expanded:
@@ -5505,7 +5692,9 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
                 _preserve_env_ref_templates(
                     item,
                     raw_by_name.get(item.get("name")),
-                    loaded_by_name.get(item.get("name")) if loaded_by_name is not None else None,
+                    loaded_by_name.get(item.get("name"))
+                    if loaded_by_name is not None
+                    else None,
                 )
                 for item in current
             ]
@@ -5634,7 +5823,6 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
             return default
         node = node[key]
     return node
-
 
 
 def read_raw_config() -> Dict[str, Any]:
@@ -5785,7 +5973,7 @@ def terminal_config_env_var_for_key(key: str) -> Optional[str]:
     prefix = "terminal."
     if not key.startswith(prefix):
         return None
-    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix):])
+    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix) :])
 
 
 def apply_terminal_config_to_env(
@@ -6028,9 +6216,13 @@ def save_config(config: Dict[str, Any]):
 
         ensure_hermes_home()
         config_path = get_config_path()
-        current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        current_normalized = _normalize_root_model_keys(
+            _normalize_max_turns_config(config)
+        )
         normalized = current_normalized
-        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+        raw_existing = _normalize_root_model_keys(
+            _normalize_max_turns_config(read_raw_config())
+        )
         if raw_existing:
             normalized = _preserve_env_ref_templates(
                 normalized,
@@ -6047,7 +6239,9 @@ def save_config(config: Dict[str, Any]):
         fb = normalized.get("fallback_model", {})
         fb_is_valid = False
         if isinstance(fb, list):
-            fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+            fb_is_valid = any(
+                isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb
+            )
         elif isinstance(fb, dict):
             fb_is_valid = bool(fb.get("provider") and fb.get("model"))
         if not fb_is_valid:
@@ -6059,7 +6253,9 @@ def save_config(config: Dict[str, Any]):
             extra_content="".join(parts) if parts else None,
         )
         _secure_file(config_path)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(
+            current_normalized
+        )
 
 
 def load_env() -> Dict[str, str]:
@@ -6109,9 +6305,9 @@ def load_env() -> Dict[str, str]:
         lines = _sanitize_env_lines(raw_lines)
         for line in lines:
             line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, _, value = line.partition('=')
-                env_vars[key.strip()] = value.strip().strip('"\'')
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                env_vars[key.strip()] = value.strip().strip("\"'")
 
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))
@@ -6124,7 +6320,9 @@ def load_env() -> Dict[str, str]:
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_env_cache: Optional[
+    Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]
+] = None
 
 
 def invalidate_env_cache() -> None:
@@ -6180,16 +6378,20 @@ def _sanitize_env_lines(lines: list) -> list:
                 idx = stripped.find(needle, idx + len(needle))
 
         split_positions = sorted({
-            s for s, e in match_ranges
+            s
+            for s, e in match_ranges
             if not any(
-                s2 <= s and e2 >= e and (s2, e2) != (s, e)
-                for s2, e2 in match_ranges
+                s2 <= s and e2 >= e and (s2, e2) != (s, e) for s2, e2 in match_ranges
             )
         })
 
         if len(split_positions) > 1:
             for i, pos in enumerate(split_positions):
-                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
+                end = (
+                    split_positions[i + 1]
+                    if i + 1 < len(split_positions)
+                    else len(stripped)
+                )
                 part = stripped[pos:end].strip()
                 if part:
                     sanitized.append(part + "\n")
@@ -6227,7 +6429,9 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
@@ -6337,8 +6541,10 @@ def save_env_value(key: str, value: str):
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
-    
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     # Preserve original permissions so Docker volume mounts aren't clobbered.
     original_mode = None
     if env_path.exists():
@@ -6347,7 +6553,7 @@ def save_env_value(key: str, value: str):
         except OSError:
             pass
     try:
-        with os.fdopen(fd, 'w', **write_kw) as f:
+        with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(lines)
             f.flush()
             os.fsync(f.fileno())
@@ -6410,7 +6616,9 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
 
     if found:
-        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+        )
         # Preserve original permissions so Docker volume mounts aren't clobbered.
         original_mode = None
         try:
@@ -6418,7 +6626,7 @@ def remove_env_value(key: str) -> bool:
         except OSError:
             pass
         try:
-            with os.fdopen(fd, 'w', **write_kw) as f:
+            with os.fdopen(fd, "w", **write_kw) as f:
                 f.writelines(new_lines)
                 f.flush()
                 os.fsync(f.fileno())
@@ -6475,7 +6683,6 @@ def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
     }
 
 
-
 def reload_env() -> int:
     """Re-read ~/.hermes/.env into os.environ. Returns count of vars updated.
 
@@ -6503,7 +6710,7 @@ def get_env_value(key: str) -> Optional[str]:
     # Check environment first
     if key in os.environ:
         return os.environ[key]
-    
+
     # Then check .env file
     env_vars = load_env()
     return env_vars.get(key)
@@ -6513,6 +6720,7 @@ def get_env_value(key: str) -> Optional[str]:
 # Config display
 # =============================================================================
 
+
 def redact_key(key: str) -> str:
     """Redact an API key for display.
 
@@ -6520,6 +6728,7 @@ def redact_key(key: str) -> str:
     "(not set)" placeholder in dim color for the empty case.
     """
     from agent.redact import mask_secret
+
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
@@ -6567,7 +6776,12 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if (
+                isinstance(k, str)
+                and k.lower() in _SECRET_CONFIG_KEYS
+                and isinstance(v, str)
+                and v
+            ):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
@@ -6582,9 +6796,19 @@ def show_config():
     config = load_config()
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print(
+        color(
+            "┌─────────────────────────────────────────────────────────┐", Colors.CYAN
+        )
+    )
+    print(
+        color("│              ⚕ Hermes Configuration                    │", Colors.CYAN)
+    )
+    print(
+        color(
+            "└─────────────────────────────────────────────────────────┘", Colors.CYAN
+        )
+    )
 
     # Managed scope: surface that some settings are administrator-pinned so the
     # user understands why their config.yaml value may not be the effective one.
@@ -6595,22 +6819,28 @@ def show_config():
     if _managed_keys or _managed_env:
         _managed_dir = managed_scope.get_managed_dir()
         print()
-        print(color(
-            f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
-            f"and cannot be changed",
-            Colors.YELLOW,
-            Colors.BOLD,
-        ))
+        print(
+            color(
+                f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
+                f"and cannot be changed",
+                Colors.YELLOW,
+                Colors.BOLD,
+            )
+        )
         if _managed_keys:
-            print(color(
-                f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
+                    Colors.YELLOW,
+                )
+            )
         if _managed_env:
-            print(color(
-                f"    Managed env keys: {', '.join(sorted(_managed_env))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed env keys: {', '.join(sorted(_managed_env))}",
+                    Colors.YELLOW,
+                )
+            )
 
     # Paths
     print()
@@ -6618,11 +6848,11 @@ def show_config():
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
-    
+
     # API Keys
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
-    
+
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
@@ -6634,76 +6864,98 @@ def show_config():
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
     ]
-    
+
     for env_key, name in keys:
         value = get_env_value(env_key)
         print(f"  {name:<14} {redact_key(value)}")
     from hermes_cli.auth import get_anthropic_key
+
     anthropic_value = get_anthropic_key()
     print(f"  {'Anthropic':<14} {redact_key(anthropic_value)}")
-    
+
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {redact_config_value(config.get('model', 'not set'))}")
-    _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
+    _cfg_max_turns = config.get("agent", {}).get(
+        "max_turns", DEFAULT_CONFIG["agent"]["max_turns"]
+    )
     print(f"  Max turns:    {_cfg_max_turns}")
     # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with
     # config.yaml (issue #17534). Read the .env FILE directly so we catch the
     # ghost even when the gateway bridge already overrode os.environ.
     try:
         _env_ghost = load_env().get("HERMES_MAX_ITERATIONS")
-        if _env_ghost is not None and str(_env_ghost).strip() != str(_cfg_max_turns).strip():
-            print(color(
-                f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
-                f"(run 'hermes doctor --fix' to remove)",
-                Colors.YELLOW,
-            ))
+        if (
+            _env_ghost is not None
+            and str(_env_ghost).strip() != str(_cfg_max_turns).strip()
+        ):
+            print(
+                color(
+                    f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
+                    f"(run 'hermes doctor --fix' to remove)",
+                    Colors.YELLOW,
+                )
+            )
     except Exception:
         pass
-    
+
     # Display
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
-    display = config.get('display', {})
+    display = config.get("display", {})
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
-    ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
-    ump_first = ump.get('first_lines', 2)
-    ump_last = ump.get('last_lines', 2)
+    print(
+        f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}"
+    )
+    ump = (
+        display.get("user_message_preview", {})
+        if isinstance(display.get("user_message_preview", {}), dict)
+        else {}
+    )
+    ump_first = ump.get("first_lines", 2)
+    ump_last = ump.get("last_lines", 2)
     print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s)")
 
     # Terminal
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
-    terminal = config.get('terminal', {})
+    terminal = config.get("terminal", {})
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
-    
-    if terminal.get('backend') == 'docker':
-        print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'singularity':
-        print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'modal':
-        print(f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        modal_token = get_env_value('MODAL_TOKEN_ID')
+
+    if terminal.get("backend") == "docker":
+        print(
+            f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "singularity":
+        print(
+            f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "modal":
+        print(
+            f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        modal_token = get_env_value("MODAL_TOKEN_ID")
         print(f"  Modal token:  {'configured' if modal_token else '(not set)'}")
-    elif terminal.get('backend') == 'daytona':
-        print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        daytona_key = get_env_value('DAYTONA_API_KEY')
+    elif terminal.get("backend") == "daytona":
+        print(
+            f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        daytona_key = get_env_value("DAYTONA_API_KEY")
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
-    elif terminal.get('backend') == 'ssh':
-        ssh_host = get_env_value('TERMINAL_SSH_HOST')
-        ssh_user = get_env_value('TERMINAL_SSH_USER')
+    elif terminal.get("backend") == "ssh":
+        ssh_host = get_env_value("TERMINAL_SSH_HOST")
+        ssh_user = get_env_value("TERMINAL_SSH_USER")
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
-    
+
     # Timezone
     print()
     print(color("◆ Timezone", Colors.CYAN, Colors.BOLD))
-    tz = config.get('timezone', '')
+    tz = config.get("timezone", "")
     if tz:
         print(f"  Timezone:     {tz}")
     else:
@@ -6712,56 +6964,68 @@ def show_config():
     # Compression
     print()
     print(color("◆ Context Compression", Colors.CYAN, Colors.BOLD))
-    compression = config.get('compression', {})
-    enabled = compression.get('enabled', True)
+    compression = config.get("compression", {})
+    enabled = compression.get("enabled", True)
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
-        print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
+        print(
+            f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved"
+        )
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
-        print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")
-        _aux_comp = config.get('auxiliary', {}).get('compression', {})
-        _sm = _aux_comp.get('model', '') or '(auto)'
+        print(
+            f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages"
+        )
+        _aux_comp = config.get("auxiliary", {}).get("compression", {})
+        _sm = _aux_comp.get("model", "") or "(auto)"
         print(f"  Model:        {_sm}")
-        comp_provider = _aux_comp.get('provider', 'auto')
-        if comp_provider and comp_provider != 'auto':
+        comp_provider = _aux_comp.get("provider", "auto")
+        if comp_provider and comp_provider != "auto":
             print(f"  Provider:     {comp_provider}")
-    
+
     # Auxiliary models
-    auxiliary = config.get('auxiliary', {})
+    auxiliary = config.get("auxiliary", {})
     aux_tasks = {
-        "Vision":      auxiliary.get('vision', {}),
-        "Web extract": auxiliary.get('web_extract', {}),
+        "Vision": auxiliary.get("vision", {}),
+        "Web extract": auxiliary.get("web_extract", {}),
     }
     has_overrides = any(
-        t.get('provider', 'auto') != 'auto' or t.get('model', '')
+        t.get("provider", "auto") != "auto" or t.get("model", "")
         for t in aux_tasks.values()
     )
     if has_overrides:
         print()
         print(color("◆ Auxiliary Models (overrides)", Colors.CYAN, Colors.BOLD))
         for label, task_cfg in aux_tasks.items():
-            prov = task_cfg.get('provider', 'auto')
-            mdl = task_cfg.get('model', '')
-            if prov != 'auto' or mdl:
+            prov = task_cfg.get("provider", "auto")
+            mdl = task_cfg.get("model", "")
+            if prov != "auto" or mdl:
                 parts = [f"provider={prov}"]
                 if mdl:
                     parts.append(f"model={mdl}")
                 print(f"  {label:12s}  {', '.join(parts)}")
-    
+
     # Messaging
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
-    
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
-    
+
+    telegram_token = get_env_value("TELEGRAM_BOT_TOKEN")
+    discord_token = get_env_value("DISCORD_BOT_TOKEN")
+
+    print(
+        f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}"
+    )
+    print(
+        f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}"
+    )
+
     # Skill config
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            resolve_skill_config_values,
+        )
+
         skill_vars = discover_all_skill_config_vars()
         if skill_vars:
             resolved = resolve_skill_config_values(skill_vars)
@@ -6772,7 +7036,9 @@ def show_config():
                 value = resolved.get(key, "")
                 skill_name = var.get("skill", "")
                 display_val = str(value) if value else color("(not set)", Colors.DIM)
-                print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
+                print(
+                    f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}"
+                )
     except Exception:
         pass
 
@@ -6790,14 +7056,14 @@ def edit_config():
         managed_error("edit configuration")
         return
     config_path = get_config_path()
-    
+
     # Ensure config exists
     if not config_path.exists():
         save_config(DEFAULT_CONFIG)
         print(f"Created {config_path}")
-    
+
     # Find editor
-    editor = os.getenv('EDITOR') or os.getenv('VISUAL')
+    editor = os.getenv("EDITOR") or os.getenv("VISUAL")
 
     if not editor:
         # Try common editors — order is platform-aware so Windows users
@@ -6806,20 +7072,21 @@ def edit_config():
         # it's more likely to be present on headless / server systems.
         import shutil
         import sys as _sys
+
         if _sys.platform == "win32":
-            candidates = ['notepad', 'code', 'vim', 'vi', 'nano']
+            candidates = ["notepad", "code", "vim", "vi", "nano"]
         else:
-            candidates = ['nano', 'vim', 'vi', 'code', 'notepad']
+            candidates = ["nano", "vim", "vi", "code", "notepad"]
         for cmd in candidates:
             if shutil.which(cmd):
                 editor = cmd
                 break
-    
+
     if not editor:
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
         return
-    
+
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
 
@@ -6847,22 +7114,44 @@ def set_config_value(key: str, value: str):
         sys.exit(1)
     # Check if it's an API key (goes to .env)
     api_keys = [
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "EXA_API_KEY",
+        "PARALLEL_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "FIRECRAWL_API_URL",
+        "FIRECRAWL_GATEWAY_URL",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_SCHEME",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "TAVILY_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY",
+        "FAL_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
+        "TERMINAL_SSH_KEY",
+        "SUDO_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "GITHUB_TOKEN",
+        "HONCHO_API_KEY",
     ]
-    
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
+
+    if (
+        key.upper() in api_keys
+        or key.upper().endswith(("_API_KEY", "_TOKEN"))
+        or key.upper().startswith("TERMINAL_SSH")
+    ):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
-    
+
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
@@ -6874,20 +7163,20 @@ def set_config_value(key: str, value: str):
                 user_config = yaml.safe_load(f) or {}
         except Exception:
             user_config = {}
-    
+
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
     # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
+    if value.lower() in {"true", "yes", "on"}:
         value = True
-    elif value.lower() in {'false', 'no', 'off'}:
+    elif value.lower() in {"false", "no", "off"}:
         value = False
     elif value.isdigit():
         value = int(value)
-    elif value.replace('.', '', 1).isdigit():
+    elif value.replace(".", "", 1).isdigit():
         value = float(value)
 
     _set_nested(user_config, key, value)
@@ -6903,8 +7192,9 @@ def set_config_value(key: str, value: str):
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()
     from utils import atomic_yaml_write
+
     atomic_yaml_write(config_path, user_config, sort_keys=False)
-    
+
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
     env_var = terminal_config_env_var_for_key(key)
@@ -6918,6 +7208,7 @@ def set_config_value(key: str, value: str):
     _leaf_key = key.rsplit(".", 1)[-1].lower()
     if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
         from agent.redact import mask_secret
+
         _display_value = mask_secret(value)
     else:
         _display_value = value
@@ -6928,19 +7219,20 @@ def set_config_value(key: str, value: str):
 # Command handler
 # =============================================================================
 
+
 def config_command(args):
     """Handle config subcommands."""
-    subcmd = getattr(args, 'config_command', None)
-    
+    subcmd = getattr(args, "config_command", None)
+
     if subcmd is None or subcmd == "show":
         show_config()
-    
+
     elif subcmd == "edit":
         edit_config()
-    
+
     elif subcmd == "set":
-        key = getattr(args, 'key', None)
-        value = getattr(args, 'value', None)
+        key = getattr(args, "key", None)
+        value = getattr(args, "value", None)
         if not key or value is None:
             print("Usage: hermes config set <key> <value>")
             print()
@@ -6950,81 +7242,89 @@ def config_command(args):
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             sys.exit(1)
         set_config_value(key, value)
-    
+
     elif subcmd == "path":
         print(get_config_path())
-    
+
     elif subcmd == "env-path":
         print(get_env_path())
-    
+
     elif subcmd == "migrate":
         print()
-        print(color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD))
+        print(
+            color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD)
+        )
         print()
-        
+
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
         current_ver, latest_ver = check_config_version()
-        
+
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
             print()
             return
-        
+
         # Show what needs to be updated
         if current_ver < latest_ver:
             print(f"  Config version: {current_ver} → {latest_ver}")
-        
+
         if missing_config:
-            print(f"\n  {len(missing_config)} new config option(s) will be added with defaults")
-        
+            print(
+                f"\n  {len(missing_config)} new config option(s) will be added with defaults"
+            )
+
         required_missing = [v for v in missing_env if v.get("is_required")]
         optional_missing = [
-            v for v in missing_env
-            if not v.get("is_required") and not v.get("advanced")
+            v for v in missing_env if not v.get("is_required") and not v.get("advanced")
         ]
-        
+
         if required_missing:
             print(f"\n  ⚠️  {len(required_missing)} required API key(s) missing:")
             for var in required_missing:
                 print(f"     • {var['name']}")
-        
+
         if optional_missing:
             print(f"\n  ℹ️  {len(optional_missing)} optional API key(s) not configured:")
             for var in optional_missing:
                 tools = var.get("tools", [])
                 tools_str = f" (enables: {', '.join(tools[:2])})" if tools else ""
                 print(f"     • {var['name']}{tools_str}")
-        
+
         print()
-        
+
         # Run migration
         results = migrate_config(interactive=True, quiet=False)
-        
+
         print()
         if results["env_added"] or results["config_added"]:
             print(color("✓ Configuration updated!", Colors.GREEN))
-        
+
         if results["warnings"]:
             print()
             for warning in results["warnings"]:
                 print(color(f"  ⚠️  {warning}", Colors.YELLOW))
-        
+
         print()
-    
+
     elif subcmd == "check":
         # Non-interactive check for what's missing
         print()
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
-        
+
         current_ver, latest_ver = check_config_version()
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:
-            print(color(f"  Config version: {current_ver} → {latest_ver} (update available)", Colors.YELLOW))
-        
+            print(
+                color(
+                    f"  Config version: {current_ver} → {latest_ver} (update available)",
+                    Colors.YELLOW,
+                )
+            )
+
         print()
         print(color("  Required:", Colors.BOLD))
         for var_name in REQUIRED_ENV_VARS:
@@ -7032,7 +7332,7 @@ def config_command(args):
                 print(f"    ✓ {var_name}")
             else:
                 print(color(f"    ✗ {var_name} (missing)", Colors.RED))
-        
+
         print()
         print(color("  Optional:", Colors.BOLD))
         for var_name, info in OPTIONAL_ENV_VARS.items():
@@ -7042,15 +7342,20 @@ def config_command(args):
                 tools = info.get("tools", [])
                 tools_str = f" → {', '.join(tools[:2])}" if tools else ""
                 print(color(f"    ○ {var_name}{tools_str}", Colors.DIM))
-        
+
         missing_config = get_missing_config_fields()
         if missing_config:
             print()
-            print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
+            print(
+                color(
+                    f"  {len(missing_config)} new config option(s) available",
+                    Colors.YELLOW,
+                )
+            )
             print("    Run 'hermes config migrate' to add them")
-        
+
         print()
-    
+
     else:
         print(f"Unknown config command: {subcmd}")
         print()
@@ -7084,8 +7389,11 @@ def _inject_profile_env_vars() -> None:
     _profile_env_vars_injected = True
     try:
         from providers import list_providers
+
         for _pp in list_providers():
-            if _pp.auth_type not in {"api_key",}:
+            if _pp.auth_type not in {
+                "api_key",
+            }:
                 continue
             for _var in _pp.env_vars:
                 if _var in OPTIONAL_ENV_VARS:
@@ -7188,8 +7496,7 @@ def _inject_platform_plugin_env_vars() -> None:
                     )
                 OPTIONAL_ENV_VARS[name] = {
                     "description": (
-                        meta.get("description")
-                        or f"{label} configuration"
+                        meta.get("description") or f"{label} configuration"
                     ),
                     "prompt": meta.get("prompt") or name,
                     "url": meta.get("url") or None,

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -77,19 +77,51 @@ class DDGSWebSearchProvider(WebSearchProvider):
                     if i >= safe_limit:
                         break
                     url = str(hit.get("href") or hit.get("url") or "")
-                    web_results.append(
-                        {
-                            "title": str(hit.get("title", "")),
-                            "url": url,
-                            "description": str(hit.get("body", "")),
-                            "position": i + 1,
-                        }
-                    )
+                    web_results.append({
+                        "title": str(hit.get("title", "")),
+                        "url": url,
+                        "description": str(hit.get("body", "")),
+                        "position": i + 1,
+                    })
         except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
             logger.warning("DDGS search error: %s", exc)
+            # Issue #467 — DDGS frequently returns empty / blocks automated
+            # queries. Surface a structured provider-dead error so the agent
+            # knows to switch provider instead of spiraling on "no results".
+            error_text = str(exc).lower()
+            if (
+                "no results" in error_text
+                or "ratelimit" in error_text
+                or "timeout" in error_text
+            ):
+                return {
+                    "success": False,
+                    "error": (
+                        f"DuckDuckGo search provider is not returning results: {exc}. "
+                        "Configure an alternative search_backend (e.g. brave-free, searxng) "
+                        "via `hermes tools` or config.yaml."
+                    ),
+                }
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}
 
-        logger.info("DDGS search '%s': %d results (limit %d)", query, len(web_results), limit)
+        # Empty result set is also a provider failure symptom (#467) — not a
+        # successful "zero results" outcome worth looping on.
+        if not web_results:
+            logger.warning(
+                "DDGS search '%s' returned no results (provider likely blocked)", query
+            )
+            return {
+                "success": False,
+                "error": (
+                    "DuckDuckGo returned no results. The provider is likely blocking "
+                    "automated queries. Configure an alternative search_backend "
+                    "(e.g. brave-free, searxng) via `hermes tools` or config.yaml."
+                ),
+            }
+
+        logger.info(
+            "DDGS search '%s': %d results (limit %d)", query, len(web_results), limit
+        )
         return {"success": True, "data": {"web": web_results}}
 
     def get_setup_schema(self) -> Dict[str, Any]:

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -78,7 +78,9 @@ class TestFailureTrigger:
         assert maybe_nudge(msgs) is not None
 
     def test_mcp_unreachable_failures(self):
-        msgs = _run("mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError")
+        msgs = _run(
+            "mcp_tqmemory_health", 3, result="server unreachable: ClosedResourceError"
+        )
         n = maybe_nudge(msgs)
         # mcp_tqmemory_health is not in mutating/idempotent sets, so 'unknown'
         # category uses the safer (lower) default -> mutating thresholds.
@@ -97,7 +99,11 @@ class TestNonRetryableTrigger:
         assert n is not None and "non-retryable" in n and "permission" in n
 
     def test_two_timeouts_stop_hard(self):
-        n = maybe_nudge(_run("terminal", 2, result="failure-class=timeout — The operation timed out"))
+        n = maybe_nudge(
+            _run(
+                "terminal", 2, result="failure-class=timeout — The operation timed out"
+            )
+        )
         assert n is not None and "non-retryable" in n and "timeout" in n
 
     def test_single_deterministic_failure_is_quiet(self):

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -16,20 +16,29 @@ class TestClassify:
 
     def test_permission(self):
         assert classify("Refusing to write to sensitive system path")[0] == "permission"
-        assert classify("error: permission denied")[0] in ("permission", "missing_command", "runtime_error")
+        assert classify("error: permission denied")[0] in (
+            "permission",
+            "missing_command",
+            "runtime_error",
+        )
 
     def test_timeout(self):
         assert classify("request timed out after 120s")[0] == "timeout"
         assert classify("ClosedResourceError: server unreachable")[0] == "timeout"
 
     def test_limit(self):
-        assert classify("value exceeds the maximum length of 2200 characters")[0] == "limit"
+        assert (
+            classify("value exceeds the maximum length of 2200 characters")[0]
+            == "limit"
+        )
 
     def test_not_found(self):
         assert classify("grep: no matches found")[0] == "not_found"
 
     def test_runtime_error_fallback(self):
-        assert classify("Traceback (most recent call last):\n  ...")[0] == "runtime_error"
+        assert (
+            classify("Traceback (most recent call last):\n  ...")[0] == "runtime_error"
+        )
         assert classify("process exited, exit code: 1")[0] == "runtime_error"
 
 

--- a/tests/run_agent/test_percentage_clamp.py
+++ b/tests/run_agent/test_percentage_clamp.py
@@ -98,7 +98,9 @@ class TestSourceLinesAreClamped:
     def test_memory_tool_clamped(self):
         src = self._read_file("tools/memory_tool.py")
         # Both _success_response and _render_block should have min(100, ...)
-        count = src.count("min(100, int((current / limit)")
+        # _success_response uses `new_total`, _render_block uses `current`;
+        # count the shared prefix to catch both.
+        count = src.count("min(100, int((")
         assert count >= 2, (
             f"memory_tool.py has only {count} clamped pct lines, expected >= 2"
         )

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -6,6 +6,7 @@ Covers:
 - Backward compatibility (web.backend still works as shared fallback)
 - Config keys merge correctly via DEFAULT_CONFIG
 """
+
 from __future__ import annotations
 
 import json
@@ -140,50 +141,72 @@ class TestPerCapabilityBackendSelection:
     def test_search_backend_overrides_generic(self, monkeypatch):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "firecrawl",
-            "search_backend": "tavily",
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "firecrawl",
+                "search_backend": "tavily",
+            },
+        )
         monkeypatch.setenv("TAVILY_API_KEY", "test-key")
         assert web_tools._get_search_backend() == "tavily"
 
     def test_extract_backend_overrides_generic(self, monkeypatch):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "tavily",
-            "extract_backend": "exa",
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "tavily",
+                "extract_backend": "exa",
+            },
+        )
         monkeypatch.setenv("EXA_API_KEY", "test-key")
         assert web_tools._get_extract_backend() == "exa"
 
     def test_falls_back_to_generic_backend_when_search_backend_empty(self, monkeypatch):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "tavily",
-            "search_backend": "",
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "tavily",
+                "search_backend": "",
+            },
+        )
         monkeypatch.setenv("TAVILY_API_KEY", "test-key")
         assert web_tools._get_search_backend() == "tavily"
 
-    def test_falls_back_to_generic_backend_when_extract_backend_empty(self, monkeypatch):
+    def test_falls_back_to_generic_backend_when_extract_backend_empty(
+        self, monkeypatch
+    ):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "parallel",
-            "extract_backend": "",
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "parallel",
+                "extract_backend": "",
+            },
+        )
         monkeypatch.setenv("PARALLEL_API_KEY", "test-key")
         assert web_tools._get_extract_backend() == "parallel"
 
     def test_search_backend_ignored_when_not_available(self, monkeypatch):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "firecrawl",
-            "search_backend": "exa",  # set but no EXA_API_KEY
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "firecrawl",
+                "search_backend": "exa",  # set but no EXA_API_KEY
+            },
+        )
         monkeypatch.delenv("EXA_API_KEY", raising=False)
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key")
         # Should fall back to firecrawl since exa isn't configured
@@ -192,9 +215,13 @@ class TestPerCapabilityBackendSelection:
     def test_fully_backward_compatible_with_web_backend_only(self, monkeypatch):
         from tools import web_tools
 
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
-            "backend": "tavily",
-        })
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "backend": "tavily",
+            },
+        )
         monkeypatch.setenv("TAVILY_API_KEY", "test-key")
         # No search_backend or extract_backend set — both fall through
         assert web_tools._get_search_backend() == "tavily"
@@ -217,10 +244,12 @@ class TestDefaultConfig:
         assert "backend" in web
         assert "search_backend" in web
         assert "extract_backend" in web
+        assert "search_backend_fallback_chain" in web
         # All empty string by default (no override)
         assert web["backend"] == ""
         assert web["search_backend"] == ""
         assert web["extract_backend"] == ""
+        assert web["search_backend_fallback_chain"] == ""
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +272,9 @@ class TestWebSearchUsesSearchBackend:
             return result
 
         monkeypatch.setattr(web_tools, "_get_search_backend", tracking_get_search)
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
+        monkeypatch.setattr(
+            web_tools, "_load_web_config", lambda: {"backend": "firecrawl"}
+        )
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake")
 
         # The function will fail at Firecrawl client level but we just
@@ -275,6 +306,7 @@ class TestUnconfiguredErrorEnvelopeParity:
         self._register_providers()
         yield
         from agent.web_search_registry import _reset_for_tests
+
         _reset_for_tests()
 
     def _clear_web_creds(self, monkeypatch):
@@ -367,6 +399,7 @@ class TestDispatchersTriggerPluginDiscovery:
 
         restore = self._clear_registry()
         try:
+
             class FakeFirecrawl(WebSearchProvider):
                 @property
                 def name(self) -> str:
@@ -384,8 +417,13 @@ class TestDispatchersTriggerPluginDiscovery:
 
                 async def extract(self, urls, format=None):
                     return [
-                        {"url": u, "title": "", "content": "ok",
-                         "raw_content": "ok", "metadata": {}}
+                        {
+                            "url": u,
+                            "title": "",
+                            "content": "ok",
+                            "raw_content": "ok",
+                            "metadata": {},
+                        }
                         for u in urls
                     ]
 
@@ -405,22 +443,23 @@ class TestDispatchersTriggerPluginDiscovery:
             # underlying ``hermes_cli.plugins._ensure_plugins_discovered`` so
             # the test stays valid even if the import inside the helper is
             # later moved to module scope or renamed.
+            monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", mock_hook)
             monkeypatch.setattr(
-                web_tools, "_ensure_web_plugins_loaded", mock_hook
-            )
-            monkeypatch.setattr(
-                web_tools, "_load_web_config",
+                web_tools,
+                "_load_web_config",
                 lambda: {"extract_backend": "firecrawl"},
             )
             # Sanity: registry IS empty before the tool call.
             assert web_search_registry.get_provider("firecrawl") is None
 
-            result = json.loads(asyncio.run(
-                web_tools.web_extract_tool(
-                    ["https://example.com"],
-                    use_llm_processing=False,
+            result = json.loads(
+                asyncio.run(
+                    web_tools.web_extract_tool(
+                        ["https://example.com"],
+                        use_llm_processing=False,
+                    )
                 )
-            ))
+            )
 
             # The hook must have been called BEFORE the registry lookup —
             # that is the invariant under regression test. Without the
@@ -448,6 +487,7 @@ class TestDispatchersTriggerPluginDiscovery:
 
         restore = self._clear_registry()
         try:
+
             class FakeBrave(WebSearchProvider):
                 @property
                 def name(self) -> str:
@@ -464,21 +504,29 @@ class TestDispatchersTriggerPluginDiscovery:
                     return True
 
                 def search(self, query, limit=5):
-                    return {"success": True, "data": {"web": [
-                        {"title": "ok", "url": "https://x", "description": "",
-                         "position": 0}
-                    ]}}
+                    return {
+                        "success": True,
+                        "data": {
+                            "web": [
+                                {
+                                    "title": "ok",
+                                    "url": "https://x",
+                                    "description": "",
+                                    "position": 0,
+                                }
+                            ]
+                        },
+                    }
 
             def _register_fake() -> None:
                 if web_search_registry.get_provider("brave-free") is None:
                     web_search_registry.register_provider(FakeBrave())
 
             mock_hook = MagicMock(wraps=_register_fake)
+            monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", mock_hook)
             monkeypatch.setattr(
-                web_tools, "_ensure_web_plugins_loaded", mock_hook
-            )
-            monkeypatch.setattr(
-                web_tools, "_load_web_config",
+                web_tools,
+                "_load_web_config",
                 lambda: {"search_backend": "brave-free"},
             )
             assert web_search_registry.get_provider("brave-free") is None
@@ -492,4 +540,3 @@ class TestDispatchersTriggerPluginDiscovery:
             assert web_search_registry.get_provider("brave-free") is not None
         finally:
             restore()
-

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -7,6 +7,7 @@ Covers:
 - _is_backend_available("ddgs") / _get_backend() integration
 - web_extract returns a search-only error when ddgs is active
 """
+
 from __future__ import annotations
 
 import json
@@ -29,12 +30,14 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None):
     class _FakeDDGS:
         def __enter__(self):
             return self
+
         def __exit__(self, *_a):
             return False
+
         def text(self, query, max_results=5):
             if text_raises is not None:
                 raise text_raises
-            for hit in (text_results or []):
+            for hit in text_results or []:
                 yield hit
 
     fake.DDGS = _FakeDDGS
@@ -53,6 +56,7 @@ class TestDDGSProviderIsConfigured:
         # Drop any cached ``plugins.web.ddgs.provider`` so is_configured re-imports ddgs fresh
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
         assert DDGSWebSearchProvider().is_available() is True
 
     def test_not_configured_when_package_missing(self, monkeypatch):
@@ -60,6 +64,7 @@ class TestDDGSProviderIsConfigured:
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
         # Block the import so ``import ddgs`` raises ImportError even if the package is actually installed
         import builtins
+
         orig_import = builtins.__import__
 
         def blocked_import(name, *args, **kwargs):
@@ -69,25 +74,31 @@ class TestDDGSProviderIsConfigured:
 
         monkeypatch.setattr(builtins, "__import__", blocked_import)
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
         assert DDGSWebSearchProvider().is_available() is False
 
     def test_provider_name(self):
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
         assert DDGSWebSearchProvider().name == "ddgs"
 
     def test_implements_web_search_provider(self):
         from agent.web_search_provider import WebSearchProvider
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
         assert issubclass(DDGSWebSearchProvider, WebSearchProvider)
 
 
 class TestDDGSProviderSearch:
     def test_happy_path_normalizes_results(self, monkeypatch):
-        _install_fake_ddgs(monkeypatch, text_results=[
-            {"title": "A", "href": "https://a.example.com", "body": "desc A"},
-            {"title": "B", "href": "https://b.example.com", "body": "desc B"},
-            {"title": "C", "href": "https://c.example.com", "body": "desc C"},
-        ])
+        _install_fake_ddgs(
+            monkeypatch,
+            text_results=[
+                {"title": "A", "href": "https://a.example.com", "body": "desc A"},
+                {"title": "B", "href": "https://b.example.com", "body": "desc B"},
+                {"title": "C", "href": "https://c.example.com", "body": "desc C"},
+            ],
+        )
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
 
         result = DDGSWebSearchProvider().search("q", limit=5)
@@ -95,13 +106,21 @@ class TestDDGSProviderSearch:
         assert result["success"] is True
         web = result["data"]["web"]
         assert len(web) == 3
-        assert web[0] == {"title": "A", "url": "https://a.example.com", "description": "desc A", "position": 1}
+        assert web[0] == {
+            "title": "A",
+            "url": "https://a.example.com",
+            "description": "desc A",
+            "position": 1,
+        }
         assert web[2]["position"] == 3
 
     def test_accepts_url_key_as_fallback_for_href(self, monkeypatch):
-        _install_fake_ddgs(monkeypatch, text_results=[
-            {"title": "A", "url": "https://a.example.com", "body": "desc A"},
-        ])
+        _install_fake_ddgs(
+            monkeypatch,
+            text_results=[
+                {"title": "A", "url": "https://a.example.com", "body": "desc A"},
+            ],
+        )
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
 
         result = DDGSWebSearchProvider().search("q", limit=5)
@@ -110,10 +129,13 @@ class TestDDGSProviderSearch:
         assert result["data"]["web"][0]["url"] == "https://a.example.com"
 
     def test_limit_is_respected(self, monkeypatch):
-        _install_fake_ddgs(monkeypatch, text_results=[
-            {"title": f"R{i}", "href": f"https://r{i}.example.com", "body": ""}
-            for i in range(10)
-        ])
+        _install_fake_ddgs(
+            monkeypatch,
+            text_results=[
+                {"title": f"R{i}", "href": f"https://r{i}.example.com", "body": ""}
+                for i in range(10)
+            ],
+        )
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
 
         result = DDGSWebSearchProvider().search("q", limit=3)
@@ -125,6 +147,7 @@ class TestDDGSProviderSearch:
         monkeypatch.delitem(sys.modules, "ddgs", raising=False)
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
         import builtins
+
         orig_import = builtins.__import__
 
         def blocked_import(name, *args, **kwargs):
@@ -147,13 +170,17 @@ class TestDDGSProviderSearch:
         assert result["success"] is False
         assert "rate limited" in result["error"] or "failed" in result["error"].lower()
 
-    def test_empty_results(self, monkeypatch):
+    def test_empty_results_return_provider_dead_error(self, monkeypatch):
+        """Issue #467: an empty DDGS result is treated as a provider failure so
+        the agent stops looping on "no results" and switches provider.
+        """
         _install_fake_ddgs(monkeypatch, text_results=[])
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
 
         result = DDGSWebSearchProvider().search("nothing", limit=5)
-        assert result["success"] is True
-        assert result["data"]["web"] == []
+        assert result["success"] is False
+        assert "no results" in result["error"].lower()
+        assert "alternative" in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -164,16 +191,19 @@ class TestDDGSProviderSearch:
 class TestDDGSBackendWiring:
     def test_is_backend_available_true_when_package_importable(self, monkeypatch):
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools._is_backend_available("ddgs") is True
 
     def test_is_backend_available_false_when_package_missing(self, monkeypatch):
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
         assert web_tools._is_backend_available("ddgs") is False
 
     def test_configured_backend_accepted(self, monkeypatch):
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools._get_backend() == "ddgs"
@@ -181,9 +211,16 @@ class TestDDGSBackendWiring:
     def test_ddgs_trails_paid_providers_in_auto_detect(self, monkeypatch):
         """Exa (priority) should win over ddgs in auto-detect."""
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
-        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
-                    "TAVILY_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+        for key in (
+            "FIRECRAWL_API_KEY",
+            "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY",
+            "TAVILY_API_KEY",
+            "SEARXNG_URL",
+            "BRAVE_SEARCH_API_KEY",
+        ):
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("EXA_API_KEY", "exa-key")
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
@@ -192,9 +229,17 @@ class TestDDGSBackendWiring:
 
     def test_auto_detect_picks_ddgs_as_last_resort(self, monkeypatch):
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
-        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
-                    "TAVILY_API_KEY", "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+        for key in (
+            "FIRECRAWL_API_KEY",
+            "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY",
+            "TAVILY_API_KEY",
+            "EXA_API_KEY",
+            "SEARXNG_URL",
+            "BRAVE_SEARCH_API_KEY",
+        ):
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
@@ -202,6 +247,7 @@ class TestDDGSBackendWiring:
 
     def test_check_web_api_key_true_when_ddgs_configured(self, monkeypatch):
         from tools import web_tools
+
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools.check_web_api_key() is True
@@ -220,6 +266,7 @@ class TestDDGSSearchOnlyErrors:
         self._register_providers()
         yield
         from agent.web_search_registry import _reset_for_tests
+
         _reset_for_tests()
 
     def test_web_extract_returns_search_only_error(self, monkeypatch):
@@ -229,11 +276,14 @@ class TestDDGSSearchOnlyErrors:
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+
         async def _allow_ssrf(_url: str) -> bool:
             return True
 
         monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
-        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr(
+            "tools.interrupt.is_interrupted", lambda: False, raising=False
+        )
 
         result_str = asyncio.get_event_loop().run_until_complete(
             web_tools.web_extract_tool(["https://example.com"])
@@ -241,4 +291,6 @@ class TestDDGSSearchOnlyErrors:
         result = json.loads(result_str)
         assert result["success"] is False
         assert "search-only" in result["error"].lower()
-        assert "duckduckgo" in result["error"].lower() or "ddgs" in result["error"].lower()
+        assert (
+            "duckduckgo" in result["error"].lower() or "ddgs" in result["error"].lower()
+        )

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -23,6 +23,7 @@ class TestFirecrawlClientConfig:
     def setup_method(self):
         """Reset client and env vars before each test."""
         import tools.web_tools
+
         tools.web_tools._firecrawl_client = None
         tools.web_tools._firecrawl_client_config = None
         for key in (
@@ -39,7 +40,10 @@ class TestFirecrawlClientConfig:
         # full firecrawl client init path sees True.
         self._managed_patchers = [
             patch("tools.web_tools.managed_nous_tools_enabled", return_value=True),
-            patch("tools.managed_tool_gateway.managed_nous_tools_enabled", return_value=True),
+            patch(
+                "tools.managed_tool_gateway.managed_nous_tools_enabled",
+                return_value=True,
+            ),
         ]
         for p in self._managed_patchers:
             p.start()
@@ -47,6 +51,7 @@ class TestFirecrawlClientConfig:
     def teardown_method(self):
         """Reset client after each test."""
         import tools.web_tools
+
         tools.web_tools._firecrawl_client = None
         tools.web_tools._firecrawl_client_config = None
         for key in (
@@ -68,15 +73,19 @@ class TestFirecrawlClientConfig:
         with patch("tools.web_tools.Firecrawl"):
             with patch("tools.web_tools._read_nous_access_token", return_value=None):
                 from tools.web_tools import _get_firecrawl_client
+
                 with pytest.raises(ValueError, match="FIRECRAWL_API_KEY"):
                     _get_firecrawl_client()
 
     def test_tool_gateway_domain_builds_firecrawl_gateway_origin(self):
         """Shared gateway domain should derive the Firecrawl vendor hostname."""
         with patch.dict(os.environ, {"TOOL_GATEWAY_DOMAIN": "nousresearch.com"}):
-            with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
+            with patch(
+                "tools.web_tools._read_nous_access_token", return_value="nous-token"
+            ):
                 with patch("tools.web_tools.Firecrawl") as mock_fc:
                     from tools.web_tools import _get_firecrawl_client
+
                     result = _get_firecrawl_client()
                     mock_fc.assert_called_once_with(
                         api_key="nous-token",
@@ -86,13 +95,19 @@ class TestFirecrawlClientConfig:
 
     def test_tool_gateway_scheme_can_switch_derived_gateway_origin_to_http(self):
         """Shared gateway scheme should allow local plain-http vendor hosts."""
-        with patch.dict(os.environ, {
-            "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
-            "TOOL_GATEWAY_SCHEME": "http",
-        }):
-            with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
+        with patch.dict(
+            os.environ,
+            {
+                "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
+                "TOOL_GATEWAY_SCHEME": "http",
+            },
+        ):
+            with patch(
+                "tools.web_tools._read_nous_access_token", return_value="nous-token"
+            ):
                 with patch("tools.web_tools.Firecrawl") as mock_fc:
                     from tools.web_tools import _get_firecrawl_client
+
                     result = _get_firecrawl_client()
                     mock_fc.assert_called_once_with(
                         api_key="nous-token",
@@ -102,24 +117,36 @@ class TestFirecrawlClientConfig:
 
     def test_invalid_tool_gateway_scheme_raises(self):
         """Unexpected shared gateway schemes should fail fast."""
-        with patch.dict(os.environ, {
-            "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
-            "TOOL_GATEWAY_SCHEME": "ftp",
-        }):
-            with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
+        with patch.dict(
+            os.environ,
+            {
+                "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
+                "TOOL_GATEWAY_SCHEME": "ftp",
+            },
+        ):
+            with patch(
+                "tools.web_tools._read_nous_access_token", return_value="nous-token"
+            ):
                 from tools.web_tools import _get_firecrawl_client
+
                 with pytest.raises(ValueError, match="TOOL_GATEWAY_SCHEME"):
                     _get_firecrawl_client()
 
     def test_explicit_firecrawl_gateway_url_takes_precedence(self):
         """An explicit Firecrawl gateway origin should override the shared domain."""
-        with patch.dict(os.environ, {
-            "FIRECRAWL_GATEWAY_URL": "https://firecrawl-gateway.localhost:3009/",
-            "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
-        }):
-            with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
+        with patch.dict(
+            os.environ,
+            {
+                "FIRECRAWL_GATEWAY_URL": "https://firecrawl-gateway.localhost:3009/",
+                "TOOL_GATEWAY_DOMAIN": "nousresearch.com",
+            },
+        ):
+            with patch(
+                "tools.web_tools._read_nous_access_token", return_value="nous-token"
+            ):
                 with patch("tools.web_tools.Firecrawl") as mock_fc:
                     from tools.web_tools import _get_firecrawl_client
+
                     _get_firecrawl_client()
                     mock_fc.assert_called_once_with(
                         api_key="nous-token",
@@ -128,9 +155,12 @@ class TestFirecrawlClientConfig:
 
     def test_default_gateway_domain_targets_nous_production_origin(self):
         """Default gateway origin should point at the Firecrawl vendor hostname."""
-        with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
+        with patch(
+            "tools.web_tools._read_nous_access_token", return_value="nous-token"
+        ):
             with patch("tools.web_tools.Firecrawl") as mock_fc:
                 from tools.web_tools import _get_firecrawl_client
+
                 _get_firecrawl_client()
                 mock_fc.assert_called_once_with(
                     api_key="nous-token",
@@ -144,19 +174,26 @@ class TestFirecrawlClientConfig:
 
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
-        (hermes_home / "auth.json").write_text(json.dumps({
-            "providers": {
-                "nous": {
-                    "access_token": "nous-token",
+        (hermes_home / "auth.json").write_text(
+            json.dumps({
+                "providers": {
+                    "nous": {
+                        "access_token": "nous-token",
+                    }
                 }
-            }
-        }))
+            })
+        )
 
-        with patch.dict(os.environ, {
-            "HOME": str(real_home),
-            "HERMES_HOME": str(hermes_home),
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "HOME": str(real_home),
+                "HERMES_HOME": str(hermes_home),
+            },
+            clear=False,
+        ):
             import tools.web_tools
+
             importlib.reload(tools.web_tools)
             assert tools.web_tools._read_nous_access_token() == "nous-token"
 
@@ -169,7 +206,10 @@ class TestFirecrawlClientConfig:
 
         with patch(
             "tools.web_tools.get_async_text_auxiliary_client",
-            side_effect=[(None, None), (MagicMock(base_url="https://api.openrouter.ai/v1"), "test-model")],
+            side_effect=[
+                (None, None),
+                (MagicMock(base_url="https://api.openrouter.ai/v1"), "test-model"),
+            ],
         ):
             assert tools.web_tools.check_auxiliary_model() is False
             assert tools.web_tools.check_auxiliary_model() is True
@@ -184,13 +224,23 @@ class TestFirecrawlClientConfig:
         response = MagicMock()
         response.choices = [MagicMock(message=MagicMock(content="summary text"))]
 
-        with patch(
-            "tools.web_tools._resolve_web_extract_auxiliary",
-            side_effect=[(None, None, {}), (MagicMock(base_url="https://api.openrouter.ai/v1"), "test-model", {})],
-        ), patch(
-            "tools.web_tools.async_call_llm",
-            new=AsyncMock(return_value=response),
-        ) as mock_async_call:
+        with (
+            patch(
+                "tools.web_tools._resolve_web_extract_auxiliary",
+                side_effect=[
+                    (None, None, {}),
+                    (
+                        MagicMock(base_url="https://api.openrouter.ai/v1"),
+                        "test-model",
+                        {},
+                    ),
+                ],
+            ),
+            patch(
+                "tools.web_tools.async_call_llm",
+                new=AsyncMock(return_value=response),
+            ) as mock_async_call,
+        ):
             assert tools.web_tools.check_auxiliary_model() is False
             result = await tools.web_tools._call_summarizer_llm(
                 "Some content worth summarizing",
@@ -208,6 +258,7 @@ class TestFirecrawlClientConfig:
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             with patch("tools.web_tools.Firecrawl") as mock_fc:
                 from tools.web_tools import _get_firecrawl_client
+
                 client1 = _get_firecrawl_client()
                 client2 = _get_firecrawl_client()
                 assert client1 is client2
@@ -216,6 +267,7 @@ class TestFirecrawlClientConfig:
     def test_constructor_failure_allows_retry(self):
         """If Firecrawl() raises, next call should retry (not return None)."""
         import tools.web_tools
+
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             with patch("tools.web_tools.Firecrawl") as mock_fc:
                 mock_fc.side_effect = [RuntimeError("init failed"), MagicMock()]
@@ -235,8 +287,11 @@ class TestFirecrawlClientConfig:
         """FIRECRAWL_API_KEY='' with no URL → should raise."""
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": ""}):
             with patch("tools.web_tools.Firecrawl"):
-                with patch("tools.web_tools._read_nous_access_token", return_value=None):
+                with patch(
+                    "tools.web_tools._read_nous_access_token", return_value=None
+                ):
                     from tools.web_tools import _get_firecrawl_client
+
                     with pytest.raises(ValueError):
                         _get_firecrawl_client()
 
@@ -266,7 +321,10 @@ class TestBackendSelection:
             os.environ.pop(key, None)
         self._managed_patchers = [
             patch("tools.web_tools.managed_nous_tools_enabled", return_value=True),
-            patch("tools.managed_tool_gateway.managed_nous_tools_enabled", return_value=True),
+            patch(
+                "tools.managed_tool_gateway.managed_nous_tools_enabled",
+                return_value=True,
+            ),
         ]
         for p in self._managed_patchers:
             p.start()
@@ -282,46 +340,72 @@ class TestBackendSelection:
     def test_config_parallel(self):
         """web.backend=parallel in config → 'parallel' regardless of keys."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}):
+
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "parallel"}
+        ):
             assert _get_backend() == "parallel"
 
     def test_config_exa(self):
         """web.backend=exa in config → 'exa' regardless of other keys."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "exa"}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={"backend": "exa"}),
+            patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}),
+        ):
             assert _get_backend() == "exa"
 
     def test_config_firecrawl(self):
         """web.backend=firecrawl in config → 'firecrawl' even if Parallel key set."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+
+        with (
+            patch(
+                "tools.web_tools._load_web_config",
+                return_value={"backend": "firecrawl"},
+            ),
+            patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}),
+        ):
             assert _get_backend() == "firecrawl"
 
     def test_config_tavily(self):
         """web.backend=tavily in config → 'tavily' regardless of other keys."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}):
+
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "tavily"}
+        ):
             assert _get_backend() == "tavily"
 
     def test_config_tavily_overrides_env_keys(self):
         """web.backend=tavily in config → 'tavily' even if Firecrawl key set."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}), \
-             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+
+        with (
+            patch(
+                "tools.web_tools._load_web_config", return_value={"backend": "tavily"}
+            ),
+            patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}),
+        ):
             assert _get_backend() == "tavily"
 
     def test_config_case_insensitive(self):
         """web.backend=Parallel (mixed case) → 'parallel'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "Parallel"}):
+
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "Parallel"}
+        ):
             assert _get_backend() == "parallel"
 
     def test_config_tavily_case_insensitive(self):
         """web.backend=Tavily (mixed case) → 'tavily'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
+
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "Tavily"}
+        ):
             assert _get_backend() == "tavily"
 
     # ── Fallback (no web.backend in config) ───────────────────────────
@@ -329,73 +413,117 @@ class TestBackendSelection:
     def test_fallback_parallel_only_key(self):
         """Only PARALLEL_API_KEY set → 'parallel'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}),
+        ):
             assert _get_backend() == "parallel"
 
     def test_fallback_exa_only_key(self):
         """Only EXA_API_KEY set → 'exa'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}),
+        ):
             assert _get_backend() == "exa"
 
     def test_fallback_exa_takes_priority_over_parallel(self):
         """Direct-credential backends are tried in the order tavily > exa > parallel
         so an explicit Exa key wins when both Exa and Parallel are configured."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "PARALLEL_API_KEY": "par-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(
+                os.environ, {"EXA_API_KEY": "exa-test", "PARALLEL_API_KEY": "par-test"}
+            ),
+        ):
             assert _get_backend() == "exa"
 
     def test_fallback_tavily_only_key(self):
         """Only TAVILY_API_KEY set → 'tavily'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}),
+        ):
             assert _get_backend() == "tavily"
 
     def test_fallback_tavily_beats_firecrawl_direct(self):
         """Tavily ranks above firecrawl in the explicit-credential block."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "FIRECRAWL_API_KEY": "fc-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(
+                os.environ,
+                {"TAVILY_API_KEY": "tvly-test", "FIRECRAWL_API_KEY": "fc-test"},
+            ),
+        ):
             assert _get_backend() == "tavily"
 
     def test_fallback_tavily_beats_parallel(self):
         """Tavily is first in the explicit-credential block so it wins over parallel."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "PARALLEL_API_KEY": "par-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(
+                os.environ,
+                {"TAVILY_API_KEY": "tvly-test", "PARALLEL_API_KEY": "par-test"},
+            ),
+        ):
             assert _get_backend() == "tavily"
 
     def test_fallback_parallel_beats_firecrawl_direct(self):
         """Parallel + Firecrawl-direct → parallel (parallel is the higher-priority
         explicit-credential backend; firecrawl-direct ranks below it)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key", "FIRECRAWL_API_KEY": "fc-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(
+                os.environ,
+                {"PARALLEL_API_KEY": "test-key", "FIRECRAWL_API_KEY": "fc-test"},
+            ),
+        ):
             assert _get_backend() == "parallel"
 
     def test_fallback_firecrawl_only_key(self):
         """Only FIRECRAWL_API_KEY set → 'firecrawl'."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}),
+        ):
             assert _get_backend() == "firecrawl"
 
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch("tools.web_tools._ddgs_package_importable", return_value=False):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch("tools.web_tools._ddgs_package_importable", return_value=False),
+        ):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
         """web.backend=invalid → ignored, uses key-based fallback."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "nonexistent"}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+
+        with (
+            patch(
+                "tools.web_tools._load_web_config",
+                return_value={"backend": "nonexistent"},
+            ),
+            patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}),
+        ):
             assert _get_backend() == "parallel"
 
     def test_managed_gateway_does_not_preempt_explicit_tavily(self):
@@ -405,9 +533,12 @@ class TestBackendSelection:
         Tavily setup would fail at runtime with "no subscription" if the
         gateway pre-empted it."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch("tools.web_tools._is_tool_gateway_ready", return_value=True), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch("tools.web_tools._is_tool_gateway_ready", return_value=True),
+            patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}),
+        ):
             assert _get_backend() == "tavily"
 
     def test_managed_gateway_only_falls_through_to_firecrawl(self):
@@ -415,8 +546,11 @@ class TestBackendSelection:
         gateway token still selects firecrawl — the convenience path is
         preserved, just no longer pre-empts."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch("tools.web_tools._is_tool_gateway_ready", return_value=True):
+
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch("tools.web_tools._is_tool_gateway_ready", return_value=True),
+        ):
             assert _get_backend() == "firecrawl"
 
 
@@ -425,6 +559,7 @@ class TestParallelClientConfig:
 
     def setup_method(self):
         import tools.web_tools
+
         tools.web_tools._parallel_client = None
         os.environ.pop("PARALLEL_API_KEY", None)
         fake_parallel = types.ModuleType("parallel")
@@ -443,6 +578,7 @@ class TestParallelClientConfig:
 
     def teardown_method(self):
         import tools.web_tools
+
         tools.web_tools._parallel_client = None
         os.environ.pop("PARALLEL_API_KEY", None)
         sys.modules.pop("parallel", None)
@@ -452,6 +588,7 @@ class TestParallelClientConfig:
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             from tools.web_tools import _get_parallel_client
             from parallel import Parallel
+
             client = _get_parallel_client()
             assert client is not None
             assert isinstance(client, Parallel)
@@ -459,6 +596,7 @@ class TestParallelClientConfig:
     def test_no_key_raises_with_helpful_message(self):
         """No PARALLEL_API_KEY → ValueError with guidance."""
         from tools.web_tools import _get_parallel_client
+
         with pytest.raises(ValueError, match="PARALLEL_API_KEY"):
             _get_parallel_client()
 
@@ -466,6 +604,7 @@ class TestParallelClientConfig:
         """Second call returns cached client."""
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             from tools.web_tools import _get_parallel_client
+
             client1 = _get_parallel_client()
             client2 = _get_parallel_client()
             assert client1 is client2
@@ -477,19 +616,25 @@ class TestWebSearchSchema:
     def test_schema_exposes_optional_limit(self):
         import tools.web_tools
 
-        limit_schema = tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["properties"]["limit"]
+        limit_schema = tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["properties"][
+            "limit"
+        ]
 
         assert limit_schema["type"] == "integer"
         assert limit_schema["minimum"] == 1
         assert limit_schema["maximum"] == 100
         assert limit_schema["default"] == 5
-        assert "limit" not in tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["required"]
+        assert (
+            "limit" not in tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["required"]
+        )
 
     def test_registered_handler_passes_limit(self):
         import tools.web_tools
 
         entry = tools.web_tools.registry.get_entry("web_search")
-        with patch("tools.web_tools.web_search_tool", return_value='{"success": true}') as mock_search:
+        with patch(
+            "tools.web_tools.web_search_tool", return_value='{"success": true}'
+        ) as mock_search:
             result = entry.handler({"query": "site:example.com docs", "limit": 12})
 
         assert result == '{"success": true}'
@@ -499,7 +644,9 @@ class TestWebSearchSchema:
         import tools.web_tools
 
         entry = tools.web_tools.registry.get_entry("web_search")
-        with patch("tools.web_tools.web_search_tool", return_value='{"success": true}') as mock_search:
+        with patch(
+            "tools.web_tools.web_search_tool", return_value='{"success": true}'
+        ) as mock_search:
             result = entry.handler({"query": "docs"})
 
         assert result == '{"success": true}'
@@ -513,7 +660,21 @@ class TestWebSearchSchema:
         # tool dispatcher resolves a provider from the registry and calls
         # provider.search(query, limit). Mock the provider lookup so we can
         # assert the limit is clamped before reaching the backend.
-        fake_search = MagicMock(return_value={"success": True, "data": {"web": []}})
+        fake_search = MagicMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "web": [
+                        {
+                            "title": "result",
+                            "url": "https://example.com",
+                            "description": "test",
+                            "position": 1,
+                        }
+                    ]
+                },
+            }
+        )
         fake_provider = MagicMock(
             name="ParallelWebSearchProvider",
             supports_search=MagicMock(return_value=True),
@@ -521,14 +682,18 @@ class TestWebSearchSchema:
         fake_provider.search = fake_search
         fake_provider.name = "parallel"
 
-        with patch("tools.web_tools._get_search_backend", return_value="parallel"), \
-             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
-             patch("tools.interrupt.is_interrupted", return_value=False), \
-             patch.object(tools.web_tools._debug, "log_call"), \
-             patch.object(tools.web_tools._debug, "save"):
+        with (
+            patch("tools.web_tools._get_search_backend", return_value="parallel"),
+            patch("agent.web_search_registry.get_provider", return_value=fake_provider),
+            patch("tools.interrupt.is_interrupted", return_value=False),
+            patch("tools.web_tools._search_backend_fallback_chain", return_value=[]),
+            patch.object(tools.web_tools._debug, "log_call"),
+            patch.object(tools.web_tools._debug, "save"),
+        ):
             result = json.loads(tools.web_tools.web_search_tool("docs", limit=500))
 
-        assert result == {"success": True, "data": {"web": []}}
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
         fake_search.assert_called_once_with("docs", 100)
 
 
@@ -549,11 +714,13 @@ class TestWebSearchErrorHandling:
         fake_provider.search.side_effect = RuntimeError("boom")
         fake_provider.name = "firecrawl"
 
-        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
-             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
-             patch("tools.interrupt.is_interrupted", return_value=False), \
-             patch.object(tools.web_tools._debug, "log_call") as mock_log_call, \
-             patch.object(tools.web_tools._debug, "save"):
+        with (
+            patch("tools.web_tools._get_search_backend", return_value="firecrawl"),
+            patch("agent.web_search_registry.get_provider", return_value=fake_provider),
+            patch("tools.interrupt.is_interrupted", return_value=False),
+            patch.object(tools.web_tools._debug, "log_call") as mock_log_call,
+            patch.object(tools.web_tools._debug, "save"),
+        ):
             result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
 
         assert result == {"error": "Error searching web: boom"}
@@ -588,7 +755,10 @@ class TestCheckWebApiKey:
             os.environ.pop(key, None)
         self._managed_patchers = [
             patch("tools.web_tools.managed_nous_tools_enabled", return_value=True),
-            patch("tools.managed_tool_gateway.managed_nous_tools_enabled", return_value=True),
+            patch(
+                "tools.managed_tool_gateway.managed_nous_tools_enabled",
+                return_value=True,
+            ),
         ]
         for p in self._managed_patchers:
             p.start()
@@ -602,53 +772,70 @@ class TestCheckWebApiKey:
     def test_parallel_key_only(self):
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_exa_key_only(self):
         with patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_firecrawl_key_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_firecrawl_url_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_URL": "http://localhost:3002"}):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key
+
         with patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
-        with patch.dict(os.environ, {
-            "PARALLEL_API_KEY": "test-key",
-            "FIRECRAWL_API_KEY": "fc-test",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "PARALLEL_API_KEY": "test-key",
+                "FIRECRAWL_API_KEY": "fc-test",
+            },
+        ):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_all_three_keys_returns_true(self):
-        with patch.dict(os.environ, {
-            "PARALLEL_API_KEY": "test-key",
-            "FIRECRAWL_API_KEY": "fc-test",
-            "TAVILY_API_KEY": "tvly-test",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "PARALLEL_API_KEY": "test-key",
+                "FIRECRAWL_API_KEY": "fc-test",
+                "TAVILY_API_KEY": "tvly-test",
+            },
+        ):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_tool_gateway_returns_true(self):
-        with patch("tools.web_tools._peek_nous_access_token", return_value="nous-token"):
+        with patch(
+            "tools.web_tools._peek_nous_access_token", return_value="nous-token"
+        ):
             from tools.web_tools import check_web_api_key
+
             assert check_web_api_key() is True
 
     def test_tool_gateway_availability_skips_refresh_for_expired_cached_token(
@@ -659,15 +846,17 @@ class TestCheckWebApiKey:
         monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         expired_at = "2000-01-01T00:00:00+00:00"
-        (tmp_path / "auth.json").write_text(json.dumps({
-            "providers": {
-                "nous": {
-                    "access_token": "expired-token",
-                    "refresh_token": "refresh-token",
-                    "expires_at": expired_at,
+        (tmp_path / "auth.json").write_text(
+            json.dumps({
+                "providers": {
+                    "nous": {
+                        "access_token": "expired-token",
+                        "refresh_token": "refresh-token",
+                        "expires_at": expired_at,
+                    }
                 }
-            }
-        }))
+            })
+        )
         refresh_calls = []
 
         def _record_refresh(*, refresh_skew_seconds=120, **_kwargs):
@@ -691,17 +880,35 @@ class TestCheckWebApiKey:
         assert refresh_calls == []
 
     def test_configured_backend_must_match_available_provider(self):
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}):
-            with patch("tools.web_tools._read_nous_access_token", return_value="nous-token"):
-                with patch.dict(os.environ, {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"}, clear=False):
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "parallel"}
+        ):
+            with patch(
+                "tools.web_tools._read_nous_access_token", return_value="nous-token"
+            ):
+                with patch.dict(
+                    os.environ,
+                    {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"},
+                    clear=False,
+                ):
                     from tools.web_tools import check_web_api_key
+
                     assert check_web_api_key() is False
 
     def test_configured_firecrawl_backend_accepts_managed_gateway(self):
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}):
-            with patch("tools.web_tools._peek_nous_access_token", return_value="nous-token"):
-                with patch.dict(os.environ, {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"}, clear=False):
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}
+        ):
+            with patch(
+                "tools.web_tools._peek_nous_access_token", return_value="nous-token"
+            ):
+                with patch.dict(
+                    os.environ,
+                    {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"},
+                    clear=False,
+                ):
                     from tools.web_tools import check_web_api_key
+
                     assert check_web_api_key() is True
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -28,11 +28,11 @@ Debug Mode:
 
 Usage:
     from web_tools import web_search_tool, web_extract_tool
-    
+
     # Search the web
     results = web_search_tool("Python machine learning libraries", limit=3)
-    
-    # Extract content from URLs  
+
+    # Extract content from URLs
     content = web_extract_tool(["https://example.com"], format="markdown")
 """
 
@@ -43,6 +43,7 @@ import re
 import asyncio
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx  # noqa: F401 — kept at module top so tests can patch tools.web_tools.httpx
+
 # After the web-provider plugin migration (PR #25182), the Firecrawl SDK
 # proxy, client construction, and response-shape normalizers all live in
 # plugins.web.firecrawl.provider. We re-export the names that external
@@ -58,6 +59,7 @@ from plugins.web.firecrawl.provider import (
     _is_tool_gateway_ready,
     check_firecrawl_api_key,
 )
+
 # Tavily helpers re-exported for backward-compat with existing unit tests
 # (tests/tools/test_web_tools_tavily.py imports these names directly).
 from plugins.web.tavily.provider import (  # noqa: F401 — backward-compat names
@@ -65,6 +67,7 @@ from plugins.web.tavily.provider import (  # noqa: F401 — backward-compat name
     _normalize_tavily_search_results,
     _tavily_request,
 )
+
 # Parallel + Exa clients re-exported for backward-compat with existing
 # unit tests (tests/tools/test_web_tools_config.py imports _get_parallel_client
 # / _get_async_parallel_client / _get_exa_client directly).
@@ -89,6 +92,7 @@ from agent.auxiliary_client import (
     get_async_text_auxiliary_client,
 )
 from tools.debug_helpers import DebugSession
+
 # Imported solely so unit tests can monkeypatch these names on
 # tools.web_tools (the firecrawl plugin reads them via its own import chain).
 from tools.managed_tool_gateway import (  # noqa: F401 — backward-compat names for tests
@@ -109,6 +113,7 @@ logger = logging.getLogger(__name__)
 
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
+
 
 def _env_value(name: str) -> str:
     """Resolve ``name`` via Hermes config-aware env, falling back to process env.
@@ -133,13 +138,16 @@ def _env_value(name: str) -> str:
 def _has_env(name: str) -> bool:
     return bool(_env_value(name))
 
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
         from hermes_cli.config import load_config
+
         return load_config().get("web", {})
     except (ImportError, Exception):
         return {}
+
 
 def _get_backend() -> str:
     """Determine which web backend to use (shared fallback).
@@ -149,7 +157,16 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {
+        "parallel",
+        "firecrawl",
+        "tavily",
+        "exa",
+        "searxng",
+        "brave-free",
+        "ddgs",
+        "xai",
+    }:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -237,6 +254,7 @@ def _is_backend_available(backend: str) -> bool:
         # runs on every web_search dispatch + every `hermes tools` repaint.
         try:
             from tools.xai_http import has_xai_credentials
+
             return has_xai_credentials()
         except Exception:
             return False
@@ -253,9 +271,72 @@ def _ddgs_package_importable() -> bool:
     """
     try:
         import ddgs  # noqa: F401
+
         return True
     except ImportError:
         return False
+
+
+def _search_backend_fallback_chain() -> list[str]:
+    """Parse ``web.search_backend_fallback_chain`` from config.yaml.
+
+    Returns a list of backend names (stripped, lower-cased) after the
+    currently active backend. If unset or empty, returns [].
+    """
+    raw = (_load_web_config().get("search_backend_fallback_chain") or "").strip()
+    if not raw:
+        return []
+    return [b.strip().lower() for b in raw.split(",") if b.strip()]
+
+
+def _search_with_fallbacks(
+    provider: Any,
+    query: str,
+    limit: int,
+    backend: str,
+) -> dict[str, Any]:
+    """Execute ``provider.search`` and, if it fails or returns empty, try the
+    configured fallback chain. Returns the first successful non-empty result,
+    or the last attempted provider's error. The returned dict includes a
+    ``provider`` key naming the backend that produced the answer.
+    """
+    from agent.web_search_registry import get_provider as _wsp_get_provider
+
+    tried = [backend]
+    result = provider.search(query, limit)
+    if result.get("success") and result.get("data", {}).get("web"):
+        result["provider"] = backend
+        return result
+
+    for fallback in _search_backend_fallback_chain():
+        if fallback in tried:
+            continue
+        fb_provider = _wsp_get_provider(fallback)
+        if fb_provider is None or not fb_provider.supports_search():
+            logger.debug(
+                "Fallback search backend '%s' is not registered/available", fallback
+            )
+            continue
+        tried.append(fallback)
+        logger.info(
+            "Web search fallback to %s: '%s' (limit: %d)", fallback, query, limit
+        )
+        result = fb_provider.search(query, limit)
+        if result.get("success") and result.get("data", {}).get("web"):
+            result["provider"] = fallback
+            return result
+
+    # Preserve the original provider's error (or empty success) but label it.
+    result["provider"] = backend
+    if result.get("success") and not result.get("data", {}).get("web"):
+        result["success"] = False
+        result["error"] = (
+            f"Search backend '{backend}' returned no results and no fallback "
+            "chain produced results. Configure an alternative search_backend "
+            "or search_backend_fallback_chain in config.yaml."
+        )
+    return result
+
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -307,6 +388,7 @@ def _web_requires_env() -> list[str]:
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000
 
+
 def _is_nous_auxiliary_client(client: Any) -> bool:
     """Return True when the resolved auxiliary backend is Nous Portal."""
     from urllib.parse import urlparse
@@ -316,7 +398,9 @@ def _is_nous_auxiliary_client(client: Any) -> bool:
     return host == "nousresearch.com" or host.endswith(".nousresearch.com")
 
 
-def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optional[Any], Optional[str], Dict[str, Any]]:
+def _resolve_web_extract_auxiliary(
+    model: Optional[str] = None,
+) -> tuple[Optional[Any], Optional[str], Dict[str, Any]]:
     """Resolve the current web-extract auxiliary client, model, and extra body."""
     client, default_model = get_async_text_auxiliary_client("web_extract")
     configured_model = os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip()
@@ -326,6 +410,7 @@ def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optiona
     if client is not None and _is_nous_auxiliary_client(client):
         from agent.auxiliary_client import get_auxiliary_extra_body
         from agent.portal_tags import nous_portal_tags
+
         extra_body = get_auxiliary_extra_body() or {"tags": nous_portal_tags()}
 
     return client, effective_model, extra_body
@@ -336,56 +421,63 @@ def _get_default_summarizer_model() -> Optional[str]:
     _, model, _ = _resolve_web_extract_auxiliary()
     return model
 
+
 _debug = DebugSession("web_tools", env_var="WEB_TOOLS_DEBUG")
 
 
 async def process_content_with_llm(
-    content: str, 
-    url: str = "", 
+    content: str,
+    url: str = "",
     title: str = "",
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
 ) -> Optional[str]:
     """
     Process web content using LLM to create intelligent summaries with key excerpts.
-    
-    This function uses Gemini 3 Flash Preview (or specified model) via OpenRouter API 
+
+    This function uses Gemini 3 Flash Preview (or specified model) via OpenRouter API
     to intelligently extract key information and create markdown summaries,
     significantly reducing token usage while preserving all important information.
-    
+
     For very large content (>500k chars), uses chunked processing with synthesis.
     For extremely large content (>2M chars), refuses to process entirely.
-    
+
     Args:
         content (str): The raw content to process
         url (str): The source URL (for context, optional)
         title (str): The page title (for context, optional)
         model (str): The model to use for processing (default: google/gemini-3-flash-preview)
         min_length (int): Minimum content length to trigger processing (default: 5000)
-        
+
     Returns:
         Optional[str]: Processed markdown content, or None if content too short or processing fails
     """
     # Size thresholds
     MAX_CONTENT_SIZE = 2_000_000  # 2M chars - refuse entirely above this
-    CHUNK_THRESHOLD = 500_000     # 500k chars - use chunked processing above this
-    CHUNK_SIZE = 100_000          # 100k chars per chunk
-    MAX_OUTPUT_SIZE = 5000        # Hard cap on final output size
-    
+    CHUNK_THRESHOLD = 500_000  # 500k chars - use chunked processing above this
+    CHUNK_SIZE = 100_000  # 100k chars per chunk
+    MAX_OUTPUT_SIZE = 5000  # Hard cap on final output size
+
     try:
         content_len = len(content)
-        
+
         # Refuse if content is absurdly large
         if content_len > MAX_CONTENT_SIZE:
             size_mb = content_len / 1_000_000
-            logger.warning("Content too large (%.1fMB > 2MB limit). Refusing to process.", size_mb)
+            logger.warning(
+                "Content too large (%.1fMB > 2MB limit). Refusing to process.", size_mb
+            )
             return f"[Content too large to process: {size_mb:.1f}MB. Try a more focused source URL.]"
-        
+
         # Skip processing if content is too short
         if content_len < min_length:
-            logger.debug("Content too short (%d < %d chars), skipping LLM processing", content_len, min_length)
+            logger.debug(
+                "Content too short (%d < %d chars), skipping LLM processing",
+                content_len,
+                min_length,
+            )
             return None
-        
+
         # Create context information
         context_info = []
         if title:
@@ -393,31 +485,43 @@ async def process_content_with_llm(
         if url:
             context_info.append(f"Source: {url}")
         context_str = "\n".join(context_info) + "\n\n" if context_info else ""
-        
+
         # Check if we need chunked processing
         if content_len > CHUNK_THRESHOLD:
-            logger.info("Content large (%d chars). Using chunked processing...", content_len)
+            logger.info(
+                "Content large (%d chars). Using chunked processing...", content_len
+            )
             return await _process_large_content_chunked(
                 content, context_str, model, CHUNK_SIZE, MAX_OUTPUT_SIZE
             )
-        
+
         # Standard single-pass processing for normal content
         logger.info("Processing content with LLM (%d characters)", content_len)
-        
+
         processed_content = await _call_summarizer_llm(content, context_str, model)
-        
+
         if processed_content:
             # Enforce output cap
             if len(processed_content) > MAX_OUTPUT_SIZE:
-                processed_content = processed_content[:MAX_OUTPUT_SIZE] + "\n\n[... summary truncated for context management ...]"
-            
+                processed_content = (
+                    processed_content[:MAX_OUTPUT_SIZE]
+                    + "\n\n[... summary truncated for context management ...]"
+                )
+
             # Log compression metrics
             processed_length = len(processed_content)
-            compression_ratio = processed_length / content_len if content_len > 0 else 1.0
-            logger.info("Content processed: %d -> %d chars (%.1f%%)", content_len, processed_length, compression_ratio * 100)
-        
+            compression_ratio = (
+                processed_length / content_len if content_len > 0 else 1.0
+            )
+            logger.info(
+                "Content processed: %d -> %d chars (%.1f%%)",
+                content_len,
+                processed_length,
+                compression_ratio * 100,
+            )
+
         return processed_content
-        
+
     except Exception as e:
         logger.warning(
             "web_extract LLM summarization failed (%s). "
@@ -440,16 +544,16 @@ async def process_content_with_llm(
 
 
 async def _call_summarizer_llm(
-    content: str, 
-    context_str: str, 
-    model: Optional[str], 
+    content: str,
+    context_str: str,
+    model: Optional[str],
     max_tokens: int = 20000,
     is_chunk: bool = False,
-    chunk_info: str = ""
+    chunk_info: str = "",
 ) -> Optional[str]:
     """
     Make a single LLM call to summarize content.
-    
+
     Args:
         content: The content to summarize
         context_str: Context information (title, URL)
@@ -457,7 +561,7 @@ async def _call_summarizer_llm(
         max_tokens: Maximum output tokens
         is_chunk: Whether this is a chunk of a larger document
         chunk_info: Information about chunk position (e.g., "Chunk 2/5")
-        
+
     Returns:
         Summarized content or None on failure
     """
@@ -509,9 +613,13 @@ Create a markdown summary that captures all key information in a well-organized,
 
     for attempt in range(max_retries):
         try:
-            aux_client, effective_model, extra_body = _resolve_web_extract_auxiliary(model)
+            aux_client, effective_model, extra_body = _resolve_web_extract_auxiliary(
+                model
+            )
             if aux_client is None or not effective_model:
-                logger.warning("No auxiliary model available for web content processing")
+                logger.warning(
+                    "No auxiliary model available for web content processing"
+                )
                 return None
             call_kwargs = {
                 "task": "web_extract",
@@ -535,7 +643,11 @@ Create a markdown summary that captures all key information in a well-organized,
             if content:
                 return content
             # Reasoning-only / empty response — let the retry loop handle it
-            logger.warning("LLM returned empty content (attempt %d/%d), retrying", attempt + 1, max_retries)
+            logger.warning(
+                "LLM returned empty content (attempt %d/%d), retrying",
+                attempt + 1,
+                max_retries,
+            )
             if attempt < max_retries - 1:
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 60)
@@ -547,65 +659,80 @@ Create a markdown summary that captures all key information in a well-organized,
         except Exception as api_error:
             last_error = api_error
             if attempt < max_retries - 1:
-                logger.warning("LLM API call failed (attempt %d/%d): %s", attempt + 1, max_retries, str(api_error)[:100])
+                logger.warning(
+                    "LLM API call failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    max_retries,
+                    str(api_error)[:100],
+                )
                 logger.warning("Retrying in %ds...", retry_delay)
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 60)
             else:
                 raise last_error
-    
+
     return None
 
 
 async def _process_large_content_chunked(
-    content: str, 
-    context_str: str, 
-    model: Optional[str], 
+    content: str,
+    context_str: str,
+    model: Optional[str],
     chunk_size: int,
-    max_output_size: int
+    max_output_size: int,
 ) -> Optional[str]:
     """
     Process large content by chunking, summarizing each chunk in parallel,
     then synthesizing the summaries.
-    
+
     Args:
         content: The large content to process
         context_str: Context information
         model: Model to use
         chunk_size: Size of each chunk in characters
         max_output_size: Maximum final output size
-        
+
     Returns:
         Synthesized summary or None on failure
     """
     # Split content into chunks
     chunks = []
     for i in range(0, len(content), chunk_size):
-        chunk = content[i:i + chunk_size]
+        chunk = content[i : i + chunk_size]
         chunks.append(chunk)
-    
+
     logger.info("Split into %d chunks of ~%d chars each", len(chunks), chunk_size)
-    
+
     # Summarize each chunk in parallel
-    async def summarize_chunk(chunk_idx: int, chunk_content: str) -> tuple[int, Optional[str]]:
+    async def summarize_chunk(
+        chunk_idx: int, chunk_content: str
+    ) -> tuple[int, Optional[str]]:
         """Summarize a single chunk."""
         try:
             chunk_info = f"[Processing chunk {chunk_idx + 1} of {len(chunks)}]"
             summary = await _call_summarizer_llm(
-                chunk_content, 
-                context_str, 
-                model, 
+                chunk_content,
+                context_str,
+                model,
                 max_tokens=10000,
                 is_chunk=True,
-                chunk_info=chunk_info
+                chunk_info=chunk_info,
             )
             if summary:
-                logger.info("Chunk %d/%d summarized: %d -> %d chars", chunk_idx + 1, len(chunks), len(chunk_content), len(summary))
+                logger.info(
+                    "Chunk %d/%d summarized: %d -> %d chars",
+                    chunk_idx + 1,
+                    len(chunks),
+                    len(chunk_content),
+                    len(summary),
+                )
             return chunk_idx, summary
         except Exception as e:
-            logger.warning("Chunk %d/%d failed: %s", chunk_idx + 1, len(chunks), str(e)[:50])
+            logger.warning(
+                "Chunk %d/%d failed: %s", chunk_idx + 1, len(chunks), str(e)[:50]
+            )
             return chunk_idx, None
-    
+
     # Run all chunk summarizations in parallel
     tasks = [summarize_chunk(i, chunk) for i, chunk in enumerate(chunks)]
     # Use return_exceptions=True so a single task failure does not discard
@@ -624,25 +751,25 @@ async def _process_large_content_chunked(
     for chunk_idx, summary in sorted(successful_results, key=lambda x: x[0]):
         if summary:
             summaries.append(f"## Section {chunk_idx + 1}\n{summary}")
-    
+
     if not summaries:
         logger.debug("All chunk summarizations failed")
         return "[Failed to process large content: all chunk summarizations failed]"
-    
+
     logger.info("Got %d/%d chunk summaries", len(summaries), len(chunks))
-    
+
     # If only one chunk succeeded, just return it (with cap)
     if len(summaries) == 1:
         result = summaries[0]
         if len(result) > max_output_size:
             result = result[:max_output_size] + "\n\n[... truncated ...]"
         return result
-    
+
     # Synthesize the summaries into a final summary
     logger.info("Synthesizing %d summaries...", len(summaries))
-    
+
     combined_summaries = "\n\n---\n\n".join(summaries)
-    
+
     synthesis_prompt = f"""You have been given summaries of different sections of a large document. 
 Synthesize these into ONE cohesive, comprehensive summary that:
 1. Removes redundancy between sections
@@ -668,7 +795,10 @@ Create a single, unified markdown summary."""
             "task": "web_extract",
             "model": effective_model,
             "messages": [
-                {"role": "system", "content": "You synthesize multiple summaries into one cohesive, comprehensive summary. Be thorough but concise."},
+                {
+                    "role": "system",
+                    "content": "You synthesize multiple summaries into one cohesive, comprehensive summary. Be thorough but concise.",
+                },
                 {"role": "user", "content": synthesis_prompt},
             ],
             "temperature": 0.1,
@@ -687,7 +817,9 @@ Create a single, unified markdown summary."""
 
         # If still None after retry, fall back to concatenated summaries
         if not final_summary:
-            logger.warning("Synthesis failed after retry — concatenating chunk summaries")
+            logger.warning(
+                "Synthesis failed after retry — concatenating chunk summaries"
+            )
             fallback = "\n\n".join(summaries)
             if len(fallback) > max_output_size:
                 fallback = fallback[:max_output_size] + "\n\n[... truncated ...]"
@@ -695,54 +827,65 @@ Create a single, unified markdown summary."""
 
         # Enforce hard cap
         if len(final_summary) > max_output_size:
-            final_summary = final_summary[:max_output_size] + "\n\n[... summary truncated for context management ...]"
-        
+            final_summary = (
+                final_summary[:max_output_size]
+                + "\n\n[... summary truncated for context management ...]"
+            )
+
         original_len = len(content)
         final_len = len(final_summary)
         compression = final_len / original_len if original_len > 0 else 1.0
-        
-        logger.info("Synthesis complete: %d -> %d chars (%.2f%%)", original_len, final_len, compression * 100)
+
+        logger.info(
+            "Synthesis complete: %d -> %d chars (%.2f%%)",
+            original_len,
+            final_len,
+            compression * 100,
+        )
         return final_summary
-        
+
     except Exception as e:
         logger.warning("Synthesis failed: %s", str(e)[:100])
         # Fall back to concatenated summaries with truncation
         fallback = "\n\n".join(summaries)
         if len(fallback) > max_output_size:
-            fallback = fallback[:max_output_size] + "\n\n[... truncated due to synthesis failure ...]"
+            fallback = (
+                fallback[:max_output_size]
+                + "\n\n[... truncated due to synthesis failure ...]"
+            )
         return fallback
 
 
 def clean_base64_images(text: str) -> str:
     """
     Remove base64 encoded images from text to reduce token count and clutter.
-    
+
     This function finds and removes base64 encoded images in various formats:
     - (data:image/png;base64,...)
     - (data:image/jpeg;base64,...)
     - (data:image/svg+xml;base64,...)
     - data:image/[type];base64,... (without parentheses)
-    
+
     Args:
         text: The text content to clean
-        
+
     Returns:
         Cleaned text with base64 images replaced with placeholders
     """
     # Pattern to match base64 encoded images wrapped in parentheses
     # Matches: (data:image/[type];base64,[base64-string])
-    base64_with_parens_pattern = r'\(data:image/[^;]+;base64,[A-Za-z0-9+/=]+\)'
-    
+    base64_with_parens_pattern = r"\(data:image/[^;]+;base64,[A-Za-z0-9+/=]+\)"
+
     # Pattern to match base64 encoded images without parentheses
     # Matches: data:image/[type];base64,[base64-string]
-    base64_pattern = r'data:image/[^;]+;base64,[A-Za-z0-9+/=]+'
-    
+    base64_pattern = r"data:image/[^;]+;base64,[A-Za-z0-9+/=]+"
+
     # Replace parentheses-wrapped images first
-    cleaned_text = re.sub(base64_with_parens_pattern, '[BASE64_IMAGE_REMOVED]', text)
-    
+    cleaned_text = re.sub(base64_with_parens_pattern, "[BASE64_IMAGE_REMOVED]", text)
+
     # Then replace any remaining non-parentheses images
-    cleaned_text = re.sub(base64_pattern, '[BASE64_IMAGE_REMOVED]', cleaned_text)
-    
+    cleaned_text = re.sub(base64_pattern, "[BASE64_IMAGE_REMOVED]", cleaned_text)
+
     return cleaned_text
 
 
@@ -793,11 +936,11 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
-    
+
     Args:
         query (str): The search query to look up
         limit (int): Maximum number of results to return (default: 5)
-    
+
     Returns:
         str: JSON string containing search results with the following structure:
              {
@@ -814,7 +957,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                      ]
                  }
              }
-    
+
     Raises:
         Exception: If search fails or API key is not set
     """
@@ -825,18 +968,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     limit = min(max(limit, 1), 100)
 
     debug_call_data = {
-        "parameters": {
-            "query": query,
-            "limit": limit
-        },
+        "parameters": {"query": query, "limit": limit},
         "error": None,
         "results_count": 0,
         "original_response_size": 0,
-        "final_response_size": 0
+        "final_response_size": 0,
     }
-    
+
     try:
         from tools.interrupt import is_interrupted
+
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
@@ -869,11 +1010,17 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         else:
             logger.info(
                 "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
+                provider.name,
+                query,
+                limit,
             )
-            response_data = provider.search(query, limit)
+            response_data = _search_with_fallbacks(
+                provider, query, limit, provider.name
+            )
 
-        debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+        debug_call_data["results_count"] = len(
+            response_data.get("data", {}).get("web", [])
+        )
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
         _debug.log_call("web_search_tool", debug_call_data)
@@ -896,7 +1043,7 @@ async def web_extract_tool(
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -912,11 +1059,11 @@ async def web_extract_tool(
         min_length (int): Minimum content length to trigger LLM processing (default: 5000)
 
     Security: URLs are checked for embedded secrets before fetching.
-    
+
     Returns:
         str: JSON string containing extracted content. If LLM processing is enabled and successful,
              the 'content' field will contain the processed markdown summary instead of raw content.
-    
+
     Raises:
         Exception: If extraction fails or API key is not set
     """
@@ -924,6 +1071,7 @@ async def web_extract_tool(
     # URL-decode first so percent-encoded secrets (%73k- = sk-) are caught.
     from agent.redact import _PREFIX_RE
     from urllib.parse import unquote
+
     normalized_urls: List[str] = []
     for _url in urls:
         normalized_url = normalize_url_for_request(_url)
@@ -936,7 +1084,7 @@ async def web_extract_tool(
             return json.dumps({
                 "success": False,
                 "error": "Blocked: URL contains what appears to be an API key or token. "
-                         "Secrets must not be sent in URLs.",
+                "Secrets must not be sent in URLs.",
             })
         normalized_urls.append(normalized_url)
 
@@ -946,7 +1094,7 @@ async def web_extract_tool(
             "format": format,
             "use_llm_processing": use_llm_processing,
             "model": model,
-            "min_length": min_length
+            "min_length": min_length,
         },
         "error": None,
         "pages_extracted": 0,
@@ -954,9 +1102,9 @@ async def web_extract_tool(
         "original_response_size": 0,
         "final_response_size": 0,
         "compression_metrics": [],
-        "processing_applied": []
+        "processing_applied": [],
     }
-    
+
     try:
         logger.info("Extracting content from %d URL(s)", len(normalized_urls))
 
@@ -966,7 +1114,9 @@ async def web_extract_tool(
         for url in normalized_urls:
             if not await async_is_safe_url(url):
                 ssrf_blocked.append({
-                    "url": url, "title": "", "content": "",
+                    "url": url,
+                    "title": "",
+                    "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 })
             else:
@@ -1026,13 +1176,12 @@ async def web_extract_tool(
                         ensure_ascii=False,
                     )
 
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
+            logger.info("Web extract via %s: %d URL(s)", provider.name, len(safe_urls))
 
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
+
             if inspect.iscoroutinefunction(provider.extract):
                 results = await provider.extract(safe_urls, format=format)
             else:
@@ -1047,51 +1196,53 @@ async def web_extract_tool(
             results = ssrf_blocked + results
 
         response = {"results": results}
-        
-        pages_extracted = len(response.get('results', []))
+
+        pages_extracted = len(response.get("results", []))
         logger.info("Extracted content from %d pages", pages_extracted)
-        
+
         debug_call_data["pages_extracted"] = pages_extracted
         debug_call_data["original_response_size"] = len(json.dumps(response))
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
-        
+
         # Process each result with LLM if enabled
         if use_llm_processing and auxiliary_available:
             logger.info("Processing extracted content with LLM (parallel)...")
             debug_call_data["processing_applied"].append("llm_processing")
-            
+
             # Prepare tasks for parallel processing
             async def process_single_result(result):
                 """Process a single result with LLM and return updated result with metrics."""
-                url = result.get('url', 'Unknown URL')
-                title = result.get('title', '')
-                raw_content = result.get('raw_content', '') or result.get('content', '')
-                
+                url = result.get("url", "Unknown URL")
+                title = result.get("title", "")
+                raw_content = result.get("raw_content", "") or result.get("content", "")
+
                 if not raw_content:
                     return result, None, "no_content"
-                
+
                 original_size = len(raw_content)
-                
+
                 # Process content with LLM
                 processed = await process_content_with_llm(
                     raw_content, url, title, effective_model, min_length
                 )
-                
+
                 if processed:
                     processed_size = len(processed)
-                    compression_ratio = processed_size / original_size if original_size > 0 else 1.0
-                    
+                    compression_ratio = (
+                        processed_size / original_size if original_size > 0 else 1.0
+                    )
+
                     # Update result with processed content
-                    result['content'] = processed
-                    result['raw_content'] = raw_content
-                    
+                    result["content"] = processed
+                    result["raw_content"] = raw_content
+
                     metrics = {
                         "url": url,
                         "original_size": original_size,
                         "processed_size": processed_size,
                         "compression_ratio": compression_ratio,
-                        "model_used": effective_model
+                        "model_used": effective_model,
                     }
                     return result, metrics, "processed"
                 else:
@@ -1101,12 +1252,12 @@ async def web_extract_tool(
                         "processed_size": original_size,
                         "compression_ratio": 1.0,
                         "model_used": None,
-                        "reason": "content_too_short"
+                        "reason": "content_too_short",
                     }
                     return result, metrics, "too_short"
-            
+
             # Run all LLM processing in parallel
-            results_list = response.get('results', [])
+            results_list = response.get("results", [])
             tasks = [process_single_result(result) for result in results_list]
             # Use return_exceptions=True so a single task failure does not
             # discard all other successfully processed results.
@@ -1118,7 +1269,7 @@ async def web_extract_tool(
                     logger.warning("Web result processing task failed: %s", result_item)
                     continue
                 result, metrics, status = result_item
-                url = result.get('url', 'Unknown URL')
+                url = result.get("url", "Unknown URL")
                 if status == "processed":
                     debug_call_data["compression_metrics"].append(metrics)
                     debug_call_data["pages_processed_with_llm"] += 1
@@ -1130,14 +1281,18 @@ async def web_extract_tool(
                     logger.warning("%s (no content to process)", url)
         else:
             if use_llm_processing and not auxiliary_available:
-                logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
-                debug_call_data["processing_applied"].append("llm_processing_unavailable")
+                logger.warning(
+                    "LLM processing requested but no auxiliary model available, returning raw content"
+                )
+                debug_call_data["processing_applied"].append(
+                    "llm_processing_unavailable"
+                )
             # Print summary of extracted pages for debugging (original behavior)
-            for result in response.get('results', []):
-                url = result.get('url', 'Unknown URL')
-                content_length = len(result.get('raw_content', ''))
+            for result in response.get("results", []):
+                url = result.get("url", "Unknown URL")
+                content_length = len(result.get("raw_content", ""))
                 logger.info("%s (%d characters)", url, content_length)
-        
+
         # Trim output to minimal fields per entry: title, content, error
         trimmed_results = [
             {
@@ -1145,7 +1300,11 @@ async def web_extract_tool(
                 "title": r.get("title", ""),
                 "content": r.get("content", ""),
                 "error": r.get("error"),
-                **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
+                **(
+                    {"blocked_by_policy": r["blocked_by_policy"]}
+                    if "blocked_by_policy" in r
+                    else {}
+                ),
             }
             for r in response.get("results", [])
         ]
@@ -1155,29 +1314,29 @@ async def web_extract_tool(
             result_json = tool_error("Content was inaccessible or not found")
 
             cleaned_result = clean_base64_images(result_json)
-        
+
         else:
             result_json = json.dumps(trimmed_response, indent=2, ensure_ascii=False)
-            
+
             cleaned_result = clean_base64_images(result_json)
-        
+
         debug_call_data["final_response_size"] = len(cleaned_result)
         debug_call_data["processing_applied"].append("base64_image_removal")
-        
+
         # Log debug information
         _debug.log_call("web_extract_tool", debug_call_data)
         _debug.save()
-        
+
         return cleaned_result
-            
+
     except Exception as e:
         error_msg = f"Error extracting content: {str(e)}"
         logger.debug("%s", error_msg)
-        
+
         debug_call_data["error"] = error_msg
         _debug.log_call("web_extract_tool", debug_call_data)
         _debug.save()
-        
+
         return tool_error(error_msg)
 
 
@@ -1185,11 +1344,29 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {
+        "exa",
+        "parallel",
+        "firecrawl",
+        "tavily",
+        "searxng",
+        "brave-free",
+        "ddgs",
+        "xai",
+    }:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in (
+            "exa",
+            "parallel",
+            "firecrawl",
+            "tavily",
+            "searxng",
+            "brave-free",
+            "ddgs",
+            "xai",
+        )
     )
 
 
@@ -1199,15 +1376,13 @@ def check_auxiliary_model() -> bool:
     return client is not None
 
 
-
-
 if __name__ == "__main__":
     """
     Simple test/demo when run directly
     """
     print("🌐 Standalone Web Tools Module")
     print("=" * 40)
-    
+
     # Check if API keys are available
     web_available = check_web_api_key()
     tool_gateway_available = _is_tool_gateway_ready()
@@ -1232,7 +1407,9 @@ if __name__ == "__main__":
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
         elif firecrawl_url_available:
-            print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
+            print(
+                f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}"
+            )
         elif firecrawl_key_available:
             print("   Using direct Firecrawl cloud API")
         elif tool_gateway_available:
@@ -1248,7 +1425,9 @@ if __name__ == "__main__":
 
     if not nous_available:
         print("❌ No auxiliary model available for LLM content processing")
-        print("Set OPENROUTER_API_KEY, configure Nous Portal, or set OPENAI_BASE_URL + OPENAI_API_KEY")
+        print(
+            "Set OPENROUTER_API_KEY, configure Nous Portal, or set OPENAI_BASE_URL + OPENAI_API_KEY"
+        )
         print("⚠️  Without an auxiliary model, LLM content processing will be disabled")
     else:
         print(f"✅ Auxiliary model available: {default_summarizer_model}")
@@ -1257,18 +1436,22 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print("🛠️  Web tools ready for use!")
-    
+
     if nous_available:
         print(f"🧠 LLM content processing available with {default_summarizer_model}")
-        print(f"   Default min length for processing: {DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION} chars")
-    
+        print(
+            f"   Default min length for processing: {DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION} chars"
+        )
+
     # Show debug mode status
     if _debug.active:
         print(f"🐛 Debug mode ENABLED - Session ID: {_debug.session_id}")
-        print(f"   Debug logs will be saved to: {_debug.log_dir}/web_tools_debug_{_debug.session_id}.json")
+        print(
+            f"   Debug logs will be saved to: {_debug.log_dir}/web_tools_debug_{_debug.session_id}.json"
+        )
     else:
         print("🐛 Debug mode disabled (set WEB_TOOLS_DEBUG=true to enable)")
-    
+
     print("\nBasic usage:")
     print("  from web_tools import web_search_tool, web_extract_tool")
     print("  import asyncio")
@@ -1280,7 +1463,7 @@ if __name__ == "__main__":
     print("  async def main():")
     print("      content = await web_extract_tool(['https://example.com'])")
     print("  asyncio.run(main())")
-    
+
     if nous_available:
         print("\nLLM-enhanced usage:")
         print("  # Content automatically processed for pages >5000 chars (default)")
@@ -1294,8 +1477,10 @@ if __name__ == "__main__":
         print("  )")
         print("")
         print("  # Disable LLM processing")
-        print("  raw_content = await web_extract_tool(['https://example.com'], use_llm_processing=False)")
-    
+        print(
+            "  raw_content = await web_extract_tool(['https://example.com'], use_llm_processing=False)"
+        )
+
     print("\nDebug mode:")
     print("  # Enable debug logging")
     print("  export WEB_TOOLS_DEBUG=true")
@@ -1305,7 +1490,7 @@ if __name__ == "__main__":
     print("  # - LLM compression metrics")
     print("  # - Final processed results")
     print("  # Logs saved to: ./logs/web_tools_debug_UUID.json")
-    
+
     print("\n📝 Run 'python test_web_tools_llm.py' to test LLM processing capabilities")
 
 
@@ -1316,24 +1501,24 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": 'Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and "exact phrase" may work when the backend supports them.',
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": "The search query to look up on the web. You may include backend-supported operators such as site:example.com, filetype:pdf, intitle:word, -term, or \"exact phrase\"."
+                "description": 'The search query to look up on the web. You may include backend-supported operators such as site:example.com, filetype:pdf, intitle:word, -term, or "exact phrase".',
             },
             "limit": {
                 "type": "integer",
                 "description": "Maximum number of results to return. Defaults to 5.",
                 "minimum": 1,
                 "maximum": 100,
-                "default": 5
-            }
+                "default": 5,
+            },
         },
-        "required": ["query"]
-    }
+        "required": ["query"],
+    },
 }
 
 WEB_EXTRACT_SCHEMA = {
@@ -1346,18 +1531,20 @@ WEB_EXTRACT_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
-                "maxItems": 5
+                "maxItems": 5,
             }
         },
-        "required": ["urls"]
-    }
+        "required": ["urls"],
+    },
 }
 
 registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(
+        args.get("query", ""), limit=args.get("limit", 5)
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",
@@ -1368,7 +1555,9 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        "markdown",
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,


### PR DESCRIPTION
Automated evolution PR for issues #544 and #467.

## Changes
- **agent/loop_guard.py**: Added short-circuit detection for idempotent spiral-prone tools (search_files/web_search/web_extract). When the same tool+arguments repeat 4+ times without progress, the model gets a same-argument nudge instead of the generic repeat nudge.
- **agent/tool_diagnostics.py**: Added `provider_dead` failure class between `limit` and `not_found` to classify dead search providers distinctly from generic not-found.
- **tools/web_tools.py**: Added `_search_backend_fallback_chain` config reader and `_search_with_fallbacks` wrapper. `web_search_tool` now tries a configured fallback chain when the primary provider returns empty or fails.
- **plugins/web/ddgs/provider.py**: Empty DDGS results now return `success=False` with provider-dead guidance instead of `success=True` with empty data. 'No results found', 'ratelimit', and 'timeout' exceptions are normalized to provider-dead errors.
- **hermes_cli/config.py**: Added `search_backend_fallback_chain` to DEFAULT_CONFIG.- **Tests**: Updated for changed behavior.