### PR TITLE
fix(evolution): count 'proposals_filed' alias so funnel no longer reports issues_created=0 (Closes #767)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -74,13 +74,29 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
         patterns = introspection_raw
     else:
         patterns = _as_dict(introspection_raw).get("patterns_found") or []
-    created = issues.get("issues_created") or issues.get("created") or []
-    if "issues_created" not in issues and "created" in issues:
-        logger.warning(
-            "Schema drift in %s: issues report uses legacy key 'created' "
-            "instead of 'issues_created'",
-            issues_path,
-        )
+    # The issues stage has historically emitted several keys for the same list.
+    # Canonical is ``issues_created``; aliases are ``created`` and
+    # ``proposals_filed`` (used briefly around 2026-07-05). Count any of them so
+    # a schema rename never silently zeros the funnel.
+    created = (
+        issues.get("issues_created")
+        or issues.get("created")
+        or issues.get("proposals_filed")
+        or []
+    )
+    if "issues_created" not in issues:
+        if "created" in issues:
+            logger.warning(
+                "Schema drift in %s: issues report uses legacy key 'created' "
+                "instead of 'issues_created'",
+                issues_path,
+            )
+        elif "proposals_filed" in issues:
+            logger.warning(
+                "Schema drift in %s: issues report uses legacy key 'proposals_filed' "
+                "instead of 'issues_created'",
+                issues_path,
+            )
 
     return {
         "date": date,

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -148,6 +148,32 @@ class TestComputeFunnel:
         assert r["issues_created"] == 1
         assert "legacy key" not in caplog.text
 
+    def test_proposals_filed_legacy_key_counts_and_warns(self, tmp_path, caplog):
+        # 2026-07-05 issue report briefly used 'proposals_filed' instead of
+        # 'issues_created', which caused metrics.jsonl to record created=0.
+        import logging
+
+        d = "2026-07-05"
+        _write(
+            tmp_path / "issues" / f"{d}.json",
+            {
+                "date": d,
+                "proposals_filed": [{"number": 734}, {"number": 735}],
+            },
+        )
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {"selected_for_implementation": [], "rejected": []},
+        )
+        _write(tmp_path / "integration" / f"{d}.json", {"merged": [], "skipped": []})
+
+        with caplog.at_level(logging.WARNING, logger="evolution_funnel"):
+            r = compute_funnel(tmp_path, d)
+
+        assert r["issues_created"] == 2
+        assert "legacy key 'proposals_filed'" in caplog.text
+        assert "2026-07-05" in caplog.text
+
 
 class TestCycleDate:
     def test_morning_run_measures_yesterday(self):


### PR DESCRIPTION
Fixes a schema mismatch where the 2026-07-05 issues report used the key `proposals_filed` for filed issues, but `evolution_funnel.py` only accepted `issues_created` (canonical) and the legacy `created`. The funnel therefore recorded `issues_created=0` despite four issues being filed that day.

Changes:
- Extend `compute_funnel()` to treat `proposals_filed` as a fallback alias.
- Emit a schema-drift warning when the alias is used.
- Add a regression test for the `proposals_filed` key.

Local checks: pre-PR targeted test shard ✓, ruff lint ✓, ruff format ✓.

Closes #767.