### PR TITLE
fix(watchdog): suppress phantom upstream-lag alarm on shallow clones (client-wide)

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -270,12 +270,27 @@ def check_upstream_lag(
     that nothing landed. This check reads the real distance to ``upstream/main``
     so the owner is pinged within a day instead of noticing weeks later.
 
-    Silent (returns []) when the repo can't be located or ``upstream/main`` is
-    unavailable — best-effort, never a false alarm from a missing remote.
+    Silent (returns []) when the repo can't be located, when the checkout is a
+    SHALLOW clone or otherwise has no shared history with ``upstream/main`` (the
+    behind-count is meaningless there — see ``_upstream_lag_unmeasurable``), or
+    when ``upstream/main`` is unavailable — best-effort, never a false alarm.
     """
     repo = repo_dir or _resolve_repo_dir()
     if repo is None:
         return []
+
+    # Installer checkouts are shallow (`git clone --depth 1` in scripts/install.sh
+    # / install.ps1). Across the shallow boundary HEAD shares no ancestry with
+    # upstream/main, so `rev-list --count HEAD..upstream/main` counts ~ALL upstream
+    # history (~13k) instead of the true distance — a phantom "fork is ~13000
+    # commits behind" alarm fired DAILY on every onboarded client (upgrade.sh
+    # registers this watchdog). Shallow is the INTENDED client default, and
+    # upstream-lag is the fork maintainer's concern: the evolution server is a full
+    # clone and still gets the real count. So skip silently here — mirrors the
+    # shallow guards already in hermes_cli/banner.py and hermes_cli/main.py.
+    if _upstream_lag_unmeasurable(runner, repo):
+        return []
+
     try:
         rc, out = runner(
             ["git", "-C", str(repo), "rev-list", "--count", "HEAD..upstream/main"]
@@ -295,6 +310,45 @@ def check_upstream_lag(
             f"of merging — resolve the backlog (see the open [UPSTREAM] issue)."
         ]
     return []
+
+
+def _upstream_lag_unmeasurable(
+    runner: Callable[[List[str]], Tuple[int, str]], repo: Path
+) -> bool:
+    """True when ``HEAD..upstream/main`` can't yield a meaningful behind-count.
+
+    Two independent signals, either of which makes the numeric count a phantom:
+      1. shallow repo — ``git rev-parse --is-shallow-repository`` == "true"
+         (the `git clone --depth 1` installer default);
+      2. no shared history — ``git merge-base HEAD upstream/main`` exits non-zero
+         with EMPTY stdout (HEAD and upstream share no common ancestor, e.g. a
+         grafted clone, even when the shallow flag is unset).
+
+    Best-effort and FAIL-OPEN: any spawn error or inconclusive result returns
+    False, so a normal full clone proceeds to the real rev-list count exactly as
+    before — this can never make the check worse than today.
+    """
+    try:
+        rc, out = runner(
+            ["git", "-C", str(repo), "rev-parse", "--is-shallow-repository"]
+        )
+        if rc == 0 and out.strip() == "true":
+            return True
+    except Exception:  # noqa: BLE001 — inconclusive probe: don't block the real check
+        return False
+
+    try:
+        rc, out = runner(["git", "-C", str(repo), "merge-base", "HEAD", "upstream/main"])
+    except Exception:  # noqa: BLE001
+        return False
+    # No common ancestor: git exits non-zero with NOTHING on stdout. A non-zero
+    # exit WITH output (e.g. "fatal: bad revision 'upstream/main'" when the remote
+    # is merely missing) is the unrelated missing-remote case — leave that to the
+    # rev-list step, which already fails silently, so we don't turn a missing
+    # remote into a spurious shallow skip.
+    if rc != 0 and not out.strip():
+        return True
+    return False
 
 
 def check_health(evolution_dir: Path) -> List[str]:

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -286,6 +286,59 @@ class TestUpstreamLag:
 
         assert check_upstream_lag(runner=fake_run) == []
 
+    def test_shallow_clone_silent_no_phantom_count(self):
+        # The installer's `git clone --depth 1` default: a shallow repo. The
+        # behind-count would balloon to ~all of upstream history (the 2026-06
+        # phantom "~13000 commits behind" alarm on every onboarded client).
+        # The shallow probe must short-circuit BEFORE rev-list is consulted, and
+        # the result must be SILENT (no alert) — shallow is the intended default.
+        def fake_run(cmd):
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "true\n")
+            if "rev-list" in cmd:
+                raise AssertionError(
+                    "rev-list must NOT run on a shallow clone — its count is phantom"
+                )
+            return (0, "")
+
+        assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
+
+    def test_unresolved_merge_base_silent(self):
+        # Non-shallow, but HEAD and upstream/main share no common ancestor
+        # (grafted/no-shared-history): `merge-base` exits non-zero with EMPTY
+        # stdout. The count is just as meaningless, so skip silently too. A
+        # missing-remote case (non-zero exit WITH text) is deliberately NOT
+        # treated as unmeasurable here — that falls through to rev-list.
+        def fake_run(cmd):
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "false\n")
+            if "merge-base" in cmd:
+                return (1, "")  # no common ancestor: non-zero, empty stdout
+            if "rev-list" in cmd:
+                raise AssertionError(
+                    "rev-list must NOT run when HEAD has no shared history with upstream"
+                )
+            return (0, "")
+
+        assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
+
+    def test_full_clone_behind_over_threshold_still_alerts(self):
+        # Regression guard: a normal FULL clone (not shallow, shared ancestry)
+        # that is genuinely behind must still alert — the evolution server is a
+        # full clone and the real upstream-lag monitoring must survive this fix.
+        def fake_run(cmd):
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "false\n")
+            if "merge-base" in cmd:
+                return (0, "abc123def456\n")  # shared ancestor exists
+            if "rev-list" in cmd:
+                return (0, "391\n")
+            return (0, "")
+
+        alerts = check_upstream_lag(runner=fake_run, repo_dir=self.REPO)
+        assert any("behind upstream/main" in a for a in alerts)
+        assert any("391" in a for a in alerts)
+
 
 class TestStagesMirrorCronSpecs:
     """STAGES duplicates cron/evolution/*.yaml; lock the two together.


### PR DESCRIPTION
## Symptom

Every onboarded client fired a daily `evolution-watchdog` alert claiming the
**fork is ~13000 commits behind upstream/main**. The number was a phantom — the
fork is not actually thousands of commits behind.

## Root cause

`scripts/install.sh` (lines 1214/1219) and `install.ps1` clone Hermes with
`git clone --depth 1`, so **every fresh client install is a SHALLOW repo**.
`upgrade.sh` then adds the `upstream` remote and registers the
`evolution-watchdog` cron (`cron/evolution/watchdog.yaml`, daily 07:47,
`deliver:all`).

On a shallow clone HEAD shares no ancestry with `upstream/main`, so
`check_upstream_lag()`'s `git rev-list --count HEAD..upstream/main` counts
~**all** of upstream history (~13031) instead of the true distance, tripping the
`UPSTREAM_BEHIND_ALERT` threshold (80) every single day on every client.

The shallow guard already exists in `hermes_cli/banner.py`
(`_check_via_local_git`) and `hermes_cli/main.py` (update-check) — but
`check_upstream_lag` was the **one update-check site that was missed**. The true
behind-count for our (full-clone, now-unshallowed) evolution server is ~391.

## Fix

A new helper `_upstream_lag_unmeasurable(runner, repo)` returns `True` when:

1. the repo is **shallow** — `git rev-parse --is-shallow-repository` == `"true"`; or
2. there is **no shared history** — `git merge-base HEAD upstream/main` exits
   non-zero with **empty** stdout (grafted / no-common-ancestor, even when the
   shallow flag is unset).

When `True`, `check_upstream_lag` returns `[]` **silently** (no alert).

The helper is **fail-open**: any inconclusive probe error falls through to the
existing exact `rev-list`/threshold path, so this can never make the check worse
than today.

## Why silent (not a diagnostic line)

Shallow is the **intended client default**, and upstream-lag is the
**fork-maintainer's** concern, not the client's. The evolution server is a
**full clone** and still gets the real count and the real alarm. Emitting any
line on shallow clients would just reintroduce daily noise (`deliver:all`) for a
condition that is normal and not actionable client-side. This mirrors the
silent-skip precedent already in `banner.py` / `main.py`.

## Test evidence

3 new `TestUpstreamLag` cases:
- shallow clone → silent, and `rev-list` is **not** consulted (asserts the phantom
  count path is never reached);
- non-shallow with unresolved (empty) `merge-base` → silent;
- full clone genuinely behind (>80) → **still alerts** (regression guard).

```
$ ./.venv/bin/pytest tests/scripts/test_evolution_watchdog.py -q
......................................                                   [100%]
38 passed
```

(`tests/scripts/test_register_evolution_cron.py` has 3 pre-existing unrelated
failures from a missing `croniter` package — out of scope for this PR; the
watchdog module is fully green.)

## Rollout

Existing deployed clients pick this up on their next `hermes update` /
`upgrade.sh` (the cron scheduler re-copies `scripts/evolution_watchdog.py` into
`HERMES_HOME/scripts`), at which point the phantom daily alarm stops.

## Note

This consolidates two competing local fixes into one: the **silent-skip
response** (mirrors the `banner.py`/`main.py` precedent) combined with the
**broader detection** (shallow OR empty merge-base, covering grafted /
no-common-ancestor clones).
