### PR TITLE
feat: tool error recovery ladder (#826) + adversarial verification (#825)

### DIFF
--- a/agent/adversarial_verification.py
+++ b/agent/adversarial_verification.py
@@ -1,0 +1,336 @@
+"""Adversarial verification pattern — separate verifier subagent.
+
+Provides prompt generation and output parsing for spawning an adversarial
+verifier subagent via ``delegate_task``. The verifier has different incentives
+(find problems), different tool access (read-only), and a fresh context window.
+
+This module is the prompt+parse layer; the actual subagent spawning is done
+by the caller via ``delegate_task``. This separation keeps the module testable
+without needing a live agent instance.
+
+Wired into the CLI via the ``/verify`` slash command, which:
+1. Takes the last agent response as the "solution"
+2. Spawns a verifier subagent with ``generate_verifier_prompt()``
+3. Parses the verdict with ``parse_verifier_output()``
+4. Reports the verdict to the user
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Severity / verdict enums ─────────────────────────────────────────────
+
+
+class VerificationSeverity(enum.Enum):
+    """How serious a found issue is."""
+
+    INFO = "info"          # suggestion, not a problem
+    MINOR = "minor"        # cosmetic / style
+    MAJOR = "major"        # functional issue
+    CRITICAL = "critical"  # breaks something important
+    BLOCKER = "blocker"    # must fix before proceeding
+
+
+class VerificationVerdict(enum.Enum):
+    """Overall verdict from the verifier."""
+
+    APPROVED = "approved"                        # no significant issues
+    APPROVED_WITH_CHANGES = "approved_with_changes"  # minor issues, fixable
+    REJECTED = "rejected"                         # major/critical issues found
+
+
+# ── Data classes ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class VerificationIssue:
+    """A single issue found by the verifier."""
+
+    severity: VerificationSeverity
+    category: str           # correctness, completeness, security, performance, style
+    description: str
+    location: str = ""      # file:line or section reference
+    evidence: str = ""      # quote or reasoning
+    recommendation: str = "" # suggested fix
+
+
+@dataclass
+class VerificationResult:
+    """Parsed result from an adversarial verification."""
+
+    verdict: VerificationVerdict
+    issues: list[VerificationIssue] = field(default_factory=list)
+    summary: str = ""
+    confidence: float = 0.0   # 0.0–1.0
+    raw_output: str = ""      # original verifier output for debugging
+
+
+# ── Prompt generation ────────────────────────────────────────────────────
+
+_VERIFIER_SYSTEM_PROMPT = """\
+You are an adversarial code verifier. Your job is to FIND PROBLEMS with the
+solution provided below. You are NOT the author — you are a critical reviewer
+with opposing incentives.
+
+Your goal: identify real issues that would cause the solution to fail, break,
+or produce wrong results. Be thorough and specific. Cite exact locations.
+
+For each issue you find, report:
+- Severity: INFO, MINOR, MAJOR, CRITICAL, or BLOCKER
+- Category: correctness, completeness, security, performance, or style
+- Description: what the problem is
+- Location: where it is (file:line or section)
+- Evidence: quote the problematic code/text
+- Recommendation: how to fix it
+
+After listing all issues, provide your verdict:
+- APPROVED: no significant issues — the solution is sound
+- APPROVED_WITH_CHANGES: minor issues that should be fixed but don't block
+- REJECTED: major or critical issues that must be fixed before proceeding
+
+Also provide a confidence score (0.0–1.0) for your verdict.
+
+Format your response as JSON:
+```json
+{
+  "verdict": "approved|approved_with_changes|rejected",
+  "confidence": 0.0,
+  "summary": "one-sentence summary of your assessment",
+  "issues": [
+    {
+      "severity": "info|minor|major|critical|blocker",
+      "category": "correctness|completeness|security|performance|style",
+      "description": "...",
+      "location": "...",
+      "evidence": "...",
+      "recommendation": "..."
+    }
+  ]
+}
+```
+
+If you find no issues, return an empty issues array with verdict "approved".
+"""
+
+
+def generate_verifier_prompt(solution: str, context: str = "", solution_type: str = "code") -> str:
+    """Generate the user-message prompt for an adversarial verifier subagent.
+
+    Parameters
+    ----------
+    solution : str
+        The solution to verify (code, file edit, research report, or decision).
+    context : str, optional
+        Additional context (the original task, constraints, etc.).
+    solution_type : str
+        Type of solution: "code", "file_edit", "research_report", or "decision".
+
+    Returns
+    -------
+    str
+        The user message to send to the verifier subagent.
+    """
+    parts = [
+        f"## Solution Type: {solution_type}",
+    ]
+    if context:
+        parts.append(f"## Context\n{context}")
+    parts.append(f"## Solution to Verify\n```\n{solution}\n```")
+    parts.append(
+        "\nReview the above solution adversarially. Find real problems. "
+        "Be specific with locations and evidence. Output the JSON verdict."
+    )
+    return "\n\n".join(parts)
+
+
+def get_verifier_system_prompt() -> str:
+    """Return the system prompt for the adversarial verifier subagent."""
+    return _VERIFIER_SYSTEM_PROMPT
+
+
+# ── Output parsing ───────────────────────────────────────────────────────
+
+
+def _parse_severity(val: str) -> VerificationSeverity:
+    """Parse a severity string, defaulting to INFO."""
+    try:
+        return VerificationSeverity(val.lower().strip())
+    except (ValueError, AttributeError):
+        return VerificationSeverity.INFO
+
+
+def _parse_verdict(val: str) -> VerificationVerdict:
+    """Parse a verdict string, defaulting to APPROVED (fail-safe)."""
+    try:
+        return VerificationVerdict(val.lower().strip())
+    except (ValueError, AttributeError):
+        return VerificationVerdict.APPROVED
+
+
+def parse_verifier_output(output: str) -> VerificationResult:
+    """Parse the verifier subagent's output into a VerificationResult.
+
+    Attempts to extract a JSON block from the output. If parsing fails,
+    returns a minimal result with verdict=APPROVED and the raw output.
+
+    Parameters
+    ----------
+    output : str
+        The raw text output from the verifier subagent.
+
+    Returns
+    -------
+    VerificationResult
+        Parsed verification result.
+    """
+    # Try to find a JSON block in the output
+    json_match = re.search(r'```json\s*\n(.*?)\n```', output, re.DOTALL)
+    if json_match:
+        json_str = json_match.group(1)
+    else:
+        # Try finding a bare JSON object
+        json_match = re.search(r'\{[^{}]*"(?:verdict|issues)"[^{}]*\}', output, re.DOTALL)
+        if json_match:
+            json_str = json_match.group(0)
+        else:
+            # Can't parse — return raw output with safe defaults
+            logger.debug("Could not extract JSON from verifier output")
+            return VerificationResult(
+                verdict=VerificationVerdict.APPROVED,
+                summary="Could not parse verifier output; defaulting to approved.",
+                confidence=0.0,
+                raw_output=output,
+            )
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        logger.debug("JSON decode error in verifier output: %s", e)
+        return VerificationResult(
+            verdict=VerificationVerdict.APPROVED,
+            summary="Could not parse verifier JSON; defaulting to approved.",
+            confidence=0.0,
+            raw_output=output,
+        )
+
+    # Parse issues
+    issues: list[VerificationIssue] = []
+    for raw_issue in data.get("issues", []):
+        if not isinstance(raw_issue, dict):
+            continue
+        issues.append(VerificationIssue(
+            severity=_parse_severity(raw_issue.get("severity", "info")),
+            category=raw_issue.get("category", ""),
+            description=raw_issue.get("description", ""),
+            location=raw_issue.get("location", ""),
+            evidence=raw_issue.get("evidence", ""),
+            recommendation=raw_issue.get("recommendation", ""),
+        ))
+
+    return VerificationResult(
+        verdict=_parse_verdict(data.get("verdict", "approved")),
+        issues=issues,
+        summary=data.get("summary", ""),
+        confidence=float(data.get("confidence", 0.0)),
+        raw_output=output,
+    )
+
+
+# ── Formatting for display ───────────────────────────────────────────────
+
+
+_SEVERITY_EMOJI = {
+    VerificationSeverity.INFO: "ℹ️",
+    VerificationSeverity.MINOR: "⚠️",
+    VerificationSeverity.MAJOR: "🔶",
+    VerificationSeverity.CRITICAL: "🔴",
+    VerificationSeverity.BLOCKER: "🚫",
+}
+
+_VERDICT_LABEL = {
+    VerificationVerdict.APPROVED: "✅ APPROVED",
+    VerificationVerdict.APPROVED_WITH_CHANGES: "⚠️ APPROVED WITH CHANGES",
+    VerificationVerdict.REJECTED: "❌ REJECTED",
+}
+
+
+def format_verification_result(result: VerificationResult) -> str:
+    """Format a VerificationResult for display to the user.
+
+    Returns a human-readable string suitable for CLI or messaging output.
+    """
+    lines = [
+        f"**Adversarial Verification: {_VERDICT_LABEL.get(result.verdict, result.verdict.value)}**",
+    ]
+    if result.summary:
+        lines.append(f"Summary: {result.summary}")
+    if result.confidence > 0:
+        lines.append(f"Confidence: {result.confidence:.0%}")
+    if result.issues:
+        lines.append(f"\nIssues found ({len(result.issues)}):")
+        for i, issue in enumerate(result.issues, 1):
+            emoji = _SEVERITY_EMOJI.get(issue.severity, "•")
+            lines.append(f"  {i}. {emoji} [{issue.severity.value.upper()}] {issue.category}: {issue.description}")
+            if issue.location:
+                lines.append(f"     Location: {issue.location}")
+            if issue.recommendation:
+                lines.append(f"     Fix: {issue.recommendation}")
+    else:
+        lines.append("\nNo issues found.")
+    return "\n".join(lines)
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def verify_adversarial(solution: str, context: str = "", solution_type: str = "code") -> VerificationResult:
+    """Run adversarial verification on a solution.
+
+    This is a convenience wrapper that generates the prompt, calls
+    ``delegate_task`` to spawn a verifier subagent, and parses the result.
+
+    Note: this function imports delegate_task lazily to avoid circular imports
+    at module load time. It requires an active agent context.
+
+    Parameters
+    ----------
+    solution : str
+        The solution text to verify.
+    context : str, optional
+        Additional context for the verification.
+    solution_type : str
+        Type of solution ("code", "file_edit", "research_report", "decision").
+
+    Returns
+    -------
+    VerificationResult
+        The parsed verification result.
+    """
+    # This function is called from the /verify CLI command, which has
+    # access to the agent instance. The actual delegate_task call is
+    # done by the CLI handler, not here — this function provides the
+    # prompt and parser. The split keeps the module testable without
+    # a live agent.
+    #
+    # The CLI handler does:
+    #   prompt = generate_verifier_prompt(solution, context, solution_type)
+    #   system = get_verifier_system_prompt()
+    #   result_text = agent.delegate_task(goal=prompt, ...)  # via delegate_task tool
+    #   result = parse_verifier_output(result_text)
+    #   print(format_verification_result(result))
+    #
+    # This function exists for programmatic callers who want to
+    # assemble the pieces themselves.
+    raise NotImplementedError(
+        "Use generate_verifier_prompt() + delegate_task + parse_verifier_output() "
+        "directly. See the /verify CLI command for the canonical wiring."
+    )

--- a/agent/tool_error_recovery.py
+++ b/agent/tool_error_recovery.py
@@ -1,0 +1,249 @@
+"""Tool-level error classification and recovery hints.
+
+Complements ``agent/error_classifier.py`` (which classifies *API-level*
+errors for the main retry loop) by classifying *tool-level* errors that
+surface when ``handle_function_call`` dispatches to a tool and the tool
+raises an exception or returns a structured ``{"error": ...}`` result.
+
+The classification is consumed by ``model_tools.handle_function_call`` to
+enrich the error string returned to the agent with a recovery hint —
+the model sees not just *what* went wrong but *what to try next*:
+retry, try an alternative tool, check file paths, etc.
+
+This module is deliberately minimal: it classifies, logs, and suggests.
+The actual retry / fallback decision is made by the model reading the hint.
+No automatic retries are attempted here — that would change the agent
+loop's semantics and risk cache-breaking mid-conversation.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Error taxonomy ──────────────────────────────────────────────────────
+
+
+class ToolErrorClass(enum.Enum):
+    """Classification of a tool-level failure."""
+
+    transient = "transient"          # timeout, resource busy — retry may help
+    not_found = "not_found"           # file/path not found — check path
+    permission = "permission"        # auth/permission denied — check credentials
+    validation = "validation"        # bad arguments — fix the call args
+    rate_limit = "rate_limit"        # tool-specific rate limit — backoff
+    dependency = "dependency"         # missing system dependency — install/configure
+    permanent = "permanent"           # structural failure — won't fix by retrying
+    unknown = "unknown"              # couldn't classify
+
+
+class RecoveryAction(enum.Enum):
+    """Suggested recovery action for a tool error."""
+
+    retry = "retry"                     # retry the same call (transient)
+    fix_args = "fix_args"               # fix the arguments and retry
+    check_path = "check_path"           # verify the file/path exists
+    check_credentials = "check_credentials"  # verify API key / permissions
+    install_dependency = "install_dependency"  # install missing system tool
+    use_alternative = "use_alternative"  # try a different tool or approach
+    escalate = "escalate"               # surface to user, can't auto-recover
+    abort = "abort"                     # stop trying — permanent failure
+
+
+@dataclass
+class ToolFailure:
+    """A classified tool failure with recovery context."""
+
+    tool_name: str
+    error_message: str
+    error_class: ToolErrorClass
+    recovery_action: RecoveryAction
+    hint: str = ""                     # human-readable recovery suggestion
+    attempt_number: int = 1
+    timestamp: float = 0.0             # set by caller if needed
+
+
+# ── Pattern-based classifier ────────────────────────────────────────────
+
+# Ordered (regex_pattern, error_class, recovery_action, hint) rules.
+# First match wins. Patterns are case-insensitive.
+# IMPORTANT: dependency patterns must be checked BEFORE not_found,
+# because "command not found" contains the substring "not found".
+_PATTERNS: list[tuple[re.Pattern, ToolErrorClass, RecoveryAction, str]] = [
+    # Dependency missing (must precede not_found — "command not found"
+    # would otherwise match the not_found pattern)
+    (
+        re.compile(r"command not found|not recognized|no module named|importerror|modulenotfound|executable.*not found", re.I),
+        ToolErrorClass.dependency,
+        RecoveryAction.install_dependency,
+        "A required system dependency is missing. Install it and retry.",
+    ),
+    # Not found
+    (
+        re.compile(r"no such file|file not found|does not exist|not found|enoent", re.I),
+        ToolErrorClass.not_found,
+        RecoveryAction.check_path,
+        "The file or path was not found. Verify the path exists and is accessible.",
+    ),
+    # Permission
+    (
+        re.compile(r"permission denied|forbidden|unauthorized|403|access denied", re.I),
+        ToolErrorClass.permission,
+        RecoveryAction.check_credentials,
+        "Permission was denied. Check file permissions or API credentials.",
+    ),
+    # Rate limit
+    (
+        re.compile(r"rate.?limit|too many requests|429|throttl", re.I),
+        ToolErrorClass.rate_limit,
+        RecoveryAction.retry,
+        "Rate limited. Wait briefly before retrying, or reduce request frequency.",
+    ),
+    # Timeout / transient
+    (
+        re.compile(r"timeout|timed out|connection reset|temporarily unavailable|try again", re.I),
+        ToolErrorClass.transient,
+        RecoveryAction.retry,
+        "A transient error occurred. Retrying the same call may succeed.",
+    ),
+    # Validation / bad args
+    (
+        re.compile(r"invalid|validation|bad request|wrong type|expected.*got|argument|param.*required|missing", re.I),
+        ToolErrorClass.validation,
+        RecoveryAction.fix_args,
+        "The tool arguments were invalid. Review the schema and fix the arguments.",
+    ),
+    # JSON / parse errors — usually bad args
+    (
+        re.compile(r"json|parse|decode|unexpected token|syntax error", re.I),
+        ToolErrorClass.validation,
+        RecoveryAction.fix_args,
+        "The input could not be parsed. Check the format of the arguments.",
+    ),
+]
+
+
+def classify_tool_error(tool_name: str, error_message: str, attempt: int = 1) -> ToolFailure:
+    """Classify a tool-level error and suggest a recovery action.
+
+    Parameters
+    ----------
+    tool_name : str
+        The name of the tool that failed (e.g. ``"terminal"``, ``"read_file"``).
+    error_message : str
+        The error message string (from the exception or the ``{"error": ...}`` JSON).
+    attempt : int
+        The attempt number (1-based). Not currently used for classification
+        but available for future circuit-breaker logic.
+
+    Returns
+    -------
+    ToolFailure
+        A classified failure with a recovery hint.
+    """
+    msg_lower = error_message.lower() if error_message else ""
+
+    for pattern, err_class, action, hint in _PATTERNS:
+        if pattern.search(msg_lower):
+            return ToolFailure(
+                tool_name=tool_name,
+                error_message=error_message,
+                error_class=err_class,
+                recovery_action=action,
+                hint=hint,
+                attempt_number=attempt,
+            )
+
+    # Default: unknown — can't suggest a specific recovery
+    return ToolFailure(
+        tool_name=tool_name,
+        error_message=error_message,
+        error_class=ToolErrorClass.unknown,
+        recovery_action=RecoveryAction.escalate,
+        hint="The error could not be classified. Review the error message and decide how to proceed.",
+        attempt_number=attempt,
+    )
+
+
+def recovery_hint(failure: ToolFailure) -> str:
+    """Format a recovery hint string suitable for appending to a tool error result.
+
+    Returns a short, actionable suggestion. If the error class is
+    ``unknown``, returns an empty string (no hint is better than a
+    misleading one).
+    """
+    if failure.error_class == ToolErrorClass.unknown:
+        return ""
+    return f" [{failure.recovery_action.value}: {failure.hint}]"
+
+
+# ── Circuit breaker (lightweight, per-tool) ──────────────────────────────
+
+
+@dataclass
+class CircuitBreaker:
+    """Simple per-tool circuit breaker.
+
+    Tracks consecutive failures for a single tool. After ``threshold``
+    consecutive failures, the circuit opens and ``should_trip()`` returns
+    True — callers can use this to fail-fast instead of retrying.
+
+    The breaker resets on any success. It does not auto-transition to
+    half-open; a success call manually resets it.
+
+    This is intentionally minimal — no timeout-based half-open, no rolling
+    window. Just consecutive-count → trip. Enough to prevent infinite
+    retry loops on a permanently broken tool without adding complexity.
+    """
+
+    threshold: int = 5
+    _consecutive_failures: int = 0
+    _is_open: bool = False
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self.threshold:
+            self._is_open = True
+            logger.warning(
+                "circuit breaker opened for tool after %d consecutive failures",
+                self._consecutive_failures,
+            )
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._is_open = False
+
+    def should_trip(self) -> bool:
+        return self._is_open
+
+
+# ── Per-tool breaker registry (process-global) ───────────────────────────
+
+_breakers: dict[str, CircuitBreaker] = {}
+
+
+def get_breaker(tool_name: str, threshold: int = 5) -> CircuitBreaker:
+    """Get or create a circuit breaker for a tool name."""
+    if tool_name not in _breakers:
+        _breakers[tool_name] = CircuitBreaker(threshold=threshold)
+    return _breakers[tool_name]
+
+
+def record_tool_outcome(tool_name: str, success: bool) -> None:
+    """Record a tool call outcome for circuit-breaker tracking.
+
+    Called from ``handle_function_call`` after every tool dispatch.
+    On failure, increments the consecutive failure count. On success,
+    resets the breaker. When the breaker trips, a warning is logged.
+    """
+    breaker = get_breaker(tool_name)
+    if success:
+        breaker.record_success()
+    else:
+        breaker.record_failure()

--- a/cli.py
+++ b/cli.py
@@ -8634,6 +8634,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._show_gateway_status()
         elif canonical == "status":
             self._show_session_status()
+        elif canonical == "verify":
+            self._handle_verify_command()
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
@@ -9229,6 +9231,107 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception as exc:
                     logging.debug("goal continuation enqueue failed: %s", exc)
 
+
+    def _handle_verify_command(self):
+        """Run adversarial verification on the last agent response.
+
+        Spawns a verifier subagent via delegate_task with an adversarial
+        system prompt. The verifier reviews the last agent response for
+        flaws and reports a verdict.
+        """
+        # Find the last assistant message in conversation history
+        last_response = ""
+        if self.conversation_history:
+            for i in range(len(self.conversation_history) - 1, -1, -1):
+                msg = self.conversation_history[i]
+                if msg.get("role") == "assistant":
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
+                        # Extract text from multimodal content
+                        content = " ".join(
+                            block.get("text", "") for block in content
+                            if isinstance(block, dict) and block.get("type") == "text"
+                        )
+                    last_response = content
+                    break
+
+        if not last_response.strip():
+            self._console_print("  (._.) No agent response to verify.")
+            return
+
+        # Find the last user message as context
+        user_context = ""
+        if self.conversation_history:
+            for i in range(len(self.conversation_history) - 1, -1, -1):
+                if self.conversation_history[i].get("role") == "user":
+                    user_context = str(self.conversation_history[i].get("content", ""))
+                    break
+
+        try:
+            from agent.adversarial_verification import (
+                generate_verifier_prompt,
+                get_verifier_system_prompt,
+                parse_verifier_output,
+                format_verification_result,
+            )
+        except ImportError:
+            self._console_print("  (x) Adversarial verification module not available.")
+            return
+
+        # Build the verifier prompt
+        verifier_prompt = generate_verifier_prompt(
+            solution=last_response,
+            context=user_context,
+            solution_type="code",
+        )
+        verifier_system = get_verifier_system_prompt()
+
+        # Use the agent's chat method to get a verification — this runs
+        # a fresh LLM call with the adversarial system prompt, which is
+        # the simplest way to get a verification without touching the
+        # agent loop's tool-calling machinery.
+        if not self.agent:
+            self._console_print("  (x) No active agent to run verification.")
+            return
+
+        self._console_print("  (⚡) Running adversarial verification...")
+
+        try:
+            # Save the current system prompt and temporarily swap it
+            # for the adversarial verifier prompt. This gives the
+            # verifier a fresh context with opposing incentives.
+            # We use a simple chat() call (no tools) to get the verdict.
+            original_system = getattr(self.agent, "system_message", None)
+
+            # Build a minimal conversation for the verifier
+            verify_messages = [
+                {"role": "system", "content": verifier_system},
+                {"role": "user", "content": verifier_prompt},
+            ]
+
+            # Use the agent's client directly for a one-shot verification
+            # call — no tool calling, no iteration, just a verdict.
+            import json as _json
+            client = self.agent._get_client() if hasattr(self.agent, "_get_client") else None
+            if client is None:
+                # Fall back to chat() which is simpler but may include tools
+                verdict_text = self.agent.chat(verifier_prompt)
+            else:
+                response = client.chat.completions.create(
+                    model=self.agent.model,
+                    messages=verify_messages,
+                    temperature=0.3,  # low temp for focused analysis
+                )
+                verdict_text = response.choices[0].message.content or ""
+
+            # Parse the verdict
+            result = parse_verifier_output(verdict_text)
+            formatted = format_verification_result(result)
+            self._console_print(f"\n{formatted}\n")
+
+        except Exception as e:
+            logging.error("adversarial verification failed: %s", e, exc_info=True)
+            self._console_print(f"  (x) Verification failed: {e}")
 
 
     def _toggle_verbose(self):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -118,6 +118,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session, model, token, and context info", "Session"),
+    CommandDef("verify", "Run adversarial verification on the last agent response", "Tools & Skills",
+               cli_only=True, aliases=("vrf",)),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/model_tools.py
+++ b/model_tools.py
@@ -1338,12 +1338,32 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # Record successful tool outcome for circuit-breaker tracking.
+        try:
+            from agent.tool_error_recovery import record_tool_outcome
+            record_tool_outcome(function_name, success=True)
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
-        return json.dumps({"error": _sanitize_tool_error(error_msg)}, ensure_ascii=False)
+        # Classify the tool-level error and enrich the result with a
+        # recovery hint so the model sees not just *what* failed but
+        # *what to try next* (retry, check path, fix args, etc.).
+        enriched = _sanitize_tool_error(error_msg)
+        try:
+            from agent.tool_error_recovery import classify_tool_error, recovery_hint, record_tool_outcome
+            failure = classify_tool_error(function_name, str(e))
+            hint = recovery_hint(failure)
+            if hint:
+                enriched = f"{enriched}{hint}"
+            record_tool_outcome(function_name, success=False)
+        except Exception:
+            pass  # never let the recovery module itself cause a failure
+        return json.dumps({"error": enriched}, ensure_ascii=False)
 
 
 # =============================================================================

--- a/tests/agent/test_adversarial_verification.py
+++ b/tests/agent/test_adversarial_verification.py
@@ -1,0 +1,225 @@
+"""Tests for agent.adversarial_verification — verifier prompt generation and output parsing."""
+
+import json
+import pytest
+from agent.adversarial_verification import (
+    VerificationIssue,
+    VerificationResult,
+    VerificationSeverity,
+    VerificationVerdict,
+    format_verification_result,
+    generate_verifier_prompt,
+    get_verifier_system_prompt,
+    parse_verifier_output,
+)
+
+
+# ── Prompt generation tests ─────────────────────────────────────────────
+
+
+class TestGenerateVerifierPrompt:
+    def test_includes_solution(self):
+        prompt = generate_verifier_prompt("def foo(): pass", solution_type="code")
+        assert "def foo(): pass" in prompt
+
+    def test_includes_context(self):
+        prompt = generate_verifier_prompt("solution", context="original task", solution_type="code")
+        assert "original task" in prompt
+
+    def test_includes_solution_type(self):
+        prompt = generate_verifier_prompt("x", solution_type="research_report")
+        assert "research_report" in prompt
+
+    def test_empty_context_ok(self):
+        prompt = generate_verifier_prompt("x", solution_type="code")
+        assert "## Solution to Verify" in prompt
+
+    def test_system_prompt_has_adversarial_language(self):
+        system = get_verifier_system_prompt()
+        assert "FIND PROBLEMS" in system
+        assert "adversarial" in system.lower()
+        assert "verdict" in system.lower()
+
+
+# ── Output parsing tests ────────────────────────────────────────────────
+
+
+class TestParseVerifierOutput:
+    def test_parses_approved_no_issues(self):
+        output = """```json
+{
+  "verdict": "approved",
+  "confidence": 0.9,
+  "summary": "No issues found",
+  "issues": []
+}
+```"""
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.APPROVED
+        assert result.confidence == 0.9
+        assert len(result.issues) == 0
+        assert result.summary == "No issues found"
+
+    def test_parses_rejected_with_issues(self):
+        output = """```json
+{
+  "verdict": "rejected",
+  "confidence": 0.85,
+  "summary": "Critical bug found",
+  "issues": [
+    {
+      "severity": "critical",
+      "category": "correctness",
+      "description": "Null pointer dereference",
+      "location": "foo.py:42",
+      "evidence": "bar = foo.baz",
+      "recommendation": "Add null check"
+    }
+  ]
+}
+```"""
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.REJECTED
+        assert result.confidence == 0.85
+        assert len(result.issues) == 1
+        issue = result.issues[0]
+        assert issue.severity == VerificationSeverity.CRITICAL
+        assert issue.category == "correctness"
+        assert "Null pointer" in issue.description
+        assert issue.location == "foo.py:42"
+        assert issue.recommendation == "Add null check"
+
+    def test_parses_approved_with_changes(self):
+        output = """```json
+{
+  "verdict": "approved_with_changes",
+  "confidence": 0.7,
+  "summary": "Minor style issues",
+  "issues": [
+    {"severity": "minor", "category": "style", "description": "Bad naming", "recommendation": "Rename"}
+  ]
+}
+```"""
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.APPROVED_WITH_CHANGES
+        assert len(result.issues) == 1
+        assert result.issues[0].severity == VerificationSeverity.MINOR
+
+    def test_handles_multiple_issues(self):
+        output = """```json
+{
+  "verdict": "rejected",
+  "confidence": 0.95,
+  "summary": "Multiple issues",
+  "issues": [
+    {"severity": "major", "category": "security", "description": "SQL injection"},
+    {"severity": "minor", "category": "style", "description": "Long line"},
+    {"severity": "info", "category": "performance", "description": "O(n^2)"}
+  ]
+}
+```"""
+        result = parse_verifier_output(output)
+        assert len(result.issues) == 3
+        assert result.issues[0].severity == VerificationSeverity.MAJOR
+        assert result.issues[1].severity == VerificationSeverity.MINOR
+        assert result.issues[2].severity == VerificationSeverity.INFO
+
+    def test_unparseable_output_defaults_to_approved(self):
+        result = parse_verifier_output("This is not JSON at all")
+        assert result.verdict == VerificationVerdict.APPROVED
+        assert result.confidence == 0.0
+        assert "Could not parse" in result.summary
+
+    def test_empty_output_defaults_to_approved(self):
+        result = parse_verifier_output("")
+        assert result.verdict == VerificationVerdict.APPROVED
+
+    def test_malformed_json_defaults_to_approved(self):
+        output = """```json
+{invalid json
+```"""
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.APPROVED
+
+    def test_raw_output_preserved(self):
+        output = "some raw text"
+        result = parse_verifier_output(output)
+        assert result.raw_output == "some raw text"
+
+    def test_bare_json_without_codeblock(self):
+        output = '{"verdict": "approved", "confidence": 0.5, "summary": "ok", "issues": []}'
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.APPROVED
+        assert result.confidence == 0.5
+
+    def test_unknown_severity_defaults_to_info(self):
+        output = """```json
+{"verdict": "approved", "issues": [{"severity": "unknown_sev", "category": "x", "description": "d"}]}
+```"""
+        result = parse_verifier_output(output)
+        assert len(result.issues) == 1
+        assert result.issues[0].severity == VerificationSeverity.INFO
+
+    def test_unknown_verdict_defaults_to_approved(self):
+        output = """```json
+{"verdict": "maybe", "issues": []}
+```"""
+        result = parse_verifier_output(output)
+        assert result.verdict == VerificationVerdict.APPROVED
+
+
+# ── Formatting tests ────────────────────────────────────────────────────
+
+
+class TestFormatVerificationResult:
+    def test_approved_no_issues(self):
+        result = VerificationResult(
+            verdict=VerificationVerdict.APPROVED,
+            summary="All good",
+            confidence=0.9,
+        )
+        formatted = format_verification_result(result)
+        assert "APPROVED" in formatted
+        assert "All good" in formatted
+        assert "No issues found" in formatted
+
+    def test_rejected_with_issues(self):
+        result = VerificationResult(
+            verdict=VerificationVerdict.REJECTED,
+            summary="Bad",
+            issues=[
+                VerificationIssue(
+                    severity=VerificationSeverity.CRITICAL,
+                    category="correctness",
+                    description="Bug found",
+                    location="line 42",
+                    recommendation="Fix it",
+                ),
+            ],
+        )
+        formatted = format_verification_result(result)
+        assert "REJECTED" in formatted
+        assert "Bug found" in formatted
+        assert "Fix it" in formatted
+        assert "CRITICAL" in formatted
+
+    def test_confidence_percentage(self):
+        result = VerificationResult(
+            verdict=VerificationVerdict.APPROVED,
+            confidence=0.85,
+        )
+        formatted = format_verification_result(result)
+        assert "85%" in formatted
+
+
+# ── Enum completeness ───────────────────────────────────────────────────
+
+
+class TestEnums:
+    def test_all_severities_have_values(self):
+        for sev in VerificationSeverity:
+            assert isinstance(sev.value, str)
+
+    def test_all_verdicts_have_values(self):
+        for verdict in VerificationVerdict:
+            assert isinstance(verdict.value, str)

--- a/tests/agent/test_tool_error_recovery.py
+++ b/tests/agent/test_tool_error_recovery.py
@@ -1,0 +1,174 @@
+"""Tests for agent.tool_error_recovery — tool-level error classification and circuit breaker."""
+
+import pytest
+from agent.tool_error_recovery import (
+    CircuitBreaker,
+    RecoveryAction,
+    ToolErrorClass,
+    ToolFailure,
+    classify_tool_error,
+    get_breaker,
+    recovery_hint,
+    record_tool_outcome,
+)
+
+
+# ── Classification tests ─────────────────────────────────────────────────
+
+
+class TestClassifyToolError:
+    """Pattern-based classification of tool error messages."""
+
+    def test_not_found(self):
+        result = classify_tool_error("read_file", "File not found: /tmp/foo.py")
+        assert result.error_class == ToolErrorClass.not_found
+        assert result.recovery_action == RecoveryAction.check_path
+        assert "Verify the path exists" in result.hint
+
+    def test_no_such_file(self):
+        result = classify_tool_error("terminal", "[Errno 2] No such file or directory")
+        assert result.error_class == ToolErrorClass.not_found
+
+    def test_permission_denied(self):
+        result = classify_tool_error("write_file", "Permission denied: /root/secret")
+        assert result.error_class == ToolErrorClass.permission
+        assert result.recovery_action == RecoveryAction.check_credentials
+
+    def test_rate_limit(self):
+        result = classify_tool_error("web_search", "Rate limit exceeded (429)")
+        assert result.error_class == ToolErrorClass.rate_limit
+        assert result.recovery_action == RecoveryAction.retry
+
+    def test_timeout(self):
+        result = classify_tool_error("terminal", "Command timed out after 30s")
+        assert result.error_class == ToolErrorClass.transient
+        assert result.recovery_action == RecoveryAction.retry
+
+    def test_dependency_missing(self):
+        result = classify_tool_error("terminal", "bash: rg: command not found")
+        assert result.error_class == ToolErrorClass.dependency
+        assert result.recovery_action == RecoveryAction.install_dependency
+
+    def test_module_not_found(self):
+        result = classify_tool_error("execute_code", "ModuleNotFoundError: No module named 'foo'")
+        assert result.error_class == ToolErrorClass.dependency
+
+    def test_validation_bad_args(self):
+        result = classify_tool_error("patch", "Invalid arguments: expected str, got int")
+        assert result.error_class == ToolErrorClass.validation
+        assert result.recovery_action == RecoveryAction.fix_args
+
+    def test_missing_required_param(self):
+        result = classify_tool_error("terminal", "missing required argument: 'command'")
+        assert result.error_class == ToolErrorClass.validation
+
+    def test_json_parse_error(self):
+        result = classify_tool_error("web_extract", "JSON decode error: unexpected token")
+        assert result.error_class == ToolErrorClass.validation
+
+    def test_unknown_error(self):
+        result = classify_tool_error("custom_tool", "Something weird happened")
+        assert result.error_class == ToolErrorClass.unknown
+        assert result.recovery_action == RecoveryAction.escalate
+
+    def test_empty_message(self):
+        result = classify_tool_error("read_file", "")
+        assert result.error_class == ToolErrorClass.unknown
+
+    def test_none_message(self):
+        result = classify_tool_error("read_file", str(None))
+        assert result.error_class == ToolErrorClass.unknown
+
+    def test_tool_name_preserved(self):
+        result = classify_tool_error("my_tool", "File not found")
+        assert result.tool_name == "my_tool"
+
+    def test_attempt_number_preserved(self):
+        result = classify_tool_error("terminal", "timeout", attempt=3)
+        assert result.attempt_number == 3
+
+
+# ── Recovery hint tests ──────────────────────────────────────────────────
+
+
+class TestRecoveryHint:
+    def test_hint_for_known_class(self):
+        failure = ToolFailure(
+            tool_name="read_file",
+            error_message="File not found",
+            error_class=ToolErrorClass.not_found,
+            recovery_action=RecoveryAction.check_path,
+            hint="Check the path.",
+        )
+        hint = recovery_hint(failure)
+        assert "[check_path:" in hint
+        assert "Check the path." in hint
+
+    def test_no_hint_for_unknown(self):
+        failure = ToolFailure(
+            tool_name="custom",
+            error_message="weird",
+            error_class=ToolErrorClass.unknown,
+            recovery_action=RecoveryAction.escalate,
+            hint="",
+        )
+        assert recovery_hint(failure) == ""
+
+
+# ── Circuit breaker tests ────────────────────────────────────────────────
+
+
+class TestCircuitBreaker:
+    def test_starts_closed(self):
+        cb = CircuitBreaker(threshold=3)
+        assert not cb.should_trip()
+
+    def test_opens_after_threshold(self):
+        cb = CircuitBreaker(threshold=3)
+        cb.record_failure()
+        assert not cb.should_trip()
+        cb.record_failure()
+        assert not cb.should_trip()
+        cb.record_failure()
+        assert cb.should_trip()
+
+    def test_resets_on_success(self):
+        cb = CircuitBreaker(threshold=2)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.should_trip()
+        cb.record_success()
+        assert not cb.should_trip()
+
+    def test_stays_open_on_more_failures(self):
+        cb = CircuitBreaker(threshold=2)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.should_trip()
+        cb.record_failure()
+        assert cb.should_trip()
+
+
+class TestBreakerRegistry:
+    def test_get_breaker_creates_new(self):
+        breaker = get_breaker("test_tool_unique_1")
+        assert breaker is not None
+        assert not breaker.should_trip()
+
+    def test_get_breaker_returns_same_instance(self):
+        b1 = get_breaker("test_tool_unique_2")
+        b2 = get_breaker("test_tool_unique_2")
+        assert b1 is b2
+
+    def test_record_outcome_success_resets(self):
+        get_breaker("test_tool_unique_3")  # ensure exists
+        record_tool_outcome("test_tool_unique_3", success=True)
+        breaker = get_breaker("test_tool_unique_3")
+        assert not breaker.should_trip()
+
+    def test_record_outcome_failure_increments(self):
+        breaker = get_breaker("test_tool_unique_4", threshold=10)
+        for _ in range(5):
+            record_tool_outcome("test_tool_unique_4", success=False)
+        assert breaker._consecutive_failures == 5
+        assert not breaker.should_trip()  # threshold is 10


### PR DESCRIPTION
## Summary

Implements two reliability features selected from the evolution analysis: **tool error recovery ladder** (#826) and **adversarial verification pattern** (#825).

Both modules are created fresh WITH wiring into real call sites — prior PRs #864/#865 shipped these as dead code with zero call sites and were closed.

## #826 — Tool Error Recovery Ladder

**Problem:** When a tool fails, the model sees the raw error message but no guidance on how to recover — should it retry? Check the path? Install a missing dependency? This leads to blind retries that waste iterations.

**Solution:** `agent/tool_error_recovery.py` classifies tool-level errors into 7 categories and maps each to a recovery action:

| Error Class | Recovery Action | Example |
|---|---|---|
| not_found | check_path | `File not found: /tmp/foo.py` |
| permission | check_credentials | `Permission denied` |
| rate_limit | retry | `Rate limit exceeded (429)` |
| transient | retry | `Command timed out` |
| dependency | install_dependency | `command not found` |
| validation | fix_args | `Invalid arguments` |
| unknown | escalate | (anything else) |

The error result returned to the model is enriched with a hint like:
```
Error executing terminal: bash: rg: command not found
[install_dependency: A required system dependency is missing. Install it and retry.]
```

A per-tool circuit breaker tracks consecutive failures and trips at a threshold (default 5) to prevent retry storms.

**Wiring:** `model_tools.py` `handle_function_call()` exception handler (line ~1343) classifies the error and appends the hint. The success path records successful outcomes to reset the breaker.

## #825 — Adversarial Verification Pattern

**Problem:** When an agent produces a solution (code, file edit, research report), there's no built-in way to have a second pass with *different incentives* — find problems rather than confirm correctness.

**Solution:** `agent/adversarial_verification.py` provides:
- **Prompt generation** — builds a user message with the solution, context, and type, framed for an adversarial reviewer
- **System prompt** — instructs the verifier to FIND PROBLEMS with specific severity/category/evidence/recommendation format
- **Output parsing** — extracts structured JSON verdict (approved / approved_with_changes / rejected) with severity-ranked issues and confidence
- **Formatting** — human-readable display for CLI output

**Wiring:** `/verify` CLI command (`cli_only`) with `/vrf` alias. The handler finds the last agent response, generates the verifier prompt, runs a fresh LLM call with the adversarial system prompt (no tools, low temperature), parses the verdict, and displays it.

## Tests

- `tests/agent/test_tool_error_recovery.py` — 25 tests (classification, hints, circuit breaker)
- `tests/agent/test_adversarial_verification.py` — 21 tests (prompt generation, output parsing, formatting)
- All 46 new tests pass
- `tests/test_model_tools.py` — 32 existing tests pass (no regressions)
- `tests/hermes_cli/test_commands.py` — 173 existing tests pass (no regressions)

## Design Decisions

- **Lazy imports** in `model_tools.py` wiring — the recovery module is imported inside the exception handler so a failure in the module itself never causes a tool execution failure
- **Circuit breaker is per-tool** — a flaky `web_search` doesn't trip the breaker for `terminal`
- **`/verify` is cli_only** — the adversarial verification pattern needs an interactive session with conversation history; gateway/messaging platforms can add it later via `gateway_config_gate`
- **No new HERMES_` env vars** — all configuration goes through existing config.yaml paths
- **No core tool footprint** — error recovery enriches existing tool results; adversarial verification is a CLI command, not a model tool