### PR TITLE
feat(#798): parallel draft mode and cost-aware model routing

### DIFF
--- a/scripts/evolution_draft_selector.py
+++ b/scripts/evolution_draft_selector.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Parallel draft mode and cost-aware routing for multi-agent coordination (#798).
+
+Complements the existing evolution_orchestrator.py (fan-out by DIFFERENT angles)
+with parallel drafts of the SAME task plus model cost-tier routing.
+
+  * ``build_draft_tasks`` — N identical delegate_task payloads for parallel
+    drafting (multiple agents attempt the same task).
+  * ``select_best_draft`` — pick the best draft from parallel results, using
+    explicit scores if provided or a heuristic otherwise.
+  * ``route_cost_tier`` — map a 0-1 complexity score to a recommended model
+    cost tier (frontier / standard / economy).
+
+Note: delegate_task does not support per-call model selection — children
+inherit the parent model. Cost-aware routing is therefore a CONFIGURATION
+RECOMMENDATION layer: it maps complexity to a tier which the caller uses
+when setting delegation.model in config.yaml.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+COST_TIERS: tuple[str, ...] = ("frontier", "standard", "economy")
+_OK_STATUSES = frozenset({"completed", "success", "ok"})
+_COMPLEXITY_LOW = 0.3
+_COMPLEXITY_HIGH = 0.7
+
+
+def route_cost_tier(complexity: float) -> str:
+    """Map a complexity score (0.0–1.0) to a recommended model cost tier.
+
+    < 0.3 → economy, < 0.7 → standard, else frontier.
+    """
+    complexity = max(0.0, min(1.0, complexity))
+    if complexity < _COMPLEXITY_LOW:
+        return "economy"
+    if complexity < _COMPLEXITY_HIGH:
+        return "standard"
+    return "frontier"
+
+
+def build_draft_tasks(
+    goal: str,
+    n_drafters: int = 2,
+    *,
+    context: str = "",
+    toolsets: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Build N identical leaf-worker tasks for parallel draft mode.
+
+    Each drafter gets the same goal — the orchestrator selects the best result
+    after collection. Returns a list of delegate_task-compatible dicts.
+    """
+    if n_drafters < 1:
+        n_drafters = 1
+    task = {
+        "goal": goal,
+        "context": context or (goal[:200] if isinstance(goal, str) else ""),
+        "role": "leaf",
+        "toolsets": list(toolsets) if toolsets else ["file"],
+    }
+    return [task.copy() for _ in range(n_drafters)]
+
+
+def select_best_draft(
+    results: List[Dict[str, Any]],
+    *,
+    scores: Optional[List[float]] = None,
+) -> Dict[str, Any]:
+    """Select the best draft from parallel delegate_task results.
+
+    If *scores* are provided (same length as *results*), picks the highest.
+    Otherwise uses a heuristic: prefer completed/success status, then longest
+    summary (proxy for thoroughness). Returns a dict with selected_index,
+    result, and reason.
+    """
+    if not results:
+        return {"selected_index": -1, "result": None, "reason": "no drafts"}
+
+    if scores and len(scores) == len(results):
+        best_idx = max(range(len(scores)), key=lambda i: scores[i])
+        return {
+            "selected_index": best_idx,
+            "result": results[best_idx],
+            "reason": "highest_score",
+        }
+
+    ok = [(i, r) for i, r in enumerate(results) if r.get("status", "") in _OK_STATUSES]
+    pool = ok if ok else list(enumerate(results))
+    best_idx = max(pool, key=lambda pair: len(str(pair[1].get("summary", ""))))[0]
+    return {
+        "selected_index": best_idx,
+        "result": results[best_idx],
+        "reason": "heuristic",
+    }

--- a/tests/scripts/test_evolution_draft_selector.py
+++ b/tests/scripts/test_evolution_draft_selector.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/evolution_draft_selector.py — parallel draft + cost routing (#798)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_draft_selector import (  # noqa: E402
+    COST_TIERS,
+    build_draft_tasks,
+    route_cost_tier,
+    select_best_draft,
+)
+
+
+class TestRouteCostTier:
+    def test_low_complexity_economy(self):
+        assert route_cost_tier(0.1) == "economy"
+
+    def test_mid_complexity_standard(self):
+        assert route_cost_tier(0.5) == "standard"
+
+    def test_high_complexity_frontier(self):
+        assert route_cost_tier(0.9) == "frontier"
+
+    def test_boundary_and_clamp(self):
+        assert route_cost_tier(0.0) == "economy"
+        assert route_cost_tier(0.3) == "standard"
+        assert route_cost_tier(0.7) == "frontier"
+        assert route_cost_tier(1.0) == "frontier"
+        assert route_cost_tier(-0.5) == "economy"
+        assert route_cost_tier(1.5) == "frontier"
+
+    def test_all_tiers_used(self):
+        results = {route_cost_tier(c) for c in (0.0, 0.5, 0.9)}
+        assert results == set(COST_TIERS)
+
+
+class TestBuildDraftTasks:
+    def test_creates_n_identical_tasks(self):
+        tasks = build_draft_tasks("Write a function", 3)
+        assert len(tasks) == 3
+        assert all(t["goal"] == "Write a function" for t in tasks)
+
+    def test_default_n_is_2(self):
+        assert len(build_draft_tasks("goal")) == 2
+
+    def test_n_below_1_clamped_to_1(self):
+        assert len(build_draft_tasks("goal", 0)) == 1
+
+    def test_role_and_toolsets(self):
+        assert all(t["role"] == "leaf" for t in build_draft_tasks("g", 2))
+        assert build_draft_tasks("g", 1)[0]["toolsets"] == ["file"]
+        assert build_draft_tasks("g", 1, toolsets=["web"])[0]["toolsets"] == ["web"]
+
+    def test_context(self):
+        assert (
+            build_draft_tasks("g", 1, context="custom ctx")[0]["context"]
+            == "custom ctx"
+        )
+        t = build_draft_tasks("A very long goal " * 20, 1)[0]
+        assert t["context"] == ("A very long goal " * 20)[:200]
+
+    def test_tasks_are_copies(self):
+        tasks = build_draft_tasks("g", 2)
+        tasks[0]["goal"] = "changed"
+        assert tasks[1]["goal"] == "g"
+
+
+class TestSelectBestDraft:
+    def test_empty_returns_nothing(self):
+        r = select_best_draft([])
+        assert r["selected_index"] == -1 and r["result"] is None
+
+    def test_with_scores_picks_highest(self):
+        results = [{"summary": "a"}, {"summary": "b"}, {"summary": "c"}]
+        r = select_best_draft(results, scores=[0.3, 0.9, 0.5])
+        assert r["selected_index"] == 1 and r["reason"] == "highest_score"
+
+    def test_heuristic_prefers_completed(self):
+        results = [
+            {"status": "running", "summary": "x" * 100},
+            {"status": "completed", "summary": "short"},
+        ]
+        r = select_best_draft(results)
+        assert r["selected_index"] == 1
+
+    def test_heuristic_longest_summary(self):
+        results = [
+            {"status": "completed", "summary": "short"},
+            {"status": "completed", "summary": "much longer summary"},
+        ]
+        r = select_best_draft(results)
+        assert r["selected_index"] == 1
+
+    def test_score_length_mismatch_falls_back(self):
+        results = [{"summary": "a"}, {"summary": "bb"}]
+        r = select_best_draft(results, scores=[0.5])
+        assert r["reason"] == "heuristic"
+
+    def test_single_result(self):
+        r = select_best_draft([{"summary": "only"}])
+        assert r["selected_index"] == 0


### PR DESCRIPTION
Automated evolution PR for issue #798.

## What

Adds `scripts/evolution_draft_selector.py` — pure-function module
complementing the existing `evolution_orchestrator.py` (fan-out by different
angles) with parallel drafts of the SAME task plus model cost-tier routing.

- `build_draft_tasks(goal, n_drafters)` — N identical `delegate_task` payloads
  for parallel drafting (multiple agents attempt the same task).
- `select_best_draft(results, scores)` — pick the best draft from parallel
  results, using explicit scores if provided or a heuristic (prefer completed
  status, then longest summary as thoroughness proxy).
- `route_cost_tier(complexity)` — map a 0–1 complexity score to a recommended
  model cost tier (frontier / standard / economy). This is a configuration
  recommendation layer — delegate_task does not support per-call model
  selection; the caller uses the tier when setting delegation.model in config.yaml.

## Tests

17 unit tests covering cost-tier routing (boundaries, clamping, all tiers),
draft task construction (n_drafters, defaults, toolsets, context, copies),
and best-draft selection (scores, heuristic, status preference, mismatches).

## Checks

- lint: ✓ (ruff check)
- format: ✓ (ruff format --check)
- tests: ✓ (17 passed)
- diff size: 199 lines (under 200-line merge gate)

Closes #798