### PR TITLE
fix(scripts): correct issues_created from legacy proposals_filed schema (Closes #767)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -75,6 +75,16 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     else:
         patterns = _as_dict(introspection_raw).get("patterns_found") or []
     created = issues.get("issues_created") or issues.get("created") or []
+    # A legacy stage report may use `proposals_filed` (a list of issue dicts)
+    # but omit `issues_created`/`created`. Count those too.
+    if not created and "proposals_filed" in issues:
+        created = issues.get("proposals_filed") or []
+        if created:
+            logger.warning(
+                "Schema drift in %s: issues report uses legacy key 'proposals_filed' "
+                "instead of 'issues_created'",
+                issues_path,
+            )
     if "issues_created" not in issues and "created" in issues:
         logger.warning(
             "Schema drift in %s: issues report uses legacy key 'created' "

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -125,15 +125,21 @@ class TestComputeFunnel:
         assert "legacy key 'created'" in caplog.text
         assert "2026-07-04" in caplog.text
 
-    def test_canonical_issues_created_key_no_warning(self, tmp_path, caplog):
-        # 2026-07-05 issue report uses canonical 'issues_created' key.
+    def test_legacy_proposals_filed_key_counts_and_warns(self, tmp_path, caplog):
+        # 2026-07-05 issue report used 'proposals_filed' instead of 'issues_created'.
         import logging
 
         d = "2026-07-05"
         _write(
             tmp_path / "issues" / f"{d}.json",
             {
-                "issues_created": [{"number": 737}],
+                "date": d,
+                "proposals_filed": [
+                    {"issue": "734", "title": "[FEATURE] Online verifier-based safety monitor", "priority_score": 1.31},
+                    {"issue": "735", "title": "[FEATURE] Stateful multi-PR attack monitor for coding agents", "priority_score": 1.40},
+                    {"issue": "736", "title": "[IMPROVEMENT] Recursive evidence replay for long-context reasoning", "priority_score": 1.25},
+                    {"issue": "737", "title": "[FIX] Harden terminal/read_file/browser tool retry spirals", "priority_score": 2.13},
+                ],
             },
         )
         _write(
@@ -145,8 +151,9 @@ class TestComputeFunnel:
         with caplog.at_level(logging.WARNING, logger="evolution_funnel"):
             r = compute_funnel(tmp_path, d)
 
-        assert r["issues_created"] == 1
-        assert "legacy key" not in caplog.text
+        assert r["issues_created"] == 4
+        assert "legacy key 'proposals_filed'" in caplog.text
+        assert d in caplog.text
 
 
 class TestCycleDate:


### PR DESCRIPTION
Fixes the daily evolution funnel so days whose issue stage report used the legacy key `proposals_filed` (e.g. 2026-07-05) are counted in `issues_created`, instead of being reported as 0.

Also adds a regression test for that schema shape.

Closes #767