### PR TITLE
feat(evolution): watchdog reality reconciliation — honest escalation for the MERGED_ZERO false alarm

### DIFF
--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -94,15 +95,17 @@ EDGE_COOLDOWN_DAYS = 7
 ALERT_STATE_FILENAME = "watchdog-alert-state.json"
 
 
-def expected_report_date(now: datetime, slot_hour: int, grace_hours: int = GRACE_HOURS) -> str:
+def expected_report_date(
+    now: datetime, slot_hour: int, grace_hours: int = GRACE_HOURS
+) -> str:
     """Date (YYYY-MM-DD) whose report should exist for a daily slot.
 
     If the slot (plus grace) has already passed today, today's report is
     expected; otherwise yesterday's is the most recent one that must exist.
     """
-    slot_deadline = now.replace(hour=slot_hour, minute=0, second=0, microsecond=0) + timedelta(
-        hours=grace_hours
-    )
+    slot_deadline = now.replace(
+        hour=slot_hour, minute=0, second=0, microsecond=0
+    ) + timedelta(hours=grace_hours)
     day = now.date() if now >= slot_deadline else (now - timedelta(days=1)).date()
     return day.isoformat()
 
@@ -145,7 +148,9 @@ def _stage_clean_job_for_slot(
     return None
 
 
-def _stage_ran_clean_for_slot(jobs: List[dict], stage: str, date: str, slot_hour: int) -> bool:
+def _stage_ran_clean_for_slot(
+    jobs: List[dict], stage: str, date: str, slot_hour: int
+) -> bool:
     """Boolean wrapper kept for existing callers — see
     ``_stage_clean_job_for_slot``."""
     return _stage_clean_job_for_slot(jobs, stage, date, slot_hour) is not None
@@ -257,7 +262,9 @@ def _default_runner(cmd: List[str]) -> Tuple[int, str]:
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
 
 
-def check_gh(runner: Callable[[List[str]], Tuple[int, str]] = _default_runner) -> List[str]:
+def check_gh(
+    runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
+) -> List[str]:
     """Alert when gh auth is broken or API rate budget is nearly gone."""
     alerts: List[str] = []
     try:
@@ -374,9 +381,15 @@ def _release_lag_alerts(
     # exits 0 = ancestor (merged), 1 = not an ancestor (missing), 128/other = bad
     # ref (tag not fetched locally yet) → unmeasurable, stay silent.
     try:
-        rc, _out = runner(
-            ["git", "-C", str(repo), "merge-base", "--is-ancestor", tag, "HEAD"]
-        )
+        rc, _out = runner([
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "--is-ancestor",
+            tag,
+            "HEAD",
+        ])
     except Exception:  # noqa: BLE001
         return []
     if rc == 0:
@@ -433,9 +446,15 @@ def _latest_upstream_release(
 ) -> Tuple[str, str] | None:
     """(tagName, publishedAt) of upstream's latest GitHub release, or None."""
     try:
-        rc, out = runner(
-            ["gh", "release", "view", "--repo", slug, "--json", "tagName,publishedAt"]
-        )
+        rc, out = runner([
+            "gh",
+            "release",
+            "view",
+            "--repo",
+            slug,
+            "--json",
+            "tagName,publishedAt",
+        ])
     except Exception:  # noqa: BLE001 — gh missing/unauthed: fail-open
         return None
     if rc != 0 or not out.strip():
@@ -535,19 +554,17 @@ def ensure_upstream_issue(
 
     # 1) Look for an existing open [UPSTREAM] issue (the idempotency key).
     try:
-        rc, out = runner(
-            [
-                "gh",
-                "issue",
-                "list",
-                "--search",
-                f"{UPSTREAM_ISSUE_PREFIX} in:title",
-                "--state",
-                "open",
-                "--json",
-                "number,title",
-            ]
-        )
+        rc, out = runner([
+            "gh",
+            "issue",
+            "list",
+            "--search",
+            f"{UPSTREAM_ISSUE_PREFIX} in:title",
+            "--state",
+            "open",
+            "--json",
+            "number,title",
+        ])
     except Exception:  # noqa: BLE001 — gh missing/spawn failure: fail-open
         return None
     if rc != 0:
@@ -577,9 +594,7 @@ def ensure_upstream_issue(
         f"fork (owner review of any conflicts), then close this issue.\n"
     )
     try:
-        rc, _out = runner(
-            ["gh", "issue", "create", "--title", title, "--body", body]
-        )
+        rc, _out = runner(["gh", "issue", "create", "--title", title, "--body", body])
     except Exception:  # noqa: BLE001 — fail-open on create spawn failure
         return None
     if rc != 0:
@@ -604,16 +619,27 @@ def _upstream_lag_unmeasurable(
     before — this can never make the check worse than today.
     """
     try:
-        rc, out = runner(
-            ["git", "-C", str(repo), "rev-parse", "--is-shallow-repository"]
-        )
+        rc, out = runner([
+            "git",
+            "-C",
+            str(repo),
+            "rev-parse",
+            "--is-shallow-repository",
+        ])
         if rc == 0 and out.strip() == "true":
             return True
     except Exception:  # noqa: BLE001 — inconclusive probe: don't block the real check
         return False
 
     try:
-        rc, out = runner(["git", "-C", str(repo), "merge-base", "HEAD", "upstream/main"])
+        rc, out = runner([
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "HEAD",
+            "upstream/main",
+        ])
     except Exception:  # noqa: BLE001
         return False
     # No common ancestor: git exits non-zero with NOTHING on stdout. A non-zero
@@ -663,17 +689,15 @@ def check_runtime_divergence(
         return []
 
     try:
-        rc_anc, _out = runner(
-            [
-                "git",
-                "-C",
-                str(repo),
-                "merge-base",
-                "--is-ancestor",
-                "HEAD",
-                "origin/main",
-            ]
-        )
+        rc_anc, _out = runner([
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "--is-ancestor",
+            "HEAD",
+            "origin/main",
+        ])
     except Exception:  # noqa: BLE001 — spawn failure: fail-open
         return []
     # rc 0 == HEAD IS an ancestor of origin/main → ff-able → not frozen.
@@ -685,9 +709,14 @@ def check_runtime_divergence(
         return []
 
     try:
-        rc_ahead, out_ahead = runner(
-            ["git", "-C", str(repo), "rev-list", "--count", "origin/main..HEAD"]
-        )
+        rc_ahead, out_ahead = runner([
+            "git",
+            "-C",
+            str(repo),
+            "rev-list",
+            "--count",
+            "origin/main..HEAD",
+        ])
     except Exception:  # noqa: BLE001
         return []
     if rc_ahead != 0:
@@ -701,9 +730,14 @@ def check_runtime_divergence(
 
     behind = 0
     try:
-        rc_behind, out_behind = runner(
-            ["git", "-C", str(repo), "rev-list", "--count", "HEAD..origin/main"]
-        )
+        rc_behind, out_behind = runner([
+            "git",
+            "-C",
+            str(repo),
+            "rev-list",
+            "--count",
+            "HEAD..origin/main",
+        ])
         if rc_behind == 0:
             behind = int(out_behind.strip().split()[0])
     except (Exception, ValueError, IndexError):  # noqa: BLE001 — count is cosmetic
@@ -728,7 +762,9 @@ def check_health(evolution_dir: Path) -> List[str]:
     there is no sidecar yet (the stage-report checks already cover 'funnel didn't
     run')."""
     try:
-        line = (evolution_dir / "evolution-health.txt").read_text(encoding="utf-8").strip()
+        line = (
+            (evolution_dir / "evolution-health.txt").read_text(encoding="utf-8").strip()
+        )
     except OSError:
         return []
     if not line or line.endswith("| healthy"):
@@ -746,7 +782,9 @@ def check_realized_impact(evolution_dir: Path) -> List[str]:
     running. This is the loop that stops the agent from optimizing a predicted
     impact it never checks against reality. Silent when healthy or absent."""
     try:
-        line = (evolution_dir / "realized-impact.txt").read_text(encoding="utf-8").strip()
+        line = (
+            (evolution_dir / "realized-impact.txt").read_text(encoding="utf-8").strip()
+        )
     except OSError:
         return []
     if not line or line.endswith("| healthy"):
@@ -771,6 +809,127 @@ def check_analysis_integrity(evolution_dir: Path) -> List[str]:
         f"analysis selection integrity: {v}"
         for v in audit_latest(evolution_dir, _resolve_repo_dir())
     ]
+
+
+# ---------------------------------------------------------------------------
+# Reality reconciliation — never forward a metric-derived diagnosis that
+# GitHub reality contradicts.
+#
+# The class of failure this catches: the pipeline measures ITSELF, so when its
+# self-measurement is wrong it draws (and escalates) a wrong conclusion. The
+# 2026-07 incident: the funnel counted `merged` only from the integration
+# stage's self-report, missing the owner's manual merges — so health screamed
+# "integration stuck / picks more than it can land" for 7 days while GitHub
+# showed 15 evolution PRs actually merging. PR #885 anchored `merged` to GitHub
+# so the sidecar is now truthful, but a self-measuring system needs a standing
+# immune response: if a FUTURE metric regression (or a mis-dated stage report,
+# #667) ever makes the health line claim a merge/selection stall while GitHub
+# shows evolution PRs merging, that is an INSTRUMENTATION fault, not a pipeline
+# stall. Relabel it so the owner gets the honest diagnosis instead of chasing a
+# phantom — and so the pipeline can act on the right (funnel/#667) issue.
+#
+# Fail-open + no-mask: any gh failure, or GitHub agreeing there are no merges
+# (a real stall), leaves the alerts EXACTLY as-is. Reconciliation can only ever
+# RELABEL a merge/selection alert that reality demonstrably contradicts; it
+# never suppresses one.
+#
+# SCOPE — only MERGED_ZERO. It is the sole health flag whose predicate is a
+# COUNT claim ("zero merges this window") that a nonzero GitHub count genuinely
+# contradicts. LOW_SUCCESS and LOW_SELECTION_EFFICIENCY are RATE/RATIO claims
+# (fraction of cycles that landed a merge; distinct-selected-that-landed /
+# distinct-selected) — a single existing merge does NOT refute a low rate
+# (select 100, land 1 → ratio 0.01 is a TRUE degradation that coexists with
+# count>=1). Relabeling those on a mere count would VIOLATE no-mask and hide the
+# very quality signal the watchdog exists to protect, so they are deliberately
+# excluded. A sound ratio reconciliation (GitHub-derived merged/selected over
+# the same window) is a possible future enhancement, not needed for correctness.
+# ---------------------------------------------------------------------------
+
+_DIVERGEABLE_FLAGS = ("MERGED_ZERO",)
+_MIN_HEALTHY_MERGES = 1  # >=1 evolution/issue-* issue merged == the zero claim is false
+_REALITY_WINDOW_DAYS = 7
+
+
+def recent_merged_evolution_issue_count(
+    now: datetime,
+    runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
+    window_days: int = _REALITY_WINDOW_DAYS,
+    branch_prefix: str = "evolution/issue-",
+) -> int | None:
+    """Distinct evolution issues merged on GitHub within the last ``window_days``.
+
+    Returns None on any gh failure so the caller can fall open (never suppress a
+    real alert on a reconciliation error). Distinct issue numbers, so increment
+    PRs (issue-798-inc1/2/3) count once."""
+    try:
+        rc, out = runner([
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--json",
+            "headRefName,mergedAt",
+            "--limit",
+            "100",
+        ])
+        if rc != 0:
+            return None
+        prs = json.loads(out)
+    except Exception:  # noqa: BLE001 — any gh/parse failure → fall open
+        return None
+    if not isinstance(prs, list):
+        return None
+    cutoff = (now - timedelta(days=window_days)).strftime("%Y-%m-%d")
+    pat = re.compile(re.escape(branch_prefix) + r"(\d+)")
+    ids: set[int] = set()
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        merged_day = str(pr.get("mergedAt", "") or "")[:10]  # ISO dates sort lexically
+        m = pat.match(str(pr.get("headRefName", "")))
+        if m and merged_day and merged_day >= cutoff:
+            ids.add(int(m.group(1)))
+    return len(ids)
+
+
+def reconcile_health_with_reality(
+    health_alerts: List[str],
+    now: datetime,
+    runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
+    window_days: int = _REALITY_WINDOW_DAYS,
+) -> List[str]:
+    """Relabel a MERGED_ZERO health alert that GitHub reality contradicts.
+
+    MERGED_ZERO claims the funnel recorded zero merges for a run of cycles. If
+    GitHub shows evolution issues actually merging in the window, that COUNT
+    claim is false — replace the alert with a single honest METRIC_DIVERGENCE
+    line (stable flag tail, so edge-triggering keys on it without re-screaming
+    the drifting merge count). Only MERGED_ZERO is in scope (see the block
+    above): rate/ratio flags are deliberately NOT relabeled on a count, to
+    preserve no-mask. Fail-open: gh unknown, or GitHub agreeing there were no
+    merges, leaves ``health_alerts`` untouched."""
+    if not any(any(f in a for f in _DIVERGEABLE_FLAGS) for a in health_alerts):
+        return health_alerts
+    merged = recent_merged_evolution_issue_count(now, runner, window_days)
+    if merged is None or merged < _MIN_HEALTHY_MERGES:
+        return health_alerts  # gh unknown OR reality agrees it's stalled → keep as-is
+    divergence = (
+        f"funnel reports zero merges, but GitHub shows {merged} evolution/issue-* "
+        f"issue(s) merged in the last {window_days}d "
+        "| METRIC_DIVERGENCE: instrumentation suspect (funnel / #667), NOT the "
+        "pipeline — verify the metric, auto-clears once the funnel backfills"
+    )
+    out: List[str] = []
+    inserted = False
+    for a in health_alerts:
+        if any(f in a for f in _DIVERGEABLE_FLAGS):
+            if not inserted:  # collapse all diverging flags into one honest line
+                out.append(divergence)
+                inserted = True
+        else:
+            out.append(a)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -851,16 +1010,19 @@ def load_alert_state(state_path: Path) -> dict | None:
     return data
 
 
-def save_alert_state(state_path: Path, signature: str, last_emitted_at: datetime) -> None:
+def save_alert_state(
+    state_path: Path, signature: str, last_emitted_at: datetime
+) -> None:
     """Persist the current signature + last-emitted timestamp. FAIL-OPEN: a
     write failure is swallowed — it must never crash the run nor (by raising)
     suppress an alert the caller already decided to emit."""
     try:
         state_path.parent.mkdir(parents=True, exist_ok=True)
         state_path.write_text(
-            json.dumps(
-                {"signature": signature, "last_emitted_at": last_emitted_at.isoformat()}
-            ),
+            json.dumps({
+                "signature": signature,
+                "last_emitted_at": last_emitted_at.isoformat(),
+            }),
             encoding="utf-8",
         )
     except OSError:
@@ -969,7 +1131,12 @@ def main() -> int:
     # but suppresses the verbatim daily repeat. No-mask + fail-open preserved.
     health: List[str] = []
     health += check_runtime_divergence()
-    health += check_health(evolution_dir)
+    # Reality-reconcile the merge/selection health line before it can page the
+    # owner: a metric that claims a stall while GitHub shows evolution PRs
+    # merging is an instrumentation fault, not a pipeline one (see the
+    # reconcile_health_with_reality block). Fail-open — never suppresses a real
+    # degradation, only relabels one reality demonstrably contradicts.
+    health += reconcile_health_with_reality(check_health(evolution_dir), now)
     health += check_realized_impact(evolution_dir)
     health += check_analysis_integrity(evolution_dir)
     health = apply_edge_trigger(health, evolution_dir / ALERT_STATE_FILENAME, now)

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -98,11 +98,23 @@ class TestStageReports:
         alerts = check_stage_reports(tmp_path, NOW)
         assert len(alerts) == len(STAGES)
 
-    def _jobs_file(self, tmp_path, name, *, status="ok", last_run="2026-06-10T22:01:00", **extra):
+    def _jobs_file(
+        self, tmp_path, name, *, status="ok", last_run="2026-06-10T22:01:00", **extra
+    ):
         f = tmp_path / "jobs.json"
-        f.write_text(json.dumps({"jobs": [
-            {"name": name, "enabled": True, "last_status": status, "last_run_at": last_run, **extra}
-        ]}))
+        f.write_text(
+            json.dumps({
+                "jobs": [
+                    {
+                        "name": name,
+                        "enabled": True,
+                        "last_status": status,
+                        "last_run_at": last_run,
+                        **extra,
+                    }
+                ]
+            })
+        )
         return f
 
     def test_missing_report_quiet_when_job_ran_clean(self, tmp_path):
@@ -112,7 +124,8 @@ class TestStageReports:
         exp = expected_report_date(NOW, slot)
         self._make_reports(tmp_path, skip=("implementation",))
         jf = self._jobs_file(
-            tmp_path, "evolution-implementation",
+            tmp_path,
+            "evolution-implementation",
             last_run=f"{exp}T{slot:02d}:01:00",
         )
         assert check_stage_reports(tmp_path, NOW, jf) == []
@@ -128,7 +141,9 @@ class TestStageReports:
         # job ran ok but BEFORE the slot (stale/previous day) → not this slot's
         # clean run → still alert.
         self._make_reports(tmp_path, skip=("integration",))
-        jf = self._jobs_file(tmp_path, "evolution-integration", last_run="2026-06-09T23:00:00")
+        jf = self._jobs_file(
+            tmp_path, "evolution-integration", last_run="2026-06-09T23:00:00"
+        )
         alerts = check_stage_reports(tmp_path, NOW, jf)
         assert len(alerts) == 1 and "integration" in alerts[0]
 
@@ -140,7 +155,8 @@ class TestStageReports:
         exp = expected_report_date(NOW, slot)
         self._make_reports(tmp_path, skip=("implementation",))
         jf = self._jobs_file(
-            tmp_path, "evolution-implementation",
+            tmp_path,
+            "evolution-implementation",
             last_run=f"{exp}T{slot:02d}:01:00",
             last_tool_calls=0,
         )
@@ -155,7 +171,8 @@ class TestStageReports:
         exp = expected_report_date(NOW, slot)
         self._make_reports(tmp_path, skip=("implementation",))
         jf = self._jobs_file(
-            tmp_path, "evolution-implementation",
+            tmp_path,
+            "evolution-implementation",
             last_run=f"{exp}T{slot:02d}:01:00",
             last_tool_calls=7,
         )
@@ -496,23 +513,31 @@ class TestCheckHealth:
 
     def test_healthy_sidecar_is_silent(self, tmp_path):
         from evolution_watchdog import check_health
+
         (tmp_path / "evolution-health.txt").write_text(
-            "[evolution-metrics] 5/5 active cycles: success=80% ... | healthy\n", encoding="utf-8"
+            "[evolution-metrics] 5/5 active cycles: success=80% ... | healthy\n",
+            encoding="utf-8",
         )
         assert check_health(tmp_path) == []
 
     def test_flagged_sidecar_alerts(self, tmp_path):
         from evolution_watchdog import check_health
+
         (tmp_path / "evolution-health.txt").write_text(
             "[evolution-metrics] 4/4 active cycles: success=10% ... | "
             "LOW_SUCCESS: <1/3 of active cycles land a merge\n",
             encoding="utf-8",
         )
         alerts = check_health(tmp_path)
-        assert len(alerts) == 1 and "health degraded" in alerts[0] and "LOW_SUCCESS" in alerts[0]
+        assert (
+            len(alerts) == 1
+            and "health degraded" in alerts[0]
+            and "LOW_SUCCESS" in alerts[0]
+        )
 
     def test_missing_sidecar_is_silent(self, tmp_path):
         from evolution_watchdog import check_health
+
         assert check_health(tmp_path) == []
 
 
@@ -635,8 +660,8 @@ class TestEdgeTrigger:
 
         sp = self._state(tmp_path)
         t0 = datetime(2026, 6, 20, 7, 47)
-        assert apply_edge_trigger(self.COND_A, sp, t0) == self.COND_A          # fault
-        assert len(apply_edge_trigger([], sp, t0 + timedelta(days=1))) == 1     # recovery
+        assert apply_edge_trigger(self.COND_A, sp, t0) == self.COND_A  # fault
+        assert len(apply_edge_trigger([], sp, t0 + timedelta(days=1))) == 1  # recovery
         # Recurrence the very next day (well within the 7d cooldown):
         out = apply_edge_trigger(self.COND_A, sp, t0 + timedelta(days=2))
         assert out == self.COND_A, "a fault recurring after recovery must re-alert"
@@ -652,7 +677,9 @@ class TestEdgeTrigger:
         # Past the cooldown, unchanged → a single "still unresolved" nudge.
         later = t0 + timedelta(days=EDGE_COOLDOWN_DAYS + 1)
         out = apply_edge_trigger(self.COND_A, sp, later)
-        assert out, "a long-persisting condition must re-remind, never go silent forever"
+        assert out, (
+            "a long-persisting condition must re-remind, never go silent forever"
+        )
         assert any("LOW_SELECTION_EFFICIENCY" in a for a in out)
         # Cooldown clock resets after the reminder → next day suppressed again.
         assert apply_edge_trigger(self.COND_A, sp, later + timedelta(days=1)) == []
@@ -702,7 +729,9 @@ class TestMainEdgeTriggerWiring:
     """main() must route ONLY health alerts through the edge-trigger and leave
     operational alerts (upstream-lag, stage reports, jobs, gh) untouched."""
 
-    def test_upstream_lag_and_infra_alerts_bypass_edge_trigger(self, tmp_path, monkeypatch, capsys):
+    def test_upstream_lag_and_infra_alerts_bypass_edge_trigger(
+        self, tmp_path, monkeypatch, capsys
+    ):
         import evolution_watchdog as w
 
         # Infra/operational alerts present every run; health alerts steady.
@@ -710,15 +739,24 @@ class TestMainEdgeTriggerWiring:
         monkeypatch.setattr(w, "check_jobs", lambda *a, **k: [])
         monkeypatch.setattr(w, "check_gh", lambda *a, **k: ["gh auth status FAILED"])
         monkeypatch.setattr(
-            w, "check_upstream_lag", lambda *a, **k: ["upstream sync stuck: fork is 301 behind"]
+            w,
+            "check_upstream_lag",
+            lambda *a, **k: ["upstream sync stuck: fork is 301 behind"],
         )
         monkeypatch.setattr(
-            w, "check_health", lambda *a, **k: [
+            w,
+            "check_health",
+            lambda *a, **k: [
                 "pipeline health degraded: x | LOW_SELECTION_EFFICIENCY: y"
-            ]
+            ],
         )
         monkeypatch.setattr(w, "check_realized_impact", lambda *a, **k: [])
         monkeypatch.setattr(w, "check_analysis_integrity", lambda *a, **k: [])
+        # Keep reconciliation hermetic (no real gh): fall open so the health
+        # alert is exercised as-is by the edge-trigger, which is what this tests.
+        monkeypatch.setattr(
+            w, "recent_merged_evolution_issue_count", lambda *a, **k: None
+        )
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
 
@@ -732,9 +770,15 @@ class TestMainEdgeTriggerWiring:
         # Run 2: health is suppressed (steady), but upstream-lag + gh STILL fire.
         w.main()
         out2 = capsys.readouterr().out
-        assert "upstream sync stuck" in out2, "operational upstream-lag must never be edge-suppressed"
-        assert "gh auth status FAILED" in out2, "operational gh failure must never be edge-suppressed"
-        assert "LOW_SELECTION_EFFICIENCY" not in out2, "steady health condition should be suppressed"
+        assert "upstream sync stuck" in out2, (
+            "operational upstream-lag must never be edge-suppressed"
+        )
+        assert "gh auth status FAILED" in out2, (
+            "operational gh failure must never be edge-suppressed"
+        )
+        assert "LOW_SELECTION_EFFICIENCY" not in out2, (
+            "steady health condition should be suppressed"
+        )
 
 
 class TestRuntimeDivergence:
@@ -832,7 +876,9 @@ class TestRuntimeDivergence:
 
         assert check_runtime_divergence(runner=fake_run) == []
 
-    def test_diverged_routed_through_edge_trigger_in_main(self, tmp_path, monkeypatch, capsys):
+    def test_diverged_routed_through_edge_trigger_in_main(
+        self, tmp_path, monkeypatch, capsys
+    ):
         # The divergence alert is steady-state (persists until the owner
         # reconciles), so it must route through the edge-trigger: emit once,
         # suppress the identical repeat next run.
@@ -846,7 +892,8 @@ class TestRuntimeDivergence:
         monkeypatch.setattr(w, "check_realized_impact", lambda *a, **k: [])
         monkeypatch.setattr(w, "check_analysis_integrity", lambda *a, **k: [])
         monkeypatch.setattr(
-            w, "check_runtime_divergence",
+            w,
+            "check_runtime_divergence",
             lambda *a, **k: [
                 "runtime checkout diverged from origin/main by 2 local "
                 "commit(s) — nightly self-update is frozen (can't fast-forward)"
@@ -1005,7 +1052,9 @@ class TestUpstreamLagFilesIssue:
             clock=self._clock(72),
         )
         assert any("not merged" in a for a in alerts), "text alert preserved"
-        assert calls.get("behind") == 391, "real escalation must ensure the tracking issue"
+        assert calls.get("behind") == 391, (
+            "real escalation must ensure the tracking issue"
+        )
         assert calls.get("tag") == "v2026.6.19", "issue names the missing release tag"
 
     def test_merged_release_does_not_file_issue(self, monkeypatch):
@@ -1013,7 +1062,8 @@ class TestUpstreamLagFilesIssue:
 
         called = {"n": 0}
         monkeypatch.setattr(
-            w, "ensure_upstream_issue",
+            w,
+            "ensure_upstream_issue",
             lambda *a, **k: called.__setitem__("n", called["n"] + 1),
         )
         assert (
@@ -1031,7 +1081,8 @@ class TestUpstreamLagFilesIssue:
 
         called = {"n": 0}
         monkeypatch.setattr(
-            w, "ensure_upstream_issue",
+            w,
+            "ensure_upstream_issue",
             lambda *a, **k: called.__setitem__("n", called["n"] + 1),
         )
         assert (
@@ -1050,7 +1101,8 @@ class TestUpstreamLagFilesIssue:
 
         called = {"n": 0}
         monkeypatch.setattr(
-            w, "ensure_upstream_issue",
+            w,
+            "ensure_upstream_issue",
             lambda *a, **k: called.__setitem__("n", called["n"] + 1),
         )
 
@@ -1063,3 +1115,131 @@ class TestUpstreamLagFilesIssue:
 
         assert check_upstream_lag(runner=fake_run, repo_dir=self.REPO) == []
         assert called["n"] == 0, "shallow path must never file an issue"
+
+
+class TestRealityReconciliation:
+    """The immune backstop: never forward a MERGED_ZERO health alert that GitHub
+    reality contradicts. Relabels it to METRIC_DIVERGENCE (instrumentation fault)
+    instead of paging the owner with a phantom 'integration stuck'. Rate/ratio
+    flags are deliberately NOT relabeled on a count (no-mask)."""
+
+    from datetime import datetime as _dt
+
+    NOW = _dt(2026, 7, 10, 8, 0)
+    # A COUNT claim (zero merges) — a nonzero GitHub count genuinely refutes it.
+    MERGED_ZERO = [
+        "pipeline health degraded: [evolution-funnel] ... merged=0 "
+        "| MERGED_ZERO x7: integration looks stuck — check CI / flaky gates"
+    ]
+    # A RATE claim — a single existing merge does NOT refute a low ratio, so this
+    # must NEVER be relabeled on a mere count (else no-mask is violated and a real
+    # low-landing-rate is hidden).
+    RATE_FLAG = [
+        "pipeline health degraded: [evolution-metrics] ... selection_efficiency=7% "
+        "| LOW_SELECTION_EFFICIENCY: picks more than it can land"
+    ]
+
+    def _runner_with_merges(self, prs):
+        def _r(cmd):
+            return (0, __import__("json").dumps(prs))
+
+        return _r
+
+    def test_relabels_mergedzero_when_github_shows_merges(self):
+        from evolution_watchdog import reconcile_health_with_reality
+
+        prs = [
+            {
+                "headRefName": "evolution/issue-752-x",
+                "mergedAt": "2026-07-09T19:16:20Z",
+            },
+            {
+                "headRefName": "evolution/issue-756-y",
+                "mergedAt": "2026-07-09T01:02:00Z",
+            },
+        ]
+        out = reconcile_health_with_reality(
+            self.MERGED_ZERO, self.NOW, runner=self._runner_with_merges(prs)
+        )
+        assert len(out) == 1
+        assert "METRIC_DIVERGENCE" in out[0]
+        assert "MERGED_ZERO" not in out[0]  # phantom diagnosis dropped
+        assert "2" in out[0]  # reports the reconciled merge count
+
+    def test_rate_flags_never_relabeled_even_with_merges(self):
+        # no-mask: a merge COUNT cannot refute a low RATIO (select 100, land 1 ->
+        # ratio 0.01 is a real degradation). LOW_SELECTION_EFFICIENCY must survive.
+        from evolution_watchdog import reconcile_health_with_reality
+
+        prs = [
+            {"headRefName": "evolution/issue-752-x", "mergedAt": "2026-07-09T19:16:20Z"}
+        ]
+
+        def _boom(cmd):
+            raise AssertionError("gh must not be probed for a rate/ratio flag")
+
+        # gh must not even be called: the guard skips non-MERGED_ZERO flags early.
+        out = reconcile_health_with_reality(self.RATE_FLAG, self.NOW, runner=_boom)
+        assert out == self.RATE_FLAG
+
+    def test_keeps_mergedzero_when_github_agrees_zero(self):
+        from evolution_watchdog import reconcile_health_with_reality
+
+        # No evolution/issue-* merges in the window -> reality agrees -> keep.
+        prs = [{"headRefName": "sync/upstream", "mergedAt": "2026-07-09T00:00:00Z"}]
+        out = reconcile_health_with_reality(
+            self.MERGED_ZERO, self.NOW, runner=self._runner_with_merges(prs)
+        )
+        assert out == self.MERGED_ZERO
+
+    def test_excludes_merges_outside_window(self):
+        from evolution_watchdog import reconcile_health_with_reality
+
+        prs = [
+            {"headRefName": "evolution/issue-700-z", "mergedAt": "2026-06-01T00:00:00Z"}
+        ]
+        out = reconcile_health_with_reality(
+            self.MERGED_ZERO, self.NOW, runner=self._runner_with_merges(prs)
+        )
+        assert out == self.MERGED_ZERO  # merge too old -> not counted -> keep alert
+
+    def test_fail_open_on_gh_error(self):
+        from evolution_watchdog import reconcile_health_with_reality
+
+        out = reconcile_health_with_reality(
+            self.MERGED_ZERO, self.NOW, runner=lambda cmd: (1, "")
+        )
+        assert out == self.MERGED_ZERO  # gh failed -> never suppress a real alert
+
+    def test_non_diverging_alerts_untouched_without_gh(self):
+        from evolution_watchdog import reconcile_health_with_reality
+
+        other = ["realized-impact degraded: ... | REALIZED_RATE_LOW: ..."]
+
+        def _boom(cmd):
+            raise AssertionError("gh must not be called when nothing diverges")
+
+        assert reconcile_health_with_reality(other, self.NOW, runner=_boom) == other
+
+    def test_recent_count_distinct_issues(self):
+        from evolution_watchdog import recent_merged_evolution_issue_count
+
+        prs = [
+            {
+                "headRefName": "evolution/issue-798-inc1",
+                "mergedAt": "2026-07-09T01:00:00Z",
+            },
+            {
+                "headRefName": "evolution/issue-798-inc2",
+                "mergedAt": "2026-07-09T02:00:00Z",
+            },
+            {
+                "headRefName": "evolution/issue-750-a",
+                "mergedAt": "2026-07-08T01:00:00Z",
+            },
+            {"headRefName": "sync/upstream", "mergedAt": "2026-07-09T01:00:00Z"},
+        ]
+        n = recent_merged_evolution_issue_count(
+            self.NOW, runner=lambda cmd: (0, __import__("json").dumps(prs))
+        )
+        assert n == 2  # {798, 750}; increments collapse, sync excluded


### PR DESCRIPTION
## Why

A self-improving pipeline measures **itself**, so a wrong self-measurement produces (and escalates) a wrong conclusion. In the 2026-07 incident the funnel counted `merged` only from the integration self-report, missing the owner's manual merges — so the watchdog paged **"integration stuck"** for 7 days while GitHub showed 15 evolution PRs actually merging. PR #885 anchored `merged` to GitHub so the sidecar is now truthful, but a self-measuring system needs a **standing immune response**, not a one-off.

## What

Reality reconciliation in the watchdog: before a **MERGED_ZERO** health alert reaches the owner, it is cross-checked against GitHub. If GitHub shows evolution issues actually merging in the window while the funnel recorded zero, that count claim is false — the alert is relabeled to one honest line:

```
funnel reports zero merges, but GitHub shows N evolution/issue-* issue(s) merged in the last 7d
| METRIC_DIVERGENCE: instrumentation suspect (funnel / #667), NOT the pipeline — verify the metric, auto-clears once the funnel backfills
```

So the owner gets the **right diagnosis** and the pipeline can act on the right (funnel/#667) issue instead of chasing a phantom "integration stuck".

## Scope — MERGED_ZERO only (deliberately)

It is the **only** health flag whose predicate is a COUNT claim that a nonzero count genuinely refutes. `LOW_SUCCESS` and `LOW_SELECTION_EFFICIENCY` are RATE/RATIO claims — a single existing merge does **not** refute a low rate (select 100, land 1 → ratio 0.01 is a true degradation coexisting with count≥1). Relabeling those on a mere count would **violate no-mask** and hide the very quality signal the watchdog protects.

> An independent cross-provider review (hermes via consilium) flagged this exact hole in an earlier draft that included the rate flags. The narrowing is that fix.

## Safety

- **fail-open**: any `gh` failure leaves the alert unchanged.
- **no-mask**: GitHub agreeing there were no merges (a real stall) leaves the alert unchanged — reconciliation can only ever *relabel* an alert reality demonstrably contradicts, never suppress one.
- Distinct issue count (increments collapse). Stable `METRIC_DIVERGENCE` flag tail so the existing edge-trigger keys on it without re-screaming the drifting count.

## Verified

Against live `osoba` merge history: a MERGED_ZERO line relabels (31 evolution issues merged in 7d); a LOW_SELECTION_EFFICIENCY line passes through unchanged (gh not even probed); a synthetic real stall passes through unchanged. **139 evolution tests pass.**

Follow-up (optional): a sound *ratio* reconciliation (GitHub-derived merged/selected over the window) could extend this to the rate flags — tracked separately, not needed for correctness.
