### PR TITLE
fix(memory): bounded file lock acquisition with timeout (#829)

### DIFF
--- a/tests/tools/test_memory_lock_timeout.py
+++ b/tests/tools/test_memory_lock_timeout.py
@@ -1,0 +1,158 @@
+"""Tests for memory tool file lock timeout (#829).
+
+Verifies that _file_lock uses non-blocking acquisition with bounded retry
+and raises TimeoutError instead of hanging indefinitely when the lock
+can't be acquired.
+"""
+
+import json
+import os
+import sys
+import time
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def test_file_lock_acquires_normally(tmp_path):
+    """A lock with no contention should be acquired immediately."""
+    from tools.memory_tool import MemoryStore
+
+    lock_file = tmp_path / "test.lock"
+    with MemoryStore._file_lock(lock_file):
+        # If we get here, the lock was acquired.
+        assert True
+
+
+def test_file_lock_releases_after_context(tmp_path):
+    """After the context manager exits, the lock should be released."""
+    from tools.memory_tool import MemoryStore
+
+    lock_file = tmp_path / "test.lock"
+    with MemoryStore._file_lock(lock_file):
+        pass
+    # Should be able to acquire again immediately.
+    with MemoryStore._file_lock(lock_file):
+        pass
+
+
+def test_file_lock_timeout_raises_timeout_error(tmp_path):
+    """When the lock is held by another thread, a TimeoutError is raised."""
+    import fcntl
+    if fcntl is None:
+        pytest.skip("fcntl not available on this platform")
+
+    from tools.memory_tool import MemoryStore
+
+    lock_file = tmp_path / "contended.lock"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Acquire the lock in a separate thread and hold it.
+    held_fd = open(lock_file, "a+", encoding="utf-8")
+    fcntl.flock(held_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    try:
+        # Use a short timeout so the test doesn't take long.
+        with pytest.raises(TimeoutError) as exc_info:
+            # We need to call _acquire_fcntl_lock directly with a short timeout.
+            fd2 = open(lock_file, "a+", encoding="utf-8")
+            try:
+                MemoryStore._acquire_fcntl_lock(fd2, timeout=0.5)
+            finally:
+                fd2.close()
+
+        assert "memory file lock" in str(exc_info.value).lower() or "lock" in str(exc_info.value).lower()
+    finally:
+        fcntl.flock(held_fd, fcntl.LOCK_UN)
+        held_fd.close()
+
+
+def test_file_lock_no_fcntl_no_msvcrt_yields_directly(tmp_path):
+    """When fcntl and msvcrt are both None, the lock is a no-op."""
+    from tools.memory_tool import MemoryStore
+
+    lock_file = tmp_path / "test.lock"
+    # Patch both to None — the context manager should yield without blocking.
+    with patch("tools.memory_tool.fcntl", None), \
+         patch("tools.memory_tool.msvcrt", None):
+        with MemoryStore._file_lock(lock_file):
+            assert True
+
+
+def test_acquire_fcntl_lock_with_contention_retries(tmp_path):
+    """_acquire_fcntl_lock retries with backoff before giving up."""
+    import fcntl
+    if fcntl is None:
+        pytest.skip("fcntl not available on this platform")
+
+    from tools.memory_tool import MemoryStore
+
+    lock_file = tmp_path / "retry.lock"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Hold the lock in another thread, release it after a short delay.
+    held_fd = open(lock_file, "a+", encoding="utf-8")
+    fcntl.flock(held_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def release_after_delay():
+        time.sleep(0.3)
+        fcntl.flock(held_fd, fcntl.LOCK_UN)
+
+    releaser = threading.Thread(target=release_after_delay, daemon=True)
+    releaser.start()
+
+    try:
+        # Should succeed after the lock is released (~0.3s).
+        fd2 = open(lock_file, "a+", encoding="utf-8")
+        try:
+            MemoryStore._acquire_fcntl_lock(fd2, timeout=5.0)
+            # If we get here, the retry worked.
+            fcntl.flock(fd2, fcntl.LOCK_UN)
+        finally:
+            fd2.close()
+    finally:
+        releaser.join(timeout=2)
+        try:
+            fcntl.flock(held_fd, fcntl.LOCK_UN)
+        except (OSError, IOError):
+            pass
+        held_fd.close()
+
+
+def test_lock_timeout_constant_exists():
+    """The _LOCK_TIMEOUT_SECONDS class constant exists and is reasonable."""
+    from tools.memory_tool import MemoryStore
+    assert hasattr(MemoryStore, "_LOCK_TIMEOUT_SECONDS")
+    assert MemoryStore._LOCK_TIMEOUT_SECONDS > 0
+    assert MemoryStore._LOCK_TIMEOUT_SECONDS <= 60  # sanity: not minutes
+
+
+def test_memory_save_and_load_under_lock(tmp_path):
+    """Memory operations work correctly under the file lock."""
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore()
+    store.add("memory", "test entry one")
+    store.save_to_disk("memory")
+
+    store2 = MemoryStore()
+    store2._reload_target("memory")
+    entries = store2._entries_for("memory")
+    assert "test entry one" in entries
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -412,6 +412,9 @@ class MemoryStore:
                 sanitized.append(parse_provenance(entry)[0])
         return sanitized
 
+    # Max time to wait for a file lock before giving up with a clear error.
+    _LOCK_TIMEOUT_SECONDS = 10.0
+
     @staticmethod
     @contextmanager
     def _file_lock(path: Path):
@@ -419,6 +422,11 @@ class MemoryStore:
 
         Uses a separate .lock file so the memory file itself can still be
         atomically replaced via os.replace().
+
+        On Unix, uses non-blocking flock with bounded retry + exponential
+        backoff so a stuck lock doesn't hang the agent indefinitely. If the
+        lock can't be acquired within _LOCK_TIMEOUT_SECONDS, raises
+        TimeoutError with a diagnostic message.
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -430,7 +438,7 @@ class MemoryStore:
         fd = open(lock_path, "a+", encoding="utf-8")
         try:
             if fcntl:
-                fcntl.flock(fd, fcntl.LOCK_EX)
+                MemoryStore._acquire_fcntl_lock(fd)
             else:
                 fd.seek(0)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
@@ -448,6 +456,33 @@ class MemoryStore:
                 except (OSError, IOError):
                     pass
             fd.close()
+
+    @staticmethod
+    def _acquire_fcntl_lock(fd, timeout: Optional[float] = None) -> None:
+        """Acquire an exclusive flock with bounded retry and backoff.
+
+        Uses LOCK_EX | LOCK_NB (non-blocking) in a retry loop with
+        exponential backoff (0.05s, 0.1s, 0.2s, ...). Raises TimeoutError
+        if the lock isn't acquired within *timeout* seconds.
+        """
+        timeout = timeout if timeout is not None else MemoryStore._LOCK_TIMEOUT_SECONDS
+        deadline = time.monotonic() + timeout
+        wait = 0.05
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return  # acquired
+            except (OSError, IOError):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Could not acquire memory file lock within "
+                        f"{timeout:.0f}s — another process may hold it. "
+                        f"Lock file: {fd.name}"
+                    )
+                sleep_time = min(wait, remaining)
+                time.sleep(sleep_time)
+                wait = min(wait * 2, 1.0)  # cap at 1s per attempt
 
     @staticmethod
     def _path_for(target: str) -> Path:


### PR DESCRIPTION
## Summary

The memory tool file lock used blocking fcntl.flock(LOCK_EX) which hangs indefinitely if another process holds the lock and never releases it. This caused 7 wrapper failures in 7 days.

## Changes

1. Replaced blocking fcntl.flock(LOCK_EX) with non-blocking LOCK_EX|LOCK_NB in a retry loop with exponential backoff (0.05s, 0.1s, 0.2s, ... capped at 1s per attempt).

2. Added _LOCK_TIMEOUT_SECONDS class constant (10s default). If the lock can't be acquired within the timeout, raises TimeoutError with a diagnostic message instead of hanging.

3. Extracted _acquire_fcntl_lock() static method for testability.

## Tests

tests/tools/test_memory_lock_timeout.py - 7 tests:
- Normal lock acquisition (no contention)
- Lock release after context exit
- TimeoutError raised when lock is held by another thread
- Retry succeeds when lock is released during retry loop
- No-op when fcntl and msvcrt are both unavailable
- _LOCK_TIMEOUT_SECONDS constant exists and is reasonable
- Memory save/load operations work correctly under lock

## Closes #829