### PR TITLE
feat(evolution): flag cron runs that complete with zero tool calls (Closes #701)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1070,6 +1070,7 @@ def create_job(
         "last_run_at": None,
         "last_status": None,
         "last_error": None,
+        "last_tool_calls": None,
         "last_delivery_error": None,
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "deliver": deliver,
@@ -1314,6 +1315,7 @@ def mark_job_run(
     success: bool,
     error: Optional[str] = None,
     delivery_error: Optional[str] = None,
+    tool_calls: Optional[int] = None,
 ):
     """
     Mark a job as having been run.
@@ -1323,6 +1325,11 @@ def mark_job_run(
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``tool_calls`` is the number of tool invocations the agent run made
+    (None = unknown: no_agent scripts, failures before the agent ran,
+    legacy callers). Persisted as ``last_tool_calls`` so the deterministic
+    evolution watchdog can flag "ran clean but could not act" runs (#701).
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1332,6 +1339,7 @@ def mark_job_run(
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
+                job["last_tool_calls"] = tool_calls
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
                 # Clear any external-fire claim so a re-armed recurring job can

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3871,6 +3871,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
+    # This run's tool-call count (#701) — claimed from the side channel right
+    # after run_job returns; None until then so an early exception reports
+    # "unknown" rather than a stale prior-run value.
+    _job_tool_calls: Optional[int] = None
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -3891,6 +3895,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # re-fires recent ones) on next startup.
         mark_job_started(job["id"])
         success, output, final_response, error = run_job(job)
+        # Claim this run's tool-call count immediately (#701): popping into a
+        # local right after run_job returns closes the window where a stale
+        # entry from a prior interrupted run could be mis-attributed by the
+        # except path below. Anything that threw BEFORE this line reports
+        # None (= unknown).
+        _job_tool_calls = _LAST_RUN_TOOL_CALLS.pop(job["id"], None)
 
         # Classify provider-layer failures so the cron failure record and any
         # delivery summary can include a stable failure_category (e.g. timeout).
@@ -4012,18 +4022,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success,
             error,
             delivery_error=delivery_error,
-            tool_calls=_LAST_RUN_TOOL_CALLS.pop(job["id"], None),
+            tool_calls=_job_tool_calls,
         )
         return True
 
     except Exception as e:
         logger.error("Error processing job %s: %s", job["id"], e)
-        mark_job_run(
-            job["id"],
-            False,
-            str(e),
-            tool_calls=_LAST_RUN_TOOL_CALLS.pop(job["id"], None),
-        )
+        mark_job_run(job["id"], False, str(e), tool_calls=_job_tool_calls)
         return False
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -32,7 +32,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -2746,6 +2746,32 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return result
 
 
+def _count_tool_calls(messages) -> int:
+    """Number of tool invocations in a run_conversation message list.
+
+    Counts ``role == "tool"`` entries — exactly one per executed tool call.
+    Tolerates junk (None, non-list, non-dict entries) because the messages
+    come back from an agent run that may have failed mid-flight (#701).
+    """
+    if not isinstance(messages, list):
+        return 0
+    return sum(
+        1
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "tool"
+    )
+
+
+# Tool-call counts per job id for the CURRENT run, written by _run_job_impl
+# and consumed (popped) by run_one_job's mark_job_run call. A side channel —
+# NOT part of run_job's (success, output, final_response, error) tuple — so
+# every existing caller and test stub of that 4-tuple contract keeps working;
+# a missing entry simply reads as None (= unknown, e.g. stubbed run_job or
+# no_agent scripts). Keys are per-job and a job cannot run concurrently with
+# itself (fire claims), so parallel ticks don't collide (#701).
+_LAST_RUN_TOOL_CALLS: Dict[str, Optional[int]] = {}
+
+
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2755,6 +2781,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    # Unknown until the agent path measures it; no_agent scripts and
+    # pre-agent failures leave it None (#701).
+    _LAST_RUN_TOOL_CALLS[job_id] = None
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -3633,6 +3662,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         final_response = result.get("final_response", "") or ""
+        # Zero-tool-call detection (#701): a "successful" run that never
+        # invoked a single tool usually means a broken or missing toolset —
+        # the agent could only talk, not act. Recorded in the side channel;
+        # run_one_job forwards it to mark_job_run so the deterministic
+        # watchdog can tell a legitimately idle stage from a silent no-op.
+        _LAST_RUN_TOOL_CALLS[job_id] = _count_tool_calls(result.get("messages"))
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":
             final_response = ""
@@ -3972,12 +4007,23 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-        mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+        mark_job_run(
+            job["id"],
+            success,
+            error,
+            delivery_error=delivery_error,
+            tool_calls=_LAST_RUN_TOOL_CALLS.pop(job["id"], None),
+        )
         return True
 
     except Exception as e:
         logger.error("Error processing job %s: %s", job["id"], e)
-        mark_job_run(job["id"], False, str(e))
+        mark_job_run(
+            job["id"],
+            False,
+            str(e),
+            tool_calls=_LAST_RUN_TOOL_CALLS.pop(job["id"], None),
+        )
         return False
 
 

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -117,28 +117,38 @@ def _load_jobs(jobs_file: Path | None) -> List[dict]:
     return data.get("jobs", data if isinstance(data, list) else [])
 
 
-def _stage_ran_clean_for_slot(jobs: List[dict], stage: str, date: str, slot_hour: int) -> bool:
-    """True when the cron job for ``stage`` ran with ``last_status == "ok"`` at or
-    after its slot on ``date``. A MISSING report is only a death if the job did
-    NOT run clean for the slot: when it did, the stage executed and simply had
-    nothing to do (e.g. analysis selected 0 → implementation/integration are
-    legitimately idle and need not emit a report). That is a clean idle cycle,
-    not 'the job died without record'."""
+def _stage_clean_job_for_slot(
+    jobs: List[dict], stage: str, date: str, slot_hour: int
+) -> dict | None:
+    """The stage's cron job record when it ran with ``last_status == "ok"`` at
+    or after its slot on ``date`` — else None. A MISSING report is only a death
+    if the job did NOT run clean for the slot: when it did, the stage executed
+    and simply had nothing to do (e.g. analysis selected 0 →
+    implementation/integration are legitimately idle and need not emit a
+    report). That is a clean idle cycle, not 'the job died without record'.
+    Callers still inspect the returned record: a "clean" run with ZERO tool
+    calls could not have done any real work (#701)."""
     name = f"evolution-{stage}"
     for job in jobs:
         if str(job.get("name", "")) != name:
             continue
         if job.get("last_status") != "ok":
-            return False
+            return None
         last_run = _parse_iso(job.get("last_run_at"))
         if last_run is None:
-            return False
+            return None
         try:
             slot_dt = datetime.fromisoformat(date).replace(hour=slot_hour)
         except ValueError:
-            return False
-        return last_run >= slot_dt
-    return False
+            return None
+        return job if last_run >= slot_dt else None
+    return None
+
+
+def _stage_ran_clean_for_slot(jobs: List[dict], stage: str, date: str, slot_hour: int) -> bool:
+    """Boolean wrapper kept for existing callers — see
+    ``_stage_clean_job_for_slot``."""
+    return _stage_clean_job_for_slot(jobs, stage, date, slot_hour) is not None
 
 
 def check_stage_reports(
@@ -154,8 +164,19 @@ def check_stage_reports(
         date = expected_report_date(now, slot_hour)
         report = evolution_dir / stage / f"{date}.{ext}"
         if not report.exists():
-            if _stage_ran_clean_for_slot(jobs, stage, date, slot_hour):
-                continue  # ran clean, nothing to do — idle cycle, not a death
+            clean_job = _stage_clean_job_for_slot(jobs, stage, date, slot_hour)
+            if clean_job is not None:
+                if clean_job.get("last_tool_calls") == 0:
+                    # "Clean" but the agent never invoked a single tool: it
+                    # could only talk, not act — a broken/missing toolset is
+                    # far more likely than a legitimately idle cycle (#701).
+                    alerts.append(
+                        f"stage '{stage}': job reported ok for slot "
+                        f"{slot_hour:02d}:00 with ZERO tool calls and no "
+                        f"report — the agent could not act (broken or "
+                        f"missing toolset?); treating as a stage failure"
+                    )
+                continue  # ran clean with real tool use — idle cycle, not a death
             alerts.append(
                 f"stage '{stage}': expected report {report.name} is MISSING "
                 f"(slot {slot_hour:02d}:00 + {GRACE_HOURS}h grace passed; "

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,7 +31,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(jid, ok, err=None, delivery_error=None, tool_calls=None):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
@@ -110,7 +110,7 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
     marks = []
     monkeypatch.setattr(
         s, "mark_job_run",
-        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok)),
+        lambda jid, ok, err=None, delivery_error=None, tool_calls=None: marks.append((jid, ok)),
     )
 
     ok = s.run_one_job({"id": "j6", "name": "t"})

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2722,6 +2722,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            tool_calls=None,
         )
 
 

--- a/tests/cron/test_zero_tool_call_tracking.py
+++ b/tests/cron/test_zero_tool_call_tracking.py
@@ -1,0 +1,52 @@
+"""Tests for #701: persist the agent's tool-call count per cron run so the
+deterministic watchdog can tell a legitimately idle stage (ran clean, used
+tools, nothing to do) from a silently no-op'd one (ran "clean" but could not
+call a single tool — broken/missing toolset)."""
+
+from cron.scheduler import _count_tool_calls
+
+
+class TestCountToolCalls:
+    def test_counts_tool_role_messages(self):
+        messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "tool_call_id": "1", "content": "ok"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "2"}]},
+            {"role": "tool", "tool_call_id": "2", "content": "ok"},
+            {"role": "assistant", "content": "done"},
+        ]
+        assert _count_tool_calls(messages) == 2
+
+    def test_zero_for_talk_only_run(self):
+        messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        assert _count_tool_calls(messages) == 0
+
+    def test_tolerates_junk(self):
+        assert _count_tool_calls(None) == 0
+        assert _count_tool_calls([]) == 0
+        assert _count_tool_calls(["garbage", 42, {"role": "tool"}]) == 1
+
+
+class TestMarkJobRunPersistsToolCalls:
+    def test_tool_calls_persisted_on_success(self):
+        from cron.jobs import create_job, get_job, mark_job_run
+
+        job = create_job(prompt="p", schedule="0 9 * * *", name="tc-test")
+        mark_job_run(job["id"], success=True, tool_calls=0)
+        assert get_job(job["id"])["last_tool_calls"] == 0
+
+        mark_job_run(job["id"], success=True, tool_calls=5)
+        assert get_job(job["id"])["last_tool_calls"] == 5
+
+    def test_defaults_to_none_when_not_provided(self):
+        from cron.jobs import create_job, get_job, mark_job_run
+
+        job = create_job(prompt="p", schedule="0 9 * * *", name="tc-default")
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"])["last_tool_calls"] is None

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -98,10 +98,10 @@ class TestStageReports:
         alerts = check_stage_reports(tmp_path, NOW)
         assert len(alerts) == len(STAGES)
 
-    def _jobs_file(self, tmp_path, name, *, status="ok", last_run="2026-06-10T22:01:00"):
+    def _jobs_file(self, tmp_path, name, *, status="ok", last_run="2026-06-10T22:01:00", **extra):
         f = tmp_path / "jobs.json"
         f.write_text(json.dumps({"jobs": [
-            {"name": name, "enabled": True, "last_status": status, "last_run_at": last_run}
+            {"name": name, "enabled": True, "last_status": status, "last_run_at": last_run, **extra}
         ]}))
         return f
 
@@ -131,6 +131,35 @@ class TestStageReports:
         jf = self._jobs_file(tmp_path, "evolution-integration", last_run="2026-06-09T23:00:00")
         alerts = check_stage_reports(tmp_path, NOW, jf)
         assert len(alerts) == 1 and "integration" in alerts[0]
+
+    def test_missing_report_alerts_when_clean_run_had_zero_tool_calls(self, tmp_path):
+        # Job reported ok for the slot but made ZERO tool calls and left no
+        # report — the agent could not act (broken/missing toolset), which is
+        # a stage failure, not an idle cycle (#701).
+        slot = STAGES["implementation"][0]
+        exp = expected_report_date(NOW, slot)
+        self._make_reports(tmp_path, skip=("implementation",))
+        jf = self._jobs_file(
+            tmp_path, "evolution-implementation",
+            last_run=f"{exp}T{slot:02d}:01:00",
+            last_tool_calls=0,
+        )
+        alerts = check_stage_reports(tmp_path, NOW, jf)
+        assert len(alerts) == 1
+        assert "zero tool calls" in alerts[0].lower()
+
+    def test_missing_report_quiet_when_clean_run_used_tools(self, tmp_path):
+        # Clean slot run WITH real tool use and no report → legitimately idle
+        # cycle, stays quiet (the pre-#701 suppression must survive).
+        slot = STAGES["implementation"][0]
+        exp = expected_report_date(NOW, slot)
+        self._make_reports(tmp_path, skip=("implementation",))
+        jf = self._jobs_file(
+            tmp_path, "evolution-implementation",
+            last_run=f"{exp}T{slot:02d}:01:00",
+            last_tool_calls=7,
+        )
+        assert check_stage_reports(tmp_path, NOW, jf) == []
 
 
 class TestJobsHealth:


### PR DESCRIPTION
## What
A broken or missing toolset makes an evolution stage 'succeed' while doing nothing: the agent can only talk, not act; the report never appears; and the watchdog suppressed the missing-report alert because `last_status` was ok. The pipeline kept scheduling downstream stages around a silent no-op (observed with introspection when its terminal toolset broke).

## How
- **cron/scheduler.py** — `_count_tool_calls` (one `role=tool` message per executed call) measures the agent result in `_run_job_impl`; the count reaches `mark_job_run` in `run_one_job` via a per-job-id side channel dict, deliberately NOT by widening `run_job`'s public 4-tuple: every existing caller and test stub of that contract keeps working, and a missing entry reads as None (= unknown).
- **cron/jobs.py** — `mark_job_run(tool_calls=...)` persists `last_tool_calls` on the job record (None for no_agent scripts / legacy callers, so old records never alert).
- **scripts/evolution_watchdog.py** — a missing stage report whose job 'ran clean' for the slot now ALERTS when `last_tool_calls == 0` (agent could not act → stage failure) instead of being suppressed as an idle cycle; clean runs with real tool use keep the existing suppression, as do legacy records without the field.

## Verification
- New tests: watchdog alert/suppression matrix (zero / >0 / absent field), `mark_job_run` persistence, `_count_tool_calls` unit tests (TDD — watched them fail first).
- Full `tests/cron/` + `tests/scripts/`: **1258 passed, 0 failed**. Two strict test stubs updated for the new keyword.

Closes #701