### PR TITLE
feat(#750): add optional Model-First Reasoning scaffold

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1362,6 +1362,12 @@ def init_agent(
     # are noisy.
     agent._environment_probe = bool(_agent_section.get("environment_probe", True))
 
+    # Optional Model-First Reasoning scaffold (issue #750).  Default False.
+    # When True, injects a prompt fragment asking the model to write an
+    # explicit problem model before planning non-trivial tasks.  Stable
+    # prefix — no prompt-cache break.
+    agent._model_first_reasoning = bool(_agent_section.get("model_first_reasoning", False))
+
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in
     # platform hint for a single messaging platform (e.g. WhatsApp) without

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -609,6 +609,23 @@ PARALLEL_TOOL_CALL_GUIDANCE = (
     "in doubt and the calls are independent, batch them."
 )
 
+# Optional Model-First Reasoning scaffold (issue #750).  Off by default —
+# injected only when ``agent.model_first_reasoning`` is True.  Asks the model
+# to write down an explicit problem model (entities, state variables,
+# preconditions/effects, constraints) before producing a plan or tool
+# sequence for complex tasks.  Stable prompt prefix → no cache break.
+# Research: arxiv 2512.14474 (Model-First Reasoning reduces constraint
+# violations and hallucinations in planning).
+MODEL_FIRST_REASONING_GUIDANCE = (
+    "# Model-First Reasoning\n"
+    "Before producing a plan or tool sequence for a non-trivial task, write a "
+    "brief problem model: list the key entities, state variables, action "
+    "preconditions and effects, and constraints. Then produce your plan or "
+    "tool sequence with that model in mind. This reduces constraint violations "
+    "and hallucinated steps. Skip the model for trivial tasks (a single read, "
+    "a one-line answer, a simple formatting request) where it adds no value."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -34,6 +34,7 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
+    MODEL_FIRST_REASONING_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
@@ -195,6 +196,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # (default True) and only injected when tools are actually loaded.
     if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
+
+    # Optional Model-First Reasoning scaffold (issue #750).  Off by default
+    # — injected only when ``agent.model_first_reasoning`` is True.  Stable
+    # prompt prefix, so no cache break.  Asks the model to write an explicit
+    # problem model before planning complex tasks.
+    if getattr(agent, "_model_first_reasoning", False) and agent.valid_tool_names:
+        stable_parts.append(MODEL_FIRST_REASONING_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -977,6 +977,14 @@ DEFAULT_CONFIG = {
         # (docker/modal/ssh — they have their own probe).  Set False to
         # disable entirely.
         "environment_probe": True,
+        # Optional Model-First Reasoning scaffold (issue #750).  Off by
+        # default — when True, injects a prompt fragment asking the model to
+        # write an explicit problem model (entities, state variables,
+        # preconditions/effects, constraints) before producing a plan or tool
+        # sequence for non-trivial tasks.  Stable prompt prefix, so it does
+        # not break prompt caching.  Costs ~80 tokens in the cached system
+        # prompt when enabled.  Set True to enable globally.
+        "model_first_reasoning": False,
         # Embedder-supplied environment description appended to the system
         # prompt's environment-hints block. Lets a host that wraps Hermes
         # (sandbox runner, managed platform) explain the runtime environment

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -122,3 +122,33 @@ class TestTqmemoryGuidance:
             platform="cli",
         )
         assert self.MARKER not in _stable_prompt(agent)
+
+
+class TestModelFirstReasoning:
+    """MODEL_FIRST_REASONING_GUIDANCE is injected only when
+    ``agent._model_first_reasoning`` is True and tools are loaded."""
+
+    MARKER = "# Model-First Reasoning"
+
+    def test_absent_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        agent = _make_agent(valid_tool_names=["read_file"], platform="cli")
+        assert self.MARKER not in _stable_prompt(agent)
+
+    def test_injected_when_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        agent = _make_agent(
+            valid_tool_names=["read_file"],
+            platform="cli",
+            _model_first_reasoning=True,
+        )
+        assert self.MARKER in _stable_prompt(agent)
+
+    def test_absent_without_tools_even_when_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        agent = _make_agent(
+            valid_tool_names=[],
+            platform="cli",
+            _model_first_reasoning=True,
+        )
+        assert self.MARKER not in _stable_prompt(agent)


### PR DESCRIPTION
## Summary

Add a config-gated, off-by-default prompt fragment that asks the model to write an explicit problem model (entities, state variables, action preconditions/effects, constraints) before producing a plan or tool sequence for non-trivial tasks. Research (arxiv 2512.14474) shows Model-First Reasoning reduces constraint violations and hallucinations in planning.

## Changes (69 lines, 5 files)

| File | Change |
|------|--------|
| `agent/prompt_builder.py` | Add `MODEL_FIRST_REASONING_GUIDANCE` constant |
| `agent/system_prompt.py` | Import + inject in stable tier, gated by `agent._model_first_reasoning` |
| `agent/agent_init.py` | Read `model_first_reasoning` from config `agent` section |
| `hermes_cli/config.py` | Add `model_first_reasoning: False` to `DEFAULT_CONFIG` |
| `tests/agent/test_system_prompt.py` | 3 tests: absent by default, injected when enabled, absent without tools |

## Design

Follows the established pattern for config-gated prompt fragments (same as `task_completion_guidance`, `parallel_tool_call_guidance`, `environment_probe`):

1. Config key in `DEFAULT_CONFIG` under `agent:` section (default `False`)
2. Attribute set on agent in `agent_init.py`
3. Conditional injection in `build_system_prompt_parts()` stable tier
4. Only injected when tools are loaded (no point without tools)

**Prompt caching is preserved**: the scaffold is a stable prompt prefix injected once at session start and cached for the conversation lifetime. No mid-session rebuild.

**Off by default** = zero token cost and zero behavior change unless the user opts in via `config.yaml`:
```yaml
agent:
  model_first_reasoning: true
```

## Test Results

```
tests/agent/test_system_prompt.py  — 10✓ 0✗
tests/agent/test_prompt_builder.py — 177✓ 0✗
tests/hermes_cli/test_config.py    — 132✓ 0✗
```

Closes #750