### PR TITLE
fix: stop forwarding unsupported session_id/pty to env.execute()

### DIFF
--- a/tests/tools/test_terminal_tool_foreground_execute_kwargs.py
+++ b/tests/tools/test_terminal_tool_foreground_execute_kwargs.py
@@ -1,0 +1,86 @@
+"""Regression test for #647: foreground terminal_tool() calls must only pass
+kwargs that BaseEnvironment.execute() actually accepts.
+
+Local/SSH environments inherit BaseEnvironment.execute() unmodified — its
+signature has no ``session_id``/``pty`` parameters. A prior change started
+forwarding both into ``execute_kwargs`` whenever ``env_type`` was "local" or
+"ssh", so every foreground call made with a non-None ``session_id`` (the
+common case — callers pass it for durable observability) raised:
+
+    TypeError: BaseEnvironment.execute() got an unexpected keyword
+    argument 'session_id'
+
+before the command was executed at all.
+"""
+import json
+from types import SimpleNamespace
+
+import tools.terminal_tool as terminal_tool_module
+
+
+def _strict_execute(command, cwd="", *, timeout=None, stdin_data=None,
+                     rewrite_compound_background=True):
+    """Mirrors BaseEnvironment.execute()'s real signature: no session_id/pty."""
+    return {"output": "ok", "returncode": 0}
+
+
+def _base_config(tmp_path):
+    return {
+        "env_type": "local",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "cwd": str(tmp_path),
+        "timeout": 30,
+    }
+
+
+def test_foreground_execute_with_session_id_does_not_raise_typeerror(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(cwd=str(tmp_path), execute=_strict_execute)
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_a, **_k: {"approved": True})
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="echo hi",
+                session_id="conversation-123",
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert "TypeError" not in (result.get("error") or "")
+    assert result.get("output") == "ok"
+
+
+def test_foreground_execute_with_pty_does_not_raise_typeerror(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(cwd=str(tmp_path), execute=_strict_execute)
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_a, **_k: {"approved": True})
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="echo hi",
+                pty=True,
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert "TypeError" not in (result.get("error") or "")
+    assert result.get("output") == "ok"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2659,11 +2659,13 @@ def terminal_tool(
                         "timeout": effective_timeout,
                         "cwd": command_cwd,
                     }
-                    if env_type == "ssh" or env_type == "local":
-                        if session_id is not None:
-                            execute_kwargs["session_id"] = session_id
-                        if pty:
-                            execute_kwargs["pty"] = pty
+                    # NOTE: session_id/pty are deliberately NOT forwarded here.
+                    # BaseEnvironment.execute() (inherited as-is by Local/SSH)
+                    # has no such parameters, so passing them raised
+                    # `TypeError: ...execute() got an unexpected keyword
+                    # argument 'session_id'` on every foreground call once a
+                    # session_id was supplied (#647). Neither parameter is
+                    # read by any environment's execute() body today.
 
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:


### PR DESCRIPTION
## Description
Local/SSH environments inherit `BaseEnvironment.execute()` unmodified, and its signature has no `session_id`/`pty` parameters. A prior merge started forwarding both into `execute_kwargs` whenever `env_type` was `ssh` or `local`, so every foreground `terminal_tool()` call made with a non-None `session_id` (the common case) raised:

```
TypeError: BaseEnvironment.execute() got an unexpected keyword argument 'session_id'
```

before the command was executed at all.

## Type
Bug fix

## Related Issues
Closes #647

## Testing
- Added `tests/tools/test_terminal_tool_foreground_execute_kwargs.py`: reproduces the exact TypeError against the pre-fix code (verified by temporarily reverting the fix) and passes against the fix.
- `ruff check tools/terminal_tool.py` — clean.
- Full `tests/tools/` suite run; the only failures are pre-existing and environment-specific (sandbox process-group guard, docker-dependent tests), identical with and without this change.
- Independently reviewed via `consult agy` (Gemini) — VERDICT: PASS.

## Breaking Changes
None — neither parameter was read by any environment's `execute()` body.

## Mode
PUBLIC