### PR TITLE
feat(agent): learn from user corrections — lean Phase 1 (per-user, enforced guard)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,44 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+# Durable-write tools the review fork holds by default. These are the ONLY
+# surfaces through which a review fork can persist something that re-enters a
+# future session (``memory`` -> MEMORY.md/USER.md; ``skill_manage`` -> the skill
+# library). The read-only memory/skill tools (skill_view, skills_list, …) are
+# intentionally NOT here — stripping these two removes durable-WRITE capability
+# while leaving inspection intact.
+_DURABLE_WRITE_TOOLS = {"memory", "skill_manage"}
+
+
+def _review_tool_whitelist(block_durable_writes: bool = False) -> set:
+    """Build the runtime tool whitelist for a background-review fork.
+
+    The whitelist is the dispatch gate: ``get_pre_tool_call_block_message``
+    (hermes_cli/plugins.py) denies any tool absent from it. Normally the fork is
+    whitelisted for the full memory + skills toolsets.
+
+    When ``block_durable_writes`` is True — the case of a correction-triggered
+    review whose correction is NOT yet promotable (transient first sighting) —
+    the durable WRITE tools (``memory`` / ``skill_manage``) are removed from the
+    whitelist, so the LLM fork is *structurally* unable to persist that one-off
+    correction. Durable persistence for the correction path then happens ONLY
+    through the deterministic ``CorrectionLearner`` promotion path. This is
+    enforcement, not advice.
+    """
+    from model_tools import get_tool_definitions
+
+    names = {
+        t["function"]["name"]
+        for t in get_tool_definitions(
+            enabled_toolsets=["memory", "skills"],
+            quiet_mode=True,
+        )
+    }
+    if block_durable_writes:
+        names -= _DURABLE_WRITE_TOOLS
+    return names
+
+
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
 #
@@ -572,12 +610,18 @@ def _run_review_in_thread(
     agent: Any,
     messages_snapshot: List[Dict],
     prompt: str,
+    block_durable_writes: bool = False,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
     Spawns a forked ``AIAgent`` inheriting the parent's runtime, runs the
     review prompt, and surfaces a compact action summary back to the user
     via ``agent._safe_print`` and ``agent.background_review_callback``.
+
+    ``block_durable_writes`` (X1 enforcement): when True (a correction-triggered
+    review for a NOT-yet-promotable transient correction), the fork's runtime
+    tool whitelist excludes the durable memory/skill writers, so the LLM fork
+    cannot persist the one-off correction. See ``_review_tool_whitelist``.
     """
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent
@@ -719,26 +763,30 @@ def _run_review_in_thread(
             # agent.compression_enabled, so this short-circuits both paths.
             review_agent.compression_enabled = False
 
-            from model_tools import get_tool_definitions
             from hermes_cli.plugins import (
                 set_thread_tool_whitelist,
                 clear_thread_tool_whitelist,
             )
 
-            review_whitelist = {
-                t["function"]["name"]
-                for t in get_tool_definitions(
-                    enabled_toolsets=["memory", "skills"],
-                    quiet_mode=True,
+            # Durable-write gate (X1). For a transient correction-triggered
+            # review the durable writers (memory / skill_manage) are stripped
+            # from the whitelist, so the fork is structurally unable to persist
+            # a one-off correction — the deterministic CorrectionLearner is the
+            # only durable gate for that path.
+            review_whitelist = _review_tool_whitelist(block_durable_writes)
+            if block_durable_writes:
+                deny_msg_fmt = (
+                    "Background review denied tool: {tool_name}. This is a "
+                    "transient (first-sighting) correction review with NO "
+                    "durable-write capability; durable persistence happens "
+                    "only via the deterministic recurrence guard."
                 )
-            }
-            set_thread_tool_whitelist(
-                review_whitelist,
-                deny_msg_fmt=(
+            else:
+                deny_msg_fmt = (
                     "Background review denied non-whitelisted tool: "
                     "{tool_name}. Only memory/skill tools are allowed."
-                ),
-            )
+                )
+            set_thread_tool_whitelist(review_whitelist, deny_msg_fmt=deny_msg_fmt)
             try:
                 # Routed to a different model -> replay a digest (cache is cold
                 # on that model anyway, so minimise cold-written tokens). Same
@@ -899,6 +947,7 @@ def spawn_background_review_thread(
     review_memory: bool = False,
     review_skills: bool = False,
     correction_hint: Optional[Dict[str, Any]] = None,
+    block_durable_writes: bool = False,
 ):
     """Build the review thread target and prompt for a background review.
 
@@ -909,6 +958,10 @@ def spawn_background_review_thread(
     ``correction_hint`` (Phase 1): when present, a focused preamble describing
     the detected INTERRUPT / DENY / STEER correction is prepended to the
     review prompt so the reviewer captures that specific correction.
+
+    ``block_durable_writes`` (X1 enforcement): threaded into the thread target so
+    a transient correction-triggered review runs with the durable memory/skill
+    writers stripped from its runtime tool whitelist.
     """
     # Pick the right prompt based on which triggers fired.  Allow per-agent
     # override (the prompts moved to module-level constants but old code paths
@@ -924,7 +977,10 @@ def spawn_background_review_thread(
         prompt = _format_correction_focus(correction_hint) + prompt
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt)
+        _run_review_in_thread(
+            agent, messages_snapshot, prompt,
+            block_durable_writes=block_durable_writes,
+        )
 
     return _target, prompt
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -836,17 +836,79 @@ def _run_review_in_thread(
             pass
 
 
+def _format_correction_focus(correction_hint: Dict[str, Any]) -> str:
+    """Build the focused-review preamble for a detected structured correction.
+
+    Phase 1 (learn-from-corrections): when the turn was an INTERRUPT / DENY /
+    STEER correction, tell the reviewer to capture THAT specific correction —
+    it is the loudest, highest-signal feedback and must not be diluted by the
+    generic nudge-driven pass.
+
+    The preamble is **tier-aware** (the generalization guard's decision is
+    threaded in via ``tier`` / ``durable``). This is the load-bearing safety
+    instruction: a TRANSIENT (first-sighting, not-yet-recurring) correction
+    must NOT be durably persisted by the LLM reviewer — otherwise a one-off
+    correction would leak straight into memory/skills on its first sighting,
+    bypassing the deterministic recurrence guard. Only a DURABLE-promoted
+    correction may be embedded where it re-enters future sessions.
+    """
+    kind = str(correction_hint.get("kind", "")).upper()
+    context = str(correction_hint.get("context", "")).strip()
+    target = correction_hint.get("target")
+    durable = bool(correction_hint.get("durable"))
+    tier = str(correction_hint.get("tier", "transient")).lower()
+    kind_phrase = {
+        "INTERRUPT": "interrupted the agent mid-turn and redirected it",
+        "DENY": "denied/vetoed an action the agent attempted",
+        "STEER": "sent an out-of-band message steering the agent mid-turn",
+    }.get(kind, "corrected the agent")
+    lines = [
+        "**Structured user correction detected this turn.** "
+        f"The user {kind_phrase}. This is the loudest, highest-signal "
+        "feedback the agent gets — pay attention to THIS correction "
+        "specifically.",
+        f"Correction kind: {kind}",
+    ]
+    if target:
+        lines.append(f"Target: {target}")
+    if context:
+        lines.append(f"What the user said / what was vetoed: {context}")
+
+    if durable or tier == "durable":
+        lines.append(
+            "This correction has recurred across sessions (or the user asked "
+            "to remember it): it is a DURABLE preference. Embed it where it "
+            "will re-enter future sessions — memory and/or the governing "
+            "skill — so the next session starts already knowing.\n"
+        )
+    else:
+        lines.append(
+            "This is the FIRST sighting of this correction (tier: transient). "
+            "It is NOT yet established as a durable preference — it may be a "
+            "one-off tied to today's task. DO NOT persist it durably to "
+            "memory or skills on this evidence alone. Note it for this "
+            "session only; the deterministic recurrence guard will promote it "
+            "automatically if it recurs in a future session.\n"
+        )
+    return "\n".join(lines) + "\n"
+
+
 def spawn_background_review_thread(
     agent: Any,
     messages_snapshot: List[Dict],
     review_memory: bool = False,
     review_skills: bool = False,
+    correction_hint: Optional[Dict[str, Any]] = None,
 ):
     """Build the review thread target and prompt for a background review.
 
     Returns a ``(target, prompt)`` tuple.  The caller (``AIAgent._spawn_background_review``)
     owns the actual ``threading.Thread`` construction so test-level patches
     of ``run_agent.threading.Thread`` keep working.
+
+    ``correction_hint`` (Phase 1): when present, a focused preamble describing
+    the detected INTERRUPT / DENY / STEER correction is prepended to the
+    review prompt so the reviewer captures that specific correction.
     """
     # Pick the right prompt based on which triggers fired.  Allow per-agent
     # override (the prompts moved to module-level constants but old code paths
@@ -857,6 +919,9 @@ def spawn_background_review_thread(
         prompt = getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)
     else:
         prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
+
+    if correction_hint:
+        prompt = _format_correction_focus(correction_hint) + prompt
 
     def _target() -> None:
         _run_review_in_thread(agent, messages_snapshot, prompt)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -370,19 +370,34 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)
 
-    # Background review fork — same cadence + signature as the default
-    # path (line ~15449). Only fires when a trigger actually tripped AND
-    # we have a real final response.
-    if (
-        turn.final_text
-        and not turn.interrupted
-        and (should_review_memory or should_review_skills)
-    ):
+    # Background review fork — routed through the SHARED correction-review
+    # decision (agent/correction_review.py) so this runtime detects + RECORDS
+    # user corrections (INTERRUPT / DENY / STEER) and spawns the fork on the
+    # SAME rules as the default finalizer, with no drift. Previously this path
+    # carried an unmodified nudge-only gate and silently never learned from a
+    # correction. Detection + recording always runs when a correction is
+    # present; the fork spawns only on a nudge or a DURABLE correction, and an
+    # unpromoted correction strips the fork's durable writers (X1).
+    from agent.correction_review import decide_correction_review
+
+    review_decision = decide_correction_review(
+        agent,
+        final_text=turn.final_text,
+        interrupted=turn.interrupted,
+        messages=messages,
+        interrupt_message=getattr(agent, "_interrupt_message", None),
+        turn_exit_reason=None,
+        should_review_memory=should_review_memory,
+        should_review_skills=should_review_skills,
+    )
+    if review_decision["spawn"]:
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
-                review_memory=should_review_memory,
-                review_skills=should_review_skills,
+                review_memory=review_decision["review_memory"],
+                review_skills=review_decision["review_skills"],
+                correction_hint=review_decision["correction_hint"],
+                block_durable_writes=review_decision["block_durable_writes"],
             )
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -372,12 +372,23 @@ def run_codex_app_server_turn(
 
     # Background review fork — routed through the SHARED correction-review
     # decision (agent/correction_review.py) so this runtime detects + RECORDS
-    # user corrections (INTERRUPT / DENY / STEER) and spawns the fork on the
-    # SAME rules as the default finalizer, with no drift. Previously this path
-    # carried an unmodified nudge-only gate and silently never learned from a
-    # correction. Detection + recording always runs when a correction is
-    # present; the fork spawns only on a nudge or a DURABLE correction, and an
-    # unpromoted correction strips the fork's durable writers (X1).
+    # user corrections on the SAME rules as the default finalizer, with no
+    # drift. Previously this path carried an unmodified nudge-only gate and
+    # silently never learned from a correction. Detection + recording always
+    # runs when a correction is present; the fork spawns only on a nudge or a
+    # DURABLE correction, and an unpromoted correction strips the fork's durable
+    # writers (X1).
+    #
+    # RUNTIME-SCOPE HONESTY (codex INTERRUPT): DENY and STEER are derived from
+    # tool-result messages and work on the codex runtime. INTERRUPT does NOT:
+    # the codex runtime never propagates a user interrupt into its session
+    # (``AIAgent.request_interrupt`` has no production callers and codex's own
+    # ``interrupted`` flag is only a deadline-timeout), so ``_interrupt_message``
+    # is never set by a real user redirect here. The capture-before-clear fix in
+    # the default finalizer does NOT revive codex INTERRUPT — that is a
+    # PRE-EXISTING codex interrupt-propagation gap, deferred and out of scope for
+    # this feature. We still pass the attribute through for parity so the branch
+    # lights up automatically once that platform gap is closed.
     from agent.correction_review import decide_correction_review
 
     review_decision = decide_correction_review(

--- a/agent/correction_learning.py
+++ b/agent/correction_learning.py
@@ -434,23 +434,14 @@ class CorrectionLearner:
         provenance_id = uuid.uuid4().hex[:12]
         content = self._durable_text(rec)
 
-        # Write to the durable re-injection path. Best-effort: if the sink
-        # write fails we still record provenance so unlearn stays coherent,
-        # but mark it so the caller can see it didn't inject.
-        injected = False
-        if self.memory_sink is not None:
-            try:
-                result = self.memory_sink.add(
-                    DURABLE_MEMORY_TARGET, content
-                )
-                injected = bool(
-                    result.get("success", True)
-                    if isinstance(result, dict) else result
-                )
-            except Exception as e:
-                logger.warning("durable memory write failed: %s", e)
-
-        ledger = self._read_json(self._learned_path, [])
+        # Atomicity ordering. The ledger write and the durable memory write are
+        # NOT transactional, so a failure between them must fail SAFE. Write the
+        # LEDGER entry FIRST, then the memory line: a crash after the ledger
+        # write but before/within the memory write leaves a ledger entry with no
+        # memory line — visible (``injected: False``), cleanable, and crucially
+        # still UNLEARNABLE. The reverse order (memory-first) would orphan a
+        # MEMORY.md line with no ledger entry: it would re-inject into every
+        # future session with no provenance id to ``unlearn`` it.
         entry = {
             "provenance_id": provenance_id,
             "origin_kind": rec.kind,
@@ -464,10 +455,42 @@ class CorrectionLearner:
             "sightings": sightings,
             "ts": rec.ts,
             "promoted_ts": _now_iso(),
-            "injected": injected,
+            "injected": False,
         }
+        ledger = self._read_json(self._learned_path, [])
         ledger.append(entry)
         self._write_json(self._learned_path, ledger)
+
+        # Now write to the durable re-injection path. Best-effort: if the sink
+        # write fails the ledger entry remains (so unlearn stays coherent),
+        # simply marked ``injected: False``.
+        injected = False
+        if self.memory_sink is not None:
+            try:
+                result = self.memory_sink.add(
+                    DURABLE_MEMORY_TARGET, content
+                )
+                injected = bool(
+                    result.get("success", True)
+                    if isinstance(result, dict) else result
+                )
+            except Exception as e:
+                logger.warning("durable memory write failed: %s", e)
+
+        # Reflect the injection outcome back into the ledger. Re-read first so a
+        # concurrent writer is not clobbered, then patch this entry in place.
+        # Guarded: a failure here must not undo a successful memory injection.
+        if injected:
+            try:
+                ledger = self._read_json(self._learned_path, [])
+                for e in ledger:
+                    if e.get("provenance_id") == provenance_id:
+                        e["injected"] = True
+                        break
+                self._write_json(self._learned_path, ledger)
+            except Exception as e:
+                logger.warning("ledger injected-flag update failed: %s", e)
+
         return provenance_id
 
     # -- ledger queries -----------------------------------------------------

--- a/agent/correction_learning.py
+++ b/agent/correction_learning.py
@@ -1,0 +1,525 @@
+"""Learn from user corrections — lean Phase 1 (per-user Fast Loop).
+
+Principle: a real user correcting a real agent on a real task is the
+highest-signal feedback an agent gets. Today Hermes captures *some* of it
+(the post-turn LLM ``background_review`` writes preferences to per-profile
+memory/skills) but misses the loudest, most structured signals — interrupted
+and denied turns are skipped entirely (``agent/turn_finalizer.py``'s
+``not interrupted`` guard). This module adds the smallest end-to-end slice
+that closes that gap *safely*.
+
+What this module is (Phase 1, deliberately minimal):
+
+1. ``detect_correction`` — DETERMINISTIC detection of a structured correction
+   on a completed turn. Three kinds, all from runtime markers (no fuzzy text
+   regex, no LLM):
+     * ``INTERRUPT`` — the user stopped the agent mid-turn AND supplied a
+       redirect message (``agent._interrupt_message``).
+     * ``DENY`` — a tool result carried ``status: "blocked"`` (the user
+       vetoed an action).
+     * ``STEER`` — an out-of-band user message was injected mid-turn
+       (``STEER_MARKER_OPEN`` in a tool result).
+
+2. ``CorrectionLearner`` — the GENERALIZATION GUARD. A correction captured
+   from these signals is TRANSIENT by default. It is promoted to DURABLE
+   (written to the persistent memory store that re-injects into future
+   sessions) ONLY on EVIDENCE:
+     (a) the same correction *signature* recurs across >= 2 DISTINCT
+         sessions, OR
+     (b) an explicit user "remember this" (``remember=True``).
+   Transient items live in a lightweight local JSON store and never change
+   behavior. The recurrence tracker (signature -> distinct sessions) is the
+   load-bearing safety piece: it is the difference between "the agent learned
+   a stable preference" and "the agent over-fit one user's one-off whim".
+
+3. PROVENANCE + UNLEARN — every durable item is tagged with its origin
+   (signal kind, session, signature, timestamps, promotion reason) in a
+   ledger. ``unlearn(provenance_id)`` removes the durable item from both the
+   ledger and the memory store, so it stops injecting. Reversible by
+   construction.
+
+What this module is NOT (deferred to later phases): the multi-dimensional
+evidence vector, the fleet/global consensus path, calibration / positive-
+negative controls, the adversarial counter-reviewer, TTL / model-version
+tagging, config-over-prompt routing. See
+``.plans/learn-from-user-corrections-SPEC.md`` §13 for the phasing.
+
+The store is fail-open: a broken or unwritable state file must never crash a
+user's turn. Every disk touch is guarded; on failure the learner degrades to
+"transient only" rather than raising.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.prompt_builder import STEER_MARKER_CLOSE, STEER_MARKER_OPEN
+
+logger = logging.getLogger(__name__)
+
+# Memory target the durable rule is written to. MEMORY.md is the per-profile
+# store that ``MemoryStore.load_from_disk`` snapshots into the system prompt at
+# the start of every future session (see ``tools/memory_tool.py`` /
+# ``agent/system_prompt.py``). Writing here is what makes a learned correction
+# re-enter behavior next session.
+DURABLE_MEMORY_TARGET = "memory"
+
+# Evidence threshold: how many DISTINCT sessions must show the same signature
+# before a transient correction is promoted to durable. 2 = "seen again in a
+# new session" — the minimum that distinguishes a stable pattern from a one-off.
+RECURRENCE_THRESHOLD = 2
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CorrectionRecord:
+    """A structured correction detected on a completed turn.
+
+    Deliberately small: kind, a stable signature (what the recurrence tracker
+    keys on), the minimal human-readable context, the session it came from,
+    and a timestamp. No raw transcript, no scoring vector.
+    """
+
+    kind: str  # "INTERRUPT" | "DENY" | "STEER"
+    signature: str
+    context: str
+    session_id: str
+    ts: str
+    target: Optional[str] = None  # tool/skill name when known
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize(text: str) -> str:
+    """Lowercase + collapse whitespace for a stable, comparable signature."""
+    return " ".join((text or "").lower().split())
+
+
+def _signature(kind: str, key_text: str, target: Optional[str]) -> str:
+    """Deterministic short signature for recurrence matching.
+
+    Same correction (kind + normalized salient text + target) -> same
+    signature across sessions and processes. A truncated SHA-256 keeps it
+    compact and non-reversible (no raw text in the key itself).
+    """
+    basis = f"{kind}\x1f{target or ''}\x1f{_normalize(key_text)}"
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+
+
+def _iter_tool_messages(messages: List[Dict]):
+    for m in messages or []:
+        if isinstance(m, dict) and m.get("role") == "tool":
+            yield m
+
+
+def _tool_text(m: Dict) -> str:
+    c = m.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return " ".join(
+            b.get("text", "") for b in c if isinstance(b, dict)
+        )
+    return ""
+
+
+def _detect_deny(messages: List[Dict]) -> Optional[Dict[str, Any]]:
+    """Return {target, error} for the LAST denied tool result, else None."""
+    found = None
+    for m in _iter_tool_messages(messages):
+        text = _tool_text(m)
+        if not text:
+            continue
+        # The terminal/approval blocked result is a JSON object with
+        # status == "blocked". Parse defensively; non-JSON tool output is
+        # ignored.
+        try:
+            data = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(data, dict) and data.get("status") == "blocked":
+            found = {
+                "target": m.get("name"),
+                "error": str(data.get("error", "")),
+            }
+    return found
+
+
+def _detect_steer(messages: List[Dict]) -> Optional[Dict[str, Any]]:
+    """Return {target, text} for the LAST mid-turn steer, else None."""
+    found = None
+    for m in _iter_tool_messages(messages):
+        text = _tool_text(m)
+        if STEER_MARKER_OPEN in text:
+            start = text.index(STEER_MARKER_OPEN) + len(STEER_MARKER_OPEN)
+            end = text.find(STEER_MARKER_CLOSE, start)
+            steer_text = text[start:end] if end != -1 else text[start:]
+            found = {
+                "target": m.get("name"),
+                "text": steer_text.strip(),
+            }
+    return found
+
+
+def detect_correction(
+    messages: List[Dict],
+    *,
+    interrupted: bool,
+    interrupt_message: Optional[str],
+    turn_exit_reason: Optional[str],
+    session_id: str,
+    ts: Optional[str] = None,
+) -> Optional[CorrectionRecord]:
+    """Deterministically classify a completed turn as a structured correction.
+
+    Returns a ``CorrectionRecord`` for the single most salient structured
+    correction on the turn, or ``None`` if the turn is not a learnable
+    correction.
+
+    Precedence (highest-signal first): INTERRUPT (the user actively stopped
+    the agent and said what to do instead) > DENY (a vetoed action) > STEER
+    (a mid-turn redirect). A turn can carry more than one; we capture the
+    loudest. No fuzzy text matching — every branch keys off a runtime marker.
+
+    A plain interrupt with NO redirect message is NOT a correction we can
+    learn from (there is nothing to capture); it returns ``None`` so the
+    caller preserves existing plain-interrupt behavior.
+    """
+    ts = ts or _now_iso()
+
+    # INTERRUPT — only learnable when the user supplied redirect text.
+    if interrupted and interrupt_message and interrupt_message.strip():
+        msg = interrupt_message.strip()
+        return CorrectionRecord(
+            kind="INTERRUPT",
+            signature=_signature("INTERRUPT", msg, None),
+            context=msg,
+            session_id=session_id,
+            ts=ts,
+            metadata={"turn_exit_reason": turn_exit_reason},
+        )
+
+    # DENY — a tool was blocked/vetoed.
+    deny = _detect_deny(messages)
+    if deny is not None:
+        err = deny["error"] or "command denied"
+        return CorrectionRecord(
+            kind="DENY",
+            signature=_signature("DENY", err, deny["target"]),
+            context=err,
+            session_id=session_id,
+            ts=ts,
+            target=deny["target"],
+        )
+
+    # STEER — a mid-turn out-of-band user redirect.
+    steer = _detect_steer(messages)
+    if steer is not None and steer["text"]:
+        return CorrectionRecord(
+            kind="STEER",
+            signature=_signature("STEER", steer["text"], steer["target"]),
+            context=steer["text"],
+            session_id=session_id,
+            ts=ts,
+            target=steer["target"],
+        )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Generalization guard + store
+# ---------------------------------------------------------------------------
+
+
+def _default_store_dir() -> Path:
+    """Per-profile correction-learning directory.
+
+    Resolves under the same profile-scoped Hermes home that the memory store
+    uses, so corrections live next to the data they may eventually promote.
+    """
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "corrections"
+
+
+class CorrectionLearner:
+    """Owns the recurrence tracker, transient store, and durable ledger.
+
+    Files under ``store_dir``:
+      * ``recurrence.json`` — ``{signature: {"sessions": [...], "kind": ...}}``
+        the distinct-session counter that flips transient -> durable.
+      * ``transient.json`` — list of transient correction records (audit /
+        future use; does NOT change behavior).
+      * ``learned.json`` — the durable provenance ledger.
+
+    ``memory_sink`` is the durable write target — in production a
+    ``MemoryStore`` (writes MEMORY.md, the re-injection path). It must expose
+    ``add(target, content, **kw)`` and ``remove(target, content_substr, **kw)``.
+    Injected for testability and to keep this module free of a hard import on
+    the memory subsystem.
+    """
+
+    def __init__(self, store_dir: Optional[Path] = None, memory_sink: Any = None):
+        self.store_dir = Path(store_dir) if store_dir else _default_store_dir()
+        self.memory_sink = memory_sink
+        self._recurrence_path = self.store_dir / "recurrence.json"
+        self._transient_path = self.store_dir / "transient.json"
+        self._learned_path = self.store_dir / "learned.json"
+
+    # -- fail-open JSON helpers (mirrors scripts/evolution_* pattern) -------
+
+    def _read_json(self, path: Path, default):
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return default
+
+    def _write_json(self, path: Path, payload) -> None:
+        # Best-effort; the caller wraps this so a raise never reaches a turn.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        os.replace(tmp, path)
+
+    # -- public API ---------------------------------------------------------
+
+    def record(
+        self, rec: CorrectionRecord, *, remember: bool = False
+    ) -> Dict[str, Any]:
+        """Register a detected correction and apply the generalization guard.
+
+        Returns ``{"tier", "durable", "provenance_id", "sightings", "reason"}``.
+        Fail-open: any persistence error degrades to a transient result rather
+        than raising.
+        """
+        try:
+            return self._record_inner(rec, remember=remember)
+        except Exception as e:  # pragma: no cover - defensive, fail-open
+            logger.warning("correction record failed (fail-open): %s", e)
+            return {
+                "tier": "transient",
+                "durable": False,
+                "provenance_id": None,
+                "sightings": 0,
+                "reason": "error",
+            }
+
+    def _record_inner(
+        self, rec: CorrectionRecord, *, remember: bool
+    ) -> Dict[str, Any]:
+        # 1. Update the recurrence tracker (distinct sessions per signature).
+        recurrence = self._read_json(self._recurrence_path, {})
+        slot = recurrence.get(rec.signature) or {"sessions": [], "kind": rec.kind}
+        sessions = slot.get("sessions", [])
+        if rec.session_id not in sessions:
+            sessions.append(rec.session_id)
+        slot["sessions"] = sessions
+        slot["kind"] = rec.kind
+        recurrence[rec.signature] = slot
+        self._write_json(self._recurrence_path, recurrence)
+
+        sightings = len(sessions)
+
+        # 2a. Idempotent promotion. If this signature is ALREADY durable,
+        #     return the existing provenance without re-writing memory or
+        #     appending a duplicate ledger entry (otherwise every later
+        #     sighting bloats the ledger and re-writes MEMORY.md). A learned
+        #     rule is a single object, not one-per-sighting.
+        for entry in self.list_durable():
+            if entry.get("signature") == rec.signature:
+                return {
+                    "tier": "durable",
+                    "durable": True,
+                    "provenance_id": entry.get("provenance_id"),
+                    "sightings": sightings,
+                    "reason": "already_durable",
+                }
+
+        # 2b. Decide tier. Durable on explicit remember OR cross-session
+        #     recurrence. Otherwise transient.
+        if remember:
+            reason = "explicit_remember"
+            durable = True
+        elif sightings >= RECURRENCE_THRESHOLD:
+            reason = "recurrence"
+            durable = True
+        else:
+            reason = "first_sighting"
+            durable = False
+
+        if not durable:
+            self._append_transient(rec, sightings)
+            return {
+                "tier": "transient",
+                "durable": False,
+                "provenance_id": None,
+                "sightings": sightings,
+                "reason": reason,
+            }
+
+        # 3. Promote to durable: write to the memory sink (re-injection path)
+        #    and record provenance in the ledger.
+        provenance_id = self._promote(rec, reason=reason, sightings=sightings)
+        return {
+            "tier": "durable",
+            "durable": True,
+            "provenance_id": provenance_id,
+            "sightings": sightings,
+            "reason": reason,
+        }
+
+    def _append_transient(self, rec: CorrectionRecord, sightings: int) -> None:
+        items = self._read_json(self._transient_path, [])
+        items.append({
+            "kind": rec.kind,
+            "signature": rec.signature,
+            "context": rec.context,
+            "session_id": rec.session_id,
+            "ts": rec.ts,
+            "sightings": sightings,
+        })
+        # Bound growth — keep the most recent 500 transient records.
+        if len(items) > 500:
+            items = items[-500:]
+        self._write_json(self._transient_path, items)
+
+    def _durable_text(self, rec: CorrectionRecord) -> str:
+        """The behavior-changing sentence written to MEMORY.md.
+
+        Phrased as a learned user preference/correction so the next session's
+        agent reads it as guidance.
+        """
+        label = {
+            "INTERRUPT": "The user redirected a turn",
+            "DENY": "The user denied an action",
+            "STEER": "The user steered mid-turn",
+        }.get(rec.kind, "The user corrected the agent")
+        return f"[learned correction] {label}: {rec.context}".strip()
+
+    def _promote(
+        self, rec: CorrectionRecord, *, reason: str, sightings: int
+    ) -> str:
+        provenance_id = uuid.uuid4().hex[:12]
+        content = self._durable_text(rec)
+
+        # Write to the durable re-injection path. Best-effort: if the sink
+        # write fails we still record provenance so unlearn stays coherent,
+        # but mark it so the caller can see it didn't inject.
+        injected = False
+        if self.memory_sink is not None:
+            try:
+                result = self.memory_sink.add(
+                    DURABLE_MEMORY_TARGET, content
+                )
+                injected = bool(
+                    result.get("success", True)
+                    if isinstance(result, dict) else result
+                )
+            except Exception as e:
+                logger.warning("durable memory write failed: %s", e)
+
+        ledger = self._read_json(self._learned_path, [])
+        entry = {
+            "provenance_id": provenance_id,
+            "origin_kind": rec.kind,
+            "signature": rec.signature,
+            "session_id": rec.session_id,
+            "context": rec.context,
+            "content": content,
+            "target": rec.target,
+            "tier": "durable",
+            "reason": reason,
+            "sightings": sightings,
+            "ts": rec.ts,
+            "promoted_ts": _now_iso(),
+            "injected": injected,
+        }
+        ledger.append(entry)
+        self._write_json(self._learned_path, ledger)
+        return provenance_id
+
+    # -- ledger queries -----------------------------------------------------
+
+    def list_durable(self) -> List[Dict[str, Any]]:
+        return self._read_json(self._learned_path, [])
+
+    def get_durable(self, provenance_id: str) -> Optional[Dict[str, Any]]:
+        for e in self.list_durable():
+            if e.get("provenance_id") == provenance_id:
+                return e
+        return None
+
+    # -- unlearn (symmetric, reversible) -----------------------------------
+
+    def unlearn(self, provenance_id: str) -> bool:
+        """Remove a durable learned item by its provenance id.
+
+        Removes it from the memory sink (so it stops injecting) and from the
+        ledger. Returns True if an item was removed, False if the id was
+        unknown. Fail-open on persistence errors.
+        """
+        try:
+            ledger = self.list_durable()
+            entry = next(
+                (e for e in ledger if e.get("provenance_id") == provenance_id),
+                None,
+            )
+            if entry is None:
+                return False
+            if self.memory_sink is not None:
+                try:
+                    self.memory_sink.remove(
+                        DURABLE_MEMORY_TARGET, entry.get("content", "")
+                    )
+                except Exception as e:
+                    logger.warning("unlearn memory remove failed: %s", e)
+            remaining = [
+                e for e in ledger if e.get("provenance_id") != provenance_id
+            ]
+            self._write_json(self._learned_path, remaining)
+            # Reset the recurrence evidence for this signature so the user's
+            # "unlearn" is not silently undone by the very next sighting (which
+            # would otherwise still see >= threshold distinct sessions and
+            # re-promote instantly). The correction must re-accumulate fresh
+            # cross-session evidence to become durable again.
+            signature = entry.get("signature")
+            if signature:
+                try:
+                    recurrence = self._read_json(self._recurrence_path, {})
+                    if signature in recurrence:
+                        del recurrence[signature]
+                        self._write_json(self._recurrence_path, recurrence)
+                except Exception as e:
+                    logger.warning("unlearn recurrence reset failed: %s", e)
+            return True
+        except Exception as e:  # pragma: no cover - defensive, fail-open
+            logger.warning("unlearn failed (fail-open): %s", e)
+            return False
+
+
+__all__ = [
+    "CorrectionRecord",
+    "CorrectionLearner",
+    "detect_correction",
+    "RECURRENCE_THRESHOLD",
+    "DURABLE_MEMORY_TARGET",
+]

--- a/agent/correction_learning.py
+++ b/agent/correction_learning.py
@@ -15,8 +15,10 @@ What this module is (Phase 1, deliberately minimal):
    regex, no LLM):
      * ``INTERRUPT`` — the user stopped the agent mid-turn AND supplied a
        redirect message (``agent._interrupt_message``).
-     * ``DENY`` — a tool result carried ``status: "blocked"`` (the user
-       vetoed an action).
+     * ``DENY`` — a tool result carried the explicit ``user_denied`` marker
+       (a real user vetoed the action at the approval prompt). Automatic
+       safety/validation blocks (which also set ``status: "blocked"`` but
+       carry no user denial) are deliberately excluded.
      * ``STEER`` — an out-of-band user message was injected mid-turn
        (``STEER_MARKER_OPEN`` in a tool result).
 
@@ -140,20 +142,31 @@ def _tool_text(m: Dict) -> str:
 
 
 def _detect_deny(messages: List[Dict]) -> Optional[Dict[str, Any]]:
-    """Return {target, error} for the LAST denied tool result, else None."""
+    """Return {target, error} for the LAST genuine USER-denied tool result.
+
+    A DENY correction must reflect a real user veto — NOT an automatic safety
+    or validation block. Many automatic blocks (the dangerous-command guard at
+    ``tools/terminal_tool.py`` and the workdir shell-injection validator) also
+    emit ``status: "blocked"`` with no user involvement, so keying on
+    ``status`` alone would mint false corrections from recurring automatic
+    blocks (defect X2).
+
+    The discriminator is the explicit ``user_denied`` marker that the approval
+    flow stamps onto the tool result ONLY when a user actively denied the action
+    at the approval prompt (``tools/approval.py`` -> ``tools/terminal_tool.py``).
+    Timeouts and automatic blocks never carry it. Parse defensively; non-JSON
+    tool output is ignored.
+    """
     found = None
     for m in _iter_tool_messages(messages):
         text = _tool_text(m)
         if not text:
             continue
-        # The terminal/approval blocked result is a JSON object with
-        # status == "blocked". Parse defensively; non-JSON tool output is
-        # ignored.
         try:
             data = json.loads(text)
         except (json.JSONDecodeError, TypeError):
             continue
-        if isinstance(data, dict) and data.get("status") == "blocked":
+        if isinstance(data, dict) and data.get("user_denied") is True:
             found = {
                 "target": m.get("name"),
                 "error": str(data.get("error", "")),

--- a/agent/correction_learning.py
+++ b/agent/correction_learning.py
@@ -14,7 +14,11 @@ What this module is (Phase 1, deliberately minimal):
    on a completed turn. Three kinds, all from runtime markers (no fuzzy text
    regex, no LLM):
      * ``INTERRUPT`` — the user stopped the agent mid-turn AND supplied a
-       redirect message (``agent._interrupt_message``).
+       redirect message (``agent._interrupt_message``). Runtime scope: this is
+       live on the default runtime (the finalizer captures the message before
+       clearing it); on the codex runtime INTERRUPT stays inert because that
+       runtime does not propagate user interrupts into its session (a
+       pre-existing platform gap, deferred). DENY/STEER work on both runtimes.
      * ``DENY`` — a tool result carried the explicit ``user_denied`` marker
        (a real user vetoed the action at the approval prompt). Automatic
        safety/validation blocks (which also set ``status: "blocked"`` but
@@ -23,12 +27,23 @@ What this module is (Phase 1, deliberately minimal):
        (``STEER_MARKER_OPEN`` in a tool result).
 
 2. ``CorrectionLearner`` — the GENERALIZATION GUARD. A correction captured
-   from these signals is TRANSIENT by default. It is promoted to DURABLE
-   (written to the persistent memory store that re-injects into future
-   sessions) ONLY on EVIDENCE:
+   from these signals is TRANSIENT by default. In Phase 1 it is promoted to
+   DURABLE (written to the persistent memory store that re-injects into future
+   sessions) on a SINGLE production trigger:
      (a) the same correction *signature* recurs across >= 2 DISTINCT
-         sessions, OR
-     (b) an explicit user "remember this" (``remember=True``).
+         sessions (cross-session recurrence).
+   Cross-session recurrence is therefore the SOLE production durable trigger in
+   Phase 1.
+
+   ``record(remember=True)`` also forces a durable promotion, but that path is
+   NOT WIRED to any production signal in Phase 1: no caller threads an explicit
+   user "remember this" through it — ``run_agent.py`` calls ``record(rec)`` with
+   ``remember`` defaulting False, and ``correction_review`` never derives a
+   remember flag. The fuzzy "remember this" detector that would feed it is
+   DEFERRED to a later phase. The ``remember`` parameter is retained ONLY as the
+   tested seam that future path will use; treat explicit-remember as
+   not-yet-reachable in production.
+
    Transient items live in a lightweight local JSON store and never change
    behavior. The recurrence tracker (signature -> distinct sessions) is the
    load-bearing safety piece: it is the difference between "the agent learned
@@ -323,6 +338,12 @@ class CorrectionLearner:
         Returns ``{"tier", "durable", "provenance_id", "sightings", "reason"}``.
         Fail-open: any persistence error degrades to a transient result rather
         than raising.
+
+        ``remember``: force a durable promotion. NOTE — in Phase 1 this is NOT
+        wired to any production caller (nothing sets it True; ``run_agent.py``
+        calls ``record(rec)``). Cross-session recurrence is the sole production
+        durable trigger; explicit-remember wiring is deferred to a later phase.
+        The parameter is kept as the tested seam that path will use.
         """
         try:
             return self._record_inner(rec, remember=remember)
@@ -367,8 +388,11 @@ class CorrectionLearner:
                     "reason": "already_durable",
                 }
 
-        # 2b. Decide tier. Durable on explicit remember OR cross-session
-        #     recurrence. Otherwise transient.
+        # 2b. Decide tier. Cross-session recurrence is the sole PRODUCTION
+        #     durable trigger in Phase 1. The ``remember`` fast-path also
+        #     promotes durably but is not wired to any production caller yet
+        #     (deferred — see class/module docstring); it stays here only as the
+        #     tested seam. Otherwise transient.
         if remember:
             reason = "explicit_remember"
             durable = True

--- a/agent/correction_review.py
+++ b/agent/correction_review.py
@@ -17,7 +17,8 @@ The decision has three moving parts, all derived deterministically:
 
 * SPAWN the LLM review fork ONLY when a nudge independently fired
   (``_healthy_review`` — the legacy healthy-completion path) OR the correction
-  was promoted to DURABLE (recurrence / explicit remember). A pure-transient
+  was promoted to DURABLE (cross-session recurrence — the sole Phase-1 durable
+  trigger; explicit-remember wiring is deferred). A pure-transient
   correction with no nudge is already recorded deterministically and the fork
   would be write-blocked anyway, so spawning it would burn an aux-model call for
   nothing (defect: wasted aux-model spend on pure-transient corrections).
@@ -73,8 +74,9 @@ def detect_and_record_correction(
             "durable": False,
         }
         # Feed the recurrence tracker (signature -> distinct sessions). Transient
-        # by default; promotes to durable only on cross-session recurrence or an
-        # explicit remember. Fail-open via the agent hook. The returned tier is
+        # by default; promotes to durable only on cross-session recurrence (the
+        # sole Phase-1 durable trigger; explicit-remember is deferred and not
+        # wired). Fail-open via the agent hook. The returned tier is
         # threaded back into the hint so the review prompt stays tier-aware.
         recorder = getattr(agent, "_record_turn_correction", None)
         if callable(recorder):

--- a/agent/correction_review.py
+++ b/agent/correction_review.py
@@ -1,0 +1,162 @@
+"""Shared correction-detection + review-spawn decision for turn finalizers.
+
+Both the default finalizer (``agent/turn_finalizer.py``) and the Codex-runtime
+finalizer (``agent/codex_runtime.py``) route through ``decide_correction_review``
+so the learn-from-corrections behavior cannot drift between the two runtimes.
+Before this seam existed the Codex path carried an unmodified nudge-only gate and
+silently never detected or recorded a user correction (defect: codex parity).
+
+The decision has three moving parts, all derived deterministically:
+
+* DETECT + RECORD (always, when a correction is present). ``detect_correction``
+  classifies the turn (INTERRUPT / DENY / STEER); the per-agent
+  ``_record_turn_correction`` hook feeds the recurrence tracker and returns the
+  promoted tier. This is the single durable gate for an unpromoted correction
+  and runs whether or not the expensive LLM review fork is spawned — including
+  the loud interrupted/denied turns the legacy ``not interrupted`` gate dropped.
+
+* SPAWN the LLM review fork ONLY when a nudge independently fired
+  (``_healthy_review`` — the legacy healthy-completion path) OR the correction
+  was promoted to DURABLE (recurrence / explicit remember). A pure-transient
+  correction with no nudge is already recorded deterministically and the fork
+  would be write-blocked anyway, so spawning it would burn an aux-model call for
+  nothing (defect: wasted aux-model spend on pure-transient corrections).
+
+* BLOCK durable writes on the fork (X1) whenever a correction is present and NOT
+  yet durable — UNIVERSALLY, even when a nudge co-occurs. The co-occurring
+  nudge's own durable write is deferred to the next nudge interval (the accepted
+  safety trade) so a transient correction can never ride a nudge into a durable
+  write. The deterministic recurrence guard stays the sole durable gate for an
+  unpromoted correction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def detect_and_record_correction(
+    agent,
+    *,
+    messages: List[Dict],
+    interrupted: bool,
+    interrupt_message: Optional[str],
+    turn_exit_reason: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Deterministically detect a structured correction and record it.
+
+    Returns the correction hint (with the recorder's promoted ``tier`` /
+    ``durable`` threaded back in) or ``None`` when the turn is not a learnable
+    correction. Best-effort: never raises into turn finalization.
+    """
+    try:
+        from agent.correction_learning import detect_correction
+
+        correction = detect_correction(
+            messages,
+            interrupted=interrupted,
+            interrupt_message=interrupt_message,
+            turn_exit_reason=turn_exit_reason,
+            session_id=getattr(agent, "session_id", "") or "",
+        )
+        if correction is None:
+            return None
+        hint: Dict[str, Any] = {
+            "kind": correction.kind,
+            "signature": correction.signature,
+            "context": correction.context,
+            "target": correction.target,
+            # Transient until the recurrence guard says otherwise. This is the
+            # safe default: the LLM reviewer is never told to durably persist a
+            # correction we have not confirmed is durable.
+            "tier": "transient",
+            "durable": False,
+        }
+        # Feed the recurrence tracker (signature -> distinct sessions). Transient
+        # by default; promotes to durable only on cross-session recurrence or an
+        # explicit remember. Fail-open via the agent hook. The returned tier is
+        # threaded back into the hint so the review prompt stays tier-aware.
+        recorder = getattr(agent, "_record_turn_correction", None)
+        if callable(recorder):
+            try:
+                outcome = recorder(hint)
+                if isinstance(outcome, dict):
+                    hint["tier"] = outcome.get("tier", "transient")
+                    hint["durable"] = bool(outcome.get("durable"))
+            except Exception:
+                pass
+        return hint
+    except Exception:
+        # Detection is best-effort; never let it break turn finalization.
+        return None
+
+
+def decide_correction_review(
+    agent,
+    *,
+    final_text: Optional[str],
+    interrupted: bool,
+    messages: List[Dict],
+    interrupt_message: Optional[str],
+    turn_exit_reason: Optional[str],
+    should_review_memory: bool,
+    should_review_skills: bool,
+) -> Dict[str, Any]:
+    """Detect+record a correction and decide the background review fork.
+
+    Returns a decision dict::
+
+        {
+          "spawn": bool,                 # spawn the LLM review fork
+          "review_memory": bool,         # pass-through for the fork
+          "review_skills": bool,         # pass-through for the fork
+          "correction_hint": dict|None,  # the detected correction
+          "block_durable_writes": bool,  # strip the fork's durable writers (X1)
+        }
+
+    See the module docstring for the spawn and block rules. Detection +
+    recording always runs (deterministic) even when ``spawn`` is False.
+    """
+    # Legacy healthy-completion nudge path: a counter fired AND the turn
+    # completed normally. Preserved exactly.
+    healthy_review = bool(
+        final_text
+        and not interrupted
+        and (should_review_memory or should_review_skills)
+    )
+
+    correction_hint = detect_and_record_correction(
+        agent,
+        messages=messages,
+        interrupted=interrupted,
+        interrupt_message=interrupt_message,
+        turn_exit_reason=turn_exit_reason,
+    )
+    correction_present = correction_hint is not None
+    correction_durable = bool(
+        correction_present and correction_hint.get("durable")
+    )
+
+    # X1 (universal): any unpromoted correction strips the fork's durable
+    # writers — even when a nudge co-occurs. The deterministic CorrectionLearner
+    # is the single durable gate for an unpromoted correction.
+    block_durable_writes = correction_present and not correction_durable
+
+    # Spawn only when a nudge fired OR the correction is already durable. A
+    # pure-transient correction with no nudge is already recorded
+    # deterministically; the fork would be write-blocked, so spawning it would
+    # waste an aux-model call.
+    spawn = bool(healthy_review or correction_durable)
+
+    return {
+        "spawn": spawn,
+        # Mirror the legacy finalizer: a present correction implies a memory
+        # review focus so the fork (when it spawns) captures it.
+        "review_memory": bool(should_review_memory or correction_present),
+        "review_skills": bool(should_review_skills),
+        "correction_hint": correction_hint,
+        "block_durable_writes": bool(block_durable_writes),
+    }
+
+
+__all__ = ["decide_correction_review", "detect_and_record_correction"]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -422,14 +422,75 @@ def finalize_turn(
         messages=messages,
     )
 
+    # Detect a structured user correction on this turn (INTERRUPT / DENY /
+    # STEER) — deterministically, from runtime markers, before deciding
+    # whether to review. A correction is the highest-signal feedback the
+    # agent gets, and the loudest ones land on interrupted/denied turns that
+    # the legacy gate below skipped. See ``agent/correction_learning.py``.
+    _correction_hint = None
+    try:
+        from agent.correction_learning import detect_correction
+
+        _correction = detect_correction(
+            messages,
+            interrupted=interrupted,
+            interrupt_message=getattr(agent, "_interrupt_message", None),
+            turn_exit_reason=_turn_exit_reason,
+            session_id=agent.session_id or "",
+        )
+        if _correction is not None:
+            _correction_hint = {
+                "kind": _correction.kind,
+                "signature": _correction.signature,
+                "context": _correction.context,
+                "target": _correction.target,
+                # Default to transient until the recurrence guard says
+                # otherwise. This is the safe default: the LLM reviewer is
+                # never told to durably persist a correction we have not
+                # confirmed is durable.
+                "tier": "transient",
+                "durable": False,
+            }
+            # Feed the recurrence tracker (signature -> distinct sessions).
+            # Transient by default; promotes to durable only on cross-session
+            # recurrence or an explicit remember. Fail-open via the agent hook.
+            # The returned tier is threaded back into the hint so the review
+            # prompt stays tier-aware (one-off-leak guard).
+            _recorder = getattr(agent, "_record_turn_correction", None)
+            if callable(_recorder):
+                try:
+                    _outcome = _recorder(_correction_hint)
+                    if isinstance(_outcome, dict):
+                        _correction_hint["tier"] = _outcome.get("tier", "transient")
+                        _correction_hint["durable"] = bool(_outcome.get("durable"))
+                except Exception:
+                    pass
+    except Exception:
+        # Detection is best-effort; never let it break turn finalization.
+        _correction_hint = None
+
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
-    if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+    #
+    # Two triggers:
+    #   * Healthy completion (legacy): a nudge counter fired AND the turn
+    #     completed normally (``final_response and not interrupted``).
+    #   * Correction (Phase 1 fix): the turn IS a structured correction —
+    #     run the review EVEN WHEN interrupted/denied, the case the legacy
+    #     guard dropped. The detected correction is passed as a hint so the
+    #     reviewer captures THAT specific correction.
+    _healthy_review = (
+        final_response
+        and not interrupted
+        and (_should_review_memory or _should_review_skills)
+    )
+    if _healthy_review or _correction_hint is not None:
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
-                review_memory=_should_review_memory,
+                review_memory=_should_review_memory or _correction_hint is not None,
                 review_skills=_should_review_skills,
+                correction_hint=_correction_hint,
             )
         except Exception:
             pass  # Background review is best-effort

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -479,10 +479,24 @@ def finalize_turn(
     #     run the review EVEN WHEN interrupted/denied, the case the legacy
     #     guard dropped. The detected correction is passed as a hint so the
     #     reviewer captures THAT specific correction.
-    _healthy_review = (
+    _healthy_review = bool(
         final_response
         and not interrupted
         and (_should_review_memory or _should_review_skills)
+    )
+    # X1 enforcement gate. Strip the review fork's durable-write capability when
+    # this review exists ONLY because of a NOT-yet-promotable (transient)
+    # correction — i.e. the legacy nudge path would NOT have fired on its own
+    # (``not _healthy_review``) and the recurrence guard has not promoted it
+    # (``not durable``). In that case the deterministic CorrectionLearner must be
+    # the single durable gate; the LLM fork gets no durable memory/skill writer.
+    # When a nudge independently fired (``_healthy_review``) the pre-existing
+    # behavior is preserved untouched, and a promoted (durable) correction keeps
+    # write capability since it is already confirmed.
+    _block_durable_writes = bool(
+        _correction_hint is not None
+        and not _correction_hint.get("durable")
+        and not _healthy_review
     )
     if _healthy_review or _correction_hint is not None:
         try:
@@ -491,6 +505,7 @@ def finalize_turn(
                 review_memory=_should_review_memory or _correction_hint is not None,
                 review_skills=_should_review_skills,
                 correction_hint=_correction_hint,
+                block_durable_writes=_block_durable_writes,
             )
         except Exception:
             pass  # Background review is best-effort

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -423,89 +423,43 @@ def finalize_turn(
     )
 
     # Detect a structured user correction on this turn (INTERRUPT / DENY /
-    # STEER) — deterministically, from runtime markers, before deciding
-    # whether to review. A correction is the highest-signal feedback the
-    # agent gets, and the loudest ones land on interrupted/denied turns that
-    # the legacy gate below skipped. See ``agent/correction_learning.py``.
-    _correction_hint = None
-    try:
-        from agent.correction_learning import detect_correction
-
-        _correction = detect_correction(
-            messages,
-            interrupted=interrupted,
-            interrupt_message=getattr(agent, "_interrupt_message", None),
-            turn_exit_reason=_turn_exit_reason,
-            session_id=agent.session_id or "",
-        )
-        if _correction is not None:
-            _correction_hint = {
-                "kind": _correction.kind,
-                "signature": _correction.signature,
-                "context": _correction.context,
-                "target": _correction.target,
-                # Default to transient until the recurrence guard says
-                # otherwise. This is the safe default: the LLM reviewer is
-                # never told to durably persist a correction we have not
-                # confirmed is durable.
-                "tier": "transient",
-                "durable": False,
-            }
-            # Feed the recurrence tracker (signature -> distinct sessions).
-            # Transient by default; promotes to durable only on cross-session
-            # recurrence or an explicit remember. Fail-open via the agent hook.
-            # The returned tier is threaded back into the hint so the review
-            # prompt stays tier-aware (one-off-leak guard).
-            _recorder = getattr(agent, "_record_turn_correction", None)
-            if callable(_recorder):
-                try:
-                    _outcome = _recorder(_correction_hint)
-                    if isinstance(_outcome, dict):
-                        _correction_hint["tier"] = _outcome.get("tier", "transient")
-                        _correction_hint["durable"] = bool(_outcome.get("durable"))
-                except Exception:
-                    pass
-    except Exception:
-        # Detection is best-effort; never let it break turn finalization.
-        _correction_hint = None
-
-    # Background memory/skill review — runs AFTER the response is delivered
-    # so it never competes with the user's task for model attention.
+    # STEER) and decide whether to spawn the background memory/skill review.
+    # This is shared with the Codex-runtime finalizer (``agent/codex_runtime.py``)
+    # via ``agent/correction_review.py`` so the two runtimes cannot drift.
     #
-    # Two triggers:
-    #   * Healthy completion (legacy): a nudge counter fired AND the turn
-    #     completed normally (``final_response and not interrupted``).
-    #   * Correction (Phase 1 fix): the turn IS a structured correction —
-    #     run the review EVEN WHEN interrupted/denied, the case the legacy
-    #     guard dropped. The detected correction is passed as a hint so the
-    #     reviewer captures THAT specific correction.
-    _healthy_review = bool(
-        final_response
-        and not interrupted
-        and (_should_review_memory or _should_review_skills)
+    # Detection + recording (the deterministic CorrectionLearner via
+    # ``agent._record_turn_correction``) ALWAYS runs when a correction is
+    # present — the highest-signal feedback the agent gets, including the loud
+    # interrupted/denied turns the legacy ``not interrupted`` gate dropped.
+    #
+    # The LLM review fork runs AFTER the response is delivered so it never
+    # competes with the user's task. It is spawned ONLY when a nudge counter
+    # fired (the legacy healthy-completion path) OR the correction was promoted
+    # to DURABLE. A pure-transient correction with no nudge is recorded
+    # deterministically but does NOT spawn the fork — the fork would be barred
+    # from durable writes anyway (X1), so it would burn an aux-model call for
+    # nothing. When the fork DOES spawn for an unpromoted correction (because a
+    # nudge co-occurred), X1 strips its durable writers universally.
+    from agent.correction_review import decide_correction_review
+
+    _review_decision = decide_correction_review(
+        agent,
+        final_text=final_response,
+        interrupted=interrupted,
+        messages=messages,
+        interrupt_message=getattr(agent, "_interrupt_message", None),
+        turn_exit_reason=_turn_exit_reason,
+        should_review_memory=_should_review_memory,
+        should_review_skills=_should_review_skills,
     )
-    # X1 enforcement gate. Strip the review fork's durable-write capability when
-    # this review exists ONLY because of a NOT-yet-promotable (transient)
-    # correction — i.e. the legacy nudge path would NOT have fired on its own
-    # (``not _healthy_review``) and the recurrence guard has not promoted it
-    # (``not durable``). In that case the deterministic CorrectionLearner must be
-    # the single durable gate; the LLM fork gets no durable memory/skill writer.
-    # When a nudge independently fired (``_healthy_review``) the pre-existing
-    # behavior is preserved untouched, and a promoted (durable) correction keeps
-    # write capability since it is already confirmed.
-    _block_durable_writes = bool(
-        _correction_hint is not None
-        and not _correction_hint.get("durable")
-        and not _healthy_review
-    )
-    if _healthy_review or _correction_hint is not None:
+    if _review_decision["spawn"]:
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
-                review_memory=_should_review_memory or _correction_hint is not None,
-                review_skills=_should_review_skills,
-                correction_hint=_correction_hint,
-                block_durable_writes=_block_durable_writes,
+                review_memory=_review_decision["review_memory"],
+                review_skills=_review_decision["review_skills"],
+                correction_hint=_review_decision["correction_hint"],
+                block_durable_writes=_review_decision["block_durable_writes"],
             )
         except Exception:
             pass  # Background review is best-effort

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -396,9 +396,17 @@ def finalize_turn(
         result["pending_steer"] = _leftover_steer
     agent._response_was_previewed = False
 
+    # Capture the interrupt redirect message into a LOCAL *before*
+    # clear_interrupt() nulls it (run_agent.py sets _interrupt_message = None).
+    # The structured-correction detector below (decide_correction_review) runs
+    # ~46 lines AFTER this clear, so reading the live attribute there would
+    # always see None and the INTERRUPT correction branch would be DEAD on the
+    # default runtime. Capture-before-clear keeps that branch live.
+    _captured_interrupt = getattr(agent, "_interrupt_message", None)
+
     # Include interrupt message if one triggered the interrupt
-    if interrupted and agent._interrupt_message:
-        result["interrupt_message"] = agent._interrupt_message
+    if interrupted and _captured_interrupt:
+        result["interrupt_message"] = _captured_interrupt
 
     # Clear interrupt state after handling
     agent.clear_interrupt()
@@ -447,7 +455,7 @@ def finalize_turn(
         final_text=final_response,
         interrupted=interrupted,
         messages=messages,
-        interrupt_message=getattr(agent, "_interrupt_message", None),
+        interrupt_message=_captured_interrupt,
         turn_exit_reason=_turn_exit_reason,
         should_review_memory=_should_review_memory,
         should_review_skills=_should_review_skills,

--- a/hermes_cli/corrections_cli.py
+++ b/hermes_cli/corrections_cli.py
@@ -1,0 +1,119 @@
+"""CLI surface for the lean Phase-1 correction-learning store.
+
+Makes ``CorrectionLearner.unlearn`` a real runtime surface rather than a
+library-only API, so the "reversible by construction" property is usable:
+
+  * ``hermes corrections list`` — show the durable learned corrections (the
+    provenance ledger): id, origin signal kind, promotion reason, and a short
+    preview of what was learned.
+  * ``hermes corrections unlearn <provenance_id>`` — reverse one durable
+    correction: remove it from the per-profile memory store (so it stops
+    re-injecting next session), drop its ledger entry, and reset the
+    signature's recurrence evidence (so it does not snap straight back to
+    durable on the next sighting).
+
+The heavy lifting lives in ``agent.correction_learning.CorrectionLearner``;
+this module is a thin, testable wrapper. ``run_list`` / ``run_unlearn`` take an
+optional ``store_dir`` / ``memory_sink`` for isolation under test; the CLI
+handlers resolve the real per-profile store and a live ``MemoryStore`` sink.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Optional
+
+
+def register_cli(parser: argparse.ArgumentParser) -> None:
+    """Attach ``list`` / ``unlearn`` subcommands to ``parser``."""
+    sub = parser.add_subparsers(dest="corrections_command")
+
+    lst = sub.add_parser("list", help="List durable learned corrections")
+    lst.set_defaults(func=cmd_list)
+
+    un = sub.add_parser(
+        "unlearn",
+        help="Reverse a durable learned correction by its provenance id",
+    )
+    un.add_argument(
+        "provenance_id",
+        help="Provenance id shown by `hermes corrections list`",
+    )
+    un.set_defaults(func=cmd_unlearn)
+
+
+def _make_learner(store_dir: Optional[Path], memory_sink: Any):
+    from agent.correction_learning import CorrectionLearner
+
+    return CorrectionLearner(store_dir=store_dir, memory_sink=memory_sink)
+
+
+def _default_memory_sink():
+    """A live ``MemoryStore`` bound to the per-profile MEMORY.md.
+
+    Needed so an unlearn actually removes the durable line from disk (stops
+    re-injection), not just the provenance ledger. Best-effort: if the memory
+    subsystem is unavailable, returns None and unlearn degrades to ledger +
+    recurrence reset only.
+    """
+    try:
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore()
+        store.load_from_disk()
+        return store
+    except Exception:
+        return None
+
+
+def run_list(store_dir: Optional[Path] = None) -> int:
+    """Print the durable provenance ledger. Returns a process exit code."""
+    learner = _make_learner(store_dir, None)
+    durable = learner.list_durable()
+    if not durable:
+        print("No durable learned corrections.")
+        return 0
+    print(f"{len(durable)} durable learned correction(s):")
+    for e in durable:
+        ctx = str(e.get("context", "")).replace("\n", " ")
+        if len(ctx) > 80:
+            ctx = ctx[:77] + "..."
+        print(
+            f"  {e.get('provenance_id')}  "
+            f"[{e.get('origin_kind')}/{e.get('reason')}]  {ctx}"
+        )
+    return 0
+
+
+def run_unlearn(
+    provenance_id: str,
+    *,
+    store_dir: Optional[Path] = None,
+    memory_sink: Any = None,
+) -> int:
+    """Reverse one durable correction. Returns 0 on success, 1 if unknown."""
+    sink = memory_sink if memory_sink is not None else _default_memory_sink()
+    learner = _make_learner(store_dir, sink)
+    ok = learner.unlearn(provenance_id)
+    if ok:
+        print(
+            f"Unlearned {provenance_id}: removed from the durable memory "
+            "store, provenance ledger entry dropped, and recurrence evidence "
+            "reset (it must re-accumulate fresh cross-session evidence to "
+            "become durable again)."
+        )
+        return 0
+    print(f"No durable correction with id {provenance_id!r}.")
+    return 1
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    return run_list(store_dir=getattr(args, "store_dir", None))
+
+
+def cmd_unlearn(args: argparse.Namespace) -> int:
+    return run_unlearn(
+        args.provenance_id,
+        store_dir=getattr(args, "store_dir", None),
+    )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12152,6 +12152,33 @@ def main():
     secrets_parser.set_defaults(func=_dispatch_secrets)
 
     # =========================================================================
+    # corrections command (learn-from-corrections Phase 1: list / unlearn)
+    # =========================================================================
+    corrections_parser = subparsers.add_parser(
+        "corrections",
+        help="Inspect and reverse durable learned user-corrections",
+        description=(
+            "List the durable corrections the agent has learned from your "
+            "interrupts / denials / steers, or reverse one with "
+            "`unlearn <provenance_id>` (removes it from memory so it stops "
+            "re-injecting, drops its provenance, and resets recurrence)."
+        ),
+    )
+
+    # Lazy import — only pays for itself when this subcommand is actually used.
+    from hermes_cli import corrections_cli as _corrections_cli
+
+    _corrections_cli.register_cli(corrections_parser)
+
+    def _dispatch_corrections(args):  # noqa: ANN001
+        if getattr(args, "corrections_command", None):
+            return args.func(args)
+        corrections_parser.print_help()
+        return 0
+
+    corrections_parser.set_defaults(func=_dispatch_corrections)
+
+    # =========================================================================
     # migrate command
     # =========================================================================
     from hermes_cli.migrate import cmd_migrate, cmd_migrate_xai

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11552,7 +11552,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
     {
         "acp", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
-        "config", "cron", "curator", "dashboard", "debug", "doctor",
+        "config", "corrections", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
         "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1502,6 +1502,7 @@ class AIAgent:
         messages_snapshot: List[Dict],
         review_memory: bool = False,
         review_skills: bool = False,
+        correction_hint: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Spawn the background memory/skill review thread.
 
@@ -1510,6 +1511,12 @@ class AIAgent:
         returns the thread target.  ``threading.Thread`` is constructed
         here so existing tests that patch ``run_agent.threading.Thread``
         keep working.
+
+        ``correction_hint`` (Phase 1, learn-from-corrections): when the turn
+        was a structured user correction (INTERRUPT / DENY / STEER), a small
+        ``{kind, signature, context, target}`` dict steers the review prompt
+        to capture THAT correction rather than relying on the generic
+        nudge-driven pass.
         """
         from agent.background_review import spawn_background_review_thread
 
@@ -1518,9 +1525,56 @@ class AIAgent:
             messages_snapshot,
             review_memory=review_memory,
             review_skills=review_skills,
+            correction_hint=correction_hint,
         )
         t = threading.Thread(target=target, daemon=True, name="bg-review")
         t.start()
+
+    def _record_turn_correction(
+        self, correction_hint: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Feed a detected structured correction into the recurrence tracker.
+
+        Phase 1 (learn-from-corrections): builds a ``CorrectionRecord`` from
+        the detected hint and records it through ``CorrectionLearner``. The
+        correction is TRANSIENT by default; it promotes to DURABLE (a write to
+        the per-profile memory store, which re-injects next session) only on
+        cross-session recurrence or an explicit "remember this". The agent's
+        live ``_memory_store`` is the durable sink so a promotion lands exactly
+        where ``load_from_disk`` reads it at the next session start.
+
+        Returns the learner outcome dict (``{tier, durable, ...}``) so the
+        caller can make the background-review prompt tier-aware — a transient
+        first-sighting must not be durably persisted by the LLM reviewer.
+        Returns ``None`` when memory is disabled or on any error.
+
+        Fail-open and best-effort: a broken store, missing memory subsystem, or
+        any error must never disturb the user's turn. Skipped entirely when
+        memory is not enabled (nowhere durable to promote to).
+        """
+        try:
+            store = getattr(self, "_memory_store", None)
+            if store is None or not getattr(self, "_memory_enabled", False):
+                return None
+            from agent.correction_learning import (
+                CorrectionLearner,
+                CorrectionRecord,
+            )
+            from datetime import datetime, timezone
+
+            rec = CorrectionRecord(
+                kind=str(correction_hint.get("kind", "")),
+                signature=str(correction_hint.get("signature", "")),
+                context=str(correction_hint.get("context", "")),
+                session_id=self.session_id or "",
+                ts=datetime.now(timezone.utc).isoformat(),
+                target=correction_hint.get("target"),
+            )
+            if not rec.signature:
+                return None
+            return CorrectionLearner(memory_sink=store).record(rec)
+        except Exception:
+            return None  # best-effort; never disturb the turn
 
     def _build_memory_write_metadata(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1503,6 +1503,7 @@ class AIAgent:
         review_memory: bool = False,
         review_skills: bool = False,
         correction_hint: Optional[Dict[str, Any]] = None,
+        block_durable_writes: bool = False,
     ) -> None:
         """Spawn the background memory/skill review thread.
 
@@ -1526,6 +1527,7 @@ class AIAgent:
             review_memory=review_memory,
             review_skills=review_skills,
             correction_hint=correction_hint,
+            block_durable_writes=block_durable_writes,
         )
         t = threading.Thread(target=target, daemon=True, name="bg-review")
         t.start()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1541,7 +1541,9 @@ class AIAgent:
         the detected hint and records it through ``CorrectionLearner``. The
         correction is TRANSIENT by default; it promotes to DURABLE (a write to
         the per-profile memory store, which re-injects next session) only on
-        cross-session recurrence or an explicit "remember this". The agent's
+        cross-session recurrence. (An explicit "remember this" durable trigger
+        is DEFERRED to a later phase — not wired in Phase 1; ``record`` is called
+        with ``remember`` defaulting False.) The agent's
         live ``_memory_store`` is the durable sink so a promotion lands exactly
         where ``load_from_disk`` reads it at the next session start.
 

--- a/tests/agent/test_codex_runtime_correction_review.py
+++ b/tests/agent/test_codex_runtime_correction_review.py
@@ -1,0 +1,169 @@
+"""Codex-runtime parity for learn-from-corrections (Phase 1).
+
+Before the shared ``agent/correction_review.py`` seam, the Codex app-server
+finalizer (``run_codex_app_server_turn``) carried an unmodified nudge-only gate:
+it never detected or recorded a user correction, so the whole feature was a
+silent no-op on the Codex runtime. These tests prove the Codex path now routes
+through the SAME decision as the default ``finalize_turn``:
+
+* a DENY correction is detected + RECORDED deterministically (the headline
+  parity fix), and
+* the spawn / block rules match the default finalizer (no fork for a pure
+  transient correction without a nudge; fork for a durable correction; nudge-
+  only behavior unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent.codex_runtime import run_codex_app_server_turn
+
+
+class _FakeTurn:
+    def __init__(self, *, final_text="ok", interrupted=False, error=None):
+        self.final_text = final_text
+        self.interrupted = interrupted
+        self.error = error
+        self.should_retire = False
+        self.projected_messages = []
+        self.tool_iterations = 0
+        self.token_usage_last = None  # forces the usage helper's no-usage branch
+        self.model_context_window = None
+        self.thread_id = "thread-1"
+        self.turn_id = "turn-1"
+
+
+class _FakeSession:
+    def __init__(self, turn):
+        self._turn = turn
+
+    def run_turn(self, *, user_input):
+        return self._turn
+
+    def close(self):
+        pass
+
+
+class _CodexStubAgent:
+    def __init__(self, turn):
+        self._codex_session = _FakeSession(turn)
+        self._iters_since_skill = 0
+        self._skill_nudge_interval = 0
+        self.valid_tool_names = {"skill_manage"}
+        self.session_api_calls = 0
+        self._session_db = None
+        self._session_db_created = False
+        self.session_id = "sess-1"
+        self.model = "codex/model"
+        self.provider = "openai"
+        self.base_url = "http://stub"
+        self._interrupt_message = None
+        self.context_compressor = None
+        self.spawned = []
+        self.recorded = []
+
+    def _sync_external_memory_for_turn(self, **k):
+        pass
+
+    def _record_turn_correction(self, hint):
+        self.recorded.append(hint)
+        return self._record_outcome
+
+    # default recorder outcome — overridden per test
+    _record_outcome = {"tier": "transient", "durable": False}
+
+    def _spawn_background_review(self, *, messages_snapshot, review_memory,
+                                review_skills, correction_hint=None,
+                                block_durable_writes=False):
+        self.spawned.append({
+            "review_memory": review_memory,
+            "review_skills": review_skills,
+            "correction_hint": correction_hint,
+            "block_durable_writes": block_durable_writes,
+        })
+
+
+def _deny_messages():
+    return [
+        {"role": "user", "content": "clean up"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"error": "Command denied: rm -rf build", "status": "blocked",
+             "user_denied": True})},
+    ]
+
+
+def _normal_messages():
+    return [
+        {"role": "user", "content": "do a thing"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def _drive(agent, messages, *, should_review_memory=False):
+    return run_codex_app_server_turn(
+        agent,
+        user_message="clean up",
+        original_user_message="clean up",
+        messages=messages,
+        effective_task_id="task-1",
+        should_review_memory=should_review_memory,
+    )
+
+
+def test_codex_path_detects_and_records_correction():
+    # Headline parity fix: a denial on the Codex runtime is now detected and
+    # recorded deterministically (it never was before). No nudge -> no fork.
+    turn = _FakeTurn(final_text="ok")
+    agent = _CodexStubAgent(turn)
+    agent._record_outcome = {"tier": "transient", "durable": False}
+    _drive(agent, _deny_messages(), should_review_memory=False)
+    assert len(agent.recorded) == 1
+    assert agent.recorded[0]["kind"] == "DENY"
+    assert agent.spawned == []  # pure transient, no nudge -> no wasted fork
+
+
+def test_codex_path_durable_correction_spawns_fork():
+    # A promoted (durable) correction spawns the fork even with no nudge, and
+    # keeps durable-write capability (block False) — same rule as the default.
+    turn = _FakeTurn(final_text="ok")
+    agent = _CodexStubAgent(turn)
+    agent._record_outcome = {"tier": "durable", "durable": True}
+    _drive(agent, _deny_messages(), should_review_memory=False)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["correction_hint"]["kind"] == "DENY"
+    assert agent.spawned[0]["block_durable_writes"] is False
+
+
+def test_codex_path_transient_correction_with_nudge_blocks_writes():
+    # Transient correction co-occurring with a memory nudge: fork spawns but
+    # durable writes are blocked (universal X1).
+    turn = _FakeTurn(final_text="ok")
+    agent = _CodexStubAgent(turn)
+    agent._record_outcome = {"tier": "transient", "durable": False}
+    _drive(agent, _deny_messages(), should_review_memory=True)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["block_durable_writes"] is True
+
+
+def test_codex_path_nudge_only_unchanged():
+    # No correction + a nudge -> fork spawns with no hint, no block (pre-existing
+    # codex behavior preserved).
+    turn = _FakeTurn(final_text="ok")
+    agent = _CodexStubAgent(turn)
+    _drive(agent, _normal_messages(), should_review_memory=True)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["correction_hint"] is None
+    assert agent.spawned[0]["block_durable_writes"] is False
+    assert agent.recorded == []
+
+
+def test_codex_path_normal_turn_no_nudge_no_fork():
+    # No correction, no nudge -> nothing recorded, no fork.
+    turn = _FakeTurn(final_text="ok")
+    agent = _CodexStubAgent(turn)
+    _drive(agent, _normal_messages(), should_review_memory=False)
+    assert agent.recorded == []
+    assert agent.spawned == []

--- a/tests/agent/test_correction_learning.py
+++ b/tests/agent/test_correction_learning.py
@@ -13,9 +13,12 @@ Design under test (``agent/correction_learning.py``):
 
 - ``CorrectionLearner`` — owns a fail-open JSON store under a per-profile
   directory. ``record(...)`` applies the generalization guard:
-  a correction is TRANSIENT by default and becomes DURABLE only on
-  EVIDENCE — the same signature recurs across >=2 distinct sessions, OR
-  an explicit ``remember=True`` ("remember this"). Durable items are
+  a correction is TRANSIENT by default and becomes DURABLE on cross-session
+  EVIDENCE — the same signature recurs across >=2 distinct sessions. The
+  ``record(remember=True)`` fast-path also promotes durably and is exercised
+  here at the unit level, but NOTE it is not wired to any production caller in
+  Phase 1 (explicit "remember this" is deferred); recurrence is the sole
+  production durable trigger. Durable items are
   written through a memory-store sink (the real re-injection path) and a
   provenance ledger entry is recorded. ``unlearn(provenance_id)`` removes
   a durable item (symmetric, reversible).

--- a/tests/agent/test_correction_learning.py
+++ b/tests/agent/test_correction_learning.py
@@ -1,0 +1,418 @@
+"""Lean Phase 1 — learn from user corrections.
+
+Tests the deterministic correction detector, the transient->durable
+generalization guard (recurrence tracker), provenance, and the symmetric
+unlearn path.
+
+Design under test (``agent/correction_learning.py``):
+
+- ``detect_correction(...)`` — deterministic. Inspects a *completed* turn
+  (its ``messages`` list + interrupt state) and returns a small structured
+  ``CorrectionRecord`` if the turn ended in a structured correction
+  (INTERRUPT / DENY / STEER), else ``None``. No fuzzy text regex.
+
+- ``CorrectionLearner`` — owns a fail-open JSON store under a per-profile
+  directory. ``record(...)`` applies the generalization guard:
+  a correction is TRANSIENT by default and becomes DURABLE only on
+  EVIDENCE — the same signature recurs across >=2 distinct sessions, OR
+  an explicit ``remember=True`` ("remember this"). Durable items are
+  written through a memory-store sink (the real re-injection path) and a
+  provenance ledger entry is recorded. ``unlearn(provenance_id)`` removes
+  a durable item (symmetric, reversible).
+
+The store directory is injected for test isolation; in production it
+resolves under ``get_hermes_home()/corrections``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.correction_learning import (
+    CorrectionLearner,
+    CorrectionRecord,
+    detect_correction,
+)
+from agent.prompt_builder import STEER_MARKER_OPEN, format_steer_marker
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeMemorySink:
+    """Stand-in for the durable re-injection path (MEMORY.md).
+
+    Mirrors ``MemoryStore.add`` / ``remove`` just enough that a durable write
+    lands somewhere the injection path would read, and an unlearn removes it.
+    ``entries`` is what a fresh session's ``load_from_disk`` would surface.
+    """
+
+    def __init__(self):
+        self.entries: list[str] = []
+
+    def add(self, target, content, **kwargs):
+        content = content.strip()
+        if content in self.entries:
+            return {"success": True, "message": "Entry already exists"}
+        self.entries.append(content)
+        return {"success": True, "message": "Entry added"}
+
+    def remove(self, target, content_substr, **kwargs):
+        before = len(self.entries)
+        self.entries = [e for e in self.entries if content_substr not in e]
+        return {"success": len(self.entries) < before}
+
+    # What a future session would inject.
+    def injected_text(self) -> str:
+        return "\n".join(self.entries)
+
+
+def _learner(tmp_path, sink=None):
+    return CorrectionLearner(
+        store_dir=tmp_path / "corrections",
+        memory_sink=sink if sink is not None else FakeMemorySink(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. DETECTION (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_interrupt():
+    messages = [
+        {"role": "user", "content": "refactor module X"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "write_file", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+    ]
+    rec = detect_correction(
+        messages,
+        interrupted=True,
+        interrupt_message="stop, do it in TypeScript instead",
+        turn_exit_reason="interrupted_by_user",
+        session_id="s1",
+    )
+    assert rec is not None
+    assert rec.kind == "INTERRUPT"
+    assert "TypeScript" in rec.context
+    assert rec.session_id == "s1"
+    assert rec.signature  # stable, non-empty
+    assert rec.ts  # timestamp recorded
+
+
+def test_detect_deny():
+    messages = [
+        {"role": "user", "content": "clean up"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"output": "", "exit_code": -1,
+             "error": "Command denied: rm -rf /tmp/x", "status": "blocked"})},
+    ]
+    rec = detect_correction(
+        messages, interrupted=False, interrupt_message=None,
+        turn_exit_reason="text_response(stop)", session_id="s1",
+    )
+    assert rec is not None
+    assert rec.kind == "DENY"
+
+
+def test_detect_steer():
+    steer = format_steer_marker("actually use pytest not unittest")
+    assert STEER_MARKER_OPEN in steer  # sanity: marker present
+    messages = [
+        {"role": "user", "content": "write tests"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file body" + steer},
+    ]
+    rec = detect_correction(
+        messages, interrupted=False, interrupt_message=None,
+        turn_exit_reason="text_response(stop)", session_id="s1",
+    )
+    assert rec is not None
+    assert rec.kind == "STEER"
+    assert "pytest" in rec.context
+
+
+def test_no_correction_on_normal_turn():
+    messages = [
+        {"role": "user", "content": "summarize this"},
+        {"role": "assistant", "content": "Here is the summary."},
+    ]
+    rec = detect_correction(
+        messages, interrupted=False, interrupt_message=None,
+        turn_exit_reason="text_response(stop)", session_id="s1",
+    )
+    assert rec is None
+
+
+def test_no_correction_on_plain_interrupt_without_message():
+    # User hit stop but gave no redirect text. Not a structured correction
+    # we can learn from (nothing to capture); existing interrupt behavior is
+    # preserved by the caller. Detector returns None.
+    messages = [{"role": "user", "content": "do a thing"}]
+    rec = detect_correction(
+        messages, interrupted=True, interrupt_message=None,
+        turn_exit_reason="interrupted_by_user", session_id="s1",
+    )
+    assert rec is None
+
+
+def test_same_correction_same_signature_across_sessions():
+    # Stable signature is what the recurrence tracker keys on.
+    def mk(sess):
+        return detect_correction(
+            [{"role": "user", "content": "x"},
+             {"role": "assistant", "content": "", "tool_calls": [
+                 {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+             {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+                 {"error": "Command denied: rm -rf build", "status": "blocked"})}],
+            interrupted=False, interrupt_message=None,
+            turn_exit_reason="t", session_id=sess,
+        )
+    a = mk("s1")
+    b = mk("s2")
+    assert a.signature == b.signature
+
+
+# ---------------------------------------------------------------------------
+# 2. GENERALIZATION GUARD (transient -> durable)
+# ---------------------------------------------------------------------------
+
+
+def test_first_sighting_stays_transient(tmp_path):
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="do not rm build",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    outcome = learner.record(rec)
+    assert outcome["tier"] == "transient"
+    assert outcome["durable"] is False
+    # NEGATIVE CONTROL: nothing written to the durable injection path.
+    assert sink.entries == []
+    assert sink.injected_text() == ""
+    # And no durable ledger entry.
+    assert learner.list_durable() == []
+
+
+def test_second_sighting_new_session_promotes_durable(tmp_path):
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec1 = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="do not rm build",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    rec2 = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="do not rm build",
+        session_id="s2", ts="2026-01-02T00:00:00Z",
+    )
+    first = learner.record(rec1)
+    assert first["durable"] is False
+    assert sink.entries == []
+
+    second = learner.record(rec2)
+    assert second["tier"] == "durable"
+    assert second["durable"] is True
+    # The durable store now contains it, where a NEW session would inject it.
+    assert sink.entries, "durable write must land on the injection path"
+    assert "build" in sink.injected_text()
+    # Provenance ledger records it with origin signal + reason.
+    durable = learner.list_durable()
+    assert len(durable) == 1
+    assert durable[0]["provenance_id"] == second["provenance_id"]
+    assert durable[0]["origin_kind"] == "DENY"
+    assert durable[0]["reason"] == "recurrence"
+    assert durable[0]["signature"] == "sig-A"
+
+
+def test_same_session_twice_does_not_promote(tmp_path):
+    # Recurrence requires DISTINCT sessions. A loop within one session must
+    # not look like cross-session evidence (over-promotion guard).
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="x",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    learner.record(rec)
+    second = learner.record(rec)  # same session_id
+    assert second["durable"] is False
+    assert sink.entries == []
+
+
+def test_explicit_remember_promotes_on_first_sighting(tmp_path):
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="STEER", signature="sig-pref", context="use pytest not unittest",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    outcome = learner.record(rec, remember=True)
+    assert outcome["tier"] == "durable"
+    assert outcome["durable"] is True
+    assert "pytest" in sink.injected_text()
+    durable = learner.list_durable()
+    assert durable[0]["reason"] == "explicit_remember"
+
+
+def test_one_off_correction_never_injects(tmp_path):
+    # NEGATIVE CONTROL (explicit): seen once, no remember -> stays ephemeral,
+    # no durable write, no injection. This is the safety core of Phase 1.
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="INTERRUPT", signature="sig-oneoff", context="this one time, skip linting",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    outcome = learner.record(rec)
+    assert outcome["durable"] is False
+    assert sink.entries == []
+    assert sink.injected_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. PROVENANCE + UNLEARN (reversibility)
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_recorded_on_durable(tmp_path):
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="STEER", signature="sig-pref", context="use pytest not unittest",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    outcome = learner.record(rec, remember=True)
+    entry = learner.get_durable(outcome["provenance_id"])
+    assert entry is not None
+    assert entry["origin_kind"] == "STEER"
+    assert entry["signature"] == "sig-pref"
+    assert entry["session_id"] == "s1"
+    assert entry["tier"] == "durable"
+    assert entry["ts"]
+    assert entry["promoted_ts"]
+
+
+def test_unlearn_removes_durable_and_stops_injection(tmp_path):
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+    rec = CorrectionRecord(
+        kind="STEER", signature="sig-pref", context="use pytest not unittest",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    outcome = learner.record(rec, remember=True)
+    pid = outcome["provenance_id"]
+    assert "pytest" in sink.injected_text()
+
+    ok = learner.unlearn(pid)
+    assert ok is True
+    # No longer durable, no longer injected.
+    assert learner.get_durable(pid) is None
+    assert learner.list_durable() == []
+    assert "pytest" not in sink.injected_text()
+
+
+def test_unlearn_unknown_id_is_safe(tmp_path):
+    learner = _learner(tmp_path)
+    assert learner.unlearn("does-not-exist") is False
+
+
+def test_promotion_is_idempotent_no_duplicate_ledger_or_memory(tmp_path):
+    # Once durable, further sightings of the SAME signature must NOT create
+    # duplicate ledger entries or re-write memory (ledger-bloat guard found in
+    # independent review). The item stays a single durable rule.
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+
+    def sight(sess):
+        rec = CorrectionRecord(
+            kind="DENY", signature="sig-A", context="do not rm build",
+            session_id=sess, ts="2026-01-01T00:00:00Z",
+        )
+        return learner.record(rec)
+
+    sight("s1")  # transient
+    out2 = sight("s2")  # promote
+    assert out2["durable"] is True
+    out3 = sight("s3")  # already durable
+    assert out3["durable"] is True
+    # Exactly ONE durable ledger entry, ONE memory entry.
+    assert len(learner.list_durable()) == 1
+    assert len(sink.entries) == 1
+    # The provenance id is stable across repeat sightings.
+    assert out3["provenance_id"] == out2["provenance_id"]
+    assert out3["reason"] == "already_durable"
+
+
+def test_unlearn_resets_recurrence_so_no_instant_repromote(tmp_path):
+    # After unlearn, the same correction must require fresh evidence again —
+    # not snap straight back to durable on the next sighting (independent
+    # review caught that recurrence history outlived the durable entry).
+    sink = FakeMemorySink()
+    learner = _learner(tmp_path, sink)
+
+    def sight(sess):
+        return learner.record(CorrectionRecord(
+            kind="DENY", signature="sig-A", context="x",
+            session_id=sess, ts="t",
+        ))
+
+    sight("s1")
+    out2 = sight("s2")
+    assert out2["durable"] is True
+    assert learner.unlearn(out2["provenance_id"]) is True
+    assert "x" not in sink.injected_text()
+
+    # Next single sighting must be transient again (evidence was reset).
+    out3 = sight("s3")
+    assert out3["durable"] is False
+    assert sink.entries == []
+
+
+# ---------------------------------------------------------------------------
+# 4. FAIL-OPEN PERSISTENCE
+# ---------------------------------------------------------------------------
+
+
+def test_state_persists_across_learner_instances(tmp_path):
+    # Recurrence must survive process restarts (cross-session evidence is the
+    # whole point). A second learner over the same dir sees the first sighting.
+    sink = FakeMemorySink()
+    rec1 = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="x",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    rec2 = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="x",
+        session_id="s2", ts="2026-01-02T00:00:00Z",
+    )
+    _learner(tmp_path, sink).record(rec1)
+    # Fresh learner instance, same store dir, NEW session.
+    second = _learner(tmp_path, sink).record(rec2)
+    assert second["durable"] is True
+
+
+def test_record_failopen_on_unwritable_store(tmp_path, monkeypatch):
+    # A broken store must never crash the turn. record() returns a result and
+    # does not raise even if persistence fails.
+    learner = _learner(tmp_path)
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(learner, "_write_json", boom)
+    rec = CorrectionRecord(
+        kind="DENY", signature="sig-A", context="x",
+        session_id="s1", ts="2026-01-01T00:00:00Z",
+    )
+    # Must not raise.
+    outcome = learner.record(rec)
+    assert outcome["durable"] is False

--- a/tests/agent/test_correction_learning.py
+++ b/tests/agent/test_correction_learning.py
@@ -106,13 +106,17 @@ def test_detect_interrupt():
 
 
 def test_detect_deny():
+    # A GENUINE user denial carries ``user_denied: True`` (stamped by the
+    # approval flow). That marker — not the bare ``status: "blocked"`` — is what
+    # the detector keys on.
     messages = [
         {"role": "user", "content": "clean up"},
         {"role": "assistant", "content": "", "tool_calls": [
             {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
         {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
             {"output": "", "exit_code": -1,
-             "error": "Command denied: rm -rf /tmp/x", "status": "blocked"})},
+             "error": "Command denied: rm -rf /tmp/x", "status": "blocked",
+             "user_denied": True})},
     ]
     rec = detect_correction(
         messages, interrupted=False, interrupt_message=None,
@@ -120,6 +124,44 @@ def test_detect_deny():
     )
     assert rec is not None
     assert rec.kind == "DENY"
+
+
+def test_automatic_dangerous_block_not_detected_as_deny():
+    # X2: an AUTOMATIC dangerous-command block (no user involved) sets
+    # ``status: "blocked"`` but NO ``user_denied`` marker. It must NOT mint a
+    # false "user correction".
+    messages = [
+        {"role": "user", "content": "clean up"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"output": "", "exit_code": -1,
+             "error": "Command denied: recursive delete", "status": "blocked"})},
+    ]
+    rec = detect_correction(
+        messages, interrupted=False, interrupt_message=None,
+        turn_exit_reason="text_response(stop)", session_id="s1",
+    )
+    assert rec is None
+
+
+def test_automatic_workdir_validation_block_not_detected_as_deny():
+    # X2: the workdir shell-injection validator also emits ``status: "blocked"``
+    # with no user involvement -> not a correction.
+    messages = [
+        {"role": "user", "content": "build it"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"output": "", "exit_code": -1,
+             "error": "Blocked: workdir contains disallowed character ';'.",
+             "status": "blocked"})},
+    ]
+    rec = detect_correction(
+        messages, interrupted=False, interrupt_message=None,
+        turn_exit_reason="text_response(stop)", session_id="s1",
+    )
+    assert rec is None
 
 
 def test_detect_steer():
@@ -172,7 +214,8 @@ def test_same_correction_same_signature_across_sessions():
              {"role": "assistant", "content": "", "tool_calls": [
                  {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
              {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
-                 {"error": "Command denied: rm -rf build", "status": "blocked"})}],
+                 {"error": "Command denied: rm -rf build", "status": "blocked",
+                  "user_denied": True})}],
             interrupted=False, interrupt_message=None,
             turn_exit_reason="t", session_id=sess,
         )

--- a/tests/agent/test_correction_learning_wiring.py
+++ b/tests/agent/test_correction_learning_wiring.py
@@ -236,6 +236,37 @@ def test_transient_correction_fork_cannot_write_durable():
     assert "skill_manage" in allowed
 
 
+def test_blocked_whitelist_denies_durable_write_at_dispatch():
+    """End-to-end enforcement proof: the dispatch gate itself denies the write.
+
+    With the transient-correction whitelist installed on the thread,
+    ``get_pre_tool_call_block_message`` — the SAME gate the review fork's tool
+    dispatch consults — returns a block for ``memory`` and ``skill_manage``,
+    while a read-only skills tool is still allowed. So the LLM fork genuinely
+    cannot persist a one-off correction durably; it is denied at dispatch, not
+    merely discouraged by a prompt.
+    """
+    from agent.background_review import _review_tool_whitelist
+    from hermes_cli.plugins import (
+        set_thread_tool_whitelist,
+        clear_thread_tool_whitelist,
+        get_pre_tool_call_block_message,
+    )
+
+    set_thread_tool_whitelist(_review_tool_whitelist(block_durable_writes=True))
+    try:
+        assert get_pre_tool_call_block_message(
+            "memory", {"action": "add", "content": "x"}
+        ), "memory write must be denied at the dispatch gate"
+        assert get_pre_tool_call_block_message(
+            "skill_manage", {"action": "write_file"}
+        ), "skill write must be denied at the dispatch gate"
+        # Read-only inspection remains allowed (gate returns None == not blocked).
+        assert get_pre_tool_call_block_message("skill_view", {}) is None
+    finally:
+        clear_thread_tool_whitelist()
+
+
 def test_spawn_threads_block_flag_into_review(monkeypatch):
     """The ``block_durable_writes`` flag reaches ``_run_review_in_thread``.
 

--- a/tests/agent/test_correction_learning_wiring.py
+++ b/tests/agent/test_correction_learning_wiring.py
@@ -43,12 +43,15 @@ class FakeMemorySink:
 
 
 def _deny_messages():
+    # Genuine USER denial — carries the ``user_denied`` marker the detector
+    # keys on (an automatic safety block sets ``status: "blocked"`` without it).
     return [
         {"role": "user", "content": "clean up"},
         {"role": "assistant", "content": "", "tool_calls": [
             {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
         {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
-            {"error": "Command denied: rm -rf build", "status": "blocked"})},
+            {"error": "Command denied: rm -rf build", "status": "blocked",
+             "user_denied": True})},
     ]
 
 
@@ -86,7 +89,14 @@ def test_acceptance_transfer_promotion_across_two_sessions(tmp_path):
 
 
 def test_acceptance_negative_control_one_off(tmp_path):
-    """A one-off correction (seen once, no remember) never injects."""
+    """A one-off correction (seen once, no remember) never injects DETERMINISTICALLY.
+
+    Scope note: this exercises ONLY the deterministic ``CorrectionLearner`` —
+    which was never the leak path. The actual one-off leak risk is the LLM
+    review fork; that is gated by ``test_transient_correction_fork_cannot_write_durable``
+    below (the fork's runtime tool whitelist strips the durable writers), not by
+    this test.
+    """
     sink = FakeMemorySink()
     store = tmp_path / "corrections"
     rec = detect_correction(
@@ -186,8 +196,10 @@ def test_finalize_records_correction_into_tracker(tmp_path, monkeypatch):
 
 
 def test_review_preamble_transient_does_not_instruct_durable_persist():
-    # One-off-leak guard at the prompt layer: a TRANSIENT correction must NOT
-    # tell the LLM reviewer to embed it durably / re-inject it next session.
+    # DEFENSE-IN-DEPTH at the prompt layer (NOT the enforcement): a TRANSIENT
+    # correction's preamble must not tell the LLM reviewer to embed it durably.
+    # The real guard is the tool whitelist (see the enforcement test below);
+    # this preamble is belt-and-suspenders, not the gate.
     from agent.background_review import _format_correction_focus
 
     transient = _format_correction_focus({
@@ -200,6 +212,57 @@ def test_review_preamble_transient_does_not_instruct_durable_persist():
     assert "re-enter future sessions" not in low
 
 
+def test_transient_correction_fork_cannot_write_durable():
+    """X1 ENFORCEMENT (not advice): the review fork built for a transient
+    correction has NO durable memory/skill WRITE tool in its runtime whitelist.
+
+    ``_review_tool_whitelist`` is exactly what ``_run_review_in_thread`` installs
+    via ``set_thread_tool_whitelist``; ``get_pre_tool_call_block_message`` denies
+    any call to a tool absent from it. So excluding ``memory`` and
+    ``skill_manage`` here means the LLM fork is structurally unable to persist a
+    one-off correction durably — only the deterministic ``CorrectionLearner``
+    promotion path can. This replaces the prior advisory-only guard.
+    """
+    from agent.background_review import _review_tool_whitelist
+
+    blocked = _review_tool_whitelist(block_durable_writes=True)
+    assert "memory" not in blocked, "memory write tool must be stripped"
+    assert "skill_manage" not in blocked, "skill write tool must be stripped"
+
+    allowed = _review_tool_whitelist(block_durable_writes=False)
+    # Sanity: the unblocked (durable / nudge) path still exposes the writers,
+    # so we are proving a real difference, not an always-empty whitelist.
+    assert "memory" in allowed
+    assert "skill_manage" in allowed
+
+
+def test_spawn_threads_block_flag_into_review(monkeypatch):
+    """The ``block_durable_writes`` flag reaches ``_run_review_in_thread``.
+
+    Proves the spawn wiring carries the gate end-to-end (finalize_turn ->
+    _spawn_background_review -> spawn_background_review_thread -> the thread
+    target), so the whitelist above is actually applied to the spawned fork.
+    """
+    import agent.background_review as br
+
+    captured = {}
+
+    def _fake_run(agent, messages_snapshot, prompt, block_durable_writes=False):
+        captured["block"] = block_durable_writes
+
+    monkeypatch.setattr(br, "_run_review_in_thread", _fake_run)
+    target, _prompt = br.spawn_background_review_thread(
+        agent=object(),
+        messages_snapshot=[],
+        review_memory=True,
+        correction_hint={"kind": "DENY", "context": "x", "tier": "transient",
+                         "durable": False},
+        block_durable_writes=True,
+    )
+    target()
+    assert captured["block"] is True
+
+
 def test_review_preamble_durable_instructs_persist():
     from agent.background_review import _format_correction_focus
 
@@ -209,6 +272,40 @@ def test_review_preamble_durable_instructs_persist():
     })
     low = durable.lower()
     assert "future sessions" in low or "embed" in low or "persist" in low
+
+
+def test_unlearn_cli_surface_reverses_durable(tmp_path):
+    """The `hermes corrections unlearn` surface actually reverses a durable item.
+
+    Proves "reversible" is not paper-only: the CLI helper removes the durable
+    line from the (fake) memory store, drops the ledger entry, and resets
+    recurrence — and reports unknown ids as a non-zero exit.
+    """
+    from hermes_cli.corrections_cli import run_unlearn, run_list
+    from agent.correction_learning import CorrectionLearner, CorrectionRecord
+
+    sink = FakeMemorySink()
+    store = tmp_path / "corrections"
+    out = CorrectionLearner(store_dir=store, memory_sink=sink).record(
+        CorrectionRecord(
+            kind="STEER", signature="sig-cli", context="use ruff not flake8",
+            session_id="s1", ts="t",
+        ),
+        remember=True,
+    )
+    pid = out["provenance_id"]
+    assert "ruff" in sink.injected_text()
+
+    # list surface runs without error while an item exists
+    assert run_list(store_dir=store) == 0
+
+    # unlearn removes it from the durable store (stops injection)
+    assert run_unlearn(pid, store_dir=store, memory_sink=sink) == 0
+    assert "ruff" not in sink.injected_text()
+    assert CorrectionLearner(store_dir=store, memory_sink=sink).list_durable() == []
+
+    # unknown id is a clean non-zero exit, not an exception
+    assert run_unlearn("does-not-exist", store_dir=store, memory_sink=sink) == 1
 
 
 def test_finalize_no_correction_does_not_record(tmp_path):

--- a/tests/agent/test_correction_learning_wiring.py
+++ b/tests/agent/test_correction_learning_wiring.py
@@ -167,7 +167,11 @@ def test_finalize_records_correction_into_tracker(tmp_path, monkeypatch):
         def _file_mutation_verifier_enabled(self): return False
         def _turn_completion_explainer_enabled(self): return False
         def _drain_pending_steer(self): return None
-        def clear_interrupt(self): pass
+        def clear_interrupt(self):
+            # Mirror production AIAgent.clear_interrupt — never a no-op, so the
+            # capture-before-clear ordering in finalize_turn stays under test.
+            self._interrupt_message = None
+            self._interrupt_requested = False
         def _sync_external_memory_for_turn(self, **k): pass
         def _spawn_background_review(self, **k): pass
 
@@ -388,7 +392,11 @@ def test_finalize_no_correction_does_not_record(tmp_path):
         def _file_mutation_verifier_enabled(self): return False
         def _turn_completion_explainer_enabled(self): return False
         def _drain_pending_steer(self): return None
-        def clear_interrupt(self): pass
+        def clear_interrupt(self):
+            # Mirror production AIAgent.clear_interrupt — never a no-op, so the
+            # capture-before-clear ordering in finalize_turn stays under test.
+            self._interrupt_message = None
+            self._interrupt_requested = False
         def _sync_external_memory_for_turn(self, **k): pass
         def _spawn_background_review(self, **k): pass
         def _record_turn_correction(self, correction_hint):

--- a/tests/agent/test_correction_learning_wiring.py
+++ b/tests/agent/test_correction_learning_wiring.py
@@ -1,0 +1,286 @@
+"""Lean Phase 1 — end-to-end wiring of correction recording into the turn.
+
+``finalize_turn`` detects a structured correction and, when the agent has a
+memory store, records it through ``CorrectionLearner`` so the recurrence
+tracker accumulates cross-session evidence. This is what lets a correction
+seen in two distinct sessions promote to durable in real use.
+
+The recording is fail-open and transient-by-default: a first sighting must
+NOT write anything durable. Two sightings across distinct sessions (separate
+``CorrectionLearner`` instances over the same store dir, simulating two real
+sessions) MUST promote to durable and land on the injection path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.correction_learning import (
+    CorrectionLearner,
+    detect_correction,
+)
+
+
+class FakeMemorySink:
+    def __init__(self):
+        self.entries = []
+
+    def add(self, target, content, **kw):
+        content = content.strip()
+        if content not in self.entries:
+            self.entries.append(content)
+        return {"success": True}
+
+    def remove(self, target, substr, **kw):
+        before = len(self.entries)
+        self.entries = [e for e in self.entries if substr not in e]
+        return {"success": len(self.entries) < before}
+
+    def injected_text(self):
+        return "\n".join(self.entries)
+
+
+def _deny_messages():
+    return [
+        {"role": "user", "content": "clean up"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"error": "Command denied: rm -rf build", "status": "blocked"})},
+    ]
+
+
+def test_acceptance_transfer_promotion_across_two_sessions(tmp_path):
+    """The headline acceptance test, end-to-end through detection + recording.
+
+    Session 1: the correction is detected and recorded -> stays transient,
+    nothing injects. Session 2 (a fresh learner over the SAME store dir, i.e.
+    a new process/session): the same correction recurs -> promoted durable ->
+    the durable store now contains it where a NEW session would inject it.
+    """
+    sink = FakeMemorySink()
+    store = tmp_path / "corrections"
+
+    # --- Session 1 ---
+    rec1 = detect_correction(
+        _deny_messages(), interrupted=False, interrupt_message=None,
+        turn_exit_reason="t", session_id="session-1",
+    )
+    assert rec1 is not None and rec1.kind == "DENY"
+    out1 = CorrectionLearner(store_dir=store, memory_sink=sink).record(rec1)
+    assert out1["durable"] is False
+    assert sink.entries == []  # NEGATIVE: nothing injects after one sighting
+
+    # --- Session 2 (new learner instance, same on-disk store) ---
+    rec2 = detect_correction(
+        _deny_messages(), interrupted=False, interrupt_message=None,
+        turn_exit_reason="t", session_id="session-2",
+    )
+    out2 = CorrectionLearner(store_dir=store, memory_sink=sink).record(rec2)
+    assert out2["durable"] is True
+    assert out2["reason"] == "recurrence"
+    # Durable write landed where a future session's load_from_disk would read.
+    assert "build" in sink.injected_text()
+
+
+def test_acceptance_negative_control_one_off(tmp_path):
+    """A one-off correction (seen once, no remember) never injects."""
+    sink = FakeMemorySink()
+    store = tmp_path / "corrections"
+    rec = detect_correction(
+        [{"role": "user", "content": "x"},
+         {"role": "assistant", "content": "", "tool_calls": [
+             {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}}]},
+         {"role": "tool", "tool_call_id": "c1",
+          "content": "ok\n\n[OUT-OF-BAND USER MESSAGE — a direct message from "
+                     "the user, delivered mid-turn; not tool output]\n"
+                     "just this once, skip the changelog\n"
+                     "[/OUT-OF-BAND USER MESSAGE]"}],
+        interrupted=False, interrupt_message=None,
+        turn_exit_reason="t", session_id="session-1",
+    )
+    assert rec is not None and rec.kind == "STEER"
+    out = CorrectionLearner(store_dir=store, memory_sink=sink).record(rec)
+    assert out["durable"] is False
+    assert sink.entries == []
+    assert sink.injected_text() == ""
+
+
+def test_finalize_records_correction_into_tracker(tmp_path, monkeypatch):
+    """``finalize_turn`` records a detected correction via the agent helper."""
+    from agent.turn_finalizer import finalize_turn
+
+    recorded = []
+
+    class _Budget:
+        used = 1
+        max_total = 10
+        remaining = 9
+
+    class _Compressor:
+        last_prompt_tokens = 0
+
+    class _Agent:
+        def __init__(self):
+            self.max_iterations = 10
+            self.iteration_budget = _Budget()
+            self.context_compressor = _Compressor()
+            self.model = "m"
+            self.provider = "p"
+            self.base_url = "b"
+            self.session_id = "sess-1"
+            self.quiet_mode = True
+            self.platform = "cli"
+            self._interrupt_message = None
+            self._tool_guardrail_halt_decision = None
+            self._response_was_previewed = False
+            self._skill_nudge_interval = 0
+            self._iters_since_skill = 0
+            for a in ("session_input_tokens", "session_output_tokens",
+                      "session_cache_read_tokens", "session_cache_write_tokens",
+                      "session_reasoning_tokens", "session_prompt_tokens",
+                      "session_completion_tokens", "session_total_tokens",
+                      "session_estimated_cost_usd"):
+                setattr(self, a, 0)
+            self.session_cost_status = "ok"
+            self.session_cost_source = "stub"
+
+        def _save_trajectory(self, *a, **k): pass
+        def _cleanup_task_resources(self, *a, **k): pass
+        def _drop_trailing_empty_response_scaffolding(self, *a, **k): pass
+        def _persist_session(self, *a, **k): pass
+        def _emit_status(self, *a, **k): pass
+        def _safe_print(self, *a, **k): pass
+        def _handle_max_iterations(self, m, n): return "SUMMARY"
+        def _file_mutation_verifier_enabled(self): return False
+        def _turn_completion_explainer_enabled(self): return False
+        def _drain_pending_steer(self): return None
+        def clear_interrupt(self): pass
+        def _sync_external_memory_for_turn(self, **k): pass
+        def _spawn_background_review(self, **k): pass
+
+        # The wiring hook under test.
+        def _record_turn_correction(self, correction_hint):
+            recorded.append(correction_hint)
+
+    agent = _Agent()
+    finalize_turn(
+        agent,
+        final_response="ok",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_deny_messages(),
+        conversation_history=None,
+        effective_task_id="t",
+        turn_id="turn-1",
+        user_message="clean up",
+        original_user_message="clean up",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(stop)",
+    )
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "DENY"
+
+
+def test_review_preamble_transient_does_not_instruct_durable_persist():
+    # One-off-leak guard at the prompt layer: a TRANSIENT correction must NOT
+    # tell the LLM reviewer to embed it durably / re-inject it next session.
+    from agent.background_review import _format_correction_focus
+
+    transient = _format_correction_focus({
+        "kind": "DENY", "context": "skip linting this once",
+        "target": "terminal", "tier": "transient", "durable": False,
+    })
+    low = transient.lower()
+    assert "do not persist" in low or "not yet" in low or "transient" in low
+    # Must not push durable embedding for a one-off.
+    assert "re-enter future sessions" not in low
+
+
+def test_review_preamble_durable_instructs_persist():
+    from agent.background_review import _format_correction_focus
+
+    durable = _format_correction_focus({
+        "kind": "STEER", "context": "use pytest not unittest",
+        "target": None, "tier": "durable", "durable": True,
+    })
+    low = durable.lower()
+    assert "future sessions" in low or "embed" in low or "persist" in low
+
+
+def test_finalize_no_correction_does_not_record(tmp_path):
+    """A normal turn records nothing."""
+    from agent.turn_finalizer import finalize_turn
+
+    recorded = []
+
+    class _Budget:
+        used = 1
+        max_total = 10
+        remaining = 9
+
+    class _Compressor:
+        last_prompt_tokens = 0
+
+    class _Agent:
+        def __init__(self):
+            self.max_iterations = 10
+            self.iteration_budget = _Budget()
+            self.context_compressor = _Compressor()
+            self.model = "m"
+            self.provider = "p"
+            self.base_url = "b"
+            self.session_id = "sess-1"
+            self.quiet_mode = True
+            self.platform = "cli"
+            self._interrupt_message = None
+            self._tool_guardrail_halt_decision = None
+            self._response_was_previewed = False
+            self._skill_nudge_interval = 0
+            self._iters_since_skill = 0
+            for a in ("session_input_tokens", "session_output_tokens",
+                      "session_cache_read_tokens", "session_cache_write_tokens",
+                      "session_reasoning_tokens", "session_prompt_tokens",
+                      "session_completion_tokens", "session_total_tokens",
+                      "session_estimated_cost_usd"):
+                setattr(self, a, 0)
+            self.session_cost_status = "ok"
+            self.session_cost_source = "stub"
+
+        def _save_trajectory(self, *a, **k): pass
+        def _cleanup_task_resources(self, *a, **k): pass
+        def _drop_trailing_empty_response_scaffolding(self, *a, **k): pass
+        def _persist_session(self, *a, **k): pass
+        def _emit_status(self, *a, **k): pass
+        def _safe_print(self, *a, **k): pass
+        def _handle_max_iterations(self, m, n): return "SUMMARY"
+        def _file_mutation_verifier_enabled(self): return False
+        def _turn_completion_explainer_enabled(self): return False
+        def _drain_pending_steer(self): return None
+        def clear_interrupt(self): pass
+        def _sync_external_memory_for_turn(self, **k): pass
+        def _spawn_background_review(self, **k): pass
+        def _record_turn_correction(self, correction_hint):
+            recorded.append(correction_hint)
+
+    agent = _Agent()
+    finalize_turn(
+        agent,
+        final_response="all done",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "hi"},
+                  {"role": "assistant", "content": "all done"}],
+        conversation_history=None,
+        effective_task_id="t",
+        turn_id="turn-1",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(stop)",
+    )
+    assert recorded == []

--- a/tests/agent/test_turn_finalizer_correction_review.py
+++ b/tests/agent/test_turn_finalizer_correction_review.py
@@ -98,11 +98,13 @@ class _StubAgent:
         pass
 
     def _spawn_background_review(self, *, messages_snapshot, review_memory,
-                                review_skills, correction_hint=None):
+                                review_skills, correction_hint=None,
+                                block_durable_writes=False):
         self.spawned.append({
             "review_memory": review_memory,
             "review_skills": review_skills,
             "correction_hint": correction_hint,
+            "block_durable_writes": block_durable_writes,
         })
 
 
@@ -114,12 +116,17 @@ def _normal_messages():
 
 
 def _deny_messages():
+    # A GENUINE user denial: the approval flow stamps ``user_denied: True`` into
+    # the tool result (see tools/approval.py + tools/terminal_tool.py). The
+    # detector keys on THAT marker, not the bare ``status: "blocked"`` that
+    # automatic safety blocks also produce.
     return [
         {"role": "user", "content": "clean up"},
         {"role": "assistant", "content": "", "tool_calls": [
             {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
         {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
-            {"error": "Command denied: rm -rf build", "status": "blocked"})},
+            {"error": "Command denied: rm -rf build", "status": "blocked",
+             "user_denied": True})},
     ]
 
 
@@ -232,3 +239,54 @@ def test_correction_hint_tier_durable_when_recorder_promotes():
     hint = agent.spawned[0]["correction_hint"]
     assert hint["tier"] == "durable"
     assert hint["durable"] is True
+
+
+# ---------------------------------------------------------------------------
+# X1 ENFORCEMENT — the durable-write capability of the review fork is GATED,
+# not merely advised. A transient (first-sighting) correction that is the SOLE
+# reason the review spawned must hand the fork ``block_durable_writes=True`` so
+# the fork's runtime tool whitelist strips the durable memory/skill writers.
+# ---------------------------------------------------------------------------
+
+
+def test_transient_correction_blocks_durable_writes():
+    # Pure correction path (no nudge), recorder says transient -> the spawned
+    # fork MUST be configured to block durable writes. This is what makes the
+    # deterministic recurrence guard the single durable gate for the correction
+    # path: the LLM fork cannot persist a one-off on its first sighting.
+    agent = _StubAgent()
+
+    def _recorder(hint):
+        return {"tier": "transient", "durable": False}
+
+    agent._record_turn_correction = _recorder
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=False)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["block_durable_writes"] is True
+
+
+def test_durable_correction_does_not_block_writes():
+    # A promotable (recurred / explicit-remember) correction is confirmed; its
+    # durable write already happened via the deterministic path. The fork keeps
+    # write capability (it may embed the confirmed preference into a skill).
+    agent = _StubAgent()
+
+    def _recorder(hint):
+        return {"tier": "durable", "durable": True}
+
+    agent._record_turn_correction = _recorder
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=False)
+    assert agent.spawned[0]["block_durable_writes"] is False
+
+
+def test_nudge_review_unchanged_does_not_block_writes():
+    # Pre-existing NUDGE-driven (non-correction) review behavior is out of
+    # scope: a healthy nudge review keeps full durable-write capability.
+    agent = _StubAgent()
+    _run(agent, messages=_normal_messages(), interrupted=False,
+         should_review_memory=True)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["correction_hint"] is None
+    assert agent.spawned[0]["block_durable_writes"] is False

--- a/tests/agent/test_turn_finalizer_correction_review.py
+++ b/tests/agent/test_turn_finalizer_correction_review.py
@@ -1,0 +1,234 @@
+"""Lean Phase 1 — the ``not interrupted`` guard fix in ``finalize_turn``.
+
+Today ``finalize_turn`` only spawns the background review when
+``final_response and not interrupted and (review_memory or review_skills)``
+(agent/turn_finalizer.py:427). That SKIPS the loudest corrections: an
+interrupted or denied turn never reaches the reviewer.
+
+Phase 1: a turn that IS a structured correction (INTERRUPT / DENY / STEER)
+still triggers the review, even when ``interrupted`` is true or no nudge
+counter fired, and the spawn is passed a hint of the correction kind so the
+reviewer captures THAT. Non-correction interrupted turns and normal turns
+keep their exact prior behavior.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+
+
+class _StubBudget:
+    used = 1
+    max_total = 10
+    remaining = 9
+
+
+class _StubCompressor:
+    last_prompt_tokens = 0
+
+
+class _StubAgent:
+    def __init__(self):
+        self.max_iterations = 10
+        self.iteration_budget = _StubBudget()
+        self.context_compressor = _StubCompressor()
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-1"
+        self.quiet_mode = True
+        self.platform = "cli"
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.spawned = []  # records (review_memory, review_skills, correction_hint)
+        for attr in (
+            "session_input_tokens", "session_output_tokens",
+            "session_cache_read_tokens", "session_cache_write_tokens",
+            "session_reasoning_tokens", "session_prompt_tokens",
+            "session_completion_tokens", "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+
+    # cleanup surfaces — all no-ops here
+    def _save_trajectory(self, *a, **k):
+        pass
+
+    def _cleanup_task_resources(self, *a, **k):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, *a, **k):
+        pass
+
+    def _persist_session(self, *a, **k):
+        pass
+
+    def _emit_status(self, *a, **k):
+        pass
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    def _handle_max_iterations(self, messages, n):
+        return "SUMMARY"
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **k):
+        pass
+
+    def _spawn_background_review(self, *, messages_snapshot, review_memory,
+                                review_skills, correction_hint=None):
+        self.spawned.append({
+            "review_memory": review_memory,
+            "review_skills": review_skills,
+            "correction_hint": correction_hint,
+        })
+
+
+def _normal_messages():
+    return [
+        {"role": "user", "content": "do a thing"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def _deny_messages():
+    return [
+        {"role": "user", "content": "clean up"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(
+            {"error": "Command denied: rm -rf build", "status": "blocked"})},
+    ]
+
+
+def _run(agent, *, messages, interrupted, final_response="ok",
+         should_review_memory=False, interrupt_message=None,
+         turn_exit_reason="text_response(stop)"):
+    agent._interrupt_message = interrupt_message
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=interrupted,
+        failed=False,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do a thing",
+        original_user_message="do a thing",
+        _should_review_memory=should_review_memory,
+        _turn_exit_reason=turn_exit_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corrections now trigger the review (the fix).
+# ---------------------------------------------------------------------------
+
+
+def test_denied_turn_triggers_review_with_hint():
+    agent = _StubAgent()
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=False)
+    assert len(agent.spawned) == 1
+    hint = agent.spawned[0]["correction_hint"]
+    assert hint is not None
+    assert hint["kind"] == "DENY"
+
+
+def test_interrupted_correction_triggers_review_with_hint():
+    agent = _StubAgent()
+    _run(agent, messages=_normal_messages(), interrupted=True,
+         final_response="", interrupt_message="no, use TypeScript instead",
+         turn_exit_reason="interrupted_by_user")
+    assert len(agent.spawned) == 1
+    hint = agent.spawned[0]["correction_hint"]
+    assert hint["kind"] == "INTERRUPT"
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION — non-corrections behave exactly as before.
+# ---------------------------------------------------------------------------
+
+
+def test_normal_turn_no_nudge_does_not_review():
+    # No correction, no nudge counter -> no spawn (unchanged behavior).
+    agent = _StubAgent()
+    _run(agent, messages=_normal_messages(), interrupted=False,
+         should_review_memory=False)
+    assert agent.spawned == []
+
+
+def test_normal_turn_with_nudge_still_reviews():
+    # The existing counter-driven path still fires for healthy turns.
+    agent = _StubAgent()
+    _run(agent, messages=_normal_messages(), interrupted=False,
+         should_review_memory=True)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["review_memory"] is True
+    # Healthy turn -> no correction hint.
+    assert agent.spawned[0]["correction_hint"] is None
+
+
+def test_plain_interrupt_without_redirect_does_not_review():
+    # User hit stop, gave no redirect, no nudge -> NOT a learnable correction.
+    # Prior behavior (skip) preserved.
+    agent = _StubAgent()
+    _run(agent, messages=_normal_messages(), interrupted=True,
+         final_response="", interrupt_message=None,
+         turn_exit_reason="interrupted_by_user")
+    assert agent.spawned == []
+
+
+def test_correction_hint_carries_tier_from_recorder():
+    # The one-off-leak guard: the recorder's tier decision is threaded into
+    # the hint so the review prompt can stay transient-aware (it must not push
+    # the LLM to durably persist a first-sighting one-off). Here the recorder
+    # reports transient -> the hint must say transient.
+    agent = _StubAgent()
+
+    def _recorder(hint):
+        return {"tier": "transient", "durable": False}
+
+    agent._record_turn_correction = _recorder
+    _run(agent, messages=_deny_messages(), interrupted=False)
+    assert len(agent.spawned) == 1
+    hint = agent.spawned[0]["correction_hint"]
+    assert hint["tier"] == "transient"
+    assert hint["durable"] is False
+
+
+def test_correction_hint_tier_durable_when_recorder_promotes():
+    agent = _StubAgent()
+
+    def _recorder(hint):
+        return {"tier": "durable", "durable": True}
+
+    agent._record_turn_correction = _recorder
+    _run(agent, messages=_deny_messages(), interrupted=False)
+    hint = agent.spawned[0]["correction_hint"]
+    assert hint["tier"] == "durable"
+    assert hint["durable"] is True

--- a/tests/agent/test_turn_finalizer_correction_review.py
+++ b/tests/agent/test_turn_finalizer_correction_review.py
@@ -1,15 +1,23 @@
-"""Lean Phase 1 — the ``not interrupted`` guard fix in ``finalize_turn``.
+"""Lean Phase 1 — correction-driven review in ``finalize_turn``.
 
-Today ``finalize_turn`` only spawns the background review when
-``final_response and not interrupted and (review_memory or review_skills)``
-(agent/turn_finalizer.py:427). That SKIPS the loudest corrections: an
-interrupted or denied turn never reaches the reviewer.
+The legacy gate only spawned the background review when
+``final_response and not interrupted and (review_memory or review_skills)``.
+That SKIPPED the loudest corrections: an interrupted or denied turn never
+reached the learner.
 
-Phase 1: a turn that IS a structured correction (INTERRUPT / DENY / STEER)
-still triggers the review, even when ``interrupted`` is true or no nudge
-counter fired, and the spawn is passed a hint of the correction kind so the
-reviewer captures THAT. Non-correction interrupted turns and normal turns
-keep their exact prior behavior.
+Phase 1 (current contract, routed through ``agent/correction_review.py``):
+
+* A structured correction (INTERRUPT / DENY / STEER) is DETECTED + RECORDED
+  deterministically on EVERY turn — even interrupted/denied — via the
+  ``_record_turn_correction`` hook (the CorrectionLearner). This always runs.
+* The expensive LLM review fork is spawned ONLY when a nudge counter fired
+  (the legacy healthy-completion path) OR the correction was promoted to
+  DURABLE. A pure-transient correction with no nudge is recorded but does NOT
+  spawn the fork (it would be write-blocked anyway — wasted aux-model spend).
+* X1 (universal): whenever the fork DOES spawn while an unpromoted correction
+  is present, it runs with ``block_durable_writes=True`` so the deterministic
+  recurrence guard stays the single durable gate.
+* Non-correction normal/nudge turns keep their exact prior behavior.
 """
 
 from __future__ import annotations
@@ -108,6 +116,30 @@ class _StubAgent:
         })
 
 
+def _transient_recorder(agent):
+    """Attach a recorder that captures hints and reports transient."""
+    recorded = []
+
+    def _rec(hint):
+        recorded.append(hint)
+        return {"tier": "transient", "durable": False}
+
+    agent._record_turn_correction = _rec
+    return recorded
+
+
+def _durable_recorder(agent):
+    """Attach a recorder that captures hints and promotes to durable."""
+    recorded = []
+
+    def _rec(hint):
+        recorded.append(hint)
+        return {"tier": "durable", "durable": True}
+
+    agent._record_turn_correction = _rec
+    return recorded
+
+
 def _normal_messages():
     return [
         {"role": "user", "content": "do a thing"},
@@ -152,22 +184,55 @@ def _run(agent, *, messages, interrupted, final_response="ok",
 
 
 # ---------------------------------------------------------------------------
-# Corrections now trigger the review (the fix).
+# Corrections are DETECTED + RECORDED deterministically (always). The fork is
+# the EXPENSIVE step and is reserved for a nudge or a DURABLE promotion.
 # ---------------------------------------------------------------------------
 
 
-def test_denied_turn_triggers_review_with_hint():
+def test_denied_correction_recorded_but_no_fork_without_nudge():
+    # A genuine denial with no nudge and no promotion: the deterministic
+    # recorder captures it, but the LLM fork is NOT spawned (it would be
+    # write-blocked anyway — wasted aux-model spend). This is the DEFECT 4
+    # optimization AND proves the loud denial is still captured.
     agent = _StubAgent()
+    recorded = _transient_recorder(agent)
     _run(agent, messages=_deny_messages(), interrupted=False,
          should_review_memory=False)
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "DENY"
+    assert agent.spawned == []  # no fork for a pure-transient correction
+
+
+def test_interrupted_correction_recorded_but_no_fork_without_nudge():
+    # The loudest correction (user interrupted + redirected) is captured even
+    # though the legacy ``not interrupted`` gate dropped it — recorded
+    # deterministically, no fork without a nudge.
+    agent = _StubAgent()
+    recorded = _transient_recorder(agent)
+    _run(agent, messages=_normal_messages(), interrupted=True,
+         final_response="", interrupt_message="no, use TypeScript instead",
+         turn_exit_reason="interrupted_by_user")
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "INTERRUPT"
+    assert agent.spawned == []
+
+
+def test_denied_correction_with_nudge_spawns_fork_with_hint():
+    # When a nudge co-occurs, the fork spawns and carries the correction hint.
+    agent = _StubAgent()
+    _transient_recorder(agent)
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=True)
     assert len(agent.spawned) == 1
     hint = agent.spawned[0]["correction_hint"]
     assert hint is not None
     assert hint["kind"] == "DENY"
 
 
-def test_interrupted_correction_triggers_review_with_hint():
+def test_durable_correction_spawns_fork_with_hint():
+    # A promoted (durable) correction spawns the fork even with no nudge.
     agent = _StubAgent()
+    _durable_recorder(agent)
     _run(agent, messages=_normal_messages(), interrupted=True,
          final_response="", interrupt_message="no, use TypeScript instead",
          turn_exit_reason="interrupted_by_user")
@@ -211,17 +276,14 @@ def test_plain_interrupt_without_redirect_does_not_review():
 
 
 def test_correction_hint_carries_tier_from_recorder():
-    # The one-off-leak guard: the recorder's tier decision is threaded into
-    # the hint so the review prompt can stay transient-aware (it must not push
-    # the LLM to durably persist a first-sighting one-off). Here the recorder
-    # reports transient -> the hint must say transient.
+    # The one-off-leak guard: the recorder's tier decision is threaded into the
+    # hint so the review prompt can stay transient-aware. A co-occurring nudge
+    # makes the fork spawn so the hint is observable; the recorder reports
+    # transient -> the hint must say transient.
     agent = _StubAgent()
-
-    def _recorder(hint):
-        return {"tier": "transient", "durable": False}
-
-    agent._record_turn_correction = _recorder
-    _run(agent, messages=_deny_messages(), interrupted=False)
+    _transient_recorder(agent)
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=True)
     assert len(agent.spawned) == 1
     hint = agent.spawned[0]["correction_hint"]
     assert hint["tier"] == "transient"
@@ -230,11 +292,7 @@ def test_correction_hint_carries_tier_from_recorder():
 
 def test_correction_hint_tier_durable_when_recorder_promotes():
     agent = _StubAgent()
-
-    def _recorder(hint):
-        return {"tier": "durable", "durable": True}
-
-    agent._record_turn_correction = _recorder
+    _durable_recorder(agent)
     _run(agent, messages=_deny_messages(), interrupted=False)
     hint = agent.spawned[0]["correction_hint"]
     assert hint["tier"] == "durable"
@@ -242,28 +300,38 @@ def test_correction_hint_tier_durable_when_recorder_promotes():
 
 
 # ---------------------------------------------------------------------------
-# X1 ENFORCEMENT — the durable-write capability of the review fork is GATED,
-# not merely advised. A transient (first-sighting) correction that is the SOLE
-# reason the review spawned must hand the fork ``block_durable_writes=True`` so
-# the fork's runtime tool whitelist strips the durable memory/skill writers.
+# X1 ENFORCEMENT + no-waste spawn rule.
+#   * A transient correction NEVER persists durable via the fork: when the fork
+#     spawns at all (because a nudge co-occurred) it is handed
+#     ``block_durable_writes=True`` (universal — DEFECT 3).
+#   * A pure-transient correction with no nudge does NOT spawn the fork at all
+#     (DEFECT 4 — no wasted aux-model call).
+#   * A durable correction keeps write capability.
 # ---------------------------------------------------------------------------
 
 
-def test_transient_correction_blocks_durable_writes():
-    # Pure correction path (no nudge), recorder says transient -> the spawned
-    # fork MUST be configured to block durable writes. This is what makes the
-    # deterministic recurrence guard the single durable gate for the correction
-    # path: the LLM fork cannot persist a one-off on its first sighting.
+def test_transient_correction_with_nudge_blocks_durable_writes():
+    # DEFECT 3 (universal X1): a transient correction co-occurring with a nudge
+    # MUST hand the spawned fork block_durable_writes=True. The nudge's own
+    # durable write is deferred to the next nudge interval so a one-off can
+    # never ride a nudge into a durable write.
     agent = _StubAgent()
-
-    def _recorder(hint):
-        return {"tier": "transient", "durable": False}
-
-    agent._record_turn_correction = _recorder
+    _transient_recorder(agent)
     _run(agent, messages=_deny_messages(), interrupted=False,
-         should_review_memory=False)
+         should_review_memory=True)
     assert len(agent.spawned) == 1
     assert agent.spawned[0]["block_durable_writes"] is True
+
+
+def test_pure_transient_correction_no_nudge_does_not_spawn_fork():
+    # DEFECT 4: pure-transient correction, no nudge -> NO fork spawned at all.
+    # The deterministic CorrectionLearner already recorded it; the fork would be
+    # write-blocked, so spawning it would burn an aux-model call for nothing.
+    agent = _StubAgent()
+    _transient_recorder(agent)
+    _run(agent, messages=_deny_messages(), interrupted=False,
+         should_review_memory=False)
+    assert agent.spawned == []
 
 
 def test_durable_correction_does_not_block_writes():
@@ -271,13 +339,10 @@ def test_durable_correction_does_not_block_writes():
     # durable write already happened via the deterministic path. The fork keeps
     # write capability (it may embed the confirmed preference into a skill).
     agent = _StubAgent()
-
-    def _recorder(hint):
-        return {"tier": "durable", "durable": True}
-
-    agent._record_turn_correction = _recorder
+    _durable_recorder(agent)
     _run(agent, messages=_deny_messages(), interrupted=False,
          should_review_memory=False)
+    assert len(agent.spawned) == 1
     assert agent.spawned[0]["block_durable_writes"] is False
 
 

--- a/tests/agent/test_turn_finalizer_correction_review.py
+++ b/tests/agent/test_turn_finalizer_correction_review.py
@@ -100,7 +100,13 @@ class _StubAgent:
         return None
 
     def clear_interrupt(self):
-        pass
+        # Mirror production AIAgent.clear_interrupt (run_agent.py): null the
+        # interrupt message + request flag. A no-op stub here would MASK the
+        # capture-before-clear bug — finalize_turn calls clear_interrupt()
+        # ~46 lines BEFORE the correction detector reads _interrupt_message,
+        # so a stub that never nulls it lets the dead INTERRUPT branch "pass".
+        self._interrupt_message = None
+        self._interrupt_requested = False
 
     def _sync_external_memory_for_turn(self, **k):
         pass
@@ -239,6 +245,32 @@ def test_durable_correction_spawns_fork_with_hint():
     assert len(agent.spawned) == 1
     hint = agent.spawned[0]["correction_hint"]
     assert hint["kind"] == "INTERRUPT"
+
+
+def test_interrupt_message_captured_before_clear_through_real_ordering():
+    # DEFECT 1 regression — capture-before-clear, proven through the REAL
+    # finalize_turn ordering with the production-mirroring stub.
+    #
+    # finalize_turn calls agent.clear_interrupt() (which nulls _interrupt_message,
+    # exactly as production AIAgent.clear_interrupt does) ~46 lines BEFORE the
+    # correction detector reads the interrupt message. If finalize_turn does not
+    # capture the message into a LOCAL before that clear, the INTERRUPT branch is
+    # dead on the default runtime. This test pins both halves of the fix:
+    #   * clear_interrupt actually ran  -> the live attribute is None afterwards
+    #   * the INTERRUPT correction was STILL detected, carrying the exact message
+    #     -> the captured local (not the already-nulled attribute) fed detection.
+    agent = _StubAgent()
+    recorded = _transient_recorder(agent)
+    _run(agent, messages=_normal_messages(), interrupted=True,
+         final_response="", interrupt_message="stop, use the staging DB",
+         turn_exit_reason="interrupted_by_user")
+    # Production-mirroring stub nulled the live attribute -> proves clear ran.
+    assert agent._interrupt_message is None
+    # Yet the correction was detected with the real redirect text -> proves the
+    # message was captured BEFORE the clear and threaded into detection.
+    assert len(recorded) == 1
+    assert recorded[0]["kind"] == "INTERRUPT"
+    assert recorded[0]["context"] == "stop, use the staging DB"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1674,6 +1674,12 @@ def check_all_command_guards(command: str, env_type: str,
                     "description": combined_desc,
                     "outcome": outcome,
                     "user_consent": False,
+                    # Explicit, unambiguous marker that a real USER actively
+                    # denied this command (not a timeout, not an automatic
+                    # safety/validation block). Correction-learning keys on this
+                    # to avoid minting false "user corrections" from automatic
+                    # blocks. True only on an explicit deny, never on timeout.
+                    "user_denied": outcome == "denied",
                 }
 
             # User approved — persist based on scope (same logic as CLI)
@@ -1750,6 +1756,8 @@ def check_all_command_guards(command: str, env_type: str,
             "description": combined_desc,
             "outcome": "denied",
             "user_consent": False,
+            # Explicit user-denial marker (see the gateway path above).
+            "user_denied": True,
         }
 
     # Persist approval for each warning individually

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2333,15 +2333,20 @@ def terminal_tool(
                     f"Command denied: {desc}. "
                     "Use the approval prompt to allow it, or rephrase the command."
                 )
-                return json.dumps(
-                    {
-                        "output": "",
-                        "exit_code": -1,
-                        "error": approval.get("message", fallback_msg),
-                        "status": "blocked",
-                    },
-                    ensure_ascii=False,
-                )
+                blocked_result = {
+                    "output": "",
+                    "exit_code": -1,
+                    "error": approval.get("message", fallback_msg),
+                    "status": "blocked",
+                }
+                # Propagate the explicit user-denial marker ONLY when a real
+                # user actively denied this command at the approval prompt. An
+                # automatic safety/validation block (hardline, sudo guard, smart
+                # deny, cron, timeout) leaves this unset, so correction-learning
+                # never mistakes an automatic block for a user correction.
+                if approval.get("user_denied"):
+                    blocked_result["user_denied"] = True
+                return json.dumps(blocked_result, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user
             if approval.get("user_approved"):
                 desc = approval.get("description", "flagged as dangerous")


### PR DESCRIPTION
## Lean Phase 1 — learn from user corrections (per-user Fast Loop)

**Do not merge.** This is a fleet-affecting change to the core agent loop and needs owner review.

### Principle
A real user correcting a real agent on a real task is the highest-signal feedback an agent gets. Today Hermes captures *some* of it (the post-turn LLM `background_review` writes preferences to per-profile memory/skills) but misses the loudest signals: interrupted and denied turns are skipped by the `not interrupted` guard in `agent/turn_finalizer.py`.

This is the smallest end-to-end vertical slice that closes that gap **safely**, per-user only. Full design in `.plans/learn-from-user-corrections-SPEC.md`.

### What this builds (lean scope)
1. **Deterministic correction detection** — `agent/correction_learning.py::detect_correction` classifies a completed turn as `INTERRUPT` / `DENY` / `STEER` from runtime markers only (no fuzzy text regex, no LLM). Returns a small `CorrectionRecord`.
2. **Stop skipping corrections** — both turn-finalize paths now detect + record a structured correction even when interrupted/denied. Non-correction interrupted turns and normal turns keep their exact prior behavior. A tier-aware hint is passed to the reviewer.
3. **Generalization guard (load-bearing)** — a captured correction is **TRANSIENT by default**. It promotes to **DURABLE** (a write to the per-profile memory store, which re-injects next session via `MemoryStore.load_from_disk`) ONLY on evidence: the same signature recurs across **≥ 2 distinct sessions** -- the sole Phase-1 production durable trigger. (An explicit "remember this" promotion exists as a tested `record(remember=True)` seam but is **deferred / not wired** to any production caller in Phase 1.) Minimal recurrence tracker (signature → distinct sessions) in a fail-open per-profile JSON store. Promotion is idempotent.
4. **Provenance + unlearn** — every durable item is tagged with origin signal kind, session, signature, timestamps, and promotion reason. `unlearn(provenance_id)` removes the durable item from the memory store AND resets the signature's recurrence evidence. Reversible by construction, and now exposed as a runtime CLI surface (`hermes corrections list` / `unlearn <id>`).

### Defect fixes after independent review (X1, X2)

A second independent review found two serious defects in the original slice. Both are now fixed with tests.

**X1 — the deterministic guard is now ACTUALLY the single durable gate for the correction path (was advisory only).**
The correction-triggered review forces the background-review LLM fork to run, and that fork holds the memory/skill **WRITE** toolset and shares the parent's `_memory_store`. In the original slice, the only thing stopping a **transient** one-off correction from being written durably by that LLM was an advisory preamble — *not enforcement*. Now **enforced, not instructed**: when a correction is present and not yet durable, the fork is built with `block_durable_writes=True`. Its runtime tool whitelist (`_review_tool_whitelist`) **strips the durable writers** (`memory`, `skill_manage`), so `get_pre_tool_call_block_message` denies any durable write at dispatch. Durable persistence for the correction path then happens **only** through the deterministic `CorrectionLearner` promotion (recurrence ≥ 2 or explicit remember). The advisory preamble remains as defense-in-depth. (See "audit round 2" below — this block is now **universal** across the nudge co-occurrence case.)

**X2 — `DENY` now fires only on a genuine USER denial, not on automatic blocks.**
`_detect_deny` keyed on `status == "blocked"` in tool-result content. But automatic terminal blocks — the dangerous-command denial and the workdir shell-injection validator in `tools/terminal_tool.py` — also emit `status: "blocked"` with **no user involvement**, so recurring automatic blocks minted false "user corrections". A real user denial is now stamped with an explicit `user_denied` marker at the user-denial sites (`tools/approval.py`), propagated into the terminal tool result **only** for genuine denials (`tools/terminal_tool.py`), and `_detect_deny` fires solely on that marker. Automatic safety/validation blocks (and timeouts) are excluded.

### Audit fixes — round 2 (CI-red, codex parity, universal X1, no-fork optimization, atomicity)

A third adversarial audit (6/10) flagged five issues. All fixed surgically with tests.

1. **CI red (highest priority) — fixed.** The `corrections` subcommand was registered in `main()` but missing from the `_BUILTIN_SUBCOMMANDS` frozenset, so `tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand` (a required check) failed. `"corrections"` is now in the frozenset; the gating test is green.

2. **`codex_runtime.py` parity — DONE (previously deferred).** Correction detection + recurrence recording + the spawn/block decision are extracted into a shared seam, **`agent/correction_review.py::decide_correction_review`**. Both `turn_finalizer.finalize_turn` and the Codex finalizer (`codex_runtime.run_codex_app_server_turn`) now route through it, so they **cannot drift**. The Codex path previously carried an unmodified nudge-only gate and silently never learned from a correction — it is now at parity for the runtime-independent kinds -- it detects + records `DENY` / `STEER` under the same spawn/block rules (codex `INTERRUPT` stays blocked by a pre-existing interrupt-propagation gap; see round 3 #4). New test: `tests/agent/test_codex_runtime_correction_review.py`.

3. **X1 co-occurrence hole — now UNIVERSAL.** `block_durable_writes` was `(correction present AND not durable AND not _healthy_review)`. The `not _healthy_review` term left a hole: a transient correction co-occurring with a nudge kept durable writers. Now `block_durable_writes = (correction present AND not durable)`, unconditional. A co-occurring nudge's own durable write is deferred to the next nudge interval — the accepted safety trade — so a one-off can never ride a nudge into the durable store.

4. **No wasted aux-model spend on pure-transient corrections.** A pure-transient correction (no nudge, not promoted) used to still spawn the LLM review fork, which is barred from durable writes anyway — burning an aux-model call for nothing. The fork now spawns **only** when a nudge independently fired **OR** the correction was promoted to durable. A pure-transient-no-nudge correction is still recorded deterministically by the `CorrectionLearner`; it just no longer spawns the fork.

5. **Promote atomicity.** `CorrectionLearner._promote` wrote the durable `memory_sink.add(...)` line **before** the ledger entry, so a failure between them orphaned a `MEMORY.md` line with no ledger entry (un-unlearnable). Order is reversed: the ledger entry is written **first** (`injected: false`), then the memory line, then the flag is patched to `true`. A failure now leaves a cleanable ledger entry without a memory line rather than an un-unlearnable orphan. Still fail-open.

### Audit fixes -- round 3 (iteration-2 audit, 6/10): INTERRUPT revival + honest scoping

A fourth adversarial audit (6/10) flagged four issues, all surgically fixed with tests (TDD -- the stub un-masking turns the INTERRUPT tests **red** against the old code; the capture fix turns them **green**).

1. **DEFECT 1 -- INTERRUPT capture-before-clear.** `finalize_turn` called `clear_interrupt()` (which nulls `_interrupt_message`) ~46 lines **before** the detector read it, so the `INTERRUPT` branch was dead on the default runtime. Fixed: capture `_interrupt_message` into a local **before** the clear, and feed that local to detection and `result["interrupt_message"]`. `agent/turn_finalizer.py`.

2. **DEFECT 2 -- tests no longer mask DEFECT 1.** The `_StubAgent` / `_Agent.clear_interrupt()` stubs were no-ops that never nulled `_interrupt_message`, so INTERRUPT tests passed against broken code. The stubs now mirror production (null the message + request flag). New test `test_interrupt_message_captured_before_clear_through_real_ordering` asserts -- through the **real** `finalize_turn` ordering -- that `clear_interrupt` ran (the attribute is `None` afterwards) yet the INTERRUPT correction was still detected with its exact redirect text, so the ordering cannot silently regress.

3. **DEFECT 3 -- explicit "remember this" downgraded to deferred.** The docstrings/comments claimed explicit-remember as a live durable trigger, but no production caller threads `remember=True` (`run_agent.py` calls `record(rec)` with it defaulting `False`). Downgraded: **cross-session recurrence (≥ 2 distinct sessions) is the sole Phase-1 production durable trigger**; the `remember` param is kept as a unit-tested seam, documented as not-yet-wired. No fuzzy "remember" text detector was built (out of scope).

4. **DEFECT 4 -- honest codex INTERRUPT scoping.** **Default runtime:** `INTERRUPT` / `DENY` / `STEER` all live after DEFECT 1. **Codex runtime:** `DENY` / `STEER` live, `INTERRUPT` blocked by a pre-existing codex interrupt-propagation gap (`AIAgent.request_interrupt` has no production callers; codex `interrupted` is deadline-only) -- deferred, **not** this feature's code. Code comments and this PR body now state this explicitly; no claim implies codex INTERRUPT works.

### The guard (transient → durable)
- First sighting → **transient**, nothing written durably, would not inject next session. A pure transient correction with no nudge does **not** spawn the LLM fork at all (round 2 #4); when the fork does spawn it has **no durable-write capability** (X1).
- Second sighting in a **distinct session** → **durable**, written to `MEMORY.md` where the next session's `load_from_disk` reads it.
- Same-session repeat does **not** count as recurrence (over-promotion guard).
- Explicit "remember this" durable promotion is **deferred** (round 3 #3) -- the `record(remember=True)` seam exists and is unit-tested, but no production caller sets it in Phase 1.
- Everything is **fail-open**: a broken store degrades to transient-only and never crashes a turn.

### Tests
Implemented under `tests/agent/` (+ `tests/hermes_cli/`):
- **Transfer/promotion**: signature seen once → transient (no durable write, no injection); seen a second time in a new session → durable write lands on the injection path.
- **Spawn/block contract (round 2)**: pure-transient + no nudge → **no fork** (assert spawn not called); transient + nudge → fork spawned with `block_durable_writes=True` (universal X1); durable correction → fork spawned with `block=False`; nudge-only → unchanged.
- **Codex parity (round 2)**: `test_codex_runtime_correction_review.py` proves the Codex path detects + records a `DENY` correction and obeys the same spawn/block rules.
- **X1 enforcement (real negative control)**: the transient correction-review fork's runtime whitelist excludes `memory` and `skill_manage`; `block_durable_writes` is threaded end-to-end through the spawn wiring.
- **X2 discrimination**: a `user_denied` tool result IS detected as a `DENY`; an automatic dangerous-command block and a workdir-validation block are NOT.
- **Explicit remember** → `record(remember=True)` promotes durably at the **unit level** (a tested seam; not wired to production in Phase 1, round 3 #3). **Regression**: non-correction and plain interrupted turns behave exactly as before. **Provenance + unlearn**: provenance recorded; unlearn removes the durable item, it stops injecting, recurrence is reset; the `hermes corrections unlearn` CLI reverses a durable item end-to-end.

All correction-learning, startup-gating, and `background_review` regression suites green (119 in the targeted set, incl. the new capture-before-clear test).

### Deferred to later phases (explicitly NOT built)
- **Integration test against a real `MemoryStore`** — the durable-write tests use a fake sink; an end-to-end test through the live `MemoryStore` injection path is deferred.
- **`trust_tier` on durable entries** — durable ledger entries are not yet tagged with a trust tier for downstream weighting.
- Multi-dimensional evidence vector, fleet/global consensus path, calibration, adversarial counter-reviewer, TTL / model-version tagging, config-over-prompt routing.

> Resolved since the original description: `codex_runtime.py` parity (round 2 #2) and the transient/nudge co-occurrence boundary (round 2 #3, now closed by universal X1) are no longer deferred.

### INTERRUPT capture-before-clear -- FIXED (round 3)
Previously flagged here as a known pre-existing no-op: `finalize_turn` called `clear_interrupt()` (nulling `_interrupt_message`) **before** the detector read it, so the `INTERRUPT` kind never fired in production -- and the unit tests masked it because the stub's `clear_interrupt` was a no-op. **Now fixed** (round 3 #1-#2): the message is captured into a local before the clear and threaded into detection, and the stubs mirror production.

**Runtime honesty.** On the **default runtime** all three kinds -- `INTERRUPT` / `DENY` / `STEER` -- are now live. On the **codex runtime**, `DENY` / `STEER` work (they read from the messages list) but `INTERRUPT` stays inert: the codex runtime never propagates a user interrupt into its session (`AIAgent.request_interrupt` has no production callers; codex `interrupted` is only a deadline-timeout), so `_interrupt_message` is never set there. That codex interrupt-propagation gap is **pre-existing and out of scope** -- deferred, not introduced here.

### Files
- `agent/correction_learning.py` — detector (DENY keys on `user_denied`), learner, guard, provenance, unlearn; `_promote` ledger-first ordering (round 2 #5)
- `agent/correction_review.py` — **new shared seam**: `decide_correction_review` (detection + record + spawn/block decision) used by both finalizers (round 2 #2)
- `agent/turn_finalizer.py` — routes through the shared seam; universal X1 block + no-fork-for-pure-transient (round 2 #3, #4); captures the interrupt message **before** `clear_interrupt` (round 3 #1)
- `agent/codex_runtime.py` — routes through the shared seam (codex parity, round 2 #2); honest codex-INTERRUPT scoping comment (round 3 #4)
- `agent/background_review.py` — `_review_tool_whitelist` durable-write gate + tier-aware preamble
- `run_agent.py` — `_spawn_background_review` gate/hint params + `_record_turn_correction`
- `tools/approval.py`, `tools/terminal_tool.py` — explicit `user_denied` marker plumbed to the tool result
- `hermes_cli/corrections_cli.py` + `hermes_cli/main.py` — `corrections list` / `unlearn` CLI surface; `"corrections"` added to `_BUILTIN_SUBCOMMANDS` (round 2 #1)
- test files under `tests/agent/` and `tests/hermes_cli/`

