### PR TITLE
fix(gateway): auto-restart on code skew to close the deploy gap

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18921,7 +18921,7 @@ def _run_planned_stop_watcher(
         stop_event.wait(poll_interval)
 
 
-def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
+def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60, runner=None):
     """Background thread for gateway-only periodic chores (NOT cron).
 
     Split out of the historical ``_start_cron_ticker`` so the cron *trigger*
@@ -18937,11 +18937,21 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     """
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
     from hermes_cli.debug import _sweep_expired_pastes
+    from gateway.code_skew import detect_code_skew
+    from hermes_cli.gateway import supports_systemd_services
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
+    # Deploy-gap self-heal: a long-lived gateway freezes its ``sys.modules`` at
+    # boot, so a ``git pull`` / ``hermes update`` / evolution-integration deploy
+    # underneath it leaves the PROCESS running STALE code until it is restarted.
+    # Poll the checkout revision every few minutes and, on a service-managed
+    # host, request a graceful restart so the freshly-pulled code actually goes
+    # live without a human remembering to ``systemctl restart``.
+    SKEW_CHECK_EVERY = 5     # ticks — every ~5 minutes at the default 60s interval
+    _skew_restart_requested = False
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)
     tick_count = 0
@@ -19005,6 +19015,64 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                 )
             except Exception as e:
                 logger.debug("Curator tick error: %s", e)
+
+        # Deploy-gap self-heal (see SKEW_CHECK_EVERY above): detect a checkout
+        # that moved under this long-lived process and, on a service-managed
+        # host, request a graceful restart so the new code goes live. This is
+        # the SAME restart path as a manual ``/restart`` / SIGUSR1 (it drains
+        # active turns, then exits 75 so systemd respawns on the fresh
+        # checkout) — it introduces no restart behaviour that operators don't
+        # already invoke by hand. Evolution cron jobs are resumable by design
+        # (loop-guard/watchdog assume interruption), so we don't block on them;
+        # we DO defer while an interactive agent turn is mid-flight.
+        if (
+            not _skew_restart_requested
+            and runner is not None
+            and loop is not None
+            and tick_count % SKEW_CHECK_EVERY == 0
+        ):
+            try:
+                skew = detect_code_skew()
+                if skew is not None:
+                    boot_rev, disk_rev = skew
+                    if not supports_systemd_services():
+                        logger.info(
+                            "Code skew detected (booted %s, disk %s) but the gateway "
+                            "is not service-managed — restart it manually to load new "
+                            "code.",
+                            boot_rev,
+                            disk_rev,
+                        )
+                        _skew_restart_requested = True  # nothing to act on; notify once
+                    elif getattr(runner, "_running_agents", None):
+                        # An interactive turn is mid-flight — defer to the next
+                        # check rather than racing its drain. Latch stays False so
+                        # we retry; do NOT act now.
+                        logger.info(
+                            "Code skew detected (booted %s, disk %s); deferring "
+                            "restart until active agent turns finish.",
+                            boot_rev,
+                            disk_rev,
+                        )
+                    else:
+                        logger.warning(
+                            "Code skew detected (gateway booted at %s, checkout now "
+                            "at %s) — requesting a graceful restart to load new code.",
+                            boot_rev,
+                            disk_rev,
+                        )
+                        loop.call_soon_threadsafe(
+                            lambda: runner.request_restart(
+                                detached=False, via_service=True
+                            )
+                        )
+                        # Latch ONLY after the restart was successfully scheduled.
+                        # If call_soon_threadsafe raised (e.g. loop closing), the
+                        # except below catches it and the latch stays False, so the
+                        # next check retries instead of silently giving up.
+                        _skew_restart_requested = True
+            except Exception as e:
+                logger.debug("Code-skew restart check error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Gateway housekeeping stopped")
@@ -19498,7 +19566,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     housekeeping_thread = threading.Thread(
         target=_start_gateway_housekeeping,
         args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
+        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop(), "runner": runner},
         daemon=True,
         name="gateway-housekeeping",
     )

--- a/tests/gateway/test_housekeeping_code_skew_restart.py
+++ b/tests/gateway/test_housekeeping_code_skew_restart.py
@@ -1,0 +1,136 @@
+"""Deploy-gap self-heal: the gateway housekeeping loop detects a checkout that
+moved under the long-lived process (git pull / hermes update / evolution deploy)
+and, on a service-managed host, requests a graceful restart so the new code
+actually goes live instead of the process running stale ``sys.modules`` forever.
+
+See ``gateway.run._start_gateway_housekeeping`` and ``gateway.code_skew``.
+"""
+import threading
+from unittest.mock import MagicMock, patch
+
+import gateway.run as run
+
+
+def _make_runner(running_agents=None):
+    runner = MagicMock()
+    # Empty dict = no interactive turn in flight (the default happy path).
+    runner._running_agents = {} if running_agents is None else running_agents
+    return runner
+
+
+def _drive(runner, skew_seq, systemd_ok=True, call_soon=None):
+    """Run the housekeeping loop until it stops.
+
+    ``skew_seq`` is a list of values ``detect_code_skew`` returns on each call;
+    the loop is stopped once the list is exhausted (or a restart is scheduled).
+    ``call_soon`` overrides the fake loop's ``call_soon_threadsafe``.
+    """
+    stop = threading.Event()
+    seq = list(skew_seq)
+
+    def fake_skew():
+        if seq:
+            val = seq.pop(0)
+        else:
+            val = None
+        if not seq:
+            # Last scripted skew value — let the loop end after this tick.
+            stop.set()
+        return val
+
+    class FakeLoop:
+        def call_soon_threadsafe(self, fn, *args):
+            if call_soon is not None:
+                call_soon(fn, *args)
+            else:
+                fn(*args)
+            stop.set()
+
+    with patch("gateway.code_skew.detect_code_skew", side_effect=fake_skew), patch(
+        "hermes_cli.gateway.supports_systemd_services", return_value=systemd_ok
+    ):
+        run._start_gateway_housekeeping(
+            stop, adapters=None, loop=FakeLoop(), interval=0, runner=runner
+        )
+
+
+def test_code_skew_on_service_host_requests_graceful_restart():
+    runner = _make_runner()
+    _drive(runner, [("aaa1111111", "bbb2222222")], systemd_ok=True)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+def test_code_skew_without_systemd_does_not_restart():
+    """A non-service-managed host (e.g. a foreground dev run) must not
+    auto-restart — it only logs; the user restarts manually."""
+    runner = _make_runner()
+    _drive(runner, [("aaa1111111", "bbb2222222")], systemd_ok=False)
+    runner.request_restart.assert_not_called()
+
+
+def test_no_code_skew_does_not_restart():
+    runner = _make_runner()
+    _drive(runner, [None], systemd_ok=True)
+    runner.request_restart.assert_not_called()
+
+
+def test_restart_deferred_while_interactive_turn_in_flight():
+    """When an interactive agent turn is mid-flight, defer the restart (do not
+    race its drain) — request_restart is NOT called this tick."""
+    runner = _make_runner(running_agents={"session-1": object()})
+    _drive(runner, [("aaa1111111", "bbb2222222")], systemd_ok=True)
+    runner.request_restart.assert_not_called()
+
+
+def test_scheduling_failure_does_not_latch_and_retries():
+    """Regression (panel review): the latch must be set ONLY after the restart
+    is successfully scheduled. If call_soon_threadsafe raises on the first skew
+    check, the loop must retry on the next check and eventually restart —
+    a premature latch would silently give up forever."""
+    runner = _make_runner()
+    attempts = {"n": 0}
+
+    def flaky_call_soon(fn, *args):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("event loop is closing")
+        fn(*args)  # second attempt succeeds
+
+    # Two skew detections: first schedule raises, second succeeds.
+    _drive(
+        runner,
+        [("aaa1111111", "bbb2222222"), ("aaa1111111", "bbb2222222")],
+        systemd_ok=True,
+        call_soon=flaky_call_soon,
+    )
+    assert attempts["n"] == 2
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+def test_no_runner_is_a_noop():
+    """Back-compat: called without a runner, the skew check never fires — the
+    detector is not even reached (the guard short-circuits first)."""
+    stop = threading.Event()
+
+    class OneShotStop:
+        """Deterministic stop: reports set() after a couple of iterations so the
+        loop terminates without spinning or timers."""
+
+        def __init__(self):
+            self._n = 0
+
+        def is_set(self):
+            self._n += 1
+            return self._n > 3
+
+        def wait(self, timeout=None):
+            return self.is_set()
+
+        def set(self):
+            self._n = 999
+
+    with patch("gateway.code_skew.detect_code_skew") as det:
+        run._start_gateway_housekeeping(
+            OneShotStop(), adapters=None, loop=MagicMock(), interval=0, runner=None
+        )
+    det.assert_not_called()


### PR DESCRIPTION
## Problem

The gateway is a single long-lived process; its `sys.modules` is frozen at boot. After a `git pull` / `hermes update` / evolution-integration deploy updates the checkout underneath it, the process keeps running **stale in-memory code** until someone manually restarts it. This is the recurring "deploy gap" — it left the merged #720 fix un-deployed on the prod server (osoba) for 2 days, and previously caused nightly incidents failing on bugs already fixed in main.

`gateway/code_skew.py` already snapshots the checkout revision at boot and exposes `detect_code_skew()`, but nothing acted on it — only `/model` refused with a "restart" message.

## Fix

Wire the existing skew detector into the gateway housekeeping loop. Every ~5 minutes, if the checkout moved since boot **and** the host is service-managed, request a graceful restart via the existing `request_restart(via_service=True)` path — which drains active turns, then exits 75 so systemd (`Restart=always`, `RestartForceExitStatus=75`) respawns on the fresh checkout.

This is the **same restart path operators already invoke** via `/restart` or SIGUSR1 — it adds no new restart behaviour, only automates the trigger. It catches ALL update methods (plain `git pull`, `hermes update`, evolution-integration), not just one.

## Review hardening

Cross-provider panel review (agy/Gemini + hermes/Kimi) before commit surfaced and fixed:
- **Premature latch (both reviewers):** the `_skew_restart_requested` latch is now set ONLY after the restart is successfully scheduled. If `call_soon_threadsafe` raises (e.g. loop closing), the check retries instead of silently disabling the self-heal for the process lifetime.
- **Job interruption (both):** defer while an interactive agent turn is in flight; evolution cron jobs are resumable-by-design (the loop-guard/watchdog architecture assumes interruption), so we don't block on those.
- **Scope:** non-systemd hosts (foreground/dev) only log — no surprise auto-restart. Container auto-restart is intentionally out of scope (kept conservative to only act where `request_restart(via_service=True)` is known to work).
- Skew-check imports hoisted to function top.

## Tests

`tests/gateway/test_housekeeping_code_skew_restart.py`: service-host restart, non-systemd no-op, no-skew no-op, deferral while a turn runs, **retry-after-scheduling-failure** (premature-latch regression), and no-runner no-op. Existing `tests/test_code_skew.py` still green.