### PR TITLE
feat(#733): local-state research fallback when web tools are unavailable

### DIFF
--- a/scripts/evolution_research_local.py
+++ b/scripts/evolution_research_local.py
@@ -46,6 +46,41 @@ _MAX_FINDINGS = 20
 _LOCAL_MARKER = "<!-- evolution-research: local-state fallback -->"
 
 
+def _default_evolution_dir() -> Path:
+    """Resolve the evolution profile directory WITHOUT hardcoding a profile name.
+
+    Priority (matches the rest of the evolution script family + the runtime):
+      1. ``$EVOLUTION_PROFILE_DIR`` — set explicitly by the evolution cron; this
+         is the authoritative path on the server.
+      2. ``<hermes_home>/profiles/<active_profile>/evolution`` — where
+         ``hermes_home`` is ``$HERMES_HOME`` or the platform default
+         (``~/.hermes``), and ``<active_profile>`` is read from the
+         ``<hermes_home>/active_profile`` marker, defaulting to ``"default"``.
+
+    The active profile is resolved dynamically, never assumed to be ``user1`` —
+    real installs (and the Osoba.ai server) use the ``default`` profile.
+    """
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+
+    hermes_home = Path(
+        os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes")
+    )
+
+    profile = "default"
+    marker = hermes_home / "active_profile"
+    try:
+        if marker.is_file():
+            name = marker.read_text(encoding="utf-8").strip()
+            if name:
+                profile = name
+    except OSError:
+        pass
+
+    return hermes_home / "profiles" / profile / "evolution"
+
+
 def web_tools_available(available_tools) -> bool:
     """Capability check: True if at least one live web/research tool is exposed.
 
@@ -327,8 +362,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--evolution-dir",
         default=None,
-        help="Path to the evolution directory (default: $EVOLUTION_PROFILE_DIR "
-        "or ~/.hermes/profiles/user1/evolution)",
+        help="Path to the evolution directory (default: $EVOLUTION_PROFILE_DIR, "
+        "else <hermes_home>/profiles/<active_profile>/evolution)",
     )
     parser.add_argument(
         "--print",
@@ -340,12 +375,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.evolution_dir:
         evolution_dir = Path(args.evolution_dir)
     else:
-        evolution_dir = Path(
-            os.environ.get(
-                "EVOLUTION_PROFILE_DIR",
-                str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
-            )
-        )
+        evolution_dir = _default_evolution_dir()
 
     if not evolution_dir.is_dir():
         print(f"Error: evolution directory not found: {evolution_dir}", file=sys.stderr)

--- a/scripts/evolution_research_local.py
+++ b/scripts/evolution_research_local.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Local-state research fallback for evolution-research (#733).
+
+When the live web tools (``web_search``, browser, GitHub, arXiv) are
+unavailable, the research stage cannot scan the frontier and would otherwise
+return an empty report, breaking the self-improvement loop on restricted
+installs.
+
+This module mines LOCAL project telemetry instead — ``metrics.jsonl``,
+``funnel-summary.txt`` and prior ``research/*.md`` reports — and surfaces
+deterministic, pipeline-quality findings (integration stalls, low selection
+efficiency, research stagnation, stale frontier scans) mapped to the SAME
+impact/effort/priority schema live research uses. No network calls.
+
+The fallback is gated by an explicit capability check (:func:`web_tools_available`),
+not a silent failure: callers switch to this path only when the live tools are
+missing, and the report is never silently empty.
+
+Usage:
+    python scripts/evolution_research_local.py [--evolution-dir DIR] [--print]
+
+Output:
+    Writes ``research/YYYY-MM-DD.md`` (Markdown, live-research schema) to the
+    evolution directory, unless a live (non-local) report already exists for
+    today. Prints a one-line summary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Live web/research tools the research stage normally needs. If NONE are
+# exposed, the caller switches to the local-state fallback in this module.
+_WEB_TOOLS = ("web_search", "web_extract", "browser", "arxiv", "github")
+
+# Priority floor shared with live research (SKILL.md: Priority Score >= 0.7).
+_MIN_PRIORITY = 0.7
+# Live research cap (SKILL.md: max 20 proposals).
+_MAX_FINDINGS = 20
+
+# Sentinel so re-runs recognise their own output and never clobber a live report.
+_LOCAL_MARKER = "<!-- evolution-research: local-state fallback -->"
+
+
+def web_tools_available(available_tools) -> bool:
+    """Capability check: True if at least one live web/research tool is exposed.
+
+    ``available_tools`` is any iterable of tool-name strings (e.g. the runtime's
+    tool registry). The research stage calls this fallback only when this
+    returns False — an explicit gate, never a silent empty report.
+    """
+    names = {str(t) for t in (available_tools or ())}
+    return any(tool in names for tool in _WEB_TOOLS)
+
+
+def _priority(impact: float, effort: float) -> float:
+    """Canonical evolution priority: impact dampened by effort, never divided.
+
+    ``base = impact * 2 * (1 - 0.4 * effort)`` — matches evolution-analysis.
+    """
+    return round(impact * 2.0 * (1.0 - 0.4 * effort), 2)
+
+
+def _load_records(metrics_file: Path) -> list[dict]:
+    """Read metrics.jsonl (one JSON object per line), skipping blank/malformed
+    lines. Kept dependency-free so the fallback needs no runtime import from
+    evolution_funnel (mirrors evolution_backlog_gate)."""
+    out: list[dict] = []
+    if not metrics_file.exists():
+        return out
+    try:
+        lines = metrics_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return out
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _trailing_zero_streak(records: list[dict], field: str) -> int:
+    """Length of the trailing run of records whose ``field`` is 0 or absent."""
+    streak = 0
+    for rec in reversed(records):
+        if int(rec.get(field, 0) or 0) == 0:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def _reject_rate(records: list[dict]) -> float:
+    """rejected / (selected + rejected) over the records; 0.0 if no decisions."""
+    selected = sum(int(r.get("selected", 0) or 0) for r in records)
+    rejected = sum(int(r.get("rejected", 0) or 0) for r in records)
+    denom = selected + rejected
+    return rejected / denom if denom else 0.0
+
+
+def _latest_report_age_days(research_dir: Path, now: datetime) -> int | None:
+    """Age in days of the newest ``research/*.md`` report, or None if none exist."""
+    if not research_dir.is_dir():
+        return None
+    reports = [f for f in research_dir.iterdir() if f.suffix == ".md"]
+    if not reports:
+        return None
+    newest = max(reports, key=lambda f: f.stat().st_mtime)
+    newest_mtime = datetime.fromtimestamp(newest.stat().st_mtime, tz=timezone.utc)
+    return max(0, (now - newest_mtime).days)
+
+
+def _finding(
+    title: str,
+    category: str,
+    impact: float,
+    effort: float,
+    source: str,
+    frontier: str,
+    description: str,
+) -> dict:
+    """Build one finding in the live-research schema."""
+    return {
+        "title": title,
+        "category": category,  # FEATURE | IMPROVEMENT | REPLACEMENT
+        "impact_score": impact,
+        "effort_score": effort,
+        "priority_score": _priority(impact, effort),
+        "source": source,
+        "frontier_standing": frontier,
+        "description": description,
+    }
+
+
+def mine_findings(
+    records: list[dict],
+    funnel_summary: str = "",
+    latest_research_age_days: int | None = None,
+) -> list[dict]:
+    """Map local telemetry signals to research findings (deterministic)."""
+    findings: list[dict] = []
+    window = records[-14:] if len(records) >= 7 else records
+
+    # 1. Integration stalled — trailing merged-zero streak.
+    merged_streak = _trailing_zero_streak(records, "merged")
+    if merged_streak >= 3:
+        findings.append(
+            _finding(
+                "[IMPROVEMENT] Integration is stuck — audit the merge pipeline "
+                "before adding more backlog",
+                "IMPROVEMENT",
+                0.8,
+                0.4,
+                f"local telemetry: metrics.jsonl merged-zero streak of {merged_streak} cycles",
+                "behind",
+                f"The last {merged_streak} cycles landed zero merges. Idea supply is not the "
+                "bottleneck — downstream integration (analysis -> implementation -> PR -> merge) "
+                "is. Audit the executor and PR-merge path (flaky CI, review gate, worktree "
+                "failures) before generating more proposals.",
+            )
+        )
+
+    # 2. Research stagnation — trailing issues_created-zero streak.
+    created_streak = _trailing_zero_streak(records, "issues_created")
+    if created_streak >= 3:
+        findings.append(
+            _finding(
+                "[IMPROVEMENT] Research produced no proposals for several cycles "
+                "— restore frontier access",
+                "IMPROVEMENT",
+                0.7,
+                0.3,
+                f"local telemetry: metrics.jsonl issues_created-zero streak of "
+                f"{created_streak} cycles",
+                "behind",
+                f"No new proposals were filed for {created_streak} cycles. On restricted installs "
+                "this usually means the live web/arXiv/GitHub tools are unavailable. Restore "
+                "frontier access or schedule a catch-up scan; meanwhile this local-state fallback "
+                "keeps the self-improvement loop alive.",
+            )
+        )
+
+    # 3. Low selection efficiency — high reject rate.
+    reject_rate = _reject_rate(window)
+    if len(window) >= 3 and reject_rate >= 0.5:
+        findings.append(
+            _finding(
+                "[IMPROVEMENT] Triage rejects most findings — raise the research evidence bar",
+                "IMPROVEMENT",
+                0.6,
+                0.3,
+                f"local telemetry: reject rate {reject_rate:.0%} over last {len(window)} cycles",
+                "at-par",
+                f"Triage rejected {reject_rate:.0%} of surfaced findings recently. Research is "
+                "spending effort on low-conviction ideas. Raise the evidence bar: fewer, "
+                "higher-frontier proposals per cycle; a popular or new trend alone is not enough.",
+            )
+        )
+    elif "HIGH_REJECT_RATE" in funnel_summary:
+        # Funnel flag reinforces the same signal when per-cycle counts are thin.
+        findings.append(
+            _finding(
+                "[IMPROVEMENT] Triage rejects most findings — raise the research evidence bar",
+                "IMPROVEMENT",
+                0.6,
+                0.3,
+                "local telemetry: funnel-summary.txt HIGH_REJECT_RATE flag",
+                "at-par",
+                "The funnel signal reports a high reject rate. Raise the research evidence bar "
+                "this cycle: fewer, higher-conviction findings.",
+            )
+        )
+
+    # 4. Stale frontier scan — newest research report is old.
+    if latest_research_age_days is not None and latest_research_age_days >= 7:
+        findings.append(
+            _finding(
+                "[IMPROVEMENT] Frontier scan is stale — schedule a catch-up once web tools return",
+                "IMPROVEMENT",
+                0.5,
+                0.2,
+                f"local telemetry: newest research report is {latest_research_age_days} days old",
+                "behind",
+                f"The most recent frontier scan is {latest_research_age_days} days old. Competitor "
+                "repos and arXiv move weekly; schedule a catch-up scan as soon as web tools return "
+                "so the agent does not drift behind the field.",
+            )
+        )
+
+    return findings
+
+
+def run_local_research(evolution_dir: Path) -> dict:
+    """Mine local telemetry and return a research-report dict (no network)."""
+    now = datetime.now(timezone.utc)
+    today = now.strftime("%Y-%m-%d")
+
+    records = _load_records(evolution_dir / "metrics.jsonl")
+
+    funnel_summary = ""
+    funnel_file = evolution_dir / "funnel-summary.txt"
+    if funnel_file.exists():
+        try:
+            funnel_summary = funnel_file.read_text(encoding="utf-8")
+        except OSError:
+            funnel_summary = ""
+
+    age = _latest_report_age_days(evolution_dir / "research", now)
+
+    findings = mine_findings(records, funnel_summary, age)
+
+    # Enforce the shared priority floor, sort by priority desc, cap the list.
+    findings = [f for f in findings if f["priority_score"] >= _MIN_PRIORITY]
+    findings.sort(key=lambda f: f["priority_score"], reverse=True)
+    findings = findings[:_MAX_FINDINGS]
+
+    result = {
+        "date": today,
+        "local_research": True,
+        "cycles_analyzed": len(records),
+        "findings": findings,
+    }
+    if not findings:
+        # Never a silent empty report — state the reason explicitly.
+        result["note"] = (
+            "No local pipeline signals crossed the priority floor; the frontier "
+            "scan is deferred until web tools are restored."
+        )
+    return result
+
+
+def render_report(result: dict) -> str:
+    """Render the result dict as the live-research Markdown schema."""
+    lines = [_LOCAL_MARKER, f"# Research Report - {result['date']}", ""]
+    findings = result.get("findings", [])
+
+    if not findings:
+        note = result.get("note", "no local findings")
+        lines.append(f"_Local-state fallback: {note}_")
+        lines.append("")
+        return "\n".join(lines)
+
+    groups: dict[str, tuple[str, list[dict]]] = {
+        "FEATURE": ("## New Features", []),
+        "IMPROVEMENT": ("## Improvements", []),
+        "REPLACEMENT": ("## Replacements", []),
+    }
+    for finding in findings:
+        groups.get(finding["category"], groups["IMPROVEMENT"])[1].append(finding)
+
+    for category in ("FEATURE", "IMPROVEMENT", "REPLACEMENT"):
+        header, items = groups[category]
+        if not items:
+            continue
+        lines.append(header)
+        lines.append("")
+        for finding in items:
+            lines.append(f"### {finding['title']}")
+            lines.append(f"- **Source**: {finding['source']}")
+            lines.append(f"- **Frontier standing**: {finding['frontier_standing']}")
+            lines.append(f"- **Impact**: {finding['impact_score']}")
+            lines.append(f"- **Effort**: {finding['effort_score']}")
+            lines.append(f"- **Priority Score**: {finding['priority_score']}")
+            lines.append("")
+            lines.append(finding["description"])
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Local-state research fallback (no web tools, no network)."
+    )
+    parser.add_argument(
+        "--evolution-dir",
+        default=None,
+        help="Path to the evolution directory (default: $EVOLUTION_PROFILE_DIR "
+        "or ~/.hermes/profiles/user1/evolution)",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        help="Print the Markdown report to stdout instead of writing a file",
+    )
+    args = parser.parse_args(argv)
+
+    if args.evolution_dir:
+        evolution_dir = Path(args.evolution_dir)
+    else:
+        evolution_dir = Path(
+            os.environ.get(
+                "EVOLUTION_PROFILE_DIR",
+                str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            )
+        )
+
+    if not evolution_dir.is_dir():
+        print(f"Error: evolution directory not found: {evolution_dir}", file=sys.stderr)
+        return 1
+
+    result = run_local_research(evolution_dir)
+    report = render_report(result)
+
+    if args.print:
+        print(report)
+        return 0
+
+    research_dir = evolution_dir / "research"
+    research_dir.mkdir(parents=True, exist_ok=True)
+    out_path = research_dir / f"{result['date']}.md"
+
+    # Don't clobber a live (non-local) report already written today.
+    if out_path.exists():
+        try:
+            existing = out_path.read_text(encoding="utf-8")
+        except OSError:
+            existing = ""
+        if _LOCAL_MARKER not in existing:
+            print(
+                f"Skipping: live research report already exists at {out_path}",
+                file=sys.stderr,
+            )
+            return 0
+
+    out_path.write_text(report + "\n", encoding="utf-8")
+    print(f"Local research fallback written to {out_path}")
+    print(f"  Cycles analyzed: {result['cycles_analyzed']}")
+    print(f"  Findings: {len(result['findings'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -51,7 +51,7 @@ Keywords: "agent", "autonomous", "LLM tool use", "multi-agent"
 0. **Read the pipeline's own funnel signal FIRST** (closes the funnel feedback
    loop — #84). This stage has only the `web` + `file` toolsets (no `terminal`),
    so READ the sidecar the nightly funnel job refreshes — do NOT try to run a
-   script: open `~/.hermes/profiles/user1/evolution/funnel-summary.txt` (a single
+   script: open `~/.hermes/profiles/default/evolution/funnel-summary.txt` (a single
    `[evolution-funnel] …` line). If it's missing, treat as `signal OK` and
    proceed. This signal is **INTERNAL — it only sets your selectivity bar. Do
    NOT mention it, the `[evolution-funnel]` line, `reject_rate`, or flag names in
@@ -93,8 +93,9 @@ self-improvement loop keeps producing signal on restricted installs (#733).
 This stage has only the `web` + `file` toolsets (no `terminal`), so mine local
 telemetry with `read_file` — never try to run a script:
 
-- Read `~/.hermes/profiles/user1/evolution/metrics.jsonl` (per-cycle counts),
-  `funnel-summary.txt` (the selectivity signal), and the newest prior
+- Read the evolution profile directory (`$EVOLUTION_PROFILE_DIR`; on a standard
+  install `~/.hermes/profiles/default/evolution`): `metrics.jsonl` (per-cycle
+  counts), `funnel-summary.txt` (the selectivity signal), and the newest prior
   `research/*.md` report.
 - Surface pipeline-quality findings from what you read: integration stalls
   (trailing `merged == 0` cycles), research stagnation (trailing
@@ -112,7 +113,7 @@ silent failure.
 
 ## Output format
 
-Save the result to `~/.hermes/profiles/user1/evolution/research/YYYY-MM-DD.md`:
+Save the result to `~/.hermes/profiles/default/evolution/research/YYYY-MM-DD.md`:
 
 ```markdown
 # Research Report - YYYY-MM-DD

--- a/skills/evolution/evolution-research/SKILL.md
+++ b/skills/evolution/evolution-research/SKILL.md
@@ -83,6 +83,33 @@ Keywords: "agent", "autonomous", "LLM tool use", "multi-agent"
    - `[REPLACEMENT]` — alternative to something existing
 4. **Generate a report** with an impact/effort assessment
 
+## Fallback: local-state research (no web tools)
+
+**Capability check first.** If the live web/research tools (`web_search`,
+`web_extract`, browser, arXiv, GitHub) are NOT exposed this session, do NOT
+return an empty report — switch to a deterministic local-state fallback so the
+self-improvement loop keeps producing signal on restricted installs (#733).
+
+This stage has only the `web` + `file` toolsets (no `terminal`), so mine local
+telemetry with `read_file` — never try to run a script:
+
+- Read `~/.hermes/profiles/user1/evolution/metrics.jsonl` (per-cycle counts),
+  `funnel-summary.txt` (the selectivity signal), and the newest prior
+  `research/*.md` report.
+- Surface pipeline-quality findings from what you read: integration stalls
+  (trailing `merged == 0` cycles), research stagnation (trailing
+  `issues_created == 0`), low selection efficiency (high reject rate /
+  `HIGH_REJECT_RATE`), and a stale frontier scan (newest report ≥ 7 days old).
+- Map each signal to the SAME schema as live research below, using the same
+  priority formula (`impact × 2 × (1 − 0.4 × effort)`, floor 0.7, max 20).
+
+The canonical, unit-tested reference for this logic is
+`scripts/evolution_research_local.py` (it mirrors `scripts/evolution_local_triage.py`,
+the analysis stage's local pass) — a terminal-capable runner such as the nightly
+funnel job can materialize the same `research/YYYY-MM-DD.md` deterministically. The
+fallback is gated by the capability check above — a deliberate switch, never a
+silent failure.
+
 ## Output format
 
 Save the result to `~/.hermes/profiles/user1/evolution/research/YYYY-MM-DD.md`:

--- a/tests/scripts/test_evolution_research_local.py
+++ b/tests/scripts/test_evolution_research_local.py
@@ -1,0 +1,256 @@
+"""Tests for the local-state research fallback (#733).
+
+Verifies the fallback mines local telemetry and emits findings in the
+live-research schema WITHOUT any network access.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_research_local import (  # noqa: E402
+    _load_records,
+    _priority,
+    _reject_rate,
+    _trailing_zero_streak,
+    main,
+    mine_findings,
+    render_report,
+    run_local_research,
+    web_tools_available,
+)
+
+
+def _write_metrics(evo_dir: Path, records: list[dict]) -> None:
+    (evo_dir / "metrics.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def evo_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "evolution"
+    d.mkdir(parents=True)
+    return d
+
+
+# ── capability gate ──────────────────────────────────────────────────────────
+
+
+def test_web_tools_available_true_when_any_present():
+    assert web_tools_available(["read_file", "web_search"]) is True
+    assert web_tools_available({"browser"}) is True
+
+
+def test_web_tools_available_false_when_none_present():
+    assert web_tools_available(["read_file", "patch", "terminal"]) is False
+    assert web_tools_available([]) is False
+    assert web_tools_available(None) is False
+
+
+# ── priority formula ─────────────────────────────────────────────────────────
+
+
+def test_priority_matches_canonical_formula():
+    # impact 0.8, effort 0.4 -> 0.8 * 2 * (1 - 0.16) = 1.344 -> 1.34
+    assert _priority(0.8, 0.4) == 1.34
+    # impact 0.7, effort 0.3 -> 1.4 * 0.88 = 1.232 -> 1.23
+    assert _priority(0.7, 0.3) == 1.23
+    # effort dampens, never divides: zero effort keeps full doubled impact
+    assert _priority(0.5, 0.0) == 1.0
+
+
+# ── telemetry helpers ────────────────────────────────────────────────────────
+
+
+def test_load_records_skips_blank_and_malformed(evo_dir: Path):
+    (evo_dir / "metrics.jsonl").write_text(
+        '{"date":"d1","merged":1}\n\nnot-json\n{"date":"d2","merged":0}\n',
+        encoding="utf-8",
+    )
+    records = _load_records(evo_dir / "metrics.jsonl")
+    assert [r["date"] for r in records] == ["d1", "d2"]
+
+
+def test_load_records_missing_file_returns_empty(evo_dir: Path):
+    assert _load_records(evo_dir / "nope.jsonl") == []
+
+
+def test_trailing_zero_streak_counts_from_end():
+    recs = [{"merged": 2}, {"merged": 0}, {"merged": 0}, {"merged": 0}]
+    assert _trailing_zero_streak(recs, "merged") == 3
+    assert _trailing_zero_streak([{"merged": 1}], "merged") == 0
+    # absent field counts as zero
+    assert _trailing_zero_streak([{}, {}], "merged") == 2
+
+
+def test_reject_rate():
+    recs = [{"selected": 1, "rejected": 3}, {"selected": 1, "rejected": 1}]
+    assert _reject_rate(recs) == pytest.approx(4 / 6)
+    assert _reject_rate([]) == 0.0
+
+
+# ── mining: at least one actionable proposal without network ──────────────────
+
+
+def test_merged_zero_streak_produces_actionable_finding(evo_dir: Path):
+    records = [{"date": "d0", "issues_created": 2, "selected": 2, "merged": 1}]
+    records += [
+        {"date": f"d{i}", "issues_created": 1, "selected": 1, "merged": 0}
+        for i in range(1, 5)
+    ]
+    _write_metrics(evo_dir, records)
+
+    result = run_local_research(evo_dir)
+
+    assert result["local_research"] is True
+    assert result["cycles_analyzed"] == len(records)
+    assert len(result["findings"]) >= 1
+    top = result["findings"][0]
+    assert top["category"] == "IMPROVEMENT"
+    assert top["priority_score"] >= 0.7
+    assert "Integration is stuck" in top["title"]
+    assert "4 cycles" in top["source"]
+
+
+def test_stagnation_and_reject_signals(evo_dir: Path):
+    # 7 cycles, all zero issues_created (stagnation) and high reject rate
+    records = [
+        {
+            "date": f"d{i}",
+            "issues_created": 0,
+            "selected": 1,
+            "rejected": 4,
+            "merged": 1,
+        }
+        for i in range(7)
+    ]
+    findings = mine_findings(records)
+    titles = " ".join(f["title"] for f in findings)
+    assert "restore frontier access" in titles
+    assert "raise the research evidence bar" in titles
+
+
+def test_high_reject_rate_funnel_flag_when_counts_thin(evo_dir: Path):
+    findings = mine_findings([], funnel_summary="[evolution-funnel] HIGH_REJECT_RATE")
+    assert any("evidence bar" in f["title"] for f in findings)
+
+
+def test_stale_research_report_finding():
+    findings = mine_findings([], latest_research_age_days=30)
+    assert any("Frontier scan is stale" in f["title"] for f in findings)
+    # fresh report -> no stale finding
+    assert not any(
+        "Frontier scan is stale" in f["title"]
+        for f in mine_findings([], latest_research_age_days=1)
+    )
+
+
+# ── never a silent empty report ──────────────────────────────────────────────
+
+
+def test_healthy_pipeline_yields_explicit_note_not_silence(evo_dir: Path):
+    records = [
+        {
+            "date": f"d{i}",
+            "issues_created": 2,
+            "selected": 2,
+            "rejected": 0,
+            "merged": 2,
+        }
+        for i in range(5)
+    ]
+    _write_metrics(evo_dir, records)
+
+    result = run_local_research(evo_dir)
+    assert result["findings"] == []
+    assert "note" in result and result["note"]
+
+    report = render_report(result)
+    assert "Local-state fallback" in report
+    assert result["note"] in report
+
+
+def test_empty_install_no_crash(evo_dir: Path):
+    result = run_local_research(evo_dir)
+    assert result["findings"] == []
+    assert "note" in result
+
+
+# ── output schema ────────────────────────────────────────────────────────────
+
+
+def test_render_report_follows_live_schema(evo_dir: Path):
+    records = [{"date": "d0", "merged": 1}] + [
+        {"date": f"d{i}", "merged": 0} for i in range(1, 4)
+    ]
+    _write_metrics(evo_dir, records)
+    report = render_report(run_local_research(evo_dir))
+
+    assert report.startswith("<!-- evolution-research: local-state fallback -->")
+    assert "# Research Report -" in report
+    assert "## Improvements" in report
+    assert "- **Priority Score**:" in report
+    assert "- **Frontier standing**:" in report
+
+
+def test_all_findings_respect_priority_floor(evo_dir: Path):
+    records = [{"date": "d0", "merged": 1}] + [
+        {
+            "date": f"d{i}",
+            "issues_created": 0,
+            "selected": 1,
+            "rejected": 9,
+            "merged": 0,
+        }
+        for i in range(1, 8)
+    ]
+    _write_metrics(evo_dir, records)
+    findings = run_local_research(evo_dir)["findings"]
+    assert findings  # signals present
+    assert all(f["priority_score"] >= 0.7 for f in findings)
+
+
+# ── main() writes a file and does not clobber a live report ───────────────────
+
+
+def test_main_writes_report_file(evo_dir: Path):
+    records = [{"date": "d0", "merged": 1}] + [
+        {"date": f"d{i}", "merged": 0} for i in range(1, 4)
+    ]
+    _write_metrics(evo_dir, records)
+
+    rc = main(["--evolution-dir", str(evo_dir)])
+    assert rc == 0
+
+    reports = list((evo_dir / "research").glob("*.md"))
+    assert len(reports) == 1
+    assert "<!-- evolution-research: local-state fallback -->" in reports[0].read_text()
+
+
+def test_main_does_not_clobber_live_report(evo_dir: Path):
+    from datetime import datetime, timezone
+
+    _write_metrics(evo_dir, [{"date": "d0", "merged": 0} for _ in range(4)])
+    research_dir = evo_dir / "research"
+    research_dir.mkdir()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    live = research_dir / f"{today}.md"
+    live.write_text(
+        "# Research Report - live\n\nreal frontier scan\n", encoding="utf-8"
+    )
+
+    rc = main(["--evolution-dir", str(evo_dir)])
+    assert rc == 0
+    # live report is preserved (no local marker written over it)
+    assert "real frontier scan" in live.read_text()
+
+
+def test_main_missing_dir_returns_error(tmp_path: Path):
+    assert main(["--evolution-dir", str(tmp_path / "absent")]) == 1

--- a/tests/scripts/test_evolution_research_local.py
+++ b/tests/scripts/test_evolution_research_local.py
@@ -15,6 +15,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_research_local import (  # noqa: E402
+    _default_evolution_dir,
     _load_records,
     _priority,
     _reject_rate,
@@ -254,3 +255,28 @@ def test_main_does_not_clobber_live_report(evo_dir: Path):
 
 def test_main_missing_dir_returns_error(tmp_path: Path):
     assert main(["--evolution-dir", str(tmp_path / "absent")]) == 1
+
+
+# ── profile-dir resolution: never hardcode 'user1' (#733 review fix) ──────────
+
+
+def test_default_dir_prefers_evolution_profile_dir_env(monkeypatch, tmp_path):
+    target = tmp_path / "srv" / "evolution"
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(target))
+    assert _default_evolution_dir() == target
+
+
+def test_default_dir_uses_default_profile_not_user1(monkeypatch, tmp_path):
+    monkeypatch.delenv("EVOLUTION_PROFILE_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    resolved = _default_evolution_dir()
+    assert resolved == tmp_path / "profiles" / "default" / "evolution"
+    assert "user1" not in str(resolved)
+
+
+def test_default_dir_honors_active_profile_marker(monkeypatch, tmp_path):
+    monkeypatch.delenv("EVOLUTION_PROFILE_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "active_profile").write_text("osoba\n", encoding="utf-8")
+    resolved = _default_evolution_dir()
+    assert resolved == tmp_path / "profiles" / "osoba" / "evolution"


### PR DESCRIPTION
## Summary

Closes #733. When the live web tools (`web_search`, browser, GitHub, arXiv) are unavailable, `evolution-research` previously returned an empty report, breaking the self-improvement loop on restricted installs.

Adds `scripts/evolution_research_local.py` — a deterministic, **network-free** miner over local telemetry (`metrics.jsonl`, `funnel-summary.txt`, prior `research/*.md`) that surfaces pipeline-quality findings (integration stalls, research stagnation, low selection efficiency, stale frontier scans) in the **same** impact/effort/priority schema as live research (`impact*2*(1-0.4*effort)`, floor 0.7, max 20).

## Design notes
- **No dead wiring.** The research stage has only `web`+`file` toolsets (no `terminal`), so the SKILL documents a **file-only** fallback (read sidecars via `read_file`) — it does *not* tell the stage to run a script. The script is the unit-tested reference implementation, runnable by terminal-capable contexts. Passes `evolution_skill_lint` (the #188 dead-wiring gate).
- **Profile-safe.** `_default_evolution_dir()` resolves `$EVOLUTION_PROFILE_DIR` (set by the evolution cron on the Osoba.ai server) → `<hermes_home>/profiles/<active_profile>/evolution`, with `active_profile` from the `active_profile` marker, defaulting to `default` — **never** a hardcoded `user1`.
- **Never silent.** A healthy pipeline yields an explicit note, not an empty report. Re-runs never clobber a live report.

## Tests
21 unit tests, no network — mining signals, schema, priority floor, capability gate, profile resolution (`default`, not `user1`), `main()` file-write + no-clobber.

## Success criteria (#733)
- [x] Produces actionable findings when web tools unavailable
- [x] Fallback output follows the same priority-score schema
- [x] No silent empty reports on restricted installs
- [x] Unit test validates fallback behavior without network calls