### PR TITLE
fix(cron): workdir redirects file-edit tools too (enables evolution-pipeline isolation)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2176,6 +2176,93 @@ def strip_reasoning_for_delivery(text: str) -> str:
     ).strip()
 
 
+# Tool-call task id that the top-level cron agent's file/terminal tools collapse
+# to (see tools/terminal_tool._resolve_container_task_id). The split-brain lives
+# on this shared env: its live cwd is file-tool priority #1 and shadows
+# $TERMINAL_CWD (#3) for a workdir job.
+_CRON_FILE_TOOL_TASK_ID = "default"
+
+
+def _seed_workdir_file_tools(workdir: str):
+    """Redirect the FILE-EDIT tools at *workdir* too — not just the terminal.
+
+    ``_run_job_impl`` already points ``TERMINAL_CWD`` at the job's workdir, which
+    the terminal/git tools read live. The file-edit tools (write_file/patch/...)
+    resolve relative paths through ``tools/file_tools._resolve_base_dir``, whose
+    top priority (#1) is the task's *live* terminal-env cwd. In a long-lived
+    gateway/daemon the shared ``"default"`` env still points at the runtime
+    checkout, so it shadows ``TERMINAL_CWD`` (#3): git honours the workdir while
+    ``write_file`` lands in the runtime mirror and dirties it (split-brain).
+
+    The fix is surgical: when such a live env exists, point ITS cwd at the
+    workdir. That single object is what both ``_resolve_base_dir`` (#1) and the
+    shell-backed ``ShellFileOperations`` read, so both file-tool paths follow the
+    workdir. When no live env exists yet the file tools already fall through to
+    ``$TERMINAL_CWD`` (#3) — but a terminal command run *during* the job lazily
+    creates the shared env seeded from ``$TERMINAL_CWD`` = workdir; left alone it
+    would persist and leak the workdir into a later (workdir-less) job (the same
+    way ``TERMINAL_CWD`` already leaks to such an env's git today). The returned
+    token records which case applied so :func:`_restore_workdir_file_tools` can
+    undo exactly what happened.
+
+    Returns an opaque restore token, or ``None`` if the terminal layer is
+    unavailable (fail-open: the job still runs with ``TERMINAL_CWD`` set).
+    """
+    try:
+        from tools import terminal_tool as _tt
+    except Exception:
+        return None
+    key = _CRON_FILE_TOOL_TASK_ID
+    with _tt._env_lock:
+        env = _tt._active_environments.get(key)
+        if env is not None and hasattr(env, "cwd"):
+            prior_cwd = env.cwd
+            env.cwd = workdir
+            return ("existing", env, prior_cwd)
+    return ("absent", None, None)
+
+
+def _restore_workdir_file_tools(token) -> None:
+    """Undo :func:`_seed_workdir_file_tools`.
+
+    ``existing``: restore the env's exact pre-job cwd (including ``None``) under
+    the env lock, mirroring the ``TERMINAL_CWD`` save/restore — the shared
+    ``"default"`` env returns to precisely its prior state, no leak.
+
+    ``absent``: neutralise any ``"default"`` env that was lazily created during
+    the job so its workdir cwd does not leak into a later, possibly
+    workdir-less, job. Non-destructive: only the ``cwd`` attribute is cleared
+    (no ``os.chdir``, no env teardown — the subprocess/container stays alive)
+    and the file-ops cache is dropped so a rebuilt ``ShellFileOperations``
+    re-reads the now-restored cwd. With a cleared cwd the file tools fall back
+    through ``$TERMINAL_CWD`` (restored) to the process cwd, exactly as a
+    workdir-less job expects.
+    """
+    if not token:
+        return
+    kind, env, prior_cwd = token
+    try:
+        from tools import terminal_tool as _tt
+
+        if kind == "existing":
+            with _tt._env_lock:
+                env.cwd = prior_cwd
+            return
+        key = _CRON_FILE_TOOL_TASK_ID
+        with _tt._env_lock:
+            lazy_env = _tt._active_environments.get(key)
+            if lazy_env is not None and hasattr(lazy_env, "cwd"):
+                lazy_env.cwd = None
+        try:
+            from tools.file_tools import clear_file_ops_cache
+
+            clear_file_ops_cache(key)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job."""
     job_id = job["id"]
@@ -2458,9 +2545,17 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         _job_workdir = None
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
+    _workdir_file_redirect = None
     if _job_workdir:
         os.environ["TERMINAL_CWD"] = _job_workdir
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
+        # TERMINAL_CWD above only redirects the terminal/git tools. Also point
+        # the file-edit tools at the workdir so relative writes land there
+        # instead of dirtying the runtime checkout (split-brain — see
+        # _seed_workdir_file_tools). Scoped + restored in finally, exactly like
+        # TERMINAL_CWD; tick() serializes workdir jobs so the shared in-process
+        # env state is safe to mutate for the duration of this job.
+        _workdir_file_redirect = _seed_workdir_file_tools(_job_workdir)
 
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
@@ -3037,6 +3132,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+            # Undo the file-edit-tool workdir redirect (cwd override + live env
+            # cwd), restoring the shared "default" env to its pre-job state.
+            _restore_workdir_file_tools(_workdir_file_redirect)
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -390,3 +391,319 @@ class TestRunJobTerminalCwd:
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+
+# ---------------------------------------------------------------------------
+# scheduler.run_job: workdir redirects BOTH file-edit tools AND terminal/git
+# ---------------------------------------------------------------------------
+
+class TestRunJobWorkdirFileTools:
+    """Regression for the cron-workdir split-brain.
+
+    Setting ``TERMINAL_CWD`` alone redirected only the terminal/git tools. The
+    file-edit tools resolve relative paths through
+    ``tools/file_tools._resolve_base_dir``, whose top priority (#1) is the
+    task's *live* terminal-env cwd. In a long-lived gateway/daemon the shared
+    ``"default"`` env still points at the runtime checkout, so it shadowed
+    ``TERMINAL_CWD`` (#3): git honoured the workdir while ``write_file`` landed
+    in the runtime mirror, dirtying it. run_job must seed the live env cwd to
+    the workdir so BOTH layers resolve there — and leave workdir-less jobs and
+    the live env's prior cwd untouched.
+    """
+
+    @staticmethod
+    def _seed_stale_default_env(runtime_dir):
+        """Install a fake long-lived ``"default"`` terminal env whose live cwd
+        points at *runtime_dir*. Returns a callable that restores prior state.
+        """
+        import tools.file_tools as ft
+        import tools.terminal_tool as tt
+
+        class _FakeEnv:
+            def __init__(self, cwd):
+                self.cwd = cwd
+
+        _sentinel = object()
+        prior_env = tt._active_environments.get("default", _sentinel)
+        prior_override = tt._task_env_overrides.get("default", _sentinel)
+        prior_fileops = ft._file_ops_cache.get("default", _sentinel)
+
+        tt._active_environments["default"] = _FakeEnv(str(runtime_dir))
+        tt._task_env_overrides.pop("default", None)
+        ft._file_ops_cache.pop("default", None)
+
+        def _restore():
+            for store, key, val in (
+                (tt._active_environments, "default", prior_env),
+                (tt._task_env_overrides, "default", prior_override),
+                (ft._file_ops_cache, "default", prior_fileops),
+            ):
+                if val is _sentinel:
+                    store.pop(key, None)
+                else:
+                    store[key] = val
+
+        return _restore
+
+    @staticmethod
+    def _install_capturing_agent(monkeypatch, observed):
+        """Install the shared run_job stubs, then swap in a FakeAgent that, at
+        run-conversation time, records where the file-edit tools and the live
+        terminal env would resolve a relative path to.
+        """
+        import sys
+
+        import tools.file_tools as ft
+        import tools.terminal_tool as tt
+
+        TestRunJobTerminalCwd._install_stubs(monkeypatch, observed)
+
+        class CapturingAgent:
+            def __init__(self, **kwargs):
+                observed["skip_context_files"] = kwargs.get("skip_context_files")
+
+            def run_conversation(self, *_a, **_kw):
+                # File-edit tools (write_file/patch/...) resolve relative paths
+                # against this base dir — the directory a `write_file` lands in.
+                observed["base_dir"] = str(ft._resolve_base_dir("default"))
+                # Terminal/git resolve commands against the live env cwd.
+                env = tt._active_environments.get("default")
+                observed["live_env_cwd"] = getattr(env, "cwd", None)
+                observed["override_during_run"] = tt._task_env_overrides.get(
+                    "default"
+                )
+                observed["terminal_cwd_env"] = os.environ.get("TERMINAL_CWD")
+                return {"final_response": "done", "messages": []}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+        fake_mod = type(sys)("run_agent")
+        fake_mod.AIAgent = CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+    def test_workdir_redirects_file_tools_and_terminal(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        import cron.scheduler as sched
+
+        workdir = tmp_path / "worktree"
+        workdir.mkdir()
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+
+        # A workdir job must never resolve file edits to the runtime mirror.
+        monkeypatch.setenv("HERMES_MODEL", "test-model")
+        monkeypatch.setenv("TERMINAL_CWD", str(runtime))
+
+        restore = self._seed_stale_default_env(runtime)
+        try:
+            observed: dict = {}
+            self._install_capturing_agent(monkeypatch, observed)
+
+            job = {
+                "id": "wd-ft",
+                "name": "wd-ft-job",
+                "workdir": str(workdir),
+                "model": "test-model",
+                "schedule_display": "manual",
+            }
+
+            success, _o, response, error = sched.run_job(job)
+            assert success is True, f"run_job failed: error={error!r} response={response!r}"
+
+            # PRE-FIX this is the runtime checkout (the stale env shadows
+            # TERMINAL_CWD) — the split-brain. POST-FIX it is the workdir.
+            assert observed["base_dir"] == str(workdir.resolve())
+            # Terminal/git resolve to the workdir too.
+            assert Path(observed["live_env_cwd"]).resolve() == workdir.resolve()
+            assert observed["terminal_cwd_env"] == str(workdir)
+
+            # The shared "default" env's live cwd is restored to its pre-job
+            # value (the runtime checkout) — no leak into later jobs.
+            import tools.terminal_tool as tt
+            assert Path(tt._active_environments["default"].cwd).resolve() == runtime.resolve()
+            # And the transient cwd override is gone.
+            assert "default" not in tt._task_env_overrides
+        finally:
+            restore()
+
+    def test_no_workdir_leaves_file_tool_resolution_untouched(self, tmp_path, monkeypatch):
+        """A workdir-less job must NOT redirect the file tools: its relative
+        edits keep resolving against the live (stale) env cwd exactly as before,
+        and no transient cwd override is registered.
+        """
+        from pathlib import Path
+
+        import cron.scheduler as sched
+        import tools.terminal_tool as tt
+
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+
+        monkeypatch.setenv("HERMES_MODEL", "test-model")
+        monkeypatch.setenv("TERMINAL_CWD", str(runtime))
+
+        restore = self._seed_stale_default_env(runtime)
+        try:
+            observed: dict = {}
+            self._install_capturing_agent(monkeypatch, observed)
+
+            job = {
+                "id": "no-wd-ft",
+                "name": "no-wd-ft-job",
+                "workdir": None,
+                "model": "test-model",
+                "schedule_display": "manual",
+            }
+
+            success, *_ = sched.run_job(job)
+            assert success is True
+
+            # Behaviour unchanged: resolution follows the live env (runtime).
+            assert observed["base_dir"] == str(runtime.resolve())
+            assert Path(observed["live_env_cwd"]).resolve() == runtime.resolve()
+            # No cwd override was registered for a workdir-less job.
+            assert observed["override_during_run"] is None
+            assert "default" not in tt._task_env_overrides
+        finally:
+            restore()
+
+    def test_sequential_workdir_then_no_workdir_no_leak(self, tmp_path, monkeypatch):
+        """A workdir job must not leak its cwd into a later workdir-less job that
+        reuses the same shared ``"default"`` env: after the workdir job restores
+        the env, the next job resolves back to the runtime checkout.
+        """
+        from pathlib import Path
+
+        import cron.scheduler as sched
+        import tools.terminal_tool as tt
+
+        workdir = tmp_path / "worktree"
+        workdir.mkdir()
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+
+        monkeypatch.setenv("HERMES_MODEL", "test-model")
+        monkeypatch.setenv("TERMINAL_CWD", str(runtime))
+
+        restore = self._seed_stale_default_env(runtime)
+        try:
+            observed: dict = {}
+            self._install_capturing_agent(monkeypatch, observed)
+
+            wd_job = {
+                "id": "seq-wd",
+                "name": "seq-wd",
+                "workdir": str(workdir),
+                "model": "test-model",
+                "schedule_display": "manual",
+            }
+            ok1, *_ = sched.run_job(wd_job)
+            assert ok1 is True
+            assert observed["base_dir"] == str(workdir.resolve())
+
+            # The shared env is back at the runtime checkout between jobs.
+            assert Path(tt._active_environments["default"].cwd).resolve() == runtime.resolve()
+
+            no_wd_job = {
+                "id": "seq-nowd",
+                "name": "seq-nowd",
+                "workdir": None,
+                "model": "test-model",
+                "schedule_display": "manual",
+            }
+            ok2, *_ = sched.run_job(no_wd_job)
+            assert ok2 is True
+            # No leak: the workdir-less job resolves to the runtime checkout, not
+            # the previous job's workdir.
+            assert observed["base_dir"] == str(runtime.resolve())
+            assert Path(observed["live_env_cwd"]).resolve() == runtime.resolve()
+        finally:
+            restore()
+
+    def test_lazily_created_env_does_not_leak_workdir(self, tmp_path, monkeypatch):
+        """Cold-start path: NO "default" env exists when the workdir job starts,
+        but a terminal command lazily creates one (seeded from TERMINAL_CWD =
+        workdir) during the run. run_job must neutralise that env on cleanup so
+        it does not leak the workdir into a later workdir-less job.
+        """
+        import sys
+        from pathlib import Path
+
+        import cron.scheduler as sched
+        import tools.file_tools as ft
+        import tools.terminal_tool as tt
+
+        workdir = tmp_path / "worktree"
+        workdir.mkdir()
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+
+        monkeypatch.setenv("HERMES_MODEL", "test-model")
+        # TERMINAL_CWD starts at the runtime checkout (a workdir-less default).
+        monkeypatch.setenv("TERMINAL_CWD", str(runtime))
+
+        class _FakeEnv:
+            def __init__(self, cwd):
+                self.cwd = cwd
+
+        # Start with a genuinely empty "default" env slot (snapshot + restore).
+        _sentinel = object()
+        prior_env = tt._active_environments.get("default", _sentinel)
+        prior_override = tt._task_env_overrides.get("default", _sentinel)
+        prior_fileops = ft._file_ops_cache.get("default", _sentinel)
+        tt._active_environments.pop("default", None)
+        tt._task_env_overrides.pop("default", None)
+        ft._file_ops_cache.pop("default", None)
+        try:
+            observed: dict = {}
+            TestRunJobTerminalCwd._install_stubs(monkeypatch, observed)
+
+            class LazyEnvAgent:
+                def __init__(self, **kwargs):
+                    pass
+
+                def run_conversation(self, *_a, **_kw):
+                    # Mimic the first terminal command of the job creating the
+                    # shared env seeded from TERMINAL_CWD (= the workdir).
+                    tt._active_environments["default"] = _FakeEnv(
+                        os.environ.get("TERMINAL_CWD")
+                    )
+                    return {"final_response": "done", "messages": []}
+
+                def get_activity_summary(self):
+                    return {"seconds_since_activity": 0.0}
+
+            fake_mod = type(sys)("run_agent")
+            fake_mod.AIAgent = LazyEnvAgent
+            monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+            wd_job = {
+                "id": "lazy-wd",
+                "name": "lazy-wd",
+                "workdir": str(workdir),
+                "model": "test-model",
+                "schedule_display": "manual",
+            }
+            ok, *_ = sched.run_job(wd_job)
+            assert ok is True
+
+            # The env was created mid-run with cwd = workdir; cleanup must have
+            # cleared that cwd so it no longer shadows a later job's resolution.
+            lazy = tt._active_environments.get("default")
+            assert lazy is not None
+            assert lazy.cwd is None, f"leaked workdir cwd: {lazy.cwd!r}"
+            # Concretely: a relative write now resolves to the runtime checkout
+            # (TERMINAL_CWD restored), NOT the previous job's workdir.
+            assert ft._resolve_base_dir("default") == Path(str(runtime)).resolve()
+        finally:
+            for store, key, val in (
+                (tt._active_environments, "default", prior_env),
+                (tt._task_env_overrides, "default", prior_override),
+                (ft._file_ops_cache, "default", prior_fileops),
+            ):
+                if val is _sentinel:
+                    store.pop(key, None)
+                else:
+                    store[key] = val


### PR DESCRIPTION
## [REVIEW] enables re-pointing evolution pipeline cron jobs to a separate work dir

**DO NOT MERGE** without owner review. Marked `[REVIEW]`: this is the fix that lets the evolution pipeline's cron jobs run against a separate work dir instead of dirtying the runtime mirror.

### The bug (split-brain)
A cron **agent** job's `workdir` only set `TERMINAL_CWD`. The terminal/git tools read `TERMINAL_CWD` live, so **git honoured the workdir** — but the **file-edit tools did not**.

`tools/file_tools._resolve_base_dir` resolves a relative path with this priority:
1. the task's **live terminal-env cwd**
2. a registered task cwd override
3. absolute `$TERMINAL_CWD`
4. `os.getcwd()`

In a long-lived gateway/daemon the shared `"default"` terminal env is still anchored at the **runtime checkout**, so its cwd (priority **#1**) **shadowed** `TERMINAL_CWD` (#3). Result: `write_file`/`patch` landed in the runtime mirror while `git commit` ran in the workdir — a split-brain that **dirtied the runtime checkout** the evolution pipeline mirrors.

### The fix
Scoped entirely to `cron/scheduler.py::_run_job_impl` (workdir setup + `finally`), alongside the existing `TERMINAL_CWD` set/restore:

- **Live env present (the real-world case):** point that env's `.cwd` at the workdir under `_env_lock`, capturing the prior cwd. The one env object backs both `_resolve_base_dir` (#1) and the shell-backed `ShellFileOperations`, so **both file-tool paths follow the workdir**. The prior cwd (incl. `None`) is restored under the lock in `finally`, mirroring the `TERMINAL_CWD` save/restore — no leak.
- **Cold start (no live env yet):** the file tools already fall through to `$TERMINAL_CWD` (#3) = workdir; a terminal command run during the job lazily creates the shared env seeded from it. On cleanup that env's cwd is cleared **non-destructively** (no `os.chdir`, no teardown — the subprocess/container stays alive) and the file-ops cache dropped, so it can't leak the workdir into a later workdir-less job.

**Not touched:** the `no_agent` script path (it already does a real per-job `os.chdir`), workdir-less jobs (verified untouched), and the file/terminal tools themselves.

### Tests (TDD)
New tests in `tests/cron/test_cron_workdir.py`, all failing pre-fix / green post-fix where they target the bug:
- `test_workdir_redirects_file_tools_and_terminal` — reproduces the split (file base dir resolves to the runtime checkout while git follows the workdir). **Fails pre-fix.**
- `test_no_workdir_leaves_file_tool_resolution_untouched` — workdir-less job unaffected.
- `test_sequential_workdir_then_no_workdir_no_leak` — a workdir job doesn't leak into a following workdir-less job.
- `test_lazily_created_env_does_not_leak_workdir` — cold-start env created mid-run is neutralised on cleanup. **Fails pre-fix.**

Suites green locally (pypy3.11): `tests/cron/test_scheduler.py`, `test_cron_no_agent.py`, `test_run_one_job.py`, `test_cron_workdir.py`, `test_parallel_pool.py`, `tests/tools/test_file_tools_cwd_resolution.py`, `test_file_ops_cwd_tracking.py` — **283 passed**. (3 pre-existing failures in `tests/tools/test_file_tools.py` are unrelated macOS `/tmp`→`/private/tmp` symlink mismatches, present without this change.) `ruff check` clean on edited files.

### Cross-review
Reviewed by two non-Claude advisors (Gemini, Kimi). An initial FAIL verdict flagged: (a) restoring `None` cwd + holding the env lock — **fixed**; (b) a lazy-env leak — **addressed** with the cold-start neutralisation + a dedicated regression test. The remaining shared-`"default"`-env concurrency between a sequential workdir job and concurrent parallel workdir-less jobs is a **pre-existing** architectural property (process-global `TERMINAL_CWD` already has the same exposure); true isolation needs task-scoped env keys and is out of scope here.

### Residual risk / merge-readiness
Safe to merge after CI is green. **End-to-end proof still requires** re-enabling the cron `workdir` on osoba and running one live evolution cycle after deploy to confirm the runtime mirror stays clean.
