### PR TITLE
fix(evolution_funnel): accept legacy 'created' alias and warn on schema drift (Closes #730, Related-to #731)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -50,6 +50,7 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     Every field defaults to 0 / {} so a missing stage report never crashes the
     metric — it just shows that stage produced nothing recorded that day.
     """
+
     # Stage reports are normally dicts, but some stages write a bare LIST (e.g.
     # introspection emits a list of patterns). Coerce non-dicts to {} so .get()
     # never crashes the metric — a list-shaped report previously raised
@@ -58,7 +59,7 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     def _as_dict(x: Any) -> Dict[str, Any]:
         return x if isinstance(x, dict) else {}
 
-    issues_raw = _load_json(evolution_dir / "issues" / f"{date}.json")
+    issues_raw = _load_json(issues_path := evolution_dir / "issues" / f"{date}.json")
     analysis = _as_dict(_load_json(evolution_dir / "analysis" / f"{date}.json"))
     integration = _as_dict(_load_json(evolution_dir / "integration" / f"{date}.json"))
     introspection_raw = _load_json(evolution_dir / "introspection" / f"{date}.json")
@@ -73,7 +74,13 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
         patterns = introspection_raw
     else:
         patterns = _as_dict(introspection_raw).get("patterns_found") or []
-    created = issues.get("issues_created") or []
+    created = issues.get("issues_created") or issues.get("created") or []
+    if "issues_created" not in issues and "created" in issues:
+        logger.warning(
+            "Schema drift in %s: issues report uses legacy key 'created' "
+            "instead of 'issues_created'",
+            issues_path,
+        )
 
     return {
         "date": date,
@@ -187,7 +194,9 @@ def summarize(records: list[Dict[str, Any]], last: int = 7) -> Dict[str, Any]:
 
     flags: list[str] = []
     if reject_rate > 0.70:
-        flags.append("HIGH_REJECT_RATE: be more selective — only high-evidence proposals")
+        flags.append(
+            "HIGH_REJECT_RATE: be more selective — only high-evidence proposals"
+        )
     if merged_zero_streak >= 3:
         flags.append(
             f"MERGED_ZERO x{merged_zero_streak}: integration looks stuck — check CI / flaky gates"
@@ -262,7 +271,10 @@ def main(argv: list[str]) -> int:
 
             date = cycle_date(_now())
         except Exception:
-            print("[evolution-funnel] no date given and clock unavailable", file=sys.stderr)
+            print(
+                "[evolution-funnel] no date given and clock unavailable",
+                file=sys.stderr,
+            )
             return 1
 
     record = compute_funnel(evolution_dir, date)
@@ -274,12 +286,14 @@ def main(argv: list[str]) -> int:
     # agree), emit a halt state. This prevents the pipeline from burning
     # API credits on a broken loop: cron jobs check for the halt file before
     # spawning expensive LLM stages.
-    _halt_threshold_merged = 5   # cycles with merged=0
-    _halt_threshold_selected = 3 # cycles with selected=0
+    _halt_threshold_merged = 5  # cycles with merged=0
+    _halt_threshold_selected = 3  # cycles with selected=0
     _halt_file = evolution_dir / "halt-state.txt"
     try:
         _all_records = load_records(evolution_dir / "metrics.jsonl")
-        _summary = summarize(_all_records, max(_halt_threshold_merged, _halt_threshold_selected))
+        _summary = summarize(
+            _all_records, max(_halt_threshold_merged, _halt_threshold_selected)
+        )
         _merged_zero = _summary.get("merged_zero_streak", 0)
         # Count consecutive cycles with selected=0 too
         _selected_zero_streak = 0
@@ -288,7 +302,10 @@ def main(argv: list[str]) -> int:
                 _selected_zero_streak += 1
             else:
                 break
-        if _merged_zero >= _halt_threshold_merged and _selected_zero_streak >= _halt_threshold_selected:
+        if (
+            _merged_zero >= _halt_threshold_merged
+            and _selected_zero_streak >= _halt_threshold_selected
+        ):
             _halt_file.write_text(
                 f"# Evolution pipeline HALTED\n"
                 f"# Date: {date}\n"
@@ -324,7 +341,8 @@ def main(argv: list[str]) -> int:
     # the `file` toolset — they can't run `--summary` themselves (#84 loop).
     try:
         (evolution_dir / "funnel-summary.txt").write_text(
-            format_summary(summarize(load_records(evolution_dir / "metrics.jsonl"), 7)) + "\n",
+            format_summary(summarize(load_records(evolution_dir / "metrics.jsonl"), 7))
+            + "\n",
             encoding="utf-8",
         )
     except OSError:
@@ -337,7 +355,10 @@ def main(argv: list[str]) -> int:
         from evolution_metrics import compute_health, format_health
 
         (evolution_dir / "evolution-health.txt").write_text(
-            format_health(compute_health(load_records(evolution_dir / "metrics.jsonl"), 30)) + "\n",
+            format_health(
+                compute_health(load_records(evolution_dir / "metrics.jsonl"), 30)
+            )
+            + "\n",
             encoding="utf-8",
         )
     except Exception:

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -26,23 +26,36 @@ def _write(p: Path, obj):
 class TestComputeFunnel:
     def test_full_cycle(self, tmp_path):
         d = "2026-06-13"
-        _write(tmp_path / "issues" / f"{d}.json", {
-            "total_proposals": 9, "proposals_passed_filter": 3,
-            "issues_created": [{"number": 1}, {"number": 2}, {"number": 3}],
-        })
-        _write(tmp_path / "analysis" / f"{d}.json", {
-            "rejected": [
-                {"reason_code": "already-exists"}, {"reason_code": "already-exists"},
-                {"reason_code": "out-of-scope"},
-            ],
-            "selected_for_implementation": [
-                {"selected_reason": "score"}, {"selected_reason": "score"},
-                {"selected_reason": "anti-starvation"},
-            ],
-        })
-        _write(tmp_path / "integration" / f"{d}.json", {
-            "merged": [{"pr": "1"}], "skipped": [{"pr": "2"}, {"pr": "3"}],
-        })
+        _write(
+            tmp_path / "issues" / f"{d}.json",
+            {
+                "total_proposals": 9,
+                "proposals_passed_filter": 3,
+                "issues_created": [{"number": 1}, {"number": 2}, {"number": 3}],
+            },
+        )
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {
+                "rejected": [
+                    {"reason_code": "already-exists"},
+                    {"reason_code": "already-exists"},
+                    {"reason_code": "out-of-scope"},
+                ],
+                "selected_for_implementation": [
+                    {"selected_reason": "score"},
+                    {"selected_reason": "score"},
+                    {"selected_reason": "anti-starvation"},
+                ],
+            },
+        )
+        _write(
+            tmp_path / "integration" / f"{d}.json",
+            {
+                "merged": [{"pr": "1"}],
+                "skipped": [{"pr": "2"}, {"pr": "3"}],
+            },
+        )
         _write(tmp_path / "introspection" / f"{d}.json", {"patterns_found": [{"p": 1}]})
 
         r = compute_funnel(tmp_path, d)
@@ -87,6 +100,54 @@ class TestComputeFunnel:
         r = compute_funnel(tmp_path, d)
         assert r["selected"] == 0 and r["merged"] == 0
 
+    def test_legacy_created_key_counts_and_warns(self, tmp_path, caplog):
+        # 2026-07-04 issue report used 'created' instead of 'issues_created'.
+        import logging
+
+        d = "2026-07-04"
+        _write(
+            tmp_path / "issues" / f"{d}.json",
+            {
+                "date": d,
+                "created": [{"number": 734}, {"number": 735}],
+            },
+        )
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {"selected_for_implementation": [], "rejected": []},
+        )
+        _write(tmp_path / "integration" / f"{d}.json", {"merged": [], "skipped": []})
+
+        with caplog.at_level(logging.WARNING, logger="evolution_funnel"):
+            r = compute_funnel(tmp_path, d)
+
+        assert r["issues_created"] == 2
+        assert "legacy key 'created'" in caplog.text
+        assert "2026-07-04" in caplog.text
+
+    def test_canonical_issues_created_key_no_warning(self, tmp_path, caplog):
+        # 2026-07-05 issue report uses canonical 'issues_created' key.
+        import logging
+
+        d = "2026-07-05"
+        _write(
+            tmp_path / "issues" / f"{d}.json",
+            {
+                "issues_created": [{"number": 737}],
+            },
+        )
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {"selected_for_implementation": [], "rejected": []},
+        )
+        _write(tmp_path / "integration" / f"{d}.json", {"merged": [], "skipped": []})
+
+        with caplog.at_level(logging.WARNING, logger="evolution_funnel"):
+            r = compute_funnel(tmp_path, d)
+
+        assert r["issues_created"] == 1
+        assert "legacy key" not in caplog.text
+
 
 class TestCycleDate:
     def test_morning_run_measures_yesterday(self):
@@ -121,15 +182,21 @@ class TestAppendFunnel:
 class TestSummary:
     def _rec(self, date, created=0, selected=0, rejected=0, merged=0, skipped=0):
         return {
-            "date": date, "issues_created": created, "selected": selected,
-            "rejected": rejected, "merged": merged, "skipped": skipped,
+            "date": date,
+            "issues_created": created,
+            "selected": selected,
+            "rejected": rejected,
+            "merged": merged,
+            "skipped": skipped,
         }
 
     def test_load_records_skips_blank_and_malformed(self, tmp_path):
         f = tmp_path / "metrics.jsonl"
         f.write_text(
-            json.dumps(self._rec("2026-06-10", merged=1)) + "\n\nnot-json\n"
-            + json.dumps(self._rec("2026-06-11", merged=2)) + "\n",
+            json.dumps(self._rec("2026-06-10", merged=1))
+            + "\n\nnot-json\n"
+            + json.dumps(self._rec("2026-06-11", merged=2))
+            + "\n",
             encoding="utf-8",
         )
         recs = load_records(f)
@@ -176,7 +243,13 @@ class TestSummarySidecar:
         # must leave a file it can read. A normal main() run writes it.
         monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
         (tmp_path / "metrics.jsonl").write_text(
-            json.dumps({"date": "2026-06-10", "selected": 1, "rejected": 9, "merged": 0}) + "\n",
+            json.dumps({
+                "date": "2026-06-10",
+                "selected": 1,
+                "rejected": 9,
+                "merged": 0,
+            })
+            + "\n",
             encoding="utf-8",
         )
         from evolution_funnel import main


### PR DESCRIPTION
Automated evolution PR for issue #730. Makes the funnel tolerate both the canonical  key and the legacy  key emitted by the 2026-07-04 issues stage report, while emitting a schema-drift warning. Includes regression tests for both shapes.

Deferred (next increment):
- Converge the issues stage writer to a versioned, validated schema (#731) so consumers no longer need aliases.