### PR TITLE
refactor(evolution): retire hardcoded 'user1' namespace → $HERMES_HOME/evolution

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -10,7 +10,7 @@ prompt: |
   
   Use the evolution-analysis skill for instructions.
   
-  Output to: ~/.hermes/profiles/user1/evolution/analysis/{current_date}.json
+  Output to: ~/.hermes/evolution/analysis/{current_date}.json
   
   CRITICAL: Verify `gh auth status` works before proceeding — the gh CLI is
   the primary auth mechanism. GITHUB_TOKEN is set as fallback. If neither
@@ -32,11 +32,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/analysis/{current_date}.json
+  file: ~/.hermes/evolution/analysis/{current_date}.json
   format: json
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-analysis.log
+log_file: ~/.hermes/logs/evolution-analysis.log
 log_level: DEBUG
 
 # Safety

--- a/cron/evolution/hydra.yaml
+++ b/cron/evolution/hydra.yaml
@@ -15,7 +15,7 @@ prompt: |
   You are the Hydra — the evolution pipeline orchestrator. Inspect the shared
   knowledge pool and dispatch subagents via delegate_task. Keep responses compact.
 
-  Let EVOLUTION = ~/.hermes/profiles/user1/evolution and KNOWLEDGE = ~/.hermes/knowledge.
+  Let EVOLUTION = ~/.hermes/evolution and KNOWLEDGE = ~/.hermes/knowledge.
 
   ## How you work
   1. READ KNOWLEDGE and EVOLUTION/{stage}/.

--- a/cron/evolution/implementation.yaml
+++ b/cron/evolution/implementation.yaml
@@ -10,7 +10,7 @@ prompt: |
   
   Use the evolution-implementation skill for instructions.
   
-  Output to: ~/.hermes/profiles/user1/evolution/implementation/{current_date}.md
+  Output to: ~/.hermes/evolution/implementation/{current_date}.md
   
   CRITICAL SAFETY RULES:
   1. NEVER merge without tests passing
@@ -39,11 +39,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/implementation/{current_date}.md
+  file: ~/.hermes/evolution/implementation/{current_date}.md
   format: markdown
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-implementation.log
+log_file: ~/.hermes/logs/evolution-implementation.log
 log_level: DEBUG
 
 # Safety

--- a/cron/evolution/integration.yaml
+++ b/cron/evolution/integration.yaml
@@ -35,11 +35,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/integration/{current_date}.json
+  file: ~/.hermes/evolution/integration/{current_date}.json
   format: json
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-integration.log
+log_file: ~/.hermes/logs/evolution-integration.log
 log_level: INFO
 
 # Safety

--- a/cron/evolution/introspection.yaml
+++ b/cron/evolution/introspection.yaml
@@ -15,7 +15,7 @@ prompt: |
   PRIVACY: analyze sessions locally; issues must contain ONLY abstracted problem
   patterns — never raw session text, user content, or PII.
 
-  Output to: ~/.hermes/profiles/user1/evolution/introspection/{current_date}.json
+  Output to: ~/.hermes/evolution/introspection/{current_date}.json
 
 skills:
   - evolution/introspection
@@ -33,11 +33,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/introspection/{current_date}.json
+  file: ~/.hermes/evolution/introspection/{current_date}.json
   format: json
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-introspection.log
+log_file: ~/.hermes/logs/evolution-introspection.log
 log_level: INFO
 
 # Limits

--- a/cron/evolution/issues.yaml
+++ b/cron/evolution/issues.yaml
@@ -10,7 +10,7 @@ prompt: |
   
   Use the evolution-issues skill for instructions.
   
-  Output to: ~/.hermes/profiles/user1/evolution/issues/{current_date}.json
+  Output to: ~/.hermes/evolution/issues/{current_date}.json
 
 skills:
   - evolution/issues
@@ -28,11 +28,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/issues/{current_date}.json
+  file: ~/.hermes/evolution/issues/{current_date}.json
   format: json
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-issues.log
+log_file: ~/.hermes/logs/evolution-issues.log
 log_level: INFO
 
 # Limits

--- a/cron/evolution/research.yaml
+++ b/cron/evolution/research.yaml
@@ -10,7 +10,7 @@ prompt: |
   
   Use the evolution-research skill for instructions.
   
-  Output to: ~/.hermes/profiles/user1/evolution/research/{current_date}.md
+  Output to: ~/.hermes/evolution/research/{current_date}.md
 
 skills:
   - evolution/research
@@ -27,11 +27,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/research/{current_date}.md
+  file: ~/.hermes/evolution/research/{current_date}.md
   format: markdown
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-research.log
+log_file: ~/.hermes/logs/evolution-research.log
 log_level: INFO
 
 # Limits

--- a/cron/evolution/upstream-sync.yaml
+++ b/cron/evolution/upstream-sync.yaml
@@ -17,7 +17,7 @@ prompt: |
   authorship-driven conflict resolution → marker guard → verify → PR; escalate
   large/entangled merges to the owner instead of blind-resolving).
 
-  Output to: ~/.hermes/profiles/user1/evolution/upstream/{current_date}.md
+  Output to: ~/.hermes/evolution/upstream/{current_date}.md
 
   CRITICAL: This job ONLY runs in PRIVATE mode.
   If GITHUB_PRIVATE_TOKEN is not set, ABORT immediately.
@@ -38,11 +38,11 @@ github:
 
 # Output configuration
 output:
-  file: ~/.hermes/profiles/user1/evolution/upstream/{current_date}.md
+  file: ~/.hermes/evolution/upstream/{current_date}.md
   format: markdown
 
 # Logging
-log_file: ~/.hermes/profiles/user1/logs/evolution-upstream-sync.log
+log_file: ~/.hermes/logs/evolution-upstream-sync.log
 log_level: DEBUG
 
 # Safety

--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -59,7 +59,7 @@ def evolution_job_stage(job: Dict[str, Any]) -> Optional[str]:
 
 def _evolution_dir(hermes_home: Optional[Path] = None) -> Path:
     home = (hermes_home or get_hermes_home()).resolve()
-    return home / "profiles" / "user1" / "evolution"
+    return home / "evolution"
 
 
 def _preflight_timeout_seconds(cfg: Optional[Any] = None) -> float:

--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -160,7 +160,7 @@ def main(argv: List[str]) -> int:
     evolution_dir = Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     )
     repo_env = os.environ.get("EVOLUTION_REPO_DIR")

--- a/scripts/evolution_backlog_gate.py
+++ b/scripts/evolution_backlog_gate.py
@@ -49,7 +49,7 @@ def _default_evolution_dir() -> Path:
     return Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     )
 

--- a/scripts/evolution_ci_diagnosis.py
+++ b/scripts/evolution_ci_diagnosis.py
@@ -588,7 +588,7 @@ def create_child_issue(
 
 
 def _report_dir() -> Path:
-    return get_hermes_home() / "profiles" / "user1" / "evolution" / "ci-diagnosis"
+    return get_hermes_home() / "evolution" / "ci-diagnosis"
 
 
 def save_diagnosis_report(

--- a/scripts/evolution_dedup.py
+++ b/scripts/evolution_dedup.py
@@ -8,7 +8,7 @@ grows forever with repo age (#91).
 
 This maintains a tiny local cache keyed on the NORMALIZED proposal title:
 
-    ~/.hermes/profiles/user1/evolution/dedup-cache.json
+    ~/.hermes/evolution/dedup-cache.json
     { "<key>": {"title": "...", "status": "filed|rejected|considered",
                 "issue": 123, "date": "YYYY-MM-DD"} }
 
@@ -99,7 +99,7 @@ def _cache_path() -> Path:
     return Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     ) / "dedup-cache.json"
 

--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -171,7 +171,7 @@ def is_evolution_halted(evolution_dir: Path | None = None) -> bool | None:
         evolution_dir = Path(
             os.environ.get(
                 "EVOLUTION_PROFILE_DIR",
-                str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+                str(Path.home() / ".hermes" / "evolution"),
             )
         )
     halt_file = evolution_dir / "halt-state.txt"
@@ -258,7 +258,7 @@ def main(argv: list[str]) -> int:
     evolution_dir = Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     )
     args = argv[1:]

--- a/scripts/evolution_hydra_gate.py
+++ b/scripts/evolution_hydra_gate.py
@@ -30,7 +30,7 @@ def _hot_path() -> Path:
     env = os.environ.get("EVOLUTION_PROFILE_DIR", "")
     if env:
         return Path(env)
-    return Path.home() / ".hermes" / "profiles" / "user1" / "evolution"
+    return Path.home() / ".hermes" / "evolution"
 
 
 def _mtime(path: Path) -> float:

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -159,7 +159,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         import os
         hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
-        evolution_dir = Path(hermes_home) / "profiles" / "user1" / "evolution"
+        evolution_dir = Path(hermes_home) / "evolution"
 
     if not evolution_dir.is_dir():
         print(f"Error: evolution directory not found: {evolution_dir}", file=sys.stderr)

--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -78,7 +78,7 @@ def compute_health(
         evolution_dir = Path(
             os.environ.get(
                 "EVOLUTION_PROFILE_DIR",
-                str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+                str(Path.home() / ".hermes" / "evolution"),
             )
         )
 
@@ -169,7 +169,7 @@ def main(argv: List[str]) -> int:
     evolution_dir = Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     )
     args = argv[1:]

--- a/scripts/evolution_postmortem_miner.py
+++ b/scripts/evolution_postmortem_miner.py
@@ -48,7 +48,7 @@ from typing import Any, Dict, List, Optional
 
 _DEFAULT_REPO = "Lexus2016/hermes-agent-evolution"
 _DEFAULT_LIMIT = 20
-_DEFAULT_OUTPUT_DIR = Path.home() / ".hermes" / "profiles" / "user1" / "evolution"
+_DEFAULT_OUTPUT_DIR = Path.home() / ".hermes" / "evolution"
 _OUTPUT_FILE = "postmortem-rules.json"
 
 # PR numbers that are always skipped (no-op / test PRs, etc.)

--- a/scripts/evolution_pre_pr_test_runner.py
+++ b/scripts/evolution_pre_pr_test_runner.py
@@ -32,7 +32,7 @@ CLI:
 
 Returns exit code 0 if all targeted tests pass, 1 if any fail.
 Logs the full pytest output to:
-    ~/.hermes/profiles/user1/evolution/pre-pr-test-results/{timestamp}.log
+    ~/.hermes/evolution/pre-pr-test-results/{timestamp}.log
 
 Standalone design: import-safe pure functions for unit-testability; the CLI
 entrypoint orchestrates IO (git diff, subprocess, file logging).
@@ -55,7 +55,7 @@ DEFAULT_TIMEOUT = 60
 DEFAULT_FALLBACK_TIMEOUT = 120
 DEFAULT_FALLBACK_KWARGS = "not slow and not docker"
 
-_LOG_DIR_TEMPLATE = "~/.hermes/profiles/user1/evolution/pre-pr-test-results"
+_LOG_DIR_TEMPLATE = "~/.hermes/evolution/pre-pr-test-results"
 
 # Source-root to test-root mapping: each source prefix maps to the
 # corresponding test directory prefix, so agent/... → tests/agent/...,
@@ -465,7 +465,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--log-dir",
         type=str,
         default=None,
-        help="Directory for test result logs (default: ~/.hermes/profiles/user1/evolution/pre-pr-test-results/)",
+        help="Directory for test result logs (default: ~/.hermes/evolution/pre-pr-test-results/)",
     )
     parser.add_argument(
         "--fail-fast",

--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -225,7 +225,7 @@ def _evolution_dir() -> Path:
     return Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(Path.home() / ".hermes" / "profiles" / "user1" / "evolution"),
+            str(Path.home() / ".hermes" / "evolution"),
         )
     )
 

--- a/scripts/evolution_research_local.py
+++ b/scripts/evolution_research_local.py
@@ -50,15 +50,13 @@ def _default_evolution_dir() -> Path:
     """Resolve the evolution profile directory WITHOUT hardcoding a profile name.
 
     Priority (matches the rest of the evolution script family + the runtime):
-      1. ``$EVOLUTION_PROFILE_DIR`` — set explicitly by the evolution cron; this
-         is the authoritative path on the server.
-      2. ``<hermes_home>/profiles/<active_profile>/evolution`` — where
-         ``hermes_home`` is ``$HERMES_HOME`` or the platform default
-         (``~/.hermes``), and ``<active_profile>`` is read from the
-         ``<hermes_home>/active_profile`` marker, defaulting to ``"default"``.
-
-    The active profile is resolved dynamically, never assumed to be ``user1`` —
-    real installs (and the Osoba.ai server) use the ``default`` profile.
+      1. ``$EVOLUTION_PROFILE_DIR`` — set explicitly by the evolution cron; the
+         authoritative override.
+      2. ``<hermes_home>/evolution`` — where ``hermes_home`` is ``$HERMES_HOME``
+         or the platform default (``~/.hermes``). HERMES_HOME already encodes the
+         active profile (default -> ``~/.hermes``, named ``foo`` ->
+         ``~/.hermes/profiles/foo``), so no profile segment is hardcoded — never
+         the legacy ``profiles/user1`` literal.
     """
     env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
     if env:
@@ -67,18 +65,7 @@ def _default_evolution_dir() -> Path:
     hermes_home = Path(
         os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes")
     )
-
-    profile = "default"
-    marker = hermes_home / "active_profile"
-    try:
-        if marker.is_file():
-            name = marker.read_text(encoding="utf-8").strip()
-            if name:
-                profile = name
-    except OSError:
-        pass
-
-    return hermes_home / "profiles" / profile / "evolution"
+    return hermes_home / "evolution"
 
 
 def web_tools_available(available_tools) -> bool:

--- a/scripts/evolution_rubric_judge.py
+++ b/scripts/evolution_rubric_judge.py
@@ -177,11 +177,11 @@ def _total_max() -> int:
 
 
 def _hot_path(evolution_dir: Path) -> Path:
-    """Canonical path: $EVOLUTION_PROFILE_DIR or ~/.hermes/profiles/user1/evolution."""
+    """Canonical path: $EVOLUTION_PROFILE_DIR or ~/.hermes/evolution."""
     env = os.environ.get("EVOLUTION_PROFILE_DIR", "")
     if env:
         return Path(env)
-    return Path.home() / ".hermes" / "profiles" / "user1" / "evolution"
+    return Path.home() / ".hermes" / "evolution"
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -927,7 +927,7 @@ def main() -> int:
     evolution_dir = Path(
         os.environ.get(
             "EVOLUTION_PROFILE_DIR",
-            str(hermes_home / "profiles" / "user1" / "evolution"),
+            str(hermes_home / "evolution"),
         )
     )
     jobs_file = hermes_home / "cron" / "jobs.json"

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -51,7 +51,7 @@ python scripts/evolution_local_triage.py
 
 What it does:
 1. Reads the most recent `issues/`, `introspection/`, and `research/` sidecars
-   from `~/.hermes/profiles/user1/evolution/`
+   from `~/.hermes/evolution/`
 2. Extracts filed proposals (decision=“filed” with issue numbers) and scores them
 3. Reads `evolution-health.txt` for `effort_budget` calibration (1.5 or 3.0)
 4. Reads `realized-impact.txt` for consolidation-mode detection
@@ -234,7 +234,7 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
 
 5a. **Selection-capability calibration — pick only what you can land (goal 3).**
     BEFORE the final selection, read the sidecar
-    `~/.hermes/profiles/user1/evolution/evolution-health.txt` (one
+    `~/.hermes/evolution/evolution-health.txt` (one
     `[evolution-metrics] …` line, refreshed by the funnel job; missing → treat as
     signal OK, proceed). This is the longitudinal calibration loop: it reports
     whether what we SELECTED actually merged. It is INTERNAL plumbing — keep it
@@ -318,7 +318,7 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
     step 1c).
 
 6c. **Realized-impact feedback — don't evolve blind (goal 3).** Read the sidecar
-    `~/.hermes/profiles/user1/evolution/realized-impact.txt` (one
+    `~/.hermes/evolution/realized-impact.txt` (one
     `[evolution-realized-impact] …` line, refreshed by the funnel job; missing →
     treat as `healthy`). It closes the loop: it reports whether what we MERGED
     actually delivered value. Let its flags set this cycle's bar, silently (this
@@ -403,7 +403,7 @@ implementation and integration can confirm.
 
 ## Output format
 
-Save to `~/.hermes/profiles/user1/evolution/analysis/YYYY-MM-DD.json`:
+Save to `~/.hermes/evolution/analysis/YYYY-MM-DD.json`:
 
 ```json
 {

--- a/skills/evolution/evolution-extract/SKILL.md
+++ b/skills/evolution/evolution-extract/SKILL.md
@@ -47,7 +47,7 @@ technique beats a list of vague gestures.
 Pick the single highest-value paper to extract from, in priority order:
 
 1. A `## Research Evidence` paper link in the latest research report
-   (`~/.hermes/profiles/user1/evolution/research/`) attached to the
+   (`~/.hermes/evolution/research/`) attached to the
    highest-`Priority Score` finding.
 2. If you were handed a specific paper/finding by an upstream stage, use that.
 
@@ -101,11 +101,11 @@ source (a draft with no traceable origin cannot be A/B tested or audited).
 
 4. **Deliver the validated draft** (the normalized object the validator returned)
    plus one line naming the paper and the single technique extracted. Save it to
-   `~/.hermes/profiles/user1/evolution/extract/YYYY-MM-DD.json` for the next stage.
+   `~/.hermes/evolution/extract/YYYY-MM-DD.json` for the next stage.
 
 ## Output format
 
-Save to `~/.hermes/profiles/user1/evolution/extract/YYYY-MM-DD.json` — the exact
+Save to `~/.hermes/evolution/extract/YYYY-MM-DD.json` — the exact
 normalized object the validator emitted on exit 0:
 
 ```json

--- a/skills/evolution/evolution-implementation/SKILL.md
+++ b/skills/evolution/evolution-implementation/SKILL.md
@@ -17,7 +17,7 @@ Implement selected issues, create versions, and self-update.
 
 ## Process
 
-1. **Load** the latest analysis from `~/.hermes/profiles/user1/evolution/analysis/`
+1. **Load** the latest analysis from `~/.hermes/evolution/analysis/`
 
 1b. **Freshness gate — NEVER consume a stale selection.** Check the loaded
     JSON's `date` field: it must be from the CURRENT cycle (today, or the most
@@ -199,7 +199,7 @@ python scripts/evolution_pre_pr_test_runner.py --changed-files "$changed"
 ```
 
 If this gate FAILS (exit ≠ 0), read the log under
-`~/.hermes/profiles/user1/evolution/pre-pr-test-results/`, fix the failures,
+`~/.hermes/evolution/pre-pr-test-results/`, fix the failures,
 re-run until green, THEN proceed to step 2. Do NOT open a PR against a red gate.
 
 **Step 2: Lint + format (CI runs `ruff` as a blocking check):**
@@ -368,7 +368,7 @@ would update itself in the middle of its own work.
 ## Output
 
 After each run, append a Markdown report to
-`~/.hermes/profiles/user1/evolution/implementation/YYYY-MM-DD.md` with the
+`~/.hermes/evolution/implementation/YYYY-MM-DD.md` with the
 following structure:
 
 ```markdown

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -306,7 +306,7 @@ PROFILE_SKILLS="${HERMES_HOME:-$HOME/.hermes}/profiles/user1/skills/evolution"
 6. **Record the merge for the realized-impact loop** (so evolution is not blind —
    we later verify whether this change actually helped). For EACH merged PR, run
    the deterministic helper to append one line to
-   `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`:
+   `~/.hermes/evolution/realized/ledger.jsonl`:
 ```bash
 python3 scripts/evolution_realized_impact.py record-merge \
   <#> "<YYYY-MM-DD>" "<the issue's analysis impact 0..1>" \
@@ -335,7 +335,7 @@ python3 scripts/evolution_realized_impact.py record-merge \
 > is not currently open per `gh pr list`, you hallucinated — STOP and redo from
 > the real list.
 
-Save to `~/.hermes/profiles/user1/evolution/integration/YYYY-MM-DD.json` on
+Save to `~/.hermes/evolution/integration/YYYY-MM-DD.json` on
 **EVERY** run — including idle cycles (`merged: []`, `skipped: []`): a missing
 report is read by the watchdog as a dead job.
 

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -101,7 +101,7 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
 6. **Post-merge verification — close the realized-impact loop (goal 3).** Evolution
    is blind unless we check whether what we MERGED actually helped. You are already
    reading real sessions here, so verify recent merges in the same pass:
-   - Read `~/.hermes/profiles/user1/evolution/realized/ledger.jsonl`; take entries
+   - Read `~/.hermes/evolution/realized/ledger.jsonl`; take entries
      **merged ≥ 5 days ago with no `verdict` yet** (matured + unverified).
    - For each, judge from the real sessions since its merge: did the `target`
      problem RECUR (the fix didn't hold)? is the merged capability actually used?

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -16,7 +16,7 @@ Create GitHub issues and pull requests based on research.
 
 ## Process
 
-1. **Load** the latest research report from `~/.hermes/profiles/user1/evolution/research/`
+1. **Load** the latest research report from `~/.hermes/evolution/research/`
 1a. **Also mine the agent's OWN traces for weaknesses (#248).** Research is the
     external signal; the agent's own execution traces are the internal one. Run
     the deterministic trace miner and consider its weakness records alongside the
@@ -68,7 +68,7 @@ Create GitHub issues and pull requests based on research.
 
     **Fast-path — local dedup cache (O(1), avoids re-pulling history every run).**
     This install keeps a cache of every idea it has already filed/considered at
-    `~/.hermes/profiles/user1/evolution/dedup-cache.json`. Check each proposal
+    `~/.hermes/evolution/dedup-cache.json`. Check each proposal
     against it FIRST; a hit means we already handled this idea — skip it with no
     gh query, no in-context comparison:
     ```bash

--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -218,7 +218,7 @@ never commit conflict markers, never merge directly into `main`.
 
 ## Output format
 
-Save the report to `~/.hermes/profiles/user1/evolution/upstream/YYYY-MM-DD.md`:
+Save the report to `~/.hermes/evolution/upstream/YYYY-MM-DD.md`:
 
 ```markdown
 # Upstream Sync Report - YYYY-MM-DD

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -59,7 +59,7 @@ class TestPreflightConfig:
 
 class TestDigestFallback:
     def test_find_latest_digest(self, tmp_path):
-        stage_dir = tmp_path / "profiles" / "user1" / "evolution" / "introspection"
+        stage_dir = tmp_path / "evolution" / "introspection"
         stage_dir.mkdir(parents=True)
         old = stage_dir / "2026-06-20.json"
         new = stage_dir / "2026-06-23.json"
@@ -70,7 +70,7 @@ class TestDigestFallback:
         assert ep.find_latest_digest("introspection", tmp_path) == new
 
     def test_load_digest_as_fallback(self, tmp_path):
-        stage_dir = tmp_path / "profiles" / "user1" / "evolution" / "analysis"
+        stage_dir = tmp_path / "evolution" / "analysis"
         stage_dir.mkdir(parents=True)
         digest = stage_dir / "2026-06-23.json"
         digest.write_text(json.dumps({"foo": "bar"}))
@@ -81,7 +81,7 @@ class TestDigestFallback:
         assert '"foo": "bar"' in text
 
     def test_load_digest_truncate(self, tmp_path):
-        stage_dir = tmp_path / "profiles" / "user1" / "evolution" / "implementation"
+        stage_dir = tmp_path / "evolution" / "implementation"
         stage_dir.mkdir(parents=True)
         digest = stage_dir / "2026-06-23.md"
         digest.write_text("x" * 300_000)
@@ -116,11 +116,13 @@ class TestPreflightProvider:
         fake_client = MagicMock()
         fake_client.chat.completions.create.return_value = MagicMock()
         with patch("openai.OpenAI", return_value=fake_client):
-            err = ep.preflight_provider({
-                "api_key": "k",
-                "model": "config-default-model",
-                "provider": "openrouter",
-            })
+            err = ep.preflight_provider(
+                {
+                    "api_key": "k",
+                    "model": "config-default-model",
+                    "provider": "openrouter",
+                }
+            )
         assert err is None
         # The model carried on the runtime dict must reach the client call.
         _, kwargs = fake_client.chat.completions.create.call_args
@@ -128,11 +130,13 @@ class TestPreflightProvider:
 
     def test_acp_treated_as_reachable(self):
         assert (
-            ep.preflight_provider({
-                "api_key": "k",
-                "model": "m",
-                "command": ["copilot"],
-            })
+            ep.preflight_provider(
+                {
+                    "api_key": "k",
+                    "model": "m",
+                    "command": ["copilot"],
+                }
+            )
             is None
         )
 
@@ -142,11 +146,13 @@ class TestPreflightProvider:
         fake_client.chat.completions.create.return_value = fake_response
         with patch("openai.OpenAI", return_value=fake_client):
             assert (
-                ep.preflight_provider({
-                    "api_key": "k",
-                    "model": "m",
-                    "provider": "openrouter",
-                })
+                ep.preflight_provider(
+                    {
+                        "api_key": "k",
+                        "model": "m",
+                        "provider": "openrouter",
+                    }
+                )
                 is None
             )
         fake_client.chat.completions.create.assert_called_once()
@@ -157,11 +163,13 @@ class TestPreflightProvider:
             "connection refused"
         )
         with patch("openai.OpenAI", return_value=fake_client):
-            err = ep.preflight_provider({
-                "api_key": "k",
-                "model": "m",
-                "provider": "openrouter",
-            })
+            err = ep.preflight_provider(
+                {
+                    "api_key": "k",
+                    "model": "m",
+                    "provider": "openrouter",
+                }
+            )
         assert err is not None
         assert "connection refused" in err
 
@@ -170,11 +178,13 @@ class TestPreflightProvider:
         fake_client = MagicMock()
         with patch("anthropic.Anthropic", return_value=fake_client):
             assert (
-                ep.preflight_provider({
-                    "api_key": "k",
-                    "model": "m",
-                    "api_mode": "anthropic_messages",
-                })
+                ep.preflight_provider(
+                    {
+                        "api_key": "k",
+                        "model": "m",
+                        "api_mode": "anthropic_messages",
+                    }
+                )
                 is None
             )
         fake_client.messages.create.assert_called_once()
@@ -184,11 +194,13 @@ class TestPreflightProvider:
         fake_client = MagicMock()
         fake_client.messages.create.side_effect = RuntimeError("timeout")
         with patch("anthropic.Anthropic", return_value=fake_client):
-            err = ep.preflight_provider({
-                "api_key": "k",
-                "model": "m",
-                "api_mode": "anthropic_messages",
-            })
+            err = ep.preflight_provider(
+                {
+                    "api_key": "k",
+                    "model": "m",
+                    "api_mode": "anthropic_messages",
+                }
+            )
         assert err is not None
         assert "timeout" in err
 
@@ -250,7 +262,7 @@ class TestSchedulerIntegration:
     def test_preflight_failure_with_digest_returns_stale_digest(self, tmp_path):
         from cron.scheduler import _run_job_impl
 
-        stage_dir = tmp_path / "profiles" / "user1" / "evolution" / "analysis"
+        stage_dir = tmp_path / "evolution" / "analysis"
         stage_dir.mkdir(parents=True)
         digest = stage_dir / "2026-06-23.json"
         digest.write_text(json.dumps({"selected": ["#123"]}))

--- a/tests/scripts/test_evolution_research_local.py
+++ b/tests/scripts/test_evolution_research_local.py
@@ -257,7 +257,7 @@ def test_main_missing_dir_returns_error(tmp_path: Path):
     assert main(["--evolution-dir", str(tmp_path / "absent")]) == 1
 
 
-# ── profile-dir resolution: never hardcode 'user1' (#733 review fix) ──────────
+# ── profile-dir resolution: $HERMES_HOME/evolution, never 'user1' ─────────────
 
 
 def test_default_dir_prefers_evolution_profile_dir_env(monkeypatch, tmp_path):
@@ -266,17 +266,20 @@ def test_default_dir_prefers_evolution_profile_dir_env(monkeypatch, tmp_path):
     assert _default_evolution_dir() == target
 
 
-def test_default_dir_uses_default_profile_not_user1(monkeypatch, tmp_path):
+def test_default_dir_uses_hermes_home_evolution_not_user1(monkeypatch, tmp_path):
     monkeypatch.delenv("EVOLUTION_PROFILE_DIR", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     resolved = _default_evolution_dir()
-    assert resolved == tmp_path / "profiles" / "default" / "evolution"
+    # HERMES_HOME already encodes the profile — no profiles/<name> segment.
+    assert resolved == tmp_path / "evolution"
     assert "user1" not in str(resolved)
+    assert "profiles" not in str(resolved)
 
 
-def test_default_dir_honors_active_profile_marker(monkeypatch, tmp_path):
+def test_default_dir_falls_back_to_home_hermes_when_no_env(monkeypatch, tmp_path):
     monkeypatch.delenv("EVOLUTION_PROFILE_DIR", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / "active_profile").write_text("osoba\n", encoding="utf-8")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     resolved = _default_evolution_dir()
-    assert resolved == tmp_path / "profiles" / "osoba" / "evolution"
+    assert resolved == tmp_path / ".hermes" / "evolution"
+    assert "user1" not in str(resolved)


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the server data-move + symlink is in place (see below)

## Problem
The evolution pipeline hardcodes `~/.hermes/profiles/user1/evolution` across **producers** (cron stage prompts, SKILL.md docs the agent obeys) and **consumers** (scripts). `user1` is a fixed literal decoupled from the active profile — it only "works" because every side agrees on the same string. The server (and standard installs) run the **`default`** profile, so the literal is wrong/misleading, and the evolution skill force-sync silently no-ops there.

## Fix
Migrate the whole namespace to **`$HERMES_HOME/evolution`** — profile-agnostic, because HERMES_HOME already encodes the profile (default → `~/.hermes`, named `foo` → `~/.hermes/profiles/foo`). No profile segment is hardcoded anywhere.

**32 files, one atomic PR** (producer + consumer switch together):
- 14 scripts + `cron/evolution_preflight.py`: drop `profiles/user1` from every evolution-dir default; `$EVOLUTION_PROFILE_DIR` override unchanged.
- `evolution_research_local.py`: realign `_default_evolution_dir()` to `$HERMES_HOME/evolution`.
- `cron/evolution/*.yaml` (8): prompt `Output to:` + vestigial `output.file`/`log_file` → `~/.hermes/evolution|logs` (agent file tools expand `~`, not `$VAR`).
- `skills/evolution/*/SKILL.md` (7): agent-facing paths → `~/.hermes/evolution`.
- tests: preflight + research_local path assertions updated.

## Required server step (do this BEFORE/AT merge — makes merge↔data ordering race-free)
Independent review (Gemini) flagged an in-flight-agent race and an `mv`-nesting hazard. The safe sequence bridges old→new so both resolve to one physical dir:
```bash
mkdir -p ~/.hermes/evolution
rsync -a ~/.hermes/profiles/user1/evolution/ ~/.hermes/evolution/
rm -rf ~/.hermes/profiles/user1/evolution
ln -s ~/.hermes/evolution ~/.hermes/profiles/user1/evolution   # bridge in-flight jobs / old prompts
# (later, after in-flight jobs drain and you've confirmed) optionally: rm the symlink
```

## Verification
- `tests/scripts/` 628 passed; `tests/cron/` 696 passed. ruff + black + evolution_skill_lint clean.
- Two unrelated failures confirmed **pre-existing on origin/main** (flaky): `test_script_timeout`, `test_codex...401_refresh` (DB-lock under parallel load — passes in isolation).

## Left untouched (flagged)
`evolution-integration/SKILL.md:299` skills-deploy path `profiles/user1/skills/evolution` — a **distinct subsystem** (skill deployment, not evolution data) with a fail-safe `-d` guard. Its correct profile-agnostic form needs the skills-deploy convention verified first; not guessed here.