### PR TITLE
fix(agent): suggest repo_map/delegate_task in exploration mono-tool nudges

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -79,6 +79,31 @@ _NONRETRY_THRESHOLD = 2
 _SHORT_CIRCUIT_IDEMPOTENT = frozenset({"search_files", "web_search", "web_extract"})
 _SHORT_CIRCUIT_REPEAT_THRESHOLD = 4
 
+# Code-exploration tools whose mono-tool spiral is a STRATEGY problem, not a
+# failure (#625): 16-17 consecutive read_file calls / 14 consecutive
+# search_files calls, one file/query at a time, each succeeding — the agent
+# just never reached for a cheaper bulk-overview alternative. Named here (not
+# folded into the generic nudge text) so the suggestion only appears for the
+# tools it actually applies to.
+_EXPLORATION_ALTERNATIVE_HINT = {
+    "read_file": (
+        " For broad codebase exploration, `repo_map` gives a structured "
+        "overview (functions/classes/methods with file:line) in a single "
+        "call — far cheaper than reading files one at a time (Python "
+        "codebases only). For a large batch of files you already know you "
+        "need, `delegate_task` a subagent to read them and report back, "
+        "keeping this context lean."
+    ),
+    "search_files": (
+        " For broad codebase exploration, `repo_map` gives a structured "
+        "overview (functions/classes/methods with file:line) in a single "
+        "call — far cheaper than many narrow searches (Python codebases "
+        "only). For a batch of searches you already know you need, "
+        "`delegate_task` a subagent to run them and report back, keeping "
+        "this context lean."
+    ),
+}
+
 # Mutating tools get LOWER thresholds than idempotent tools because a fixation
 # on mutating operations (writing files, running commands) is more costly and
 # indicates a deeper strategy problem (#432).
@@ -415,6 +440,7 @@ def maybe_nudge(
         # Build diversity score for the nudge.
         score = _tool_spiral_score(tool, count, repeat_threshold)
         score_line = f"\n{score}" if score else ""
+        exploration_hint = _EXPLORATION_ALTERNATIVE_HINT.get(tool, "")
 
         if count >= escalate_threshold:
             return (
@@ -426,6 +452,7 @@ def maybe_nudge(
                 f"progress exists, state the actual blocker explicitly and "
                 f"propose a fundamentally different strategy — do NOT call "
                 f"`{tool}` again until you have provided this summary."
+                f"{exploration_hint}"
             )
 
         return (
@@ -435,6 +462,7 @@ def maybe_nudge(
             f"plan/success criterion, then either change strategy, move to the "
             f"next step, or report the blocker. Avoid another near-identical "
             f"`{tool}` call."
+            f"{exploration_hint}"
         )
 
     return None

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -172,6 +172,57 @@ class TestEscalatedInterrupt:
         assert n is not None and "spiral-intensity" in n
 
 
+class TestExplorationAlternativeHint:
+    """#625: 16-17 consecutive read_file / 14 consecutive search_files calls
+    in real sessions, never reaching for repo_map or delegate_task. The
+    mono-tool spiral nudge for these two tools specifically should surface
+    those alternatives — other tools' nudges must stay unchanged."""
+
+    @staticmethod
+    def _varied_args_run(tool, n, *, result="ok"):
+        """n consecutive single-tool turns with DIFFERENT arguments each —
+        avoids the #467 same-query short-circuit so the generic mono-tool
+        repeat_threshold path is what actually fires."""
+        msgs = [{"role": "user", "content": "explore the codebase"}]
+        for i in range(n):
+            cid = f"c{i}"
+            msgs.append(_asst(tool, args=json.dumps({"path": f"file_{i}.py"}), call_id=cid))
+            msgs.append(_result(result, call_id=cid))
+        return msgs
+
+    def test_read_file_regular_nudge_suggests_alternatives(self):
+        # read_file is idempotent (repeat_threshold=8); 8 calls -> regular nudge.
+        n = maybe_nudge(_run("read_file", 8))
+        assert n is not None
+        assert "repo_map" in n and "delegate_task" in n
+
+    def test_search_files_regular_nudge_suggests_alternatives(self):
+        # search_files is short-circuit-prone on SAME args (#467); use varied
+        # args so the generic repeat_threshold path fires instead, matching
+        # #625's actual pattern (different queries, not a repeated one).
+        n = maybe_nudge(self._varied_args_run("search_files", 8))
+        assert n is not None
+        assert "repo_map" in n and "delegate_task" in n
+
+    def test_read_file_escalated_nudge_suggests_alternatives(self):
+        # idempotent escalate_threshold=15.
+        n = maybe_nudge(_run("read_file", 15))
+        assert n is not None
+        assert "ESCALATED INTERRUPT" in n
+        assert "repo_map" in n and "delegate_task" in n
+
+    def test_unrelated_tool_nudge_has_no_exploration_hint(self):
+        n = maybe_nudge(_run("terminal", 4))
+        assert n is not None
+        assert "repo_map" not in n and "delegate_task" not in n
+
+    def test_write_file_nudge_has_no_exploration_hint(self):
+        n = maybe_nudge(_run("write_file", 4))
+        assert n is not None
+        assert "repo_map" not in n and "delegate_task" not in n
+
+
+
 class TestRunBoundaries:
     def test_tool_change_breaks_the_run(self):
         # 5x terminal then 1x read_file at the tail -> only the read_file run (len 1)

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -211,6 +211,12 @@ class TestExplorationAlternativeHint:
         assert "ESCALATED INTERRUPT" in n
         assert "repo_map" in n and "delegate_task" in n
 
+    def test_search_files_escalated_nudge_suggests_alternatives(self):
+        n = maybe_nudge(self._varied_args_run("search_files", 15))
+        assert n is not None
+        assert "ESCALATED INTERRUPT" in n
+        assert "repo_map" in n and "delegate_task" in n
+
     def test_unrelated_tool_nudge_has_no_exploration_hint(self):
         n = maybe_nudge(_run("terminal", 4))
         assert n is not None
@@ -219,6 +225,16 @@ class TestExplorationAlternativeHint:
     def test_write_file_nudge_has_no_exploration_hint(self):
         n = maybe_nudge(_run("write_file", 4))
         assert n is not None
+        assert "repo_map" not in n and "delegate_task" not in n
+
+    def test_same_query_short_circuit_has_no_exploration_hint(self):
+        # #467 same-query short-circuit is a DIFFERENT problem (repeating the
+        # identical query) with its own, already-relevant advice — the
+        # exploration hint must not bleed into this path.
+        msgs = _run("search_files", 4)  # identical args -> short-circuit, not repeat_threshold
+        n = maybe_nudge(msgs)
+        assert n is not None
+        assert "SAME arguments" in n  # confirms the short-circuit path fired
         assert "repo_map" not in n and "delegate_task" not in n
 
 


### PR DESCRIPTION
## Description
In code exploration tasks, the agent reads files sequentially with `read_file` (peak 16-17 consecutive calls in real sessions) or searches sequentially with `search_files` (peak 14 consecutive) instead of using `repo_map` (a single call for a structured codebase overview) or delegating batched reads to a subagent. 49 of 95 sessions in one week had ≥4 consecutive same-tool calls — the most widespread inefficiency pattern in the evidence. These are **not** failure-driven (every call succeeds); the strategy itself is just expensive.

## Type
Improvement / UX

## Related Issues
Closes #625

## Changes
Adds `_EXPLORATION_ALTERNATIVE_HINT`, a small tool→hint-text map consulted by the existing mono-tool spiral nudge (both the regular and ESCALATED variants) in `loop_guard.maybe_nudge()`. When the spiraling tool is `read_file` or `search_files`, the nudge now explicitly names `repo_map` (noting its Python-only limitation) and `delegate_task` as concrete, cheaper alternatives — delivered exactly when the pattern is already detected, a just-in-time reminder rather than upfront system-prompt text competing for attention with everything else in a large system prompt. Other tools' nudges are unchanged.

## Deliberately out of scope
- **System-prompt-level guidance** to use `repo_map` first (issue proposal #1). `repo_map`'s own tool-schema description already says "Use this at the START of a coding task" — the evidence shows the model doesn't reliably follow that even with the schema description present, so more static upfront text has uncertain marginal value. Adding prose to the live system-prompt pipeline (`agent/coding_context.py`, 850+ lines, assembled for every session) is a much larger blast radius for uncertain gain vs. this fix's targeted, just-in-time nudge.
- **A dedicated skill/pattern doc** (proposal #3) — the nudge text now carries the same guidance at the moment it matters; a separate skill file's adoption is unproven.
- **Codebase-size-based auto-delegation** (proposal #4) — needs new detection logic, out of scope for this effort budget.

## Testing
- `tests/agent/test_loop_guard.py::TestExplorationAlternativeHint` — 8 tests: regular + escalated nudges for both `read_file` and `search_files` include the hint; unrelated tools (`terminal`, `write_file`) don't get it; the pre-existing #467 same-query short-circuit path (a different problem with its own relevant advice) correctly does NOT pick up the hint.
- Full `tests/agent/test_loop_guard.py`: 44 passed.
- `ruff check` clean.
- Independently reviewed via a `consult` panel (Gemini + opencode/deepseek). Both flagged two real coverage gaps (fixed: added `search_files` escalated-nudge test + same-query-short-circuit-excludes-hint test). Gemini's panel also raised two claims I verified and found incorrect: a "missing `json` import" (it's present at the top of the file, just outside the diff hunk) and a "non-existent `delegate_task` tool, should be `invoke_subagent`" (verified via `tools/delegate_tool.py` — `delegate_task` is the real, registered tool; `invoke_subagent` doesn't exist anywhere in this codebase).

## Breaking Changes
None — purely additive text in an existing advisory message.

## Mode
PUBLIC