### PR TITLE
fix(#667): enforce deterministic date in evolution skill instructions

### DIFF
--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -336,13 +336,29 @@ python3 scripts/evolution_realized_impact.py record-merge \
 > is not currently open per `gh pr list`, you hallucinated — STOP and redo from
 > the real list.
 
-Save to `~/.hermes/evolution/integration/YYYY-MM-DD.json` on
+> ⚠️ **Date is deterministic — NEVER type a date from memory.** Issue #667: the
+> agent wrote future-dated reports (2026-08-31.json on July 2, dates up to
+> September) because it hallucinated the date. This corrupts funnel metrics
+> and effort_budget calibration. ALWAYS get the date from the shell:
+> ```bash
+> TODAY=$(date +%Y-%m-%d)
+> ```
+> Use `$TODAY` as the `date` field AND the filename. Never type a date literal.
+
+Save to `~/.hermes/evolution/integration/$TODAY.json` on
 **EVERY** run — including idle cycles (`merged: []`, `skipped: []`): a missing
 report is read by the watchdog as a dead job.
 
+```bash
+# Deterministic date — NEVER type a date from memory (issue #667).
+TODAY=$(date +%Y-%m-%d)
+REPORT="$HOME/.hermes/evolution/integration/${TODAY}.json"
+mkdir -p "$(dirname "$REPORT")"
+```
+
 ```json
 {
-  "date": "YYYY-MM-DD",
+  "date": "<$TODAY — from `date +%Y-%m-%d`, never from memory>",
   "merged": [
     {"pr": "<real PR number you merged>", "issue": "<#>", "title": "<...>", "self_update": "ok|deferred|failed"}
   ],


### PR DESCRIPTION
## Summary

Fixes #667

The agent was writing future-dated stage reports (2026-08-31.json on July 2, dates up to September) because it hallucinated the date from memory instead of getting it from the system. This corrupts funnel metrics and effort_budget calibration.

## Root cause

The evolution-integration SKILL.md used 'YYYY-MM-DD' as a date placeholder in the output path and JSON schema. The agent was resolving this by typing a date from memory, which was sometimes wrong (future-dated by weeks or months).

## Fix

Adds explicit deterministic date instructions to the SKILL.md:

1. A prominent warning block explaining issue #667 and why it matters
2. A bash snippet: `TODAY=$(date +%Y-%m-%d)` to get the date deterministically
3. The JSON schema date field says '<$TODAY — from date +%Y-%m-%d, never from memory>' instead of 'YYYY-MM-DD'
4. The output path uses $TODAY variable instead of a literal date placeholder
5. Explicit instruction: 'NEVER type a date literal'

## Test plan

- [x] SKILL.md instructions are clear and unambiguous
- [x] The bash snippet produces the correct date format
- [x] The warning block explains the problem and solution concisely