### PR TITLE
fix(evolution): skills force-sync uses $HERMES_HOME/skills, not profiles/user1

### DIFF
--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -291,12 +291,13 @@ for s in evolution_funnel evolution_watchdog; do
   diff -q "scripts/$s.py" "${HERMES_HOME:-$HOME/.hermes}/scripts/$s.py" >/dev/null 2>&1 \
     || echo "WARN: $s.py did NOT deploy to HERMES_HOME/scripts — investigate before relying on it"
 done
-# The SKILLS the agent READS live in the profile (profiles/<profile>/skills/),
-# seeded as COPIES by `hermes update` — which KEEPS copies it deems
+# The SKILLS the agent READS live under HERMES_HOME (<hermes_home>/skills/ —
+# ~/.hermes/skills on the default profile, ~/.hermes/profiles/<name>/skills on a
+# named one), seeded as COPIES by `hermes update` — which KEEPS copies it deems
 # user-modified, so a merged evolution-SKILL change (e.g. this very file) can
 # silently never reach the running agent. Force-sync our own evolution skills
 # (system-managed, not user content) from the just-synced checkout:
-PROFILE_SKILLS="${HERMES_HOME:-$HOME/.hermes}/profiles/user1/skills/evolution"
+PROFILE_SKILLS="${HERMES_HOME:-$HOME/.hermes}/skills/evolution"
 [ -d "$PROFILE_SKILLS" ] && cp -rf skills/evolution/. "$PROFILE_SKILLS"/ \
   && echo "evolution skills synced to profile" || echo "WARN: profile skills dir absent"
 ```


### PR DESCRIPTION
## Summary
Follow-up to #803 (the flagged skills-deploy path). The evolution-integration force-sync targeted `${HERMES_HOME:-$HOME/.hermes}/profiles/user1/skills/evolution` — a path that **does not exist on the default-profile server**. Skills live at `get_profile_dir()/skills` = `$HERMES_HOME/skills` (`~/.hermes/skills` on default, `~/.hermes/profiles/<name>/skills` on a named profile — verified in `hermes_cli/profiles.py:348,754`). The `-d` guard made the force-sync **silently no-op**, so merged evolution-SKILL changes never reached the running agent.

## Fix
`skills/evolution/evolution-integration/SKILL.md`: point the sync at `${HERMES_HOME:-$HOME/.hermes}/skills/evolution` (profile-agnostic), and correct the doc comment.

Verified: no `user1` literals remain in live evolution files; `evolution_skill_lint` clean.