### PR TITLE
fix(cron): only hard-stop a loop-guard spiral on genuine non-progress (#765)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -780,6 +780,13 @@ def _run_conversation_impl(
             ):
                 _lg_nudge = _loop_guard.maybe_nudge(messages)
                 if _lg_nudge:
+                    # Decide hard-stop eligibility on the trailing run BEFORE the
+                    # advisory nudge is appended (appending a user message would
+                    # truncate what the guard sees as the trailing single-tool
+                    # run and always read "not stuck").
+                    _lg_genuine_spiral = _loop_guard.run_warrants_cron_hard_stop(
+                        messages
+                    )
                     messages.append({"role": "user", "content": _lg_nudge})
                     _lg_warnings = getattr(agent, "_loop_guard_warning_count", 0) + 1
                     agent._loop_guard_warning_count = _lg_warnings
@@ -791,8 +798,11 @@ def _run_conversation_impl(
                             _lg_tool,
                             _lg_count,
                         )
-                    if _loop_guard.should_cron_hard_stop(
-                        getattr(agent, "platform", None), _lg_warnings
+                    if (
+                        _loop_guard.should_cron_hard_stop(
+                            getattr(agent, "platform", None), _lg_warnings
+                        )
+                        and _lg_genuine_spiral
                     ):
                         logger.warning(
                             "loop_guard: cron hard stop — `%s` stuck run nudged "

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -214,6 +214,17 @@ _IDEMPOTENT_FAIL_THRESHOLD = 4
 _MUTATING_ESCALATE_THRESHOLD = 8
 _IDEMPOTENT_ESCALATE_THRESHOLD = 15
 
+# Monitoring/polling tools whose whole PURPOSE is to be called repeatedly to
+# observe a long-running background job (CI runs, `hermes update`, a spawned
+# process). Re-checking the same handle and getting the same "still running"
+# answer is legitimate WAITING, not a spiral, so these are exempt from the cron
+# HARD STOP below (they still receive purely-advisory nudges, and a genuinely
+# FAILING poll is still caught by the failure branch). Without this, the
+# evolution-integration job — which polls a background process while it waits
+# for a PR's CI to settle — was hard-stopped and marked failed on essentially
+# every run (see run_warrants_cron_hard_stop).
+_POLLING_TOOLS = frozenset({"process"})
+
 # Unattended cron sessions get real enforcement, not just advisory text (#624):
 # advisory nudges are routinely ignored by the model with no human present to
 # course-correct (observed: 9 warnings ignored, 65 consecutive terminal calls).
@@ -582,3 +593,103 @@ def current_run_signature(messages: List[Dict[str, Any]]) -> Optional[Tuple[str,
     if not runs:
         return None
     return (runs[0][0], len(runs))
+
+
+def run_warrants_cron_hard_stop(messages: List[Dict[str, Any]]) -> bool:
+    """Second gate on the #624 cron hard stop: end the turn as a failure ONLY
+    when the trailing single-tool run is genuinely FLAILING (no progress), never
+    when it is doing legitimate mono-tool work that merely LOOKS repetitive.
+
+    The advisory-nudge counter alone over-triggers: the evolution
+    implementation and integration jobs were hard-stopped and marked failed on
+    essentially every run because their legitimate core workflow IS a burst of
+    consecutive same-tool calls —
+
+      * implementation: a run of DISTINCT, successful `terminal` calls to
+        finalize a change (lint -> format -> git add -> commit -> push ->
+        gh pr create). Distinct successful commands are real progress, not a
+        spiral.
+      * integration: repeated `process` polls while WAITING for a PR's CI to
+        settle. Re-checking a background job is that tool's purpose, not a loop.
+
+    So a hard stop is warranted only for genuine non-progress:
+
+      1. A deterministic non-retryable failure repeated (`_NON_RETRYABLE`).
+      2. The tool FAILING `fail_threshold`+ times in a row (the real #624 case:
+         terminal timeouts / denied paths retried unchanged).
+      3. A non-monitoring tool called `>= 2` times with the EXACT same arguments
+         and no failure — a degenerate identical-call loop (`echo hi` x N).
+         Deliberately strict (not a diversity ratio): cyclic INSPECTION with
+         varied args (git status/diff across files) is legitimate progress.
+
+    A trailing run of DISTINCT, successful calls (real progress) or any polling
+    of a `_POLLING_TOOLS` handle returns False here: keep nudging advisorily,
+    but do NOT kill the run. The iteration/budget guard remains the backstop
+    against a truly unbounded distinct-call loop.
+    """
+    runs = _recent_tool_runs(messages)
+    if not runs:
+        return False
+    tool = runs[0][0]
+    same = [r for r in runs if r[0] == tool]
+
+    # Trailing consecutive failures (most-recent-first), tracking a run of the
+    # SAME deterministic non-retryable class — mirrors maybe_nudge's counting.
+    consec_fail = 0
+    consec_nonretry = 0
+    nonretry_class: Optional[str] = None
+    counting_nonretry = True
+    for _t, failed, category, _arg_hash in same:
+        if failed:
+            consec_fail += 1
+        else:
+            break
+        if counting_nonretry and category in _NON_RETRYABLE:
+            if nonretry_class is None or category == nonretry_class:
+                nonretry_class = category
+                consec_nonretry += 1
+            else:
+                counting_nonretry = False
+        else:
+            counting_nonretry = False
+
+    cat = _tool_category(tool)
+    is_mutating_or_unknown = cat in ("mutating", "unknown")
+    fail_threshold = (
+        _MUTATING_FAIL_THRESHOLD
+        if is_mutating_or_unknown
+        else _IDEMPOTENT_FAIL_THRESHOLD
+    )
+
+    # (1) + (2): genuine failing spiral — applies to every tool, including
+    # polling tools (a `process` that keeps ERRORING is still a real problem).
+    if consec_nonretry >= _NONRETRY_THRESHOLD:
+        return True
+    if consec_fail >= fail_threshold:
+        return True
+
+    # Polling/monitoring tools: repeated SUCCESSFUL identical polls are
+    # legitimate waiting, not a loop. Only the failure branch above can stop
+    # them. (Observed in prod: the integration job uses 60s BLOCKING waits, so
+    # a tight budget-burn is not the real pattern; the iteration budget is the
+    # backstop for a pathological no-sleep poller.)
+    if tool in _POLLING_TOOLS:
+        return False
+
+    # (3): degenerate EXACT-identical repetition with no failure — the same call
+    # producing the same non-progressing result (the canonical #624 `echo hi`
+    # x N loop). Deliberately STRICT (all args identical), not a diversity
+    # ratio: a cross-provider review (Kimi) showed that any "unique <= calls/2"
+    # style ratio false-positives on legitimate cyclic INSPECTION — e.g. a merge
+    # resolution doing `git status` -> `git diff A` -> `git diff B` -> `git
+    # status` ... (3 unique over 6 calls) is real progress with intervening
+    # state changes, not a spiral. Since the whole point of this gate is to stop
+    # KILLING legitimate work, we err toward the conservative check: a genuine
+    # oscillation that this misses merely wastes one run's budget (the iteration
+    # budget backstops it), whereas a false positive re-creates the exact
+    # daily-failure pain we are fixing. Distinct commands == real progress.
+    arg_hashes = [r[3] for r in same if r[3] is not None]
+    if len(same) >= 2 and arg_hashes and len(set(arg_hashes)) == 1:
+        return True
+
+    return False

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -12,6 +12,7 @@ from agent.loop_guard import (
     CRON_LOOP_GUARD_HARD_STOP_THRESHOLD,
     current_run_signature,
     maybe_nudge,
+    run_warrants_cron_hard_stop,
     should_cron_hard_stop,
 )
 
@@ -481,3 +482,68 @@ class TestFailureClassAndDiversionHints:
         n = maybe_nudge(_run("read_file", 8))
         assert n is not None
         assert "repo_map" in n
+
+
+def _distinct_run(tool, n, *, result="ok"):
+    """n consecutive single-tool turns with DISTINCT arguments each (real
+    progress: a burst of different successful commands)."""
+    msgs = [{"role": "user", "content": "finalize the change"}]
+    for i in range(n):
+        cid = f"c{i}"
+        msgs.append(_asst(tool, args=json.dumps({"command": f"step-{i}"}), call_id=cid))
+        msgs.append(_result(result, call_id=cid))
+    return msgs
+
+
+class TestRunWarrantsCronHardStop:
+    """The second #624 gate: a cron hard stop is warranted ONLY for genuine
+    non-progress, never for legitimate mono-tool work that merely looks
+    repetitive (the evolution implementation/integration false positives)."""
+
+    def test_distinct_successful_terminal_burst_does_not_warrant(self):
+        # Implementation job: lint -> git add -> commit -> push -> gh pr create,
+        # 8 DISTINCT successful `terminal` calls. Real progress, not a spiral.
+        assert run_warrants_cron_hard_stop(_distinct_run("terminal", 8)) is False
+
+    def test_identical_successful_terminal_repeat_warrants(self):
+        # Canonical #624 degenerate loop: the SAME successful `echo hi` x N.
+        # Identical args + no progress -> hard stop stays warranted.
+        assert run_warrants_cron_hard_stop(_run("terminal", 6)) is True
+
+    def test_oscillating_successful_terminal_cycle_is_spared(self):
+        # Cyclic INSPECTION with varied args (git status -> git diff A ->
+        # git diff B -> ...) is legitimate progress with intervening state
+        # changes, NOT a spiral. A cross-provider review (Kimi) flagged that a
+        # diversity ratio would false-positive here and kill real merge-
+        # resolution work, so the gate deliberately spares varied-arg cycles
+        # (they are backstopped by the iteration budget, not hard-stopped).
+        msgs = [{"role": "user", "content": "figure out the state"}]
+        for i in range(6):
+            cid = f"c{i}"
+            cmd = "git status" if i % 2 == 0 else "git diff"
+            msgs.append(_asst("terminal", args=json.dumps({"command": cmd}), call_id=cid))
+            msgs.append(_result("ok", call_id=cid))
+        assert run_warrants_cron_hard_stop(msgs) is False
+
+    def test_process_polling_identical_success_does_not_warrant(self):
+        # Integration job: polling a background `process` handle while waiting
+        # for CI. Identical successful polls are legitimate waiting, not a loop.
+        assert run_warrants_cron_hard_stop(_run("process", 8)) is False
+
+    def test_process_repeated_failure_still_warrants(self):
+        # A polling tool that keeps ERRORING is a real problem — the failure
+        # branch applies even to exempt polling tools.
+        msgs = _run("process", 3, result="error: process crashed")
+        assert run_warrants_cron_hard_stop(msgs) is True
+
+    def test_failing_terminal_spiral_warrants(self):
+        # The real-world #624 case: terminal retried unchanged, failing.
+        msgs = _run("terminal", 3, result="error: build step blew up")
+        assert run_warrants_cron_hard_stop(msgs) is True
+
+    def test_no_tools_does_not_warrant(self):
+        assert run_warrants_cron_hard_stop([{"role": "user", "content": "hi"}]) is False
+
+    def test_distinct_process_calls_do_not_warrant(self):
+        # Even distinct successful process calls (varied handles) are fine.
+        assert run_warrants_cron_hard_stop(_distinct_run("process", 8)) is False

--- a/tests/agent/test_loop_guard_cron_enforcement.py
+++ b/tests/agent/test_loop_guard_cron_enforcement.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 
 from run_agent import AIAgent
 
+from agent.loop_guard import CRON_LOOP_GUARD_HARD_STOP_THRESHOLD
+
 
 def _make_tool_defs(*names: str) -> list[dict]:
     return [
@@ -200,6 +202,90 @@ def test_non_cron_platform_keeps_nudging_advisory_only():
         patch.object(agent, "_cleanup_task_resources"),
     ):
         result = agent.run_conversation("run the same command repeatedly")
+
+    assert result.get("failed") is not True
+    assert result["turn_exit_reason"] != "loop_guard_cron_hard_stop"
+
+
+def _distinct_terminal_run(n: int):
+    """n DISTINCT successful terminal calls, then a text-only "done" — models an
+    implementation job's real finalization burst (lint -> git add -> commit ->
+    push -> gh pr create): a run of different, succeeding commands, NOT a loop."""
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("terminal", json.dumps({"command": f"step-{i}"}), f"c{i}")
+            ],
+        )
+        for i in range(n)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    return responses
+
+
+def _process_polling_run(n: int):
+    """n identical successful `process` polls (waiting on a background CI job),
+    then a text-only "done" — models an integration job polling a background
+    process while a PR's checks settle. Legitimate waiting, not a spiral."""
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("process", json.dumps({"action": "status", "id": "p1"}), f"c{i}")
+            ],
+        )
+        for i in range(n)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    return responses
+
+
+def test_cron_does_not_hard_stop_distinct_successful_terminal_burst():
+    """Regression: the evolution-implementation job was hard-stopped and marked
+    failed on essentially every run because its PR-finalization burst of
+    DISTINCT successful `terminal` calls tripped the advisory-nudge counter.
+    The nudges still fire (proving the counter reached the hard-stop
+    threshold), but the second gate (run_warrants_cron_hard_stop) recognizes
+    real progress and refuses to kill the run."""
+    agent = _make_agent("terminal", max_iterations=25, platform="cron")
+    agent.client.chat.completions.create.side_effect = _distinct_terminal_run(18)
+
+    with (
+        patch("run_agent.handle_function_call", return_value="command completed"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("finalize and open the PR")
+
+    # The advisory counter DID reach the hard-stop threshold (>=2 nudges) ...
+    nudge_msgs = [
+        m for m in result["messages"]
+        if m.get("role") == "user" and "[loop-guard]" in str(m.get("content", ""))
+    ]
+    assert len(nudge_msgs) >= CRON_LOOP_GUARD_HARD_STOP_THRESHOLD
+    # ... but the run was NOT hard-stopped — distinct successful work is progress.
+    assert result.get("failed") is not True
+    assert result["turn_exit_reason"] != "loop_guard_cron_hard_stop"
+
+
+def test_cron_does_not_hard_stop_process_polling():
+    """Regression: the evolution-integration job was hard-stopped on every run
+    while legitimately polling a background `process` for CI completion.
+    Polling tools are exempt from the hard stop (only a FAILING poll stops)."""
+    agent = _make_agent("process", max_iterations=25, platform="cron")
+    agent.client.chat.completions.create.side_effect = _process_polling_run(18)
+
+    with (
+        patch("run_agent.handle_function_call", return_value="still running"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("merge the PR once CI is green")
 
     assert result.get("failed") is not True
     assert result["turn_exit_reason"] != "loop_guard_cron_hard_stop"


### PR DESCRIPTION
Fixes #765.

## Problem
`evolution-implementation` and `evolution-integration` were marked `error` on essentially **every run for days** (83 / 88 failure records). The #624 cron loop-guard HARD STOP fires after 2 advisory nudges, and the advisory counter over-triggers on legitimate consecutive same-tool work:
- impl: DISTINCT successful `terminal` calls finalizing a PR (lint→format→git add→commit→push→gh pr create) — killed mid-finalization at call 7.
- integration: repeated `process` polls (60s BLOCKING waits) while waiting for CI — killed as 'stuck'.

## Fix
New `loop_guard.run_warrants_cron_hard_stop(messages)` gates the hard stop on **genuine non-progress** only: repeated non-retryable failure, tool failing `fail_threshold`+ in a row, or EXACT-identical successful repetition. Distinct successful bursts and `process` polling are spared (iteration/token budget is the backstop). Evaluated before the nudge is appended so the trailing run is intact.

## Tests
- `tests/agent/test_loop_guard.py::TestRunWarrantsCronHardStop` — 8 pure-function cases (distinct burst spared, identical repeat warrants, cyclic inspection spared, process polling spared, process failure warrants, failing terminal warrants).
- `tests/agent/test_loop_guard_cron_enforcement.py` — end-to-end wiring: distinct terminal burst and process polling do NOT hard-stop; existing identical-echo-hi hard-stop preserved.

## Review
Cross-provider reviewed (Gemini + Kimi). A diversity-ratio variant was rejected: Kimi showed it false-positives on legitimate cyclic inspection (git status/diff across files). Chose the conservative strict-identical check.