### PR TITLE
fix(cron): re-assert workdir TERMINAL_CWD inside the worker thread (D)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3612,8 +3612,26 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
+
+        def _cron_run_reassert_workdir():
+            # run_conversation runs in this worker thread under the copied
+            # context above. That context restore (plus the agent's own init)
+            # can re-apply a TERMINAL_CWD captured BEFORE this job set its
+            # workdir — so the agent's lazily-created terminal/file env was built
+            # in the gateway's primary DEPLOY checkout instead of the job's
+            # workdir. For a git-worktree workdir that meant reading wrong paths
+            # (files "missing") and running `git checkout -B`/edits against the
+            # LIVE checkout, corrupting the running deployment. Re-assert the
+            # workdir override here — inside the worker context, immediately
+            # before the agent runs — so it wins over any stale value. Serialized
+            # by the workdir write-lock held for this whole run, so it can't leak
+            # into a concurrent workdir-less job.
+            if _job_workdir:
+                os.environ["TERMINAL_CWD"] = _job_workdir
+            return agent.run_conversation(prompt)
+
         _cron_future = _cron_pool.submit(
-            _cron_context.run, agent.run_conversation, prompt
+            _cron_context.run, _cron_run_reassert_workdir
         )
         _inactivity_timeout = False
         try:

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -265,8 +265,15 @@ class TestRunJobTerminalCwd:
     """
 
     @staticmethod
-    def _install_stubs(monkeypatch, observed: dict):
-        """Patch enough of run_job's deps that it executes without real creds."""
+    def _install_stubs(monkeypatch, observed: dict, clobber_cwd: str | None = None):
+        """Patch enough of run_job's deps that it executes without real creds.
+
+        ``clobber_cwd``: if set, ``FakeAgent.__init__`` overwrites
+        ``TERMINAL_CWD`` with it AFTER recording the value it saw — simulating
+        the real regression where the agent's construction (worker-thread
+        context restore + init) re-applied a stale TERMINAL_CWD, so the env was
+        built in the primary deploy checkout instead of the job workdir.
+        """
         import os
         import sys
         import cron.scheduler as sched
@@ -278,6 +285,8 @@ class TestRunJobTerminalCwd:
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
+                if clobber_cwd is not None:
+                    os.environ["TERMINAL_CWD"] = clobber_cwd
 
             def run_conversation(self, *_a, **_kw):
                 observed["terminal_cwd_during_run"] = os.environ.get(
@@ -351,6 +360,44 @@ class TestRunJobTerminalCwd:
         assert observed["terminal_cwd_during_run"] == str(tmp_path.resolve())
 
         # And it was restored to the original value in finally.
+        assert os.environ["TERMINAL_CWD"] == "/original/cwd"
+
+    def test_workdir_survives_agent_init_clobber(self, tmp_path, monkeypatch):
+        """Regression: the agent runs in a worker thread under a copied context;
+        that context restore + the agent's own construction could re-apply a
+        stale TERMINAL_CWD AFTER run_job set the job workdir, so the agent's
+        terminal/file env was built in the gateway's primary DEPLOY checkout
+        instead of the workdir — reading wrong paths (files "missing") and, for a
+        git-worktree workdir, running git/edits against the LIVE checkout and
+        corrupting the running deployment. run_job must re-assert the workdir
+        override inside the worker, immediately before run_conversation, so the
+        clobber cannot win."""
+        import os
+        import cron.scheduler as sched
+
+        monkeypatch.setenv("TERMINAL_CWD", "/original/cwd")
+        observed: dict = {}
+        # Agent construction clobbers TERMINAL_CWD to a wrong absolute path,
+        # mimicking the real deploy-checkout clobber.
+        self._install_stubs(
+            monkeypatch, observed, clobber_cwd="/wrong/deploy/checkout"
+        )
+
+        job = {
+            "id": "abc",
+            "name": "wd-job",
+            "workdir": str(tmp_path),
+            "schedule_display": "manual",
+        }
+        success, _output, response, error = sched.run_job(job)
+        assert success is True, f"run_job failed: error={error!r} response={response!r}"
+
+        # Construction recorded the workdir (set by run_job) BEFORE it clobbered...
+        assert observed["terminal_cwd_during_init"] == str(tmp_path.resolve())
+        # ...but by the time the agent RAN, the workdir override was re-asserted.
+        # Without the fix this is "/wrong/deploy/checkout".
+        assert observed["terminal_cwd_during_run"] == str(tmp_path.resolve())
+        # And the prior value is still restored in finally.
         assert os.environ["TERMINAL_CWD"] == "/original/cwd"
 
     def test_no_workdir_leaves_terminal_cwd_untouched(self, monkeypatch):


### PR DESCRIPTION
**THE root cause** behind the evolution pipeline shipping nothing AND intermittently corrupting the live deploy checkout. Follow-up to #766/#771/#772 (necessary but not sufficient).

## Root cause (confirmed by live tracing on prod)
`run_job` sets `os.environ['TERMINAL_CWD'] = <job workdir>` (a git worktree) under the workdir write-lock — verified still correct right before `AIAgent(...)`. But `agent.run_conversation` is dispatched to a worker thread via `_cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)`; the copied-context restore + agent construction re-apply a TERMINAL_CWD captured **before** the workdir was set. So the terminal/file env (lazily created in the worker) is built in the gateway's **primary deploy checkout**, not the workdir.

Live trace: `TERMINAL_CWD=worktree` at the pre-agent point, `=deploy-checkout` at env creation. Effect on the evolution server (workdir = a worktree of the deploy checkout): the implementer read wrong paths → declared present modules 'missing' → blocked implementable issues → shipped nothing; and ran `git checkout -B` / edits in the LIVE checkout, moving it off main and breaking deploys. (Masked for a while by an unrelated process-global TERMINAL_CWD leak; a gateway restart exposed it.)

## Fix
Wrap `run_conversation` in a closure that re-asserts `os.environ['TERMINAL_CWD'] = _job_workdir` **inside the worker context, immediately before the agent runs**, so it wins over the stale value. Still under the workdir write-lock (held until the outer `finally` restores TERMINAL_CWD and only THEN releases the lock — so no reader job sees the override; no leak).

## Validation
- **Live**: after deploying the fix, a triggered impl run's terminal env cwd = the worktree (was the deploy checkout). No deploy-checkout corruption.
- **Regression test** `test_workdir_survives_agent_init_clobber`: a FakeAgent whose `__init__` clobbers TERMINAL_CWD; the env seen by `run_conversation` must still be the workdir. **Verified it FAILS without this change, passes with it.** Full tests/cron/{test_cron_workdir,test_terminal_cwd_lock,test_parallel_pool} green (39).
- **Cross-provider review** (Gemini): its leak concern is refuted by the existing outer `finally` (restores TERMINAL_CWD before releasing the write-lock). A ContextVar/explicit-cwd refactor is a cleaner long-term option, noted as follow-up.