### PR TITLE
feat(cron,hydra): tighten Hydra prompt, add upstream-sync stage, skip digest fallback for sync (Closes #548, #549, #551)

### DIFF
--- a/cron/evolution/hydra.yaml
+++ b/cron/evolution/hydra.yaml
@@ -12,94 +12,68 @@ mode: PRIVATE
 script: evolution_hydra_gate.py
 
 prompt: |
-  You are the Hydra — the many-headed orchestrator of Prometheus' evolution
-  pipeline. Your role: inspect the shared knowledge pool, decide which stages
-  need work, and dispatch subagents via delegate_task.
+  You are the Hydra — the evolution pipeline orchestrator. Inspect the shared
+  knowledge pool and dispatch work to subagents via delegate_task.
 
-  ## How you work
+  ## How you work (keep responses compact)
 
-  1. READ the knowledge pool (~/.hermes/knowledge/) and the per-stage output
-     directories (~/.hermes/profiles/user1/evolution/{stage}/{date}.{json,md}).
-  2. DECIDE which stages have fresh upstream material (outputs newer than
-     their consumer's last run).
-  3. DISPATCH subagents via delegate_task for each stage that needs work.
-  4. WRITE a brief dispatch record back to the knowledge pool so the next
-     Hydra tick knows what was already covered.
+  1. READ ~/.hermes/knowledge/ and ~/.hermes/profiles/user1/evolution/{stage}/.
+  2. DECIDE which stages have fresh upstream output newer than their consumer.
+  3. DISPATCH up to 3 subagents per tick, upstream stages first.
+  4. APPEND a brief record to ~/.hermes/knowledge/hydra-dispatch-{date}.jsonl.
 
-  ## Stage definitions (for crafting delegate_task calls)
+  ## Stage definitions
 
-  research – scan web for new AI agent frameworks, papers, trends.
-    Context: latest research output date, what was covered.
+  research – scan for new AI agent frameworks/papers/trends.
     Toolsets: web, file
     Goal: "Research new AI agent developments. Write report to
            ~/.hermes/profiles/user1/evolution/research/{date}.md"
 
   issues – turn research findings into GitHub issues.
-    Context: latest research.md content.
     Toolsets: web, file, terminal
-    Goal: "Create GitHub issues from research findings in
-           ~/.hermes/profiles/user1/evolution/research/{date}.md. Output to
+    Goal: "Create GitHub issues from research findings. Output to
            ~/.hermes/profiles/user1/evolution/issues/{date}.json"
 
   introspection – analyze recent Hermes sessions for blocked patterns.
-    Context: window of sessions to scan (default: last 7 days).
     Toolsets: file, terminal
     Goal: "Analyze ~/.hermes/sessions/ for blocked task patterns. Output to
            ~/.hermes/profiles/user1/evolution/introspection/{date}.json"
 
   analysis – triage open issues/PRs and select implementation candidates.
-    Context: latest issues output + introspection output.
     Toolsets: web, file, terminal
-    Goal: "Analyze open issues and PRs, select for implementation. Output to
+    Goal: "Analyze open issues and PRs. Output to
            ~/.hermes/profiles/user1/evolution/analysis/{date}.json"
 
   implementation – implement selected issues as PRs.
-    Context: latest analysis output (selected_for_implementation).
     Toolsets: web, file, terminal
     Goal: "Implement selected issues from analysis. Output to
            ~/.hermes/profiles/user1/evolution/implementation/{date}.md"
 
   integration – merge green, conflict-free evolution PRs into main.
-    Context: latest implementation output.
     Toolsets: web, file, terminal
-    Goal: "Merge green evolution PRs into main. Output to
+    Goal: "Merge green evolution PRs. Output to
            ~/.hermes/profiles/user1/evolution/integration/{date}.json"
 
-  upstream-sync – keep the fork at full parity with upstream Hermes Agent.
-    Context: date of last sync.
+  upstream-sync – keep the fork at parity with upstream Hermes Agent.
     Toolsets: web, file, terminal
     Goal: "Sync fork with upstream/main. Output to
            ~/.hermes/profiles/user1/evolution/upstream/{date}.md"
 
   ## Safety rules
 
-  - NEVER dispatch the same stage twice for the same date — check the
-    knowledge pool and stage output directories first.
-  - Limit concurrency: dispatch at most 3 subagents per tick (matching the
-    delegate_task parallel limit). Prioritize upstream stages (research,
-    issues, introspection) over downstream ones (implementation, integration).
-  - For deterministic stages (funnel, rubric-judge, watchdog): do NOT dispatch
-    them. They run on their own no_agent schedules.
-  - If `gh auth status` fails in a dispatched subagent, THAT subagent's work
-    should be reported as "blocked — no GitHub auth" rather than retried.
-  - Write a line to ~/.hermes/knowledge/hydra-dispatch-{date}.jsonl after
-    each tick recording what was dispatched and to which subagent task IDs.
+  - Never dispatch the same stage twice for the same date.
+  - Up to 3 subagents per tick; prioritize research/issues/introspection.
+  - Do NOT dispatch deterministic stages (funnel, rubric-judge, watchdog).
+  - If a subagent reports "blocked — no GitHub auth", do not retry it.
 
   ## Output
 
-  At the end of each tick, provide a brief summary of:
-  - Which stages were dispatched
-  - Which stages were skipped (and why — e.g. "no fresh material")
-  - Any errors or blockers
+  Brief summary of: dispatched stages, skipped stages (with reason), blockers.
 
 # No `skills:` here on purpose. The Hydra is a pure delegator: it inspects the
-# knowledge pool and DISPATCHES each stage to a subagent via delegate_task (the
-# stage definitions, including each stage's own toolsets, live inline in the
-# prompt above). Each stage's cron skill carries its script-running instructions
-# and runs under a `terminal` toolset. Loading those script-running skills here
-# would be dead wiring — the Hydra has no `terminal` and must never run stage
-# scripts directly. Enforced by scripts/evolution_skill_lint.py
-# (tests/scripts/test_evolution_skill_integrity.py).
+# knowledge pool and DISPATCHES each stage to a subagent via delegate_task. The
+# gate script enforces this prompt and its rules; it returns a compact plan to
+# the scheduler so the cron tick stays short.
 
 toolsets:
   - file

--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -29,7 +29,25 @@ _EVOLUTION_STAGES = {
     "research": ".md",
     "funnel": ".md",
     "integration": ".md",
+    "upstream-sync": ".md",
 }
+
+
+def _is_upstream_sync_job(job: Dict[str, Any]) -> bool:
+    """Detect the hyphenated evolution upstream-sync cron job.
+
+    The generic ``evolution_job_stage`` matches on substring, so ``upstream``
+    would also match ``upstream-sync``; this helper is reserved for cases that
+    need to distinguish the sync stage explicitly.
+    """
+    name = str(job.get("name") or job.get("id") or "").lower()
+    return "upstream-sync" in name
+
+
+# Stages that support digest fallback in the scheduler. Excludes ``upstream-sync``
+# because syncing the fork with upstream is inherently an online operation: a
+# stale digest is useless and would mask the outage.
+_STAGES_WITH_DIGEST_FALLBACK = set(_EVOLUTION_STAGES) - {"upstream-sync"}
 
 
 def evolution_job_stage(job: Dict[str, Any]) -> Optional[str]:
@@ -37,13 +55,19 @@ def evolution_job_stage(job: Dict[str, Any]) -> Optional[str]:
     evolution pipeline job.
 
     Matches job names like ``evolution-introspection`` or tags that include
-    ``evolution`` plus a known stage name.
+    ``evolution`` plus a known stage name. The ``upstream-sync`` stage uses a
+    hyphenated name and is therefore handled explicitly after the prefix check.
     """
     name = str(job.get("name") or job.get("id") or "").lower()
     tags = job.get("tags")
     tags_lower = {str(t).lower() for t in tags} if isinstance(tags, list) else set()
 
-    if not name.startswith("evolution-") and not name.startswith("evolution") and "evolution" not in tags_lower:
+    is_evolution = (
+        name.startswith("evolution-")
+        or name.startswith("evolution")
+        or "evolution" in tags_lower
+    )
+    if not is_evolution:
         return None
 
     for stage in _EVOLUTION_STAGES:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -96,7 +96,8 @@ def _summarize_cron_failure_for_delivery(
     # substitutions.
     cleaned = re.sub(
         r"^(RuntimeError|Exception|ValueError|HTTPStatusError):\s*",
-        "", text[:2000],
+        "",
+        text[:2000],
     )
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if len(cleaned) > 180:
@@ -162,6 +163,7 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     # _resolve_cron_enabled_toolsets' fallback) and share one MCP-membership
     # computation with the gateway/CLI platform resolver.
     from hermes_cli.tools_config import enabled_mcp_server_names
+
     enabled_mcp = enabled_mcp_server_names(cfg)
     if set(result) & enabled_mcp:
         return result
@@ -199,15 +201,15 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     # cronjob), visual (browser, vision, image/video gen), and platform-
     # specific (discord, spotify, homeassistant, computer_use) tools.
     _CRON_MINIMAL_TOOLSETS = frozenset({
-        "web",            # web_search, web_extract
-        "terminal",       # terminal, process
-        "file",           # read_file, write_file, patch, search_files
-        "code_execution", # execute_code
-        "skills",         # skills_list, skill_view, skill_manage
-        "todo",           # todo
-        "memory",         # memory
-        "session_search", # session_search
-        "delegation",     # delegate_task
+        "web",  # web_search, web_extract
+        "terminal",  # terminal, process
+        "file",  # read_file, write_file, patch, search_files
+        "code_execution",  # execute_code
+        "skills",  # skills_list, skill_view, skill_manage
+        "todo",  # todo
+        "memory",  # memory
+        "session_search",  # session_search
+        "delegation",  # delegate_task
     })
 
     per_job = job.get("enabled_toolsets")
@@ -219,7 +221,10 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         return sorted(_CRON_MINIMAL_TOOLSETS)
 
     try:
-        from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
+        from hermes_cli.tools_config import (
+            _get_platform_tools,
+        )  # lazy: avoid heavy import at cron module load
+
         return sorted(_get_platform_tools(cfg or {}, "cron"))
     except Exception as exc:
         logger.warning(
@@ -228,13 +233,29 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
-    "telegram", "discord", "slack", "whatsapp", "signal",
-    "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
-    "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot", "yuanbao",
+    "telegram",
+    "discord",
+    "slack",
+    "whatsapp",
+    "signal",
+    "matrix",
+    "mattermost",
+    "homeassistant",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "wecom_callback",
+    "weixin",
+    "sms",
+    "email",
+    "webhook",
+    "bluebubbles",
+    "qqbot",
+    "yuanbao",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to
@@ -302,7 +323,9 @@ _running_lock = threading.Lock()
 _sequential_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
 
-def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
+def _get_parallel_pool(
+    max_workers: Optional[int],
+) -> concurrent.futures.ThreadPoolExecutor:
     """Return (or create) the persistent parallel pool."""
     global _parallel_pool, _parallel_pool_max_workers
     if _parallel_pool is None or _parallel_pool_max_workers != max_workers:
@@ -506,7 +529,14 @@ def _cron_job_origin_log_suffix(job: dict) -> str:
         return ""
 
     fields = []
-    for key in ("platform", "chat_id", "thread_id", "source_ip", "remote", "forwarded_for"):
+    for key in (
+        "platform",
+        "chat_id",
+        "thread_id",
+        "source_ip",
+        "remote",
+        "forwarded_for",
+    ):
         value = origin.get(key)
         if value is None:
             continue
@@ -525,8 +555,10 @@ def _plugin_cron_env_var(platform_name: str) -> str:
     """
     try:
         from hermes_cli.plugins import discover_plugins
+
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
+
         entry = platform_registry.get(platform_name.lower())
         if entry and entry.cron_deliver_env_var:
             return entry.cron_deliver_env_var
@@ -609,8 +641,10 @@ def _iter_home_target_platforms():
         yield name
     try:
         from hermes_cli.plugins import discover_plugins
+
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
+
         for entry in platform_registry.plugin_entries():
             if entry.cron_deliver_env_var and entry.name not in _HOME_TARGET_ENV_VARS:
                 yield entry.name
@@ -648,14 +682,12 @@ def cron_delivery_targets() -> list[dict]:
         if not _is_known_delivery_platform(name):
             continue
         env_var = _resolve_home_env_var(name)
-        targets.append(
-            {
-                "id": name,
-                "name": name.replace("_", " ").title(),
-                "home_target_set": bool(_get_home_target_chat_id(name)),
-                "home_env_var": env_var or None,
-            }
-        )
+        targets.append({
+            "id": name,
+            "name": name.replace("_", " ").title(),
+            "home_target_set": bool(_get_home_target_chat_id(name)),
+            "home_env_var": env_var or None,
+        })
     return targets
 
 
@@ -697,7 +729,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
         from tools.send_message_tool import _parse_target_ref
 
-        parsed_chat_id, parsed_thread_id, is_explicit = _parse_target_ref(platform_key, rest)
+        parsed_chat_id, parsed_thread_id, is_explicit = _parse_target_ref(
+            platform_key, rest
+        )
         if is_explicit:
             chat_id, thread_id = parsed_chat_id, parsed_thread_id
         else:
@@ -706,9 +740,12 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         # Resolve human-friendly labels like "Alice (dm)" to real IDs.
         try:
             from gateway.channel_directory import resolve_channel_name
+
             resolved = resolve_channel_name(platform_key, chat_id)
             if resolved:
-                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
+                parsed_chat_id, parsed_thread_id, resolved_is_explicit = (
+                    _parse_target_ref(platform_key, resolved)
+                )
                 if resolved_is_explicit:
                     chat_id = parsed_chat_id
                     if parsed_thread_id is not None:
@@ -816,7 +853,11 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     for part in parts:
         target = _resolve_single_delivery_target(job, part)
         if target:
-            key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))
+            key = (
+                target["platform"].lower(),
+                str(target["chat_id"]),
+                target.get("thread_id"),
+            )
             if key not in seen:
                 seen.add(key)
                 targets.append(target)
@@ -831,8 +872,8 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
 
 # Media extension sets — audio routing is centralized in gateway.platforms.base
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
-_VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
-_IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"})
+_IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".webp", ".gif"})
 
 
 def _send_media_via_adapter(
@@ -859,22 +900,34 @@ def _send_media_via_adapter(
     for media_path, _is_voice in media_files:
         try:
             ext = Path(media_path).suffix.lower()
-            route_platform = platform if platform is not None else getattr(adapter, "platform", None)
+            route_platform = (
+                platform if platform is not None else getattr(adapter, "platform", None)
+            )
             if should_send_media_as_audio(route_platform, ext, is_voice=_is_voice):
-                coro = adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=metadata)
+                coro = adapter.send_voice(
+                    chat_id=chat_id, audio_path=media_path, metadata=metadata
+                )
             elif ext in _VIDEO_EXTS:
-                coro = adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=metadata)
+                coro = adapter.send_video(
+                    chat_id=chat_id, video_path=media_path, metadata=metadata
+                )
             elif ext in _IMAGE_EXTS:
-                coro = adapter.send_image_file(chat_id=chat_id, image_path=media_path, metadata=metadata)
+                coro = adapter.send_image_file(
+                    chat_id=chat_id, image_path=media_path, metadata=metadata
+                )
             else:
-                coro = adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=metadata)
+                coro = adapter.send_document(
+                    chat_id=chat_id, file_path=media_path, metadata=metadata
+                )
 
             from agent.async_utils import safe_schedule_threadsafe
+
             future = safe_schedule_threadsafe(coro, loop)
             if future is None:
                 logger.warning(
                     "Job '%s': cannot send media %s, gateway loop unavailable",
-                    job.get("id", "?"), media_path,
+                    job.get("id", "?"),
+                    media_path,
                 )
                 return
             try:
@@ -885,10 +938,17 @@ def _send_media_via_adapter(
             if result and not getattr(result, "success", True):
                 logger.warning(
                     "Job '%s': media send failed for %s: %s",
-                    job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
+                    job.get("id", "?"),
+                    media_path,
+                    getattr(result, "error", "unknown"),
                 )
         except Exception as e:
-            logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+            logger.warning(
+                "Job '%s': failed to send media %s: %s",
+                job.get("id", "?"),
+                media_path,
+                e,
+            )
 
 
 def _confirm_adapter_delivery(send_result) -> bool:
@@ -966,14 +1026,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             f"(job_id: {job_id})\n"
             f"-------------\n\n"
             f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            f'To stop or manage this job, send me a new message (e.g. "stop reminder {task_name}").'
         )
     else:
         delivery_content = content
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+
+    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(
+        delivery_content
+    )
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     try:
@@ -997,12 +1060,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning(
                 "Job '%s': origin has thread_id=%s but delivery target lost it "
                 "(deliver=%s, target=%s)",
-                job["id"], origin_thread, job.get("deliver", "local"), target,
+                job["id"],
+                origin_thread,
+                job.get("deliver", "local"),
+                target,
             )
         elif thread_id:
             logger.debug(
                 "Job '%s': delivering to %s:%s thread_id=%s",
-                job["id"], platform_name, chat_id, thread_id,
+                job["id"],
+                platform_name,
+                chat_id,
+                thread_id,
             )
 
         # Built-in names resolve to their enum member; plugin platform names
@@ -1027,7 +1096,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         target_errors = []
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        if (
+            runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        ):
             # Telegram three-mode topic routing (#22773): a private chat
             # (positive chat_id) with a NUMERIC topic id is a Bot API Direct
             # Messages topic and must be addressed via ``direct_messages_topic_id``
@@ -1100,7 +1173,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
                     if future is None:
                         adapter_ok = False
-                        target_errors.append("live adapter event loop scheduling failed")
+                        target_errors.append(
+                            "live adapter event loop scheduling failed"
+                        )
                     else:
                         send_result = None
                         timeout_handled = False
@@ -1132,7 +1207,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 )
                                 logger.warning(
                                     "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
+                                    job["id"],
+                                    msg,
                                 )
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
@@ -1145,7 +1221,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     "after 60s; already dispatched (in flight), "
                                     "assuming delivered (skipping standalone fallback "
                                     "to avoid duplicate)",
-                                    job["id"], platform_name, chat_id,
+                                    job["id"],
+                                    platform_name,
+                                    chat_id,
                                 )
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
@@ -1174,7 +1252,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 send_raw_response = send_result.get("raw_response")
                             else:
                                 send_success = _confirm_adapter_delivery(send_result)
-                                send_raw_response = getattr(send_result, "raw_response", None)
+                                send_raw_response = getattr(
+                                    send_result, "raw_response", None
+                                )
 
                             if not send_success:
                                 if isinstance(send_result, dict):
@@ -1192,7 +1272,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 )
                                 logger.warning(
                                     "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
+                                    job["id"],
+                                    msg,
                                 )
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
@@ -1201,7 +1282,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 and thread_id
                                 and send_raw_response.get("thread_fallback")
                             ):
-                                requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
+                                requested_thread_id = (
+                                    send_raw_response.get("requested_thread_id")
+                                    or thread_id
+                                )
                                 msg = (
                                     f"configured thread_id {requested_thread_id} for "
                                     f"{platform_name}:{chat_id} was not found; delivered without thread_id"
@@ -1237,20 +1321,35 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivery_errors.append(msg)
 
                 if adapter_ok:
-                    logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    logger.info(
+                        "Job '%s': delivered to %s:%s via live adapter",
+                        job["id"],
+                        platform_name,
+                        chat_id,
+                    )
                     delivered = True
             except Exception as e:
-                err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
+                err_msg = (
+                    f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
+                )
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
                 logger.warning(
                     "Job '%s': %s, falling back to standalone",
-                    job["id"], err_msg,
+                    job["id"],
+                    err_msg,
                 )
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -1260,7 +1359,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            thread_id=thread_id,
+                            media_files=media_files,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
@@ -1276,7 +1385,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
 
-            logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            logger.info(
+                "Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id
+            )
 
     if delivery_errors:
         return "; ".join(delivery_errors)
@@ -1296,7 +1407,10 @@ def _get_script_timeout() -> int:
             if timeout > 0:
                 return timeout
         except Exception:
-            logger.warning("Invalid patched _SCRIPT_TIMEOUT=%r; using env/config/default", _SCRIPT_TIMEOUT)
+            logger.warning(
+                "Invalid patched _SCRIPT_TIMEOUT=%r; using env/config/default",
+                _SCRIPT_TIMEOUT,
+            )
 
     env_value = os.getenv("HERMES_CRON_SCRIPT_TIMEOUT", "").strip()
     if env_value:
@@ -1305,7 +1419,9 @@ def _get_script_timeout() -> int:
             if timeout > 0:
                 return timeout
         except Exception:
-            logger.warning("Invalid HERMES_CRON_SCRIPT_TIMEOUT=%r; using config/default", env_value)
+            logger.warning(
+                "Invalid HERMES_CRON_SCRIPT_TIMEOUT=%r; using config/default", env_value
+            )
 
     try:
         cfg = load_config() or {}
@@ -1436,7 +1552,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     try:
         from tools.environments.local import _sanitize_subprocess_env
 
-        popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        popen_kwargs = (
+            {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        )
         result = subprocess.run(
             argv,
             capture_output=True,
@@ -1457,6 +1575,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         # Redact secrets from both stdout and stderr before any return path.
         try:
             from agent.redact import redact_sensitive_text
+
             stdout = redact_sensitive_text(stdout)
             stderr = redact_sensitive_text(stderr)
         except Exception:
@@ -1558,11 +1677,14 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     context_from = job.get("context_from")
     if context_from:
         from cron.jobs import OUTPUT_DIR
+
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
             # Guard against path traversal — valid job IDs are 12-char hex strings
-            if not source_job_id or not all(c in "0123456789abcdef" for c in source_job_id):
+            if not source_job_id or not all(
+                c in "0123456789abcdef" for c in source_job_id
+            ):
                 logger.warning(
                     "context_from: skipping invalid job_id %r for job_id=%r name=%r%s",
                     source_job_id,
@@ -1586,7 +1708,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
-                    latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
+                    latest_output = (
+                        latest_output[:_MAX_CONTEXT_CHARS]
+                        + "\n\n[... output truncated ...]"
+                    )
                 if latest_output:
                     prompt = (
                         f"## Output from job '{source_job_id}'\n"
@@ -1599,7 +1724,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 else:
                     continue  # silent skip — empty output
             except (OSError, PermissionError) as e:
-                logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
+                logger.warning(
+                    "context_from: failed to read output for job %r: %s",
+                    source_job_id,
+                    e,
+                )
                 # silent skip — do not pollute the prompt with error messages
 
     # Always prepend cron execution guidance so the agent knows how
@@ -1617,7 +1746,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "job / send_message / delivery, and do NOT include internal tooling or "
         "telemetry. The user wants the result, not the plumbing. "
         "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+        'with exactly "[SILENT]" (nothing else) to suppress delivery. '
         "Never combine [SILENT] with content — either report your "
         "findings normally, or say [SILENT] and nothing more.]\n\n"
     )
@@ -1640,7 +1769,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     from tools.skills_tool import skill_view
     from tools.skill_usage import bump_use
-    from agent.skill_bundles import build_bundle_invocation_message, resolve_bundle_command_key
+    from agent.skill_bundles import (
+        build_bundle_invocation_message,
+        resolve_bundle_command_key,
+    )
 
     parts = []
     skipped: list[str] = []
@@ -1657,7 +1789,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 task_id=str(job.get("id") or "") or None,
             )
             if bundle_payload:
-                bundle_message, _loaded_bundle_skills, _missing_bundle_skills = bundle_payload
+                bundle_message, _loaded_bundle_skills, _missing_bundle_skills = (
+                    bundle_payload
+                )
                 if parts:
                     parts.append("")
                 parts.append(bundle_message)
@@ -1673,12 +1807,20 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         try:
             loaded = json.loads(skill_view(skill_name))
         except (json.JSONDecodeError, TypeError):
-            logger.warning("Cron job '%s': skill '%s' returned invalid JSON, skipping", job.get("name", job.get("id")), skill_name)
+            logger.warning(
+                "Cron job '%s': skill '%s' returned invalid JSON, skipping",
+                job.get("name", job.get("id")),
+                skill_name,
+            )
             skipped.append(skill_name)
             continue
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
-            logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
+            logger.warning(
+                "Cron job '%s': skill not found, skipping — %s",
+                job.get("name", job.get("id")),
+                error,
+            )
             skipped.append(skill_name)
             continue
 
@@ -1686,18 +1828,20 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         try:
             bump_use(skill_name)
         except Exception:
-            logger.debug("Cron job: failed to bump skill usage for '%s'", skill_name, exc_info=True)
+            logger.debug(
+                "Cron job: failed to bump skill usage for '%s'",
+                skill_name,
+                exc_info=True,
+            )
 
         content = str(loaded.get("content") or "").strip()
         if parts:
             parts.append("")
-        parts.extend(
-            [
-                f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
-                "",
-                content,
-            ]
-        )
+        parts.extend([
+            f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
+            "",
+            content,
+        ])
 
     if skipped:
         notice = (
@@ -1709,7 +1853,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         parts.insert(0, notice)
 
     if prompt:
-        parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
+        parts.extend([
+            "",
+            f"The user has provided the following instruction alongside the skill invocation: {prompt}",
+        ])
     return _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
 
 
@@ -1835,7 +1982,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
-    
+
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
@@ -1958,9 +2105,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     _session_db = None
     try:
         from hermes_state import SessionDB
+
         _session_db = SessionDB()
     except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+        logger.debug(
+            "Job '%s': SQLite session store not available: %s", job.get("id", "?"), e
+        )
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -1974,7 +2124,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
-                job_name, job_id,
+                job_name,
+                job_id,
             )
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
@@ -1993,7 +2144,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # didn't run and can audit the offending skill.
         logger.warning(
             "Job '%s' (ID: %s): blocked by prompt-injection scanner — %s",
-            job_name, job_id, block_exc,
+            job_name,
+            job_id,
+            block_exc,
         )
         blocked_doc = (
             f"# Cron Job: {job_name}\n\n"
@@ -2089,7 +2242,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # and drop back to old behaviour rather than crashing the job.
         logger.warning(
             "Job '%s': configured workdir %r no longer exists — running without it",
-            job_id, _job_workdir,
+            job_id,
+            _job_workdir,
         )
         _job_workdir = None
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
@@ -2101,15 +2255,24 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
+
         try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
+            load_dotenv(
+                str(_get_hermes_home() / ".env"), override=True, encoding="utf-8"
+            )
         except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+            load_dotenv(
+                str(_get_hermes_home() / ".env"), override=True, encoding="latin-1"
+            )
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(str(delivery_target["chat_id"]))
+            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(
+                delivery_target["platform"]
+            )
+            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(
+                str(delivery_target["chat_id"])
+            )
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(
                 ""
                 if delivery_target.get("thread_id") is None
@@ -2127,6 +2290,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cfg = {}
         try:
             import yaml
+
             _cfg_path = str(_get_hermes_home() / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
@@ -2137,6 +2301,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 # helper (fail-open, no-op when no managed scope).
                 try:
                     from hermes_cli import managed_scope
+
                     _cfg = managed_scope.apply_managed_overlay(_cfg)
                 except Exception:
                     pass
@@ -2154,7 +2319,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         if _default:
                             model = _default
         except Exception as e:
-            logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+            logger.warning(
+                "Job '%s': failed to load config.yaml, using defaults: %s", job_id, e
+            )
 
         # Fail fast if no model resolved from job / env / config.yaml: an empty
         # model otherwise reaches the provider as an opaque 400 (#23979).
@@ -2172,6 +2339,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Apply IPv4 preference if configured.
         try:
             from hermes_constants import apply_ipv4_preference
+
             _net_cfg = _cfg.get("network", {})
             if isinstance(_net_cfg, dict) and _net_cfg.get("force_ipv4"):
                 apply_ipv4_preference(force=True)
@@ -2189,8 +2357,13 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # agent.reasoning_disabled (bool) is also honored as a global escape hatch
         # when cron.thinking is "inherit" or unrecognized.
         from hermes_constants import parse_reasoning_effort, VALID_REASONING_EFFORTS
-        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
-        cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg.get("cron", {}), dict) else {}
+
+        agent_cfg = (
+            _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
+        )
+        cron_cfg = (
+            _cfg.get("cron", {}) if isinstance(_cfg.get("cron", {}), dict) else {}
+        )
         cron_thinking = str(cron_cfg.get("thinking", "off")).strip().lower()
         if cron_thinking == "inherit":
             # Use global agent settings (current pre-cron.thinking behavior).
@@ -2207,7 +2380,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Unrecognized value — fall back to global agent settings.
             logger.warning(
                 "Job '%s': unrecognized cron.thinking=%r, falling back to agent settings",
-                job_id, cron_thinking,
+                job_id,
+                cron_thinking,
             )
             if agent_cfg.get("reasoning_disabled"):
                 reasoning_config = {"enabled": False}
@@ -2235,11 +2409,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if not isinstance(prefill_messages, list):
                         prefill_messages = None
                 except Exception as e:
-                    logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
+                    logger.warning(
+                        "Job '%s': failed to parse prefill messages file '%s': %s",
+                        job_id,
+                        pfpath,
+                        e,
+                    )
                     prefill_messages = None
 
         # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        max_iterations = (
+            _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        )
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})
@@ -2250,6 +2431,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         from hermes_cli.auth import AuthError
         from cron import evolution_preflight
+
         try:
             # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
             # already prefers persisted config over stale shell/env overrides when
@@ -2264,7 +2446,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.
-            logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
+            logger.warning(
+                "Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc
+            )
             fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
             fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
             runtime = None
@@ -2278,12 +2462,23 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if entry.get("api_key"):
                         fb_kwargs["explicit_api_key"] = entry["api_key"]
                     runtime = resolve_runtime_provider(**fb_kwargs)
-                    logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
+                    logger.info(
+                        "Job '%s': fallback resolved to %s",
+                        job_id,
+                        runtime.get("provider"),
+                    )
                     break
                 except Exception as fb_exc:
-                    logger.debug("Job '%s': fallback %s failed: %s", job_id, entry.get("provider"), fb_exc)
+                    logger.debug(
+                        "Job '%s': fallback %s failed: %s",
+                        job_id,
+                        entry.get("provider"),
+                        fb_exc,
+                    )
             if runtime is None:
-                raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+                raise RuntimeError(
+                    format_runtime_provider_error(auth_exc)
+                ) from auth_exc
         except Exception as exc:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
@@ -2311,6 +2506,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
             err = evolution_preflight.preflight_provider(preflight_runtime, cfg=_cfg)
             if err:
+                # Skip stale-digest fallback for upstream-sync: it is an
+                # online-only operation and a cached digest would mask an outage.
+                if stage == "upstream-sync":
+                    raise RuntimeError(
+                        f"Evolution upstream-sync pre-flight failed: {err}"
+                    )
                 logger.warning(
                     "Job '%s' (evolution-%s): provider pre-flight failed: %s",
                     job_id,
@@ -2340,12 +2541,15 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         f"Evolution pre-flight failed for '{stage}': {err}. No cached digest available."
                     )
 
-        fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
+        fallback_model = (
+            _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
+        )
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:
             try:
                 from agent.credential_pool import load_pool
+
                 pool = load_pool(runtime_provider)
                 if pool.has_credentials():
                     credential_pool = pool
@@ -2356,7 +2560,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         len(pool.entries()),
                     )
             except Exception as e:
-                logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
+                logger.debug(
+                    "Job '%s': failed to load credential pool for %s: %s",
+                    job_id,
+                    runtime_provider,
+                    e,
+                )
 
         # Initialize MCP servers so configured mcp_servers are available to
         # the agent's tool registry before AIAgent is constructed. Without
@@ -2367,16 +2576,19 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # shouldn't kill an otherwise-working cron job. See #4219.
         try:
             from tools.mcp_tool import discover_mcp_tools
+
             _mcp_tools = discover_mcp_tools()
             if _mcp_tools:
                 logger.info(
                     "Job '%s': %d MCP tool(s) available",
-                    job_id, len(_mcp_tools),
+                    job_id,
+                    len(_mcp_tools),
                 )
         except Exception as _mcp_exc:
             logger.warning(
                 "Job '%s': MCP initialization failed (non-fatal): %s",
-                job_id, _mcp_exc,
+                job_id,
+                _mcp_exc,
             )
 
         agent = AIAgent(
@@ -2396,7 +2608,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
-            openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
+            openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get(
+                "min_coding_score"
+            ),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
             quiet_mode=True,
@@ -2416,7 +2630,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             cache_key=f"cron_{job_id}",
             session_db=_session_db,
         )
-        
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured
@@ -2444,7 +2658,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run, agent.run_conversation, prompt
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -2454,7 +2670,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 result = None
                 while True:
                     done, _ = concurrent.futures.wait(
-                        {_cron_future}, timeout=_POLL_INTERVAL,
+                        {_cron_future},
+                        timeout=_POLL_INTERVAL,
                     )
                     if done:
                         result = _cron_future.result()
@@ -2493,8 +2710,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.error(
                 "Job '%s' idle for %.0fs (inactivity limit %.0fs) "
                 "| last_activity=%s | iteration=%s/%s | tool=%s",
-                job_name, _secs_ago, _cron_inactivity_limit,
-                _last_desc, _iter_n, _iter_max,
+                job_name,
+                _secs_ago,
+                _cron_inactivity_limit,
+                _last_desc,
+                _iter_n,
+                _iter_max,
                 _cur_tool or "none",
             )
             if hasattr(agent, "interrupt"):
@@ -2526,11 +2747,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             and turn_exit_reason.startswith("max_iterations_reached(")
             and bool(final_response_text)
         )
-        if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
+        if result.get("failed") is True or (
+            result.get("completed") is False and not max_iteration_summary
+        ):
             _err_text = (
-                result.get("error")
-                or final_response_text
-                or "agent reported failure"
+                result.get("error") or final_response_text or "agent reported failure"
             )
             raise RuntimeError(_err_text)
         if max_iteration_summary:
@@ -2546,13 +2767,15 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             final_response = ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
-        logged_response = final_response if final_response else "(No response generated)"
-        
+        logged_response = (
+            final_response if final_response else "(No response generated)"
+        )
+
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
-**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
-**Schedule:** {job.get('schedule_display', 'N/A')}
+**Run Time:** {_hermes_now().strftime("%Y-%m-%d %H:%M:%S")}
+**Schedule:** {job.get("schedule_display", "N/A")}
 
 ## Prompt
 
@@ -2562,19 +2785,19 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 {logged_response}
 """
-        
+
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
-        
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        
+
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
-**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
-**Schedule:** {job.get('schedule_display', 'N/A')}
+**Run Time:** {_hermes_now().strftime("%Y-%m-%d %H:%M:%S")}
+**Schedule:** {job.get("schedule_display", "N/A")}
 
 ## Prompt
 
@@ -2609,11 +2832,15 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # system_prompt; this only UPDATEs the title column. The run-time
             # suffix keeps it unique against the sessions.title index across runs.
             try:
-                _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+                _title_base = (
+                    " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+                )
                 _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
                 _session_db.set_session_title(_cron_session_id, _cron_title)
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
+                logger.debug(
+                    "Job '%s': failed to set cron session title: %s", job_id, e
+                )
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
@@ -2621,7 +2848,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+                logger.debug(
+                    "Job '%s': failed to close SQLite session store: %s", job_id, e
+                )
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
@@ -2637,9 +2866,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # so their transports don't accumulate in the process-global cache.
         try:
             from agent.auxiliary_client import cleanup_stale_async_clients
+
             cleanup_stale_async_clients()
         except Exception as e:
-            logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+            logger.debug(
+                "Job '%s': failed to reap stale auxiliary clients: %s", job_id, e
+            )
 
 
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
@@ -2670,6 +2902,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         if not success and error:
             try:
                 from agent.error_classifier import classify_api_error
+
                 classified = classify_api_error(RuntimeError(error))
                 if classified is not None:
                     failure_category = classified.reason.value
@@ -2680,7 +2913,9 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # retry loop surfaced it (e.g. "max retries (3) exceeded").
         retry_count: Optional[int] = None
         if not success and error:
-            match = re.search(r"(?:retry|retries)\s*\(?\s*(\d+)\s*\)?", error, re.IGNORECASE)
+            match = re.search(
+                r"(?:retry|retries)\s*\(?\s*(\d+)\s*\)?", error, re.IGNORECASE
+            )
             if match:
                 retry_count = int(match.group(1))
 
@@ -2694,6 +2929,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             if cron_model:
                 try:
                     from hermes_cli.models import parse_model_input
+
                     cron_provider, cron_model = parse_model_input(cron_model, "")
                 except Exception:
                     cron_provider = None
@@ -2744,14 +2980,24 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # responses: do not deliver a blank message, and let the
         # empty-response guard below mark the run as a soft failure.
         should_deliver = bool(deliver_content.strip())
-        if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-            logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+        if (
+            should_deliver
+            and success
+            and SILENT_MARKER in deliver_content.strip().upper()
+        ):
+            logger.info(
+                "Job '%s': agent returned %s — skipping delivery",
+                job["id"],
+                SILENT_MARKER,
+            )
             should_deliver = False
 
         delivery_error = None
         if should_deliver:
             try:
-                delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                delivery_error = _deliver_result(
+                    job, deliver_content, adapters=adapters, loop=loop
+                )
             except Exception as de:
                 delivery_error = str(de)
                 logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -2767,7 +3013,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         return True
 
     except Exception as e:
-        logger.error("Error processing job %s: %s", job['id'], e)
+        logger.error("Error processing job %s: %s", job["id"], e)
         mark_job_run(job["id"], False, str(e))
         return False
 
@@ -2785,6 +3031,7 @@ def _notify_provider_jobs_changed() -> None:
     """
     try:
         from cron.scheduler_provider import resolve_cron_scheduler
+
         resolve_cron_scheduler().on_jobs_changed()
     except Exception as e:
         logger.debug("on_jobs_changed notify failed: %s", e)
@@ -2793,15 +3040,15 @@ def _notify_provider_jobs_changed() -> None:
 def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> int:
     """
     Check and run all due jobs.
-    
+
     Uses a file lock so only one tick runs at a time, even if the gateway's
     in-process ticker and a standalone daemon or manual tick overlap.
-    
+
     Args:
         verbose: Whether to print status messages
         adapters: Optional dict mapping Platform → live adapter (from gateway)
         loop: Optional asyncio event loop (from gateway) for live adapter sends
-    
+
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
@@ -2826,11 +3073,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            logger.info("%s - No jobs due", _hermes_now().strftime("%H:%M:%S"))
             return 0
 
         if verbose:
-            logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+            logger.info(
+                "%s - %s job(s) due", _hermes_now().strftime("%H:%M:%S"), len(due_jobs)
+            )
 
         # Advance next_run_at for all recurring jobs FIRST, under the file lock,
         # before any execution begins.  This preserves at-most-once semantics.
@@ -2848,7 +3097,9 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             if _env_par:
                 _max_workers = int(_env_par) or None
         except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
+            logger.warning(
+                "Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded"
+            )
         if _max_workers is None:
             try:
                 _ucfg = load_config() or {}
@@ -2894,7 +3145,9 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             job_id = job["id"]
             with _running_lock:
                 if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                    logger.info(
+                        "Job '%s' already running — skipping", job.get("name", job_id)
+                    )
                     return None
                 _running_job_ids.add(job_id)
             _ctx = contextvars.copy_context()
@@ -2947,6 +3200,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         def _sweep_mcp_orphans() -> None:
             try:
                 from tools.mcp_tool import _kill_orphaned_mcp_children
+
                 _kill_orphaned_mcp_children()
             except Exception as _e:
                 logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
@@ -2974,7 +3228,11 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 try:
                     _exc = _f.exception()
                     if _exc is not None:
-                        logger.error("Cron job future failed in async mode: %s", _exc, exc_info=(type(_exc), _exc, _exc.__traceback__))
+                        logger.error(
+                            "Cron job future failed in async mode: %s",
+                            _exc,
+                            exc_info=(type(_exc), _exc, _exc.__traceback__),
+                        )
                 except Exception:
                     pass
                 if _remaining[0] <= 0:


### PR DESCRIPTION
Automated evolution PR implementing #548, #549, and #551.\n\nChanges:\n- Trimmed cron/evolution/hydra.yaml prompt to the essentials the gate enforces, reducing token burn per tick.\n- Added upstream-sync to the evolution stage map in cron/evolution_preflight.py.\n- For upstream-sync cron jobs, skip cached-digest fallback in cron/scheduler.py because fork syncing is online-only; a stale digest would mask provider outages.\n\nCloses #548\nCloses #549\nCloses #551