### PR TITLE
feat: dynamic backlog cap (Closes #769)

### DIFF
--- a/scripts/evolution_backlog_gate.py
+++ b/scripts/evolution_backlog_gate.py
@@ -23,7 +23,9 @@ CLI (so a skill can call it from the terminal tool):
 Prints a one-line JSON summary on stdout either way:
     {"open_features": 42, "cap": 25, "throttle": true}
 
-Cap resolution: --cap arg > env EVOLUTION_FEATURE_BACKLOG_CAP > DEFAULT_CAP.
+Cap resolution: --cap arg > env EVOLUTION_FEATURE_BACKLOG_CAP > dynamic cap
+from metrics.jsonl > DEFAULT_CAP.  The dynamic cap shrinks when integration is
+stuck so the backlog does not keep growing while the pipeline cannot land work.
 Pure functions are import-safe for unit tests (the gh call is injected).
 """
 
@@ -34,6 +36,7 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
 
 DEFAULT_CAP = 25
@@ -42,7 +45,95 @@ DEFAULT_CAP = 25
 _REPO = "Lexus2016/hermes-agent-evolution"
 
 
-def resolve_cap(arg_cap: int | None = None) -> int:
+def _default_evolution_dir() -> Path:
+    return Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+        )
+    )
+
+
+def _load_records(metrics_file: Path) -> list[Dict[str, Any]]:
+    """Read metrics.jsonl-style records (one JSON object per line), skipping
+    blank/malformed lines. Kept local so the gate has no import dependency on
+    evolution_funnel at runtime."""
+    out: list[Dict[str, Any]] = []
+    if not metrics_file.exists():
+        return out
+    for ln in metrics_file.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _merged_zero_streak(records: list[Dict[str, Any]]) -> int:
+    """Trailing run of cycles with merged == 0."""
+    streak = 0
+    for r in reversed(records):
+        if int(r.get("merged", 0) or 0) == 0:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def _cycle_success_rate(records: list[Dict[str, Any]]) -> float:
+    """Fraction of active cycles (selected > 0 or issues_created > 0) that landed
+    >=1 merge over the trailing window."""
+    active = [
+        r
+        for r in records
+        if int(r.get("selected", 0) or 0) > 0
+        or int(r.get("issues_created", 0) or 0) > 0
+    ]
+    if not active:
+        return 1.0
+    succeeded = sum(1 for r in active if int(r.get("merged", 0) or 0) > 0)
+    return succeeded / len(active)
+
+
+def resolve_dynamic_cap(
+    records: list[Dict[str, Any]],
+    base_cap: int = DEFAULT_CAP,
+) -> int:
+    """Shrink the feature-backlog cap when integration is stuck.
+
+    Logic mirrors the health sidecar's consolidation signal:
+      - merged-zero streak >= 5                -> cap 5  (deep freeze)
+      - merged-zero streak >= 3 or success rate < 1/3 -> cap 8 (consolidation)
+      - otherwise                              -> base_cap
+    Bugs are NEVER throttled by this adjustment.
+    """
+    streak = _merged_zero_streak(records)
+    window = records[-14:] if len(records) >= 7 else records
+    success_rate = _cycle_success_rate(window)
+
+    if streak >= 5:
+        return 5
+    if streak >= 3 or success_rate < 1 / 3:
+        return 8
+    return base_cap
+
+
+def resolve_cap(
+    arg_cap: int | None = None,
+    records: list[Dict[str, Any]] | None = None,
+    evolution_dir: Path | None = None,
+) -> int:
+    """Cap resolution: --cap arg > env EVOLUTION_FEATURE_BACKLOG_CAP > dynamic
+    cap from metrics.jsonl > DEFAULT_CAP.
+
+    The dynamic path only fires when neither an explicit --cap nor the env
+    override is set, keeping existing overrides intact.
+    """
     if arg_cap is not None:
         return arg_cap
     env = os.environ.get("EVOLUTION_FEATURE_BACKLOG_CAP", "").strip()
@@ -51,7 +142,12 @@ def resolve_cap(arg_cap: int | None = None) -> int:
             return int(env)
         except ValueError:
             pass
-    return DEFAULT_CAP
+    if records is not None:
+        return resolve_dynamic_cap(records, DEFAULT_CAP)
+    if evolution_dir is None:
+        evolution_dir = _default_evolution_dir()
+    records = _load_records(evolution_dir / "metrics.jsonl")
+    return resolve_dynamic_cap(records, DEFAULT_CAP)
 
 
 def is_bug(issue: Dict[str, Any]) -> bool:
@@ -88,9 +184,17 @@ def fetch_open_issues(
     """Return the list of open issues, or None if gh failed (fail-open)."""
     runner = runner or _default_runner
     rc, out = runner([
-        "gh", "issue", "list", "--repo", _REPO,
-        "--state", "open", "--limit", "300",
-        "--json", "number,title,labels",
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        _REPO,
+        "--state",
+        "open",
+        "--limit",
+        "300",
+        "--json",
+        "number,title,labels",
     ])
     if rc != 0:
         return None
@@ -109,8 +213,12 @@ def evaluate(
     — never block bug/feature generation just because the count couldn't be read."""
     issues = fetch_open_issues(runner)
     if issues is None:
-        return {"open_features": None, "cap": cap, "throttle": False,
-                "note": "gh unavailable; defaulting to no throttle"}
+        return {
+            "open_features": None,
+            "cap": cap,
+            "throttle": False,
+            "note": "gh unavailable; defaulting to no throttle",
+        }
     n = count_open_features(issues)
     return {"open_features": n, "cap": cap, "throttle": should_throttle(n, cap)}
 
@@ -118,15 +226,26 @@ def evaluate(
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Throttle FEATURE proposals when the open backlog is full "
-                    "(bugs are never throttled)."
+        "(bugs are never throttled)."
     )
     parser.add_argument("action", choices=["check"], help="check the gate")
-    parser.add_argument("--cap", type=int, default=None,
-                        help=f"feature-backlog cap (default {DEFAULT_CAP} / "
-                             f"env EVOLUTION_FEATURE_BACKLOG_CAP)")
+    parser.add_argument(
+        "--cap",
+        type=int,
+        default=None,
+        help=f"feature-backlog cap (default {DEFAULT_CAP} / "
+        f"env EVOLUTION_FEATURE_BACKLOG_CAP)",
+    )
+    parser.add_argument(
+        "--evolution-dir",
+        type=Path,
+        default=None,
+        help="directory holding metrics.jsonl for dynamic cap",
+    )
     args = parser.parse_args(argv)
 
-    result = evaluate(resolve_cap(args.cap))
+    evolution_dir = args.evolution_dir or _default_evolution_dir()
+    result = evaluate(resolve_cap(args.cap, evolution_dir=evolution_dir))
     print(json.dumps(result))
     # exit 1 = THROTTLE (skip features), 0 = OK to create features.
     return 1 if result["throttle"] else 0

--- a/tests/scripts/test_evolution_backlog_gate.py
+++ b/tests/scripts/test_evolution_backlog_gate.py
@@ -24,7 +24,9 @@ class TestIsBug:
         assert gate.is_bug(_issue("something broken", labels=["bug"])) is True
 
     def test_feature_is_not_bug(self):
-        assert gate.is_bug(_issue("[FEATURE] new thing", labels=["enhancement"])) is False
+        assert (
+            gate.is_bug(_issue("[FEATURE] new thing", labels=["enhancement"])) is False
+        )
 
     def test_improvement_is_not_bug(self):
         assert gate.is_bug(_issue("[IMPROVEMENT] x", labels=["proposal"])) is False
@@ -35,8 +37,8 @@ class TestCounting:
         issues = [
             _issue("[FEATURE] a", ["proposal"]),
             _issue("[IMPROVEMENT] b", ["enhancement"]),
-            _issue("[FIX] c"),                       # bug — excluded
-            _issue("broken", ["bug"]),               # bug — excluded
+            _issue("[FIX] c"),  # bug — excluded
+            _issue("broken", ["bug"]),  # bug — excluded
             _issue("[REPLACEMENT] d", ["proposal"]),
         ]
         assert gate.count_open_features(issues) == 3
@@ -48,27 +50,114 @@ class TestCounting:
 
 
 class TestCapResolution:
-    def test_arg_wins(self, monkeypatch):
+    def test_arg_wins(self, monkeypatch, tmp_path):
         monkeypatch.setenv("EVOLUTION_FEATURE_BACKLOG_CAP", "10")
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
         assert gate.resolve_cap(30) == 30
 
-    def test_env_used_when_no_arg(self, monkeypatch):
+    def test_env_used_when_no_arg(self, monkeypatch, tmp_path):
         monkeypatch.setenv("EVOLUTION_FEATURE_BACKLOG_CAP", "10")
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
         assert gate.resolve_cap(None) == 10
 
-    def test_default_when_nothing(self, monkeypatch):
+    def test_default_when_nothing(self, monkeypatch, tmp_path):
         monkeypatch.delenv("EVOLUTION_FEATURE_BACKLOG_CAP", raising=False)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
         assert gate.resolve_cap(None) == gate.DEFAULT_CAP
 
-    def test_bad_env_falls_back(self, monkeypatch):
+    def test_bad_env_falls_back(self, monkeypatch, tmp_path):
         monkeypatch.setenv("EVOLUTION_FEATURE_BACKLOG_CAP", "notanint")
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
         assert gate.resolve_cap(None) == gate.DEFAULT_CAP
+
+
+class TestDynamicCap:
+    """Dynamic cap shrinks when integration is stuck (MERGED_ZERO xN) and never
+    overrides explicit --cap or env EVOLUTION_FEATURE_BACKLOG_CAP."""
+
+    def _record(self, merged, selected=1, created=0):
+        return {"merged": merged, "selected": selected, "issues_created": created}
+
+    def test_streak_zero_returns_base_cap(self):
+        records = [self._record(1), self._record(1), self._record(1)]
+        assert gate.resolve_dynamic_cap(records) == gate.DEFAULT_CAP
+
+    def test_streak_three_shrinks_to_eight(self):
+        records = [self._record(1), self._record(0), self._record(0), self._record(0)]
+        assert gate.resolve_dynamic_cap(records) == 8
+
+    def test_streak_five_shrinks_to_five(self):
+        records = [self._record(0)] * 5
+        assert gate.resolve_dynamic_cap(records) == 5
+
+    def test_low_success_rate_shrinks_to_eight(self):
+        # 7 active cycles, only 1 merge -> success rate 1/7 < 1/3
+        records = [self._record(0)] * 6 + [self._record(1)]
+        assert gate.resolve_dynamic_cap(records) == 8
+
+    def test_resolve_cap_prefers_arg_over_dynamic(self, tmp_path):
+        metrics = tmp_path / "metrics.jsonl"
+        metrics.write_text(
+            "\n".join(json.dumps(self._record(0)) for _ in range(5)) + "\n"
+        )
+        assert gate.resolve_cap(100, evolution_dir=tmp_path) == 100
+
+    def test_resolve_cap_prefers_env_over_dynamic(self, monkeypatch, tmp_path):
+        metrics = tmp_path / "metrics.jsonl"
+        metrics.write_text(
+            "\n".join(json.dumps(self._record(0)) for _ in range(5)) + "\n"
+        )
+        monkeypatch.setenv("EVOLUTION_FEATURE_BACKLOG_CAP", "12")
+        assert gate.resolve_cap(None, evolution_dir=tmp_path) == 12
+
+    def test_resolve_cap_uses_dynamic_when_no_override(self, tmp_path):
+        metrics = tmp_path / "metrics.jsonl"
+        metrics.write_text(
+            "\n".join(json.dumps(self._record(0)) for _ in range(5)) + "\n"
+        )
+        assert gate.resolve_cap(None, evolution_dir=tmp_path) == 5
+
+    def test_dynamic_cap_ignores_idle_cycles_for_success_rate(self):
+        # Idle cycles (selected=0, created=0) must not dilute the success rate.
+        records = [self._record(0, selected=0, created=0)] * 5 + [self._record(1)]
+        assert gate.resolve_dynamic_cap(records) == gate.DEFAULT_CAP
+
+    def test_dynamic_cap_never_throttles_bugs(self):
+        # Cap value itself is computed without issue type; throttling decision is
+        # made later by count_open_features. A tiny cap with only bugs still ok.
+        records = [self._record(0)] * 5
+        issues = [
+            _issue("[FIX] a"),
+            _issue("[FIX] b"),
+            _issue("broken", labels=["bug"]),
+        ]
+
+        def runner(cmd):
+            return 0, json.dumps(issues)
+
+        r = gate.evaluate(gate.resolve_dynamic_cap(records), runner=runner)
+        assert r["throttle"] is False and r["open_features"] == 0
+
+    def test_empty_metrics_falls_back_to_base_cap(self):
+        assert gate.resolve_dynamic_cap([]) == gate.DEFAULT_CAP
+
+    def test_arg_cap_disables_dynamic_in_cli(self, capsys, monkeypatch, tmp_path):
+        metrics = tmp_path / "metrics.jsonl"
+        metrics.write_text(
+            "\n".join(json.dumps(self._record(0)) for _ in range(5)) + "\n"
+        )
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        monkeypatch.setattr(gate, "_default_runner", lambda cmd: (0, json.dumps([])))
+        rc = gate.main(["check", "--cap", "25"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0 and out["cap"] == 25
 
 
 class TestEvaluate:
     def _runner(self, issues, rc=0):
         def run(cmd):
             return rc, json.dumps(issues)
+
         return run
 
     def test_throttles_when_over_cap(self):
@@ -92,12 +181,14 @@ class TestEvaluate:
     def test_fails_open_when_gh_errors(self):
         def run(cmd):
             return 1, "error: not authenticated"
+
         r = gate.evaluate(25, runner=run)
         assert r["throttle"] is False  # never block on a failed count
 
     def test_fails_open_on_garbage(self):
         def run(cmd):
             return 0, "not json"
+
         r = gate.evaluate(25, runner=run)
         assert r["throttle"] is False
 
@@ -105,14 +196,18 @@ class TestEvaluate:
 class TestCLI:
     def test_exit_1_when_throttled(self, capsys, monkeypatch):
         issues = [_issue(f"[FEATURE] {i}", ["proposal"]) for i in range(30)]
-        monkeypatch.setattr(gate, "_default_runner", lambda cmd: (0, json.dumps(issues)))
+        monkeypatch.setattr(
+            gate, "_default_runner", lambda cmd: (0, json.dumps(issues))
+        )
         rc = gate.main(["check", "--cap", "25"])
         out = json.loads(capsys.readouterr().out)
         assert rc == 1 and out["throttle"] is True
 
     def test_exit_0_when_ok(self, capsys, monkeypatch):
         issues = [_issue("[FEATURE] one", ["proposal"])]
-        monkeypatch.setattr(gate, "_default_runner", lambda cmd: (0, json.dumps(issues)))
+        monkeypatch.setattr(
+            gate, "_default_runner", lambda cmd: (0, json.dumps(issues))
+        )
         rc = gate.main(["check", "--cap", "25"])
         out = json.loads(capsys.readouterr().out)
         assert rc == 0 and out["throttle"] is False


### PR DESCRIPTION
Automated evolution PR for issue #769.

Changes:
-  now reads  from the evolution profile directory and lowers the feature-backlog cap when integration is stuck.
- merged-zero streak >= 5 → cap 5; streak >= 3 or trailing success rate < 1/3 → cap 8.
- Explicit  and  still override.
- Bugs remain unthrottled.
- Added unit tests for dynamic cap logic, override precedence, and CLI behavior.

Closes #769.