### PR TITLE
feat: error recovery ladder — ErrorClassifier + RecoveryStrategy (#826 inc 1)

### DIFF
--- a/agent/error_recovery.py
+++ b/agent/error_recovery.py
@@ -1,0 +1,259 @@
+"""Error recovery ladder — increment 1 of #826.
+
+Structured failure classification and recovery strategy mapping for the agent
+loop.  Addresses 122+ tool failures from the 2026-07-08 introspection cycle:
+terminal (64 failures/33 sessions), read_file (40/16), search_files (10/11),
+patch (8).
+
+This increment delivers the **classification + strategy core** — a standalone
+module that classifies tool/provider errors into broad categories and maps
+them to recovery actions.  Wiring into the agent loop is a separate increment.
+
+Existing circuit breakers (MCP per-server, kanban dispatcher) are
+domain-specific; this module provides the general-purpose error taxonomy
+that those systems and the agent loop can share.
+
+Public API
+----------
+    from agent.error_recovery import classify_error, recommend_action
+
+    err_class = classify_error("Connection timed out")
+    action = recommend_action(err_class, attempt_number=2)
+    if action == RecoveryAction.RETRY_WITH_BACKOFF:
+        ...
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Dict, List, Optional, Pattern, Tuple
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ErrorClass(IntEnum):
+    """Broad classification of a tool/provider failure."""
+
+    TRANSIENT = 0  # network blip, rate limit, temporary unavailability
+    PERMANENT = 1  # auth failure, validation error, file not found
+    CRITICAL = 2  # unrepairable system state, infinite loop detected
+    UNKNOWN = 3  # could not classify — treat conservatively
+
+
+class RecoveryAction(IntEnum):
+    """Recommended recovery action for a given (ErrorClass, attempt)."""
+
+    RETRY = 0  # immediate retry (same call, same params)
+    RETRY_WITH_BACKOFF = 1  # retry after delay with exponential backoff
+    FALLBACK = 2  # use an alternative tool/approach
+    ESCALATE = 3  # hand off to user/human with context
+    ABORT = 4  # stop — further attempts are futile or harmful
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+# Pattern → ErrorClass mapping.  Ordered by specificity: more specific
+# patterns (rate limit, auth) are checked before generic ones (timeout).
+_ERROR_PATTERNS: List[Tuple[Pattern[str], ErrorClass]] = [
+    # --- Rate limiting (transient — retry after backoff) ---
+    (
+        re.compile(r"rate.?limit|429|too many requests|throttl", re.I),
+        ErrorClass.TRANSIENT,
+    ),
+    (re.compile(r"quota|usage.?limit|credit", re.I), ErrorClass.TRANSIENT),
+    # --- Auth/permission (permanent — retrying won't help) ---
+    (
+        re.compile(
+            r"401|403|unauthor|forbidden|permission.?denied|access.?denied", re.I
+        ),
+        ErrorClass.PERMANENT,
+    ),
+    (
+        re.compile(r"api.?key|token.*(invalid|expired|revoked)", re.I),
+        ErrorClass.PERMANENT,
+    ),
+    # --- Not found (permanent — the resource doesn't exist) ---
+    (
+        re.compile(
+            r"404|not.?found|no such (file|directory|module)|does not exist", re.I
+        ),
+        ErrorClass.PERMANENT,
+    ),
+    # --- Validation/bad request (permanent — the request itself is wrong) ---
+    (
+        re.compile(
+            r"400|bad.?request|validation|invalid.*(param|argument|input|format)", re.I
+        ),
+        ErrorClass.PERMANENT,
+    ),
+    (
+        re.compile(r"syntax.?error|parse.?error|json.?decode", re.I),
+        ErrorClass.PERMANENT,
+    ),
+    # --- Timeout/transient network (transient — retry with backoff) ---
+    (re.compile(r"timeout|timed.?out|deadline.?exceeded", re.I), ErrorClass.TRANSIENT),
+    (
+        re.compile(
+            r"connection.*(refused|reset|closed|abort)|ECONNREFUSED|ECONNRESET", re.I
+        ),
+        ErrorClass.TRANSIENT,
+    ),
+    (
+        re.compile(
+            r"5\d{2}\b|internal.?server|service.?unavailable|bad.?gateway|gateway.?timeout",
+            re.I,
+        ),
+        ErrorClass.TRANSIENT,
+    ),
+    (
+        re.compile(r"temporar|transient|retryable|retry.?again", re.I),
+        ErrorClass.TRANSIENT,
+    ),
+    # --- Critical system state ---
+    (
+        re.compile(r"out.?of.?memory|OOM|disk.?full|no space left", re.I),
+        ErrorClass.CRITICAL,
+    ),
+    (
+        re.compile(
+            r"infinite.?loop|recursion.?error|stack.?overflow|maximum.?recursion", re.I
+        ),
+        ErrorClass.CRITICAL,
+    ),
+]
+
+
+@dataclass
+class ClassifiedError:
+    """Result of classifying an error."""
+
+    error_class: ErrorClass
+    matched_pattern: str = ""
+    tool_name: str = ""
+    error_message: str = ""
+
+    @property
+    def is_transient(self) -> bool:
+        return self.error_class == ErrorClass.TRANSIENT
+
+    @property
+    def is_permanent(self) -> bool:
+        return self.error_class == ErrorClass.PERMANENT
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "error_class": self.error_class.name,
+            "matched_pattern": self.matched_pattern,
+            "tool_name": self.tool_name,
+            "error_message": self.error_message,
+        }
+
+
+def classify_error(
+    error_message: str,
+    tool_name: str = "",
+    status_code: Optional[int] = None,
+) -> ClassifiedError:
+    """Classify a tool/provider error into a broad category.
+
+    Pattern-matches the error message against known error signatures.
+    If a status code is provided, it takes precedence for HTTP-status
+    ranges (429 → transient, 5xx → transient, 4xx → permanent).
+
+    Returns a ``ClassifiedError`` with the best-guess class.  Unknown
+    errors default to ``ErrorClass.UNKNOWN`` (treated conservatively).
+    """
+    # Status-code fast path
+    if status_code is not None:
+        if status_code == 429:
+            return ClassifiedError(
+                ErrorClass.TRANSIENT, f"HTTP {status_code}", tool_name, error_message
+            )
+        if 500 <= status_code < 600:
+            return ClassifiedError(
+                ErrorClass.TRANSIENT, f"HTTP {status_code}", tool_name, error_message
+            )
+        if 400 <= status_code < 500:
+            return ClassifiedError(
+                ErrorClass.PERMANENT, f"HTTP {status_code}", tool_name, error_message
+            )
+
+    # Pattern matching
+    for pattern, err_class in _ERROR_PATTERNS:
+        match = pattern.search(error_message)
+        if match:
+            return ClassifiedError(err_class, match.group(0), tool_name, error_message)
+
+    return ClassifiedError(ErrorClass.UNKNOWN, "", tool_name, error_message)
+
+
+# ---------------------------------------------------------------------------
+# Recovery strategy
+# ---------------------------------------------------------------------------
+
+# (ErrorClass, max_attempts) → RecoveryAction
+# Strategy: transient → retry with backoff up to max, then fallback;
+#           permanent → fallback immediately (retrying won't fix the request);
+#           critical → escalate; unknown → retry once, then escalate.
+_DEFAULT_STRATEGY: Dict[ErrorClass, List[RecoveryAction]] = {
+    ErrorClass.TRANSIENT: [
+        RecoveryAction.RETRY,
+        RecoveryAction.RETRY_WITH_BACKOFF,
+        RecoveryAction.RETRY_WITH_BACKOFF,
+        RecoveryAction.FALLBACK,
+    ],
+    ErrorClass.PERMANENT: [
+        RecoveryAction.FALLBACK,
+        RecoveryAction.ESCALATE,
+    ],
+    ErrorClass.CRITICAL: [
+        RecoveryAction.ESCALATE,
+    ],
+    ErrorClass.UNKNOWN: [
+        RecoveryAction.RETRY,
+        RecoveryAction.ESCALATE,
+    ],
+}
+
+
+def recommend_action(
+    error_class: ErrorClass,
+    attempt_number: int = 1,
+    strategy: Optional[Dict[ErrorClass, List[RecoveryAction]]] = None,
+) -> RecoveryAction:
+    """Recommend a recovery action for a classified error.
+
+    ``attempt_number`` is 1-indexed: the first failure is attempt 1.
+    The strategy is a mapping from ``ErrorClass`` to an ordered list of
+    actions; the action at ``min(attempt_number - 1, len(actions) - 1)``
+    is returned.  Past the last entry, the final action is returned
+    (usually ESCALATE or FALLBACK).
+    """
+    strat = strategy or _DEFAULT_STRATEGY
+    if error_class in strat:
+        actions = strat[error_class]
+    else:
+        actions = strat.get(ErrorClass.UNKNOWN) or _DEFAULT_STRATEGY[ErrorClass.UNKNOWN]
+    if not actions:
+        return RecoveryAction.ESCALATE
+    idx = min(attempt_number - 1, len(actions) - 1)
+    return actions[idx]
+
+
+def should_retry(
+    error_class: ErrorClass,
+    attempt_number: int = 1,
+    max_attempts: int = 3,
+    strategy: Optional[Dict[ErrorClass, List[RecoveryAction]]] = None,
+) -> bool:
+    """Convenience: True if the recommended action is a retry variant."""
+    if attempt_number >= max_attempts:
+        return False
+    action = recommend_action(error_class, attempt_number, strategy)
+    return action in (RecoveryAction.RETRY, RecoveryAction.RETRY_WITH_BACKOFF)

--- a/tests/agent/test_error_recovery.py
+++ b/tests/agent/test_error_recovery.py
@@ -1,0 +1,187 @@
+"""Tests for agent.error_recovery (#826 increment 1)."""
+
+from __future__ import annotations
+
+from agent.error_recovery import (
+    ClassifiedError,
+    ErrorClass,
+    RecoveryAction,
+    classify_error,
+    recommend_action,
+    should_retry,
+)
+
+
+class TestClassifyError:
+    def test_rate_limit_transient(self):
+        for msg in ["rate limit exceeded", "HTTP 429 too many requests", "throttled"]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.TRANSIENT, msg
+
+    def test_quota_transient(self):
+        assert classify_error("quota exceeded").error_class == ErrorClass.TRANSIENT
+
+    def test_auth_permanent(self):
+        for msg in [
+            "401 unauthorized",
+            "403 forbidden",
+            "API key invalid",
+            "token expired",
+        ]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.PERMANENT, msg
+
+    def test_permission_denied_permanent(self):
+        assert classify_error("permission denied").error_class == ErrorClass.PERMANENT
+
+    def test_not_found_permanent(self):
+        for msg in [
+            "404 not found",
+            "No such file or directory",
+            "module does not exist",
+        ]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.PERMANENT, msg
+
+    def test_validation_permanent(self):
+        for msg in [
+            "400 bad request",
+            "validation error",
+            "invalid parameter",
+            "JSON decode error",
+        ]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.PERMANENT, msg
+
+    def test_timeout_transient(self):
+        for msg in [
+            "Connection timed out",
+            "deadline exceeded",
+            "ECONNREFUSED",
+            "connection reset",
+        ]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.TRANSIENT, msg
+
+    def test_5xx_transient(self):
+        for msg in [
+            "500 internal server error",
+            "503 service unavailable",
+            "502 bad gateway",
+        ]:
+            r = classify_error(msg)
+            assert r.error_class == ErrorClass.TRANSIENT, msg
+
+    def test_temporary_transient(self):
+        assert (
+            classify_error("temporary failure, retry again").error_class
+            == ErrorClass.TRANSIENT
+        )
+
+    def test_critical_oom(self):
+        assert classify_error("out of memory").error_class == ErrorClass.CRITICAL
+
+    def test_critical_recursion(self):
+        assert (
+            classify_error("maximum recursion depth exceeded").error_class
+            == ErrorClass.CRITICAL
+        )
+
+    def test_unknown_unclassifiable(self):
+        r = classify_error("something weird happened")
+        assert r.error_class == ErrorClass.UNKNOWN
+
+    def test_status_code_429_transient(self):
+        assert (
+            classify_error("msg", status_code=429).error_class == ErrorClass.TRANSIENT
+        )
+
+    def test_status_code_5xx_transient(self):
+        assert (
+            classify_error("msg", status_code=503).error_class == ErrorClass.TRANSIENT
+        )
+
+    def test_status_code_4xx_permanent(self):
+        assert (
+            classify_error("msg", status_code=404).error_class == ErrorClass.PERMANENT
+        )
+
+    def test_status_code_takes_precedence(self):
+        # Even if the message says "timeout", a 403 is permanent
+        assert (
+            classify_error("timeout", status_code=403).error_class
+            == ErrorClass.PERMANENT
+        )
+
+    def test_tool_name_preserved(self):
+        r = classify_error("timeout", tool_name="terminal")
+        assert r.tool_name == "terminal"
+
+    def test_matched_pattern_populated(self):
+        r = classify_error("rate limit exceeded")
+        assert r.matched_pattern  # non-empty
+
+    def test_is_transient_is_permanent(self):
+        assert ClassifiedError(ErrorClass.TRANSIENT).is_transient
+        assert not ClassifiedError(ErrorClass.TRANSIENT).is_permanent
+        assert ClassifiedError(ErrorClass.PERMANENT).is_permanent
+        assert not ClassifiedError(ErrorClass.PERMANENT).is_transient
+
+    def test_to_dict(self):
+        r = classify_error("timeout", tool_name="read_file")
+        d = r.to_dict()
+        assert "error_class" in d
+        assert d["tool_name"] == "read_file"
+
+
+class TestRecommendAction:
+    def test_transient_first_attempt_retry(self):
+        assert recommend_action(ErrorClass.TRANSIENT, 1) == RecoveryAction.RETRY
+
+    def test_transient_second_backoff(self):
+        assert (
+            recommend_action(ErrorClass.TRANSIENT, 2)
+            == RecoveryAction.RETRY_WITH_BACKOFF
+        )
+
+    def test_transient_exhausted_fallback(self):
+        assert recommend_action(ErrorClass.TRANSIENT, 5) == RecoveryAction.FALLBACK
+
+    def test_permanent_fallback_immediately(self):
+        assert recommend_action(ErrorClass.PERMANENT, 1) == RecoveryAction.FALLBACK
+
+    def test_permanent_second_escalate(self):
+        assert recommend_action(ErrorClass.PERMANENT, 2) == RecoveryAction.ESCALATE
+
+    def test_critical_escalate(self):
+        assert recommend_action(ErrorClass.CRITICAL, 1) == RecoveryAction.ESCALATE
+
+    def test_unknown_retry_then_escalate(self):
+        assert recommend_action(ErrorClass.UNKNOWN, 1) == RecoveryAction.RETRY
+        assert recommend_action(ErrorClass.UNKNOWN, 2) == RecoveryAction.ESCALATE
+
+    def test_custom_strategy(self):
+        custom = {ErrorClass.TRANSIENT: [RecoveryAction.ABORT]}
+        assert recommend_action(ErrorClass.TRANSIENT, 1, custom) == RecoveryAction.ABORT
+
+    def test_empty_strategy_escalates(self):
+        custom = {ErrorClass.TRANSIENT: []}
+        assert (
+            recommend_action(ErrorClass.TRANSIENT, 1, custom) == RecoveryAction.ESCALATE
+        )
+
+
+class TestShouldRetry:
+    def test_transient_retryable(self):
+        assert should_retry(ErrorClass.TRANSIENT, 1)
+        assert should_retry(ErrorClass.TRANSIENT, 2)
+
+    def test_permanent_not_retryable(self):
+        assert not should_retry(ErrorClass.PERMANENT, 1)
+
+    def test_max_attempts_limit(self):
+        assert not should_retry(ErrorClass.TRANSIENT, 3, max_attempts=3)
+
+    def test_unknown_retry_once(self):
+        assert should_retry(ErrorClass.UNKNOWN, 1)
+        assert not should_retry(ErrorClass.UNKNOWN, 2)


### PR DESCRIPTION
## Summary

Increment 1 of #826: structured failure classification and recovery strategy mapping for the agent loop. Addresses 122+ tool failures from the 2026-07-08 introspection cycle (terminal 64/33, read_file 40/16, search_files 10/11, patch 8).

## What's included

**Module:** `agent/error_recovery.py` (~260 lines)
- `ErrorClass` enum: TRANSIENT, PERMANENT, CRITICAL, UNKNOWN
- `RecoveryAction` enum: RETRY, RETRY_WITH_BACKOFF, FALLBACK, ESCALATE, ABORT
- `ClassifiedError` dataclass with `is_transient`/`is_permanent` helpers + `to_dict()`
- `classify_error()`: regex pattern matching for timeout/auth/not-found/validation/rate-limit errors, plus HTTP status-code fast path (429→transient, 5xx→transient, 4xx→permanent)
- `recommend_action()`: maps (ErrorClass, attempt_number) → RecoveryAction using a configurable strategy ladder
- `should_retry()`: convenience wrapper

**Tests:** `tests/agent/test_error_recovery.py` (~190 lines, 33 tests)
- Error classification for all 6 error categories + status codes
- Recovery strategy mapping across attempt numbers
- Custom strategy override support

## Design decisions

- **No core changes** — pure standalone module. Wiring into the agent loop (actually intercepting tool failures and applying recovery actions) is a separate increment.
- **No `lib/` directory** — the issue proposed `lib/error_recovery_ladder.py`, but `lib/` does not exist on `main`. New modules belong in `agent/`.
- **Complementary to existing circuit breakers** — MCP per-server and kanban dispatcher circuit breakers are domain-specific. This module provides the general-purpose error taxonomy.
- **Pattern matching first, status codes override** — HTTP status codes take precedence when available (a 403 with "timeout" in the message is still permanent).

## Deferred (next increment)

- `CircuitBreaker` class (CLOSED → OPEN → HALF_OPEN state machine) — exists in MCP but needs general-purpose version
- `RetryPolicy` with exponential backoff + jitter
- `FailurePatternLearner` — records failure patterns, suggests alternatives
- `RollbackSnapshot` — records state before file modifications
- `ErrorRecoveryLadder` orchestrator class
- Wiring into `run_agent.py` / `model_tools.py` to actually intercept tool failures

## Checks

- Lint: ✓ (ruff check + ruff format)
- Tests: ✓ (33/33 passing)
- Diff size: 446 insertions (exceeds 200-line autonomous merge cap — requires human review)

Automated evolution PR for issue #826 (increment 1).