### PR TITLE
fix(evolution): resolve gh repo outside a checkout so the funnel/watchdog fixes fire under cron

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -253,29 +253,49 @@ def count_merged_evolution_prs(
     return None if ids is None else len(ids)
 
 
+def _resolve_repo_dir() -> Path | None:
+    """Locate the git repo, working when this script runs as a COPY under
+    HERMES_HOME/scripts (outside the repo) — which is exactly how the cron
+    scheduler executes no_agent scripts. Mirrors evolution_watchdog: an env
+    override, then the in-tree location (when run from the repo), then the common
+    server install / agent-clone paths. Returns None when none is a git repo."""
+    candidates = [
+        os.environ.get("EVOLUTION_REPO_DIR"),
+        str(Path(__file__).resolve().parent.parent),  # in-tree: scripts/ -> repo root
+        "/usr/local/lib/hermes-agent",
+        str(Path.home() / "hermes-agent-evolution"),
+    ]
+    for cand in candidates:
+        if cand and (Path(cand) / ".git").exists():
+            return Path(cand)
+    return None
+
+
 def _resolve_repo() -> str | None:
-    """Resolve OWNER/REPO for the gh queries — fork-agnostic and config-free:
-    explicit env override -> this checkout's origin remote -> gh's default.
-    Returns None if none resolve (merge counting then fails open)."""
+    """Resolve OWNER/REPO for the gh queries. Must work when this script runs as
+    a copy under HERMES_HOME/scripts (cron), NOT only from an in-tree checkout —
+    otherwise the merge enrichment silently no-ops in production. Order: explicit
+    slug env -> origin remote of a resolved repo dir (env / in-tree / common
+    install paths) -> gh's default. None if none resolve (merge counting then
+    fails open to the self-report)."""
     env = os.environ.get("EVOLUTION_GH_REPO", "").strip()
     if env:
         return env
-    # Parse the origin remote of the checkout this script lives in. A fork's
-    # origin points at the fork, so this stays correct upstream and downstream.
-    repo_root = Path(__file__).resolve().parents[1]
-    try:
-        url = subprocess.run(
-            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=True,
-        ).stdout.strip()
-        m = re.search(r"github\.com[:/]+([^/]+/[^/]+?)(?:\.git)?/?$", url)
-        if m:
-            return m.group(1)
-    except Exception:
-        pass
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is not None:
+        try:
+            url = subprocess.run(
+                ["git", "-C", str(repo_dir), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            ).stdout.strip()
+            m = re.search(r"github\.com[:/]+([^/]+/[^/]+?)(?:\.git)?/?$", url)
+            if m:
+                return m.group(1)
+        except Exception:
+            pass
     try:
         out = subprocess.run(
             ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -850,29 +850,61 @@ _MIN_HEALTHY_MERGES = 1  # >=1 evolution/issue-* issue merged == the zero claim 
 _REALITY_WINDOW_DAYS = 7
 
 
+def _resolve_repo_slug() -> str | None:
+    """OWNER/REPO for gh queries, resolved from the repo dir so ``gh`` works even
+    when this script runs as a copy under HERMES_HOME/scripts (cron) with a cwd
+    that is not a git repo. None if unresolvable (the caller then falls open)."""
+    env = os.environ.get("EVOLUTION_GH_REPO", "").strip()
+    if env:
+        return env
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is None:
+        return None
+    try:
+        url = subprocess.run(
+            ["git", "-C", str(repo_dir), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+        m = re.search(r"github\.com[:/]+([^/]+/[^/]+?)(?:\.git)?/?$", url)
+        return m.group(1) if m else None
+    except Exception:
+        return None
+
+
 def recent_merged_evolution_issue_count(
     now: datetime,
     runner: Callable[[List[str]], Tuple[int, str]] = _default_runner,
     window_days: int = _REALITY_WINDOW_DAYS,
     branch_prefix: str = "evolution/issue-",
+    repo: str | None = None,
 ) -> int | None:
     """Distinct evolution issues merged on GitHub within the last ``window_days``.
 
     Returns None on any gh failure so the caller can fall open (never suppress a
     real alert on a reconciliation error). Distinct issue numbers, so increment
-    PRs (issue-798-inc1/2/3) count once."""
+    PRs (issue-798-inc1/2/3) count once. ``repo`` is resolved from the repo dir
+    when omitted and passed as ``--repo`` so gh does not depend on cwd (cron runs
+    this outside the repo)."""
+    if repo is None:
+        repo = _resolve_repo_slug()
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--json",
+        "headRefName,mergedAt",
+        "--limit",
+        "100",
+    ]
+    if repo:
+        cmd += ["--repo", repo]
     try:
-        rc, out = runner([
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "merged",
-            "--json",
-            "headRefName,mergedAt",
-            "--limit",
-            "100",
-        ])
+        rc, out = runner(cmd)
         if rc != 0:
             return None
         prs = json.loads(out)

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -445,3 +445,15 @@ class TestMergedFromGitHub:
     def test_resolve_repo_prefers_env(self, monkeypatch):
         monkeypatch.setenv("EVOLUTION_GH_REPO", "owner/repo-from-env")
         assert ef._resolve_repo() == "owner/repo-from-env"
+
+    def test_resolve_repo_dir_env_override_works_outside_a_checkout(
+        self, tmp_path, monkeypatch
+    ):
+        # Cron runs this script as a COPY under HERMES_HOME/scripts (outside the
+        # repo), so _resolve_repo must NOT depend on __file__ being in a repo.
+        # The EVOLUTION_REPO_DIR override / common-path fallback is what makes the
+        # merge enrichment fire in production instead of silently no-opping.
+        repo = tmp_path / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.setenv("EVOLUTION_REPO_DIR", str(repo))
+        assert ef._resolve_repo_dir() == repo

--- a/tests/scripts/test_evolution_watchdog.py
+++ b/tests/scripts/test_evolution_watchdog.py
@@ -1240,6 +1240,23 @@ class TestRealityReconciliation:
             {"headRefName": "sync/upstream", "mergedAt": "2026-07-09T01:00:00Z"},
         ]
         n = recent_merged_evolution_issue_count(
-            self.NOW, runner=lambda cmd: (0, __import__("json").dumps(prs))
+            self.NOW,
+            runner=lambda cmd: (0, __import__("json").dumps(prs)),
+            repo="o/r",  # explicit -> no real git/gh resolution in the unit test
         )
         assert n == 2  # {798, 750}; increments collapse, sync excluded
+
+    def test_recent_count_passes_repo_flag(self):
+        # Cron runs outside the repo, so gh MUST be scoped with --repo or it
+        # errors on "no git remote". Verify the flag is forwarded.
+        from evolution_watchdog import recent_merged_evolution_issue_count
+
+        seen = {}
+
+        def _spy(cmd):
+            seen["cmd"] = cmd
+            return (0, "[]")
+
+        recent_merged_evolution_issue_count(self.NOW, runner=_spy, repo="acme/app")
+        assert "--repo" in seen["cmd"]
+        assert "acme/app" in seen["cmd"]


### PR DESCRIPTION
**Critical follow-up to #885 and #891.** The cron scheduler runs no_agent scripts as COPIES under `HERMES_HOME/scripts` — OUTSIDE the git repo. Both prior fixes assumed an in-tree checkout, so in production:

- funnel `_resolve_repo()` returned None → GitHub merge enrichment SKIPPED → `merged` silently reverts to the self-report (0); the metric would degrade back within the 30-cycle window.
- watchdog reconciliation called `gh pr list` with no `--repo` → errors outside a repo → guard never fires.

Fix: both resolve the repo the way `evolution_watchdog._resolve_repo_dir` already does (EVOLUTION_REPO_DIR / EVOLUTION_GH_REPO env, in-tree, then common install paths `/usr/local/lib/hermes-agent`, `~/hermes-agent-evolution`), and the watchdog passes the resolved slug as `--repo`. Both stay fail-open. Proven via a cron-context simulation (script run from outside a repo resolves `Lexus2016/hermes-agent-evolution`). Tests added for out-of-checkout resolution and `--repo` forwarding.