### PR TITLE
fix(cron): steer next run away from a loop-guard hard-stopped tool (Closes #720)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2374,7 +2374,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # One-shot diversion directive: if the previous run of this job was
     # hard-stopped by the cron loop guard (see #720), steer this run away
-    # from the tool it got stuck on, then clear the flag so it only fires once.
+    # from the tool it got stuck on. The flag is cleared by the caller
+    # (_run_job_impl) once it knows the agent run is actually going ahead —
+    # NOT here, since this function can be short-circuited afterwards
+    # (CronPromptInjectionBlocked, empty script output) before any agent
+    # ever sees the directive.
     stuck_tool = job.get("last_hard_stop_tool")
     if stuck_tool:
         try:
@@ -2393,17 +2397,6 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         except Exception:
             logger.debug(
                 "loop_guard: failed to build diversion hint for job_id=%r%s",
-                job.get("id"),
-                _cron_job_origin_log_suffix(job),
-                exc_info=True,
-            )
-        try:
-            update_job(
-                job["id"], {"last_hard_stop_tool": None, "last_hard_stop_at": None}
-            )
-        except Exception:
-            logger.debug(
-                "loop_guard: failed to clear hard-stop flag for job_id=%r%s",
                 job.get("id"),
                 _cron_job_origin_log_suffix(job),
                 exc_info=True,
@@ -3005,6 +2998,23 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
+
+    # The prompt (including any one-shot hard-stop diversion directive built
+    # by _build_job_prompt above) is final and the agent run is definitely
+    # going ahead — safe to consume the one-shot flag now. Doing this here,
+    # rather than inside _build_job_prompt, avoids clearing it on a run that
+    # never actually reaches the agent (see the two early returns above).
+    if job.get("last_hard_stop_tool"):
+        try:
+            update_job(
+                job_id, {"last_hard_stop_tool": None, "last_hard_stop_at": None}
+            )
+        except Exception:
+            logger.debug(
+                "loop_guard: failed to clear hard-stop flag for job '%s'",
+                job_name,
+                exc_info=True,
+            )
 
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -301,6 +301,7 @@ from cron.jobs import (
     _jobs_lock,
     advance_next_run,
     claim_dispatch,
+    update_job,
 )
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -2257,6 +2258,12 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+# Number of turns the one-shot post-hard-stop diversion directive (see #720)
+# asks the agent to avoid the previously stuck tool for, at the start of the
+# next run of the same cron job.
+_HARD_STOP_DIVERSION_TURNS = 5
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -2364,6 +2371,43 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     e,
                 )
                 # silent skip — do not pollute the prompt with error messages
+
+    # One-shot diversion directive: if the previous run of this job was
+    # hard-stopped by the cron loop guard (see #720), steer this run away
+    # from the tool it got stuck on, then clear the flag so it only fires once.
+    stuck_tool = job.get("last_hard_stop_tool")
+    if stuck_tool:
+        try:
+            from agent.loop_guard import _diversion_hint
+
+            advice = _diversion_hint(stuck_tool)
+            prompt = (
+                f"[NOTE: The previous run of this cron job was stopped by the "
+                f"loop guard after getting stuck repeating `{stuck_tool}` calls "
+                f"with no progress. For at least your first {_HARD_STOP_DIVERSION_TURNS} "
+                f"turns this run, avoid `{stuck_tool}` and prefer alternatives "
+                f"(file reads, repo_map, delegating to a subagent) unless it is "
+                f"truly unavoidable."
+                f"{(' ' + advice) if advice else ''}]\n\n"
+            ) + prompt
+        except Exception:
+            logger.debug(
+                "loop_guard: failed to build diversion hint for job_id=%r%s",
+                job.get("id"),
+                _cron_job_origin_log_suffix(job),
+                exc_info=True,
+            )
+        try:
+            update_job(
+                job["id"], {"last_hard_stop_tool": None, "last_hard_stop_at": None}
+            )
+        except Exception:
+            logger.debug(
+                "loop_guard: failed to clear hard-stop flag for job_id=%r%s",
+                job.get("id"),
+                _cron_job_origin_log_suffix(job),
+                exc_info=True,
+            )
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
@@ -3650,6 +3694,23 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if result.get("failed") is True or (
             result.get("completed") is False and not max_iteration_summary
         ):
+            if turn_exit_reason == "loop_guard_cron_hard_stop":
+                _stuck_tool = getattr(agent, "_loop_guard_tracked_tool", None)
+                if _stuck_tool:
+                    try:
+                        update_job(
+                            job_id,
+                            {
+                                "last_hard_stop_tool": _stuck_tool,
+                                "last_hard_stop_at": _hermes_now().isoformat(),
+                            },
+                        )
+                    except Exception:
+                        logger.debug(
+                            "loop_guard: failed to persist hard-stop tool for job '%s'",
+                            job_name,
+                            exc_info=True,
+                        )
             _err_text = (
                 result.get("error") or final_response_text or "agent reported failure"
             )

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2896,8 +2896,14 @@ class TestBuildJobPromptSilentHint:
 
 class TestBuildJobPromptHardStopDiversion:
     """Issue #720: a job whose previous run was hard-stopped by the cron loop
-    guard gets a one-shot directive steering it away from the stuck tool, and
-    the flag is cleared so it only fires on the very next run."""
+    guard gets a one-shot directive steering it away from the stuck tool.
+
+    _build_job_prompt only builds the directive text — it must NOT clear the
+    flag itself, since the run can still be short-circuited afterwards
+    (CronPromptInjectionBlocked, empty script output) before the agent ever
+    sees it. Clearing is _run_job_impl's job, once the run is confirmed to
+    proceed — covered by TestLoopGuardHardStopPersistence below.
+    """
 
     def test_no_directive_when_no_hard_stop_recorded(self):
         job = {"id": "abc123deadbe", "prompt": "do something"}
@@ -2918,10 +2924,8 @@ class TestBuildJobPromptHardStopDiversion:
         assert "loop guard" in result
         # Reused straight from agent.loop_guard._DIVERSION_HINT["terminal"].
         assert "Read the failing output above" in result
-        mock_update_job.assert_called_once_with(
-            "abc123deadbe",
-            {"last_hard_stop_tool": None, "last_hard_stop_at": None},
-        )
+        # _build_job_prompt only builds text — clearing happens in _run_job_impl.
+        mock_update_job.assert_not_called()
 
     def test_directive_precedes_user_prompt(self):
         job = {
@@ -2935,9 +2939,9 @@ class TestBuildJobPromptHardStopDiversion:
         prompt_pos = result.index("My custom prompt")
         assert directive_pos < prompt_pos
 
-    def test_directive_clears_flag_even_for_unknown_tool(self):
+    def test_directive_built_for_unknown_tool_without_clearing(self):
         """An unrecognized tool name (no entry in the hint tables) should
-        still produce a directive and still clear the one-shot flag."""
+        still produce a directive; the flag is left for _run_job_impl to clear."""
         job = {
             "id": "abc123deadbe",
             "prompt": "do something",
@@ -2946,10 +2950,99 @@ class TestBuildJobPromptHardStopDiversion:
         with patch("cron.scheduler.update_job") as mock_update_job:
             result = _build_job_prompt(job)
         assert "`some_future_tool`" in result
+        mock_update_job.assert_not_called()
+
+
+class TestHardStopFlagClearing:
+    """Issue #720: the one-shot ``last_hard_stop_tool`` flag must be cleared
+    only once the agent run is confirmed to actually proceed — never on a
+    run that gets short-circuited before ``AIAgent`` is ever constructed
+    (wake-gate ``{"wakeAgent": false}``, ``CronPromptInjectionBlocked``).
+    See TestBuildJobPromptHardStopDiversion above for why the clearing call
+    lives in _run_job_impl rather than _build_job_prompt.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_runtime_provider(self):
+        fake_runtime = {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "stub",
+            "requested_provider": None,
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ):
+            yield
+
+    def _make_job(self, **overrides):
+        job = {
+            "id": "job_hard-stop-clear",
+            "name": "hard-stop-clear-test",
+            "prompt": "Do a thing",
+            "schedule": "*/5 * * * *",
+            "last_hard_stop_tool": "terminal",
+            "last_hard_stop_at": "2026-07-01T00:00:00+00:00",
+        }
+        job.update(overrides)
+        return job
+
+    def test_normal_run_clears_hard_stop_flag(self):
+        """A run that proceeds all the way to the agent clears the one-shot
+        flag so the diversion directive doesn't repeat forever."""
+        import cron.scheduler as scheduler
+
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok", "messages": []
+        })
+        with patch("run_agent.AIAgent", return_value=agent), \
+             patch("cron.scheduler.update_job") as mock_update_job:
+            success, doc, final, err = scheduler.run_job(self._make_job())
+
+        assert success is True
         mock_update_job.assert_called_once_with(
-            "abc123deadbe",
+            "job_hard-stop-clear",
             {"last_hard_stop_tool": None, "last_hard_stop_at": None},
         )
+
+    def test_wake_gate_false_does_not_clear_flag(self):
+        """The wake-gate short-circuit fires BEFORE the agent is ever
+        constructed — the flag must survive so the diversion directive is
+        still there on the NEXT run."""
+        import cron.scheduler as scheduler
+
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, '{"wakeAgent": false}')), \
+             patch("run_agent.AIAgent") as agent_cls, \
+             patch("cron.scheduler.update_job") as mock_update_job:
+            success, doc, final, err = scheduler.run_job(
+                self._make_job(script="check.py")
+            )
+
+        assert success is True
+        agent_cls.assert_not_called()
+        mock_update_job.assert_not_called()
+
+    def test_prompt_injection_block_does_not_clear_flag(self):
+        """If the assembled prompt trips the injection scanner, the agent
+        never runs — the flag must be preserved for the next attempt."""
+        import cron.scheduler as scheduler
+
+        with patch.object(
+            scheduler, "_build_job_prompt",
+            side_effect=scheduler.CronPromptInjectionBlocked("prompt_injection: test"),
+        ), \
+             patch("run_agent.AIAgent") as agent_cls, \
+             patch("cron.scheduler.update_job") as mock_update_job:
+            success, doc, final, err = scheduler.run_job(self._make_job())
+
+        assert success is False
+        agent_cls.assert_not_called()
+        mock_update_job.assert_not_called()
 
 
 class TestParseWakeGate:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1899,6 +1899,99 @@ class TestRunJobSessionPersistence:
         assert fake_db.close.call_count == 2
 
 
+class TestLoopGuardHardStopPersistence:
+    """Issue #720: when the cron loop guard hard-stops a run, persist the
+    stuck tool onto the job record so the NEXT run of the same job can be
+    steered away from it (see _build_job_prompt's diversion directive).
+    """
+
+    def _run(self, tmp_path, agent_result, tracked_tool):
+        job = {
+            "id": "hard-stop-job",
+            "name": "hard stop test job",
+            "prompt": "do something",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch("cron.scheduler.update_job") as mock_update_job:
+            mock_agent = MagicMock()
+            mock_agent._loop_guard_tracked_tool = tracked_tool
+            mock_agent.run_conversation.return_value = agent_result
+            mock_agent_cls.return_value = mock_agent
+
+            result = run_job(job)
+
+        return result, mock_update_job
+
+    def test_hard_stop_persists_stuck_tool_on_job(self, tmp_path):
+        agent_result = {
+            "final_response": "",
+            "completed": False,
+            "failed": True,
+            "turn_exit_reason": "loop_guard_cron_hard_stop",
+            "error": "[loop-guard] Unattended cron session stuck on `terminal` ...",
+        }
+        (success, output, final_response, error), mock_update_job = self._run(
+            tmp_path, agent_result, tracked_tool="terminal"
+        )
+
+        assert success is False
+        mock_update_job.assert_called_once()
+        called_job_id, called_updates = mock_update_job.call_args[0]
+        assert called_job_id == "hard-stop-job"
+        assert called_updates["last_hard_stop_tool"] == "terminal"
+        assert called_updates["last_hard_stop_at"]  # non-empty ISO timestamp
+
+    def test_non_hard_stop_failure_does_not_persist(self, tmp_path):
+        """A regular agent failure (not the loop-guard hard stop) must not
+        write a hard-stop marker — only the specific exit reason does."""
+        agent_result = {
+            "final_response": "",
+            "completed": False,
+            "failed": True,
+            "turn_exit_reason": "",
+            "error": "some other failure",
+        }
+        (success, output, final_response, error), mock_update_job = self._run(
+            tmp_path, agent_result, tracked_tool="terminal"
+        )
+
+        assert success is False
+        mock_update_job.assert_not_called()
+
+    def test_hard_stop_without_tracked_tool_does_not_persist(self, tmp_path):
+        """Defensive: if the loop guard hard-stopped but no tool name was
+        tracked on the agent, there is nothing useful to persist."""
+        agent_result = {
+            "final_response": "",
+            "completed": False,
+            "failed": True,
+            "turn_exit_reason": "loop_guard_cron_hard_stop",
+            "error": "[loop-guard] ...",
+        }
+        (success, output, final_response, error), mock_update_job = self._run(
+            tmp_path, agent_result, tracked_tool=None
+        )
+
+        assert success is False
+        mock_update_job.assert_not_called()
+
+
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""
 
@@ -2799,6 +2892,64 @@ class TestBuildJobPromptSilentHint:
         system_pos = result.index("do NOT use send_message")
         prompt_pos = result.index("My custom prompt")
         assert system_pos < prompt_pos
+
+
+class TestBuildJobPromptHardStopDiversion:
+    """Issue #720: a job whose previous run was hard-stopped by the cron loop
+    guard gets a one-shot directive steering it away from the stuck tool, and
+    the flag is cleared so it only fires on the very next run."""
+
+    def test_no_directive_when_no_hard_stop_recorded(self):
+        job = {"id": "abc123deadbe", "prompt": "do something"}
+        with patch("cron.scheduler.update_job") as mock_update_job:
+            result = _build_job_prompt(job)
+        assert "loop guard" not in result
+        mock_update_job.assert_not_called()
+
+    def test_directive_mentions_stuck_tool_and_advice(self):
+        job = {
+            "id": "abc123deadbe",
+            "prompt": "do something",
+            "last_hard_stop_tool": "terminal",
+        }
+        with patch("cron.scheduler.update_job") as mock_update_job:
+            result = _build_job_prompt(job)
+        assert "`terminal`" in result
+        assert "loop guard" in result
+        # Reused straight from agent.loop_guard._DIVERSION_HINT["terminal"].
+        assert "Read the failing output above" in result
+        mock_update_job.assert_called_once_with(
+            "abc123deadbe",
+            {"last_hard_stop_tool": None, "last_hard_stop_at": None},
+        )
+
+    def test_directive_precedes_user_prompt(self):
+        job = {
+            "id": "abc123deadbe",
+            "prompt": "My custom prompt",
+            "last_hard_stop_tool": "terminal",
+        }
+        with patch("cron.scheduler.update_job"):
+            result = _build_job_prompt(job)
+        directive_pos = result.index("loop guard")
+        prompt_pos = result.index("My custom prompt")
+        assert directive_pos < prompt_pos
+
+    def test_directive_clears_flag_even_for_unknown_tool(self):
+        """An unrecognized tool name (no entry in the hint tables) should
+        still produce a directive and still clear the one-shot flag."""
+        job = {
+            "id": "abc123deadbe",
+            "prompt": "do something",
+            "last_hard_stop_tool": "some_future_tool",
+        }
+        with patch("cron.scheduler.update_job") as mock_update_job:
+            result = _build_job_prompt(job)
+        assert "`some_future_tool`" in result
+        mock_update_job.assert_called_once_with(
+            "abc123deadbe",
+            {"last_hard_stop_tool": None, "last_hard_stop_at": None},
+        )
 
 
 class TestParseWakeGate:


### PR DESCRIPTION
## Problem

The cron loop-guard hard-stops a run that gets stuck repeating the same
tool call with no progress (#624). That correctly ends the wasted run,
but nothing carries the lesson into the NEXT run of the same job — so
the identical tool-loop repeats on every subsequent run of that job.

## Fix

- When `_run_job_impl` sees `turn_exit_reason == "loop_guard_cron_hard_stop"`,
  it now persists the stuck tool name (`agent._loop_guard_tracked_tool`)
  and a timestamp onto the job record via the existing `update_job` helper.
- `_build_job_prompt` checks for a recorded `last_hard_stop_tool` and, if
  present, prepends a one-shot directive telling the agent to avoid that
  tool for its first few turns and prefer alternatives (file reads,
  repo_map, subagent delegation) — reusing the existing
  `agent.loop_guard._diversion_hint()` advice text per tool.
- The one-shot flag is cleared in `_run_job_impl`, **not** inside
  `_build_job_prompt` — see "Review" below for why.

## Review

Per this repo's commit hook policy, the initial diff was sent through a
cross-provider `consult --panel` review (agy/Gemini) before sealing. It
correctly flagged a Command-Query Separation violation: the first version
cleared the flag inside `_build_job_prompt`, but `_run_job_impl` has two
early-return short-circuits *after* that call and *before* the agent is
ever invoked (wake-gate `{"wakeAgent": false}`, and
`CronPromptInjectionBlocked`) — so the flag could be silently lost on a
run that never actually reached the agent.

This PR's second commit moves the clearing call out of `_build_job_prompt`
(which now only reads the flag and builds directive text) into
`_run_job_impl`, right after both short-circuit paths — i.e. only once
the run is confirmed to actually proceed.

## Tests

- `TestLoopGuardHardStopPersistence` — hard-stop persists the stuck tool;
  a non-hard-stop failure or a hard-stop with no tracked tool does not.
- `TestBuildJobPromptHardStopDiversion` — directive text/ordering, and
  `_build_job_prompt` itself never calls `update_job`.
- `TestHardStopFlagClearing` — a normal run clears the flag; wake-gate-false
  and `CronPromptInjectionBlocked` short-circuits do not.

427 tests pass across `test_scheduler.py`, `test_loop_guard.py`,
`test_loop_guard_cron_enforcement.py`, `test_interrupted_jobs.py`,
`test_jobs.py`, `test_run_one_job.py`, `test_cron_prompt_injection_skill.py`.

Closes #720