### PR TITLE
fix(evolution): guard upstream-sync against a shallow runtime clone (#823)

### DIFF
--- a/skills/evolution/evolution-upstream-sync/SKILL.md
+++ b/skills/evolution/evolution-upstream-sync/SKILL.md
@@ -37,6 +37,13 @@ Nothing in a release is skipped; nothing of ours is lost.
 
 ```bash
 gh auth setup-git                      # route git auth through gh (no GH_TOKEN export)
+# Guard against a SHALLOW runtime clone (#823): a shallow clone carries an
+# artificial root commit with NO common ancestor to upstream release tags, so the
+# later `git merge <release>` fails with "refusing to merge unrelated histories"
+# and every sync escalates. Deepen to full history BEFORE any fetch/merge so
+# merge-base (and the BEHIND/AHEAD counts below) resolve correctly. Idempotent —
+# a no-op once the clone is full.
+[ -f .git/shallow ] && { echo "[upstream-sync] shallow clone — unshallowing (#823)"; git fetch origin --unshallow --quiet || true; }
 git fetch upstream --tags --quiet && git fetch origin --quiet
 git checkout main && git pull --ff-only origin main
 # The latest PUBLISHED upstream release (the v2026.M.D tags ARE the GitHub releases).


### PR DESCRIPTION
Prevention follow-up to #823. The upstream-sync stage escalated with `refusing to merge unrelated histories` because the pipeline's server clone was a **shallow clone** (4 commits, artificial root, no common ancestor to upstream tags) — not a real fork-history problem.

Adds a preflight guard at the top of Step 0 of evolution-upstream-sync: `[ -f .git/shallow ] && git fetch origin --unshallow` before any fetch/merge, so merge-base and BEHIND/AHEAD resolve. Idempotent (no-op on a full clone).

This is the **exact fix already verified live on the server** (clone 4 → 14531 commits, shared root restored, `merge-base main v2026.7.7.2` resolves). skill-lint clean.