### PR TITLE
fix: realized-impact ledger initialization (Closes #746)

### DIFF
--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -29,6 +29,7 @@ Pure functions + explicit IO so it is import-safe and unit-testable.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -69,6 +70,60 @@ def load_ledger(ledger_file: Path) -> List[Dict[str, Any]]:
     return [folded[k] for k in order]
 
 
+def append_ledger_record(ledger_file: Path, record: Dict[str, Any]) -> None:
+    """Append a single JSON line to the ledger atomically.
+
+    Creates parent directories if missing. Malformed records are rejected with
+    ValueError so callers cannot silently write invalid ledger lines.
+    """
+    if not isinstance(record, dict) or "issue" not in record:
+        raise ValueError("ledger record must be a dict with an 'issue' key")
+    ledger_file.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True)
+    with open(ledger_file, "a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def record_merge(
+    ledger_file: Path,
+    issue: int,
+    merged_at: str,
+    predicted_impact: float,
+    target: str,
+) -> None:
+    """Record a merge event in the realized-impact ledger."""
+    append_ledger_record(
+        ledger_file,
+        {
+            "issue": issue,
+            "merged_at": merged_at,
+            "predicted_impact": predicted_impact,
+            "target": target,
+        },
+    )
+
+
+def record_verdict(
+    ledger_file: Path,
+    issue: int,
+    verdict: str,
+    verified_at: str,
+    note: str,
+) -> None:
+    """Record a post-merge verification verdict in the ledger."""
+    if verdict not in (VERDICTS_GOOD | VERDICTS_BAD):
+        raise ValueError(f"verdict must be one of {VERDICTS_GOOD | VERDICTS_BAD}")
+    append_ledger_record(
+        ledger_file,
+        {
+            "issue": issue,
+            "verdict": verdict,
+            "verified_at": verified_at,
+            "note": note,
+        },
+    )
+
+
 def _days_between(a: Optional[str], b: Optional[str]) -> Optional[int]:
     """Whole days from ISO date ``a`` to ISO date ``b`` (both YYYY-MM-DD)."""
     if not a or not b:
@@ -97,7 +152,9 @@ def compute_realized(
     """
     window = records[-last:] if last and last > 0 else list(records)
 
-    verdicted = [r for r in window if r.get("verdict") in (VERDICTS_GOOD | VERDICTS_BAD)]
+    verdicted = [
+        r for r in window if r.get("verdict") in (VERDICTS_GOOD | VERDICTS_BAD)
+    ]
     confirmed = [r for r in verdicted if r.get("verdict") in VERDICTS_GOOD]
 
     # Matured-but-unverified: merged long enough ago to have been exercised, yet
@@ -142,7 +199,9 @@ def compute_realized(
         "verified": len(verdicted),
         "confirmed": len(confirmed),
         "matured_unverified": len(matured_unverified),
-        "realized_impact_rate": round(realized_rate, 3) if realized_rate is not None else None,
+        "realized_impact_rate": round(realized_rate, 3)
+        if realized_rate is not None
+        else None,
         "miss_streak": streak,
         "flags": flags,
     }
@@ -162,16 +221,56 @@ def format_realized(h: Dict[str, Any]) -> str:
     )
 
 
-def main(argv: List[str]) -> int:
-    import os
-
-    evolution_dir = Path(
+def _evolution_dir() -> Path:
+    return Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
             str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
         )
     )
+
+
+def main(argv: List[str]) -> int:
+    evolution_dir = _evolution_dir()
+    ledger_file = evolution_dir / "realized" / "ledger.jsonl"
     args = argv[1:]
+
+    # Subcommand: record a merge line
+    if args and args[0] == "record-merge":
+        try:
+            issue = int(args[1])
+            merged_at = args[2]
+            predicted = float(args[3])
+            target = args[4]
+        except (IndexError, ValueError):
+            print(
+                "usage: evolution_realized_impact.py record-merge "
+                "<issue> <YYYY-MM-DD> <predicted_impact> <target>",
+                file=sys.stderr,
+            )
+            return 2
+        record_merge(ledger_file, issue, merged_at, predicted, target)
+        print(f"[realized-impact] recorded merge for issue #{issue}")
+        return 0
+
+    # Subcommand: record a verdict line
+    if args and args[0] == "record-verdict":
+        try:
+            issue = int(args[1])
+            verdict = args[2]
+            verified_at = args[3]
+            note = args[4]
+        except (IndexError, ValueError):
+            print(
+                "usage: evolution_realized_impact.py record-verdict "
+                "<issue> <confirmed|no-signal|regressed> <YYYY-MM-DD> <note>",
+                file=sys.stderr,
+            )
+            return 2
+        record_verdict(ledger_file, issue, verdict, verified_at, note)
+        print(f"[realized-impact] recorded verdict for issue #{issue}")
+        return 0
+
     last = 30
     if "--last" in args:
         i = args.index("--last")
@@ -191,7 +290,7 @@ def main(argv: List[str]) -> int:
 
         today = datetime.now(timezone.utc).date().isoformat()
 
-    records = load_ledger(evolution_dir / "realized" / "ledger.jsonl")
+    records = load_ledger(ledger_file)
     health = compute_realized(records, today=today, last=last)
     line = format_realized(health)
     print(line)

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -301,12 +301,13 @@ PROFILE_SKILLS="${HERMES_HOME:-$HOME/.hermes}/profiles/user1/skills/evolution"
    cycle and record it — a merged change broke the build and was rolled back.
 
 6. **Record the merge for the realized-impact loop** (so evolution is not blind —
-   we later verify whether this change actually helped). For EACH merged PR,
-   append one line to `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`:
+   we later verify whether this change actually helped). For EACH merged PR, run
+   the deterministic helper to append one line to
+   `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`:
 ```bash
-mkdir -p ~/.hermes/profiles/user1/evolution/realized
-echo '{"issue": <#>, "merged_at": "<YYYY-MM-DD>", "predicted_impact": <the issue'"'"'s analysis impact 0..1>, "target": "<one line: the concrete problem this was meant to fix>"}' \
-  >> ~/.hermes/profiles/user1/evolution/realized/ledger.jsonl
+python3 scripts/evolution_realized_impact.py record-merge \
+  <#> "<YYYY-MM-DD>" "<the issue's analysis impact 0..1>" \
+  "<one line: the concrete problem this was meant to fix>"
 ```
    `predicted_impact` is the impact the analysis stage assigned the issue; `target`
    is what "done" means for it. introspection later appends a `verdict` line for

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -106,8 +106,11 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    - For each, judge from the real sessions since its merge: did the `target`
      problem RECUR (the fix didn't hold)? is the merged capability actually used?
      did the friction it targeted disappear?
-   - Append ONE verdict line per such issue to the same ledger:
-     `{"issue": <#>, "verdict": "confirmed|no-signal|regressed", "verified_at": "<YYYY-MM-DD>", "note": "<one line of session evidence>"}`
+   - Record ONE verdict per such issue via the deterministic helper:
+     ```bash
+     python3 scripts/evolution_realized_impact.py record-verdict \
+       <#> "<confirmed|no-signal|regressed>" "<YYYY-MM-DD>" "<one line of session evidence>"
+     ```
      — `confirmed` = problem gone / change used; `no-signal` = no evidence it
      changed anything; `regressed` = problem recurred or got worse.
    - Be honest: a `no-signal`/`regressed` verdict on the agent's OWN past change is

--- a/tests/scripts/test_evolution_realized_impact.py
+++ b/tests/scripts/test_evolution_realized_impact.py
@@ -6,18 +6,31 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_realized_impact import (  # noqa: E402
+    append_ledger_record,
     compute_realized,
     format_realized,
     load_ledger,
+    record_merge,
+    record_verdict,
 )
 
 
 def _merge(issue, merged_at, predicted=0.8, target="fix X"):
-    return {"issue": issue, "merged_at": merged_at, "predicted_impact": predicted, "target": target}
+    return {
+        "issue": issue,
+        "merged_at": merged_at,
+        "predicted_impact": predicted,
+        "target": target,
+    }
 
 
 def _verdict(issue, verdict, verified_at="2026-06-20", note=""):
-    return {"issue": issue, "verdict": verdict, "verified_at": verified_at, "note": note}
+    return {
+        "issue": issue,
+        "verdict": verdict,
+        "verified_at": verified_at,
+        "note": note,
+    }
 
 
 class TestLoadLedger:
@@ -27,13 +40,11 @@ class TestLoadLedger:
     def test_folds_merge_and_verdict_lines_for_same_issue(self, tmp_path):
         f = tmp_path / "ledger.jsonl"
         f.write_text(
-            "\n".join(
-                [
-                    '{"issue": 1, "merged_at": "2026-06-01", "predicted_impact": 0.9, "target": "t1"}',
-                    '{"issue": 2, "merged_at": "2026-06-02", "predicted_impact": 0.5, "target": "t2"}',
-                    '{"issue": 1, "verdict": "confirmed", "verified_at": "2026-06-10"}',
-                ]
-            )
+            "\n".join([
+                '{"issue": 1, "merged_at": "2026-06-01", "predicted_impact": 0.9, "target": "t1"}',
+                '{"issue": 2, "merged_at": "2026-06-02", "predicted_impact": 0.5, "target": "t2"}',
+                '{"issue": 1, "verdict": "confirmed", "verified_at": "2026-06-10"}',
+            ])
             + "\n",
             encoding="utf-8",
         )
@@ -92,7 +103,9 @@ class TestComputeRealized:
         assert h["flags"] == []
 
     def test_healthy_when_mostly_confirmed(self):
-        recs = [_merge(i, "2026-06-0%d" % i) | _verdict(i, "confirmed") for i in range(1, 4)]
+        recs = [
+            _merge(i, "2026-06-0%d" % i) | _verdict(i, "confirmed") for i in range(1, 4)
+        ]
         h = compute_realized(recs, today="2026-06-30")
         assert h["realized_impact_rate"] == 1.0
         assert h["flags"] == []
@@ -105,3 +118,78 @@ class TestFormat:
         assert line.startswith("[evolution-realized-impact]")
         assert "realized_rate=" in line
         assert "healthy" in line
+
+
+class TestAppendLedgerRecord:
+    def test_appends_and_creates_parent_dir(self, tmp_path):
+        f = tmp_path / "deep" / "ledger.jsonl"
+        append_ledger_record(f, {"issue": 10, "merged_at": "2026-06-01"})
+        assert f.exists()
+        assert "issue" in f.read_text(encoding="utf-8")
+
+    def test_rejects_invalid_record(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        try:
+            append_ledger_record(f, {"no_issue": True})
+        except ValueError as exc:
+            assert "issue" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestRecordMerge:
+    def test_record_merge_appends_merge_shape(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_merge(
+            f,
+            issue=99,
+            merged_at="2026-07-07",
+            predicted_impact=0.9,
+            target="fix ledger init",
+        )
+        recs = load_ledger(f)
+        assert len(recs) == 1
+        assert recs[0]["issue"] == 99
+        assert recs[0]["merged_at"] == "2026-07-07"
+        assert recs[0]["predicted_impact"] == 0.9
+        assert recs[0]["target"] == "fix ledger init"
+
+
+class TestRecordVerdict:
+    def test_record_verdict_appends_verdict_shape(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_verdict(
+            f,
+            issue=99,
+            verdict="confirmed",
+            verified_at="2026-07-12",
+            note="sessions show use",
+        )
+        recs = load_ledger(f)
+        assert len(recs) == 1
+        assert recs[0]["issue"] == 99
+        assert recs[0]["verdict"] == "confirmed"
+        assert recs[0]["verified_at"] == "2026-07-12"
+
+    def test_invalid_verdict_rejected(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        try:
+            record_verdict(
+                f, issue=1, verdict="great", verified_at="2026-07-12", note="x"
+            )
+        except ValueError as exc:
+            assert "verdict" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestIntegration:
+    def test_merge_then_verdict_is_folDed_correctly(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_merge(f, 7, "2026-06-01", 0.8, "target")
+        record_verdict(f, 7, "confirmed", "2026-06-10", "note")
+        recs = load_ledger(f)
+        assert len(recs) == 1
+        assert recs[0]["verdict"] == "confirmed"
+        assert recs[0]["target"] == "target"
+        assert recs[0]["predicted_impact"] == 0.8


### PR DESCRIPTION
Fix the dead post-merge verification loop by adding deterministic ledger helpers.

Changes:
- `scripts/evolution_realized_impact.py` gains `record-merge` and `record-verdict` subcommands plus an `append_ledger_record()` helper with validation + auto-dir creation.
- Updated `evolution-integration` and `evolution-introspection` skills to invoke the helpers instead of shell `echo`.
- Added tests for the new helpers, validation, and merge+verdict folding.

Validation:
- `ruff check . && ruff format --check .` ✅
- `python -m pytest tests/scripts/test_evolution_realized_impact.py` ✅ (15 passed)
- `python scripts/evolution_pre_pr_test_runner.py --changed-files "scripts/evolution_realized_impact.py,tests/scripts/test_evolution_realized_impact.py"` ✅

Closes #746