### PR TITLE
feat(agent): failure-class naming and per-tool diversion advice in loop-guard nudges

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -111,14 +111,15 @@ _EXPLORATION_ALTERNATIVE_HINT = {
 # keep their dedicated #625 hints above (checked first in _diversion_hint).
 _DIVERSION_HINT = {
     "terminal": (
-        " Before ANY further `terminal` call: read the failing output above, "
-        "verify cwd/env/prerequisites with ONE read-only check, and change the "
-        "command accordingly."
+        " Read the failing output above and act on its CONTENT (fix the code "
+        "or the command); only if the failure looks environmental, verify "
+        "cwd/env/prerequisites with one read-only check before another run."
     ),
     "patch": (
-        " Re-read the exact target region with `read_file` first — the file "
-        "content or anchor text likely differs from what you assumed; for a "
-        "large rewrite use `write_file` instead of another near-identical patch."
+        " Anchor-not-found failures: re-read the exact target region with "
+        "`read_file` — the file likely differs from what you assumed. Content "
+        "errors after a successful match: fix the replacement text itself. "
+        "Large rewrites: use `write_file`."
     ),
     "memory": (
         " Split the write into smaller entries or recall via `session_search` "
@@ -488,15 +489,23 @@ def maybe_nudge(
         )
 
     if consec_fail >= fail_threshold:
-        # Name the dominant failure class and surface its recovery hint (#365)
-        # so the model reacts to WHAT is failing, not just that it failed.
-        dominant = next(
-            (c for _t, failed, c, _a in same[:consec_fail] if failed and c), None
-        )
+        # Name the most frequent failure class among the trailing failures and
+        # surface its recovery hint (#365) so the model reacts to WHAT is
+        # failing, not just that it failed. Ties resolve to the most recent
+        # class (same is most-recent-first).
+        _fail_classes = [
+            c for _t, failed, c, _a in same[:consec_fail] if failed and c
+        ]
+        dominant = None
+        if _fail_classes:
+            _counts: Dict[str, int] = {}
+            for c in _fail_classes:
+                _counts[c] = _counts.get(c, 0) + 1
+            dominant = max(_counts, key=lambda k: (_counts[k], -_fail_classes.index(k)))
         class_note = ""
         if dominant:
             _hint = _category_hint(dominant)
-            class_note = f" Dominant error class: `{dominant}`." + (
+            class_note = f" Most frequent error class: `{dominant}`." + (
                 f" {_hint}" if _hint else ""
             )
         return (
@@ -526,10 +535,12 @@ def maybe_nudge(
                 f"Do NOT repeat `{tool}` with those identical arguments. Rephrase "
                 f"the query, broaden or narrow it, switch to a different information "
                 f"source, or state the blocker if no relevant results are available."
-                # Deliberately NOT _diversion_hint: the #625 exploration hint
-                # must not bleed into the #467 identical-query path (its advice
-                # is already specific); only the family diversion table applies.
-                f"{_DIVERSION_HINT.get(tool, '')}"
+                # Deliberately NO appended hints here: this branch's advice is
+                # already specific to identical-argument repetition, and e.g.
+                # web_search's 'stop reformulating' diversion would directly
+                # contradict the 'rephrase the query' instruction above
+                # (consult review). The #625 exploration hints are excluded by
+                # the same long-standing design decision.
             )
 
     if count >= repeat_threshold:

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -104,6 +104,63 @@ _EXPLORATION_ALTERNATIVE_HINT = {
     ),
 }
 
+# Per-tool diversion advice appended to every nudge branch for the tools the
+# introspection evidence shows spiraling (#694 family): navigation (#680),
+# patch retries (#697), memory ops (#698), tool routing (#699), query
+# reformulation (#700), and terminal diagnostics (#694). Exploration tools
+# keep their dedicated #625 hints above (checked first in _diversion_hint).
+_DIVERSION_HINT = {
+    "terminal": (
+        " Before ANY further `terminal` call: read the failing output above, "
+        "verify cwd/env/prerequisites with ONE read-only check, and change the "
+        "command accordingly."
+    ),
+    "patch": (
+        " Re-read the exact target region with `read_file` first — the file "
+        "content or anchor text likely differs from what you assumed; for a "
+        "large rewrite use `write_file` instead of another near-identical patch."
+    ),
+    "memory": (
+        " Split the write into smaller entries or recall via `session_search` "
+        "instead of retrying the identical memory operation."
+    ),
+    "tool_call": (
+        " Verify the tool name and argument schema first (`tool_describe` / "
+        "`skills_list`); if an MCP server is unavailable, pick a native "
+        "alternative instead of re-invoking it."
+    ),
+    "tool_describe": (
+        " Verify the tool name first (`skills_list` or the available-tools "
+        "list); if an MCP server is unavailable, pick a native alternative."
+    ),
+    "browser_navigate": (
+        " Stop navigating: extract what you need from the CURRENT page "
+        "(`browser_snapshot` for structure, `web_extract` for content) or "
+        "change the information source entirely."
+    ),
+    "web_search": (
+        " Stop reformulating queries: synthesize an answer from the results "
+        "you already have, or `web_extract` the most promising hit for depth."
+    ),
+}
+
+
+def _diversion_hint(tool: str) -> str:
+    """Tool-specific redirect advice for a nudge; empty when none is defined."""
+    return _EXPLORATION_ALTERNATIVE_HINT.get(tool) or _DIVERSION_HINT.get(tool, "")
+
+
+def _category_hint(category: Optional[str]) -> Optional[str]:
+    """tool_diagnostics recovery hint for a failure category (#365). Lazy
+    import with a no-op fallback so loop_guard stays standalone."""
+    if not category:
+        return None
+    try:
+        from agent.tool_diagnostics import hint_for
+    except Exception:  # pragma: no cover - keep standalone if import path differs
+        return None
+    return hint_for(category)
+
 # Mutating tools get LOWER thresholds than idempotent tools because a fixation
 # on mutating operations (writing files, running commands) is more costly and
 # indicates a deeper strategy problem (#432).
@@ -424,9 +481,21 @@ def maybe_nudge(
             f"`{tool}` the same way again. Change the approach now: adjust the "
             f"parameters/path/command, route to a fallback tool, or report the "
             f"blocker concisely if it can't be resolved."
+            f"{_diversion_hint(tool)}"
         )
 
     if consec_fail >= fail_threshold:
+        # Name the dominant failure class and surface its recovery hint (#365)
+        # so the model reacts to WHAT is failing, not just that it failed.
+        dominant = next(
+            (c for _t, failed, c, _a in same[:consec_fail] if failed and c), None
+        )
+        class_note = ""
+        if dominant:
+            _hint = _category_hint(dominant)
+            class_note = f" Dominant error class: `{dominant}`." + (
+                f" {_hint}" if _hint else ""
+            )
         return (
             f"[loop-guard] The `{tool}` tool ({cat_label}) has failed "
             f"{consec_fail} times in a row with the same approach. STOP repeating "
@@ -435,6 +504,8 @@ def maybe_nudge(
             f"different tool or strategy, or — if the blocker can't be resolved "
             f"— report it concisely instead of retrying. Do not call `{tool}` "
             f"again the same way."
+            f"{class_note}"
+            f"{_diversion_hint(tool)}"
         )
 
     # Same-argument repetition for known spiral-prone idempotent tools (#467).
@@ -452,13 +523,17 @@ def maybe_nudge(
                 f"Do NOT repeat `{tool}` with those identical arguments. Rephrase "
                 f"the query, broaden or narrow it, switch to a different information "
                 f"source, or state the blocker if no relevant results are available."
+                # Deliberately NOT _diversion_hint: the #625 exploration hint
+                # must not bleed into the #467 identical-query path (its advice
+                # is already specific); only the family diversion table applies.
+                f"{_DIVERSION_HINT.get(tool, '')}"
             )
 
     if count >= repeat_threshold:
         # Build diversity score for the nudge.
         score = _tool_spiral_score(tool, count, repeat_threshold)
         score_line = f"\n{score}" if score else ""
-        exploration_hint = _EXPLORATION_ALTERNATIVE_HINT.get(tool, "")
+        exploration_hint = _diversion_hint(tool)
 
         if count >= escalate_threshold:
             return (

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -122,12 +122,13 @@ _DIVERSION_HINT = {
     ),
     "memory": (
         " Split the write into smaller entries or recall via `session_search` "
-        "instead of retrying the identical memory operation."
+        "(if it is in your toolset) instead of retrying the identical memory "
+        "operation."
     ),
     "tool_call": (
         " Verify the tool name and argument schema first (`tool_describe` / "
-        "`skills_list`); if an MCP server is unavailable, pick a native "
-        "alternative instead of re-invoking it."
+        "`skills_list`, if available); if an MCP server is unavailable, pick a "
+        "native alternative instead of re-invoking it."
     ),
     "tool_describe": (
         " Verify the tool name first (`skills_list` or the available-tools "
@@ -135,12 +136,14 @@ _DIVERSION_HINT = {
     ),
     "browser_navigate": (
         " Stop navigating: extract what you need from the CURRENT page "
-        "(`browser_snapshot` for structure, `web_extract` for content) or "
-        "change the information source entirely."
+        "(`browser_snapshot` for structure, `web_extract` for content — "
+        "whichever is in your toolset) or change the information source "
+        "entirely."
     ),
     "web_search": (
         " Stop reformulating queries: synthesize an answer from the results "
-        "you already have, or `web_extract` the most promising hit for depth."
+        "you already have, or `web_extract` (if available) the most promising "
+        "hit for depth."
     ),
 }
 

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -98,6 +98,18 @@ def classify(content: Any) -> Optional[Tuple[str, str]]:
     return None
 
 
+def hint_for(category: str) -> Optional[str]:
+    """Recovery hint for a known failure category, else None.
+
+    Lets consumers that only stored the category (e.g. loop_guard's run
+    tracking) surface the same actionable advice ``classify`` would have
+    returned, without re-classifying the original content (#365)."""
+    for _pattern, cat, hint in _RULES:
+        if cat == category:
+            return hint
+    return None
+
+
 def inline_diagnostics_enabled(config: Optional[dict] = None) -> bool:
     """Return whether ``diagnostic_suffix`` may inject its hint into the
     tool result text the model sees.

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -442,7 +442,27 @@ class TestFailureClassAndDiversionHints:
         assert n is not None
         assert "browser_snapshot" in n
 
-    def test_web_search_same_args_gets_synthesis_diversion(self):
+    def test_web_search_reformulation_run_gets_synthesis_diversion(self):
+        # #700's actual shape: many DIFFERENT queries (reformulations), each
+        # "succeeding", no synthesis. Hits the generic repeat path (idempotent
+        # threshold = 8).
+        msgs = [{"role": "user", "content": "go"}]
+        for i in range(8):
+            cid = f"c{i}"
+            msgs.append(
+                _asst("web_search", args=json.dumps({"query": f"attempt {i}"}), call_id=cid)
+            )
+            msgs.append(
+                _result("<untrusted_tool_result>10 hits</untrusted_tool_result>", call_id=cid)
+            )
+        n = maybe_nudge(msgs)
+        assert n is not None
+        assert "synthesize" in n.lower() or "web_extract" in n
+
+    def test_web_search_same_args_branch_has_no_contradicting_hint(self):
+        # The identical-args short-circuit (#467) carries NO appended hints —
+        # its own advice ('rephrase the query') would be directly contradicted
+        # by the 'stop reformulating' diversion (consult review).
         msgs = [{"role": "user", "content": "go"}]
         for i in range(4):
             cid = f"c{i}"
@@ -453,8 +473,8 @@ class TestFailureClassAndDiversionHints:
                 _result("<untrusted_tool_result>10 hits</untrusted_tool_result>", call_id=cid)
             )
         n = maybe_nudge(msgs)
-        assert n is not None
-        assert "synthesize" in n.lower() or "web_extract" in n
+        assert n is not None and "SAME arguments" in n
+        assert "Stop reformulating" not in n
 
     def test_read_file_exploration_hint_survives(self):
         # #625 hint must not be displaced by the new diversion table.

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -400,3 +400,64 @@ class TestShouldCronHardStop:
         huge_count = CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 100
         for platform in ("cli", "telegram", "discord", "gateway", None, ""):
             assert should_cron_hard_stop(platform, huge_count) is False, platform
+
+
+class TestFailureClassAndDiversionHints:
+    """#694 family: the generic failure nudge names the dominant error class
+    with its tool_diagnostics recovery hint (#365), and the observed spiral
+    tools get concrete diversion advice (#680 #697 #698 #699 #700)."""
+
+    def _fail_run(self, tool, n, content):
+        msgs = [{"role": "user", "content": "go"}]
+        for i in range(n):
+            cid = f"c{i}"
+            msgs.append(_asst(tool, call_id=cid))
+            msgs.append(_result(content, call_id=cid))
+        return msgs
+
+    def test_generic_fail_nudge_names_dominant_class(self):
+        # "does not exist" classifies as not_found (retryable) → generic branch
+        n = maybe_nudge(self._fail_run("terminal", 2, "error: config.yaml does not exist"))
+        assert n is not None
+        assert "not_found" in n
+        assert "Re-check the path" in n
+
+    def test_patch_failures_get_reread_diversion(self):
+        n = maybe_nudge(self._fail_run("patch", 2, "error: old content not found in file"))
+        assert n is not None
+        assert "read_file" in n
+
+    def test_memory_failures_get_recall_diversion(self):
+        n = maybe_nudge(self._fail_run("memory", 2, "error: memory write failed"))
+        assert n is not None
+        assert "session_search" in n
+
+    def test_tool_call_failures_get_routing_diversion(self):
+        n = maybe_nudge(self._fail_run("tool_call", 2, "error: unknown tool 'frobnicate'"))
+        assert n is not None
+        assert "tool name" in n
+
+    def test_browser_navigate_repeat_gets_extraction_diversion(self):
+        n = maybe_nudge(_run("browser_navigate", 4))
+        assert n is not None
+        assert "browser_snapshot" in n
+
+    def test_web_search_same_args_gets_synthesis_diversion(self):
+        msgs = [{"role": "user", "content": "go"}]
+        for i in range(4):
+            cid = f"c{i}"
+            msgs.append(
+                _asst("web_search", args=json.dumps({"query": "same"}), call_id=cid)
+            )
+            msgs.append(
+                _result("<untrusted_tool_result>10 hits</untrusted_tool_result>", call_id=cid)
+            )
+        n = maybe_nudge(msgs)
+        assert n is not None
+        assert "synthesize" in n.lower() or "web_extract" in n
+
+    def test_read_file_exploration_hint_survives(self):
+        # #625 hint must not be displaced by the new diversion table.
+        n = maybe_nudge(_run("read_file", 8))
+        assert n is not None
+        assert "repo_map" in n


### PR DESCRIPTION
## What
Completes the observed-spiral family with the two missing mechanism pieces:
1. **Failure-class naming (#365's intent):** the generic repeated-failure nudge names the most frequent failure class over the trailing failures and appends its `tool_diagnostics` recovery hint — the model reacts to WHAT is failing. `tool_diagnostics` gains a public `hint_for(category)`.
2. **Per-tool diversion table:** concrete redirect advice appended to the nudges for the tools introspection evidence shows spiraling — terminal (act on the failing output's content), patch (anchor-not-found vs content-error paths), memory, tool_call/tool_describe, browser_navigate (extract instead of navigating), web_search (synthesize / web_extract instead of reformulating). Cross-toolset references hedged with 'if available' (the #669 defect class). #625 exploration hints preserved; the #467 identical-args branch deliberately keeps ALL hints excluded (its own advice would be contradicted).

Together with already-shipped pieces (fail thresholds < repeat thresholds, deterministic-class stop #231, same-args short-circuit #467, escalated interrupt #432, cron hard stop #662, consecutive-429 fail-fast #704) this closes out the family.

## Review
External consult (agy) found 6 issues; 4 accepted and fixed in review commits (same-args contradiction, terminal/patch one-sidedness, first-match-as-dominant), 1 rejected with evidence (search_files DOES carry the repo_map hint), 1 mitigated (bloat — hints trimmed to 1-2 sentences).

## Verification
78 passed across test_loop_guard / cron enforcement / tool_diagnostics; 8 new tests (TDD — watched them fail first), incl. regression pins for hint-exclusion decisions.

Closes #694
Closes #680
Closes #695
Closes #696
Closes #697
Closes #698
Closes #699
Closes #700