### PR TITLE
fix(evolution): cohort selection-efficiency from GitHub — kill the funnel's false MERGED_ZERO alarm

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
@@ -69,6 +71,17 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     rejected = analysis.get("rejected") or []
     merged = integration.get("merged") or []
     skipped = integration.get("skipped") or []
+    # Issue numbers of the selected picks — lets evolution_metrics compute a
+    # COHORT selection-efficiency (distinct selected issues that landed >=1 merge
+    # / distinct selected issues), which is bounded 0..1 and immune to
+    # increment-PR inflation, unlike a raw merged/selected count ratio.
+    selected_issue_ids: list[int] = []
+    for _e in selected if isinstance(selected, list) else []:
+        if isinstance(_e, dict):
+            try:
+                selected_issue_ids.append(int(_e["issue_number"]))
+            except (KeyError, TypeError, ValueError):
+                continue
     # introspection may be a bare list of patterns OR a dict with patterns_found.
     if isinstance(introspection_raw, list):
         patterns = introspection_raw
@@ -108,6 +121,7 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
         # triage / selection
         "selected": len(selected) if isinstance(selected, list) else 0,
         "selected_by_reason": _counts_by(selected, "selected_reason"),
+        "selected_issue_ids": selected_issue_ids,
         "rejected": len(rejected) if isinstance(rejected, list) else 0,
         "rejected_by_reason": _counts_by(rejected, "reason_code"),
         # outflow
@@ -153,6 +167,128 @@ def load_records(metrics_file: Path) -> list[Dict[str, Any]]:
         if isinstance(obj, dict):
             out.append(obj)
     return out
+
+
+# ── GitHub-authoritative merge counting ──────────────────────────────────────
+# The `merged` funnel signal used to come ONLY from the integration stage's
+# self-report (integration/<date>.json). That undercounted reality two ways:
+#   1. Blind to owner-reviewed merges — the human merges evolution PRs in
+#      batches (including oversized ones the autonomous <=200-line self-merge
+#      gate cannot touch), and those never appear in a self-merge report.
+#   2. LLM stages sometimes write FUTURE-dated reports (#667), so even a
+#      recorded merge landed in a file compute_funnel never reads for the real
+#      cycle date.
+# Both inflated a FALSE MERGED_ZERO / LOW_SELECTION_EFFICIENCY watchdog alarm.
+# GitHub is the authority for "did the selected work actually land", so count
+# merged evolution/issue-* PRs directly. Deterministic + fail-open: any failure
+# (gh missing, unauth, offline, bad JSON) returns None and the caller keeps the
+# self-report, so this no_agent job never depends on the network.
+
+_EVOLUTION_BRANCH_PREFIX = "evolution/issue-"
+
+
+def _gh_pr_list_merged(repo: str, limit: int = 200, timeout: int = 30):
+    """Return merged PRs for ``repo`` as a list of dicts, or None on any failure.
+    Injection seam: tests monkeypatch this to stay off the network."""
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "merged",
+                "--json",
+                "number,headRefName,mergedAt",
+                "--limit",
+                str(limit),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        ).stdout
+        data = json.loads(out)
+    except Exception:  # gh missing / unauth / network / bad JSON — fail open
+        return None
+    return data if isinstance(data, list) else None
+
+
+def merged_evolution_issue_ids(
+    date: str, repo: str, branch_prefix: str = _EVOLUTION_BRANCH_PREFIX
+) -> set[int] | None:
+    """Return the DISTINCT issue numbers whose ``branch_prefix`` PRs merged ON
+    ``date`` (UTC) in ``repo`` — e.g. issue-798-inc1/inc2/inc3 collapse to
+    ``{798}``. Returns None when GitHub is unavailable so the caller can fall
+    back to the integration stage's self-report. Collapsing to distinct issues
+    keeps the selection-efficiency numerator dimensionally aligned with the
+    distinct selected-issue denominator (increment PRs must not inflate it)."""
+    prs = _gh_pr_list_merged(repo)
+    if prs is None:
+        return None
+    pat = re.compile(re.escape(branch_prefix) + r"(\d+)")
+    ids: set[int] = set()
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        head = str(pr.get("headRefName", ""))
+        merged_at = str(pr.get("mergedAt", "") or "")
+        if merged_at[:10] != date:
+            continue
+        m = pat.match(head)
+        if m:
+            ids.add(int(m.group(1)))
+    return ids
+
+
+def count_merged_evolution_prs(
+    date: str, repo: str, branch_prefix: str = _EVOLUTION_BRANCH_PREFIX
+) -> int | None:
+    """Count DISTINCT issues merged ON ``date`` (see merged_evolution_issue_ids).
+    Returns None when GitHub is unavailable so the caller can fall back to the
+    integration stage's self-report count."""
+    ids = merged_evolution_issue_ids(date, repo, branch_prefix)
+    return None if ids is None else len(ids)
+
+
+def _resolve_repo() -> str | None:
+    """Resolve OWNER/REPO for the gh queries — fork-agnostic and config-free:
+    explicit env override -> this checkout's origin remote -> gh's default.
+    Returns None if none resolve (merge counting then fails open)."""
+    env = os.environ.get("EVOLUTION_GH_REPO", "").strip()
+    if env:
+        return env
+    # Parse the origin remote of the checkout this script lives in. A fork's
+    # origin points at the fork, so this stays correct upstream and downstream.
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        url = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+        m = re.search(r"github\.com[:/]+([^/]+/[^/]+?)(?:\.git)?/?$", url)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    try:
+        out = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+        if out:
+            return out
+    except Exception:
+        pass
+    return None
 
 
 def is_evolution_halted(evolution_dir: Path | None = None) -> bool | None:
@@ -294,6 +430,28 @@ def main(argv: list[str]) -> int:
             return 1
 
     record = compute_funnel(evolution_dir, date)
+
+    # Replace the integration stage's self-reported merge count with GitHub
+    # truth when available: this counts owner-reviewed merges the self-report
+    # can't see AND is immune to future-dated stage reports (#667). Fail-open —
+    # keep the self-report if gh is unavailable so this deterministic no_agent
+    # job never depends on the network.
+    _repo = _resolve_repo()
+    if _repo:
+        _merged_ids = merged_evolution_issue_ids(date, _repo)
+        if _merged_ids is not None:
+            _gh_merged = len(_merged_ids)
+            if _gh_merged != record["merged"]:
+                logger.info(
+                    "funnel merged[%s]: self-report=%d -> gh=%d distinct issues "
+                    "(authoritative)",
+                    date,
+                    record["merged"],
+                    _gh_merged,
+                )
+            record["merged"] = _gh_merged
+            record["merged_issue_ids"] = sorted(_merged_ids)
+
     append_funnel(evolution_dir / "metrics.jsonl", record)
 
     # ── Halt detection gate (#evolution — zero-deliverables auto-halt) ──

--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -90,7 +90,37 @@ def compute_health(
 
     succeeded = sum(1 for r in active if _int(r, "merged") > 0)
     cycle_success_rate = (succeeded / len(active)) if active else None
-    selection_efficiency = (mrg / sel) if sel else None
+
+    # Cohort selection-efficiency (evolution watchdog false-alarm fix): the
+    # honest "can it land what it picks" signal is the fraction of DISTINCT
+    # selected issues that landed >=1 merged PR — bounded 0..1 and immune to the
+    # increment-PR inflation (issue-798-inc1/2/3 collapse to one issue) that a
+    # raw merged/selected count ratio suffered (it swung to a meaningless
+    # ~100%). Falls back to the legacy count ratio for pre-cohort records that
+    # predate the funnel emitting issue-id lists.
+    def _id_set(key: str) -> set:
+        s: set = set()
+        for r in window:
+            v = r.get(key)
+            if isinstance(v, list):
+                for x in v:
+                    try:
+                        s.add(int(x))
+                    except (TypeError, ValueError):
+                        continue
+        return s
+
+    _has_cohort = any(
+        "selected_issue_ids" in r or "merged_issue_ids" in r for r in window
+    )
+    if _has_cohort:
+        _sel_ids = _id_set("selected_issue_ids")
+        _mrg_ids = _id_set("merged_issue_ids")
+        selection_efficiency = (
+            len(_sel_ids & _mrg_ids) / len(_sel_ids) if _sel_ids else None
+        )
+    else:
+        selection_efficiency = (mrg / sel) if sel else None
     reject_rate = (rej / triaged) if triaged else None
 
     flags: List[str] = []

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -4,10 +4,13 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from datetime import datetime  # noqa: E402
 
+import evolution_funnel as ef  # noqa: E402
 from evolution_funnel import (  # noqa: E402
     append_funnel,
     compute_funnel,
@@ -21,6 +24,15 @@ from evolution_funnel import (  # noqa: E402
 def _write(p: Path, obj):
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _no_real_gh(monkeypatch):
+    """Hermetic default: the funnel's GitHub `merged` enrichment must NEVER hit
+    the network in tests. Each test that exercises merged-from-GitHub opts in by
+    re-patching `_gh_pr_list_merged` (a later setattr wins). raising=False keeps
+    the fixture valid during the TDD red phase before the seam exists."""
+    monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda *a, **k: None, raising=False)
 
 
 class TestComputeFunnel:
@@ -288,3 +300,148 @@ class TestSummarySidecar:
         assert body.startswith("[evolution-funnel] last")
         # the seeded 90% reject cycle should surface the directive
         assert "HIGH_REJECT_RATE" in body
+
+
+class TestMergedFromGitHub:
+    """`merged` is counted authoritatively from GitHub, not the integration
+    stage's self-report. This is the fix for the evolution watchdog's 7-day
+    false MERGED_ZERO / LOW_SELECTION_EFFICIENCY alarm: owner-reviewed merges
+    (and merges the autonomous <=200-line gate can't perform) become visible,
+    and the count is immune to future-dated stage reports (#667)."""
+
+    # A realistic slice of the real 2026-07-08/09 merge history on osoba.
+    _PRS = [
+        {
+            "number": 854,
+            "headRefName": "evolution/issue-752-memory-importance-v2",
+            "mergedAt": "2026-07-09T19:16:20Z",
+        },
+        {
+            "number": 819,
+            "headRefName": "evolution/issue-756-refusal-taxonomy",
+            "mergedAt": "2026-07-09T01:02:00Z",
+        },
+        {
+            "number": 843,
+            "headRefName": "evolution/issue-798-inc3",
+            "mergedAt": "2026-07-09T17:12:26Z",
+        },
+        {
+            "number": 816,
+            "headRefName": "evolution/issue-750-mfr-v2",
+            "mergedAt": "2026-07-08T21:02:53Z",
+        },
+        # excluded: not an evolution/issue-* branch
+        {
+            "number": 806,
+            "headRefName": "evolution/fix-research-skill-default-path",
+            "mergedAt": "2026-07-08T12:39:00Z",
+        },
+        {
+            "number": 848,
+            "headRefName": "sync/upstream-release-v2026.7.7.2",
+            "mergedAt": "2026-07-09T20:09:01Z",
+        },
+    ]
+
+    def test_counts_only_evolution_issue_branches_on_that_date(self, monkeypatch):
+        monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda repo, **k: list(self._PRS))
+        # 2026-07-09: #854, #819, #843 are evolution/issue-*; #848 (sync/*) excluded
+        assert ef.count_merged_evolution_prs("2026-07-09", "o/r") == 3
+        # 2026-07-08: #816 is evolution/issue-*; #806 (evolution/fix-*) excluded
+        assert ef.count_merged_evolution_prs("2026-07-08", "o/r") == 1
+        # a day with no evolution/issue-* merges
+        assert ef.count_merged_evolution_prs("2026-07-07", "o/r") == 0
+
+    def test_increment_prs_collapse_to_distinct_issue(self, monkeypatch):
+        # issue-798-inc1/inc2/inc3 are three PRs for ONE issue — they must count
+        # as a single landed issue, else selection-efficiency inflates past 100%.
+        prs = [
+            {
+                "number": 817,
+                "headRefName": "evolution/issue-798-draft-selector",
+                "mergedAt": "2026-07-09T01:02:12Z",
+            },
+            {
+                "number": 820,
+                "headRefName": "evolution/issue-798-cost-routing",
+                "mergedAt": "2026-07-09T07:36:04Z",
+            },
+            {
+                "number": 843,
+                "headRefName": "evolution/issue-798-inc3",
+                "mergedAt": "2026-07-09T17:12:26Z",
+            },
+        ]
+        monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda repo, **k: prs)
+        assert ef.merged_evolution_issue_ids("2026-07-09", "o/r") == {798}
+        assert ef.count_merged_evolution_prs("2026-07-09", "o/r") == 1  # not 3
+
+    def test_compute_funnel_records_selected_issue_ids(self, tmp_path):
+        d = "2026-07-09"
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {
+                "selected_for_implementation": [
+                    {"issue_number": 756, "selected_reason": "score"},
+                    {"issue_number": 798, "selected_reason": "score"},
+                    {"selected_reason": "anti-starvation"},  # no issue_number
+                ],
+                "rejected": [],
+            },
+        )
+        r = compute_funnel(tmp_path, d)
+        assert r["selected"] == 3
+        assert r["selected_issue_ids"] == [756, 798]  # entry without id skipped
+
+    def test_fail_open_returns_none_when_gh_unavailable(self, monkeypatch):
+        monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda repo, **k: None)
+        assert ef.count_merged_evolution_prs("2026-07-09", "o/r") is None
+        assert ef.merged_evolution_issue_ids("2026-07-09", "o/r") is None
+
+    def test_main_overrides_selfreport_merged_with_github_truth(
+        self, tmp_path, monkeypatch
+    ):
+        # Integration self-report says merged=0 (read-only / future-dated), but
+        # GitHub shows evolution/issue-* PRs actually merged that day.
+        d = "2026-07-09"
+        _write(
+            tmp_path / "analysis" / f"{d}.json",
+            {
+                "selected_for_implementation": [
+                    {"issue_number": 756, "selected_reason": "score"}
+                ],
+                "rejected": [],
+            },
+        )
+        _write(tmp_path / "integration" / f"{d}.json", {"merged": [], "skipped": []})
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        monkeypatch.setenv("EVOLUTION_GH_REPO", "o/r")
+        monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda repo, **k: list(self._PRS))
+
+        rc = ef.main(["evolution_funnel.py", d])
+        assert rc == 0
+        rec = [r for r in load_records(tmp_path / "metrics.jsonl") if r["date"] == d][0]
+        assert rec["merged"] == 3  # distinct issues {752, 756, 798}, not 0
+        assert rec["merged_issue_ids"] == [752, 756, 798]
+        assert rec["selected_issue_ids"] == [756]
+
+    def test_main_fail_open_keeps_selfreport_when_gh_none(self, tmp_path, monkeypatch):
+        # gh unavailable (offline/CI) -> keep the integration self-report count.
+        d = "2026-07-01"
+        _write(
+            tmp_path / "integration" / f"{d}.json",
+            {"merged": [{"pr": 1}], "skipped": []},
+        )
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        monkeypatch.setenv("EVOLUTION_GH_REPO", "o/r")
+        monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda repo, **k: None)
+
+        rc = ef.main(["evolution_funnel.py", d])
+        assert rc == 0
+        rec = [r for r in load_records(tmp_path / "metrics.jsonl") if r["date"] == d][0]
+        assert rec["merged"] == 1  # self-report preserved (fail-open)
+
+    def test_resolve_repo_prefers_env(self, monkeypatch):
+        monkeypatch.setenv("EVOLUTION_GH_REPO", "owner/repo-from-env")
+        assert ef._resolve_repo() == "owner/repo-from-env"

--- a/tests/scripts/test_evolution_metrics.py
+++ b/tests/scripts/test_evolution_metrics.py
@@ -129,3 +129,58 @@ class TestComputeHealth:
         assert h["halted"] is False
         assert not any("HALTED" in f for f in h["flags"])
         assert "| healthy" in format_health(h)
+
+
+class TestCohortSelectionEfficiency:
+    """selection_efficiency is a COHORT ratio when the funnel emits issue-id
+    lists: distinct selected issues that landed >=1 merge / distinct selected
+    issues. Bounded 0..1, immune to increment-PR inflation and temporal skew.
+    Falls back to the legacy merged/selected count ratio for pre-cohort records.
+    """
+
+    def _crec(self, date, selected_ids=None, merged_ids=None, rejected=0):
+        r = {
+            "date": date,
+            "issues_created": 0,
+            "selected": len(selected_ids or []),
+            "merged": len(merged_ids or []),
+            "rejected": rejected,
+        }
+        if selected_ids is not None:
+            r["selected_issue_ids"] = list(selected_ids)
+        if merged_ids is not None:
+            r["merged_issue_ids"] = list(merged_ids)
+        return r
+
+    def test_cohort_ratio_from_issue_ids(self):
+        # 4 distinct selected issues; 2 of them landed -> 0.5, NOT merged/selected.
+        recs = [
+            self._crec("d1", selected_ids=[1, 2], merged_ids=[2]),
+            self._crec("d2", selected_ids=[3, 4], merged_ids=[4]),
+        ]
+        h = compute_health(recs)
+        assert h["selection_efficiency"] == 0.5
+
+    def test_increment_merges_do_not_exceed_100pct(self):
+        # One selected issue, three increment merges recorded as one issue id.
+        recs = [
+            self._crec(f"d{i}", selected_ids=[798], merged_ids=[798]) for i in range(3)
+        ]
+        h = compute_health(recs)
+        assert h["selection_efficiency"] == 1.0  # bounded, never >1
+
+    def test_temporal_lag_issue_selected_then_merged_next_cycle(self):
+        # Selected on d1 (no merge yet), merged on d2 -> counts as landed.
+        recs = [
+            self._crec("d1", selected_ids=[798], merged_ids=[]),
+            self._crec("d2", selected_ids=[801], merged_ids=[798]),
+        ]
+        h = compute_health(recs)
+        # both 798 and 801 selected; only 798 landed -> 0.5
+        assert h["selection_efficiency"] == 0.5
+
+    def test_legacy_records_without_ids_use_count_ratio(self):
+        # No issue-id fields -> fall back to merged/selected counts (0.3).
+        recs = [_rec(f"d{i}", selected=10, merged=3) for i in range(5)]
+        h = compute_health(recs)
+        assert h["selection_efficiency"] == round(15 / 50, 3)


### PR DESCRIPTION
## What this fixes

The evolution watchdog fired **`LOW_SELECTION_EFFICIENCY` (7%) / `LOW_SUCCESS` (28%) / `MERGED_ZERO x7`** unchanged for **7 days**. Investigation on `osoba` showed this is a **measurement artifact, not a stalled pipeline** — the pipeline's selected work IS landing.

### Root cause
- `merged` was counted **only** from the integration stage's self-report (`integration/<date>.json` self-merge). But the owner reviews & merges `evolution/issue-*` PRs in batches — including oversized ones the autonomous ≤200-line self-merge gate physically can't touch. Those human merges were invisible to the metric. **Verified: 15 `evolution/issue-*` PRs actually merged 2026-07-08/09 while `metrics.jsonl` recorded `merged=0`.**
- LLM stages also write **future-dated** reports (#667, closed but still live — dirs polluted with `2026-08-*`/`2026-09-*` files written in July), so even a self-reported merge lands in a file the funnel never reads for the real cycle date.

## The fix
1. **`merged` counted authoritatively from GitHub** — `evolution/issue-*` PRs by `mergedAt` date, collapsed to **distinct issue numbers** so increment PRs (`issue-798-inc1/2/3`) don't over-count. Deterministic + **fail-open** (any `gh` failure keeps the self-report, so the `no_agent` job never needs the network). Repo resolved fork-agnostically (`EVOLUTION_GH_REPO` → origin remote → `gh` default).
2. **`selection_efficiency` is now a cohort ratio** — distinct selected issues that landed ≥1 merge / distinct selected issues. The funnel records `selected_issue_ids` + `merged_issue_ids`; `compute_health` unions them over the window. Bounded 0..1, immune to increment inflation and temporal skew, with a legacy count-ratio fallback for pre-cohort records.

### Why cohort, not a raw PR count
A raw `merged/selected` ratio swings efficiency to a meaningless **~97%** (increment PRs + async merges) — which would **mask** the real signal instead of surfacing it. Cross-checked with an independent advisor (Gemini via consilium); confirmed on live data the true distinct-issue landing rate is **43%**.

## Verification (live `osoba` data)
| | BEFORE | AFTER |
|---|---|---|
| success | 28% | **88%** |
| selection_efficiency | 7% (false-low) | **43% (honest)** |
| merged_zero_streak | 7 → `MERGED_ZERO x7` | **0 → `signal OK`** |
| flags | `LOW_SUCCESS` + `LOW_SELECTION_EFFICIENCY` | **`healthy`** |

If the landing rate ever drops below 34% the flag now fires **correctly** instead of being masked. The genuine `REALIZED_RATE_LOW` (40%) signal is untouched and now visible without the false alarms drowning it.

**Tests:** 161 pass (funnel + metrics + watchdog + realized-impact + backlog); ruff clean.

## After merge — required backfill
`main` auto-deploys to `osoba` via nightly-sync. To correct history immediately (otherwise the false flag lingers until old `merged=0` records roll out of the 30-cycle window), re-run the funnel for the recorded dates (idempotent per date):
```bash
cd /root/hermes-agent-evolution
for d in $(python3 -c "import json;[print(json.loads(l)['date']) for l in open('/root/.hermes/profiles/user1/evolution/metrics.jsonl') if l.strip()]"); do
  python3 scripts/evolution_funnel.py "$d"
done
```

## Follow-up (separate)
Reopen **#667** — future-dated stage reports are still written systemically. `merged` is now immune, but `selected`/`created` still read `<stage>/{real_date}.json`; a deterministic-date writer is the proper fix.
