### PR TITLE
feat(#784): support batch multi-path reads in read_file

### DIFF
--- a/tests/tools/test_read_file_batch.py
+++ b/tests/tools/test_read_file_batch.py
@@ -1,0 +1,95 @@
+"""Tests for read_file batch mode (multi-path reads).
+
+#757/#784 — read_file accepts a list of paths to read multiple files
+in a single tool call, returning per-file results in a structured JSON.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.file_tools import _handle_read_file, _BATCH_READ_MAX_FILES
+
+
+@pytest.fixture
+def _two_files(tmp_path):
+    f1 = tmp_path / "alpha.txt"
+    f1.write_text("alpha\nbravo\ncharlie\n")
+    f2 = tmp_path / "beta.txt"
+    f2.write_text("delta\necho\nfoxtrot\n")
+    return str(f1), str(f2)
+
+
+def test_batch_read_returns_per_file_content(_two_files):
+    f1, f2 = _two_files
+    result = _handle_read_file({"path": [f1, f2]}, task_id="test-batch")
+    data = json.loads(result)
+    assert data["batch"] is True
+    assert len(data["files"]) == 2
+    assert data["files"][0]["path"] == f1
+    assert "alpha" in data["files"][0]["content"]
+    assert data["files"][1]["path"] == f2
+    assert "delta" in data["files"][1]["content"]
+
+
+def test_batch_read_preserves_total_lines(_two_files):
+    f1, f2 = _two_files
+    result = _handle_read_file({"path": [f1, f2]}, task_id="test-batch")
+    data = json.loads(result)
+    assert data["files"][0]["total_lines"] == 3
+    assert data["files"][1]["total_lines"] == 3
+
+
+def test_batch_read_with_nonexistent_file_includes_error(tmp_path):
+    good = tmp_path / "exists.txt"
+    good.write_text("hello\n")
+    ghost = str(tmp_path / "ghost.txt")
+    result = _handle_read_file({"path": [str(good), ghost]}, task_id="test-batch")
+    data = json.loads(result)
+    assert data["batch"] is True
+    assert len(data["files"]) == 2
+    assert "content" in data["files"][0]
+    assert "hello" in data["files"][0]["content"]
+    assert "error" in data["files"][1]
+    assert data["files"][1]["path"] == ghost
+
+
+def test_batch_read_respects_pagination(tmp_path):
+    f = tmp_path / "numbered.txt"
+    f.write_text("\n".join(f"LINE_{i:04d}" for i in range(1, 51)) + "\n")
+    result = _handle_read_file({"path": [str(f)], "offset": 10, "limit": 5}, task_id="test-batch")
+    data = json.loads(result)
+    assert data["files"][0]["total_lines"] == 50
+    assert "LINE_0010" in data["files"][0]["content"]
+    assert "LINE_0014" in data["files"][0]["content"]
+    assert "LINE_0009" not in data["files"][0]["content"]
+
+
+def test_batch_read_rejects_too_many_paths(tmp_path):
+    paths = [str(tmp_path / f"file_{i}.txt") for i in range(_BATCH_READ_MAX_FILES + 1)]
+    result = _handle_read_file({"path": paths}, task_id="test-batch")
+    data = json.loads(result)
+    assert "error" in data
+    assert str(_BATCH_READ_MAX_FILES) in data["error"]
+
+
+def test_single_string_path_still_works(tmp_path):
+    """Backward compatibility: a single string path must not trigger batch mode."""
+    f = tmp_path / "single.txt"
+    f.write_text("solo\n")
+    result = _handle_read_file({"path": str(f)}, task_id="test-single")
+    data = json.loads(result)
+    assert "batch" not in data
+    assert "content" in data
+    assert "solo" in data["content"]
+
+
+def test_batch_read_empty_list_returns_empty_files():
+    result = _handle_read_file({"path": []}, task_id="test-batch")
+    data = json.loads(result)
+    assert data["batch"] is True
+    assert data["files"] == []

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1851,11 +1851,15 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text. NOTE: Cannot read images or other binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text. NOTE: Cannot read images or other binary files — use vision_analyze for images. The 'path' parameter can also be a list of paths to read multiple files in one call (batch mode, max 10 files).",
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
+            "path": {
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "description": "Path to the file to read (absolute, relative, or ~/path), or a list of up to 10 paths for batch reading",
+            },
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
             "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
         },
@@ -1954,7 +1958,44 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    path = args.get("path", "")
+    # #757/#784 — batch mode: read multiple files in one tool call.
+    if isinstance(path, list):
+        return _handle_read_file_batch(path, args, tid)
+    return read_file_tool(path=path, offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+
+
+_BATCH_READ_MAX_FILES = 10
+
+
+def _handle_read_file_batch(paths: list, args: dict, tid: str) -> str:
+    """Read multiple files in one call. Returns JSON with per-file results."""
+    if len(paths) > _BATCH_READ_MAX_FILES:
+        return json.dumps({
+            "error": (
+                f"Batch read supports at most {_BATCH_READ_MAX_FILES} files per call; "
+                f"got {len(paths)}. Split into smaller batches."
+            ),
+        })
+    offset = args.get("offset", 1)
+    limit = args.get("limit", 500)
+    files = []
+    for p in paths:
+        if not isinstance(p, str):
+            files.append({"path": str(p), "error": "Invalid path type: expected string"})
+            continue
+        raw = read_file_tool(path=p, offset=offset, limit=limit, task_id=tid)
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            parsed = {"raw": raw}
+        entry = {"path": p}
+        if "error" in parsed:
+            entry["error"] = parsed["error"]
+        else:
+            entry.update(parsed)
+        files.append(entry)
+    return json.dumps({"batch": True, "files": files}, ensure_ascii=False)
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary

Extend read_file to accept a list of paths in addition to a single string path. When given a list, the tool reads each file individually and returns a structured JSON with per-file results (content, total_lines, file_size, errors). This saves round-trips when the agent needs to inspect multiple files.

## Changes
- Update READ_FILE_SCHEMA: path type is now ["string", "array"] with items of type string
- Update _handle_read_file: detect list path and dispatch to _handle_read_file_batch
- Add _handle_read_file_batch: loops over paths, calls read_file_tool for each, combines results
- Add _BATCH_READ_MAX_FILES = 10 guard
- Per-file errors captured per-entry without aborting the batch
- Backward compatible: single string path works exactly as before

## Test Results
- 7 new tests: all pass
- 6 existing read_file tests: all still pass

Closes #784