### PR TITLE
fix(cron): mark zero-tool-call sessions cron_noop instead of cron_complete

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3375,17 +3375,37 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Minimum-action guard (#607): a cron session that finishes
         # successfully but never invoked a single tool (or delegate_task,
         # itself a tool call) never actually attempted the scheduled
-        # deliverable — no file read, no search run, no issue created. Only
-        # check when `messages` is actually present: a caller-provided
-        # result without it (e.g. a minimal test stub) can't be classified
-        # either way, so default to the existing `cron_complete` behavior
-        # rather than guess.
-        _cron_messages = result.get("messages")
-        if isinstance(_cron_messages, list):
-            _cron_noop = not any(
-                isinstance(_m, dict) and _m.get("role") == "tool"
-                for _m in _cron_messages
-            )
+        # deliverable — no file read, no search run, no issue created.
+        # Read from the DURABLE session DB (include_inactive=True) rather
+        # than result["messages"]: the latter is the in-memory list handed
+        # to the API, which in-place context compaction (#38763) can rewrite
+        # mid-session, replacing early tool-call turns with a summary and
+        # erasing the "did it call a tool" signal for an otherwise-productive
+        # long session. The DB's soft-delete mechanic keeps compacted-away
+        # rows queryable, so this stays accurate regardless of compaction.
+        # Only checked when a session DB is actually wired up; without one
+        # there's no durable record to check, so default to the existing
+        # `cron_complete` behavior rather than guess.
+        #
+        # Known limitation: a job whose prompt genuinely never requires a
+        # tool (a pure text/summary reply) will also be flagged — this is a
+        # session-shape heuristic, not intent detection. The label is purely
+        # observational (no retry/failure side effects), so a false positive
+        # here costs a misleading status, not a broken job.
+        if _session_db:
+            try:
+                _db_messages = _session_db.get_messages(
+                    _cron_session_id, include_inactive=True
+                )
+                _cron_noop = not any(
+                    isinstance(_m, dict) and _m.get("role") == "tool"
+                    for _m in _db_messages
+                )
+            except Exception as _exc:
+                logger.debug(
+                    "Job '%s': failed to check tool-call activity for cron_noop "
+                    "detection: %s", job_id, _exc,
+                )
             if _cron_noop:
                 logger.warning(
                     "Job '%s': completed with ZERO tool calls — the model "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2660,6 +2660,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    # Set once the agent run completes successfully with zero tool calls
+    # (#607) so the finally block below can mark the session `cron_noop`
+    # instead of `cron_complete` — a text-only turn that never touched a
+    # tool/delegate_task means the scheduled deliverable was never attempted,
+    # and `cron_complete` was masking that as a normal, healthy run.
+    _cron_noop = False
 
     # Ensure the session row exists before the agent starts so that
     # end_session() in the finally block always has a row to update.
@@ -2669,6 +2675,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _session_db.ensure_session(_cron_session_id, _origin_platform)
         except (Exception, KeyboardInterrupt) as _exc:
             logger.debug("Job '%s': failed to ensure session row: %s", job_id, _exc)
+
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -3365,6 +3372,28 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 {logged_response}
 """
 
+        # Minimum-action guard (#607): a cron session that finishes
+        # successfully but never invoked a single tool (or delegate_task,
+        # itself a tool call) never actually attempted the scheduled
+        # deliverable — no file read, no search run, no issue created. Only
+        # check when `messages` is actually present: a caller-provided
+        # result without it (e.g. a minimal test stub) can't be classified
+        # either way, so default to the existing `cron_complete` behavior
+        # rather than guess.
+        _cron_messages = result.get("messages")
+        if isinstance(_cron_messages, list):
+            _cron_noop = not any(
+                isinstance(_m, dict) and _m.get("role") == "tool"
+                for _m in _cron_messages
+            )
+            if _cron_noop:
+                logger.warning(
+                    "Job '%s': completed with ZERO tool calls — the model "
+                    "produced only text, so the scheduled deliverable was "
+                    "never attempted. Session will be marked cron_noop.",
+                    job_name,
+                )
+
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
 
@@ -3424,7 +3453,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     "Job '%s': failed to set cron session title: %s", job_id, e
                 )
             try:
-                _session_db.end_session(_cron_session_id, "cron_complete")
+                _session_db.end_session(
+                    _cron_session_id, "cron_noop" if _cron_noop else "cron_complete"
+                )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -983,6 +983,12 @@ class TestRunJobSessionPersistence:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
+            fake_db.get_messages.return_value = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                {"role": "tool", "content": "did something"},
+                {"role": "assistant", "content": "ok"},
+            ]
 
             success, output, final_response, error = run_job(job)
 
@@ -1030,17 +1036,21 @@ class TestRunJobSessionPersistence:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {
                 "final_response": "I'll take care of that.",
-                "messages": [
-                    {"role": "user", "content": "hello"},
-                    {"role": "assistant", "content": "I'll take care of that."},
-                ],
             }
             mock_agent_cls.return_value = mock_agent
+            fake_db.get_messages.return_value = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "I'll take care of that."},
+            ]
 
             success, output, final_response, error = run_job(job)
 
         assert success is True
         assert error is None
+        fake_db.get_messages.assert_called_once()
+        get_messages_args = fake_db.get_messages.call_args
+        assert get_messages_args[0][0].startswith("cron_noop-job_")
+        assert get_messages_args[1]["include_inactive"] is True
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args
         assert call_args[0][1] == "cron_noop"
@@ -1069,16 +1079,72 @@ class TestRunJobSessionPersistence:
              ), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "Done."}
+            mock_agent_cls.return_value = mock_agent
+            fake_db.get_messages.return_value = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                {"role": "tool", "content": "file written"},
+                {"role": "assistant", "content": "Done."},
+            ]
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        fake_db.end_session.assert_called_once()
+        call_args = fake_db.end_session.call_args
+        assert call_args[0][1] == "cron_complete"
+
+    def test_run_job_survives_in_place_compaction_without_false_cron_noop(self, tmp_path):
+        """#607 follow-up: in-place context compaction (#38763) can rewrite the
+        in-memory ``messages`` list mid-session, replacing early tool-call
+        turns with a summary. The noop check must read the DURABLE session DB
+        (include_inactive=True) rather than the agent's returned
+        ``result["messages"]``, so a genuinely productive session that got
+        compacted is never misclassified as cron_noop."""
+        job = {
+            "id": "compacted-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            # The live API-facing list post-compaction: the earlier tool
+            # call/result turns have been rewritten into a summary message —
+            # no role=="tool" entry survives here.
             mock_agent.run_conversation.return_value = {
                 "final_response": "Done.",
                 "messages": [
-                    {"role": "user", "content": "hello"},
-                    {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
-                    {"role": "tool", "content": "file written"},
+                    {"role": "user", "content": "[compacted summary of earlier work]"},
                     {"role": "assistant", "content": "Done."},
                 ],
             }
             mock_agent_cls.return_value = mock_agent
+            # The durable DB (include_inactive=True) still has the original
+            # tool turns as soft-deleted rows.
+            fake_db.get_messages.return_value = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                {"role": "tool", "content": "file written", "active": 0},
+                {"role": "user", "content": "[compacted summary of earlier work]"},
+                {"role": "assistant", "content": "Done."},
+            ]
 
             success, output, final_response, error = run_job(job)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1002,6 +1002,92 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_marks_cron_noop_when_zero_tool_calls(self, tmp_path):
+        """#607: a cron session that ends successfully but never called a
+        tool (or delegate_task) never attempted the scheduled deliverable —
+        end_session must record 'cron_noop', not 'cron_complete'."""
+        job = {
+            "id": "noop-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "I'll take care of that.",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "I'll take care of that."},
+                ],
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        fake_db.end_session.assert_called_once()
+        call_args = fake_db.end_session.call_args
+        assert call_args[0][1] == "cron_noop"
+
+    def test_run_job_keeps_cron_complete_when_tool_calls_happened(self, tmp_path):
+        """A session with at least one real tool result stays 'cron_complete'."""
+        job = {
+            "id": "worked-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "Done.",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                    {"role": "tool", "content": "file written"},
+                    {"role": "assistant", "content": "Done."},
+                ],
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        fake_db.end_session.assert_called_once()
+        call_args = fake_db.end_session.call_args
+        assert call_args[0][1] == "cron_complete"
+
     def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
         """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).
         For cron, that abnormal-empty explainer must be treated as empty so it


### PR DESCRIPTION
## Description
Multiple cron-scheduled sessions ended with `cron_complete` status despite the model producing **zero tool calls** across the whole session — the scheduled deliverable (research, file edit, issue creation, etc.) was never even attempted, but `cron_complete` masked it as a normal, healthy run. 6 of 49 cron sessions in one week of real usage, per the issue.

## Type
Bug fix

## Related Issues
Closes #607

## Changes
`_run_job_impl()` now checks the durable session DB (`_session_db.get_messages(session_id, include_inactive=True)`) on the success path: if no message has `role == "tool"` (no tool call — including `delegate_task`, itself a tool call — ever produced a result), the session end_reason is `cron_noop` instead of `cron_complete`, and a warning is logged.

Reads from the **durable DB**, not `result["messages"]` (the in-memory list handed to the API) — in-place context compaction (#38763) can rewrite that list mid-session, replacing early tool-call turns with a summary. The DB's soft-delete mechanic keeps compacted-away rows queryable via `include_inactive=True`, so the check stays accurate regardless of compaction.

## Deliberately out of scope
- Surfacing `cron_noop` in an evolution health/funnel summary (issue proposal #2) — no such session-level health dashboard exists yet (`scripts/evolution_funnel.py` tracks the research→issue→PR pipeline, not per-session tool-call activity); building one is a separate, larger feature.
- The retry-on-noop idea (proposal #3) — this guard's job is to make the no-op visible, not to change cron's retry semantics.
- Crashed/exception-path sessions still get `cron_complete` in the `finally` block — pre-existing behavior, unrelated to and not worsened by this change.
- A cron job whose prompt genuinely never requires a tool (pure text/summary reply) will also be flagged `cron_noop` — a known limitation of a session-shape heuristic. The label is purely observational with no retry/failure side effects, so a false positive here costs a misleading status, not a broken job.

## Testing
- `tests/cron/test_scheduler.py`: added tests for the noop case, the normal tool-use case, and a dedicated in-place-compaction-resilience case (session's live `messages` shows no tool call post-compaction, but the durable DB confirms one happened — stays `cron_complete`). Updated the pre-existing `test_run_job_passes_session_db_and_cron_platform` fixture to include a realistic tool-call in its mocked DB history.
- Full `tests/cron/` suite: 645 passed, 1 pre-existing failure unrelated to this change (sandbox process-signal guard, identical with and without the diff).
- `ruff check` clean.
- Independently reviewed via a `consult` panel (Gemini + opencode/deepseek): first pass surfaced a real gap (context-compaction could erase the signal from the in-memory messages list) — fixed by switching to the durable DB read. Final VERDICT: PASS.

## Breaking Changes
None — `cron_noop` is a new, additive session end-reason string; nothing currently branches on `cron_complete` vs. other values besides display/audit code.

## Mode
PUBLIC