### PR TITLE
feat(watchdog): silent-freeze divergence detection + idempotent [UPSTREAM] issue

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -62,6 +62,17 @@ MIN_GH_RATE_REMAINING = 200
 # fork silently accumulates a backlog for days (2026-06-19 → 301 behind).
 UPSTREAM_BEHIND_ALERT = 80
 
+# Title prefix of the GitHub tracking issue the daily upstream-sync escalates to
+# when it can no longer auto-merge. The watchdog re-files this idempotently on a
+# real escalation so the owner never has to open it by hand (issue #562 was
+# opened manually). An OPEN issue carrying this prefix is the idempotency key —
+# its presence blocks creation of a duplicate.
+UPSTREAM_ISSUE_PREFIX = "[UPSTREAM]"
+# Toggle the gh issue-filing side effect. Default on; flip to "0" to fall back to
+# text-only (e.g. CI, or a box where gh isn't authed). Filing is ALWAYS fail-open
+# regardless of this flag — a missing/unauthed gh never crashes the watchdog.
+UPSTREAM_ISSUE_ENABLED = os.environ.get("WATCHDOG_FILE_UPSTREAM_ISSUE", "1") != "0"
+
 # Jobs that are weekly, not daily (looser staleness threshold).
 WEEKLY_JOBS = {"evolution-upstream-sync"}
 # The watchdog itself must not alert about its own first run.
@@ -315,12 +326,115 @@ def check_upstream_lag(
     except (ValueError, IndexError):
         return []
     if behind > UPSTREAM_BEHIND_ALERT:
+        # Real escalation on a measurable (full) clone: ensure the tracking issue
+        # exists so the owner doesn't have to open it by hand. Idempotent and
+        # fail-open — never raises, never crashes the watchdog. (#561's shallow /
+        # no-shared-history cases returned above and never reach here.)
+        ahead = _count_ahead_of_upstream(runner, repo)
+        ensure_upstream_issue(behind=behind, ahead=ahead, gh_enabled=UPSTREAM_ISSUE_ENABLED)
         return [
             f"upstream sync stuck: fork is {behind} commits behind upstream/main "
             f"(threshold {UPSTREAM_BEHIND_ALERT}). The daily sync escalates instead "
             f"of merging — resolve the backlog (see the open [UPSTREAM] issue)."
         ]
     return []
+
+
+def _count_ahead_of_upstream(
+    runner: Callable[[List[str]], Tuple[int, str]], repo: Path
+) -> int:
+    """Commits the fork has that upstream/main does not (best-effort, 0 on error)."""
+    try:
+        rc, out = runner(
+            ["git", "-C", str(repo), "rev-list", "--count", "upstream/main..HEAD"]
+        )
+    except Exception:  # noqa: BLE001
+        return 0
+    if rc != 0:
+        return 0
+    try:
+        return int(out.strip().split()[0])
+    except (ValueError, IndexError):
+        return 0
+
+
+def ensure_upstream_issue(
+    behind: int,
+    ahead: int,
+    runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
+    gh_enabled: bool = True,
+) -> str | None:
+    """Idempotently ensure a GitHub ``[UPSTREAM]`` tracking issue exists.
+
+    Called only on a REAL upstream escalation (full clone, behind > threshold —
+    the #561 shallow case never reaches here). The owner had to open issue #562
+    by hand; this closes that gap.
+
+    Idempotency key: an OPEN issue whose title starts with ``UPSTREAM_ISSUE_PREFIX``.
+    If one exists we do NOT create a duplicate (de-duped / edge-triggered on the
+    issue's own existence — no daily spam). If none exists we create one with the
+    real behind/ahead counts.
+
+    ALL gh interaction goes through the injectable ``runner`` seam, so this is
+    unit-testable without network. FAIL-OPEN throughout: gh missing/unauthed, a
+    failed search, or any spawn error → return None and do nothing (the text
+    alert from ``check_upstream_lag`` still informs the owner). Returns a short
+    human confirmation string when it actually created an issue, else None.
+    """
+    if not gh_enabled:
+        return None
+
+    # 1) Look for an existing open [UPSTREAM] issue (the idempotency key).
+    try:
+        rc, out = runner(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--search",
+                f"{UPSTREAM_ISSUE_PREFIX} in:title",
+                "--state",
+                "open",
+                "--json",
+                "number,title",
+            ]
+        )
+    except Exception:  # noqa: BLE001 — gh missing/spawn failure: fail-open
+        return None
+    if rc != 0:
+        # Search failed: do NOT blind-create (would risk duplicates/spam).
+        return None
+    try:
+        issues = json.loads(out) if out.strip() else []
+    except ValueError:
+        return None
+    for issue in issues if isinstance(issues, list) else []:
+        title = str(issue.get("title", "")) if isinstance(issue, dict) else ""
+        if title.startswith(UPSTREAM_ISSUE_PREFIX):
+            return None  # already tracked — never duplicate
+
+    # 2) None exists → create one with the real counts.
+    title = (
+        f"{UPSTREAM_ISSUE_PREFIX} Catch-up needed: ~{behind} commits behind "
+        f"upstream/main (owner review)"
+    )
+    body = (
+        f"The autonomous upstream-sync can no longer auto-merge: the fork is "
+        f"~{behind} commit(s) behind `upstream/main` and ~{ahead} commit(s) "
+        f"ahead, past the auto-merge ceiling.\n\n"
+        f"This issue was filed automatically by the evolution watchdog so the "
+        f"backlog is visible. Resolve by reconciling the fork to `upstream/main` "
+        f"(owner review of conflicting changes), then close this issue.\n"
+    )
+    try:
+        rc, _out = runner(
+            ["gh", "issue", "create", "--title", title, "--body", body]
+        )
+    except Exception:  # noqa: BLE001 — fail-open on create spawn failure
+        return None
+    if rc != 0:
+        return None
+    return f"filed {UPSTREAM_ISSUE_PREFIX} tracking issue ({behind} behind)"
 
 
 def _upstream_lag_unmeasurable(
@@ -360,6 +474,97 @@ def _upstream_lag_unmeasurable(
     if rc != 0 and not out.strip():
         return True
     return False
+
+
+def check_runtime_divergence(
+    runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
+    repo_dir: Path | None = None,
+) -> List[str]:
+    """Alert when the local runtime checkout has diverged from ``origin/main``.
+
+    THE SILENT FREEZE (root cause of the stalled nightly self-update): the
+    runtime checkout self-updates with ``git pull --ff-only``. When the evolution
+    pipeline (or a contributor) leaves LOCAL commits on the tracking branch that
+    later squash-merge upstream under a DIFFERENT SHA, local HEAD diverges from
+    ``origin/main``; ff-only can no longer fast-forward, so the nightly update
+    silently no-ops and the box freezes on an old revision with NO signal.
+
+    We DETECT + ALERT only — never auto-reset/auto-heal (that risks losing the
+    local commits). The fix is making the freeze loud via the owner's channel.
+
+    DIVERGED (the high-confidence signal we alert on):
+      * ``rev-list --count origin/main..HEAD`` > 0  (local commits not on origin)
+      * AND ``merge-base --is-ancestor HEAD origin/main`` is FALSE (HEAD is not
+        reachable from origin/main → a plain ff-only pull CANNOT advance).
+    The is-ancestor probe is authoritative: if HEAD is still an ancestor of
+    origin/main, ff-only would advance, so it is NOT a freeze even if rev-list
+    reports stray local commits.
+
+    STALE (behind but ff-able) is deliberately NOT alerted here: a healthy box
+    that simply hasn't pulled yet today is behind-but-fast-forwardable, and
+    alerting on it would storm every morning. The upstream-lag check already
+    covers the genuine "sync is stuck" case for the fork maintainer.
+
+    FAIL-OPEN: repo unresolved, any git/spawn error, or unparseable output →
+    return [] (behaves exactly as today, never a false alarm).
+    """
+    repo = repo_dir or _resolve_repo_dir()
+    if repo is None:
+        return []
+
+    try:
+        rc_anc, _out = runner(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "merge-base",
+                "--is-ancestor",
+                "HEAD",
+                "origin/main",
+            ]
+        )
+    except Exception:  # noqa: BLE001 — spawn failure: fail-open
+        return []
+    # rc 0 == HEAD IS an ancestor of origin/main → ff-able → not frozen.
+    # rc 1 == not an ancestor → potential divergence. Any other rc (e.g. 128 for
+    # a bad repo/ref) is inconclusive → fail-open silent.
+    if rc_anc == 0:
+        return []
+    if rc_anc != 1:
+        return []
+
+    try:
+        rc_ahead, out_ahead = runner(
+            ["git", "-C", str(repo), "rev-list", "--count", "origin/main..HEAD"]
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if rc_ahead != 0:
+        return []
+    try:
+        local_commits = int(out_ahead.strip().split()[0])
+    except (ValueError, IndexError):
+        return []
+    if local_commits <= 0:
+        return []
+
+    behind = 0
+    try:
+        rc_behind, out_behind = runner(
+            ["git", "-C", str(repo), "rev-list", "--count", "HEAD..origin/main"]
+        )
+        if rc_behind == 0:
+            behind = int(out_behind.strip().split()[0])
+    except (Exception, ValueError, IndexError):  # noqa: BLE001 — count is cosmetic
+        behind = 0
+
+    plural = "s" if local_commits != 1 else ""
+    return [
+        f"runtime checkout diverged from origin/main by {local_commits} local "
+        f"commit{plural} (origin is {behind} ahead) — nightly self-update is "
+        f"frozen (can't fast-forward); reconcile to origin/main."
+    ]
 
 
 def check_health(evolution_dir: Path) -> List[str]:
@@ -605,7 +810,15 @@ def main() -> int:
     # every run. Only THESE pass through the edge-trigger (transitions, not
     # steady state) — see the design block above. Fail-open: on any state error
     # the layer emits exactly as the watchdog does today.
+    #
+    # check_runtime_divergence rides this edge-trigger path too: a diverged
+    # runtime checkout is a steady condition that persists UNCHANGED until the
+    # owner reconciles it, so re-screaming it every run is pure fatigue. The
+    # signature keys on the alert text (no '|' tail), so it emits on first
+    # sighting, on any change (commit count moves), and on the cooldown nudge —
+    # but suppresses the verbatim daily repeat. No-mask + fail-open preserved.
     health: List[str] = []
+    health += check_runtime_divergence()
     health += check_health(evolution_dir)
     health += check_realized_impact(evolution_dir)
     health += check_analysis_integrity(evolution_dir)

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -12,8 +12,10 @@ from evolution_watchdog import (  # noqa: E402
     STAGES,
     check_gh,
     check_jobs,
+    check_runtime_divergence,
     check_stage_reports,
     check_upstream_lag,
+    ensure_upstream_issue,
     expected_report_date,
 )
 
@@ -618,3 +620,285 @@ class TestMainEdgeTriggerWiring:
         assert "upstream sync stuck" in out2, "operational upstream-lag must never be edge-suppressed"
         assert "gh auth status FAILED" in out2, "operational gh failure must never be edge-suppressed"
         assert "LOW_SELECTION_EFFICIENCY" not in out2, "steady health condition should be suppressed"
+
+
+class TestRuntimeDivergence:
+    """Feature 1 — silent-freeze detection for the local runtime checkout.
+
+    The runtime checkout self-updates with `git pull --ff-only`. When the
+    evolution pipeline (or a contributor) leaves LOCAL commits on the tracking
+    branch that later squash-merge upstream under a different SHA, the local
+    HEAD diverges and the nightly ff-only pull silently no-ops — freezing
+    self-update with no signal. This check makes that freeze LOUD.
+    """
+
+    REPO = Path("/repo")  # bypass _resolve_repo_dir via explicit repo_dir
+
+    def _run(self, *, ahead, behind, is_ancestor):
+        """Build a fake git runner.
+
+        ahead        = `rev-list --count origin/main..HEAD`  (local commits)
+        behind       = `rev-list --count HEAD..origin/main`  (upstream-ahead)
+        is_ancestor  = `merge-base --is-ancestor HEAD origin/main` rc==0 ?
+        """
+
+        def fake_run(cmd):
+            joined = " ".join(cmd)
+            if "merge-base" in cmd and "--is-ancestor" in cmd:
+                return (0 if is_ancestor else 1, "")
+            if "rev-list" in cmd and "origin/main..HEAD" in joined:
+                return (0, f"{ahead}\n")
+            if "rev-list" in cmd and "HEAD..origin/main" in joined:
+                return (0, f"{behind}\n")
+            raise AssertionError(f"unexpected git command: {cmd}")
+
+        return fake_run
+
+    def test_diverged_alerts(self):
+        # 2 local commits AND HEAD is not an ancestor of origin/main → frozen.
+        run = self._run(ahead=2, behind=5, is_ancestor=False)
+        alerts = check_runtime_divergence(runner=run, repo_dir=self.REPO)
+        assert len(alerts) == 1
+        assert "diverged" in alerts[0].lower()
+        assert "2 local commit" in alerts[0]
+        assert "frozen" in alerts[0].lower() or "self-update" in alerts[0].lower()
+
+    def test_healthy_head_equals_origin_silent(self):
+        # HEAD == origin/main: 0 ahead, 0 behind, HEAD is its own ancestor.
+        run = self._run(ahead=0, behind=0, is_ancestor=True)
+        assert check_runtime_divergence(runner=run, repo_dir=self.REPO) == []
+
+    def test_fast_forwardable_only_is_not_diverged(self):
+        # Behind but NOT diverged: 0 local commits, HEAD ancestor of origin/main.
+        # A plain ff-only pull WOULD advance here, so this is not a freeze.
+        # Conservative choice: behind-by-a-few is NOT alerted (avoid false
+        # positives on a healthy box that simply updates later the same day).
+        run = self._run(ahead=0, behind=3, is_ancestor=True)
+        assert check_runtime_divergence(runner=run, repo_dir=self.REPO) == []
+
+    def test_local_commits_but_still_ancestor_is_not_diverged(self):
+        # Defensive: if rev-list reports local commits but merge-base still says
+        # HEAD is an ancestor of origin/main (ff-able), it is NOT frozen — the
+        # is-ancestor signal is authoritative for "can ff-only advance".
+        run = self._run(ahead=1, behind=0, is_ancestor=True)
+        assert check_runtime_divergence(runner=run, repo_dir=self.REPO) == []
+
+    def test_git_failure_fails_open_silent(self):
+        def fake_run(cmd):
+            if "merge-base" in cmd:
+                return (128, "fatal: not a git repository")
+            return (128, "fatal")
+
+        assert check_runtime_divergence(runner=fake_run, repo_dir=self.REPO) == []
+
+    def test_spawn_error_fails_open_silent(self):
+        def fake_run(cmd):
+            raise FileNotFoundError("git")
+
+        assert check_runtime_divergence(runner=fake_run, repo_dir=self.REPO) == []
+
+    def test_garbage_count_fails_open_silent(self):
+        def fake_run(cmd):
+            if "merge-base" in cmd and "--is-ancestor" in cmd:
+                return (1, "")
+            if "rev-list" in cmd:
+                return (0, "not-a-number")
+            raise AssertionError("unexpected")
+
+        assert check_runtime_divergence(runner=fake_run, repo_dir=self.REPO) == []
+
+    def test_no_repo_silent(self, monkeypatch):
+        import evolution_watchdog as w
+
+        monkeypatch.setattr(w, "_resolve_repo_dir", lambda: None)
+
+        def fake_run(cmd):
+            raise AssertionError("runner must not run when repo is unresolved")
+
+        assert check_runtime_divergence(runner=fake_run) == []
+
+    def test_diverged_routed_through_edge_trigger_in_main(self, tmp_path, monkeypatch, capsys):
+        # The divergence alert is steady-state (persists until the owner
+        # reconciles), so it must route through the edge-trigger: emit once,
+        # suppress the identical repeat next run.
+        import evolution_watchdog as w
+
+        monkeypatch.setattr(w, "check_stage_reports", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_jobs", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_gh", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_upstream_lag", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_health", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_realized_impact", lambda *a, **k: [])
+        monkeypatch.setattr(w, "check_analysis_integrity", lambda *a, **k: [])
+        monkeypatch.setattr(
+            w, "check_runtime_divergence",
+            lambda *a, **k: [
+                "runtime checkout diverged from origin/main by 2 local "
+                "commit(s) — nightly self-update is frozen (can't fast-forward)"
+            ],
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+
+        w.main()
+        out1 = capsys.readouterr().out
+        assert "diverged from origin/main" in out1
+
+        # Run 2: identical divergence → edge-suppressed (no fresh information).
+        w.main()
+        out2 = capsys.readouterr().out
+        assert "diverged from origin/main" not in out2, (
+            "steady divergence must be edge-suppressed on identical repeat run"
+        )
+
+
+class TestEnsureUpstreamIssue:
+    """Feature 2 — idempotent GitHub [UPSTREAM] tracking issue on real escalation.
+
+    All gh interaction goes through the injected ``runner`` seam; the tests
+    NEVER hit GitHub. Idempotency key = an existing OPEN issue whose title
+    starts with the ``[UPSTREAM]`` prefix.
+    """
+
+    def _runner(self, *, existing_issues, created_sink, fail_search=False):
+        """Fake gh runner.
+
+        existing_issues: list returned by `gh issue list ... --json number,title`
+        created_sink:    list mutated when `gh issue create` is invoked
+        """
+
+        def fake_run(cmd):
+            joined = " ".join(cmd)
+            if "issue" in cmd and "list" in cmd:
+                if fail_search:
+                    return (1, "gh: could not search")
+                return (0, json.dumps(existing_issues))
+            if "issue" in cmd and "create" in cmd:
+                created_sink.append(joined)
+                return (0, "https://github.com/x/y/issues/999\n")
+            raise AssertionError(f"unexpected gh command: {cmd}")
+
+        return fake_run
+
+    def test_creates_issue_when_none_exists(self):
+        created = []
+        run = self._runner(existing_issues=[], created_sink=created)
+        out = ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=True)
+        assert len(created) == 1, "must create exactly one [UPSTREAM] issue"
+        assert "[UPSTREAM]" in created[0]
+        assert "391" in created[0]
+        # Returns a short confirmation string (or None) — must not crash.
+        assert out is None or isinstance(out, str)
+
+    def test_does_not_duplicate_when_open_issue_exists(self):
+        created = []
+        run = self._runner(
+            existing_issues=[{"number": 562, "title": "[UPSTREAM] Catch-up needed"}],
+            created_sink=created,
+        )
+        ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=True)
+        assert created == [], "an existing open [UPSTREAM] issue must block creation"
+
+    def test_ignores_non_upstream_open_issues(self):
+        # An unrelated open issue must NOT count as the tracking issue.
+        created = []
+        run = self._runner(
+            existing_issues=[{"number": 10, "title": "fix flaky test"}],
+            created_sink=created,
+        )
+        ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=True)
+        assert len(created) == 1, "non-[UPSTREAM] issues are not the idempotency key"
+
+    def test_gh_disabled_is_noop(self):
+        created = []
+
+        def run(cmd):
+            raise AssertionError("runner must not be called when gh disabled")
+
+        out = ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=False)
+        assert created == []
+        assert out is None
+
+    def test_search_failure_fails_open_no_create(self):
+        # If the search itself fails we must NOT blindly create (could spam);
+        # fail-open = do nothing, never crash.
+        created = []
+        run = self._runner(existing_issues=[], created_sink=created, fail_search=True)
+        out = ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=True)
+        assert created == []
+        assert out is None
+
+    def test_spawn_error_fails_open(self):
+        def run(cmd):
+            raise FileNotFoundError("gh")
+
+        # gh missing entirely → never crash.
+        out = ensure_upstream_issue(behind=391, ahead=4, runner=run, gh_enabled=True)
+        assert out is None
+
+
+class TestUpstreamLagFilesIssue:
+    """check_upstream_lag still emits text AND now ensures the tracking issue
+    exists, idempotently, via the mockable gh seam — only on REAL escalation."""
+
+    REPO = Path("/repo")
+
+    def _git_runner(self, behind):
+        def fake_run(cmd):
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "false\n")
+            if "merge-base" in cmd and "--is-ancestor" not in cmd:
+                return (0, "abc123\n")  # shared ancestor exists
+            if "rev-list" in cmd:
+                joined = " ".join(cmd)
+                if "HEAD..upstream/main" in joined:
+                    return (0, f"{behind}\n")
+                return (0, "0\n")
+            raise AssertionError(f"unexpected git command: {cmd}")
+
+        return fake_run
+
+    def test_real_escalation_ensures_issue(self, monkeypatch):
+        import evolution_watchdog as w
+
+        calls = {}
+
+        def fake_ensure(behind, ahead, **kw):
+            calls["behind"] = behind
+            return None
+
+        monkeypatch.setattr(w, "ensure_upstream_issue", fake_ensure)
+        alerts = check_upstream_lag(runner=self._git_runner(391), repo_dir=self.REPO)
+        assert any("behind upstream/main" in a for a in alerts), "text alert preserved"
+        assert calls.get("behind") == 391, "real escalation must ensure the tracking issue"
+
+    def test_within_threshold_does_not_file_issue(self, monkeypatch):
+        import evolution_watchdog as w
+
+        called = {"n": 0}
+        monkeypatch.setattr(
+            w, "ensure_upstream_issue",
+            lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+        )
+        assert check_upstream_lag(runner=self._git_runner(9), repo_dir=self.REPO) == []
+        assert called["n"] == 0, "no escalation → no issue churn"
+
+    def test_shallow_clone_does_not_file_issue(self, monkeypatch):
+        # #561 regression: shallow clones stay silent AND never file an issue.
+        import evolution_watchdog as w
+
+        called = {"n": 0}
+        monkeypatch.setattr(
+            w, "ensure_upstream_issue",
+            lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+        )
+
+        def fake_run(cmd):
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "true\n")
+            if "rev-list" in cmd:
+                raise AssertionError("rev-list must not run on shallow clone")
+            return (0, "")
+
+        assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
+        assert called["n"] == 0, "shallow path must never file an issue"


### PR DESCRIPTION
## Summary

Two robustness improvements to the evolution watchdog in one PR, closing the gaps behind the **frozen nightly self-update** and the **manually-opened upstream issue (#562)**. TDD; fail-open everywhere.

## Root cause (osoba investigation, read-only)

The prod runtime checkout `/root/hermes-agent-evolution` is configured as `user.name = Hermes Evolution` and the evolution pipeline makes **local commits directly in-place** (reflog shows e.g. `HEAD@{5}: commit: feat(cron,hydra)...` on temp branches, then `checkout main` in the **same** checkout — it does not use a worktree). When those changes squash-merge upstream under a **different SHA**, local `main` diverges and `git pull --ff-only` can no longer fast-forward — silently freezing nightly `hermes update` with no signal. That silent no-op is exactly what this PR makes loud.

## Feature 1 — silent-freeze detection (`check_runtime_divergence`)

Alerts when the local runtime checkout has DIVERGED from `origin/main` such that ff-only self-update silently no-ops:
- DIVERGED = `rev-list --count origin/main..HEAD > 0` **AND** `merge-base --is-ancestor HEAD origin/main` is **false** (HEAD unreachable from origin → ff-only can't advance). The is-ancestor probe is authoritative.
- A behind-but-**fast-forwardable** box (healthy, just hasn't pulled yet) is deliberately **not** alerted — avoids a daily false-positive storm. STALE is left to the existing upstream-lag check.
- DETECT + ALERT only — never auto-reset (would risk losing the local commits).
- Routed through the existing **#564 edge-trigger HEALTH layer** (`apply_edge_trigger`): a steady divergence emits once, then the verbatim daily repeat is suppressed, with the cooldown re-reminder backstop intact.
- Fail-open: repo unresolved / any git or spawn error / unparseable output → no alert.

`scripts/evolution_watchdog.py:check_runtime_divergence` + wired into `main()` health path.

## Feature 2 — idempotent GitHub `[UPSTREAM]` issue (`ensure_upstream_issue`)

On a **real** upstream escalation (full clone, behind > threshold — the #561 shallow case never reaches here), `check_upstream_lag` now ensures the `[UPSTREAM]` tracking issue exists instead of leaving the owner to open it by hand:
- Idempotency key = an **open** issue whose title starts with `[UPSTREAM]`. If present → no duplicate. Else → create one with the real behind/ahead counts.
- All gh interaction goes through an injectable `runner` seam (unit-testable, **no real network in tests**).
- Fail-open: gh missing/unauthed, failed search, or any spawn error → no-op (never blind-create, never crash). Gated by `WATCHDOG_FILE_UPSTREAM_ISSUE` (default on).

`scripts/evolution_watchdog.py:ensure_upstream_issue` (+ `_count_ahead_of_upstream`).

## Tests (18 new, TDD)

`tests/scripts/test_evolution_watchdog.py`:
- **TestRuntimeDivergence**: diverged → alert; HEAD==origin → silent; ff-able-only → silent; local-commits-but-still-ancestor → silent; git failure / spawn error / garbage → fail-open silent; no-repo silent; **edge-trigger routing in main()** (emit once, suppress identical repeat).
- **TestEnsureUpstreamIssue**: creates when none exists; no duplicate when open `[UPSTREAM]` exists; ignores non-`[UPSTREAM]` issues; gh-disabled no-op; search-failure fail-open (no blind create); spawn-error fail-open.
- **TestUpstreamLagFilesIssue**: real escalation ensures issue (text alert preserved); within-threshold no churn; **#561 shallow path stays silent AND never files an issue**.

Regressions covered: #561 shallow guard still silent, #564 edge-trigger still works.

## Test evidence

```
$ ./.venv/bin/pytest tests/scripts/test_evolution_watchdog.py -q
69 passed in 1.69s        # 51 baseline + 18 new

# zero real gh/git: PATH stripped of both, seams fully mocked
$ PATH="$(mktemp -d)" pytest -k "EnsureUpstreamIssue or UpstreamLagFilesIssue or RuntimeDivergence" -q
18 passed, 51 deselected

$ python3 -c "import ast;ast.parse(open('scripts/evolution_watchdog.py').read())"   # OK
$ ruff check scripts/evolution_watchdog.py tests/scripts/test_evolution_watchdog.py # All checks passed!
```

## Review

Cross-AI panel (Gemini) reviewed the diff; its FAIL rested on three claims (`repo_dir` TypeError, missing `import json`, runner-seam bypass) — all verified **false** against the full file (advisor saw only the diff): `check_upstream_lag` already takes `repo_dir`, `import json` is at line 29, and the gh seam is `ensure_upstream_issue`'s own mockable `runner` (proven by the PATH-stripped run above). No real network in tests.

## Residual risk

- Divergence count text is cosmetic (behind-count best-effort 0 on error); the DIVERGED decision rests only on the authoritative is-ancestor + ahead-count signals.
- Issue idempotency relies on the title prefix; a manually-renamed `[UPSTREAM]` issue could allow one duplicate (acceptable — owner-visible, not spam).
