### PR TITLE
fix(agent): fail fast after two consecutive unrecovered rate limits (Closes #704)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2965,6 +2965,9 @@ def _run_conversation_impl(
                     )
                 )
                 if recovered_with_pool:
+                    # A fresh credential means the next 429 is a new story —
+                    # don't let the pre-rotation hits trip the fail-fast (#704).
+                    _retry.consecutive_rate_limit_hits = 0
                     continue
 
                 # Image-too-large recovery: shrink oversized native image
@@ -3708,6 +3711,9 @@ def _run_conversation_impl(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
+                            # New provider — restart the consecutive-429
+                            # fail-fast count from zero (#704).
+                            _retry.consecutive_rate_limit_hits = 0
                             continue
 
                 # ── Auth-failure provider failover ───────────────────────
@@ -3813,6 +3819,60 @@ def _run_conversation_impl(
                     # Upstream capacity 429: fall through to normal
                     # retry logic.  A different model (or the same
                     # model a moment later) will typically succeed.
+
+                # ── Consecutive-429 fail-fast (#704) ─────────────────────
+                # Reaching here rate-limited means NOTHING recovered on this
+                # pass: pool rotation didn't recover (or absorbed the error
+                # as a same-credential retry) and no fallback activated. One
+                # same-provider retry is allowed — the second consecutive
+                # 429 is deterministic (the quota window has not reset), so
+                # end the turn with a structured diagnostic instead of
+                # burning the remaining retry budget against an exhausted
+                # provider. Billing is excluded: it has its own guidance in
+                # the max-retries path. Counter resets on rotation/fallback
+                # success above and is per-API-call state (TurnRetryState).
+                if classified.reason in {
+                    FailoverReason.rate_limit,
+                    FailoverReason.upstream_rate_limit,
+                }:
+                    _retry.consecutive_rate_limit_hits += 1
+                    if _retry.consecutive_rate_limit_hits >= 2:
+                        _rl_provider = getattr(agent, "provider", "unknown")
+                        _rl_model = getattr(agent, "model", "unknown")
+                        _rl_summary = agent._summarize_api_error(api_error)
+                        _rl_diag = (
+                            f"Rate limited twice in a row by {_rl_provider}/{_rl_model} "
+                            "with no recovery path left: credential rotation did not "
+                            "recover and no fallback provider activated. Retrying the "
+                            "same provider cannot succeed until its quota window "
+                            "resets. Options: wait for the rate-limit window to reset, "
+                            "configure a fallback model/provider, or continue with "
+                            "steps that need no LLM call."
+                        )
+                        agent._emit_status(f"⛔ {_rl_diag}")
+                        logger.error(
+                            "%sConsecutive rate-limit fail-fast: 2 x %s from "
+                            "provider=%s model=%s with no rotation/fallback recovery "
+                            "— ending turn instead of retrying (#704). %s",
+                            agent.log_prefix,
+                            classified.reason.value,
+                            _rl_provider,
+                            _rl_model,
+                            _rl_summary,
+                        )
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": _rl_diag,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _rl_summary,
+                            # Same contract as the max-retries path: callers
+                            # (kanban worker, cron) distinguish a quota wall
+                            # from a real task error via failure_reason.
+                            "failure_reason": classified.reason.value,
+                        }
 
                 is_payload_too_large = (
                     classified.reason == FailoverReason.payload_too_large

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -58,6 +58,12 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
+    # Consecutive rate-limit errors on this attempt where NO recovery fired
+    # (pool rotation didn't recover, no fallback activated). At 2 the loop
+    # fails fast with a structured diagnostic instead of burning the rest of
+    # the retry budget against a provider whose quota window hasn't reset
+    # (#704). Reset whenever rotation or fallback succeeds.
+    consecutive_rate_limit_hits: int = 0
 
     # ── Fail-fast guard for non-retryable client errors ─────────────────
     fail_fast_attempted: bool = False

--- a/tests/agent/test_rate_limit_fail_fast.py
+++ b/tests/agent/test_rate_limit_fail_fast.py
@@ -1,0 +1,170 @@
+"""Runtime tests for #704: two consecutive rate-limit errors with no recovery
+path (no credential-pool rotation recovered, no fallback provider activated)
+must end the turn with a structured diagnostic instead of burning the rest of
+the retry budget against a provider whose quota window has not reset.
+
+The classifier already marks 429 as ``FailoverReason.rate_limit`` with
+rotation+fallback flags; the observed gap (12 recurrences of ``429:rate_limit``
+in 7 days of real sessions) is the retry loop hammering the SAME exhausted
+provider when neither recovery is available — the common cron shape: one
+provider, no pool, no fallback chain. These tests drive ``run_conversation``
+through mocked API errors and prove the fail-fast wiring end-to-end.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class _RateLimitError(Exception):
+    """Bare 429 with no Retry-After header and no response body — the
+    minimal shape ``classify_api_error`` maps to ``rate_limit``."""
+
+    def __init__(self):
+        super().__init__("Rate limit exceeded, please try again later")
+        self.status_code = 429
+
+
+def _make_agent(max_iterations: int = 10) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    from unittest.mock import MagicMock
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _fast_backoff_patches():
+    """Make the single allowed backoff instant so the tests don't sleep."""
+    return (
+        patch("agent.conversation_loop.jittered_backoff", return_value=0.01),
+        patch(
+            "agent.conversation_loop.adaptive_rate_limit_backoff",
+            side_effect=lambda retry_count, **kw: (0.01, None),
+        ),
+    )
+
+
+def test_two_consecutive_429s_without_recovery_fail_fast():
+    agent = _make_agent()
+    # Safety-net success responses after the two 429s: if the fail-fast does
+    # NOT fire, the loop would consume one of these and the assertions on
+    # failed/call_count below flag it loudly (instead of a StopIteration).
+    agent.client.chat.completions.create.side_effect = [
+        _RateLimitError(),
+        _RateLimitError(),
+        _mock_response(content="done"),
+        _mock_response(content="done"),
+    ]
+
+    jb, arb = _fast_backoff_patches()
+    with (
+        jb,
+        arb,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "rate_limit"
+    assert "rate limited twice in a row" in result["final_response"].lower()
+    # Exactly one same-provider retry was allowed — the second consecutive
+    # 429 ended the turn instead of continuing toward max_retries.
+    assert agent.client.chat.completions.create.call_count == 2
+
+
+def test_single_429_then_success_completes_normally():
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _RateLimitError(),
+        _mock_response(content="done"),
+    ]
+
+    jb, arb = _fast_backoff_patches()
+    with (
+        jb,
+        arb,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result.get("failed") is not True
+    assert result["final_response"] == "done"
+    assert agent.client.chat.completions.create.call_count == 2
+
+
+def test_fresh_api_call_gets_a_fresh_counter():
+    """A 429 pair split across two DIFFERENT API calls (each preceded by a
+    success) must not fail fast: ``TurnRetryState`` is created per API call,
+    so non-consecutive rate limits never accumulate."""
+    agent = _make_agent()
+    tool_call = SimpleNamespace(
+        id=f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments=json.dumps({"command": "echo hi"})),
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _RateLimitError(),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[tool_call]),
+        _RateLimitError(),
+        _mock_response(content="done"),
+    ]
+
+    jb, arb = _fast_backoff_patches()
+    with (
+        jb,
+        arb,
+        patch("run_agent.handle_function_call", return_value="command completed"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("run a command")
+
+    assert result.get("failed") is not True
+    assert result["final_response"] == "done"
+    assert agent.client.chat.completions.create.call_count == 4

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -28,6 +28,7 @@ EXPECTED_FIELDS = {
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
     "has_retried_429",
+    "consecutive_rate_limit_hits",
     "fail_fast_attempted",
     "auth_failover_attempted",
     "restart_with_compressed_messages",
@@ -36,10 +37,18 @@ EXPECTED_FIELDS = {
 }
 
 
+# The one non-boolean field: a consecutive-event counter, not a one-shot guard
+# (#704). Everything else must stay a False-defaulting bool.
+COUNTER_FIELDS = {"consecutive_rate_limit_hits"}
+
+
 def test_all_guards_default_false():
     s = TurnRetryState()
     for name, value in s:
-        assert value is False, f"{name} should default to False"
+        if name in COUNTER_FIELDS:
+            assert value == 0, f"{name} should default to 0"
+        else:
+            assert value is False, f"{name} should default to False"
 
 
 def test_field_set_matches_contract():


### PR DESCRIPTION
## What
Real sessions show `429:rate_limit` recurring (12 hits in 7 days) despite correct classification: when neither credential-pool rotation nor a fallback chain can act — the common unattended-cron shape of one provider and one key — the retry loop hammered the exhausted provider through the whole retry budget, and every subsequent API call in the turn repeated the cycle.

## How
- New `TurnRetryState.consecutive_rate_limit_hits`: incremented only when a `rate_limit`/`upstream_rate_limit` error reaches the point where **no recovery fired this pass** (rotation didn't recover or merely absorbed the error as a same-credential retry; no fallback activated).
- One same-provider retry stays allowed; the **second** consecutive hit ends the turn with a deterministic diagnostic and `failure_reason=rate_limit` — the same contract as the max-retries path, so cron/kanban callers distinguish a quota wall from a task error.
- Counter resets on rotation success and on fallback activation; `TurnRetryState` is per-API-call, so non-consecutive 429s across a session never accumulate (pinned by a dedicated test).
- Billing keeps its dedicated guidance in the max-retries path (excluded). Nous genuine account-level 429s still take their cross-session breaker first.

## Review
External consult (deepseek-v4-pro) challenged the state lifetime (claimed per-conversation accumulation). Verified wrong on both code structure (`TurnRetryState()` is instantiated inside the outer turn loop, conversation_loop.py:1230 under the loop at :704) and behavior (`test_fresh_api_call_gets_a_fresh_counter` drives 429→success→429→success with no fail-fast).

## Verification
- 3 new e2e tests in `tests/agent/test_rate_limit_fail_fast.py` (fail-fast fires at exactly 2; single 429 recovers; fresh API call gets fresh counter). Confirmed the main test FAILS against pre-fix code.
- `tests/agent` related files: 77 passed. Full `tests/run_agent/`: **1876 passed, 3 skipped, 0 failed** (13 min).

Closes #704