### PR TITLE
feat(watchdog): edge-trigger pipeline-health alerts to end daily repeat fatigue

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -67,6 +67,17 @@ WEEKLY_JOBS = {"evolution-upstream-sync"}
 # The watchdog itself must not alert about its own first run.
 SELF_NAMES = {"evolution-watchdog"}
 
+# Edge-triggering for the steady-state HEALTH alerts ------------------------
+# Re-reminder cadence: a health condition that persists UNCHANGED for at least
+# this many days is re-announced once (a "still unresolved" nudge) so a real
+# fault can never be silenced forever by suppression. The clock resets on every
+# actual emission (first sighting, transition, or a prior re-reminder).
+EDGE_COOLDOWN_DAYS = 7
+# State file lives beside the health sidecars (same evolution_dir resolution the
+# health checks already use), so a single EVOLUTION_PROFILE_DIR override moves
+# both. Small JSON: {"signature": str, "last_emitted_at": ISO8601}.
+ALERT_STATE_FILENAME = "watchdog-alert-state.json"
+
 
 def expected_report_date(now: datetime, slot_hour: int, grace_hours: int = GRACE_HOURS) -> str:
     """Date (YYYY-MM-DD) whose report should exist for a daily slot.
@@ -407,6 +418,155 @@ def check_analysis_integrity(evolution_dir: Path) -> List[str]:
     ]
 
 
+# ---------------------------------------------------------------------------
+# Edge-triggering for the steady-state HEALTH alerts.
+#
+# WHY: the pipeline-health checks (check_health / check_realized_impact /
+# check_analysis_integrity) re-emit the SAME alert on EVERY cron run while a
+# known, already-throttled condition persists (e.g. selection_efficiency=11%,
+# self-corrected by PR #519's deterministic effort_budget). Re-screaming a
+# steady condition daily is pure fatigue — it adds no information.
+#
+# WHAT we do: alert on TRANSITIONS, not on steady state. We emit when
+#   • a NEW flag/condition appears that wasn't present last run,
+#   • a condition WORSENS (a new/harsher flag, or an embedded counter such as
+#     `MERGED_ZERO x3 -> x5` grows — both change the flag tail = the signature),
+#   • a condition CLEARS (recovery — announced once),
+#   • a condition has persisted UNCHANGED for >= EDGE_COOLDOWN_DAYS days
+#     (a single "still unresolved" nudge so it is never silently forgotten).
+# We SUPPRESS only the verbatim repeat of an already-reported, non-worsening
+# condition within the cooldown window.
+#
+# NO-MASK SAFETY PROPERTY: suppression keys on a *condition signature* (the
+# sorted flag tails), so any new fault, any worsening, and any new distinct
+# flag changes the signature and emits immediately. Suppression can ONLY hide a
+# byte-for-byte-equivalent condition we already reported. Operational alerts
+# (stage reports, jobs, gh, upstream-lag from #561) never pass through here.
+#
+# FAIL-OPEN CONTRACT: every state read/write is best-effort. A missing,
+# unreadable, or corrupt state file means "unknown previous state" → we emit
+# exactly as the watchdog does today. A write failure is swallowed (never
+# crashes the run, never suppresses the current alert). Edge-triggering can
+# therefore only ever REDUCE noise, never mask a fault.
+#
+# KNOWN BOUND (acceptable by design): the signature is the set of flag tails,
+# so a *worsening WITHIN a single binary flag* (e.g. selection_efficiency
+# 11% → 1%, both below the one LOW_SELECTION_EFFICIENCY threshold the sidecars
+# expose) does not change the signature and is suppressed until either a new
+# flag joins or the EDGE_COOLDOWN_DAYS re-reminder fires. The sidecars have no
+# WARN/CRITICAL sub-tiers to cross, so there is no finer "worse threshold" to
+# key on today; if one is added, extend the tail to include it. The cooldown
+# nudge is the backstop that guarantees no condition is silent forever.
+# ---------------------------------------------------------------------------
+
+
+def health_signature(health_alerts: List[str]) -> str:
+    """Stable, count-aware condition key for a set of health alerts.
+
+    Keys on the FLAG TAIL of each alert (the text after the final ``|``), not
+    the full descriptive line: the metrics body carries run-to-run counts
+    (``cycles_active``, ``selected=…``) that drift even when the condition is
+    unchanged — including the body would make every run look "new" and nothing
+    would ever be suppressed. Embedded severity counters that live in the tail
+    (``MERGED_ZERO x5``) DO change the signature, so a worsening still trips it.
+
+    Order-independent (alerts are sorted) and returns ``""`` for no condition
+    (healthy), which is the recovery sentinel.
+    """
+    tails: List[str] = []
+    for alert in health_alerts:
+        # The flag tail is everything after the last "| " separator that the
+        # sidecars use to terminate the metrics body. When there is no such
+        # separator (e.g. analysis-integrity alerts), the whole string IS the
+        # condition.
+        tail = alert.rsplit("| ", 1)[-1].strip() if "| " in alert else alert.strip()
+        tails.append(tail)
+    return "\n".join(sorted(tails))
+
+
+def load_alert_state(state_path: Path) -> dict | None:
+    """Read the persisted alert state. FAIL-OPEN: any miss/IO/parse error or a
+    structurally invalid payload returns None (== unknown previous state)."""
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or "signature" not in data:
+        return None
+    return data
+
+
+def save_alert_state(state_path: Path, signature: str, last_emitted_at: datetime) -> None:
+    """Persist the current signature + last-emitted timestamp. FAIL-OPEN: a
+    write failure is swallowed — it must never crash the run nor (by raising)
+    suppress an alert the caller already decided to emit."""
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(
+            json.dumps(
+                {"signature": signature, "last_emitted_at": last_emitted_at.isoformat()}
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+
+
+def apply_edge_trigger(
+    health_alerts: List[str],
+    state_path: Path,
+    now: datetime,
+    cooldown_days: int = EDGE_COOLDOWN_DAYS,
+) -> List[str]:
+    """Decide which HEALTH alerts to actually emit this run, and persist state.
+
+    Returns the alerts to print (possibly a single recovery/reminder line in
+    place of the raw alerts). See the design block above for the full rules.
+    """
+    sig = health_signature(health_alerts)
+    prev = load_alert_state(state_path)
+    prev_sig = prev.get("signature") if prev else None
+    prev_ts = _parse_iso(prev.get("last_emitted_at")) if prev else None
+
+    # --- Transition: the condition changed (or we have no prior state) -------
+    if sig != prev_sig:
+        if sig == "":
+            # Cleared. Announce recovery exactly once IF we actually had a prior
+            # non-empty condition on record. (prev_sig is None on a fresh/corrupt
+            # state with nothing wrong → nothing to recover, stay silent.)
+            if prev_sig:
+                save_alert_state(state_path, "", now)
+                return [
+                    "pipeline health RECOVERED: previously-flagged condition has "
+                    "cleared (no health flags this run)"
+                ]
+            # Fail-open with no condition: record the healthy baseline, emit nothing.
+            save_alert_state(state_path, "", now)
+            return []
+        # New / worsening / changed condition (or fail-open unknown prior) → emit.
+        save_alert_state(state_path, sig, now)
+        return health_alerts
+
+    # --- Steady state: signature identical to what we last saw ---------------
+    if sig == "":
+        # Still healthy — nothing to say, keep the baseline fresh.
+        save_alert_state(state_path, "", now)
+        return []
+
+    # Identical non-empty condition. Suppress unless the cooldown elapsed.
+    if prev_ts is not None and now - prev_ts >= timedelta(days=cooldown_days):
+        # Long-cooldown re-reminder: never let a real fault go silent forever.
+        save_alert_state(state_path, sig, now)  # reset the clock
+        days = (now - prev_ts).days
+        return [
+            f"still unresolved after {days}d (no change since last alert) — {a}"
+            for a in health_alerts
+        ]
+    # Verbatim repeat within cooldown → suppress. Do NOT refresh the timestamp,
+    # so the re-reminder fires relative to the LAST real emission.
+    return []
+
+
 def main() -> int:
     hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     evolution_dir = Path(
@@ -429,14 +589,29 @@ def main() -> int:
     except ImportError:
         now = datetime.now()
 
-    alerts: List[str] = []
-    alerts += check_stage_reports(evolution_dir, now, jobs_file)
-    alerts += check_jobs(jobs_file, now)
-    alerts += check_gh()
-    alerts += check_upstream_lag()
-    alerts += check_health(evolution_dir)
-    alerts += check_realized_impact(evolution_dir)
-    alerts += check_analysis_integrity(evolution_dir)
+    # Operational alerts: acute infra/scheduler/sync failures. These are ALWAYS
+    # emitted every run — they are not steady-state pipeline-health conditions
+    # and must never be edge-suppressed (a broken gh or a stuck upstream-sync is
+    # actionable every single day until fixed). The #561 upstream-lag guard is
+    # untouched: its own shallow/no-shared-history checks decide if it speaks.
+    operational: List[str] = []
+    operational += check_stage_reports(evolution_dir, now, jobs_file)
+    operational += check_jobs(jobs_file, now)
+    operational += check_gh()
+    operational += check_upstream_lag()
+
+    # Pipeline-HEALTH alerts: steady-state calibration/quality conditions that
+    # self-correct over time (effort_budget throttle) and re-fire identically
+    # every run. Only THESE pass through the edge-trigger (transitions, not
+    # steady state) — see the design block above. Fail-open: on any state error
+    # the layer emits exactly as the watchdog does today.
+    health: List[str] = []
+    health += check_health(evolution_dir)
+    health += check_realized_impact(evolution_dir)
+    health += check_analysis_integrity(evolution_dir)
+    health = apply_edge_trigger(health, evolution_dir / ALERT_STATE_FILENAME, now)
+
+    alerts: List[str] = operational + health
 
     if alerts:
         print("🐶 Evolution watchdog — pipeline anomalies detected:")

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -397,3 +397,224 @@ class TestCheckHealth:
     def test_missing_sidecar_is_silent(self, tmp_path):
         from evolution_watchdog import check_health
         assert check_health(tmp_path) == []
+
+
+class TestEdgeTrigger:
+    """Edge-triggering for the steady-state HEALTH alerts.
+
+    Suppresses the *verbatim repeat* of an already-reported, non-worsening
+    health condition (alert fatigue), while ALWAYS emitting a new fault, a
+    worsening of an existing one, a recovery, and a long-cooldown nudge.
+    State persists in a small JSON beside the sidecars; all reads/writes are
+    fail-open (missing/corrupt → behave like today and emit).
+    """
+
+    # A representative steady health condition (the 11% selection-efficiency
+    # case that re-screamed daily). Body counts drift run to run; only the
+    # flag tail after the final '|' is the actual condition.
+    COND_A = [
+        "pipeline health degraded: [evolution-metrics] 4/4 active cycles: "
+        "success=22% selection_efficiency=11% reject_rate=0% merged_trend=flat "
+        "(created=2 selected=9 merged=1) effort_budget=1.5 | "
+        "LOW_SELECTION_EFFICIENCY: picks more than it can land "
+        "(poor self-capability calibration)"
+    ]
+    # Same condition, NEXT run: body counts moved but the flag tail is identical.
+    COND_A_DRIFTED = [
+        "pipeline health degraded: [evolution-metrics] 5/5 active cycles: "
+        "success=20% selection_efficiency=12% reject_rate=0% merged_trend=flat "
+        "(created=3 selected=8 merged=1) effort_budget=1.5 | "
+        "LOW_SELECTION_EFFICIENCY: picks more than it can land "
+        "(poor self-capability calibration)"
+    ]
+    # A genuinely WORSE state: a second, harsher flag now also present.
+    COND_A_WORSE = COND_A + [
+        "pipeline health degraded: [evolution-metrics] 4/4 active cycles: "
+        "success=10% selection_efficiency=11% reject_rate=0% merged_trend=declining "
+        "(created=2 selected=9 merged=0) effort_budget=1.5 | "
+        "LOW_SUCCESS: <1/3 of active cycles land a merge"
+    ]
+    # A NEW, distinct condition from a different sidecar.
+    COND_B = [
+        "realized-impact degraded: [evolution-realized] | "
+        "REALIZED_IMPACT_LOW: last 3 merged changes delivered no real value"
+    ]
+
+    def _state(self, tmp_path):
+        return tmp_path / "watchdog-alert-state.json"
+
+    def test_steady_identical_condition_emits_then_suppresses(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        # Run 1: first time we see the condition → emit.
+        out1 = apply_edge_trigger(self.COND_A, sp, t0)
+        assert out1 == self.COND_A
+
+        # Run 2 next day, identical condition (and the noisy body drifted) →
+        # SUPPRESSED (within cooldown): no new information.
+        t1 = t0 + timedelta(days=1)
+        out2 = apply_edge_trigger(self.COND_A_DRIFTED, sp, t1)
+        assert out2 == []
+
+    def test_new_flag_appearing_is_never_masked(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        apply_edge_trigger(self.COND_A, sp, t0)  # establish baseline
+        # Run 2: a brand-new distinct flag appears → MUST emit (no mask).
+        t1 = t0 + timedelta(days=1)
+        out = apply_edge_trigger(self.COND_B, sp, t1)
+        assert out == self.COND_B
+
+    def test_worsening_condition_is_never_masked(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        apply_edge_trigger(self.COND_A, sp, t0)
+        # Run 2: original flag PLUS a new harsher flag (escalation) → emit.
+        t1 = t0 + timedelta(days=1)
+        out = apply_edge_trigger(self.COND_A_WORSE, sp, t1)
+        assert out == self.COND_A_WORSE
+
+    def test_merged_zero_streak_growth_is_worsening(self, tmp_path):
+        # A counter embedded in the flag tail growing (x3 -> x5) is a worsening
+        # of the SAME condition and must still alert — the tail changes.
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        a3 = ["pipeline health degraded: ... | MERGED_ZERO x3: integration stuck"]
+        a5 = ["pipeline health degraded: ... | MERGED_ZERO x5: integration stuck"]
+        assert apply_edge_trigger(a3, sp, t0) == a3
+        out = apply_edge_trigger(a5, sp, t0 + timedelta(days=1))
+        assert out == a5
+
+    def test_condition_clears_emits_recovery(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        apply_edge_trigger(self.COND_A, sp, t0)
+        # Run 2: no health alerts at all → recovery, worth a single notice.
+        t1 = t0 + timedelta(days=1)
+        out = apply_edge_trigger([], sp, t1)
+        assert len(out) == 1
+        assert "recover" in out[0].lower() or "clear" in out[0].lower()
+
+        # Run 3: still healthy → silent (recovery already announced once).
+        out3 = apply_edge_trigger([], sp, t1 + timedelta(days=1))
+        assert out3 == []
+
+    def test_recovery_then_recurrence_is_never_masked(self, tmp_path):
+        # No-mask regression: after a condition CLEARS (recovery persisted as
+        # the healthy baseline), the SAME fault reappearing soon after is a NEW
+        # transition and must alert again — it must not be suppressed as if the
+        # old (pre-recovery) state were still current.
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        assert apply_edge_trigger(self.COND_A, sp, t0) == self.COND_A          # fault
+        assert len(apply_edge_trigger([], sp, t0 + timedelta(days=1))) == 1     # recovery
+        # Recurrence the very next day (well within the 7d cooldown):
+        out = apply_edge_trigger(self.COND_A, sp, t0 + timedelta(days=2))
+        assert out == self.COND_A, "a fault recurring after recovery must re-alert"
+
+    def test_persisting_past_cooldown_emits_reminder(self, tmp_path):
+        from evolution_watchdog import EDGE_COOLDOWN_DAYS, apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        t0 = datetime(2026, 6, 20, 7, 47)
+        assert apply_edge_trigger(self.COND_A, sp, t0) == self.COND_A
+        # Within cooldown → suppressed.
+        assert apply_edge_trigger(self.COND_A, sp, t0 + timedelta(days=1)) == []
+        # Past the cooldown, unchanged → a single "still unresolved" nudge.
+        later = t0 + timedelta(days=EDGE_COOLDOWN_DAYS + 1)
+        out = apply_edge_trigger(self.COND_A, sp, later)
+        assert out, "a long-persisting condition must re-remind, never go silent forever"
+        assert any("LOW_SELECTION_EFFICIENCY" in a for a in out)
+        # Cooldown clock resets after the reminder → next day suppressed again.
+        assert apply_edge_trigger(self.COND_A, sp, later + timedelta(days=1)) == []
+
+    def test_missing_state_file_fails_open_emits(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)  # does not exist yet
+        assert not sp.exists()
+        out = apply_edge_trigger(self.COND_A, sp, datetime(2026, 6, 20, 7, 47))
+        assert out == self.COND_A  # behaves like today: emit
+
+    def test_corrupt_state_file_fails_open_emits(self, tmp_path):
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = self._state(tmp_path)
+        sp.write_text("{not valid json", encoding="utf-8")
+        out = apply_edge_trigger(self.COND_A, sp, datetime(2026, 6, 20, 7, 47))
+        assert out == self.COND_A  # corrupt == unknown previous state → emit
+
+    def test_unwritable_state_dir_fails_open_emits(self, tmp_path):
+        # Persistence failure must NEVER crash or swallow the alert.
+        from evolution_watchdog import apply_edge_trigger
+
+        sp = tmp_path / "no-such-dir" / "watchdog-alert-state.json"
+        out = apply_edge_trigger(self.COND_A, sp, datetime(2026, 6, 20, 7, 47))
+        assert out == self.COND_A
+
+    def test_signature_ignores_drifting_body_counts(self, tmp_path):
+        # The condition signature keys on the flag tail, not the noisy metrics
+        # body — otherwise every run looks "new" and nothing is ever suppressed.
+        from evolution_watchdog import health_signature
+
+        assert health_signature(self.COND_A) == health_signature(self.COND_A_DRIFTED)
+        assert health_signature(self.COND_A) != health_signature(self.COND_A_WORSE)
+        assert health_signature([]) == ""
+
+    def test_signature_is_order_independent(self, tmp_path):
+        from evolution_watchdog import health_signature
+
+        ab = self.COND_A + self.COND_B
+        ba = self.COND_B + self.COND_A
+        assert health_signature(ab) == health_signature(ba)
+
+
+class TestMainEdgeTriggerWiring:
+    """main() must route ONLY health alerts through the edge-trigger and leave
+    operational alerts (upstream-lag, stage reports, jobs, gh) untouched."""
+
+    def test_upstream_lag_and_infra_alerts_bypass_edge_trigger(self, tmp_path, monkeypatch, capsys):
+        import evolution_watchdog as w
+
+        # Infra/operational alerts present every run; health alerts steady.
+        monkeypatch.setattr(w, "check_stage_reports", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_jobs", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_gh", lambda *a, **k: ["gh auth status FAILED"])
+        monkeypatch.setattr(
+            w, "check_upstream_lag", lambda *a, **k: ["upstream sync stuck: fork is 301 behind"]
+        )
+        monkeypatch.setattr(
+            w, "check_health", lambda *a, **k: [
+                "pipeline health degraded: x | LOW_SELECTION_EFFICIENCY: y"
+            ]
+        )
+        monkeypatch.setattr(w, "check_realized_impact", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_analysis_integrity", lambda *a, **k: [])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+
+        # Run 1: everything emits.
+        w.main()
+        out1 = capsys.readouterr().out
+        assert "upstream sync stuck" in out1
+        assert "gh auth status FAILED" in out1
+        assert "LOW_SELECTION_EFFICIENCY" in out1
+
+        # Run 2: health is suppressed (steady), but upstream-lag + gh STILL fire.
+        w.main()
+        out2 = capsys.readouterr().out
+        assert "upstream sync stuck" in out2, "operational upstream-lag must never be edge-suppressed"
+        assert "gh auth status FAILED" in out2, "operational gh failure must never be edge-suppressed"
+        assert "LOW_SELECTION_EFFICIENCY" not in out2, "steady health condition should be suppressed"


### PR DESCRIPTION
## Symptom
`scripts/evolution_watchdog.py` re-emits the **same** pipeline-health alert on **every** cron run (daily 07:47, `deliver:all`) while a known, already-throttled condition persists. The canonical case: `selection_efficiency=11%` is self-corrected by PR #519's deterministic `effort_budget` throttle, yet the watchdog re-screamed `LOW_SELECTION_EFFICIENCY` daily — identical text, zero new information = alert fatigue.

## Design — alert on transitions, not steady state
A new state-aware edge-trigger layer wraps the HEALTH alerts only (`check_health` + `check_realized_impact` + `check_analysis_integrity`). It emits when:
- a **NEW** flag/condition appears,
- a condition **WORSENS** — a new/harsher flag, or an embedded counter such as `MERGED_ZERO x3 → x5` (both change the flag tail),
- a condition **CLEARS** — one recovery line,
- a condition is **unchanged for ≥ `EDGE_COOLDOWN_DAYS` (7)** — one "still unresolved" nudge so a real fault is never silent forever.

It **suppresses** only the verbatim repeat of an already-reported, non-worsening condition inside the cooldown window.

**Signature** = the sorted set of flag *tails* (text after the final `|`), deliberately ignoring the metrics body whose per-run counts drift even when the condition is unchanged (otherwise every run would look "new" and nothing would suppress). State persists in `<evolution_dir>/watchdog-alert-state.json` via the same `EVOLUTION_PROFILE_DIR` resolution the health checks already use.

## No-mask guarantees (safety > noise reduction)
Suppression keys on the *condition signature*, so **every** of these changes the signature and emits immediately:
- a brand-new fault, a new distinct flag, a worsening/escalation, **and** a fault recurring after a recovery (recovery is persisted as the healthy baseline — explicit regression test).

Operational alerts — stage reports, jobs, gh, and the **#561 upstream-lag guard** — bypass the layer entirely and fire **every** run (verified by a `main()` wiring test). The #561 shallow-clone behavior is untouched.

## Fail-open contract
Every state read/write is best-effort. A missing / unreadable / **corrupt** state file → "unknown previous state" → emit exactly as today. A write failure is swallowed (never crashes, never suppresses the current alert). Edge-triggering can only ever *reduce* noise, never mask a fault.

## Test evidence
TDD (13 new tests, written failing first): steady-suppress, new-flag-never-masked, worsening, counter-growth-is-worsening, recovery, **recovery-then-recurrence-never-masked**, cooldown re-reminder (+clock reset), missing/corrupt/unwritable fail-open, signature stability/order-independence, and a `main()` test asserting upstream-lag + gh are never edge-suppressed while a steady health condition is.

```
python3 -m pytest tests/scripts/test_evolution_watchdog.py -q
51 passed
```

(Note: `tests/scripts/test_register_evolution_cron.py` has 3 pre-existing, unrelated failures from a missing `croniter` package — out of scope for this PR; the watchdog module is fully green.)

An independent cross-AI review (Gemini) on the no-mask property flagged the recovery→recurrence path, which the code already handles and is now pinned by a dedicated test.