### PR TITLE
feat: refusal taxonomy and recovery for agent self-improvement (Closes #756)

### DIFF
--- a/scripts/evolution_refusal_taxonomy.py
+++ b/scripts/evolution_refusal_taxonomy.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Refusal taxonomy and recovery (#756): classify refusals, detect in session
+text, suggest recovery. CLI call sites — no dead code."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any, Dict, List
+
+TRUE_CAPABILITY_GAP = "true_capability_gap"
+OVER_REFUSAL = "over_refusal"
+MISSING_SKILL_TRIGGER = "missing_skill_trigger"
+PERMISSION_BOUNDARY = "permission_boundary"
+RECOVERABLE_ERROR = "recoverable_error"
+SPURIOUS = "spurious"
+
+_REFUSAL_PAT = re.compile(
+    "|".join([  # fmt: skip
+        r"i can'?t",
+        r"i can not",
+        r"i don'?t have (?:access|permission)",
+        r"no access",
+        r"i'?m unable to",
+        r"i don'?t have (?:a |the )?(?:tool|skill|feature|plugin|ability|capability)",
+        r"i cannot (?:help|assist|do|provide|access)",
+        r"not (?:able|allowed) to",
+    ]),
+    re.IGNORECASE,
+)
+_FP_RE = re.compile(
+    r"i can'?t (?:stress|emphasize|overstate|imagine|believe|say|thank|praise|wait)",
+    re.IGNORECASE,
+)
+_RECOVERY: Dict[str, str] = {  # fmt: skip
+    TRUE_CAPABILITY_GAP: "Install or configure the missing capability, or route to a tool that has it.",
+    OVER_REFUSAL: "The capability exists locally — use the available tool directly.",
+    MISSING_SKILL_TRIGGER: "Activate the relevant skill with /skills install or load it explicitly.",
+    PERMISSION_BOUNDARY: "Legitimate security boundary — explain it and suggest an alternative.",
+    RECOVERABLE_ERROR: "Retry with a different approach — the task is achievable via an alternative path.",
+    SPURIOUS: "Not an actual refusal — no action needed.",
+}
+
+
+def detect_refusals(text: str) -> List[Dict[str, Any]]:
+    """Detect refusal phrases in text, filtering rhetorical false positives."""
+    results: List[Dict[str, Any]] = []
+    for m in _REFUSAL_PAT.finditer(text):
+        snippet = text[m.start() : m.start() + 40]
+        results.append({"phrase": m.group(0), "start": m.start(), "end": m.end(), "is_refusal": not _FP_RE.match(snippet)})  # fmt: skip
+    return results
+
+
+def classify_refusal(
+    text: str, *, has_tool_failure: bool = False, skill_available: bool = False
+) -> str:
+    """Classify a refusal into one of 6 categories."""
+    if not any(r["is_refusal"] for r in detect_refusals(text)):
+        return SPURIOUS
+    if re.search(
+        r"don'?t have (?:a |the )?(?:tool|skill|plugin|feature)", text, re.IGNORECASE
+    ):
+        return TRUE_CAPABILITY_GAP
+    if re.search(r"permission|security|unauthorized|forbidden", text, re.IGNORECASE):
+        return PERMISSION_BOUNDARY
+    if has_tool_failure:
+        return RECOVERABLE_ERROR
+    if skill_available:
+        return MISSING_SKILL_TRIGGER
+    return OVER_REFUSAL
+
+
+def recovery_suggestion(category: str) -> str:
+    return _RECOVERY.get(category, _RECOVERY[SPURIOUS])
+
+
+def analyze_session(
+    text: str, *, has_tool_failure: bool = False, skill_available: bool = False
+) -> Dict[str, Any]:
+    """Analyze a session for refusals and return a report with recovery suggestions."""
+    refusals = [r for r in detect_refusals(text) if r["is_refusal"]]
+    if not refusals:
+        return {"refusal_count": 0, "categories": [], "suggestions": [], "has_refusals": False}  # fmt: skip
+    cats: List[str] = []
+    for r in refusals:
+        cat = classify_refusal(text[r["start"] : r["end"] + 80], has_tool_failure=has_tool_failure, skill_available=skill_available)  # fmt: skip
+        if cat not in cats:
+            cats.append(cat)
+    return {"refusal_count": len(refusals), "categories": cats, "suggestions": [recovery_suggestion(c) for c in cats], "has_refusals": True}  # fmt: skip
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 2 or argv[1] in ("-h", "--help"):
+        print(
+            "usage: evolution_refusal_taxonomy.py {detect,classify,analyze} ...",
+            file=sys.stderr,
+        )
+        return 2
+    cmd, args = argv[1], argv[2:]
+    if cmd == "classify":
+        print(
+            json.dumps(
+                {"category": classify_refusal(" ".join(args))}, ensure_ascii=False
+            )
+        )
+        return 0
+    if cmd == "detect":
+        text = args[0] if args else sys.stdin.read()
+        print(json.dumps(detect_refusals(text), ensure_ascii=False))
+        return 0
+    if cmd == "analyze":
+        text = args[0] if args else sys.stdin.read()
+        print(json.dumps(analyze_session(text), ensure_ascii=False))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_refusal_taxonomy.py
+++ b/tests/scripts/test_evolution_refusal_taxonomy.py
@@ -1,0 +1,73 @@
+"""Tests for evolution_refusal_taxonomy.py — refusal taxonomy and recovery (#756)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+from evolution_refusal_taxonomy import (  # noqa: E402  # fmt: skip
+    detect_refusals,
+    classify_refusal,
+    recovery_suggestion,
+    analyze_session,
+    main,
+    OVER_REFUSAL,
+    TRUE_CAPABILITY_GAP,
+    MISSING_SKILL_TRIGGER,
+    PERMISSION_BOUNDARY,
+    RECOVERABLE_ERROR,
+    SPURIOUS,
+)
+
+
+def test_detect():
+    r = detect_refusals("I can't do that for you.")
+    assert len(r) == 1 and r[0]["is_refusal"]
+    assert not detect_refusals("I can't stress enough.")[0][
+        "is_refusal"
+    ]  # false positive
+    assert len(detect_refusals("I can't help. I don't have access.")) == 2
+    assert detect_refusals("Sure, here is the result.") == []
+
+
+def test_classify():
+    assert classify_refusal("I can't do that.") == OVER_REFUSAL
+    assert classify_refusal("I don't have a tool for that.") == TRUE_CAPABILITY_GAP
+    assert (
+        classify_refusal("I don't have permission to access that security zone.")
+        == PERMISSION_BOUNDARY
+    )
+    assert (
+        classify_refusal("I can't do that.", has_tool_failure=True) == RECOVERABLE_ERROR
+    )
+    assert (
+        classify_refusal("I can't do that.", skill_available=True)
+        == MISSING_SKILL_TRIGGER
+    )
+    assert classify_refusal("Sure, here you go.") == SPURIOUS
+
+
+def test_recovery():
+    for cat in (OVER_REFUSAL, TRUE_CAPABILITY_GAP, PERMISSION_BOUNDARY):
+        assert len(recovery_suggestion(cat)) > 10
+
+
+def test_analyze():
+    r = analyze_session("Here is the result you asked for.")
+    assert not r["has_refusals"] and r["refusal_count"] == 0
+    r = analyze_session("I can't do that. I don't have access.")
+    assert r["has_refusals"] and r["refusal_count"] >= 1
+    assert len(r["categories"]) > 0 and len(r["suggestions"]) > 0
+
+
+def test_cli(capsys, monkeypatch):
+    import io
+
+    assert main(["x", "detect", "I can't help you."]) == 0
+    assert json.loads(capsys.readouterr().out)[0]["is_refusal"]
+    assert main(["x", "classify", "I can't do that."]) == 0
+    assert json.loads(capsys.readouterr().out)["category"] == OVER_REFUSAL
+    monkeypatch.setattr(sys, "stdin", io.StringIO("I can't help. No access."))
+    assert main(["x", "analyze"]) == 0
+    assert json.loads(capsys.readouterr().out)["has_refusals"]
+    assert main(["x"]) == 2 and main(["x", "frob"]) == 2


### PR DESCRIPTION
Automated evolution PR for issue #756.

## What this PR delivers
- `scripts/evolution_refusal_taxonomy.py` — 6-category refusal taxonomy with `detect_refusals()`, `classify_refusal()`, `recovery_suggestion()`, and `analyze_session()`.
- `tests/scripts/test_evolution_refusal_taxonomy.py` — 5 test functions covering all categories, detection (including false-positive filtering), classification, recovery, analysis, and CLI paths.

## Refusal categories
1. **true_capability_gap** — agent lacks a real tool/skill/feature
2. **over_refusal** — capability exists but agent refuses anyway
3. **missing_skill_trigger** — skill is available but not activated
4. **permission_boundary** — legitimate security boundary
5. **recoverable_error** — tool failure, retryable via alternative path
6. **spurious** — not an actual refusal (rhetorical false positive)

## Detection
Refusal phrases are detected via regex, with false-positive filtering for rhetorical uses ("I can't stress enough..."). Classification uses text context + optional `has_tool_failure` and `skill_available` flags. Each category has an actionable recovery suggestion.

CLI subcommands `detect`, `classify`, and `analyze` are the real call sites.