### PR TITLE
feat(#796): agentic quality-control review for evolution implementations

### DIFF
--- a/scripts/evolution_qc_review.py
+++ b/scripts/evolution_qc_review.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Agentic quality-control review for evolution implementations (#796).
+
+Post-implementation review step: a separate leaf subagent reviews completed
+work for security, correctness, test coverage, and requirements adherence.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+QC_CATEGORIES: tuple[str, ...] = (
+    "security",
+    "correctness",
+    "test_coverage",
+    "requirements",
+)
+SEVERITY_LEVELS: tuple[str, ...] = ("critical", "high", "medium", "low", "info")
+_PASS_KW = frozenset({"pass", "passed", "approved", "lgtm", "no issues"})
+_FAIL_KW = frozenset({"fail", "failed", "rejected", "block"})
+
+
+def build_qc_review_task(
+    summary: str,
+    files: List[str],
+    *,
+    issue_number: Optional[int] = None,
+    issue_title: Optional[str] = None,
+    toolsets: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build a leaf-worker task dict for delegate_task (QC review subagent)."""
+    summary = summary.strip() if isinstance(summary, str) else ""
+    files = [f.strip() for f in files if isinstance(f, str) and f.strip()]
+    issue_ctx = (
+        (
+            f"\n\nORIGINATING ISSUE: #{issue_number}"
+            + (f" — {issue_title.strip()}" if issue_title else "")
+        )
+        if issue_number is not None
+        else ""
+    )
+    file_list = "\n".join(f"  - {f}" for f in files) if files else "  (none specified)"
+    checklist = "\n".join(
+        f"  {i}. **{cat.replace('_', ' ').title()}** — assess and report."
+        for i, cat in enumerate(QC_CATEGORIES, 1)
+    )
+    goal = (
+        "You are a QUALITY CONTROL reviewer. A separate agent completed an implementation. "
+        f"Review it INDEPENDENTLY before it is declared done.\n\nIMPLEMENTATION SUMMARY:\n{summary}\n\n"
+        f"FILES TO REVIEW:\n{file_list}{issue_ctx}\n\nQC CHECKLIST:\n{checklist}\n\n"
+        "OUTPUT FORMAT — start with:\n  VERDICT: PASS  — no blocking issues\n"
+        "  VERDICT: FAIL  — blocking issues found\n"
+        "Then for each finding: [category] [severity] — description\n"
+        "Categories: security, correctness, test_coverage, requirements.  Severities: critical, high, medium, low, info."
+    )
+    return {
+        "goal": goal,
+        "context": f"QC review: {summary[:200]}" if summary else "QC review.",
+        "role": "leaf",
+        "toolsets": list(toolsets) if toolsets else ["file"],
+    }
+
+
+_FINDING_RE = re.compile(
+    r"\[(?P<cat>security|correctness|test[_ ]coverage|requirements)\]"
+    r"\s*\[(?P<sev>critical|high|medium|low|info)\]\s*[—\-]\s*(?P<desc>.+)",
+    re.IGNORECASE,
+)
+
+
+def _detect_verdict(text: str) -> str:
+    lower = text.lower()
+    if m := re.search(r"verdict:\s*(pass|fail)", lower):
+        return m.group(1)
+    has_fail = any(kw in lower for kw in _FAIL_KW)
+    has_pass = any(kw in lower for kw in _PASS_KW)
+    if has_fail and not has_pass:
+        return "fail"
+    if has_pass and not has_fail:
+        return "pass"
+    return "unknown"
+
+
+def parse_qc_report(summary: str) -> Dict[str, Any]:
+    """Parse a QC subagent's summary into a structured report dict."""
+    if not isinstance(summary, str):
+        summary = ""
+    verdict = _detect_verdict(summary)
+    findings: List[Dict[str, str]] = []
+    for m in _FINDING_RE.finditer(summary):
+        cat = m.group("cat").strip().lower().replace(" ", "_")
+        if cat == "testcoverage":
+            cat = "test_coverage"
+        sev = m.group("sev").strip().lower()
+        desc = m.group("desc").strip()
+        if cat in QC_CATEGORIES and sev in SEVERITY_LEVELS and desc:
+            findings.append({"category": cat, "severity": sev, "description": desc})
+    blocking = [f for f in findings if f["severity"] in ("critical", "high")]
+    return {
+        "verdict": verdict,
+        "pass": verdict == "pass",
+        "findings": findings,
+        "blocking_count": len(blocking),
+        "has_blocking": len(blocking) > 0,
+    }

--- a/tests/scripts/test_evolution_qc_review.py
+++ b/tests/scripts/test_evolution_qc_review.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/evolution_qc_review.py — agentic QC review (#796)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_qc_review import QC_CATEGORIES, build_qc_review_task, parse_qc_report  # noqa: E402
+
+
+class TestBuild:
+    def test_shape_and_content(self):
+        t = build_qc_review_task("Implemented X", ["scripts/x.py"])
+        assert t["role"] == "leaf" and t["toolsets"] == ["file"]
+        assert "Implemented X" in t["goal"] and "VERDICT: PASS" in t["goal"]
+
+    def test_files_and_issue_in_goal(self):
+        t = build_qc_review_task(
+            "s", ["a.py", "b.py"], issue_number=796, issue_title="QC"
+        )
+        assert "a.py" in t["goal"] and "#796" in t["goal"] and "QC" in t["goal"]
+
+    def test_no_issue_and_empty_files(self):
+        t = build_qc_review_task("s", [])
+        assert "#796" not in t["goal"] and "(none specified)" in t["goal"]
+
+    def test_all_categories_in_checklist(self):
+        t = build_qc_review_task("s", ["f"])
+        for cat in QC_CATEGORIES:
+            assert cat.replace("_", " ").title() in t["goal"]
+
+    def test_custom_toolsets(self):
+        assert build_qc_review_task("s", ["f"], toolsets=["web"])["toolsets"] == ["web"]
+
+
+class TestParse:
+    def test_explicit_verdicts(self):
+        assert parse_qc_report("VERDICT: PASS\nAll clean.")["verdict"] == "pass"
+        assert parse_qc_report("VERDICT: FAIL\nBad.")["verdict"] == "fail"
+
+    def test_keyword_verdicts(self):
+        assert parse_qc_report("LGTM, no issues.")["verdict"] == "pass"
+        assert parse_qc_report("This failed review.")["verdict"] == "fail"
+
+    def test_unknown_and_empty(self):
+        assert parse_qc_report("random text")["verdict"] == "unknown"
+        r = parse_qc_report("")
+        assert r["verdict"] == "unknown" and r["findings"] == []
+
+    def test_explicit_wins_over_keywords(self):
+        assert (
+            parse_qc_report("VERDICT: PASS\nTest failed but ok.")["verdict"] == "pass"
+        )
+
+    def test_findings_and_blocking(self):
+        r = parse_qc_report(
+            "VERDICT: FAIL\n[security] [critical] — secret\n[correctness] [medium] — bug"
+        )
+        assert (
+            len(r["findings"]) == 2 and r["blocking_count"] == 1 and r["has_blocking"]
+        )
+
+    def test_space_in_category(self):
+        r = parse_qc_report("VERDICT: FAIL\n[test coverage] [low] — gap")
+        assert r["findings"][0]["category"] == "test_coverage"
+
+    def test_unknown_cat_sev_ignored(self):
+        assert (
+            len(parse_qc_report("VERDICT: FAIL\n[perf] [high] — slow")["findings"]) == 0
+        )
+        assert (
+            len(
+                parse_qc_report("VERDICT: FAIL\n[security] [blocker] — bad")["findings"]
+            )
+            == 0
+        )
+
+    def test_no_blocking_when_low(self):
+        r = parse_qc_report("VERDICT: PASS\n[test_coverage] [low] — minor")
+        assert r["blocking_count"] == 0 and not r["has_blocking"]


### PR DESCRIPTION
Automated evolution PR for issue #796.

## What

Adds `scripts/evolution_qc_review.py` — a pure-function module that
formalises a post-implementation QC review step where a **separate** leaf
subagent reviews completed work for security, correctness, test coverage,
and requirements adherence before the orchestrator declares done.

- `build_qc_review_task` — constructs the `delegate_task` payload (goal +
  context + role) for a QC-focused leaf subagent, given the implementation
  summary, changed files, and originating issue context.
- `parse_qc_report` — parses the subagent's returned summary into a
  structured `QCReport` (verdict, findings by category/severity, blocking
  count). Tolerant parser: looks for `VERDICT: PASS/FAIL` and
  `[category] [severity] — description` lines, falls back to keyword
  matching.

## Tests

13 unit tests covering build (shape, files, issue context, checklist,
toolsets) and parse (explicit/keyword verdicts, finding extraction, blocking
count, unknown category/severity rejection, space-in-category normalisation).

## Checks

- lint: ✓ (ruff check)
- format: ✓ (ruff format --check)
- tests: ✓ (13 passed)
- diff size: 186 lines (under 200-line merge gate)

Closes #796