### PR TITLE
feat(#787): consume fallback_directive in agent loop guardrail output

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -420,18 +420,28 @@ class ToolCallGuardrailController:
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
-    """Build a synthetic role=tool content string for a blocked tool call."""
-    return json.dumps(
-        {
-            "error": decision.message,
-            "guardrail": decision.to_metadata(),
-        },
-        ensure_ascii=False,
-    )
+    """Build a synthetic role=tool content string for a blocked tool call.
+
+    When the decision carries a ``fallback_directive`` (#744/#785/#787), it is
+    surfaced as a top-level field so the model sees a concrete alternative
+    action instead of only the free-text error message.
+    """
+    payload: dict[str, Any] = {
+        "error": decision.message,
+        "guardrail": decision.to_metadata(),
+    }
+    if decision.fallback_directive:
+        payload["fallback_directive"] = decision.fallback_directive
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
-    """Append runtime guidance to the current tool result content."""
+    """Append runtime guidance to the current tool result content.
+
+    When the decision carries a ``fallback_directive`` (#744/#785/#787), the
+    directive is appended as a separate labelled line so the model sees a
+    concrete alternative action alongside the loop warning.
+    """
     if decision.action not in {"warn", "halt"} or not decision.message:
         return result
     label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
@@ -439,6 +449,8 @@ def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> s
         f"\n\n[{label}: "
         f"{decision.code}; count={decision.count}; {decision.message}]"
     )
+    if decision.fallback_directive:
+        suffix += f"\n[Fallback directive: {decision.fallback_directive}]"
     return (result or "") + suffix
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6000,12 +6000,17 @@ class AIAgent:
         self, decision: ToolGuardrailDecision
     ) -> str:
         tool = decision.tool_name or "a tool"
-        return (
+        response = (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "
             "attempts. The last tool result explains the blocker; the next step is "
             "to change strategy instead of repeating the same call."
         )
+        # #744/#787 — surface the concrete fallback directive so the model
+        # (and the user) sees a suggested alternative action, not just a halt.
+        if decision.fallback_directive:
+            response += f" Suggested alternative: {decision.fallback_directive}."
+        return response
 
     def _append_guardrail_observation(
         self,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -6,8 +6,10 @@ from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
     ToolCallSignature,
+    append_toolguard_guidance,
     canonical_tool_args,
     classify_tool_failure,
+    toolguard_synthetic_result,
 )
 
 
@@ -365,3 +367,93 @@ def test_fallback_directive_covers_video_media_tools():
 
     assert "read_file" in _fallback_directive_for("video_analyze")
     assert "placeholder" in _fallback_directive_for("video_generate")
+
+
+# ── #787: fallback_directive consumption in guardrail output ──────────────────
+
+
+def _make_warn_decision_with_directive(
+    tool_name: str = "read_file", directive: str = "use search_files instead"
+):
+    """Build a warn decision with a non-empty fallback_directive for output tests."""
+    from agent.tool_guardrails import ToolGuardrailDecision, ToolCallSignature
+
+    return ToolGuardrailDecision(
+        action="warn",
+        code="repeated_exact_failure_warning",
+        message="read_file has failed 2 times with identical arguments.",
+        tool_name=tool_name,
+        count=2,
+        signature=ToolCallSignature.from_call(tool_name, {"path": "/bad"}),
+        fallback_directive=directive,
+    )
+
+
+def test_synthetic_result_includes_fallback_directive_as_top_level_field():
+    """toolguard_synthetic_result surfaces fallback_directive at the top level (#787)."""
+    decision = _make_warn_decision_with_directive(directive="use search_files instead")
+    payload = json.loads(toolguard_synthetic_result(decision))
+
+    assert "fallback_directive" in payload
+    assert payload["fallback_directive"] == "use search_files instead"
+    # The directive is also in the nested guardrail metadata (from #785)
+    assert payload["guardrail"]["fallback_directive"] == "use search_files instead"
+
+
+def test_synthetic_result_omits_fallback_directive_when_empty():
+    """When fallback_directive is empty, the top-level key is absent (backward compat)."""
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="repeated_exact_failure_block",
+        message="blocked",
+        tool_name="web_search",
+        count=5,
+        fallback_directive="",
+    )
+    payload = json.loads(toolguard_synthetic_result(decision))
+
+    assert "fallback_directive" not in payload
+    assert "fallback_directive" not in payload.get("guardrail", {})
+
+
+def test_append_guidance_includes_fallback_directive_in_suffix():
+    """append_toolguard_guidance appends the fallback directive as a labelled line (#787)."""
+    decision = _make_warn_decision_with_directive(directive="use search_files instead")
+    result = append_toolguard_guidance("tool output here", decision)
+
+    assert "[Fallback directive: use search_files instead]" in result
+    assert "[Tool loop warning:" in result
+    assert result.startswith("tool output here")
+
+
+def test_append_guidance_omits_fallback_directive_line_when_empty():
+    """When fallback_directive is empty, no directive line is appended (backward compat)."""
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    decision = ToolGuardrailDecision(
+        action="warn",
+        code="repeated_exact_failure_warning",
+        message="failed 2 times",
+        tool_name="web_search",
+        count=2,
+        fallback_directive="",
+    )
+    result = append_toolguard_guidance("output", decision)
+
+    assert "[Fallback directive:" not in result
+    assert "[Tool loop warning:" in result
+
+
+def test_append_guidance_no_directive_for_allow_decision():
+    """Allow decisions are unchanged by fallback_directive wiring (#787 regression)."""
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    decision = ToolGuardrailDecision(
+        action="allow",
+        tool_name="read_file",
+        fallback_directive="",
+    )
+    result = append_toolguard_guidance("output", decision)
+    assert result == "output"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,44 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+# ── #787: fallback_directive consumption in halt response ─────────────────────
+
+
+def test_controlled_halt_response_includes_fallback_directive_when_present():
+    """The halt response surfaces the fallback_directive so the model sees an alternative (#787)."""
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    agent = _make_agent("web_search")
+    decision = ToolGuardrailDecision(
+        action="halt",
+        code="same_tool_failure_halt",
+        message="web_search failed 8 times this turn.",
+        tool_name="web_search",
+        count=8,
+        fallback_directive="use web_extract on a known URL instead",
+    )
+    response = agent._toolguard_controlled_halt_response(decision)
+
+    assert "stopped retrying web_search" in response
+    assert "Suggested alternative: use web_extract on a known URL instead." in response
+
+
+def test_controlled_halt_response_omits_directive_when_empty():
+    """When fallback_directive is empty, the halt response is unchanged (backward compat)."""
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    agent = _make_agent("web_search")
+    decision = ToolGuardrailDecision(
+        action="halt",
+        code="same_tool_failure_halt",
+        message="web_search failed 8 times this turn.",
+        tool_name="web_search",
+        count=8,
+        fallback_directive="",
+    )
+    response = agent._toolguard_controlled_halt_response(decision)
+
+    assert "stopped retrying web_search" in response
+    assert "Suggested alternative:" not in response


### PR DESCRIPTION
## Summary

Closes #787. Wires the `fallback_directive` field (added by #785) into all three guardrail consumption points so the model sees a concrete alternative action instead of only a halt/warning message.

## Changes

1. **`toolguard_synthetic_result`** (`agent/tool_guardrails.py`): surface `fallback_directive` as a top-level JSON field (not just nested in guardrail metadata) so the model sees it prominently in blocked-call results.

2. **`append_toolguard_guidance`** (`agent/tool_guardrails.py`): append the directive as a labelled `[Fallback directive: ...]` line after warn/halt warnings so the model sees the alternative alongside the loop warning.

3. **`_toolguard_controlled_halt_response`** (`run_agent.py`): append `Suggested alternative: ...` to the halt response so both the model and the user see a concrete next step.

All three sites are no-ops when `fallback_directive` is empty (backward compatible).

## Tests

7 new tests covering directive-present and directive-empty paths for each consumption point:
- `test_synthetic_result_includes_fallback_directive_as_top_level_field`
- `test_synthetic_result_omits_fallback_directive_when_empty`
- `test_append_guidance_includes_fallback_directive_in_suffix`
- `test_append_guidance_omits_fallback_directive_line_when_empty`
- `test_append_guidance_no_directive_for_allow_decision`
- `test_controlled_halt_response_includes_fallback_directive_when_present`
- `test_controlled_halt_response_omits_directive_when_empty`

All 37 tests in the guardrail test files pass via `scripts/run_tests.sh`.

## Diff size

170 changed lines (160 insertions, 10 deletions) across 4 files — within the 200-line self-merge cap.

## Pre-existing failure note

`tests/agent/test_copilot_acp_client.py::test_run_prompt_preserves_real_home_when_profile_home_available` fails on clean `origin/main` (verified via `git stash`) — unrelated to this PR.