### PR TITLE
fix(delegate): surface denied toolsets to the subagent's own prompt

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -158,7 +158,18 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Research the topic", denied_toolsets=["web"])
         self.assertIn("TOOLSET LIMITATION", prompt)
         self.assertIn("web", prompt)
-        self.assertIn("parent", prompt.lower())
+        self.assertIn("PARENT session doesn't have it enabled", prompt)
+
+    def test_denied_toolsets_singular_grammar(self):
+        prompt = _build_child_system_prompt("Research the topic", denied_toolsets=["web"])
+        self.assertIn("toolset was requested", prompt)
+        self.assertNotIn("toolsets were requested", prompt)
+
+    def test_denied_toolsets_plural_grammar(self):
+        prompt = _build_child_system_prompt(
+            "Research and build", denied_toolsets=["web", "browser"]
+        )
+        self.assertIn("toolsets were requested", prompt)
 
     def test_denied_toolsets_lists_all_missing_names(self):
         prompt = _build_child_system_prompt(
@@ -3018,3 +3029,50 @@ class TestDeniedToolsetsSurfacedToChild(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         prompt = call_kwargs["ephemeral_system_prompt"]
         self.assertNotIn("TOOLSET LIMITATION", prompt)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_duplicate_requested_toolsets_deduplicated_in_note(self, MockAgent, mock_cfg):
+        """A duplicated request (e.g. ["web", "web"]) must not render as
+        'web, web' in the note."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal"]
+
+        _build_child_agent(
+            task_index=0, goal="research the topic", context=None,
+            toolsets=["web", "web"], model=None, max_iterations=50,
+            parent_agent=parent, task_count=1,
+        )
+        call_kwargs = MockAgent.call_args[1]
+        prompt = call_kwargs["ephemeral_system_prompt"]
+        self.assertIn("TOOLSET LIMITATION", prompt)
+        self.assertNotIn("web, web", prompt)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_denied_toolsets_reflects_final_list_not_intermediate_state(
+        self, MockAgent, mock_cfg
+    ):
+        """#648 review fix: denied_toolsets must be computed against the
+        FINAL child_toolsets (after blocked-tool stripping), not an
+        intermediate state — otherwise a toolset dropped by
+        _strip_blocked_tools (not by the parent-toolset intersection) would
+        be silently missing from the child with no note at all. 'delegation'
+        is always stripped for a non-orchestrator (default 'leaf') child
+        regardless of whether the parent has it."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "delegation"]
+
+        _build_child_agent(
+            task_index=0, goal="do the thing", context=None,
+            toolsets=["terminal", "delegation"], model=None, max_iterations=50,
+            parent_agent=parent, task_count=1, role="leaf",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        prompt = call_kwargs["ephemeral_system_prompt"]
+        self.assertIn("TOOLSET LIMITATION", prompt)
+        self.assertIn("delegation", prompt)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -143,6 +143,30 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_denied_toolsets_default_omits_limitation_note(self):
+        prompt = _build_child_system_prompt("Research the topic")
+        self.assertNotIn("TOOLSET LIMITATION", prompt)
+
+    def test_denied_toolsets_empty_list_omits_limitation_note(self):
+        prompt = _build_child_system_prompt("Research the topic", denied_toolsets=[])
+        self.assertNotIn("TOOLSET LIMITATION", prompt)
+
+    def test_denied_toolsets_present_adds_limitation_note(self):
+        """#648: toolsets requested but dropped because the PARENT session
+        doesn't have them must be surfaced to the subagent up front, instead
+        of it discovering the gap by trying and failing."""
+        prompt = _build_child_system_prompt("Research the topic", denied_toolsets=["web"])
+        self.assertIn("TOOLSET LIMITATION", prompt)
+        self.assertIn("web", prompt)
+        self.assertIn("parent", prompt.lower())
+
+    def test_denied_toolsets_lists_all_missing_names(self):
+        prompt = _build_child_system_prompt(
+            "Research and build", denied_toolsets=["web", "browser"]
+        )
+        self.assertIn("web", prompt)
+        self.assertIn("browser", prompt)
+
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
@@ -2932,3 +2956,65 @@ class TestShallowDelegationDetector(unittest.TestCase):
         entry = self._run_child(messages=messages)["results"][0]
         self.assertNotIn("shallow_result", entry)
         self.assertNotIn("SHALLOW DELEGATION", entry["summary"])
+
+
+class TestDeniedToolsetsSurfacedToChild(unittest.TestCase):
+    """#648: requesting toolsets the parent doesn't have silently dropped
+    them from the child, with no visibility into why — the subagent
+    discovered the gap only by trying and failing, wasting a full
+    delegation cycle. _build_child_agent must now surface exactly which
+    requested toolsets were denied, in the child's own system prompt."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_denied_toolsets_appear_in_child_system_prompt(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        _build_child_agent(
+            task_index=0, goal="research the topic", context=None,
+            toolsets=["terminal", "web"], model=None, max_iterations=50,
+            parent_agent=parent, task_count=1,
+        )
+        call_kwargs = MockAgent.call_args[1]
+        prompt = call_kwargs["ephemeral_system_prompt"]
+        self.assertIn("TOOLSET LIMITATION", prompt)
+        self.assertIn("web", prompt)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_no_note_when_all_requested_toolsets_available(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file", "web"]
+
+        _build_child_agent(
+            task_index=0, goal="research the topic", context=None,
+            toolsets=["terminal", "web"], model=None, max_iterations=50,
+            parent_agent=parent, task_count=1,
+        )
+        call_kwargs = MockAgent.call_args[1]
+        prompt = call_kwargs["ephemeral_system_prompt"]
+        self.assertNotIn("TOOLSET LIMITATION", prompt)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_no_note_when_toolsets_not_requested(self, MockAgent, mock_cfg):
+        """Omitting toolsets inherits the parent's set entirely — nothing
+        was denied, so no limitation note is expected."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        _build_child_agent(
+            task_index=0, goal="research the topic", context=None,
+            toolsets=None, model=None, max_iterations=50,
+            parent_agent=parent, task_count=1,
+        )
+        call_kwargs = MockAgent.call_args[1]
+        prompt = call_kwargs["ephemeral_system_prompt"]
+        self.assertNotIn("TOOLSET LIMITATION", prompt)

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -63,3 +63,25 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+    def test_denied_toolsets_names_what_the_parent_lacks(self):
+        """#648: the toolsets dropped by the intersection (not by
+        _strip_blocked_tools) must be identifiable so they can be surfaced to
+        the subagent — silently disappearing is what causes the delegated
+        task to fail without the parent understanding why."""
+        parent_toolsets = {"terminal", "file"}
+        requested = ["terminal", "file", "web", "browser"]
+
+        scoped = [t for t in requested if t in parent_toolsets]
+        denied = [t for t in requested if t not in parent_toolsets]
+
+        assert sorted(scoped) == ["file", "terminal"]
+        assert sorted(denied) == ["browser", "web"]
+
+    def test_no_denied_toolsets_when_all_requested_are_available(self):
+        parent_toolsets = {"terminal", "file", "web"}
+        requested = ["terminal", "web"]
+
+        denied = [t for t in requested if t not in parent_toolsets]
+
+        assert denied == []

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -978,14 +978,19 @@ def _build_child_system_prompt(
     the LLM doesn't confabulate nesting capabilities that don't exist.
 
     ``denied_toolsets`` (#648): toolsets the delegating call explicitly
-    asked for that were silently dropped because the PARENT session
-    doesn't have them enabled — a subagent must never gain tools its
-    parent lacks. Without this note the subagent discovers the gap only
-    by trying and failing, wasting a full delegation cycle before the
-    parent even learns why. Named here, in the prompt, rather than
-    fixed by relaxing the parent-toolset intersection: that intersection
-    is a security boundary (no privilege escalation via delegation), not
-    a bug.
+    asked for that are missing from the FINAL resolved child toolset list
+    (computed against child_toolsets after parent intersection, MCP
+    preservation, and blocked-tool stripping — so it reflects reality
+    regardless of which step dropped a name). Usually this is because the
+    PARENT session doesn't have them enabled — a subagent must never gain
+    tools its parent lacks — but a few toolsets are restricted for
+    subagents by default regardless of the parent (e.g. delegation itself
+    for non-orchestrator children). Without this note the subagent
+    discovers the gap only by trying and failing, wasting a full
+    delegation cycle before the parent even learns why. Named here, in
+    the prompt, rather than fixed by relaxing the parent-toolset
+    intersection: that intersection is a security boundary (no privilege
+    escalation via delegation), not a bug.
     """
     parts = [
         "You are a focused subagent working on a specific delegated task.",
@@ -1001,16 +1006,21 @@ def _build_child_system_prompt(
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
         )
     if denied_toolsets:
+        _plural = len(denied_toolsets) > 1
         parts.append(
-            "\nTOOLSET LIMITATION: the following toolset(s) were requested for "
-            f"you but are NOT available — {', '.join(denied_toolsets)} — because "
-            "your PARENT session doesn't have them enabled (a subagent can never "
-            "gain tools its parent lacks). Do not assume you have these tools or "
-            "waste calls discovering this yourself. If the task cannot be "
-            "completed without them, say so plainly in your summary and "
-            "recommend the operator either enable the missing toolset(s) on the "
-            "parent session before delegating, or complete this specific part "
-            "of the work without delegation."
+            f"\nTOOLSET LIMITATION: the following toolset{'s' if _plural else ''} "
+            f"{'were' if _plural else 'was'} requested for you but "
+            f"{'are' if _plural else 'is'} NOT available in your final toolset — "
+            f"{', '.join(denied_toolsets)}. This is usually because your PARENT "
+            "session doesn't have it enabled (a subagent can never gain tools its "
+            "parent lacks), though a small set of toolsets (like delegation "
+            "itself) are restricted for subagents by default regardless of the "
+            "parent. Do not assume you have these tools or waste calls "
+            "discovering this yourself. If the task cannot be completed without "
+            "them, say so plainly in your summary and recommend the operator "
+            "either enable the missing toolset(s) on the parent session before "
+            "delegating, or complete this specific part of the work without "
+            "delegation."
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -1435,10 +1445,6 @@ def _build_child_agent(
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
         child_toolsets = [t for t in toolsets if t in expanded_parent]
-        # Toolsets explicitly requested but dropped ONLY because the parent
-        # doesn't have them (#648) — surfaced to the subagent below so it
-        # doesn't have to discover the gap by trying and failing.
-        denied_toolsets = [t for t in toolsets if t not in expanded_parent]
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -1446,13 +1452,10 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
-        denied_toolsets = []
     elif parent_toolsets:
         child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
-        denied_toolsets = []
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
-        denied_toolsets = []
 
     # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
     # removed.  The re-add is unconditional on parent-toolset membership because
@@ -1460,6 +1463,22 @@ def _build_child_agent(
     # test_intersection_preserves_delegation_bound test for the design rationale.
     if effective_role == "orchestrator" and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
+
+    # Toolsets explicitly requested but missing from the FINAL child list
+    # (#648) — computed against child_toolsets AFTER every adjustment above
+    # (parent intersection, MCP preservation, blocked-tool stripping), not
+    # against an intermediate state, so this always reflects what the child
+    # actually ended up with regardless of WHICH step dropped a name.
+    # Deduplicated and order-preserving. Only meaningful when toolsets were
+    # explicitly requested — omitting toolsets inherits the parent wholesale,
+    # so nothing was denied.
+    denied_toolsets = []
+    if toolsets:
+        _seen_denied = set()
+        for t in toolsets:
+            if t not in child_toolsets and t not in _seen_denied:
+                denied_toolsets.append(t)
+                _seen_denied.add(t)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -967,6 +967,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    denied_toolsets: Optional[List[str]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -975,6 +976,16 @@ def _build_child_system_prompt(
     inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
+
+    ``denied_toolsets`` (#648): toolsets the delegating call explicitly
+    asked for that were silently dropped because the PARENT session
+    doesn't have them enabled — a subagent must never gain tools its
+    parent lacks. Without this note the subagent discovers the gap only
+    by trying and failing, wasting a full delegation cycle before the
+    parent even learns why. Named here, in the prompt, rather than
+    fixed by relaxing the parent-toolset intersection: that intersection
+    is a security boundary (no privilege escalation via delegation), not
+    a bug.
     """
     parts = [
         "You are a focused subagent working on a specific delegated task.",
@@ -988,6 +999,18 @@ def _build_child_system_prompt(
             "\nWORKSPACE PATH:\n"
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
+    if denied_toolsets:
+        parts.append(
+            "\nTOOLSET LIMITATION: the following toolset(s) were requested for "
+            f"you but are NOT available — {', '.join(denied_toolsets)} — because "
+            "your PARENT session doesn't have them enabled (a subagent can never "
+            "gain tools its parent lacks). Do not assume you have these tools or "
+            "waste calls discovering this yourself. If the task cannot be "
+            "completed without them, say so plainly in your summary and "
+            "recommend the operator either enable the missing toolset(s) on the "
+            "parent session before delegating, or complete this specific part "
+            "of the work without delegation."
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -1412,6 +1435,10 @@ def _build_child_agent(
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
         child_toolsets = [t for t in toolsets if t in expanded_parent]
+        # Toolsets explicitly requested but dropped ONLY because the parent
+        # doesn't have them (#648) — surfaced to the subagent below so it
+        # doesn't have to discover the gap by trying and failing.
+        denied_toolsets = [t for t in toolsets if t not in expanded_parent]
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -1419,10 +1446,13 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
+        denied_toolsets = []
     elif parent_toolsets:
         child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
+        denied_toolsets = []
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+        denied_toolsets = []
 
     # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
     # removed.  The re-add is unconditional on parent-toolset membership because
@@ -1439,6 +1469,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        denied_toolsets=denied_toolsets,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)


### PR DESCRIPTION
## Description
Delegated subagents frequently lack toolsets they need (web/terminal/file) and return "blocked: no tools available" — the parent then has to re-delegate or abandon the task, wasting a full delegation cycle (spin-up + context transfer + return) before discovering the subagent was never equipped.

## Type
Bug fix / UX

## Related Issues
Closes #648

## Root cause
`_build_child_agent()` already intersects any explicitly requested `toolsets` with the PARENT's own `enabled_toolsets` (a subagent must never gain tools its parent lacks — a security boundary, not a bug). When a narrowly-scoped parent (e.g. a cron job configured for memory maintenance with only tqmemory toolsets enabled) delegates a broader task and asks for e.g. `toolsets=["web"]`, that request is silently dropped by the intersection — the child gets nothing, and neither the child nor the parent has any way to know **why** beyond guessing.

## Changes
`_build_child_agent()` now computes `denied_toolsets` — toolsets explicitly requested but missing from the **final** resolved child toolset list (checked after parent intersection, MCP preservation, AND blocked-tool stripping, so it's correct regardless of which step caused the absence) — and `_build_child_system_prompt()` adds a "TOOLSET LIMITATION" note naming exactly which toolsets are missing and why, so the subagent can report this as a clear blocker in its summary immediately instead of discovering the gap by trying and failing.

## Deliberately out of scope
- **Automatic toolset inference** from the task description ("research" → web, "build" → terminal) — guessing intent from free text is its own source of surprising behavior, and doesn't fix the actual constraint (a narrowly-scoped parent still can't grant tools it doesn't have).
- **`toolsets: "inherit"` as an explicit sentinel** — omitting `toolsets` already inherits the parent's full enabled set today (see the schema: "Default: inherits your enabled toolsets"); the actual gap was visibility when an EXPLICIT request gets narrowed, which this fix addresses directly.

## Testing
- `tests/tools/test_delegate.py::TestChildSystemPrompt` — unit tests for the `denied_toolsets` parameter (present/absent/empty, grammar, all names listed).
- `tests/tools/test_delegate.py::TestDeniedToolsetsSurfacedToChild` — end-to-end tests driving the real `_build_child_agent()` with a mocked `AIAgent`, including a regression test proving denial is computed against the *final* toolset list (catches a toolset dropped by blocked-tool stripping, not just the parent intersection) and a dedup test.
- `tests/tools/test_delegate_toolset_scope.py` — simulated-logic tests matching the file's existing convention.
- Full `test_delegate.py` + `test_delegate_toolset_scope.py`: 165 passed. `ruff check` clean.
- Verified zero regressions across the broader delegation test suite (shallow-retry, agent-team, handoff-collapse, async-delegation, subagent-stop-hook, cli-interrupt-subagent) with and without this change.
- Independently reviewed via `consult` (Gemini). First pass found a real bug: `denied_toolsets` was computed mid-resolution, before MCP-preservation and blocked-tool stripping ran, causing false positives/negatives. Fixed by computing it once, at the end, against the fully-resolved `child_toolsets`. Final round: PASS.

## Breaking Changes
None — purely additive text in the subagent's own ephemeral system prompt.

## Mode
PUBLIC