### PR TITLE
fix(#739): media-tool failure fallback directives — stop blind retries

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -107,8 +107,9 @@ _EXPLORATION_ALTERNATIVE_HINT = {
 # Per-tool diversion advice appended to every nudge branch for the tools the
 # introspection evidence shows spiraling (#694 family): navigation (#680),
 # patch retries (#697), memory ops (#698), tool routing (#699), query
-# reformulation (#700), and terminal diagnostics (#694). Exploration tools
-# keep their dedicated #625 hints above (checked first in _diversion_hint).
+# reformulation (#700), terminal diagnostics (#694), and media generation /
+# analysis (#739). Exploration tools keep their dedicated #625 hints above
+# (checked first in _diversion_hint).
 _DIVERSION_HINT = {
     "terminal": (
         " Read the failing output above and act on its CONTENT (fix the code "
@@ -145,6 +146,28 @@ _DIVERSION_HINT = {
         " Stop reformulating queries: synthesize an answer from the results "
         "you already have, or `web_extract` (if available) the most promising "
         "hit for depth."
+    ),
+    "vision_analyze": (
+        " Stop re-calling: confirm the image path exists and the format is "
+        "supported (png/jpg/webp) with `read_file`. If the input is invalid or "
+        "the tool is unavailable, describe the visual from surrounding context "
+        "and report the blocker instead of retrying the same analysis."
+    ),
+    "image_generate": (
+        " Stop re-generating: verify the prompt and that an image provider is "
+        "configured. If generation keeps failing, deliver a text "
+        "description/placeholder and report the visual blocker rather than "
+        "looping on the same call."
+    ),
+    "video_analyze": (
+        " Stop re-calling: confirm the video path and format with `read_file`. "
+        "If the input is invalid or the tool is unavailable, work from a text "
+        "summary and report the blocker instead of retrying."
+    ),
+    "video_generate": (
+        " Stop re-generating: verify the prompt and that a video provider is "
+        "configured. If generation keeps failing, deliver a text placeholder "
+        "and report the visual blocker rather than looping."
     ),
 }
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -476,6 +476,13 @@ _TOOL_FALLBACK_DIRECTIVE: dict[str, str] = {
     "patch": "use read_file to verify the exact text before patching, or use write_file",
     "write_file": "verify the directory exists with terminal, or use patch for targeted edits",
     "process": "use process action=list to find the correct session_id before retrying",
+    # #739 — media tools: a failed visual call is usually a bad path/format or an
+    # unavailable provider, not something a blind retry fixes. Route to a check
+    # or a text fallback instead of spiraling on the same call.
+    "vision_analyze": "verify the image path exists and is a supported format (png/jpg/webp) with read_file, or proceed from a text description instead of retrying",
+    "image_generate": "report the visual blocker and supply a text description/placeholder instead of retrying, or verify the prompt and image-provider configuration",
+    "video_analyze": "verify the video path and format with read_file, or work from a text summary of the video instead of retrying",
+    "video_generate": "report the visual blocker and supply a text placeholder instead of retrying, or verify the prompt and video-provider configuration",
 }
 
 

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -483,6 +483,23 @@ class TestFailureClassAndDiversionHints:
         assert n is not None
         assert "repo_map" in n
 
+    def test_vision_analyze_failures_get_media_diversion(self):
+        # #739: a failed visual call is redirected to a check / text fallback,
+        # not a blind retry.
+        n = maybe_nudge(
+            self._fail_run("vision_analyze", 2, "vision_analyze failed: invalid image")
+        )
+        assert n is not None
+        assert "read_file" in n
+
+    def test_image_generate_failures_get_media_diversion(self):
+        # #739: repeated generation failures route to a text/placeholder fallback.
+        n = maybe_nudge(
+            self._fail_run("image_generate", 2, "image generation failed: provider down")
+        )
+        assert n is not None
+        assert "placeholder" in n or "provider" in n
+
 
 def _distinct_run(tool, n, *, result="ok"):
     """n consecutive single-tool turns with DISTINCT arguments each (real

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -325,3 +325,43 @@ def test_fallback_directive_in_metadata():
     controller.before_call("read_file", {"path": "/tmp/other"})
     allow_decision = controller.after_call("read_file", {"path": "/tmp/other"}, "ok", failed=False)
     assert "fallback_directive" not in allow_decision.to_metadata()
+
+
+# ── #739: media-tool fallback directives ──────────────────────────────────────
+
+
+def test_fallback_directive_populated_for_vision_analyze():
+    """Repeated vision_analyze failures carry a media-aware fallback_directive."""
+    controller = ToolCallGuardrailController()
+    args = {"path": "/bad.png"}
+    for _ in range(3):
+        controller.before_call("vision_analyze", args)
+        decision = controller.after_call(
+            "vision_analyze", args, '{"success": false, "error": "invalid image"}', failed=True
+        )
+    assert decision.action == "warn"
+    assert decision.fallback_directive != ""
+    assert "read_file" in decision.fallback_directive
+
+
+def test_fallback_directive_populated_for_image_generate():
+    """Repeated image_generate failures route to a text/placeholder fallback."""
+    controller = ToolCallGuardrailController()
+    args = {"prompt": "a cat"}
+    # exact_failure_warn_after = 2 by default
+    for _ in range(2):
+        controller.before_call("image_generate", args)
+        decision = controller.after_call(
+            "image_generate", args, '{"success": false, "error": "provider error"}', failed=True
+        )
+    assert decision.action == "warn"
+    assert decision.fallback_directive != ""
+    assert "placeholder" in decision.fallback_directive
+
+
+def test_fallback_directive_covers_video_media_tools():
+    """video_analyze / video_generate also carry non-empty fallback directives."""
+    from agent.tool_guardrails import _fallback_directive_for
+
+    assert "read_file" in _fallback_directive_for("video_analyze")
+    assert "placeholder" in _fallback_directive_for("video_generate")


### PR DESCRIPTION
## Summary

Closes #739. `vision_analyze` / `image_generate` failures had no fallback guidance, so the agent retried the same failing call and blocked visual tasks (evidence: vision_analyze 8 failures, image_generate 7 failures in a 7d window).

## Change (additive, mirrors the #785 / #694 precedents)
- **`agent/tool_guardrails.py`** — add the media tools (`vision_analyze`, `image_generate`, `video_analyze`, `video_generate`) to `_TOOL_FALLBACK_DIRECTIVE`. A repeated media failure now surfaces a **structured directive** — verify the path/format via `read_file`, or fall back to a text description/placeholder — instead of a silent retry. Media failures already classify as `failed=True` (their JSON carries `"error"`), so **no detection change** is needed.
- **`agent/loop_guard.py`** — add matching `_DIVERSION_HINT` nudge advice for the same tools (fires when the failure text is recognised), extending the #694 per-tool diversion family.

No change to failure detection, thresholds, or any existing entry — purely new dict keys.

## Tests
5 new tests (3 guardrails + 2 loop_guard); full `tests/agent/{test_tool_guardrails,test_loop_guard,test_tool_diagnostics}.py` green (106).

## Maps to #739's proposed direction
- [x] Treat vision_analyze failures as non-retryable → fallback directive to verify path/format
- [x] Route image_generate failures to a text/placeholder fallback
- [x] Surface a concise diagnostic instead of silent retries