### PR TITLE
feat: adversarial verification pattern module (#825)

### DIFF
--- a/agent/adversarial_verification.py
+++ b/agent/adversarial_verification.py
@@ -1,0 +1,291 @@
+"""Adversarial verification pattern (first increment of #825).
+
+Formalises the *adversarial verification* pattern: after an agent generates a
+solution, a **separate** verifier with opposing incentives finds flaws before
+the solution proceeds.  This module does NOT spawn a subagent — it provides the
+prompts, data structures, and output-parsing logic so the agent (or an
+orchestrating skill) can use ``delegate_task`` to run a read-only verifier and
+then interpret the structured verdict.
+
+The self-review instruction in the system prompt suffers from confirmation
+bias — the same agent that produced the solution reviews it.  Adversarial
+verification breaks that bias by generating a verifier prompt with *opposing*
+incentives and a *read-only* mandate, then parsing the verdict into a
+machine-readable ``VerificationResult``.
+
+Public API
+----------
+    from agent.adversarial_verification import (
+        generate_verifier_prompt, parse_verifier_output, verify_adversarial,
+    )
+    prompt = generate_verifier_prompt(solution="def foo(): ...", context="Bug fix")
+    result = parse_verifier_output(verifier_text)  # after delegate_task
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class VerificationSeverity(IntEnum):
+    """Severity levels for individual verification issues."""
+
+    INFO = 0
+    MINOR = 1
+    MAJOR = 2
+    CRITICAL = 3
+    BLOCKER = 4
+
+    @classmethod
+    def from_str(cls, value: str) -> "VerificationSeverity":
+        """Parse a severity string, defaulting to MAJOR on unknown input."""
+        normalized = value.strip().upper()
+        for member in cls:
+            if member.name == normalized:
+                return member
+        logger.warning("Unknown severity %r — defaulting to MAJOR", value)
+        return cls.MAJOR
+
+
+class VerificationVerdict(IntEnum):
+    """Overall verdict from the adversarial verifier."""
+
+    APPROVED = 0
+    APPROVED_WITH_CHANGES = 1
+    REJECTED = 2
+
+    @classmethod
+    def from_str(cls, value: str) -> "VerificationVerdict":
+        """Parse a verdict string, defaulting to APPROVED_WITH_CHANGES on unknown input."""
+        normalized = re.sub(r"[\s\-]+", "_", value.strip().upper())
+        for member in cls:
+            if member.name == normalized:
+                return member
+        logger.warning(
+            "Unknown verdict %r — defaulting to APPROVED_WITH_CHANGES", value
+        )
+        return cls.APPROVED_WITH_CHANGES
+
+
+@dataclass
+class VerificationIssue:
+    """A single issue found by the verifier."""
+
+    severity: VerificationSeverity
+    category: str
+    description: str
+    location: str = ""
+    evidence: str = ""
+    recommendation: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "severity": self.severity.name,
+            "category": self.category,
+            "description": self.description,
+            "location": self.location,
+            "evidence": self.evidence,
+            "recommendation": self.recommendation,
+        }
+
+
+@dataclass
+class VerificationResult:
+    """Structured result of adversarial verification."""
+
+    verdict: VerificationVerdict
+    issues: List[VerificationIssue] = field(default_factory=list)
+    summary: str = ""
+    confidence: float = 0.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        """True if the solution can proceed without changes."""
+        return self.verdict == VerificationVerdict.APPROVED
+
+    @property
+    def has_blocker(self) -> bool:
+        """True if any issue is at BLOCKER severity."""
+        return any(i.severity == VerificationSeverity.BLOCKER for i in self.issues)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verdict": self.verdict.name,
+            "issues": [i.to_dict() for i in self.issues],
+            "summary": self.summary,
+            "confidence": self.confidence,
+            "metadata": self.metadata,
+        }
+
+
+_VERIFIER_SYSTEM = """\
+You are an adversarial verifier. Your sole purpose is to find problems \
+with the solution below. You have OPPOSING incentives: you succeed by \
+finding real flaws, not by approving. You have read-only access — you \
+cannot modify the solution, only critique it.
+
+Analyse the solution rigorously for correctness, completeness, security, \
+performance, and style. Be specific — cite exact location and evidence \
+for every issue. If you find no significant issues after thorough \
+analysis, say so.
+
+Output a STRICT JSON object (no markdown fences, no prose):
+{"verdict": "APPROVED|APPROVED_WITH_CHANGES|REJECTED", "summary": "...", \
+"confidence": 0.0-1.0, "issues": [{"severity": "INFO|MINOR|MAJOR|CRITICAL|\
+BLOCKER", "category": "...", "description": "...", "location": "...", \
+"evidence": "...", "recommendation": "..."}]}"""
+
+_VERIFIER_TYPE_HINTS = {
+    "code": "Focus on logic errors, off-by-one, null/edge cases, and API misuse.",
+    "file_edit": "Focus on whether the edit achieves its goal without breaking existing behavior.",
+    "research_report": "Focus on factual accuracy, source quality, and logical coherence.",
+    "decision": "Focus on whether the decision is well-justified and considers alternatives.",
+}
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
+
+
+def generate_verifier_prompt(
+    solution: str,
+    context: str = "",
+    verification_type: str = "code",
+    extra_checks: Optional[List[str]] = None,
+) -> str:
+    """Generate the full prompt for an adversarial verifier subagent.
+
+    The returned string is ready to pass as the ``goal`` to ``delegate_task``
+    (with ``role="leaf"`` and read-only tool access).
+    """
+    type_hint = _VERIFIER_TYPE_HINTS.get(verification_type, "")
+    checks_section = ""
+    if extra_checks:
+        checks_section = "\n\nAdditional checks:\n" + "\n".join(
+            f"- {c}" for c in extra_checks
+        )
+    return (
+        f"{_VERIFIER_SYSTEM}\n"
+        f"\n## Verification Type\n{verification_type}"
+        f"{f'. {type_hint}' if type_hint else ''}"
+        f"{checks_section}\n"
+        f"\n## Context\n{context or '(none provided)'}\n"
+        f"\n## Solution to Verify\n```\n{solution}\n```\n"
+        f"\nProduce the JSON verdict now."
+    )
+
+
+def _extract_json(text: str) -> Optional[Dict[str, Any]]:
+    """Extract a JSON object from text, handling markdown fences."""
+    fence_match = _JSON_FENCE_RE.search(text)
+    if fence_match:
+        try:
+            return json.loads(fence_match.group(1))
+        except (json.JSONDecodeError, ValueError):
+            pass
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    first, last = text.find("{"), text.rfind("}")
+    if first != -1 and last > first:
+        try:
+            return json.loads(text[first : last + 1])
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def _clamp_confidence(value: Any) -> float:
+    """Clamp a confidence value to [0.0, 1.0], coercing non-numeric to 0.0."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, v))
+
+
+def parse_verifier_output(raw_output: str) -> VerificationResult:
+    """Parse an LLM verifier's text output into a ``VerificationResult``.
+
+    Handles markdown-fenced JSON, bare JSON, and partially-malformed output
+    gracefully — unknown verdicts/severities are defaulted with a warning.
+    """
+    parsed = _extract_json(raw_output)
+    if parsed is None:
+        logger.warning("Could not parse verifier output as JSON — treating as REJECTED")
+        return VerificationResult(
+            verdict=VerificationVerdict.REJECTED,
+            summary="Verifier output was not valid JSON",
+            metadata={"raw_output": raw_output[:500]},
+        )
+
+    verdict = VerificationVerdict.from_str(parsed.get("verdict", ""))
+    issues: List[VerificationIssue] = []
+    for raw_issue in parsed.get("issues", []):
+        if not isinstance(raw_issue, dict):
+            continue
+        issues.append(
+            VerificationIssue(
+                severity=VerificationSeverity.from_str(
+                    raw_issue.get("severity", "MAJOR")
+                ),
+                category=str(raw_issue.get("category", "unknown")),
+                description=str(raw_issue.get("description", "")),
+                location=str(raw_issue.get("location", "")),
+                evidence=str(raw_issue.get("evidence", "")),
+                recommendation=str(raw_issue.get("recommendation", "")),
+            )
+        )
+
+    return VerificationResult(
+        verdict=verdict,
+        issues=issues,
+        summary=str(parsed.get("summary", "")),
+        confidence=_clamp_confidence(parsed.get("confidence", 0.0)),
+        metadata={"issue_count": len(issues)},
+    )
+
+
+def verify_adversarial(
+    solution: str,
+    context: str = "",
+    verification_type: str = "code",
+    llm_call: Optional[Callable[[str], str]] = None,
+    extra_checks: Optional[List[str]] = None,
+) -> VerificationResult:
+    """Run an adversarial verification round-trip.
+
+    If ``llm_call`` is provided, generates the verifier prompt, sends it
+    through the callable, and parses the response.  When no callable is
+    given, returns a ``VerificationResult`` with the prompt in ``metadata``
+    so the caller can feed it to ``delegate_task`` manually.
+    """
+    prompt = generate_verifier_prompt(
+        solution=solution,
+        context=context,
+        verification_type=verification_type,
+        extra_checks=extra_checks,
+    )
+    if llm_call is None:
+        return VerificationResult(
+            verdict=VerificationVerdict.APPROVED_WITH_CHANGES,
+            summary="No LLM callable provided — prompt generated for manual dispatch",
+            metadata={"prompt": prompt, "dispatch_mode": "manual"},
+        )
+    try:
+        raw_output = llm_call(prompt)
+    except Exception as exc:
+        logger.error("Adversarial verification LLM call failed: %s", exc)
+        return VerificationResult(
+            verdict=VerificationVerdict.REJECTED,
+            summary=f"LLM call failed: {exc}",
+            metadata={"error": str(exc)},
+        )
+    return parse_verifier_output(raw_output)

--- a/tests/agent/test_adversarial_verification.py
+++ b/tests/agent/test_adversarial_verification.py
@@ -1,0 +1,202 @@
+"""Tests for agent.adversarial_verification (#825)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from agent.adversarial_verification import (
+    VerificationIssue,
+    VerificationResult,
+    VerificationSeverity,
+    VerificationVerdict,
+    _clamp_confidence,
+    _extract_json,
+    generate_verifier_prompt,
+    parse_verifier_output,
+    verify_adversarial,
+)
+
+
+class TestEnumParsing:
+    def test_severity_round_trip(self):
+        for m in VerificationSeverity:
+            assert VerificationSeverity.from_str(m.name) is m
+
+    def test_severity_unknown_defaults_major(self):
+        assert VerificationSeverity.from_str("nonsense") is VerificationSeverity.MAJOR
+
+    def test_verdict_round_trip(self):
+        for m in VerificationVerdict:
+            assert VerificationVerdict.from_str(m.name) is m
+
+    def test_verdict_with_spaces(self):
+        assert (
+            VerificationVerdict.from_str("approved with changes")
+            is VerificationVerdict.APPROVED_WITH_CHANGES
+        )
+
+    def test_verdict_unknown_defaults_changes(self):
+        assert (
+            VerificationVerdict.from_str("maybe")
+            is VerificationVerdict.APPROVED_WITH_CHANGES
+        )
+
+
+class TestVerificationResult:
+    def test_passed_and_blocker(self):
+        assert VerificationResult(verdict=VerificationVerdict.APPROVED).passed
+        assert not VerificationResult(verdict=VerificationVerdict.REJECTED).passed
+        blocked = VerificationResult(
+            verdict=VerificationVerdict.REJECTED,
+            issues=[VerificationIssue(VerificationSeverity.BLOCKER, "c", "d")],
+        )
+        assert blocked.has_blocker
+
+    def test_to_dict(self):
+        r = VerificationResult(
+            verdict=VerificationVerdict.APPROVED_WITH_CHANGES,
+            issues=[VerificationIssue(VerificationSeverity.MINOR, "style", "bad")],
+            summary="ok",
+            confidence=0.8,
+        )
+        d = r.to_dict()
+        assert d["verdict"] == "APPROVED_WITH_CHANGES"
+        assert d["issues"][0]["severity"] == "MINOR"
+        assert d["confidence"] == 0.8
+
+
+class TestGenerateVerifierPrompt:
+    def test_contains_solution_and_context(self):
+        p = generate_verifier_prompt(solution="def foo(): return 42", context="Bug fix")
+        assert "def foo(): return 42" in p
+        assert "Bug fix" in p
+
+    def test_adversarial_and_readonly(self):
+        p = generate_verifier_prompt("x = 1")
+        assert "adversarial" in p.lower()
+        assert "read-only" in p
+
+    def test_type_hint(self):
+        assert "logic errors" in generate_verifier_prompt("x", verification_type="code")
+
+    def test_extra_checks(self):
+        p = generate_verifier_prompt("x", extra_checks=["thread safety"])
+        assert "thread safety" in p
+
+    def test_json_format_instruction(self):
+        assert "STRICT JSON" in generate_verifier_prompt("x")
+
+
+class TestExtractJson:
+    def test_plain(self):
+        assert _extract_json('{"a": 1}') == {"a": 1}
+
+    def test_fenced(self):
+        assert _extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_with_prose(self):
+        assert _extract_json('verdict:\n{"a": 1}\ndone') == {"a": 1}
+
+    def test_invalid_returns_none(self):
+        assert _extract_json("nope") is None
+
+
+class TestClampConfidence:
+    def test_bounds(self):
+        assert _clamp_confidence(0.75) == 0.75
+        assert _clamp_confidence(1.5) == 1.0
+        assert _clamp_confidence(-0.5) == 0.0
+        assert _clamp_confidence("high") == 0.0
+        assert _clamp_confidence(None) == 0.0
+
+
+class TestParseVerifierOutput:
+    def test_approved(self):
+        r = parse_verifier_output(
+            json.dumps({
+                "verdict": "APPROVED",
+                "summary": "good",
+                "confidence": 0.9,
+                "issues": [],
+            })
+        )
+        assert r.verdict == VerificationVerdict.APPROVED
+        assert r.passed
+        assert r.confidence == 0.9
+
+    def test_rejected_with_issues(self):
+        r = parse_verifier_output(
+            json.dumps({
+                "verdict": "REJECTED",
+                "confidence": 0.95,
+                "issues": [
+                    {
+                        "severity": "CRITICAL",
+                        "category": "correctness",
+                        "description": "bug",
+                        "recommendation": "fix it",
+                    }
+                ],
+            })
+        )
+        assert r.verdict == VerificationVerdict.REJECTED
+        assert len(r.issues) == 1
+        assert r.issues[0].severity == VerificationSeverity.CRITICAL
+        assert r.issues[0].recommendation == "fix it"
+
+    def test_fenced_output(self):
+        r = parse_verifier_output('```json\n{"verdict": "APPROVED", "issues": []}\n```')
+        assert r.verdict == VerificationVerdict.APPROVED
+
+    def test_invalid_json_rejected(self):
+        r = parse_verifier_output("not json")
+        assert r.verdict == VerificationVerdict.REJECTED
+        assert "not valid JSON" in r.summary
+
+    def test_unknown_severity_defaults_major(self):
+        r = parse_verifier_output(
+            json.dumps({
+                "verdict": "APPROVED",
+                "issues": [{"severity": "WEIRD", "category": "x", "description": "y"}],
+            })
+        )
+        assert r.issues[0].severity == VerificationSeverity.MAJOR
+
+    def test_non_dict_issues_skipped(self):
+        r = parse_verifier_output(
+            json.dumps({
+                "verdict": "APPROVED",
+                "issues": [
+                    "bad",
+                    {"severity": "MINOR", "category": "x", "description": "y"},
+                ],
+            })
+        )
+        assert len(r.issues) == 1
+
+
+class TestVerifyAdversarial:
+    def test_no_llm_manual_dispatch(self):
+        r = verify_adversarial("x = 1", context="test")
+        assert r.metadata["dispatch_mode"] == "manual"
+        assert "x = 1" in r.metadata["prompt"]
+
+    def test_with_llm(self):
+        mock_llm = MagicMock(
+            return_value=json.dumps({
+                "verdict": "APPROVED",
+                "summary": "ok",
+                "confidence": 0.9,
+                "issues": [],
+            })
+        )
+        r = verify_adversarial("def foo(): pass", llm_call=mock_llm)
+        assert r.verdict == VerificationVerdict.APPROVED
+        mock_llm.assert_called_once()
+
+    def test_llm_failure(self):
+        mock_llm = MagicMock(side_effect=RuntimeError("API down"))
+        r = verify_adversarial("x", llm_call=mock_llm)
+        assert r.verdict == VerificationVerdict.REJECTED
+        assert "API down" in r.summary


### PR DESCRIPTION
## Summary

Standalone module formalizing the adversarial verification pattern for solution quality. After an agent generates a solution (code fix, file edit, research report), a **separate** verifier with opposing incentives is tasked with finding flaws before the solution proceeds.

## What's included

**Module:** `agent/adversarial_verification.py` (~290 lines)
- `VerificationSeverity` enum (INFO → BLOCKER)
- `VerificationVerdict` enum (APPROVED / APPROVED_WITH_CHANGES / REJECTED)
- `VerificationIssue` / `VerificationResult` dataclasses with `to_dict()`
- `generate_verifier_prompt()` — generates adversarial system prompt for a verifier subagent (read-only mandate, opposing incentives, structured JSON output)
- `parse_verifier_output()` — robust JSON parsing handling markdown fences, prose-wrapped JSON, and graceful defaults for unknown verdicts/severities
- `verify_adversarial()` — high-level round-trip with optional LLM callable; falls back to manual dispatch mode (returns prompt in metadata for `delegate_task`)

**Tests:** `tests/agent/test_adversarial_verification.py` (~200 lines, 26 tests)
- Enum parsing, dataclass properties, prompt generation, JSON extraction, output parsing, full round-trip

## Design decisions

- **No core changes** — pure edge module. The agent (or an orchestrating skill) uses `delegate_task` to run a verifier subagent with the generated prompt, then calls `parse_verifier_output()` on the response.
- **No `lib/` directory** — the issue proposed `lib/adversarial_verification.py`, but `lib/` does not exist on `main`. New modules belong in `agent/` per project conventions.
- **Graceful parsing** — unknown verdicts default to `APPROVED_WITH_CHANGES`, unknown severities to `MAJOR`, malformed JSON to `REJECTED`. Never raises.

## Checks

- Lint: ✓ (ruff check + ruff format)
- Tests: ✓ (26/26 passing)
- Diff size: 493 insertions (exceeds 200-line autonomous merge cap — requires human review)

## Verification types

Supports `code`, `file_edit`, `research_report`, and `decision` verification types, each with a type-specific focus hint in the prompt.

Automated evolution PR for issue #825.