### PR TITLE
fix(#888): populate error field for non-zero terminal exits

### DIFF
--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -336,13 +336,29 @@ python3 scripts/evolution_realized_impact.py record-merge \
 > is not currently open per `gh pr list`, you hallucinated — STOP and redo from
 > the real list.
 
-Save to `~/.hermes/evolution/integration/YYYY-MM-DD.json` on
+> ⚠️ **Date is deterministic — NEVER type a date from memory.** Issue #667: the
+> agent wrote future-dated reports (2026-08-31.json on July 2, dates up to
+> September) because it hallucinated the date. This corrupts funnel metrics
+> and effort_budget calibration. ALWAYS get the date from the shell:
+> ```bash
+> TODAY=$(date +%Y-%m-%d)
+> ```
+> Use `$TODAY` as the `date` field AND the filename. Never type a date literal.
+
+Save to `~/.hermes/evolution/integration/$TODAY.json` on
 **EVERY** run — including idle cycles (`merged: []`, `skipped: []`): a missing
 report is read by the watchdog as a dead job.
 
+```bash
+# Deterministic date — NEVER type a date from memory (issue #667).
+TODAY=$(date +%Y-%m-%d)
+REPORT="$HOME/.hermes/evolution/integration/${TODAY}.json"
+mkdir -p "$(dirname "$REPORT")"
+```
+
 ```json
 {
-  "date": "YYYY-MM-DD",
+  "date": "<$TODAY — from `date +%Y-%m-%d`, never from memory>",
   "merged": [
     {"pr": "<real PR number you merged>", "issue": "<#>", "title": "<...>", "self_update": "ok|deferred|failed"}
   ],

--- a/tests/tools/test_terminal_failure_classifier.py
+++ b/tests/tools/test_terminal_failure_classifier.py
@@ -323,3 +323,144 @@ class TestTerminalStreakHelpers:
         assert terminal_tool._increment_terminal_streak(None) == 1
         assert terminal_tool.get_terminal_streak() == 1
         terminal_tool._reset_terminal_streak(None)
+
+
+# ---------------------------------------------------------------------------
+# Signal-based exit code classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySignalExits:
+    """Signal-based exits (128+signal) should be classified with a
+    human-readable signal name rather than a generic persistent_error."""
+
+    @pytest.mark.parametrize(
+        "exit_code, expected_signal",
+        [
+            (130, "SIGINT"),
+            (137, "SIGKILL"),
+            (139, "SIGSEGV"),
+            (143, "SIGTERM"),
+            (134, "SIGABRT"),
+            (129, "SIGHUP"),
+        ],
+    )
+    def test_signal_exit_classified_with_name(self, exit_code, expected_signal):
+        result = classifier.classify_terminal_failure(
+            "somecmd", exit_code, "", ""
+        )
+        assert result.category == classifier.FailureCategory.persistent_error
+        assert result.should_retry is False
+        assert expected_signal in result.hint
+
+    def test_unknown_signal_still_classified(self):
+        """Exit codes >= 128 that aren't in the known map still get a
+        generic 'signal N' hint."""
+        result = classifier.classify_terminal_failure(
+            "somecmd", 159, "", ""
+        )
+        assert result.category == classifier.FailureCategory.persistent_error
+        assert "signal" in result.hint.lower()
+
+    def test_signal_exit_hint_mentions_investigation(self):
+        result = classifier.classify_terminal_failure(
+            "somecmd", 137, "", ""
+        )
+        assert "investigate" in result.hint.lower() or "switch" in result.hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# Error field population for non-zero exits (issue #888)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorFieldPopulation:
+    """Non-zero exits should populate the 'error' field with a minimum
+    diagnostic instead of leaving it null (issue #888)."""
+
+    def test_unknown_nonzero_exit_populates_error(self, monkeypatch):
+        """A non-zero exit that the classifier can't match to a specific
+        category should still produce a non-null error field (the
+        classifier's persistent_error hint) instead of null."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([{"output": "some output", "returncode": 42}])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("mycommand", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 42
+        assert data["error"] is not None
+        assert data["failure_class"] == "persistent_error"
+
+    def test_unknown_nonzero_no_output_populates_error(self, monkeypatch):
+        """A non-zero exit with no output should still produce a non-null
+        error field so the agent knows something went wrong."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([{"output": "", "returncode": 5}])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("mycommand", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 5
+        assert data["error"] is not None
+        assert data["failure_class"] == "persistent_error"
+
+    def test_informational_exit_error_is_none(self, monkeypatch):
+        """Informational exits (grep=1) should still have error=None
+        because exit_note is set."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([{"output": "", "returncode": 1}])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("grep foo bar", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 1
+        assert data.get("error") is None
+        assert data.get("exit_code_meaning") == "No matches found (not an error)"
+
+    def test_classified_failure_error_has_hint(self, monkeypatch):
+        """Classified failures (e.g. missing_command) should populate
+        the error field with the classification hint."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([
+            {"output": "bash: notreal: command not found", "returncode": 127}
+        ])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("notreal", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 127
+        assert data["failure_class"] == "missing_command"
+        assert data["error"] is not None
+        assert data["error"] == data["suggestion"]
+
+    def test_signal_exit_populates_error_field(self, monkeypatch):
+        """Signal-based exits (e.g. 137=SIGKILL) should populate the
+        error field with the signal hint."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([{"output": "", "returncode": 137}])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("memoryhog", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 137
+        assert data["failure_class"] == "persistent_error"
+        assert data["error"] is not None
+        assert "SIGKILL" in data["error"]
+
+    def test_zero_exit_error_is_none(self, monkeypatch):
+        """Successful commands (exit 0) should still have error=None."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FakeEnvironment([{"output": "ok", "returncode": 0}])
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        result = terminal_tool.terminal_tool("echo ok", task_id="test-streak")
+        data = json.loads(result)
+
+        assert data["exit_code"] == 0
+        assert data.get("error") is None

--- a/tools/terminal_failure_classifier.py
+++ b/tools/terminal_failure_classifier.py
@@ -177,6 +177,32 @@ def classify_terminal_failure(
             should_retry=False,
         )
 
+    # Signal-based termination (128 + signal number).  These frequently
+    # produce empty output and would otherwise fall through to
+    # persistent_error with a generic message.  Surface the signal so the
+    # agent can distinguish OOM kills, segfaults, and user interrupts.
+    if exit_code >= 128:
+        _signal_hints = {
+            129: "SIGHUP (terminal hang up)",
+            130: "SIGINT (interrupted by Ctrl+C or stop signal)",
+            131: "SIGQUIT (quit with core dump)",
+            134: "SIGABRT (abort, possibly assert failure or OOM)",
+            137: "SIGKILL (killed, likely OOM killer or manual kill -9)",
+            139: "SIGSEGV (segmentation fault — bug in the command)",
+            143: "SIGTERM (terminated by request or timeout)",
+        }
+        sig_name = _signal_hints.get(exit_code, f"signal {exit_code - 128}")
+        return TerminalFailureClassification(
+            category=FailureCategory.persistent_error,
+            hint=(
+                f"Command terminated by {sig_name}. "
+                "This is not a retryable error — investigate the cause "
+                "(memory limits, missing dependencies, user interrupt) "
+                "or switch to a different approach."
+            ),
+            should_retry=False,
+        )
+
     # Some commands use non-zero exit codes for normal informational purposes.
     if base_cmd in _EXPECTED_NONZERO_COMMANDS:
         return TerminalFailureClassification(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1887,6 +1887,21 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     if cmd_semantics and exit_code in cmd_semantics:
         return cmd_semantics[exit_code]
 
+    # Signal-based exit codes (128 + signal number).  These are common,
+    # frequently produce empty stderr, and leave the agent with no
+    # diagnostic because the "unknown" path sets error=None.
+    _SIGNAL_NAMES = {
+        129: "SIGHUP (hang up)",
+        130: "SIGINT (interrupted by Ctrl+C)",
+        131: "SIGQUIT (quit)",
+        134: "SIGABRT (abort)",
+        137: "SIGKILL (killed, possibly OOM)",
+        139: "SIGSEGV (segmentation fault)",
+        143: "SIGTERM (terminated)",
+    }
+    if exit_code >= 128 and exit_code in _SIGNAL_NAMES:
+        return f"Process terminated by {_SIGNAL_NAMES[exit_code]}"
+
     return None
 
 
@@ -2826,7 +2841,7 @@ def terminal_tool(
                         result_dict = {
                             "output": output,
                             "exit_code": returncode,
-                            "error": None,
+                            "error": classification.hint,
                             "failure_class": classification.category.value,
                             "suggestion": classification.hint,
                             "should_retry": False,
@@ -2924,10 +2939,25 @@ def terminal_tool(
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")
             exit_note = _interpret_exit_code(command, returncode)
 
+            # Minimum diagnostic for non-zero exits on the "unknown" path.
+            # Without this, 511 non-zero exits produce error=null, leaving
+            # the agent with no signal that anything went wrong and causing
+            # it to retry the same failing command.
+            _min_error = None
+            if returncode != 0 and not exit_note:
+                _min_error = (
+                    f"Command exited with code {returncode}."
+                )
+                if not output.strip():
+                    _min_error += " No output was produced."
+                _min_error += (
+                    " Review the output above for details."
+                )
+
             result_dict = {
                 "output": output,
                 "exit_code": returncode,
-                "error": None,
+                "error": _min_error,
             }
             try:
                 from agent.verification_evidence import record_terminal_result


### PR DESCRIPTION
## Summary

Terminal tool returned `error: null` for 511 non-zero exit codes (48% of terminal failures across 360 sessions), leaving the agent with no signal that anything went wrong and causing it to retry the same failing command.

## Changes

### `tools/terminal_tool.py` (34 lines)
- **Enriched failure path**: populate `error` field with `classification.hint` instead of `None` for classified failures (missing_command, permission_denied, timeout, persistent_error)
- **Unknown path**: add minimum diagnostic (`Command exited with code N`) for non-zero exits that don't get an `exit_note`
- **Signal-based exit codes**: add 130=SIGINT, 137=SIGKILL, 139=SIGSEGV, 143=SIGTERM to `_interpret_exit_code`

### `tools/terminal_failure_classifier.py` (26 lines)
- Add signal-based exit code classification (128+signal) with human-readable signal names
- Returns `persistent_error` with signal-specific hint instead of generic message

### `tests/tools/test_terminal_failure_classifier.py` (141 lines)
- `TestClassifySignalExits`: signal exits classified with correct name and hint
- `TestErrorFieldPopulation`: non-zero exits populate `error` field; informational exits keep `error=None`; signal exits populate error with signal name

## Test Results
```
48 tests passed, 0 failed (100% complete)
```

## Note
The `skills/evolution/evolution-integration/SKILL.md` diff is a pre-existing worktree change, not part of this fix.

Closes #888