### PR TITLE
feat(evolution): track upstream RELEASES, not bleeding-edge main

### DIFF
--- a/cron/evolution/upstream-sync.yaml
+++ b/cron/evolution/upstream-sync.yaml
@@ -1,19 +1,21 @@
 name: evolution-upstream-sync
-schedule: "0 8 * * *"  # daily 8 AM (before research 09:00) — hold full parity; each run merges ~1 day of upstream commits (small, usually conflict-free), so security fixes land within a day
+schedule: "0 8 * * *"  # checked daily 8 AM (before research 09:00); merges ONLY when upstream published a new RELEASE since last sync — most days finds BEHIND==0 and stops. Release-tracking (not upstream/main): upstream lands ~300 commits/day, so chasing main stalled the sync; a tagged release (~weekly) is a bounded, stabilized batch.
 enabled: true
 mode: PRIVATE
 
 prompt: |
   You are Hermes Evolution Upstream Sync Manager.
 
-  Your task: keep the fork at FULL PARITY with upstream Hermes Agent by merging
-  upstream/main into our fork (our evolution work is the base; we want everything
-  upstream has, nothing skipped, nothing of ours lost).
+  Your task: keep the fork current with upstream Hermes Agent by merging its
+  latest PUBLISHED RELEASE tag into our fork (our evolution work is the base; a
+  release is a bounded, upstream-stabilized batch — nothing in it skipped, nothing
+  of ours lost). Do NOT merge bleeding-edge upstream/main: being behind unreleased
+  main churn is expected under release-tracking and is not a backlog.
 
-  Use the evolution-upstream-sync skill for instructions (full-merge model:
-  git merge upstream/main → authorship-driven conflict resolution → marker guard →
-  verify → PR; escalate large/entangled merges to the owner instead of
-  blind-resolving).
+  Use the evolution-upstream-sync skill for instructions (release-merge model:
+  find latest upstream release via `gh release view` → git merge <release-tag> →
+  authorship-driven conflict resolution → marker guard → verify → PR; escalate
+  large/entangled merges to the owner instead of blind-resolving).
 
   Output to: ~/.hermes/profiles/user1/evolution/upstream/{current_date}.md
 
@@ -48,20 +50,20 @@ safety:
   require_private_mode: true
   test_after_merge: true
   auto_rollback_on_failure: true
-  # Full-parity model: merge ALL of upstream (no per-run commit cap, no selective
-  # skip). The guard is the ESCALATION threshold — if a run's merge is large
-  # (long catch-up) or conflict-heavy (>10 files, or any in core agent/persistence/
-  # cli), the agent must open a draft PR and hand off to the owner instead of
-  # blind-resolving judgement-heavy conflicts. Routine daily runs (≤ ~80 commits,
-  # ≤10 mechanical conflicts) resolve autonomously.
+  # Release-tracking model: merge the LATEST upstream RELEASE tag (a bounded,
+  # upstream-stabilized batch), NOT bleeding-edge upstream/main. The guard is the
+  # ESCALATION threshold — if a release merge is unusually large (a multi-release
+  # catch-up) or conflict-heavy (>10 files, or any in core agent/persistence/cli),
+  # the agent opens a draft PR and hands off to the owner instead of blind-resolving.
+  # A single release is normally well under these thresholds and resolves autonomously.
   escalate_if_commits_over: 80
   escalate_if_conflicts_over: 10
 
-# Sync strategy — full merge, never selective cherry-pick
+# Sync strategy — merge the latest published release tag, never selective cherry-pick
 strategy:
-  mode: full_merge                      # git merge upstream/main (NOT cherry-pick)
+  mode: release_merge                   # git merge <latest upstream release tag> (NOT upstream/main, NOT cherry-pick)
   conflict_resolution: authorship_first # keep OURS, follow upstream incl. reverts
-  security_fixes: auto_merge
+  security_fixes: auto_merge            # picked up via upstream patch releases (e.g. v2026.5.29.2)
   bug_fixes: auto_merge
   upstream_domain: take_theirs          # desktop/ui-tui/web/unused-platforms — always current
   large_or_entangled: manual_review_required

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -56,15 +56,19 @@ DAILY_STALE_HOURS = 26
 WEEKLY_STALE_HOURS = 8 * 24
 STUCK_RUNNING_HOURS = 12
 MIN_GH_RATE_REMAINING = 200
-# Alert when the fork falls this far behind upstream — the autonomous
-# upstream-sync's own auto-merge ceiling. Past it the daily sync escalates
-# (files an [UPSTREAM] issue) instead of merging, and without this check the
-# fork silently accumulates a backlog for days (2026-06-19 → 301 behind).
-UPSTREAM_BEHIND_ALERT = 80
+# RELEASE-tracking model (2026-07-01): the fork mirrors upstream's PUBLISHED
+# releases, not bleeding-edge ``upstream/main``. Upstream lands ~300 commits/day —
+# chasing every one is an unwinnable tax for a heavily-customized fork, and every
+# daily wholesale ``git merge upstream/main`` exceeded the escalation ceiling and
+# stalled. So the fork tracks upstream RELEASE tags (~weekly/biweekly) and THIS
+# check alerts only when a published upstream release has not been merged within a
+# grace window. Raw "behind upstream/main" (unreleased churn) is expected now and
+# is NOT an anomaly — alerting on it was a permanent false alarm under this model.
+UPSTREAM_RELEASE_GRACE_HOURS = 36  # one+ daily release-sync cycle to absorb a new tag
 
-# Title prefix of the GitHub tracking issue the daily upstream-sync escalates to
-# when it can no longer auto-merge. The watchdog re-files this idempotently on a
-# real escalation so the owner never has to open it by hand (issue #562 was
+# Title prefix of the GitHub tracking issue the release-sync escalates to when it
+# can no longer land a release cleanly. The watchdog re-files this idempotently on
+# a real escalation so the owner never has to open it by hand (issue #562 was
 # opened manually). An OPEN issue carrying this prefix is the idempotency key —
 # its presence blocks creation of a duplicate.
 UPSTREAM_ISSUE_PREFIX = "[UPSTREAM]"
@@ -280,74 +284,188 @@ def _resolve_repo_dir() -> Path | None:
     return None
 
 
+def _utcnow() -> datetime:
+    """Injectable clock seam (tz-aware UTC). Overridden in tests for the grace."""
+    from datetime import timezone
+
+    return datetime.now(timezone.utc)
+
+
 def check_upstream_lag(
     runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
     repo_dir: Path | None = None,
+    clock: Callable[[], datetime] = _utcnow,
 ) -> List[str]:
-    """Alert when the fork is too far behind upstream (sync stuck).
+    """Alert when the fork is missing the latest PUBLISHED upstream release.
 
-    The daily upstream-sync can run "ok" every day yet never MERGE — once a
-    core conflict appears it escalates (files an [UPSTREAM] issue) and the fork
-    falls further behind each day. ``check_jobs`` only sees the job ran, not
-    that nothing landed. This check reads the real distance to ``upstream/main``
-    so the owner is pinged within a day instead of noticing weeks later.
+    RELEASE-tracking model (2026-07-01): the fork mirrors upstream's tagged
+    releases, not bleeding-edge ``upstream/main`` (which lands ~300 commits/day —
+    an unwinnable chase for a heavily-customized fork). So this check no longer
+    alarms on raw "behind upstream/main" (that is expected, unreleased churn).
+    Instead it pings the owner when a published upstream release has NOT been
+    merged into the fork within ``UPSTREAM_RELEASE_GRACE_HOURS`` — i.e. the
+    release-sync is genuinely stuck, not merely a fresh tag awaiting the next run.
 
-    Silent (returns []) when the repo can't be located, when the checkout is a
-    SHALLOW clone or otherwise has no shared history with ``upstream/main`` (the
-    behind-count is meaningless there — see ``_upstream_lag_unmeasurable``), or
-    when ``upstream/main`` is unavailable — best-effort, never a false alarm.
+    Silent (returns []) when the repo can't be located, on a SHALLOW clone or one
+    with no shared history with upstream (the #561 client guard — the release
+    logic NEVER runs there), or on ANY gh/git/parse failure — fail-open, never a
+    false alarm.
     """
     repo = repo_dir or _resolve_repo_dir()
     if repo is None:
         return []
 
     # Installer checkouts are shallow (`git clone --depth 1` in scripts/install.sh
-    # / install.ps1). Across the shallow boundary HEAD shares no ancestry with
-    # upstream/main, so `rev-list --count HEAD..upstream/main` counts ~ALL upstream
-    # history (~13k) instead of the true distance — a phantom "fork is ~13000
-    # commits behind" alarm fired DAILY on every onboarded client (upgrade.sh
-    # registers this watchdog). Shallow is the INTENDED client default, and
-    # upstream-lag is the fork maintainer's concern: the evolution server is a full
-    # clone and still gets the real count. So skip silently here — mirrors the
-    # shallow guards already in hermes_cli/banner.py and hermes_cli/main.py.
+    # / install.ps1) and share no ancestry with upstream — the behind-count is a
+    # phantom there (the 2026-06 "~13000 behind" alarm on every onboarded client).
+    # Shallow is the INTENDED client default; release-tracking is the fork
+    # maintainer's concern (the evolution server is a full clone). Skip silently
+    # BEFORE any release logic — mirrors the guards in hermes_cli/banner.py &
+    # main.py. This guard is what keeps every onboarded client silent.
     if _upstream_lag_unmeasurable(runner, repo):
         return []
 
     try:
-        rc, out = runner(
-            ["git", "-C", str(repo), "rev-list", "--count", "HEAD..upstream/main"]
-        )
-    except Exception:  # noqa: BLE001 — any git/spawn failure: skip silently
+        return _release_lag_alerts(runner, repo, clock)
+    except Exception:  # noqa: BLE001 — the release probe must never crash the watchdog
         return []
-    if rc != 0:
+
+
+def _release_lag_alerts(
+    runner: Callable[[List[str]], Tuple[int, str]],
+    repo: Path,
+    clock: Callable[[], datetime],
+) -> List[str]:
+    """Core release-lag logic (wrapped by check_upstream_lag's fail-open guard)."""
+    slug = _upstream_slug(runner, repo)
+    if not slug:
         return []
+    latest = _latest_upstream_release(runner, slug)
+    if latest is None:
+        return []
+    tag, published = latest
+
+    # Is the release already contained in the fork? `merge-base --is-ancestor`
+    # exits 0 = ancestor (merged), 1 = not an ancestor (missing), 128/other = bad
+    # ref (tag not fetched locally yet) → unmeasurable, stay silent.
     try:
-        behind = int(out.strip().split()[0])
-    except (ValueError, IndexError):
+        rc, _out = runner(
+            ["git", "-C", str(repo), "merge-base", "--is-ancestor", tag, "HEAD"]
+        )
+    except Exception:  # noqa: BLE001
         return []
-    if behind > UPSTREAM_BEHIND_ALERT:
-        # Real escalation on a measurable (full) clone: ensure the tracking issue
-        # exists so the owner doesn't have to open it by hand. Idempotent and
-        # fail-open — never raises, never crashes the watchdog. (#561's shallow /
-        # no-shared-history cases returned above and never reach here.)
-        ahead = _count_ahead_of_upstream(runner, repo)
-        ensure_upstream_issue(behind=behind, ahead=ahead, gh_enabled=UPSTREAM_ISSUE_ENABLED)
-        return [
-            f"upstream sync stuck: fork is {behind} commits behind upstream/main "
-            f"(threshold {UPSTREAM_BEHIND_ALERT}). The daily sync escalates instead "
-            f"of merging — resolve the backlog (see the open [UPSTREAM] issue)."
-        ]
-    return []
+    if rc == 0:
+        return []  # latest release contained → fully current under release-tracking
+    if rc != 1:
+        return []  # bad/unknown ref → cannot measure, never false-alarm
+
+    # Release genuinely not merged. Give the daily release-sync a grace window
+    # before escalating, so a tag published minutes ago (sync simply hasn't run
+    # yet) is not reported as "stuck".
+    if not _release_older_than(published, clock, UPSTREAM_RELEASE_GRACE_HOURS):
+        return []
+
+    behind = _behind_release(runner, repo, tag)
+    ahead = _count_ahead_of_release(runner, repo, tag)
+    ensure_upstream_issue(
+        behind=behind, ahead=ahead, tag=tag, gh_enabled=UPSTREAM_ISSUE_ENABLED
+    )
+    return [
+        f"upstream release {tag} not merged: the fork is missing the latest "
+        f"published upstream release ({behind} commit(s) behind {tag}, released "
+        f">{UPSTREAM_RELEASE_GRACE_HOURS}h ago). The release-sync has not landed "
+        f"it — resolve the sync (see the open [UPSTREAM] issue)."
+    ]
 
 
-def _count_ahead_of_upstream(
+def _upstream_slug(
     runner: Callable[[List[str]], Tuple[int, str]], repo: Path
-) -> int:
-    """Commits the fork has that upstream/main does not (best-effort, 0 on error)."""
+) -> str | None:
+    """``owner/name`` of the ``upstream`` remote, or None (fail-open)."""
+    try:
+        rc, out = runner(["git", "-C", str(repo), "remote", "get-url", "upstream"])
+    except Exception:  # noqa: BLE001
+        return None
+    if rc != 0:
+        return None
+    url = out.strip()
+    if url.endswith(".git"):
+        url = url[:-4]
+    # scp-form (git@host:owner/name) vs URL-form (https://host/owner/name)
+    path = url.split(":", 1)[1] if ":" in url and "//" not in url else url
+    parts = [p for p in path.replace(":", "/").strip("/").split("/") if p]
+    if len(parts) < 2:
+        return None
+    return f"{parts[-2]}/{parts[-1]}"
+
+
+def _latest_upstream_release(
+    runner: Callable[[List[str]], Tuple[int, str]], slug: str
+) -> Tuple[str, str] | None:
+    """(tagName, publishedAt) of upstream's latest GitHub release, or None."""
     try:
         rc, out = runner(
-            ["git", "-C", str(repo), "rev-list", "--count", "upstream/main..HEAD"]
+            ["gh", "release", "view", "--repo", slug, "--json", "tagName,publishedAt"]
         )
+    except Exception:  # noqa: BLE001 — gh missing/unauthed: fail-open
+        return None
+    if rc != 0 or not out.strip():
+        return None
+    try:
+        data = json.loads(out)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tag = str(data.get("tagName") or "").strip()
+    if not tag:
+        return None
+    return tag, str(data.get("publishedAt") or "").strip()
+
+
+def _release_older_than(
+    published_iso: str, clock: Callable[[], datetime], hours: int
+) -> bool:
+    """True when the release was published at least ``hours`` ago.
+
+    Missing/unparseable timestamp → True (do not suppress a genuinely-unmerged
+    release; this path is server-only, so there is no client-spam risk).
+    """
+    if not published_iso:
+        return True
+    from datetime import timezone
+
+    try:
+        pub = datetime.fromisoformat(published_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if pub.tzinfo is None:
+        pub = pub.replace(tzinfo=timezone.utc)
+    now = clock()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return (now - pub) >= timedelta(hours=hours)
+
+
+def _behind_release(
+    runner: Callable[[List[str]], Tuple[int, str]], repo: Path, tag: str
+) -> int:
+    """Commits in the release tag not yet in the fork (best-effort, 0 on error)."""
+    return _rev_list_count(runner, repo, f"HEAD..{tag}")
+
+
+def _count_ahead_of_release(
+    runner: Callable[[List[str]], Tuple[int, str]], repo: Path, tag: str
+) -> int:
+    """Commits the fork has that the release tag does not (best-effort, 0)."""
+    return _rev_list_count(runner, repo, f"{tag}..HEAD")
+
+
+def _rev_list_count(
+    runner: Callable[[List[str]], Tuple[int, str]], repo: Path, rng: str
+) -> int:
+    try:
+        rc, out = runner(["git", "-C", str(repo), "rev-list", "--count", rng])
     except Exception:  # noqa: BLE001
         return 0
     if rc != 0:
@@ -361,19 +479,20 @@ def _count_ahead_of_upstream(
 def ensure_upstream_issue(
     behind: int,
     ahead: int,
+    tag: str = "",
     runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
     gh_enabled: bool = True,
 ) -> str | None:
     """Idempotently ensure a GitHub ``[UPSTREAM]`` tracking issue exists.
 
-    Called only on a REAL upstream escalation (full clone, behind > threshold —
-    the #561 shallow case never reaches here). The owner had to open issue #562
-    by hand; this closes that gap.
+    Called only on a REAL escalation (full clone, a published upstream release
+    unmerged past the grace window — the #561 shallow case never reaches here).
+    The owner had to open issue #562 by hand; this closes that gap.
 
     Idempotency key: an OPEN issue whose title starts with ``UPSTREAM_ISSUE_PREFIX``.
     If one exists we do NOT create a duplicate (de-duped / edge-triggered on the
-    issue's own existence — no daily spam). If none exists we create one with the
-    real behind/ahead counts.
+    issue's own existence — no daily spam). If none exists we create one naming the
+    missing release tag and the real behind/ahead counts.
 
     ALL gh interaction goes through the injectable ``runner`` seam, so this is
     unit-testable without network. FAIL-OPEN throughout: gh missing/unauthed, a
@@ -413,18 +532,19 @@ def ensure_upstream_issue(
         if title.startswith(UPSTREAM_ISSUE_PREFIX):
             return None  # already tracked — never duplicate
 
-    # 2) None exists → create one with the real counts.
+    # 2) None exists → create one naming the missing release + real counts.
+    rel = f"release `{tag}`" if tag else "the latest upstream release"
     title = (
-        f"{UPSTREAM_ISSUE_PREFIX} Catch-up needed: ~{behind} commits behind "
-        f"upstream/main (owner review)"
+        f"{UPSTREAM_ISSUE_PREFIX} Release not merged: fork ~{behind} commit(s) "
+        f"behind {('`' + tag + '`') if tag else 'the latest upstream release'} "
+        f"(owner review)"
     )
     body = (
-        f"The autonomous upstream-sync can no longer auto-merge: the fork is "
-        f"~{behind} commit(s) behind `upstream/main` and ~{ahead} commit(s) "
-        f"ahead, past the auto-merge ceiling.\n\n"
+        f"The autonomous release-sync could not land {rel}: the fork is ~{behind} "
+        f"commit(s) behind it and ~{ahead} commit(s) ahead.\n\n"
         f"This issue was filed automatically by the evolution watchdog so the "
-        f"backlog is visible. Resolve by reconciling the fork to `upstream/main` "
-        f"(owner review of conflicting changes), then close this issue.\n"
+        f"missing release is visible. Resolve by merging the release tag into the "
+        f"fork (owner review of any conflicts), then close this issue.\n"
     )
     try:
         rc, _out = runner(

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -311,23 +311,27 @@ def check_upstream_lag(
     logic NEVER runs there), or on ANY gh/git/parse failure — fail-open, never a
     false alarm.
     """
-    repo = repo_dir or _resolve_repo_dir()
-    if repo is None:
-        return []
-
-    # Installer checkouts are shallow (`git clone --depth 1` in scripts/install.sh
-    # / install.ps1) and share no ancestry with upstream — the behind-count is a
-    # phantom there (the 2026-06 "~13000 behind" alarm on every onboarded client).
-    # Shallow is the INTENDED client default; release-tracking is the fork
-    # maintainer's concern (the evolution server is a full clone). Skip silently
-    # BEFORE any release logic — mirrors the guards in hermes_cli/banner.py &
-    # main.py. This guard is what keeps every onboarded client silent.
-    if _upstream_lag_unmeasurable(runner, repo):
-        return []
-
+    # Fail-open in FULL: a client must NEVER crash on this check, so repo
+    # resolution and the shallow guard live inside the net too (a broken/absent
+    # git must not raise into a client's cron).
     try:
+        repo = repo_dir or _resolve_repo_dir()
+        if repo is None:
+            return []
+
+        # Installer checkouts are shallow (`git clone --depth 1` in
+        # scripts/install.sh / install.ps1) and share no ancestry with upstream —
+        # the behind-count is a phantom there (the 2026-06 "~13000 behind" alarm on
+        # every onboarded client). Shallow is the INTENDED client default;
+        # release-tracking is the fork maintainer's concern (the evolution server
+        # is a full clone). Skip silently BEFORE any release logic — mirrors the
+        # guards in hermes_cli/banner.py & main.py. This is what keeps every
+        # onboarded client silent.
+        if _upstream_lag_unmeasurable(runner, repo):
+            return []
+
         return _release_lag_alerts(runner, repo, clock)
-    except Exception:  # noqa: BLE001 — the release probe must never crash the watchdog
+    except Exception:  # noqa: BLE001 — this check must never crash the watchdog
         return []
 
 
@@ -368,7 +372,11 @@ def _release_lag_alerts(
     behind = _behind_release(runner, repo, tag)
     ahead = _count_ahead_of_release(runner, repo, tag)
     ensure_upstream_issue(
-        behind=behind, ahead=ahead, tag=tag, gh_enabled=UPSTREAM_ISSUE_ENABLED
+        behind=behind,
+        ahead=ahead,
+        tag=tag,
+        runner=runner,
+        gh_enabled=UPSTREAM_ISSUE_ENABLED,
     )
     return [
         f"upstream release {tag} not merged: the fork is missing the latest "
@@ -428,17 +436,18 @@ def _release_older_than(
 ) -> bool:
     """True when the release was published at least ``hours`` ago.
 
-    Missing/unparseable timestamp → True (do not suppress a genuinely-unmerged
-    release; this path is server-only, so there is no client-spam risk).
+    Fail-open SILENT: a missing timestamp (draft/odd state) or an unparseable one
+    (e.g. gh changes its format) returns False, so the watchdog never nags on data
+    it cannot interpret. The next sync still merges the release regardless.
     """
     if not published_iso:
-        return True
+        return False
     from datetime import timezone
 
     try:
         pub = datetime.fromisoformat(published_iso.replace("Z", "+00:00"))
     except ValueError:
-        return True
+        return False
     if pub.tzinfo is None:
         pub = pub.replace(tzinfo=timezone.utc)
     now = clock()

--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: evolution-upstream-sync
-description: Keep the fork at full parity with upstream Hermes Agent via incremental merges
-version: 2.0.0
+description: Keep the fork current with upstream Hermes Agent by merging its published RELEASE tags (not bleeding-edge main)
+version: 3.0.0
 author: Hermes Evolution
 category: evolution
 mode: PRIVATE
@@ -13,35 +13,44 @@ mode: PRIVATE
 
 ## Task
 
-Keep this fork at **full parity** with the original Hermes Agent (upstream): our
-fork is the base — our evolution work — and we roll **all** upstream changes into
-it. We want everything upstream has, present and future (desktop `apps/desktop`,
-TUI `ui-tui`, gateway, web, plugins, every platform). Nothing is skipped; nothing
-of ours is lost.
+Keep this fork current with the original Hermes Agent (upstream) by merging its
+**published RELEASE tags** — our fork is the base (our evolution work) and we roll
+each stabilized upstream release into it. We want everything a release contains
+(desktop `apps/desktop`, TUI `ui-tui`, gateway, web, plugins, every platform).
+Nothing in a release is skipped; nothing of ours is lost.
 
-> **Model change (v2.0.0):** the old model selectively cherry-picked a "relevant"
-> subset and *banned* `git merge upstream/main`. That is OBSOLETE. As of the
-> 2026-06-14 full-parity sync (PR #211) the fork carries upstream's entire
-> history (`git merge-base --is-ancestor upstream/main main` is true) plus our
-> evolution commits on top. We now **merge upstream wholesale, incrementally**.
-> There is no `.evolution/upstream-sync-state.json` cursor, no `deferred[]`, no
-> `skipped_scopes`, no per-run commit cap.
+> **Model change (v3.0.0 — 2026-07-01):** we track upstream **releases**, NOT
+> `upstream/main`. Upstream lands ~300 commits/day; chasing every commit made the
+> daily wholesale `git merge upstream/main` exceed the escalation ceiling and
+> stall — the fork drifted hundreds of commits behind and every run escalated
+> instead of merging. Upstream cuts a tagged release ~weekly/biweekly (the
+> `v2026.M.D` tags = GitHub releases); we merge to the LATEST such tag. This is a
+> bounded, stabilized batch instead of an unwinnable daily churn chase. The old
+> `git merge upstream/main` model (v2.0.0) is OBSOLETE. Security/critical fixes
+> upstream ships as patch releases (e.g. `v2026.5.29.2`) are picked up the same
+> way; anything more urgent than the next release goes through the curated
+> critical-backport lane (see issue tracker), never an unattended main merge.
 
 ## Process
 
-### 0. Baseline — confirm current parity
+### 0. Baseline — find the latest upstream RELEASE and measure the gap
 
 ```bash
 gh auth setup-git                      # route git auth through gh (no GH_TOKEN export)
-git fetch upstream main --quiet && git fetch origin --quiet
+git fetch upstream --tags --quiet && git fetch origin --quiet
 git checkout main && git pull --ff-only origin main
-BEHIND=$(git rev-list --count main..upstream/main)   # new upstream commits since last sync
-AHEAD=$(git rev-list --count upstream/main..main)    # our evolution work
-echo "behind upstream: $BEHIND | our commits ahead: $AHEAD"
+# The latest PUBLISHED upstream release (the v2026.M.D tags ARE the GitHub releases).
+LR=$(gh release view --repo nousresearch/hermes-agent --json tagName --jq .tagName)
+git fetch upstream "refs/tags/$LR:refs/tags/$LR" --quiet 2>/dev/null || true
+BEHIND=$(git rev-list --count "main..$LR")   # release commits not yet in the fork
+AHEAD=$(git rev-list --count "$LR..main")    # our evolution work + newer merges
+echo "latest release: $LR | behind release: $BEHIND | our commits ahead: $AHEAD"
 ```
 
-If `BEHIND == 0` → already at parity, nothing to do; write a one-line report and stop.
-The normal steady state is `BEHIND` = a handful (one day of upstream commits).
+If `BEHIND == 0` → the fork already contains the latest release; nothing to do,
+write a one-line report and stop. This is the NORMAL steady state on most days (a
+release lands only ~weekly/biweekly). Do **NOT** merge `upstream/main`: being
+behind bleeding-edge main is expected under release-tracking and is not a backlog.
 
 ### 1. Size the merge — decide autonomous vs escalate
 
@@ -50,21 +59,23 @@ The normal steady state is `BEHIND` = a handful (one day of upstream commits).
 # artifacts to (e.g. website/static/api/model-catalog.json, whose `updated_at`
 # timestamp collides every single sync). Without this the driver name is unknown
 # and git falls back to a normal conflict — which, on an hermes_cli-adjacent
-# file, would force escalation every day. Idempotent:
+# file, would force escalation. Idempotent:
 git config merge.theirs.driver 'cp -f "%B" "%A"'
-git merge --no-ff --no-commit upstream/main || true   # stage the merge, surface conflicts
+git merge --no-ff --no-commit "$LR" || true   # stage the RELEASE merge, surface conflicts
 CONFLICTS=$(git diff --name-only --diff-filter=U | wc -l)
 echo "conflicted files: $CONFLICTS"
 git diff --name-only --diff-filter=U
 ```
 
-- **`BEHIND` small (≤ ~80) AND `CONFLICTS` ≤ 10, none in core persistence/agent
-  runtime** → resolve autonomously (step 2) and open a normal PR.
-- **`BEHIND` large (a long catch-up) OR `CONFLICTS` > 10 OR any conflict in
-  `run_agent.py` / `agent/` / `cron/scheduler.py` / `hermes_cli/` persistence** →
-  this needs owner judgement. `git merge --abort`, then open a **draft** PR / file
-  an issue describing the backlog + conflict surface and STOP. Do NOT blind-resolve
-  a judgement-heavy merge autonomously — that is how features get silently dropped.
+- **`CONFLICTS` ≤ 10, none in core persistence/agent runtime** → resolve
+  autonomously (step 2) and open a normal PR. A single release is a bounded batch,
+  so `BEHIND` is naturally small; the `escalate_if_commits_over` guard still applies.
+- **`BEHIND` unusually large (a multi-release catch-up) OR `CONFLICTS` > 10 OR any
+  conflict in `run_agent.py` / `agent/` / `cron/scheduler.py` / `hermes_cli/`
+  persistence** → this needs owner judgement. `git merge --abort`, then open a
+  **draft** PR / file an issue describing the release + conflict surface and STOP.
+  Do NOT blind-resolve a judgement-heavy merge autonomously — that is how features
+  get silently dropped.
 
 ### 2. Resolve conflicts — authorship-driven, keep OURS, follow upstream
 
@@ -149,12 +160,12 @@ skills sync). CI's 6-shard suite is the full gate.
 ### 5. Commit + PR (never a direct merge into `main`)
 
 ```bash
-git checkout -b sync/upstream-YYYY-MM-DD
-git commit -m "Merge upstream/main into fork — sync (<BEHIND> commits)"   # the staged merge
-git push origin sync/upstream-YYYY-MM-DD
-gh pr create --base main --head sync/upstream-YYYY-MM-DD \
-  --title "[UPSTREAM] Sync upstream/main — full parity (<BEHIND> commits)" \
-  --body "git merge upstream/main. Conflicts resolved authorship-first (keep ours, follow upstream incl. reverts). See sync report."
+git checkout -b sync/upstream-release-$LR
+git commit -m "Merge upstream release $LR into fork — sync (<BEHIND> commits)"   # the staged merge
+git push origin sync/upstream-release-$LR
+gh pr create --base main --head sync/upstream-release-$LR \
+  --title "[UPSTREAM] Sync upstream release $LR (<BEHIND> commits)" \
+  --body "git merge $LR (latest upstream release). Conflicts resolved authorship-first (keep ours, follow upstream incl. reverts). See sync report."
 ```
 
 - Merge into `main` only after **green CI** (`tests.yml` 6 shards + `lint.yml` +
@@ -172,12 +183,12 @@ gh pr create --base main --head sync/upstream-YYYY-MM-DD \
 
 ### 6. Inherit the upstream version marker (in the sync PR)
 
-After parity, stamp the banner from the newest upstream release tag that is now an
-ancestor of `main`:
+After merging, stamp the banner from the release we just merged (it is now the
+newest upstream release tag reachable from `main`):
 
 ```bash
-TAG=$(git describe --tags --abbrev=0 --match 'v20*' upstream/main 2>/dev/null)
-DATE=$(echo "$TAG" | sed 's/^v//')        # e.g. 2026.6.14
+TAG=$LR                                    # the release tag we just merged
+DATE=$(echo "$TAG" | sed 's/^v//')        # e.g. 2026.6.19
 ```
 If `TAG` advanced, update `hermes_cli/__init__.py` `__release_date__ = "<DATE>"`
 (the banner renders `Hermes Agent v<__version__> (<__release_date__>)`). Commit on
@@ -185,10 +196,14 @@ the `sync/*` branch so it rides the same PR + CI.
 
 ## Sync frequency
 
-Daily (`0 8 * * *`, before research at 09:00). Because we hold full parity, each
-run merges only ~one day of upstream commits — small and almost always
-conflict-free. Security/critical upstream fixes are therefore picked up within a
-day, automatically, without any selection step.
+Checked daily (`0 8 * * *`, before research at 09:00), but a run only MERGES when
+upstream has published a new release since the last sync — most days it finds
+`BEHIND == 0` and stops silently. Because a release is a bounded, upstream-
+stabilized batch, each real merge is small and almost always conflict-free.
+Upstream ships security/critical fixes as patch releases (e.g. `v2026.5.29.2`),
+so those are picked up on the next daily check; anything more urgent than the next
+release is handled by the curated critical-backport lane, never an unattended
+`upstream/main` merge.
 
 ## Rollback
 

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -239,26 +239,80 @@ class TestGhCheck:
 class TestUpstreamLag:
     REPO = Path("/repo")  # bypass _resolve_repo_dir via explicit repo_dir
 
-    def test_behind_over_threshold_alerts(self):
+    SLUG = "nousresearch/hermes-agent"
+    RELEASED = "2026-06-19T12:00:00Z"
+
+    def _clock(self, hours_after_release):
+        from datetime import datetime, timedelta, timezone
+
+        base = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+        return lambda: base + timedelta(hours=hours_after_release)
+
+    def _release_runner(
+        self,
+        *,
+        tag="v2026.6.19",
+        is_ancestor_rc=1,
+        behind=150,
+        ahead=1666,
+        release_rc=0,
+        release_out=None,
+    ):
+        """Full-clone runner simulating the release-lag probe end to end."""
+
         def fake_run(cmd):
-            assert "rev-list" in cmd
-            return (0, "301\n")
+            joined = " ".join(cmd)
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                return (0, "false\n")
+            if "merge-base" in cmd and "--is-ancestor" not in cmd:
+                return (0, "sharedbase\n")  # shared ancestry: measurable
+            if "remote" in cmd and "get-url" in cmd:
+                return (0, f"https://github.com/{self.SLUG}.git\n")
+            if "release" in cmd and "view" in cmd:
+                if release_out is not None:
+                    return (release_rc, release_out)
+                return (
+                    release_rc,
+                    json.dumps({"tagName": tag, "publishedAt": self.RELEASED}),
+                )
+            if "merge-base" in cmd and "--is-ancestor" in cmd:
+                return (is_ancestor_rc, "")
+            if "rev-list" in cmd and f"HEAD..{tag}" in joined:
+                return (0, f"{behind}\n")
+            if "rev-list" in cmd and f"{tag}..HEAD" in joined:
+                return (0, f"{ahead}\n")
+            raise AssertionError(f"unexpected command: {cmd}")
 
-        alerts = check_upstream_lag(runner=fake_run, repo_dir=self.REPO)
-        assert any("behind upstream" in a for a in alerts)
-        assert any("301" in a for a in alerts)
+        return fake_run
 
-    def test_within_threshold_silent(self):
-        def fake_run(cmd):
-            return (0, "9\n")
+    def test_missing_release_past_grace_alerts(self):
+        # A published release NOT merged (is_ancestor rc=1), released well past
+        # the grace window → the release-sync is stuck → alert naming the tag.
+        run = self._release_runner(tag="v2026.6.19", is_ancestor_rc=1, behind=150)
+        alerts = check_upstream_lag(
+            runner=run, repo_dir=self.REPO, clock=self._clock(72)
+        )
+        assert any("v2026.6.19" in a and "not merged" in a for a in alerts)
+        assert any("150" in a for a in alerts)
 
-        assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
+    def test_latest_release_merged_silent(self):
+        # The fork already contains the latest release (is_ancestor rc=0) — the
+        # steady state under release-tracking. Fully silent even though the fork
+        # is hundreds of commits behind bleeding-edge upstream/main.
+        run = self._release_runner(is_ancestor_rc=0)
+        assert (
+            check_upstream_lag(runner=run, repo_dir=self.REPO, clock=self._clock(999))
+            == []
+        )
 
-    def test_at_threshold_silent(self):
-        def fake_run(cmd):
-            return (0, "80\n")  # exactly the threshold is not "over"
-
-        assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
+    def test_fresh_release_within_grace_silent(self):
+        # A release published minutes ago (sync simply hasn't run yet) must NOT
+        # be reported as stuck — the grace window suppresses it.
+        run = self._release_runner(is_ancestor_rc=1)
+        assert (
+            check_upstream_lag(runner=run, repo_dir=self.REPO, clock=self._clock(2))
+            == []
+        )
 
     def test_git_failure_silent(self):
         def fake_run(cmd):
@@ -324,21 +378,32 @@ class TestUpstreamLag:
 
         assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
 
-    def test_full_clone_behind_over_threshold_still_alerts(self):
-        # Regression guard: a normal FULL clone (not shallow, shared ancestry)
-        # that is genuinely behind must still alert — the evolution server is a
-        # full clone and the real upstream-lag monitoring must survive this fix.
-        def fake_run(cmd):
-            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
-                return (0, "false\n")
-            if "merge-base" in cmd:
-                return (0, "abc123def456\n")  # shared ancestor exists
-            if "rev-list" in cmd:
-                return (0, "391\n")
-            return (0, "")
+    def test_unknown_tag_ref_silent(self):
+        # merge-base --is-ancestor returns 128 (tag not fetched locally) →
+        # unmeasurable → stay silent, never false-alarm.
+        run = self._release_runner(is_ancestor_rc=128)
+        assert (
+            check_upstream_lag(runner=run, repo_dir=self.REPO, clock=self._clock(72))
+            == []
+        )
 
-        alerts = check_upstream_lag(runner=fake_run, repo_dir=self.REPO)
-        assert any("behind upstream/main" in a for a in alerts)
+    def test_gh_release_unavailable_silent(self):
+        # gh release view fails (unauthed / offline) → fail-open silent.
+        run = self._release_runner(release_rc=1, release_out="gh: not found")
+        assert (
+            check_upstream_lag(runner=run, repo_dir=self.REPO, clock=self._clock(72))
+            == []
+        )
+
+    def test_full_clone_missing_release_still_alerts(self):
+        # Regression guard: a normal FULL clone (not shallow, shared ancestry)
+        # genuinely missing a published release must still alert — the evolution
+        # server is a full clone and real monitoring must survive the model change.
+        run = self._release_runner(tag="v2026.6.19", is_ancestor_rc=1, behind=391)
+        alerts = check_upstream_lag(
+            runner=run, repo_dir=self.REPO, clock=self._clock(72)
+        )
+        assert any("not merged" in a for a in alerts)
         assert any("391" in a for a in alerts)
 
 
@@ -838,22 +903,37 @@ class TestEnsureUpstreamIssue:
 
 
 class TestUpstreamLagFilesIssue:
-    """check_upstream_lag still emits text AND now ensures the tracking issue
-    exists, idempotently, via the mockable gh seam — only on REAL escalation."""
+    """check_upstream_lag emits text AND ensures the [UPSTREAM] tracking issue
+    exists, idempotently, via the mockable gh seam — only on a REAL escalation
+    (a published upstream release unmerged past the grace window)."""
 
     REPO = Path("/repo")
+    SLUG = "nousresearch/hermes-agent"
+    RELEASED = "2026-06-19T12:00:00Z"
 
-    def _git_runner(self, behind):
+    def _clock(self, hours_after_release):
+        from datetime import datetime, timedelta, timezone
+
+        base = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+        return lambda: base + timedelta(hours=hours_after_release)
+
+    def _release_runner(self, *, tag="v2026.6.19", is_ancestor_rc=1, behind=391):
         def fake_run(cmd):
+            joined = " ".join(cmd)
             if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
                 return (0, "false\n")
             if "merge-base" in cmd and "--is-ancestor" not in cmd:
-                return (0, "abc123\n")  # shared ancestor exists
-            if "rev-list" in cmd:
-                joined = " ".join(cmd)
-                if "HEAD..upstream/main" in joined:
-                    return (0, f"{behind}\n")
-                return (0, "0\n")
+                return (0, "sharedbase\n")
+            if "remote" in cmd and "get-url" in cmd:
+                return (0, f"https://github.com/{self.SLUG}.git\n")
+            if "release" in cmd and "view" in cmd:
+                return (0, json.dumps({"tagName": tag, "publishedAt": self.RELEASED}))
+            if "merge-base" in cmd and "--is-ancestor" in cmd:
+                return (is_ancestor_rc, "")
+            if "rev-list" in cmd and f"HEAD..{tag}" in joined:
+                return (0, f"{behind}\n")
+            if "rev-list" in cmd and f"{tag}..HEAD" in joined:
+                return (0, "1666\n")
             raise AssertionError(f"unexpected git command: {cmd}")
 
         return fake_run
@@ -863,16 +943,22 @@ class TestUpstreamLagFilesIssue:
 
         calls = {}
 
-        def fake_ensure(behind, ahead, **kw):
+        def fake_ensure(behind, ahead, tag="", **kw):
             calls["behind"] = behind
+            calls["tag"] = tag
             return None
 
         monkeypatch.setattr(w, "ensure_upstream_issue", fake_ensure)
-        alerts = check_upstream_lag(runner=self._git_runner(391), repo_dir=self.REPO)
-        assert any("behind upstream/main" in a for a in alerts), "text alert preserved"
+        alerts = check_upstream_lag(
+            runner=self._release_runner(behind=391),
+            repo_dir=self.REPO,
+            clock=self._clock(72),
+        )
+        assert any("not merged" in a for a in alerts), "text alert preserved"
         assert calls.get("behind") == 391, "real escalation must ensure the tracking issue"
+        assert calls.get("tag") == "v2026.6.19", "issue names the missing release tag"
 
-    def test_within_threshold_does_not_file_issue(self, monkeypatch):
+    def test_merged_release_does_not_file_issue(self, monkeypatch):
         import evolution_watchdog as w
 
         called = {"n": 0}
@@ -880,8 +966,33 @@ class TestUpstreamLagFilesIssue:
             w, "ensure_upstream_issue",
             lambda *a, **k: called.__setitem__("n", called["n"] + 1),
         )
-        assert check_upstream_lag(runner=self._git_runner(9), repo_dir=self.REPO) == []
-        assert called["n"] == 0, "no escalation → no issue churn"
+        assert (
+            check_upstream_lag(
+                runner=self._release_runner(is_ancestor_rc=0),
+                repo_dir=self.REPO,
+                clock=self._clock(999),
+            )
+            == []
+        )
+        assert called["n"] == 0, "latest release already merged → no issue churn"
+
+    def test_within_grace_does_not_file_issue(self, monkeypatch):
+        import evolution_watchdog as w
+
+        called = {"n": 0}
+        monkeypatch.setattr(
+            w, "ensure_upstream_issue",
+            lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+        )
+        assert (
+            check_upstream_lag(
+                runner=self._release_runner(is_ancestor_rc=1),
+                repo_dir=self.REPO,
+                clock=self._clock(2),
+            )
+            == []
+        )
+        assert called["n"] == 0, "fresh release inside grace → no issue churn"
 
     def test_shallow_clone_does_not_file_issue(self, monkeypatch):
         # #561 regression: shallow clones stay silent AND never file an issue.
@@ -896,8 +1007,8 @@ class TestUpstreamLagFilesIssue:
         def fake_run(cmd):
             if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
                 return (0, "true\n")
-            if "rev-list" in cmd:
-                raise AssertionError("rev-list must not run on shallow clone")
+            if "release" in cmd or "rev-list" in cmd:
+                raise AssertionError("release/rev-list must not run on shallow clone")
             return (0, "")
 
         assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []


### PR DESCRIPTION
## What & why

Upstream Hermes lands **~300 commits/day**. The wholesale `git merge upstream/main` model made the daily sync exceed its 80-commit escalation ceiling on **every** run, so it escalated instead of merging and the fork drifted hundreds of commits behind — an unwinnable chase for a heavily-customized fork, and the source of the recurring `[UPSTREAM]` backlog + the daily "600 behind" watchdog false alarm.

Peer-reviewed independently by two non-Claude advisors (Gemini + GLM) and owner-approved: **switch to release-tracking (option C).**

## Changes
- **`evolution-upstream-sync` skill + cron** — merge the **latest upstream RELEASE tag** (`gh release view nousresearch/hermes-agent`), a bounded, upstream-stabilized batch (~weekly/biweekly), not `upstream/main`. Most days `BEHIND == 0` → silent no-op. Escalation guards unchanged.
- **`evolution_watchdog.py`** — `check_upstream_lag` now alerts only when a **published upstream release is unmerged past a 36h grace window**, not on raw "behind upstream/main" (a permanent false alarm under this model). Fail-open throughout.

## Client safety
- The **#561 shallow-clone guard runs FIRST**: onboarded clients are shallow clones → `_upstream_lag_unmeasurable` returns `[]` before any release logic runs. Clients stay silent exactly as before (regression test kept: `test_shallow_clone_does_not_file_issue`).
- `hermes update`'s `_sync_with_upstream_if_needed` already skips when the fork has local commits (`origin_ahead > 0`), so nothing here changes client update behavior.
- All new code is fail-open (never raises) and CI-gated.

## Context
The fork **already contains the latest release** (`v2026.6.19`), so **no catch-up merge is needed** — behind-release is 0 today. Security fixes ship as upstream patch releases (e.g. `v2026.5.29.2`) and are picked up on the next daily check; a curated critical-backport lane for faster-than-release fixes is a tracked follow-up.

## Tests
- `tests/scripts` — **559 passed**, ruff clean. Watchdog upstream-lag suite rewritten for the release model: grace window, tag-ancestor detection (rc 0/1/128), gh-unavailable fail-open, and the preserved shallow-clone client guard.