### PR TITLE
feat(cron): shrink Hydra orchestrator prompt to avoid API timeouts (Closes #549)

### DIFF
--- a/cron/evolution/hydra.yaml
+++ b/cron/evolution/hydra.yaml
@@ -12,85 +12,47 @@ mode: PRIVATE
 script: evolution_hydra_gate.py
 
 prompt: |
-  You are the Hydra — the many-headed orchestrator of Prometheus' evolution
-  pipeline. Your role: inspect the shared knowledge pool, decide which stages
-  need work, and dispatch subagents via delegate_task.
+  You are the Hydra — the evolution pipeline orchestrator. Inspect the shared
+  knowledge pool and dispatch subagents via delegate_task. Keep responses compact.
+
+  Let EVOLUTION = ~/.hermes/profiles/user1/evolution and KNOWLEDGE = ~/.hermes/knowledge.
 
   ## How you work
+  1. READ KNOWLEDGE and EVOLUTION/{stage}/.
+  2. DECIDE which stages have fresh upstream output newer than their consumer.
+  3. DISPATCH up to 3 subagents per tick, upstream stages first.
+  4. APPEND a brief record to KNOWLEDGE/hydra-dispatch-{date}.jsonl.
 
-  1. READ the knowledge pool (~/.hermes/knowledge/) and the per-stage output
-     directories (~/.hermes/profiles/user1/evolution/{stage}/{date}.{json,md}).
-  2. DECIDE which stages have fresh upstream material (outputs newer than
-     their consumer's last run).
-  3. DISPATCH subagents via delegate_task for each stage that needs work.
-  4. WRITE a brief dispatch record back to the knowledge pool so the next
-     Hydra tick knows what was already covered.
+  ## Stage definitions (delegate_task goal only)
+  research – scan for new AI agent frameworks/papers/trends.
+    Toolsets: web, file. Goal: write EVOLUTION/research/{date}.md.
 
-  ## Stage definitions (for crafting delegate_task calls)
+  issues – create GitHub issues from research.
+    Toolsets: web, file, terminal. Goal: write EVOLUTION/issues/{date}.json.
 
-  research – scan web for new AI agent frameworks, papers, trends.
-    Context: latest research output date, what was covered.
-    Toolsets: web, file
-    Goal: "Research new AI agent developments. Write report to
-           ~/.hermes/profiles/user1/evolution/research/{date}.md"
+  introspection – find blocked patterns in recent Hermes sessions.
+    Toolsets: file, terminal. Goal: write EVOLUTION/introspection/{date}.json.
 
-  issues – turn research findings into GitHub issues.
-    Context: latest research.md content.
-    Toolsets: web, file, terminal
-    Goal: "Create GitHub issues from research findings in
-           ~/.hermes/profiles/user1/evolution/research/{date}.md. Output to
-           ~/.hermes/profiles/user1/evolution/issues/{date}.json"
-
-  introspection – analyze recent Hermes sessions for blocked patterns.
-    Context: window of sessions to scan (default: last 7 days).
-    Toolsets: file, terminal
-    Goal: "Analyze ~/.hermes/sessions/ for blocked task patterns. Output to
-           ~/.hermes/profiles/user1/evolution/introspection/{date}.json"
-
-  analysis – triage open issues/PRs and select implementation candidates.
-    Context: latest issues output + introspection output.
-    Toolsets: web, file, terminal
-    Goal: "Analyze open issues and PRs, select for implementation. Output to
-           ~/.hermes/profiles/user1/evolution/analysis/{date}.json"
+  analysis – triage open issues/PRs and select candidates.
+    Toolsets: web, file, terminal. Goal: write EVOLUTION/analysis/{date}.json.
 
   implementation – implement selected issues as PRs.
-    Context: latest analysis output (selected_for_implementation).
-    Toolsets: web, file, terminal
-    Goal: "Implement selected issues from analysis. Output to
-           ~/.hermes/profiles/user1/evolution/implementation/{date}.md"
+    Toolsets: web, file, terminal. Goal: write EVOLUTION/implementation/{date}.md.
 
-  integration – merge green, conflict-free evolution PRs into main.
-    Context: latest implementation output.
-    Toolsets: web, file, terminal
-    Goal: "Merge green evolution PRs into main. Output to
-           ~/.hermes/profiles/user1/evolution/integration/{date}.json"
+  integration – merge green, conflict-free evolution PRs.
+    Toolsets: web, file, terminal. Goal: write EVOLUTION/integration/{date}.json.
 
-  upstream-sync – keep the fork at full parity with upstream Hermes Agent.
-    Context: date of last sync.
-    Toolsets: web, file, terminal
-    Goal: "Sync fork with upstream/main. Output to
-           ~/.hermes/profiles/user1/evolution/upstream/{date}.md"
+  upstream-sync – keep the fork at parity with upstream Hermes Agent.
+    Toolsets: web, file, terminal. Goal: write EVOLUTION/upstream/{date}.md.
 
   ## Safety rules
-
-  - NEVER dispatch the same stage twice for the same date — check the
-    knowledge pool and stage output directories first.
-  - Limit concurrency: dispatch at most 3 subagents per tick (matching the
-    delegate_task parallel limit). Prioritize upstream stages (research,
-    issues, introspection) over downstream ones (implementation, integration).
-  - For deterministic stages (funnel, rubric-judge, watchdog): do NOT dispatch
-    them. They run on their own no_agent schedules.
-  - If `gh auth status` fails in a dispatched subagent, THAT subagent's work
-    should be reported as "blocked — no GitHub auth" rather than retried.
-  - Write a line to ~/.hermes/knowledge/hydra-dispatch-{date}.jsonl after
-    each tick recording what was dispatched and to which subagent task IDs.
+  - Never dispatch the same stage twice for the same date.
+  - Up to 3 subagents per tick; prioritize research/issues/introspection.
+  - Do NOT dispatch deterministic stages (funnel, rubric-judge, watchdog).
+  - If a subagent reports "blocked — no GitHub auth", do not retry it.
 
   ## Output
-
-  At the end of each tick, provide a brief summary of:
-  - Which stages were dispatched
-  - Which stages were skipped (and why — e.g. "no fresh material")
-  - Any errors or blockers
+  Brief summary of dispatched stages, skipped stages (with reason), and blockers.
 
 # No `skills:` here on purpose. The Hydra is a pure delegator: it inspects the
 # knowledge pool and DISPATCHES each stage to a subagent via delegate_task (the

--- a/tests/cron/test_hydra_prompt.py
+++ b/tests/cron/test_hydra_prompt.py
@@ -1,0 +1,63 @@
+"""Regression tests for the evolution Hydra orchestrator prompt.
+
+The Hydra prompt is sent on every cron tick, so its size directly affects
+API latency and timeout risk. These tests assert invariants rather than
+freezing exact wording.
+"""
+
+from pathlib import Path
+
+import yaml
+
+HYDRA_YAML = Path(__file__).resolve().parents[2] / "cron" / "evolution" / "hydra.yaml"
+
+
+def _load_prompt() -> str:
+    data = yaml.safe_load(HYDRA_YAML.read_text(encoding="utf-8"))
+    return data["prompt"]
+
+
+class TestHydraPromptInvariants:
+    def test_yaml_is_valid_and_has_prompt(self):
+        prompt = _load_prompt()
+        assert isinstance(prompt, str) and len(prompt) > 0
+
+    def test_prompt_stays_small(self):
+        """The prompt must remain compact enough for fast/cheap flash models."""
+        prompt = _load_prompt()
+        assert len(prompt) <= 2500, (
+            f"Hydra prompt is {len(prompt)} chars; keep it under 2500 to avoid "
+            "deepseek-v4-flash timeouts."
+        )
+
+    def test_prompt_requires_delegate_task_and_file_toolsets(self):
+        prompt_lower = _load_prompt().lower()
+        assert "delegate_task" in prompt_lower
+        assert "toolsets" in prompt_lower
+
+    def test_prompt_lists_all_evolution_stages(self):
+        prompt_lower = _load_prompt().lower()
+        for stage in (
+            "research",
+            "issues",
+            "introspection",
+            "analysis",
+            "implementation",
+            "integration",
+            "upstream-sync",
+        ):
+            assert stage in prompt_lower, f"Hydra prompt missing stage: {stage}"
+
+    def test_prompt_keeps_core_safety_rules(self):
+        prompt_lower = _load_prompt().lower()
+        assert "never dispatch the same stage twice" in prompt_lower
+        assert "blocked" in prompt_lower and "github auth" in prompt_lower
+
+    def test_yaml_toolsets_exclude_terminal(self):
+        """The Hydra is a pure delegator and must never run stage scripts itself."""
+        raw = HYDRA_YAML.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw)
+        toolsets = data.get("toolsets") or []
+        assert "terminal" not in [str(t).lower() for t in toolsets], (
+            "Hydra must not have the terminal toolset; it only dispatches subagents."
+        )


### PR DESCRIPTION
Shrinks the evolution-hydra system prompt from ~3678 to ~1876 characters (49% reduction) to reduce deepseek-v4-flash timeout risk.

- Condenses all stage definitions to one-line toolset + goal summaries.
- Introduces EVOLUTION/KNOWLEDGE abbreviations to avoid repeating long paths.
- Preserves every safety rule and the no-terminal delegator constraint.
- Adds tests/cron/test_hydra_prompt.py to guard prompt size, stage coverage, and toolset constraints.

Closes #549