### PR TITLE
fix: subagent SessionDB nil handle (Closes #723)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -586,7 +586,7 @@ class AIAgent:
             pass_session_id=pass_session_id,
         )
 
-    def _get_session_db_for_recall(self):
+    def _get_session_db_for_recall(self, *, reason: str = "recall"):
         """Return a SessionDB for recall, lazily creating it if an entrypoint forgot.
 
         Most frontends pass ``session_db`` into ``AIAgent`` explicitly, but recall
@@ -608,15 +608,30 @@ class AIAgent:
             self._session_db = SessionDB()
             return self._session_db
         except Exception as exc:
-            logger.debug("SessionDB unavailable for recall", exc_info=True)
+            logger.debug("SessionDB unavailable for %s", reason, exc_info=True)
             return None
 
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if getattr(self, "_persist_disabled", False):
             return
-        if self._session_db_created or not self._session_db:
+        if self._session_db_created:
             return
+        # Subagent (and other forked) sessions may be constructed without a
+        # parent-provided SessionDB handle. Open the canonical DB lazily here
+        # before any append_message / compression lock usage, rather than
+        # proceeding with a nil handle and silently losing persistence.
+        if not self._session_db:
+            db = self._get_session_db_for_recall(reason="subagent persistence")
+            if db is None:
+                from hermes_state import get_last_init_error
+
+                detail = get_last_init_error() or "state.db could not be opened"
+                raise RuntimeError(
+                    f"Session DB handle is nil; persistence and compression "
+                    f"are unavailable for this subagent session: {detail}"
+                )
+            self._session_db = db
         source = _session_source_for_agent(self.platform)
         try:
             self._session_db.create_session(

--- a/tests/run_agent/test_subagent_session_db_nil_handle.py
+++ b/tests/run_agent/test_subagent_session_db_nil_handle.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from run_agent import AIAgent
+from hermes_state import SessionDB
+
+
+def _make_subagent():
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_db=None,
+        platform="subagent",
+    )
+
+
+class TestSubagentSessionDBNilHandle(unittest.TestCase):
+    """Issue #723: subagent sessions must open state.db if no handle was provided."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name) / ".hermes"
+        self.home.mkdir(parents=True, exist_ok=True)
+        self._orig_hermes_home = os.environ.get("HERMES_HOME")
+        os.environ["HERMES_HOME"] = str(self.home)
+
+    def tearDown(self):
+        if self._orig_hermes_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = self._orig_hermes_home
+        self.tmp.cleanup()
+
+    def test_subagent_session_opens_canonical_db(self):
+        """A subagent without session_db lazily opens canonical state.db on first use."""
+        agent = _make_subagent()
+        self.assertIsNone(agent._session_db)
+        agent._ensure_db_session()
+        self.assertIsInstance(agent._session_db, SessionDB)
+        self.assertTrue(agent._session_db_created)
+
+        # Row exists and is tagged as a subagent child of the parent session.
+        agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "hello"}], conversation_history=[]
+        )
+        row = agent._session_db.get_session(agent.session_id)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["source"], "subagent")
+
+    def test_nil_handle_with_persist_disabled_does_not_open(self):
+        """Background-review forks must not open canonical state.db."""
+        agent = _make_subagent()
+        agent._persist_disabled = True
+        agent._ensure_db_session()
+        self.assertIsNone(agent._session_db)
+        self.assertFalse(agent._session_db_created)
+
+    def test_existing_session_db_is_preserved(self):
+        """When a SessionDB is passed in, it is still used unchanged."""
+        db = SessionDB(self.home / "state.db")
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=db,
+            platform="subagent",
+        )
+        self.assertIs(agent._session_db, db)
+        agent._ensure_db_session()
+        self.assertIs(agent._session_db, db)
+        self.assertTrue(agent._session_db_created)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Automated evolution PR for issue #723.\n\n## What changed\n- :  now lazily opens the canonical  when a subagent is constructed without an explicit  handle, instead of returning early and silently losing persistence.\n- Persist-disabled forks continue to no-op.\n- Added  covering the lazy-open path, the persist-disabled path, and the existing-handle preservation path.\n\nCloses #723