### PR TITLE
feat: repo_map-first exploration guidance and early loop-guard nudge (Closes #625)

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -74,12 +74,28 @@ INTERACTIVE_CODING_PLATFORMS = {"cli", "tui", "acp", "desktop", ""}
 # Project-root signals that mark a directory as a code workspace even when it
 # isn't (yet) a git repo. Cheap filename checks — no parsing.
 _PROJECT_MARKERS = (
-    "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt",
-    "package.json", "tsconfig.json", "deno.json",
-    "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts",
-    "Gemfile", "composer.json", "mix.exs", "pubspec.yaml",
-    "CMakeLists.txt", "Makefile", "Dockerfile",
-    "AGENTS.md", "CLAUDE.md", ".cursorrules",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "package.json",
+    "tsconfig.json",
+    "deno.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "composer.json",
+    "mix.exs",
+    "pubspec.yaml",
+    "CMakeLists.txt",
+    "Makefile",
+    "Dockerfile",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".cursorrules",
 )
 
 # Agent-instruction files surfaced separately from manifests in the snapshot.
@@ -90,17 +106,63 @@ _CONTEXT_FILES = ("AGENTS.md", "CLAUDE.md", ".cursorrules")
 # non-coding use case) would flip the whole session into the coding posture just
 # for having a `.git`. A manifest still wins on its own (see `_PROJECT_MARKERS`).
 _CODE_EXTENSIONS = frozenset({
-    ".py", ".pyi", ".ipynb", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
-    ".go", ".rs", ".java", ".kt", ".kts", ".scala", ".rb", ".php", ".c", ".h",
-    ".cc", ".cpp", ".hpp", ".cs", ".swift", ".m", ".mm", ".dart", ".ex", ".exs",
-    ".lua", ".sh", ".bash", ".zsh", ".sql", ".vue", ".svelte", ".r", ".jl",
-    ".hs", ".clj", ".erl", ".pl",
+    ".py",
+    ".pyi",
+    ".ipynb",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".cjs",
+    ".go",
+    ".rs",
+    ".java",
+    ".kt",
+    ".kts",
+    ".scala",
+    ".rb",
+    ".php",
+    ".c",
+    ".h",
+    ".cc",
+    ".cpp",
+    ".hpp",
+    ".cs",
+    ".swift",
+    ".m",
+    ".mm",
+    ".dart",
+    ".ex",
+    ".exs",
+    ".lua",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".sql",
+    ".vue",
+    ".svelte",
+    ".r",
+    ".jl",
+    ".hs",
+    ".clj",
+    ".erl",
+    ".pl",
 })
 
 # Dirs never worth scanning for the code check (deps/build/vcs/venv noise).
 _CODE_SCAN_SKIP_DIRS = frozenset({
-    ".git", "node_modules", "venv", ".venv", "__pycache__", "dist", "build",
-    "target", ".next", ".turbo", "vendor",
+    ".git",
+    "node_modules",
+    "venv",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "build",
+    "target",
+    ".next",
+    ".turbo",
+    "vendor",
 })
 
 # Bounded sweep: a code workspace reveals itself in the first handful of entries.
@@ -130,7 +192,12 @@ def _has_code_files(root: Path) -> bool:
                         if entry.is_file():
                             if os.path.splitext(name)[1].lower() in _CODE_EXTENSIONS:
                                 return True
-                        elif is_root and entry.is_dir() and name not in _CODE_SCAN_SKIP_DIRS and not name.startswith("."):
+                        elif (
+                            is_root
+                            and entry.is_dir()
+                            and name not in _CODE_SCAN_SKIP_DIRS
+                            and not name.startswith(".")
+                        ):
                             stack.append((Path(entry.path), False))
                     except OSError:
                         continue
@@ -138,15 +205,32 @@ def _has_code_files(root: Path) -> bool:
             continue
     return False
 
+
 # Lockfile → package manager, checked in priority order.
-_PY_LOCKFILES = (("uv.lock", "uv"), ("poetry.lock", "poetry"), ("Pipfile.lock", "pipenv"))
+_PY_LOCKFILES = (
+    ("uv.lock", "uv"),
+    ("poetry.lock", "poetry"),
+    ("Pipfile.lock", "pipenv"),
+)
 _JS_LOCKFILES = (
-    ("pnpm-lock.yaml", "pnpm"), ("bun.lockb", "bun"), ("bun.lock", "bun"),
-    ("yarn.lock", "yarn"), ("package-lock.json", "npm"),
+    ("pnpm-lock.yaml", "pnpm"),
+    ("bun.lockb", "bun"),
+    ("bun.lock", "bun"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
 )
 
 # package.json scripts / Makefile targets worth surfacing as verify commands.
-_VERIFY_TARGETS = ("test", "tests", "lint", "typecheck", "check", "build", "fmt", "format")
+_VERIFY_TARGETS = (
+    "test",
+    "tests",
+    "lint",
+    "typecheck",
+    "check",
+    "build",
+    "fmt",
+    "format",
+)
 _MAX_VERIFY_COMMANDS = 8
 _MAX_FACT_FILE_BYTES = 256 * 1024
 
@@ -176,9 +260,24 @@ _EDIT_FORMAT_GUIDANCE: dict[str, tuple[tuple[str, ...], str]] = {
         "single-file edits. It's the edit format you handle most reliably.",
     ),
     "replace": (
-        ("claude", "sonnet", "opus", "haiku",
-         "gemini", "gemma", "deepseek", "qwen", "kimi", "glm", "grok",
-         "hermes", "llama", "mistral", "devstral", "minimax"),
+        (
+            "claude",
+            "sonnet",
+            "opus",
+            "haiku",
+            "gemini",
+            "gemma",
+            "deepseek",
+            "qwen",
+            "kimi",
+            "glm",
+            "grok",
+            "hermes",
+            "llama",
+            "mistral",
+            "devstral",
+            "minimax",
+        ),
         "- Edit format: author new files with `write_file`; for edits to "
         "existing code prefer `patch` in `mode='replace'` — match a unique "
         "snippet and swap it. Reach for `mode='patch'` (V4A) only when an edit "
@@ -219,9 +318,13 @@ CODING_AGENT_GUIDANCE = (
     "Operate like a careful senior engineer.\n"
     "\n"
     "Gather context first:\n"
-    "- Read the relevant files with `read_file` and locate code with "
-    "`search_files` before changing anything. Trace a symbol to its definition "
-    "and usages rather than guessing its shape.\n"
+    "- Before editing an unfamiliar codebase, get a bird's-eye view with "
+    "`repo_map` (ranks functions/classes/methods by usage and gives "
+    "`file:line` locations). It is far cheaper than repeatedly calling "
+    "`read_file` / `search_files` to discover where things live. Then read "
+    "the relevant files with `read_file` and locate code with `search_files` "
+    "before changing anything. Trace a symbol to its definition and usages "
+    "rather than guessing its shape.\n"
     "- Batch independent lookups: when several reads/searches don't depend on "
     "each other, issue them together in one turn instead of one at a time.\n"
     "- Never invent files, symbols, APIs, or imports. If you haven't seen it in "
@@ -302,9 +405,23 @@ class ContextProfile:
 # full entries). Coding-adjacent categories (devops, github, mcp,
 # data-science, diagramming, research, security, …) are intentionally absent.
 _NON_CODING_SKILL_CATEGORIES = (
-    "apple", "communication", "cooking", "creative", "email", "finance",
-    "gaming", "gifs", "health", "media", "music", "note-taking",
-    "productivity", "shopping", "smart-home", "social-media", "travel",
+    "apple",
+    "communication",
+    "cooking",
+    "creative",
+    "email",
+    "finance",
+    "gaming",
+    "gifs",
+    "health",
+    "media",
+    "music",
+    "note-taking",
+    "productivity",
+    "shopping",
+    "smart-home",
+    "social-media",
+    "travel",
     "yuanbao",
 )
 
@@ -468,7 +585,9 @@ class RuntimeMode:
     def is_coding(self) -> bool:
         return self.profile.name == CODING_PROFILE.name
 
-    def toolset_selection(self, config: Optional[dict[str, Any]] = None) -> Optional[list[str]]:
+    def toolset_selection(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> Optional[list[str]]:
         """Toolset list for this posture, or ``None`` to keep the platform default.
 
         Non-``None`` only under the opt-in ``focus`` mode. The default posture
@@ -674,7 +793,10 @@ def _parse_status(porcelain: str) -> tuple[dict[str, str], dict[str, int]]:
             branch["upstream"] = line.split(maxsplit=2)[-1]
         elif line.startswith("# branch.ab"):
             parts = line.split()
-            branch["ahead"], branch["behind"] = parts[2].lstrip("+"), parts[3].lstrip("-")
+            branch["ahead"], branch["behind"] = (
+                parts[2].lstrip("+"),
+                parts[3].lstrip("-"),
+            )
         elif line.startswith(("1 ", "2 ")):
             xy = line.split(maxsplit=2)[1]
             if xy[0] != ".":
@@ -720,9 +842,15 @@ def detect_project_facts(root: Path) -> ProjectFacts:
     of truth for both the prompt snapshot (:func:`_project_facts`) and the
     gateway's ``project.facts`` — so the UI never re-sniffs verify commands.
     """
-    manifests = [m for m in _PROJECT_MARKERS if m not in _CONTEXT_FILES and (root / m).is_file()]
+    manifests = [
+        m for m in _PROJECT_MARKERS if m not in _CONTEXT_FILES and (root / m).is_file()
+    ]
     package_managers = list(
-        dict.fromkeys(pm for lock, pm in (*_PY_LOCKFILES, *_JS_LOCKFILES) if (root / lock).is_file())
+        dict.fromkeys(
+            pm
+            for lock, pm in (*_PY_LOCKFILES, *_JS_LOCKFILES)
+            if (root / lock).is_file()
+        )
     )
 
     verify: list[str] = []
@@ -730,17 +858,27 @@ def detect_project_facts(root: Path) -> ProjectFacts:
         verify.append("scripts/run_tests.sh")
     if (root / "package.json").is_file():
         try:
-            scripts = json.loads(_read_small(root / "package.json") or "{}").get("scripts") or {}
+            scripts = (
+                json.loads(_read_small(root / "package.json") or "{}").get("scripts")
+                or {}
+            )
         except (json.JSONDecodeError, AttributeError):
             scripts = {}
-        js_pm = next((pm for lock, pm in _JS_LOCKFILES if (root / lock).is_file()), "npm")
-        verify.extend(f"{js_pm} run {name}" for name in _VERIFY_TARGETS if name in scripts)
-    if (root / "pytest.ini").is_file() or "[tool.pytest" in _read_small(root / "pyproject.toml"):
+        js_pm = next(
+            (pm for lock, pm in _JS_LOCKFILES if (root / lock).is_file()), "npm"
+        )
+        verify.extend(
+            f"{js_pm} run {name}" for name in _VERIFY_TARGETS if name in scripts
+        )
+    if (root / "pytest.ini").is_file() or "[tool.pytest" in _read_small(
+        root / "pyproject.toml"
+    ):
         verify.append("pytest")
     makefile = _read_small(root / "Makefile")
     if makefile:
         verify.extend(
-            f"make {name}" for name in _VERIFY_TARGETS
+            f"make {name}"
+            for name in _VERIFY_TARGETS
             if re.search(rf"^{re.escape(name)}\s*:", makefile, re.MULTILINE)
         )
 
@@ -811,11 +949,15 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
     if root is None:
         return ""
 
-    lines = ["Workspace (snapshot at session start — re-check with `git` before acting on it):"]
+    lines = [
+        "Workspace (snapshot at session start — re-check with `git` before acting on it):"
+    ]
     lines.append(f"- Root: {root}")
 
     if git_root is not None:
-        branch, counts = _parse_status(_git(root, "status", "--porcelain=2", "--branch"))
+        branch, counts = _parse_status(
+            _git(root, "status", "--porcelain=2", "--branch")
+        )
         head = branch.get("head", "")
         if head and head != "(detached)":
             line = f"- Branch: {head}"
@@ -833,14 +975,27 @@ def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
         # are shared state) but deliberately do NOT expose the primary tree path —
         # giving the model a second absolute path causes it to sometimes run commands
         # in the wrong directory.
-        git_dir, common_dir = _git(root, "rev-parse", "--git-dir"), _git(root, "rev-parse", "--git-common-dir")
-        if git_dir and common_dir and Path(git_dir).resolve() != Path(common_dir).resolve():
+        git_dir, common_dir = (
+            _git(root, "rev-parse", "--git-dir"),
+            _git(root, "rev-parse", "--git-common-dir"),
+        )
+        if (
+            git_dir
+            and common_dir
+            and Path(git_dir).resolve() != Path(common_dir).resolve()
+        ):
             lines.append("- Worktree: linked (git state shared with primary tree)")
 
-        dirty = [f"{n} {label}" for label, n in (
-            ("staged", counts["staged"]), ("modified", counts["modified"]),
-            ("untracked", counts["untracked"]), ("conflicts", counts["conflicts"]),
-        ) if n]
+        dirty = [
+            f"{n} {label}"
+            for label, n in (
+                ("staged", counts["staged"]),
+                ("modified", counts["modified"]),
+                ("untracked", counts["untracked"]),
+                ("conflicts", counts["conflicts"]),
+            )
+            if n
+        ]
         lines.append(f"- Status: {', '.join(dirty) if dirty else 'clean'}")
 
         recent = _git(root, "log", "-3", "--pretty=%h %s")

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -79,12 +79,38 @@ _NONRETRY_THRESHOLD = 2
 _SHORT_CIRCUIT_IDEMPOTENT = frozenset({"search_files", "web_search", "web_extract"})
 _SHORT_CIRCUIT_REPEAT_THRESHOLD = 4
 
-# Code-exploration tools whose mono-tool spiral is a STRATEGY problem, not a
-# failure (#625): 16-17 consecutive read_file calls / 14 consecutive
-# search_files calls, one file/query at a time, each succeeding — the agent
+# Exploration-only idempotent tools that often spiral because the agent is trying
+# to build a mental model one file/query at a time. A separate, longer
+# threshold lets us suggest the bird's-eye repo_map tool before the generic
+# repeat path fires, without conflating repo_map itself as a spiral tool.
+_EXPLORATION_TOOLS = frozenset({"read_file", "search_files"})
+_EXPLORATION_REPO_MAP_NUDGE_THRESHOLD = 4
+
+# Mutating tools get LOWER thresholds than idempotent tools because a fixation
+# on mutating operations (writing files, running commands) is more costly and
+# indicates a deeper strategy problem (#432).
 # just never reached for a cheaper bulk-overview alternative. Named here (not
 # folded into the generic nudge text) so the suggestion only appears for the
 # tools it actually applies to.
+# Per-tool short hint appended to the early repo_map nudge (#625) for
+# read_file / search_files. Kept brief and repo_map-only so the early
+# intervention is actionable and not cluttered.
+_EXPLORATION_REPO_MAP_HINT = {
+    "read_file": (
+        " Use `repo_map` on the project root for a structured overview of "
+        "functions/classes/methods with file:line locations (Python codebases "
+        "only)."
+    ),
+    "search_files": (
+        " Use `repo_map` on the project root for a structured overview of "
+        "functions/classes/methods with file:line locations (Python codebases "
+        "only)."
+    ),
+}
+
+# Longer hint appended to the generic idempotent repeat/escalate nudge for
+# read_file / search_files, once the agent has already passed the early
+# repo_map suggestion and is still spiraling.
 _EXPLORATION_ALTERNATIVE_HINT = {
     "read_file": (
         " For broad codebase exploration, `repo_map` gives a structured "
@@ -453,6 +479,33 @@ def maybe_nudge(
                 f"the query, broaden or narrow it, switch to a different information "
                 f"source, or state the blocker if no relevant results are available."
             )
+
+    # Early, one-time nudge for exploration-only spirals (#625): when the
+    # agent has made exactly _EXPLORATION_REPO_MAP_NUDGE_THRESHOLD consecutive
+    # read_file / search_files calls without resolving the task, suggest
+    # repo_map as a cheaper alternative. Each call may have succeeded, but the
+    # strategy of building a mental model one file/query at a time is wasteful.
+    # We fire only at the threshold (not on every subsequent call) so the
+    # normal idempotent repeat/escalate paths still apply if the suggestion is
+    # ignored.
+    if (
+        tool in _EXPLORATION_TOOLS
+        and count == _EXPLORATION_REPO_MAP_NUDGE_THRESHOLD
+        and count < repeat_threshold
+    ):
+        score = _tool_spiral_score(tool, count, _EXPLORATION_REPO_MAP_NUDGE_THRESHOLD)
+        score_line = f"\n{score}" if score else ""
+        hint = _EXPLORATION_REPO_MAP_HINT.get(tool, "")
+        return (
+            f"[loop-guard] You have called `{tool}` {count} times in a row "
+            f"without resolving the task.{score_line} For broad codebase "
+            f"exploration, `repo_map` gives a structured overview (functions/"
+            f"classes/methods with file:line) in a single call — far cheaper "
+            f"than many `{tool}` calls (Python codebases only). Read the goal, "
+            f"check what progress these calls made, then either switch to "
+            f"`repo_map` or batch the remaining targeted reads/searches and "
+            f"move on.{hint}"
+        )
 
     if count >= repeat_threshold:
         # Build diversity score for the nudge.

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -191,15 +191,27 @@ class TestExplorationAlternativeHint:
         msgs = [{"role": "user", "content": "explore the codebase"}]
         for i in range(n):
             cid = f"c{i}"
-            msgs.append(_asst(tool, args=json.dumps({"path": f"file_{i}.py"}), call_id=cid))
+            msgs.append(
+                _asst(tool, args=json.dumps({"path": f"file_{i}.py"}), call_id=cid)
+            )
             msgs.append(_result(result, call_id=cid))
         return msgs
 
     def test_read_file_regular_nudge_suggests_alternatives(self):
-        # read_file is idempotent (repeat_threshold=8); 8 calls -> regular nudge.
-        n = maybe_nudge(_run("read_file", 8))
+        # read_file exploration nudge fires at 4 calls now (#625 early guidance).
+        n = maybe_nudge(_run("read_file", 4))
         assert n is not None
-        assert "repo_map" in n and "delegate_task" in n
+        assert "repo_map" in n
+
+    def test_read_file_below_exploration_threshold_is_quiet(self):
+        # 3 read_file calls should not trigger any nudge yet.
+        assert maybe_nudge(_run("read_file", 3)) is None
+
+    def test_search_files_varied_args_nudge_suggests_repo_map(self):
+        # varied args avoid the #467 same-query path; exploration nudge at 4.
+        n = maybe_nudge(self._varied_args_run("search_files", 4))
+        assert n is not None
+        assert "repo_map" in n
 
     def test_search_files_regular_nudge_suggests_alternatives(self):
         # search_files is short-circuit-prone on SAME args (#467); use varied
@@ -236,12 +248,43 @@ class TestExplorationAlternativeHint:
         # #467 same-query short-circuit is a DIFFERENT problem (repeating the
         # identical query) with its own, already-relevant advice — the
         # exploration hint must not bleed into this path.
-        msgs = _run("search_files", 4)  # identical args -> short-circuit, not repeat_threshold
+        msgs = _run(
+            "search_files", 4
+        )  # identical args -> short-circuit, not repeat_threshold
         n = maybe_nudge(msgs)
         assert n is not None
         assert "SAME arguments" in n  # confirms the short-circuit path fired
         assert "repo_map" not in n and "delegate_task" not in n
 
+    def test_read_file_exploration_nudge_mentions_repo_map_only(self):
+        n = maybe_nudge(_run("read_file", 4))
+        assert n is not None
+        assert "repo_map" in n
+        assert "delegate_task" not in n  # early exploration nudge is brief
+
+    def test_search_files_exploration_nudge_mentions_repo_map_only(self):
+        n = maybe_nudge(self._varied_args_run("search_files", 4))
+        assert n is not None
+        assert "repo_map" in n
+        assert "delegate_task" not in n  # early exploration nudge is brief
+
+    def test_read_file_exploration_nudge_stops_at_repeat_threshold(self):
+        # 8 calls hit the generic idempotent repeat nudge, not the early repo_map nudge.
+        n = maybe_nudge(_run("read_file", 8))
+        assert n is not None
+        assert "ESCALATED INTERRUPT" not in n
+        assert "repo_map" in n and "delegate_task" in n
+
+    def test_search_files_exploration_nudge_stops_at_repeat_threshold(self):
+        n = maybe_nudge(self._varied_args_run("search_files", 8))
+        assert n is not None
+        assert "ESCALATED INTERRUPT" not in n
+        assert "repo_map" in n and "delegate_task" in n
+
+    def test_read_file_exploration_nudge_does_not_block_escalation(self):
+        n = maybe_nudge(_run("read_file", 15))
+        assert n is not None
+        assert "ESCALATED INTERRUPT" in n
 
 
 class TestRunBoundaries:
@@ -306,7 +349,9 @@ class TestSameQueryShortCircuit:
         msgs = [{"role": "user", "content": "research the topic"}]
         for i in range(4):
             cid = f"c{i}"
-            msgs.append(_asst("web_search", args={"query": "best cat food"}, call_id=cid))
+            msgs.append(
+                _asst("web_search", args={"query": "best cat food"}, call_id=cid)
+            )
             msgs.append(_result("3 relevant hits", call_id=cid))
         n = maybe_nudge(msgs)
         assert n is not None and "SAME arguments" in n
@@ -355,13 +400,21 @@ class TestShouldCronHardStop:
     text — interactive surfaces (a human is present) are never affected."""
 
     def test_below_threshold_never_stops(self):
-        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD - 1) is False
+        assert (
+            should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD - 1)
+            is False
+        )
 
     def test_at_threshold_stops(self):
-        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD) is True
+        assert (
+            should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD) is True
+        )
 
     def test_above_threshold_stops(self):
-        assert should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 5) is True
+        assert (
+            should_cron_hard_stop("cron", CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 5)
+            is True
+        )
 
     def test_zero_warnings_never_stops(self):
         assert should_cron_hard_stop("cron", 0) is False


### PR DESCRIPTION
Automated evolution PR for issue #625.\n\n- Adds repo_map-first guidance to the coding posture system prompt.\n- Adds an early loop-guard nudge when read_file/search_files repeat 4 times, suggesting repo_map as a cheaper overview.\n- Keeps existing idempotent repeat (8) and escalate (15) thresholds intact.\n- Includes targeted test updates.\n\nCloses #625