### PR TITLE
feat(#783): local triage pass without GitHub API calls

### DIFF
--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Local triage pass for evolution-analysis (#783).
+
+Reads local sidecar files (issues/, introspection/, research/) and
+produces a thin-list triage JSON in the standard analysis format —
+WITHOUT any GitHub API calls or private-tool dispatch.
+
+This makes the analysis stage independently runnable: when private
+tools are unavailable, the local triage still produces output so the
+pipeline is not blind.
+
+Usage:
+    python scripts/evolution_local_triage.py [--evolution-dir DIR]
+
+Output:
+    Writes analysis/YYYY-MM-DD.json to the evolution directory.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Sidecar subdirectories to scan
+_SIDECAR_DIRS = ("issues", "introspection", "research")
+
+
+def _latest_file(directory: Path) -> Path | None:
+    """Return the most recently modified .json or .md file in a directory."""
+    if not directory.is_dir():
+        return None
+    candidates = sorted(
+        (f for f in directory.iterdir() if f.suffix in (".json", ".md")),
+        key=lambda f: f.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _read_sidecar(path: Path) -> dict:
+    """Read a sidecar file (JSON or MD) and return a dict with metadata."""
+    if path.suffix == ".json":
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {"path": str(path), "error": "unreadable"}
+        return {"path": str(path), "data": data}
+    # MD files — just note existence (research reports are free-form)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {"path": str(path), "error": "unreadable"}
+    return {"path": str(path), "char_count": len(text)}
+
+
+def _extract_proposals(issues_sidecar: dict) -> list[dict]:
+    """Extract filed proposals from the latest issues sidecar."""
+    data = issues_sidecar.get("data", {})
+    proposals = data.get("proposals", [])
+    filed = []
+    for p in proposals:
+        if p.get("decision") == "filed" and p.get("issue"):
+            filed.append({
+                "issue_number": p["issue"],
+                "title": p.get("title", ""),
+                "priority_score": p.get("priority_score", 0.0),
+                "impact_score": p.get("impact", 0.0),
+                "effort_score": p.get("effort", 0.0),
+                "category": p.get("category", ""),
+                "selected_reason": "local-triage",
+            })
+    return filed
+
+
+def _read_calibration(evolution_dir: Path) -> dict:
+    """Read health and realized-impact sidecars for calibration."""
+    cal = {"effort_budget": 3.0, "consolidation_mode": False}
+
+    health_file = evolution_dir / "evolution-health.txt"
+    if health_file.exists():
+        text = health_file.read_text(encoding="utf-8")
+        for token in ("effort_budget=1.5", "effort_budget=1.5"):
+            if token in text:
+                cal["effort_budget"] = 1.5
+                break
+        # Check for LOW_SELECTION_EFFICIENCY
+        if "LOW_SELECTION_EFFICIENCY" in text:
+            cal["effort_budget"] = 1.5
+
+    realized_file = evolution_dir / "realized-impact.txt"
+    if realized_file.exists():
+        text = realized_file.read_text(encoding="utf-8")
+        if "REALIZED_IMPACT_LOW" in text:
+            cal["consolidation_mode"] = True
+
+    return cal
+
+
+def run_local_triage(evolution_dir: Path) -> dict:
+    """Run the local triage pass and return the analysis JSON dict."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # Read latest sidecars
+    sidecars = {}
+    for subdir in _SIDECAR_DIRS:
+        latest = _latest_file(evolution_dir / subdir)
+        if latest:
+            sidecars[subdir] = _read_sidecar(latest)
+
+    # Extract proposals from issues sidecar
+    proposals = []
+    if "issues" in sidecars and "data" in sidecars["issues"]:
+        proposals = _extract_proposals(sidecars["issues"])
+
+    # Read calibration
+    cal = _read_calibration(evolution_dir)
+
+    # Sort by priority score (descending)
+    proposals.sort(key=lambda p: p["priority_score"], reverse=True)
+
+    # Apply effort budget cap
+    max_effort = cal["effort_budget"]
+    selected = []
+    total_effort = 0.0
+    for p in proposals:
+        if total_effort + p["effort_score"] > max_effort:
+            continue
+        selected.append(p)
+        total_effort += p["effort_score"]
+
+    # Build output in standard analysis format
+    output = {
+        "date": today,
+        "local_triage": True,
+        "sidecars_read": {k: v.get("path", "") for k, v in sidecars.items()},
+        "effort_budget": max_effort,
+        "consolidation_mode": cal["consolidation_mode"],
+        "rejected": [],
+        "selected_for_implementation": selected,
+    }
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Local triage pass (no GitHub API calls)")
+    parser.add_argument(
+        "--evolution-dir",
+        default=None,
+        help="Path to the evolution directory (default: auto-detect from HERMES_HOME)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.evolution_dir:
+        evolution_dir = Path(args.evolution_dir)
+    else:
+        import os
+        hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+        evolution_dir = Path(hermes_home) / "profiles" / "user1" / "evolution"
+
+    if not evolution_dir.is_dir():
+        print(f"Error: evolution directory not found: {evolution_dir}", file=sys.stderr)
+        return 1
+
+    output = run_local_triage(evolution_dir)
+
+    # Write to analysis/YYYY-MM-DD.json
+    analysis_dir = evolution_dir / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    output_path = analysis_dir / f"{output['date']}.json"
+
+    # Don't overwrite if a full (non-local) analysis already exists for today
+    if output_path.exists():
+        existing = json.loads(output_path.read_text(encoding="utf-8"))
+        if not existing.get("local_triage", False):
+            # A real analysis exists — don't clobber it with a local-only pass
+            print(f"Skipping: full analysis already exists at {output_path}", file=sys.stderr)
+            return 0
+
+    output_path.write_text(json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Local triage written to {output_path}")
+    print(f"  Sidecars read: {', '.join(output['sidecars_read'].keys())}")
+    print(f"  Selected: {len(output['selected_for_implementation'])} issues")
+    print(f"  Effort budget: {output['effort_budget']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -33,6 +33,45 @@ implementation. The mission focus test above is applied before scoring.
 
 ## Process
 
+### Phase 0 — Local triage pass (no GitHub API calls)
+
+**When private tools (GitHub token / `gh` CLI) are unavailable, this phase
+runs first and independently — producing a thin-list triage JSON from local
+sidecar files alone, so the pipeline is never blind.** When private tools ARE
+available, this phase still runs as a pre-pass to warm the selection with
+local context before the GitHub-dependent steps.
+
+```bash
+python scripts/evolution_local_triage.py
+# Reads: issues/, introspection/, research/ sidecars + evolution-health.txt
+#        + realized-impact.txt
+# Writes: analysis/YYYY-MM-DD.json (standard format, "local_triage": true)
+# Does NOT call any GitHub API
+```
+
+What it does:
+1. Reads the most recent `issues/`, `introspection/`, and `research/` sidecars
+   from `~/.hermes/profiles/user1/evolution/`
+2. Extracts filed proposals (decision=“filed” with issue numbers) and scores them
+3. Reads `evolution-health.txt` for `effort_budget` calibration (1.5 or 3.0)
+4. Reads `realized-impact.txt` for consolidation-mode detection
+5. Sorts by priority score, applies the effort budget cap, and writes the
+   result to `analysis/YYYY-MM-DD.json` in the standard format
+
+**Non-clobber rule:** if a full (non-local) analysis already exists for today,
+the script skips writing — a local-only pass never overwrites a complete one.
+
+When this phase produces output (private tools were unavailable), the analysis
+stage is DONE for this cycle — the `local_triage: true` flag in the JSON tells
+downstream stages the selection is local-only and the private dispatch (PR
+creation, implementation handoff) is deferred until private tools are available.
+
+### Phase 1 — Full analysis (requires GitHub token / gh CLI)
+
+The steps below are the original full-analysis pipeline. They run when private
+tools are available, producing a richer analysis that includes live issue
+bodies, rejection comments, and GitHub-side state.
+
 1. **Retrieve** all open issues — THIN first (context economy). `gh` is
    authorized via persistent `gh auth login` (~/.config/gh), set up by
    setup-hermes.sh — do NOT export GH_TOKEN from env (Hermes strips GitHub

--- a/tests/scripts/test_evolution_local_triage.py
+++ b/tests/scripts/test_evolution_local_triage.py
@@ -1,0 +1,154 @@
+"""Tests for evolution_local_triage.py (#783).
+
+Verifies the local triage pass:
+- Reads local sidecar files without GitHub API calls
+- Extracts filed proposals from issues sidecar
+- Applies effort budget from health sidecar
+- Detects consolidation mode from realized-impact sidecar
+- Produces output in the standard analysis JSON format
+- Does not clobber existing full (non-local) analysis files
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_local_triage import run_local_triage, _latest_file, _read_sidecar
+
+
+@pytest.fixture
+def evo_dir(tmp_path):
+    """Create a minimal evolution directory with sidecars."""
+    evo = tmp_path / "evolution"
+    issues_dir = evo / "issues"
+    issues_dir.mkdir(parents=True)
+    (issues_dir / "2026-07-08.json").write_text(json.dumps({
+        "date": "2026-07-08",
+        "proposals": [
+            {"title": "Alpha", "decision": "filed", "issue": 100,
+             "priority_score": 1.5, "impact": 0.8, "effort": 0.3},
+            {"title": "Beta", "decision": "skipped", "issue": None,
+             "priority_score": 0.5, "impact": 0.2, "effort": 0.1},
+            {"title": "Gamma", "decision": "filed", "issue": 200,
+             "priority_score": 0.9, "impact": 0.5, "effort": 0.8},
+        ]
+    }))
+    return evo
+
+
+def test_local_triage_basic(evo_dir):
+    result = run_local_triage(evo_dir)
+    assert result["local_triage"] is True
+    assert result["date"]  # ISO date string
+    assert "issues" in result["sidecars_read"]
+
+
+def test_local_triage_excludes_skipped_proposals(evo_dir):
+    result = run_local_triage(evo_dir)
+    nums = [s["issue_number"] for s in result["selected_for_implementation"]]
+    assert 100 in nums
+    assert 200 in nums
+    # Beta was "skipped" with issue=None — must not appear
+    assert None not in nums
+
+
+def test_local_triage_sorted_by_priority(evo_dir):
+    result = run_local_triage(evo_dir)
+    scores = [s["priority_score"] for s in result["selected_for_implementation"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_local_triage_effort_budget_default(evo_dir):
+    """Without health sidecar, effort_budget defaults to 3.0."""
+    result = run_local_triage(evo_dir)
+    assert result["effort_budget"] == 3.0
+
+
+def test_local_triage_effort_budget_throttled(evo_dir):
+    """Health sidecar with LOW_SELECTION_EFFICIENCY sets budget to 1.5."""
+    (evo_dir / "evolution-health.txt").write_text(
+        "[evolution-metrics] LOW_SELECTION_EFFICIENCY effort_budget=1.5"
+    )
+    result = run_local_triage(evo_dir)
+    assert result["effort_budget"] == 1.5
+
+
+def test_local_triage_consolidation_mode(evo_dir):
+    """Realized-impact sidecar with REALIZED_IMPACT_LOW sets consolidation."""
+    (evo_dir / "realized-impact.txt").write_text(
+        "[evolution-realized-impact] REALIZED_IMPACT_LOW"
+    )
+    result = run_local_triage(evo_dir)
+    assert result["consolidation_mode"] is True
+
+
+def test_local_triage_no_consolidation_without_signal(evo_dir):
+    result = run_local_triage(evo_dir)
+    assert result["consolidation_mode"] is False
+
+
+def test_local_triage_effort_budget_enforced(evo_dir):
+    """Total selected effort must not exceed the budget."""
+    (evo_dir / "evolution-health.txt").write_text(
+        "[evolution-metrics] effort_budget=1.5"
+    )
+    result = run_local_triage(evo_dir)
+    total = sum(s["effort_score"] for s in result["selected_for_implementation"])
+    assert total <= 1.5
+
+
+def test_local_triage_standard_format(evo_dir):
+    """Output must have the standard analysis JSON keys."""
+    result = run_local_triage(evo_dir)
+    assert "date" in result
+    assert "rejected" in result
+    assert "selected_for_implementation" in result
+    for entry in result["selected_for_implementation"]:
+        assert "issue_number" in entry
+        assert "title" in entry
+        assert "priority_score" in entry
+        assert "selected_reason" in entry
+
+
+def test_local_triage_empty_issues_dir(tmp_path):
+    """If no sidecars exist, produce empty output without error."""
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    result = run_local_triage(evo)
+    assert result["local_triage"] is True
+    assert result["selected_for_implementation"] == []
+    assert result["sidecars_read"] == {}
+
+
+def test_latest_file_returns_most_recent(tmp_path):
+    """_latest_file should return the most recently modified file."""
+    d = tmp_path / "issues"
+    d.mkdir()
+    old = d / "2026-07-01.json"
+    new = d / "2026-07-08.json"
+    old.write_text("{}")
+    new.write_text("{}")
+    # Ensure new is modified after old
+    import os
+    os.utime(old, (1, 1))
+    os.utime(new, (2, 2))
+    result = _latest_file(d)
+    assert result == new
+
+
+def test_read_sidecar_json(tmp_path):
+    f = tmp_path / "test.json"
+    f.write_text('{"key": "value"}')
+    result = _read_sidecar(f)
+    assert result["data"]["key"] == "value"
+
+
+def test_read_sidecar_md(tmp_path):
+    f = tmp_path / "test.md"
+    f.write_text("# Research report\n\nContent here.")
+    result = _read_sidecar(f)
+    assert result["char_count"] > 0


### PR DESCRIPTION
## Summary

Split the evolution-analysis pipeline into two phases:
- **Phase 0: Local triage** — reads sidecar files (issues/, introspection/, research/) without any GitHub API calls, produces a standard-format analysis JSON with `local_triage: true`
- **Phase 1: Full analysis** — the existing GitHub-dependent pipeline (requires gh CLI / token)

## Problem
The analysis stage produced no output for days when private tools were unavailable, leaving the evolution pipeline blind.

## Solution
Added `scripts/evolution_local_triage.py` which:
1. Reads the most recent issues/, introspection/, research/ sidecars
2. Extracts filed proposals (decision=filed with issue numbers)
3. Reads evolution-health.txt for effort_budget calibration (1.5 or 3.0)
4. Reads realized-impact.txt for consolidation-mode detection
5. Sorts by priority score, applies effort budget cap
6. Writes standard-format analysis JSON with local_triage: true

Non-clobber rule: if a full (non-local) analysis already exists for today, the script skips writing.

## Test Results
- 13 new tests: all pass
- Verified against real sidecar files in ~/.hermes/profiles/user1/evolution/

Closes #783