### PR TITLE
fix(evolution): upstream-sync every 6h to keep batches under the escalation ceiling

### DIFF
--- a/cron/evolution/upstream-sync.yaml
+++ b/cron/evolution/upstream-sync.yaml
@@ -1,5 +1,5 @@
 name: evolution-upstream-sync
-schedule: "0 8 * * *"  # daily 8 AM (before research 09:00) — hold full parity; each run merges ~1 day of upstream commits (small, usually conflict-free), so security fixes land within a day
+schedule: "7 */6 * * *"  # every 6h — upstream now lands >80 commits/day, so a once-daily batch exceeds escalate_if_commits_over (80) and the run escalates instead of merging, letting the fork drift. 4x/day keeps each batch ~40-50 commits: small, usually conflict-free, auto-merged within the guard. Restores the original "one small sync window" assumption without weakening the escalation ceiling.
 enabled: true
 mode: PRIVATE
 


### PR DESCRIPTION
## Fix: run `evolution-upstream-sync` every 6h so it keeps pace with upstream

### Problem (the recurring watchdog alert)
`evolution-upstream-sync` runs once daily (`0 8 * * *`) and auto-merges only when the batch is under `escalate_if_commits_over: 80`. Upstream Hermes Agent now lands **>80 commits/day** (today the fork is **207 behind**, merge-base correct). So every daily run exceeds the ceiling, escalates to the owner instead of merging, and the fork silently drifts — exactly what the watchdog (`UPSTREAM_BEHIND_ALERT = 80`) keeps flagging.

### Why not just raise the ceiling
Raising `escalate_if_commits_over` to ~200 would force the autonomous agent to **blind-resolve large, conflict-heavy merges daily** (today's 207-batch = 44 conflict hunks across 16 files, incl. structural divergences in `docker.yml` and a 16-hunk `web_tools.py`). That is the param-drop trap the escalation guard exists to avoid.

### Fix
Run **every 6h** (`7 */6 * * *`). At ~165 upstream commits/day that is **~40-50 commits per batch** — small, usually conflict-free, auto-merged — which restores the skill's original "one small sync window" assumption **without weakening the escalation ceiling**. The `escalate_if_commits_over=80` / `escalate_if_conflicts_over=10` guards stay intact to catch genuine spikes.

### Sequencing
Effective **once the current 207-commit backlog is cleared** by a one-off catch-up sync (a separate, #634-scale merge). Merging this before the backlog clears just makes the 6h runs escalate 4×/day instead of 1× until then — so land this **with / right after** the catch-up sync.

1-line schedule change; guards and prompt unchanged.
