### PR TITLE
fix(evolution): stop the implementer fabricating environment/loop-guard blockers (C)

### DIFF
--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -124,6 +124,29 @@ Implement selected issues, create versions, and self-update.
      gh issue comment <N> --repo Lexus2016/hermes-agent-evolution \
        --body "Blocked: <exact missing prerequisite, e.g. token lacks workflow scope>. A human must <action>."
      ```
+   - **Evidence rule for `blocked` — do NOT fabricate a blocker.** The `blocked`
+     label asserts a human/infrastructure action is required. It is NOT an
+     escape hatch for transient friction, and a fabricated block wastes a whole
+     cycle. Hard rules:
+     - A SINGLE failed `read_file` / `search_files` / `terminal` call (an empty
+       read, a one-off timeout) is NORMAL. Retry it ONCE or route around it (a
+       different path, `terminal cat <file>`, a broader search). One error — or
+       even a few scattered across dozens of successful calls — is NEVER grounds
+       to block.
+     - Block ONLY when a SPECIFIC operation failed **3+ times in a row with the
+       SAME deterministic error** (e.g. `permission denied` on a real path, a
+       missing binary), and the comment MUST quote the exact command + the exact
+       error output you saw THIS session.
+     - NEVER cite "loop-guard", "anti-retry rules", "tool-read timeouts", or an
+       "environment regression / #647" as a blocker UNLESS you literally
+       received a `[loop-guard]` message in THIS session. If you did not see that
+       exact `[loop-guard]` text, the guard did not fire — claiming it did is a
+       fabricated blocker.
+     - Blocking MULTIPLE issues in one run with the same vague "environment
+       limitation" reason is a RED FLAG that you gave up, not that the work was
+       impossible. If `read_file` / `terminal` returned content on other calls
+       this session, the tools ARE working. Implement at least one issue
+       end-to-end before ever concluding the environment is unusable.
    - **Evidence rule for `already-exists`** (same as evolution-analysis): the
      closing comment MUST contain the exact file path / code location you
      verified in THIS session with a real `ls`/`grep` whose output you saw.


### PR DESCRIPTION
Follow-up to #766 (loop-guard) and #771 (worktree/AGENTS.md). Those fixed the infrastructure — all 13 evolution jobs are now `ok`, tool calls succeed ~98.5%, no worktree errors, no truncation, no hard-stops. But a validation run STILL shipped nothing:

> Selected: 4 · Implemented: 0 · **Blocked: 4** — 'repeated tool-read failures (runtime_error, permission, timeout) across read_file/search_files/terminal … following loop-guard anti-retry rules, work was halted.'

**The logs contradict both claims**: 65 successful tool calls vs **1** transient empty read, and **0** `[loop-guard]` messages that run. The kimi-k2.7 implementer catastrophized one hiccup into 'environment is broken' and **invented** a loop-guard citation to justify giving up.

## Fix (skill-only)
The 'Blocked by infrastructure … environment limits' bullet was the escape hatch. Add a hard **'Evidence rule for `blocked` — do NOT fabricate a blocker'**:
- one/a-few scattered tool errors are NORMAL → retry once / route around, never block;
- block ONLY on a specific op failing **3+ times in a row with the SAME deterministic error**, quoting the exact command + output seen this session;
- NEVER cite loop-guard / anti-retry / 'environment regression #647' unless a literal `[loop-guard]` message was actually received this session;
- blocking MULTIPLE issues with the same vague 'environment limitation' is a red flag of giving up — implement at least one issue end-to-end first.

Deployed by force-syncing skills/evolution/. into profiles/<profile>/skills/evolution/ (the copy the agent reads).