### PR TITLE
fix(mcp): pin brotli-free Accept-Encoding on HTTP/SSE transport (#724)

### DIFF
--- a/tests/tools/test_mcp_accept_encoding.py
+++ b/tests/tools/test_mcp_accept_encoding.py
@@ -1,0 +1,110 @@
+"""Regression tests for #724: the MCP HTTP/SSE transport must pin a brotli-free
+``Accept-Encoding`` so httpx never negotiates ``br``.
+
+With brotlicffi importable, httpx advertises ``Accept-Encoding: gzip, deflate, br``
+by default; some MCP servers' streamed JSON then trips a brotlicffi decoder bug
+that fails ``initialize()`` and drops the whole server's tools for the run (204
+brotli DecodingErrors + downstream lazyweb CancelledErrors in the prod logs).
+``_run_http`` now seeds ``accept-encoding: gzip, deflate`` on the transport
+headers (before all three transport branches), respecting an explicit override.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _build_sse_server():
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask("accept-encoding-test")
+    server._auth_type = ""
+    server._sampling = None
+    return server
+
+
+@pytest.fixture
+def patch_sse_client():
+    """Replace ``sse_client`` with a fake that records its kwargs (incl. headers)."""
+    captured: dict = {}
+
+    class _FakeStream:
+        async def __aenter__(self):
+            return (AsyncMock(), AsyncMock())
+
+        async def __aexit__(self, *a):
+            return False
+
+    def fake_sse_client(**kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        return _FakeStream()
+
+    class _FakeSession:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            s = MagicMock()
+            s.initialize = AsyncMock()
+            return s
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("tools.mcp_tool.sse_client", new=fake_sse_client), patch(
+        "tools.mcp_tool.ClientSession", new=_FakeSession
+    ):
+        yield captured
+
+
+def _drive_run_http(server, config):
+    from tools.mcp_tool import MCPServerTask
+
+    async def drive():
+        with patch.object(
+            MCPServerTask, "_wait_for_lifecycle_event",
+            new=AsyncMock(return_value="shutdown"),
+        ), patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+            try:
+                await asyncio.wait_for(server._run_http(config), timeout=2.0)
+            except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                pass
+
+    asyncio.run(drive())
+
+
+def _accept_encoding(headers):
+    if not headers:
+        return None
+    for k, v in headers.items():
+        if k.lower() == "accept-encoding":
+            return v
+    return None
+
+
+class TestAcceptEncodingPin:
+    def test_default_accept_encoding_excludes_brotli(self, patch_sse_client):
+        server = _build_sse_server()
+        _drive_run_http(
+            server,
+            {"url": "https://example.com/mcp/sse", "transport": "sse", "timeout": 60},
+        )
+        ae = _accept_encoding(patch_sse_client.get("headers"))
+        assert ae == "gzip, deflate", f"Accept-Encoding = {ae!r}"
+        assert "br" not in (ae or ""), "brotli must not be negotiated (#724)"
+
+    def test_explicit_accept_encoding_override_is_respected(self, patch_sse_client):
+        server = _build_sse_server()
+        _drive_run_http(
+            server,
+            {
+                "url": "https://example.com/mcp/sse",
+                "transport": "sse",
+                "timeout": 60,
+                "headers": {"Accept-Encoding": "identity"},
+            },
+        )
+        assert _accept_encoding(patch_sse_client.get("headers")) == "identity"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2109,6 +2109,16 @@ class MCPServerTask:
         # case-insensitive so conventional casing is preserved.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
+        # Pin a brotli-free Accept-Encoding (#724). httpx negotiates ``br``
+        # whenever brotlicffi is importable; some MCP servers' streamed JSON
+        # then trips a brotlicffi decoder bug ("decoder process called with
+        # data when 'can_accept_more_data()' is False") that fails
+        # initialize() and drops the whole server's tools for the run — the
+        # 204 brotli DecodingErrors plus the downstream lazyweb CancelledErrors
+        # in #724. gzip/deflate decode fine; we simply never negotiate br.
+        # Respect an explicit per-server override (case-insensitive).
+        if not any(key.lower() == "accept-encoding" for key in headers):
+            headers["accept-encoding"] = "gzip, deflate"
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)


### PR DESCRIPTION
## Problem (live in prod)

httpx advertises `Accept-Encoding: gzip, deflate, br` whenever `brotlicffi` is importable. Some MCP servers' streamed JSON then trips a brotlicffi decoder bug — `DecodingError: brotli: decoder process called with data when 'can_accept_more_data()' is False` — which fails `ClientSession.initialize()` and drops that server's **entire toolset** for the run.

Production gateway logs (server osoba) showed **204 brotli DecodingErrors + 102 lazyweb CancelledErrors** in the analysis window, recurring **hourly at cron startup** and degrading MCP tool availability for evolution-hydra and other jobs. lazyweb is the affected streamable-HTTP server, so its CancelledErrors are the downstream symptom of the same brotli failure.

## Fix

`_run_http` now seeds `accept-encoding: gzip, deflate` on the transport headers, upstream of all three transport branches (SSE, new & deprecated streamable HTTP), so httpx never negotiates `br`. gzip/deflate decode fine. An explicit per-server `Accept-Encoding` override is respected (case-insensitive), mirroring the existing `MCP-Protocol-Version` seeding right above it.

This should eliminate both the brotli DecodingErrors and the downstream lazyweb CancelledErrors (same root cause).

## Tests

`tests/tools/test_mcp_accept_encoding.py`: default excludes brotli (`gzip, deflate`, no `br`); explicit override respected. Existing MCP suite (272 tests across `test_mcp_tool.py`, `test_mcp_client_cert.py`, `test_mcp_config.py`, `test_mcp_sse_transport.py`) still green.

Closes #724