### PR TITLE
fix(agent): enforce loop-guard hard stop for unattended cron sessions

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -716,6 +716,15 @@ def _run_conversation_impl(
         # spiral and re-check the goal (#173/#174/#175/#176/#143). Advisory only:
         # it appends a user message, never blocks a tool call. Nudges once per
         # stuck run (tracked by the trailing tool name) to avoid spamming.
+        #
+        # Cron exception (#624): advisory nudges are routinely ignored by the
+        # model (observed: 9 warnings, 65 consecutive terminal calls, zero
+        # course-correction) with no human present to intervene. In unattended
+        # cron sessions specifically, once the SAME stuck run has already been
+        # nudged CRON_LOOP_GUARD_HARD_STOP_THRESHOLD times, stop wasting the
+        # rest of the budget: end the turn as a failure instead of nudging
+        # again. Interactive surfaces (CLI/gateway/messaging) keep the purely
+        # advisory behavior — a human is present to course-correct there.
         try:
             from agent import loop_guard as _loop_guard
 
@@ -732,6 +741,7 @@ def _run_conversation_impl(
             # re-nudges keep pressure on a persistent loop.
             if _lg_tool is None:
                 agent._loop_guard_nudged = None  # run ended — re-arm
+                agent._loop_guard_warning_count = 0
             elif (
                 _lg_prev is None
                 or _lg_prev[0] != _lg_tool
@@ -739,7 +749,13 @@ def _run_conversation_impl(
             ):
                 _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
-                    messages.append({"role": "user", "content": _lg_nudge})
+                    _lg_prior_warnings = getattr(agent, "_loop_guard_warning_count", 0)
+                    _lg_warnings = (
+                        1
+                        if (_lg_prev is None or _lg_prev[0] != _lg_tool)
+                        else _lg_prior_warnings + 1
+                    )
+                    agent._loop_guard_warning_count = _lg_warnings
                     agent._loop_guard_nudged = (_lg_tool, _lg_count)
                     if "ESCALATED INTERRUPT" in _lg_nudge:
                         logger.warning(
@@ -748,6 +764,28 @@ def _run_conversation_impl(
                             _lg_tool,
                             _lg_count,
                         )
+                    if _loop_guard.should_cron_hard_stop(
+                        getattr(agent, "platform", None), _lg_warnings
+                    ):
+                        logger.warning(
+                            "loop_guard: cron hard stop — `%s` stuck run nudged "
+                            "%d times unattended, ending turn as a failure "
+                            "instead of burning the rest of the budget (#624)",
+                            _lg_tool,
+                            _lg_warnings,
+                        )
+                        final_response = (
+                            f"[loop-guard] Unattended cron session stuck on `{_lg_tool}` "
+                            f"— {_lg_warnings} advisory warnings were ignored across "
+                            f"{_lg_count} consecutive calls with no course-correction. "
+                            f"Stopping now rather than exhausting the run's budget."
+                        )
+                        failed = True
+                        _turn_exit_reason = "loop_guard_cron_hard_stop"
+                        messages.append(
+                            {"role": "assistant", "content": final_response}
+                        )
+                        break
                     if not agent.quiet_mode:
                         agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
         except Exception as _lg_err:  # never let the guard break the loop

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -734,27 +734,33 @@ def _run_conversation_impl(
             _lg_prev = getattr(
                 agent, "_loop_guard_nudged", None
             )  # (tool, count) | None
-            # Re-nudge when the stuck run is NEW (tool changed/ended) OR it has
+            # The cron warning counter tracks a SEPARATE "which tool is the
+            # trailing run currently on" identity from `_loop_guard_nudged`
+            # (which only updates when a nudge actually fires). Without this,
+            # a resolved spiral's warning count silently survives an
+            # intervening run of a DIFFERENT (or no) tool and wrongly carries
+            # over once the same tool name starts a brand-new, unrelated
+            # spiral later in the session — inflating its warning count and
+            # cron-hard-stopping on what should be only its first nudge.
+            # Reset whenever the trailing run's tool identity changes at all,
+            # not just when it goes fully quiet.
+            if _lg_tool != getattr(agent, "_loop_guard_tracked_tool", None):
+                agent._loop_guard_tracked_tool = _lg_tool
+                agent._loop_guard_nudged = None
+                agent._loop_guard_warning_count = 0
+                _lg_prev = None
+            # Re-nudge when the stuck run is NEW (no nudge yet) OR it has
             # grown by >=3 calls since the last nudge. Without the growth check a
             # single nudge fired once and then went silent for the next dozen
             # identical calls — the spiral ran on to 15+ unguided (#231). Escalating
             # re-nudges keep pressure on a persistent loop.
-            if _lg_tool is None:
-                agent._loop_guard_nudged = None  # run ended — re-arm
-                agent._loop_guard_warning_count = 0
-            elif (
-                _lg_prev is None
-                or _lg_prev[0] != _lg_tool
-                or _lg_count - _lg_prev[1] >= 3
+            if _lg_tool is not None and (
+                _lg_prev is None or _lg_count - _lg_prev[1] >= 3
             ):
                 _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
-                    _lg_prior_warnings = getattr(agent, "_loop_guard_warning_count", 0)
-                    _lg_warnings = (
-                        1
-                        if (_lg_prev is None or _lg_prev[0] != _lg_tool)
-                        else _lg_prior_warnings + 1
-                    )
+                    messages.append({"role": "user", "content": _lg_nudge})
+                    _lg_warnings = getattr(agent, "_loop_guard_warning_count", 0) + 1
                     agent._loop_guard_warning_count = _lg_warnings
                     agent._loop_guard_nudged = (_lg_tool, _lg_count)
                     if "ESCALATED INTERRUPT" in _lg_nudge:

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -128,6 +128,24 @@ _IDEMPOTENT_FAIL_THRESHOLD = 4
 _MUTATING_ESCALATE_THRESHOLD = 8
 _IDEMPOTENT_ESCALATE_THRESHOLD = 15
 
+# Unattended cron sessions get real enforcement, not just advisory text (#624):
+# advisory nudges are routinely ignored by the model with no human present to
+# course-correct (observed: 9 warnings ignored, 65 consecutive terminal calls).
+# After this many nudges for the SAME stuck run, the cron turn ends as a
+# failure instead of nudging again. Interactive surfaces are unaffected — this
+# constant is only consulted when ``agent.platform == "cron"``.
+CRON_LOOP_GUARD_HARD_STOP_THRESHOLD = 2
+
+
+def should_cron_hard_stop(platform: Optional[str], warning_count: int) -> bool:
+    """True when an unattended cron turn should end as a failure instead of
+    nudging again (#624): only ever True for ``platform == "cron"`` once the
+    same stuck run has already been nudged
+    ``CRON_LOOP_GUARD_HARD_STOP_THRESHOLD`` times. Interactive surfaces
+    (CLI/gateway/messaging) always return False — a human is present there to
+    course-correct, so the guard stays purely advisory."""
+    return platform == "cron" and warning_count >= CRON_LOOP_GUARD_HARD_STOP_THRESHOLD
+
 
 def _failure_category(content: Any) -> Optional[str]:
     """The tool_diagnostics failure class of a result, or None if not a failure.

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -8,7 +8,12 @@ use higher thresholds. Tests use ``terminal`` (mutating, threshold=4) and
 
 import json
 
-from agent.loop_guard import current_run_signature, maybe_nudge
+from agent.loop_guard import (
+    CRON_LOOP_GUARD_HARD_STOP_THRESHOLD,
+    current_run_signature,
+    maybe_nudge,
+    should_cron_hard_stop,
+)
 
 
 def _asst(tool, args="{}", call_id="c"):
@@ -276,3 +281,25 @@ class TestSameQueryShortCircuit:
         assert n is not None
         assert "SAME arguments" not in n  # not the #467 short-circuit
         assert "web_search" in n  # the generic spiral nudge still fires
+
+
+class TestShouldCronHardStop:
+    """#624: unattended cron turns get real enforcement, not just advisory
+    text — interactive surfaces (a human is present) are never affected."""
+
+    def test_below_threshold_never_stops(self):
+        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD - 1) is False
+
+    def test_at_threshold_stops(self):
+        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD) is True
+
+    def test_above_threshold_stops(self):
+        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 5) is True
+
+    def test_zero_warnings_never_stops(self):
+        assert should_cron_hard_stop("cron", 0) is False
+
+    def test_non_cron_platforms_never_stop_regardless_of_count(self):
+        huge_count = CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 100
+        for platform in ("cli", "telegram", "discord", "gateway", None, ""):
+            assert should_cron_hard_stop(platform, huge_count) is False, platform

--- a/tests/agent/test_loop_guard_cron_enforcement.py
+++ b/tests/agent/test_loop_guard_cron_enforcement.py
@@ -75,7 +75,16 @@ def _make_agent(*tool_names: str, max_iterations: int = 20, platform: str | None
 def _repeated_terminal_run(n: int, command: str = "echo hi"):
     """n identical successful terminal tool-call responses, then a final
     text-only "stop" response as a safety net in case the hard stop doesn't
-    fire and the loop keeps going."""
+    fire and the loop keeps going.
+
+    Note: each fired nudge is injected into ``messages`` as a ``role="user"``
+    entry, which resets what ``current_run_signature`` sees as the trailing
+    single-tool run (it stops walking backward at the first non-tool
+    message). So after the first nudge (at raw call 4 for a mutating tool),
+    the run must regrow by a full ``repeat_threshold`` worth of calls from
+    that injection point — not from the original start — before the re-nudge
+    growth check re-admits a second nudge. Empirically the cron hard stop
+    fires at raw call 12 for ``terminal`` (mutating, repeat_threshold=4)."""
     responses = [
         _mock_response(
             content="",
@@ -90,7 +99,7 @@ def _repeated_terminal_run(n: int, command: str = "echo hi"):
 
 def test_cron_platform_hard_stops_after_repeated_advisory_nudges():
     agent = _make_agent("terminal", max_iterations=20, platform="cron")
-    agent.client.chat.completions.create.side_effect = _repeated_terminal_run(9)
+    agent.client.chat.completions.create.side_effect = _repeated_terminal_run(15)
 
     with (
         patch("run_agent.handle_function_call", return_value="command completed"),
@@ -104,10 +113,78 @@ def test_cron_platform_hard_stops_after_repeated_advisory_nudges():
     assert result["turn_exit_reason"] == "loop_guard_cron_hard_stop"
     assert "loop-guard" in result["final_response"].lower()
     # Stopped well short of exhausting the iteration budget or the full
-    # 9-call canned run — proves it broke out of the loop early rather than
-    # running to the safety-net "done" response.
+    # 15-call canned run — proves it broke out of the loop early rather than
+    # running to the safety-net "done" response. Empirically verified at 12.
     assert result["api_calls"] < agent.max_iterations
-    assert result["api_calls"] < 9
+    assert result["api_calls"] == 12
+
+
+def test_resolved_spiral_state_does_not_leak_into_a_later_unrelated_tool_run():
+    """Regression: an earlier `terminal` spiral that racked up multiple
+    advisory nudges and was then resolved (the agent moved on to healthy,
+    varied work on a different tool) must NOT leave stale
+    `_loop_guard_warning_count` / `_loop_guard_nudged` state behind. Without
+    resetting the tracked-tool identity on every switch (not just when the
+    run goes fully quiet), a LATER, unrelated spiral on the SAME tool name
+    would inherit the old warning count and could cron-hard-stop far earlier
+    or later than its own two genuine warnings warrant.
+
+    Uses platform=None (interactive) so the spiral is free to accumulate
+    several real nudges without being cut short by the cron hard-stop —
+    that lets the stale count grow past the trivial "exactly
+    repeat_threshold" case, which is otherwise indistinguishable from a
+    fresh run's first nudge count and would mask the bug. The assertion is
+    on internal state directly (not an emergent hard-stop position), since
+    at the shipped CRON_LOOP_GUARD_HARD_STOP_THRESHOLD=2 any cron session
+    that reached a 2nd nudge would already have stopped before it could
+    "resolve peacefully" — this scenario can only be exercised end-to-end
+    on a surface where nudges are purely advisory.
+    """
+    agent = _make_agent("terminal", "read_file", max_iterations=30, platform=None)
+
+    first_spiral = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("terminal", json.dumps({"command": "echo hi"}), f"a{i}")],
+        )
+        for i in range(20)  # empirically: 2 nudges accumulate over 20 calls
+        # (each fired nudge resets the visible run per _repeated_terminal_run's
+        # docstring, so nudge #2 needs a full regrowth from the injection
+        # point, not just +3 from the original start)
+    ]
+    healthy_interlude = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("read_file", json.dumps({"path": f"/tmp/f{i}.txt"}), f"b{i}")],
+        )
+        for i in range(3)  # varied args, different tool -> lets the reset settle
+    ]
+    trailing_done = [_mock_response(content="done", finish_reason="stop", tool_calls=None)]
+    agent.client.chat.completions.create.side_effect = (
+        first_spiral + healthy_interlude + trailing_done
+    )
+
+    with (
+        patch("run_agent.handle_function_call", return_value="command completed"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do varied work, some of it repetitive")
+
+    # The first spiral genuinely racked up multiple warnings (2, verified via
+    # the loop-guard nudge messages actually delivered to the model)...
+    nudge_msgs = [
+        m for m in result["messages"]
+        if m.get("role") == "user" and "[loop-guard]" in str(m.get("content", ""))
+    ]
+    assert len(nudge_msgs) == 2
+    # ...but by the time healthy read_file work follows, the tracked tool and
+    # warning count must reflect ONLY that new, unrelated activity.
+    assert agent._loop_guard_tracked_tool == "read_file"
+    assert agent._loop_guard_warning_count == 0
 
 
 def test_non_cron_platform_keeps_nudging_advisory_only():

--- a/tests/agent/test_loop_guard_cron_enforcement.py
+++ b/tests/agent/test_loop_guard_cron_enforcement.py
@@ -1,0 +1,129 @@
+"""Runtime test for #624: unattended cron turns enforce the loop-guard
+instead of only nudging. Advisory nudges are routinely ignored by the model
+with no human present to course-correct (observed: 9 warnings ignored, 65
+consecutive terminal calls in one real session). Once the SAME stuck run has
+been nudged ``CRON_LOOP_GUARD_HARD_STOP_THRESHOLD`` times on
+``agent.platform == "cron"``, the turn must end as a failure instead of
+nudging again. Interactive surfaces are unaffected — this is exercised in
+``tests/agent/test_loop_guard.py::TestShouldCronHardStop`` at the pure-function
+level; this file proves the actual conversation_loop wiring.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name="terminal", arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(*tool_names: str, max_iterations: int = 20, platform: str | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform=platform,
+        )
+    from unittest.mock import MagicMock
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _repeated_terminal_run(n: int, command: str = "echo hi"):
+    """n identical successful terminal tool-call responses, then a final
+    text-only "stop" response as a safety net in case the hard stop doesn't
+    fire and the loop keeps going."""
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("terminal", json.dumps({"command": command}), f"c{i}")],
+        )
+        for i in range(n)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    return responses
+
+
+def test_cron_platform_hard_stops_after_repeated_advisory_nudges():
+    agent = _make_agent("terminal", max_iterations=20, platform="cron")
+    agent.client.chat.completions.create.side_effect = _repeated_terminal_run(9)
+
+    with (
+        patch("run_agent.handle_function_call", return_value="command completed"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("run the same command repeatedly")
+
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "loop_guard_cron_hard_stop"
+    assert "loop-guard" in result["final_response"].lower()
+    # Stopped well short of exhausting the iteration budget or the full
+    # 9-call canned run — proves it broke out of the loop early rather than
+    # running to the safety-net "done" response.
+    assert result["api_calls"] < agent.max_iterations
+    assert result["api_calls"] < 9
+
+
+def test_non_cron_platform_keeps_nudging_advisory_only():
+    """Same stuck-run shape on an interactive surface (platform=None) must
+    NOT hard-stop — a human is present to course-correct there."""
+    agent = _make_agent("terminal", max_iterations=20, platform=None)
+    agent.client.chat.completions.create.side_effect = _repeated_terminal_run(9)
+
+    with (
+        patch("run_agent.handle_function_call", return_value="command completed"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("run the same command repeatedly")
+
+    assert result.get("failed") is not True
+    assert result["turn_exit_reason"] != "loop_guard_cron_hard_stop"
+    assert result["final_response"] == "done"


### PR DESCRIPTION
## Description
The loop-guard fires frequently (64 warnings across 36 of 95 sessions in 7d) but is purely advisory — it injects a user-message warning but never blocks a tool call. In the worst observed session the model received 9 warnings yet continued with 65 consecutive terminal calls with zero course-correction. In unattended cron sessions this wastes the entire budget with no human present to intervene.

## Type
Bug fix

## Related Issues
Closes #624

## Changes
- `agent.loop_guard.should_cron_hard_stop(platform, warning_count)`: a pure, standalone-testable helper — True only when `platform == "cron"` and the same stuck run has already been nudged `CRON_LOOP_GUARD_HARD_STOP_THRESHOLD` (2) times.
- `conversation_loop.py` tracks a per-stuck-run warning counter and, when the helper returns True, ends the turn as a failure (`failed=True`, `turn_exit_reason='loop_guard_cron_hard_stop'`) instead of nudging again. This flows into `cron/scheduler.py`'s **existing** failure-handling path unchanged — no scheduler.py changes needed.
- Interactive surfaces (CLI/gateway/messaging) are completely unaffected — a human is present there to course-correct, so the guard stays purely advisory exactly as before.

## Deliberately out of scope (documented in commit message)
- Hard tool-switch / plan-revision enforcement on ALL surfaces (issue proposals #1/#2) — too broad/risky; legitimate repeated tool use (e.g. working through a file list) would get blocked on interactive surfaces where a human can already react to the advisory.
- Structured `loop_guard_violation` event replacing the prose nudge (proposal #4) — larger interface change with no reported problem attached in the issue's evidence.

## Testing
- `tests/agent/test_loop_guard.py::TestShouldCronHardStop` — 5 pure unit tests for the threshold/platform decision.
- `tests/agent/test_loop_guard_cron_enforcement.py` — 3 end-to-end tests driving `run_conversation()` with mocked API responses: cron hard-stops after repeated nudges, interactive platforms keep nudging only, and a dedicated regression test proving a resolved spiral's warning state doesn't leak into a later unrelated one.
- Verified zero regressions across the ~26 test files that actually call `run_conversation()` (716+ passed; the handful of failures present are identical pre-existing sandbox/environment gaps, confirmed via baseline diff both with and without this change).
- Independently reviewed via two `consult` panel rounds (Gemini + opencode/deepseek). Round 1 found a real stale-state bug (fixed by tracking tool identity independently of nudge firing). While building the regression test for that fix, I also self-caught and fixed a **more severe** issue: my first rewrite had accidentally deleted the line that delivers the advisory nudge text to the model, silently breaking the pre-existing advisory mechanism (#173) for every platform, not just cron. Final round: independently re-verified PASS.

## Breaking Changes
None for interactive surfaces. Unattended cron sessions that were previously silently burning their entire budget in a mono-tool spiral will now end early as a failure (visible, not silent) — this is the intended fix.

## Mode
PUBLIC