### PR TITLE
test: fix stale percentage-clamp guard blocking ALL merges on main (Case B)

### DIFF
--- a/tests/run_agent/test_percentage_clamp.py
+++ b/tests/run_agent/test_percentage_clamp.py
@@ -96,9 +96,58 @@ class TestSourceLinesAreClamped:
         )
 
     def test_memory_tool_clamped(self):
+        """Every user-facing percentage in memory_tool.py must be clamped <=100.
+
+        The invariant under guard: no display path can ever emit a percentage
+        above 100% (token/char counts can transiently overshoot the limit
+        during streaming or before compaction fires). The original guard
+        hard-coded the literal ``min(100, int((current / limit)`` and counted
+        occurrences, which silently broke when #537 renamed the local
+        ``limit`` -> ``effective_limit`` in ``_success_response`` for the
+        per-apply_batch override (the clamp was preserved, only the variable
+        name changed). We now assert the real invariant directly: every
+        ``... * 100`` percentage expression is wrapped in a ``min(100, ...)``
+        clamp, which is refactor-resilient and strictly stronger than a
+        literal-line count.
+        """
+        import re
+
         src = self._read_file("tools/memory_tool.py")
-        # Both _success_response and _render_block should have min(100, ...)
-        count = src.count("min(100, int((current / limit)")
-        assert count >= 2, (
-            f"memory_tool.py has only {count} clamped pct lines, expected >= 2"
+
+        # Find every percentage expression: an ``int(...)`` cast that scales a
+        # ratio by 100 (the display-pct idiom in this file, e.g.
+        # ``int((current / limit) * 100)``). Each one MUST be immediately
+        # preceded by ``min(100, `` so the result can never exceed 100. We
+        # anchor on a single ``int(`` (so the standard single-paren form
+        # ``int(current / limit * 100)`` is also guarded, not only the
+        # double-paren idiom) and accept the ``* 100`` factor in either order.
+        # The match deliberately stops at the ``100`` factor (not the closing
+        # parens) so it captures both the clamped form (``... * 100))``) and a
+        # hypothetical unclamped regression (``... * 100)``).
+        pct_exprs = list(
+            re.finditer(r"int\((?:[^\n]*?\*\s*100|[^\n]*?100\s*\*[^\n]*?)", src)
+        )
+        assert pct_exprs, (
+            "expected at least one ``int(... * 100`` percentage expression "
+            "in memory_tool.py — has the display format changed?"
+        )
+
+        unclamped = [
+            src[m.start():m.start() + 40]
+            for m in pct_exprs
+            if not src[max(0, m.start() - 9):m.start()].endswith("min(100, ")
+        ]
+        assert not unclamped, (
+            "memory_tool.py has unclamped percentage expression(s) that can "
+            f"emit >100%: {unclamped}. Wrap each in min(100, ...)."
+        )
+
+        # Secondary sanity check: the two original distinct display sites
+        # (_success_response + _render_block, plus _compact's usage line) are
+        # still present. Count the shared clamp prefix rather than a single
+        # variable-specific literal so a future rename does not break this.
+        clamp_sites = src.count("min(100, int((")
+        assert clamp_sites >= 2, (
+            f"memory_tool.py has only {clamp_sites} clamped pct site(s), "
+            "expected >= 2 (the success-response and render-block displays)"
         )


### PR DESCRIPTION
## Why this unblocks everything

The required meta-check **\"All required checks pass\"** is RED on `main`, which **blocks ALL merges** into main: PR #561 is currently `BLOCKED`, the evolution pipeline's autonomous merges are stalled, and PRs #542 / #546 / #552 cannot land either. The single failing test is:

```
tests/run_agent/test_percentage_clamp.py::TestSourceLinesAreClamped::test_memory_tool_clamped
AssertionError: memory_tool.py has only 1 clamped pct lines, expected >= 2
assert 1 >= 2
```

Confirmed RED on a clean `origin/main` worktree (the literal count is genuinely 1).

## Root cause — Case B: STALE GUARD, not a correctness regression

The guard counted the **literal substring** `min(100, int((current / limit)` and required `>= 2`. Commit `59502d357` (#537, *per-apply_batch memory_char_limit override*) renamed the local `limit` → `effective_limit` inside `_success_response`, so its clamp line became:

```python
pct = min(100, int((current / effective_limit) * 100)) if effective_limit > 0 else 0
```

The clamp is **fully preserved** — only the variable name changed — but the brittle literal no longer matched there, dropping the count 2 → 1.

**All three percentage sites in `tools/memory_tool.py` remain correctly clamped (verified):**

| Line | Method | Expression |
|------|--------|-----------|
| 847 | `_compact` | `min(100, int((new_total / limit) * 100))` |
| 1099 | `_success_response` | `min(100, int((current / effective_limit) * 100))` |
| 1128 | `_render_block` | `min(100, int((current / limit) * 100))` |

There is **no unclamped percentage path** — no display can ever emit >100%. `tools/memory_tool.py` is intentionally **left untouched**.

## The fix (test only)

Replace the variable-specific literal count with a **refactor-resilient guard that asserts the real invariant**: every `int(... * 100)` percentage expression in `memory_tool.py` is immediately wrapped in `min(100, ...)`. This is **strictly stronger** than the old line-count — it actively detects an unclamped regression (verified with negative tests for both the double-paren and the standard single-paren `int(current / limit * 100)` forms) and survives future variable renames. A secondary `min(100, int((` `>= 2` site-count sanity check is retained.

## Verification

- `pytest tests/run_agent/test_percentage_clamp.py -q` → **11 passed**
- `pytest tests/run_agent/ -q -k \"clamp or percentage or memory\"` → **78 passed, 0 failed**
- Negative tests prove the guard fails if any clamp is removed.
- Cross-AI (Gemini) review confirmed the new guard is at least as strong as the old one; its feedback prompted broadening the regex to also cover the single-paren cast form.

## Note for reviewer

This modifies a **safety-guard test** (Case B), so per process it is left for a human nod rather than auto-merged. The source clamps are unchanged and the new guard is strictly stronger, so the safety guarantee is preserved/improved, not weakened. Note: PR #552 independently contains a narrower version of this same fix (`min(100, int((`); this PR supersedes that test change with a stronger invariant-based guard.