### PR TITLE
fix(diagnostics): gate inline failure-class hint behind config, default off

### DIFF
--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -14,6 +14,7 @@ timeout / missing_command / runtime_error.
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Any, Optional, Tuple
 
@@ -97,10 +98,46 @@ def classify(content: Any) -> Optional[Tuple[str, str]]:
     return None
 
 
-def diagnostic_suffix(content: Any) -> str:
+def inline_diagnostics_enabled(config: Optional[dict] = None) -> bool:
+    """Return whether ``diagnostic_suffix`` may inject its hint into the
+    tool result text the model sees.
+
+    Precedence: an explicit ``HERMES_DIAGNOSTICS_INLINE`` env var wins, then
+    ``agent.diagnostics.inline`` in config. Default is ``False`` (#606):
+    ``classify()`` is a plain regex heuristic over result text, not a real
+    success/failure signal, so it repeatedly misfires on successful results
+    that merely mention words like "timeout" or "error" — e.g. reading
+    source code that discusses them — inflating context with non-actionable
+    noise (209 occurrences across 95 sessions in one week of real usage).
+    ``loop_guard`` calls ``classify()`` directly for its own tracking and is
+    unaffected by this flag either way.
+    """
+    env = os.environ.get("HERMES_DIAGNOSTICS_INLINE")
+    if env is not None:
+        return env.strip().lower() not in {"0", "false", "no", "off"}
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+    try:
+        from hermes_cli.config import cfg_get
+
+        return bool(cfg_get(config, "agent", "diagnostics", "inline", default=False))
+    except Exception:
+        return False
+
+
+def diagnostic_suffix(content: Any, config: Optional[dict] = None) -> str:
     """Return a one-line diagnostic annotation to append to a failing tool
-    result, or '' if the result is not a recognized failure. Trusted text
-    (our annotation), kept outside any untrusted-content wrapper by the caller."""
+    result, or '' if the result is not a recognized failure or inline
+    diagnostics are disabled (the default — see ``inline_diagnostics_enabled``).
+    Trusted text (our annotation), kept outside any untrusted-content wrapper
+    by the caller."""
+    if not inline_diagnostics_enabled(config):
+        return ""
     hit = classify(content)
     if not hit:
         return ""

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -117,9 +117,11 @@ def inline_diagnostics_enabled(config: Optional[dict] = None) -> bool:
         return env.strip().lower() not in {"0", "false", "no", "off"}
     if config is None:
         try:
-            from hermes_cli.config import load_config
+            # Read-only, cache-hit fast path (~130us, no deepcopy) — this
+            # runs on every tool result, a hot loop in long sessions.
+            from hermes_cli.config import load_config_readonly
 
-            config = load_config()
+            config = load_config_readonly()
         except Exception:
             config = {}
     try:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -646,6 +646,15 @@ agent:
   # force it on or off; the HERMES_VERIFY_ON_STOP env var (1/0) takes precedence.
   # verify_on_stop: auto
 
+  # Tool-result failure-class diagnostics: a one-line
+  # "[diagnostic] failure-class=... — <hint>" annotation appended to a tool
+  # result that looks like a failure. Default off — the classifier is a
+  # text heuristic (not a real success/failure signal) and can false-positive
+  # on successful results that merely mention words like "timeout" or
+  # "error"; the HERMES_DIAGNOSTICS_INLINE env var (1/0) takes precedence.
+  # diagnostics:
+  #   inline: false
+
   # Enable verbose logging
   verbose: false
   

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1024,6 +1024,21 @@ DEFAULT_CONFIG = {
         # abandoned prompt — lower it if a single session must free up the
         # guard sooner.
         "clarify_timeout": 3600,
+        # Tool-result failure-class diagnostics (agent/tool_diagnostics.py):
+        # a one-line "[diagnostic] failure-class=... — <hint>" annotation
+        # appended to a tool result the classifier thinks looks like a
+        # failure. Default OFF — the classifier is a plain text heuristic
+        # (regex over the result content, not an actual success/failure
+        # signal), so it repeatedly false-positives on successful results
+        # that merely mention words like "timeout" or "error" (e.g. reading
+        # source code that discusses them), polluting context with
+        # non-actionable noise (#606). loop_guard's own failure-class
+        # tracking calls tool_diagnostics.classify() directly and is
+        # unaffected by this flag. Set true to restore the inline hint for
+        # debugging.
+        "diagnostics": {
+            "inline": False,
+        },
         # Periodic "still working" notification interval (seconds).
         # Sends a status message every N seconds so the user knows the
         # agent hasn't died during long tasks.  0 = disable notifications.

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -34,19 +34,43 @@ class TestClassify:
 
 
 class TestDiagnosticSuffix:
+    """Inline injection defaults OFF (#606) — classify() is a text heuristic,
+    not a real success/failure signal, and false-positives on successful
+    results that merely mention words like "timeout" or "error"."""
+
     def test_empty_for_success(self):
         assert diagnostic_suffix("done, all good") == ""
 
-    def test_suffix_for_failure(self):
-        s = diagnostic_suffix("permission denied")
+    def test_disabled_by_default_even_for_a_real_failure(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        assert diagnostic_suffix("permission denied", config={}) == ""
+
+    def test_suffix_for_failure_when_explicitly_enabled_via_config(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        config = {"agent": {"diagnostics": {"inline": True}}}
+        s = diagnostic_suffix("permission denied", config=config)
         assert s.startswith("\n\n[diagnostic] failure-class=") and "permission" in s
+
+    def test_suffix_for_failure_when_explicitly_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DIAGNOSTICS_INLINE", "1")
+        s = diagnostic_suffix("permission denied", config={})
+        assert s.startswith("\n\n[diagnostic] failure-class=") and "permission" in s
+
+    def test_env_var_disables_even_if_config_enables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DIAGNOSTICS_INLINE", "0")
+        config = {"agent": {"diagnostics": {"inline": True}}}
+        assert diagnostic_suffix("permission denied", config=config) == ""
 
 
 class TestWiredIntoToolResult:
-    def test_failure_result_gets_hint(self):
+    def test_failure_result_unchanged_by_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
         msg = make_tool_result_message("terminal", "bash: x: command not found", "c1")
-        assert "[diagnostic] failure-class=missing_command" in msg["content"]
+        assert "[diagnostic]" not in msg["content"]
 
-    def test_success_result_unchanged(self):
+    def test_success_result_unchanged(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
         msg = make_tool_result_message("read_file", "file contents, all fine", "c2")
         assert "[diagnostic]" not in msg["content"]
+
+

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -1,6 +1,6 @@
 """Tests for agent/tool_diagnostics.py — normalized failure taxonomy (#130/#175)."""
 
-from agent.tool_diagnostics import classify, diagnostic_suffix
+from agent.tool_diagnostics import classify, diagnostic_suffix, inline_diagnostics_enabled
 from agent.tool_dispatch_helpers import make_tool_result_message
 
 
@@ -31,6 +31,41 @@ class TestClassify:
     def test_runtime_error_fallback(self):
         assert classify("Traceback (most recent call last):\n  ...")[0] == "runtime_error"
         assert classify("process exited, exit code: 1")[0] == "runtime_error"
+
+
+class TestInlineDiagnosticsEnabled:
+    def test_default_off_with_empty_config(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        assert inline_diagnostics_enabled(config={}) is False
+
+    def test_config_true_enables(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        assert inline_diagnostics_enabled(config={"agent": {"diagnostics": {"inline": True}}}) is True
+
+    def test_env_var_truthy_values_enable(self, monkeypatch):
+        for value in ("1", "true", "True", "yes", "on"):
+            monkeypatch.setenv("HERMES_DIAGNOSTICS_INLINE", value)
+            assert inline_diagnostics_enabled(config={}) is True, value
+
+    def test_env_var_falsy_values_disable(self, monkeypatch):
+        for value in ("0", "false", "False", "no", "off"):
+            monkeypatch.setenv("HERMES_DIAGNOSTICS_INLINE", value)
+            assert inline_diagnostics_enabled(config={"agent": {"diagnostics": {"inline": True}}}) is False, value
+
+    def test_malformed_config_section_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        # "agent" is a string, not a dict — cfg_get() must not raise.
+        assert inline_diagnostics_enabled(config={"agent": "oops"}) is False
+
+    def test_config_none_falls_back_to_load_config_readonly(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
+        import hermes_cli.config as config_module
+
+        monkeypatch.setattr(
+            config_module, "load_config_readonly",
+            lambda: {"agent": {"diagnostics": {"inline": True}}},
+        )
+        assert inline_diagnostics_enabled(config=None) is True
 
 
 class TestDiagnosticSuffix:
@@ -72,5 +107,14 @@ class TestWiredIntoToolResult:
         monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)
         msg = make_tool_result_message("read_file", "file contents, all fine", "c2")
         assert "[diagnostic]" not in msg["content"]
+
+    def test_failure_result_gets_hint_when_explicitly_enabled(self, monkeypatch):
+        # Restores the pre-#606 integration coverage for the opt-in path: the
+        # full make_tool_result_message() wiring must still surface the hint
+        # when an operator turns inline diagnostics back on for debugging.
+        monkeypatch.setenv("HERMES_DIAGNOSTICS_INLINE", "1")
+        msg = make_tool_result_message("terminal", "bash: x: command not found", "c1")
+        assert "[diagnostic] failure-class=missing_command" in msg["content"]
+
 
 


### PR DESCRIPTION
## Description
`tool_diagnostics.diagnostic_suffix()` appended a `[diagnostic] failure-class=... — <hint>` line to tool results that its regex classifier thought looked like a failure — 209 occurrences across 95 sessions in one week of real usage. `classify()` is a plain text heuristic, not a real success/failure signal, so it repeatedly false-positived on **successful** results that merely mention words like "timeout" or "error" (e.g. reading source code that discusses them), consuming context budget with non-actionable noise on every subsequent turn.

## Type
Bug fix / performance

## Related Issues
Closes #606

## Changes
- `agent.diagnostics.inline` config flag (default `false`) / `HERMES_DIAGNOSTICS_INLINE` env var (takes precedence) gate the inline injection. Uses `load_config_readonly()` (cached, no deepcopy) since this runs on every tool result.
- `loop_guard` calls `tool_diagnostics.classify()` directly for its own tracking — unaffected by this flag either way.
- Documented in `cli-config.yaml.example` and `DEFAULT_CONFIG`.

## Deliberately out of scope
Per-session per-class deduplication (issue proposals #2/#3). That needs session identity plumbed through `make_tool_result_message()` and its ~9 call sites across `tool_executor.py`/`agent_runtime_helpers.py`/`mini_swe_runner.py` for a rarely-exercised opt-in debug path. The default-off gate already eliminates the reported noise for the overwhelmingly common case (nobody opts in).

## Testing
- `tests/agent/test_tool_diagnostics.py`: 21 tests covering `classify()`, the config/env precedence and edge cases of `inline_diagnostics_enabled()`, and both the default-off and explicitly-enabled paths through `make_tool_result_message()`.
- `ruff check` clean.
- Independently reviewed via a `consult` panel (Gemini + opencode/deepseek): first pass surfaced 4 real gaps (missing direct unit tests, no cached config read, lost integration coverage for the enabled path, missing dedup) — all but the deliberately-scoped-out dedup were fixed and re-verified. Final VERDICT: PASS.

## Breaking Changes
None — the diagnostic hint was pure text overhead; nothing parses it back out of tool results.

## Mode
PUBLIC