### PR TITLE
feat: parallel draft mode for multi-agent coordination — increment 1 of #798

### DIFF
--- a/scripts/evolution_draft_selector.py
+++ b/scripts/evolution_draft_selector.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Parallel draft mode (#798 inc 1): build N draft tasks, select best. Cost routing deferred."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+DEFAULT_MAX_DRAFTERS = 3
+_OK = frozenset({"completed", "success", "ok"})
+_PAT = r"(?:^|\n)\s*(?:#{1,3}\s|```|[-*]\s|\d+\.\s)"
+
+
+def _s(v: Any) -> str:
+    return v.strip() if isinstance(v, str) else ""
+
+
+def build_draft_tasks(
+    goal: str,
+    n_drafters: int = DEFAULT_MAX_DRAFTERS,
+    *,
+    context: str = "",
+    toolsets: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Build N identical leaf-worker tasks for parallel draft mode via delegate_task."""
+    n = max(1, int(n_drafters))
+    ctx = (
+        _s(context)
+        or "You are one of several independent drafters. Produce your best complete draft."
+    )
+    t = {
+        "goal": _s(goal),
+        "context": ctx,
+        "toolsets": list(toolsets) if toolsets is not None else ["web", "file"],
+        "role": "leaf",
+    }
+    return [dict(t) for _ in range(n)], 0
+
+
+def _score(text: str) -> float:
+    if not text:
+        return 0.0
+    s = min(len(text) / 2000.0, 1.0) * 0.3
+    s += min(len(re.findall(_PAT, text)) / 10.0, 1.0) * 0.3
+    s += min(len(re.findall(r"https?://\S+|\[\d+\]", text)) / 5.0, 1.0) * 0.4
+    return round(s, 4)
+
+
+def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, Any]]]:
+    """Score drafts, pick winner: (best_index, best_score, drafts)."""
+    results = (
+        delegate_output.get("results", [])
+        if isinstance(delegate_output, dict)
+        else (delegate_output if isinstance(delegate_output, list) else [])
+    )
+    drafts: List[Dict[str, Any]] = []
+    for pos, entry in enumerate(results if isinstance(results, list) else []):
+        if not isinstance(entry, dict):
+            entry = {}
+        try:
+            idx = int(entry.get("task_index", pos))
+        except (TypeError, ValueError):
+            idx = pos
+        st, sm = _s(entry.get("status")).lower(), _s(entry.get("summary"))
+        ok = st in _OK and bool(sm)
+        drafts.append({
+            "index": idx,
+            "status": st,
+            "ok": ok,
+            "summary": sm,
+            "score": _score(sm) if ok else 0.0,
+        })
+    drafts.sort(key=lambda d: d["index"])
+    bi, bs = -1, 0.0
+    for d in drafts:
+        if d["ok"] and d["score"] > bs:
+            bs, bi = d["score"], d["index"]
+    return bi, bs, drafts
+
+
+def _load_json(path: Optional[str]) -> Tuple[Any, Optional[str]]:
+    try:
+        raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+        return json.loads(raw), None
+    except (OSError, ValueError) as exc:
+        return None, str(exc)
+
+
+def _flag(args: List[str], name: str) -> Optional[str]:
+    if name in args:
+        i = args.index(name)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 2 or argv[1] in ("-h", "--help"):
+        print("usage: evolution_draft_selector.py {build,select} ...", file=sys.stderr)
+        return 2
+    cmd, args = argv[1], argv[2:]
+    if cmd == "build":
+        goal = _flag(args, "--goal")
+        if not goal:
+            return 2
+        n = DEFAULT_MAX_DRAFTERS
+        dval = _flag(args, "--drafters")
+        if dval:
+            try:
+                n = int(dval)
+            except ValueError:
+                return 2
+        ts_str = _flag(args, "--toolsets")
+        ts = [t.strip() for t in ts_str.split(",") if t.strip()] if ts_str else None
+        tasks, dropped = build_draft_tasks(
+            goal, n, context=_flag(args, "--context") or "", toolsets=ts
+        )
+        print(json.dumps({"tasks": tasks, "dropped": dropped}, ensure_ascii=False))
+        return 0
+    if cmd == "select":
+        path = args[0] if args and not args[0].startswith("-") else None
+        data, err = _load_json(path)
+        if err:
+            return 2
+        bi, bs, drafts = select_best_draft(data)
+        print(
+            json.dumps(
+                {"best_index": bi, "best_score": bs, "drafts": drafts},
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_draft_selector.py
+++ b/tests/scripts/test_evolution_draft_selector.py
@@ -1,0 +1,48 @@
+"""Tests for evolution_draft_selector.py — parallel draft mode (#798 inc 1)."""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+from evolution_draft_selector import DEFAULT_MAX_DRAFTERS, build_draft_tasks, select_best_draft, main  # noqa: E402  # fmt: skip
+
+
+def test_build():
+    tasks, dropped = build_draft_tasks("X", 3)
+    assert dropped == 0 and len(tasks) == 3
+    assert all(t["goal"] == "X" and t["role"] == "leaf" for t in tasks)
+    assert len(build_draft_tasks("g")[0]) == DEFAULT_MAX_DRAFTERS
+    assert len(build_draft_tasks("g", 0)[0]) == 1
+    t2 = build_draft_tasks("g", 1, toolsets=["t"])[0]
+    assert all(t["toolsets"] == ["t"] for t in t2)
+
+
+def test_select():
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "Short."},
+        {"task_index": 1, "status": "completed", "summary": "## H\n\n```python\nx\n```\n\nhttps://e.com\n" * 3},
+    ]}  # fmt: skip
+    bi, bs, drafts = select_best_draft(out)
+    assert bi == 1 and bs > 0.0 and drafts[1]["score"] > drafts[0]["score"]
+    bi2, bs2, _ = select_best_draft({
+        "results": [{"task_index": 0, "status": "timeout", "summary": ""}]
+    })
+    assert bi2 == -1 and bs2 == 0.0
+    for bad in (None, 42, "x", {"no_results": True}):
+        assert select_best_draft(bad)[0] == -1
+
+
+def test_cli(capsys, monkeypatch):
+    assert main(["x", "build", "--goal", "g", "--drafters", "2"]) == 0
+    assert len(json.loads(capsys.readouterr().out)["tasks"]) == 2
+    assert main(["x", "build", "--drafters", "2"]) == 2
+    payload = json.dumps({"results": [
+        {"task_index": 0, "status": "completed", "summary": "s"},
+        {"task_index": 1, "status": "completed", "summary": "## H\nhttps://x.com\n"},
+    ]})  # fmt: skip
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert main(["x", "select"]) == 0
+    assert json.loads(capsys.readouterr().out)["best_index"] == 1
+    assert main(["x"]) == 2 and main(["x", "frob"]) == 2


### PR DESCRIPTION
First coherent slice of #798: parallel draft mode with `build_draft_tasks()` and `select_best_draft()` wired into real CLI call sites.

## What this PR delivers
- `scripts/evolution_draft_selector.py` — `build_draft_tasks(goal, n_drafters)` creates N identical leaf-worker tasks for `delegate_task` batch mode; `select_best_draft(delegate_output)` heuristic-scores collected results (length, structure, citations) and picks the winner.
- `tests/scripts/test_evolution_draft_selector.py` — tests for build, select, and CLI paths.
- CLI subcommands `build` and `select` are the real call sites (no dead code — the rework brief required wiring into real call sites).

## Deferred (next increment)
- `route_cost_tier(complexity)` — cost-aware model routing that maps task complexity to a model tier hint for `delegation.model` in config.yaml. Will add the `route` CLI subcommand and `_TIERS`/`_CMAP` lookup tables.

This is a partial roadmap slice — do NOT close #798 on merge; integration should re-queue it as `next-increment`.