### PR TITLE
feat(#785): add fallback_directive field to ToolGuardrailDecision

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -154,6 +154,11 @@ class ToolGuardrailDecision:
     tool_name: str = ""
     count: int = 0
     signature: ToolCallSignature | None = None
+    # #744/#785 — structured fallback guidance for non-retryable failures.
+    # Populated on warn/halt decisions arising from repeated tool failures so
+    # the agent loop (or a policy interceptor) can surface a concrete
+    # alternative action instead of only a free-text message.
+    fallback_directive: str = ""
 
     @property
     def allows_execution(self) -> bool:
@@ -173,6 +178,8 @@ class ToolGuardrailDecision:
         }
         if self.signature is not None:
             data["signature"] = self.signature.to_metadata()
+        if self.fallback_directive:
+            data["fallback_directive"] = self.fallback_directive
         return data
 
 
@@ -343,6 +350,7 @@ class ToolCallGuardrailController:
                     tool_name=tool_name,
                     count=same_count,
                     signature=signature,
+                    fallback_directive=_fallback_directive_for(tool_name),
                 )
                 self._halt_decision = decision
                 return decision
@@ -359,6 +367,7 @@ class ToolCallGuardrailController:
                     tool_name=tool_name,
                     count=exact_count,
                     signature=signature,
+                    fallback_directive=_fallback_directive_for(tool_name),
                 )
 
             if self.config.warnings_enabled and same_count >= self.config.same_tool_failure_warn_after:
@@ -369,6 +378,7 @@ class ToolCallGuardrailController:
                     tool_name=tool_name,
                     count=same_count,
                     signature=signature,
+                    fallback_directive=_fallback_directive_for(tool_name),
                 )
 
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
@@ -450,6 +460,28 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
         "or a different tool that can make progress. If the blocker is external, report "
         "the blocker after one diagnostic attempt instead of repeating the same failing path."
     )
+
+
+# #744/#785 — concise, structured fallback directives keyed by tool name.
+# Unlike _tool_failure_recovery_hint (which is a free-text nudge), these are
+# short imperative phrases suitable for structured consumption by the agent
+# loop or policy interceptors: "use <alternative> instead".
+_TOOL_FALLBACK_DIRECTIVE: dict[str, str] = {
+    "read_file": "use search_files to locate the file, or vision_analyze for binary/image files",
+    "terminal": "run a read-only diagnostic (pwd, ls) before retrying, or switch to read_file/patch",
+    "execute_code": "install missing packages via terminal, or verify the interpreter/venv first",
+    "web_search": "try web_extract on a known URL, or refine the query terms",
+    "web_extract": "try web_search to find alternative URLs, or use the browser tool",
+    "search_files": "try a broader glob pattern, or use read_file on a known path",
+    "patch": "use read_file to verify the exact text before patching, or use write_file",
+    "write_file": "verify the directory exists with terminal, or use patch for targeted edits",
+    "process": "use process action=list to find the correct session_id before retrying",
+}
+
+
+def _fallback_directive_for(tool_name: str) -> str:
+    """Return a concise fallback directive for a failing tool, or empty string."""
+    return _TOOL_FALLBACK_DIRECTIVE.get(tool_name, "")
 
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,72 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+# ── #744/#785: fallback_directive field on ToolGuardrailDecision ──────────────
+
+
+def test_fallback_directive_populated_on_same_tool_failure_warning():
+    """A repeated same-tool failure warning carries a non-empty fallback_directive."""
+    controller = ToolCallGuardrailController()
+    args = {"path": "/nonexistent"}
+    # read_file is idempotent (fail_threshold for same_tool = 3 by default)
+    for _ in range(3):
+        controller.before_call("read_file", args)
+        decision = controller.after_call("read_file", args, '{"error":"not found"}', failed=True)
+    assert decision.action == "warn"
+    assert decision.fallback_directive != ""
+    assert "search_files" in decision.fallback_directive
+
+
+def test_fallback_directive_populated_on_exact_failure_warning():
+    """A repeated exact-failure warning carries a non-empty fallback_directive."""
+    controller = ToolCallGuardrailController()
+    args = {"query": "same"}
+    # exact_failure_warn_after = 2 by default
+    for _ in range(2):
+        controller.before_call("web_search", args)
+        decision = controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
+    assert decision.action == "warn"
+    assert decision.fallback_directive != ""
+    assert "web_extract" in decision.fallback_directive
+
+
+def test_fallback_directive_empty_on_allow():
+    """A non-failure (allow) decision has an empty fallback_directive."""
+    controller = ToolCallGuardrailController()
+    controller.before_call("read_file", {"path": "/tmp/x"})
+    decision = controller.after_call("read_file", {"path": "/tmp/x"}, "content", failed=False)
+    assert decision.action == "allow"
+    assert decision.fallback_directive == ""
+
+
+def test_fallback_directive_empty_for_unknown_tool():
+    """An unknown tool without a known fallback gets an empty fallback_directive."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_tool_failure_warn_after=2)
+    )
+    args = {"key": "val"}
+    for _ in range(2):
+        controller.before_call("mcp_custom_tool", args)
+        decision = controller.after_call("mcp_custom_tool", args, '{"error":"bad"}', failed=True)
+    assert decision.action == "warn"
+    assert decision.fallback_directive == ""
+
+
+def test_fallback_directive_in_metadata():
+    """to_metadata() includes fallback_directive when non-empty, omits when empty."""
+    controller = ToolCallGuardrailController()
+    args = {"path": "/nonexistent"}
+    for _ in range(3):
+        controller.before_call("read_file", args)
+        decision = controller.after_call("read_file", args, '{"error":"not found"}', failed=True)
+    assert decision.fallback_directive != ""
+    meta = decision.to_metadata()
+    assert "fallback_directive" in meta
+    assert meta["fallback_directive"] == decision.fallback_directive
+
+    # Allow decisions omit the key entirely
+    controller.before_call("read_file", {"path": "/tmp/other"})
+    allow_decision = controller.after_call("read_file", {"path": "/tmp/other"}, "ok", failed=False)
+    assert "fallback_directive" not in allow_decision.to_metadata()


### PR DESCRIPTION
## Summary

Add a structured `fallback_directive` field to `ToolGuardrailDecision` that provides concise, action-oriented alternative guidance when a tool fails repeatedly. Unlike the free-text recovery hint message, this is a short imperative phrase suitable for structured consumption by the agent loop or policy interceptors.

## Changes
- Add `fallback_directive: str = ""` to `ToolGuardrailDecision` dataclass
- Include `fallback_directive` in `to_metadata()` when non-empty
- Add `_TOOL_FALLBACK_DIRECTIVE` dict mapping tool names to directives
- Add `_fallback_directive_for()` helper
- Wire `fallback_directive` into all 3 failure decision paths: `same_tool_failure_halt`, `repeated_exact_failure_warning`, `same_tool_failure_warning`
- Add 5 tests covering: warning population, allow emptiness, unknown tool emptiness, metadata inclusion/omission

## Test Results
All 18 tests pass (13 existing + 5 new).

Closes #785