### PR TITLE
fix(evolution): worktree-native git in skills + fit AGENTS.md in large context (B1/B3)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1420,7 +1420,14 @@ CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 # slice of the window on context files since they share the cached prefix with
 # the system prompt, tools, memory, and the whole conversation.
 _CONTEXT_FILE_CHARS_PER_TOKEN = 4
-_CONTEXT_FILE_WINDOW_FRACTION = 0.06
+# Bumped 0.06 -> 0.08 (#B3): at 0.06 a 256K-context model capped context files at
+# ~62.9K chars, which TRUNCATED the repo's 72K AGENTS.md — the evolution cron
+# agents silently lost its whole tail (## Known Pitfalls, incl. "squash merges
+# from stale branches silently revert fixes" — directly relevant to the merge
+# pipeline — and ## Testing standards). 0.08 fits AGENTS.md in full on a 256K
+# window. This only raises the cap for LARGE-context models; small-context models
+# stay pinned to the CONTEXT_FILE_MAX_CHARS (20K) floor, so nothing regresses.
+_CONTEXT_FILE_WINDOW_FRACTION = 0.08
 _CONTEXT_FILE_DYNAMIC_CEILING = 500_000
 
 

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -134,9 +134,15 @@ Implement selected issues, create versions, and self-update.
 
 ### Create a branch
 ```bash
-git checkout main
-git pull origin main
-git checkout -b evolution/issue-123-feature-name
+# This job runs INSIDE a dedicated git worktree (its workdir is a separate
+# checkout, e.g. /root/hermes-evolution-work). `git checkout main` FAILS there
+# with "fatal: 'main' is already used by worktree at ..." because main is
+# checked out in the primary repo. Create the issue branch DIRECTLY from a
+# freshly-fetched origin/main with `-B` — this both starts from clean latest
+# main AND resets the shared worktree, discarding any leftover branch/state from
+# a previous run. Do NOT `git checkout main` here.
+git fetch origin main
+git checkout -B evolution/issue-123-feature-name origin/main
 ```
 
 ### Implement the changes

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -276,7 +276,10 @@ hermes update --yes
 # PRE-merge scripts, and the no_agent fix (funnel/watchdog/etc.) silently never
 # deploys. The tree is clean at this step (we only ran gh, no edits), so a
 # fast-forward to origin/main is safe and deterministic:
-git fetch origin --quiet && git checkout main 2>/dev/null && git reset --hard origin/main
+# worktree-safe: this job runs inside a shared worktree where `git checkout main`
+# fails ("main is already used by worktree"). Fetch + hard-reset the current
+# worktree branch to origin/main reaches the same clean, up-to-date main state.
+git fetch origin --quiet && git reset --hard origin/main
 # Re-deploy evolution scripts + cron. The scheduler runs scripts from
 # HERMES_HOME/scripts and cron jobs from ~/.hermes/cron/jobs.json — NOT from the
 # repo checkout. register_evolution_cron copies the whole evolution_* script

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -238,10 +238,10 @@ class TestDynamicContextFileCap:
         assert _dynamic_context_file_max_chars(8_000) == CONTEXT_FILE_MAX_CHARS
 
     def test_dynamic_scales_above_floor_for_large_window(self):
-        # 200K-token window → ~48K (200000 * 4 * 0.06), well above the floor
+        # 200K-token window → 64K (200000 * 4 * 0.08), well above the floor
         # and above Codex's 32 KiB project_doc default.
         cap = _dynamic_context_file_max_chars(200_000)
-        assert cap == 48_000
+        assert cap == 64_000
         assert cap > CONTEXT_FILE_MAX_CHARS
 
     def test_dynamic_respects_ceiling(self):
@@ -254,7 +254,7 @@ class TestDynamicContextFileCap:
 
     def test_get_context_file_max_chars_uses_context_length(self):
         # With no explicit config, the resolver derives the cap from context.
-        assert _get_context_file_max_chars(200_000) == 48_000
+        assert _get_context_file_max_chars(200_000) == 64_000
         assert _get_context_file_max_chars(None) == CONTEXT_FILE_MAX_CHARS
 
     def test_explicit_config_beats_dynamic(self, monkeypatch):
@@ -267,7 +267,7 @@ class TestDynamicContextFileCap:
 
     def test_large_window_avoids_truncation_of_midsize_doc(self):
         # A 30K-char AGENTS.md is truncated at the flat default but survives
-        # whole on a large-context model (dynamic cap ~48K).
+        # whole on a large-context model (dynamic cap ~64K).
         content = "z" * 30_000
         small = _truncate_content(content, "AGENTS.md", context_length=8_000)
         big = _truncate_content(content, "AGENTS.md", context_length=200_000)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1801,3 +1801,27 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+class TestDynamicContextFileCapFitsAgentsMd:
+    """#B3: at the old 0.06 window fraction, a 256K-context model capped context
+    files at ~62.9K chars and TRUNCATED the repo's ~72K AGENTS.md, so the
+    evolution cron agents silently lost its tail (## Known Pitfalls, ## Testing).
+    The cap for a large-context model must comfortably fit AGENTS.md, while
+    small-context models must stay pinned to the 20K floor."""
+
+    def test_large_context_model_fits_a_72k_agents_md(self):
+        # kimi-k2.7 and peers report a 256K token window.
+        cap = _dynamic_context_file_max_chars(262_144)
+        assert cap >= 72_500, f"cap {cap} would truncate a ~72K AGENTS.md"
+        assert cap <= _CONTEXT_FILE_DYNAMIC_CEILING
+
+    def test_small_context_model_stays_at_floor(self):
+        # A 32K-window model must not be pushed above the historical 20K floor by
+        # the fraction bump — the cap scales with the window but never drops the
+        # floor, and a small window's budget stays below it.
+        assert _dynamic_context_file_max_chars(32_000) == CONTEXT_FILE_MAX_CHARS
+
+    def test_unknown_context_length_uses_flat_default(self):
+        assert _dynamic_context_file_max_chars(None) == CONTEXT_FILE_MAX_CHARS
+        assert _dynamic_context_file_max_chars(0) == CONTEXT_FILE_MAX_CHARS
+
+


### PR DESCRIPTION
Follow-up to #766. Two root causes behind evolution runs doing real work but shipping nothing.

## B1 — `git checkout main` fails inside the shared worktree
implementation/integration/upstream-sync run in a shared git worktree (workdir=/root/hermes-evolution-work). `git checkout main` FAILS there ("'main' is already used by worktree"). The implementation skill's checkout was unswallowed → the agent saw the error, thrashed on terminal (feeding the #765 loop-guard hard-stop), and branched off stale worktree state.
- **implementation**: `git checkout main; git pull; git checkout -b <b>` → `git fetch origin main; git checkout -B <b> origin/main` (worktree-safe, clean latest main, resets the shared worktree in one step).
- **integration**: drop the failing `git checkout main 2>/dev/null`; `git fetch origin --quiet && git reset --hard origin/main` reaches the same clean-main state.
- upstream-sync also uses `git checkout main` but currently no-ops safely; its merge/push flow needs main-checkout access — left for separate review.

**Empirically validated**: ran the exact new command in the live worktree (was on stale evolution/issue-746) → `git checkout -B … origin/main` succeeded, HEAD == origin/main, no error.

## B3 — AGENTS.md truncated on a 256K-context model
Window fraction 0.06 capped context files at ~62.9K chars, truncating the repo's ~72K AGENTS.md. The cron agents silently lost its tail: **## Known Pitfalls** (incl. 'squash merges from stale branches silently revert fixes' — directly relevant to the merge pipeline) and **## Testing**. Bump 0.06 → 0.08 so AGENTS.md fits on a 256K window. Only raises the cap for large-context models; small-context models stay pinned to the 20K floor.

## Tests
`TestDynamicContextFileCapFitsAgentsMd` (large fits / small floored / unknown default). Skill changes are markdown.

## Deploy note
Profile skills (profiles/user1/skills/) are COPIES that `hermes update` won't refresh; deploy force-syncs `cp -rf skills/evolution/. profiles/user1/skills/evolution/`. prompt_builder change needs a gateway restart.