### PR TITLE
feat: read_file anti-spiral fallback + patch resilience (#886, #889)

### DIFF
--- a/tests/tools/test_read_patch_resilience.py
+++ b/tests/tools/test_read_patch_resilience.py
@@ -1,0 +1,103 @@
+"""Tests for read_file anti-spiral fallback (#886) and patch resilience (#889)."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from tools.file_operations import ShellFileOperations
+from tools.fuzzy_match import fuzzy_find_and_replace, format_no_match_hint
+
+
+def _make_file_ops(tmp):
+    """Build a ShellFileOperations that runs shell cmds in *tmp*."""
+    ops = ShellFileOperations.__new__(ShellFileOperations)
+    ops._escape_shell_arg = lambda s: f"'{s}'"
+    ops._expand_path = lambda s: s if s.startswith("/") else str(tmp / s)
+
+    def _exec(cmd):
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=str(tmp), timeout=5)
+
+        class _R:
+            exit_code = r.returncode
+            stdout = r.stdout
+            stderr = r.stderr
+
+        return _R()
+
+    ops._exec = _exec
+    return ops
+
+
+class TestSuggestSimilarFilesAntiSpiral:
+    def setup_method(self):
+        self._d = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._d.name)
+        (self.tmp / "analysis").mkdir()
+        (self.tmp / "analysis" / "2026-07-10.json").write_text("{}")
+        (self.tmp / "analysis" / "2026-07-09.json").write_text("{}")
+        (self.tmp / "config.yaml").write_text("k: v")
+        self.ops = _make_file_ops(self.tmp)
+
+    def teardown_method(self):
+        self._d.cleanup()
+
+    def test_existing_dir_no_similar_lists_available(self):
+        r = self.ops._suggest_similar_files(str(self.tmp / "analysis" / "nope.json"))
+        assert "File not found" in r.error and ("Available" in r.error or "2026-07-10" in r.error)
+
+    def test_nonexistent_dir_walks_to_ancestor(self):
+        r = self.ops._suggest_similar_files(str(self.tmp / "bad" / "sub" / "f.json"))
+        assert "File not found" in r.error and ("does not exist" in r.error or "ancestor" in r.error)
+
+    def test_similar_files_still_returned(self):
+        r = self.ops._suggest_similar_files(str(self.tmp / "analysis" / "2026-07-11.json"))
+        assert any("2026-07-10" in f for f in r.similar_files)
+
+class TestIdenticalStrings:
+    def test_sentinel_strategy(self):
+        _, c, st, err = fuzzy_find_and_replace("hello", "hello", "hello")
+        assert c == 0 and st == "identical" and err is not None and "identical" in err
+
+    def test_patch_replace_clean_message(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("def foo():\n    pass\n")
+            fp = f.name
+        try:
+            ops = _make_file_ops(Path(fp).parent)
+            ops._expand_path = lambda s: s
+            ops._is_write_denied = lambda s: False
+            ops._strip_bom = lambda s: (s, False)
+            ops._detect_line_ending = lambda s: None
+            ops.write_file = lambda p, c: type("W", (), {"error": None})()
+            r = ops.patch_replace(fp, "def foo():", "def foo():")
+            assert "identical" in r.error.lower() and "no changes" in r.error.lower()
+        finally:
+            os.unlink(fp)
+
+class TestAmbiguousLineNumbers:
+    def test_includes_line_numbers(self):
+        _, c, _, err = fuzzy_find_and_replace("x=1\nx=1\nx=1\n", "x=1", "x=2")
+        assert c == 0 and err is not None and "3 matches" in err and "line" in err.lower()
+
+    def test_line_numbers_correct(self):
+        _, c, _, err = fuzzy_find_and_replace("a\nfoo\nb\nfoo\nc\nfoo\n", "foo", "bar")
+        assert c == 0 and err is not None and "3 matches" in err
+        for n in ("2", "4", "6"):
+            assert n in err
+
+    def test_replace_all_still_works(self):
+        new, c, _, err = fuzzy_find_and_replace("x=1\nx=1\n", "x=1", "x=2", replace_all=True)
+        assert err is None and c == 2
+
+
+class TestHintGating:
+    def test_identical_no_hint(self):
+        assert format_no_match_hint("old_string and new_string are identical", 0, "a", "a") == ""
+
+    def test_ambiguous_no_hint(self):
+        assert format_no_match_hint("Found 3 matches.", 0, "a", "a\na\na") == ""
+
+    def test_genuine_no_match_gives_hint(self):
+        ct = "def foo():\n    return 42\n\ndef bar():\n    pass\n"
+        assert "Did you mean" in format_no_match_hint("Could not find a match", 0, "def foo():\n    return 43", ct)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1204,7 +1204,15 @@ class ShellFileOperations(FileOperations):
         )
     
     def _suggest_similar_files(self, path: str) -> ReadResult:
-        """Suggest similar files when the requested file is not found."""
+        """Suggest similar files when the requested file is not found.
+
+        When the parent directory exists, scores its entries by similarity to
+        the requested filename.  When no similar files are found (or the
+        directory itself doesn't exist), falls back to listing the available
+        files in the nearest existing ancestor directory so the agent can see
+        what *is* on disk instead of guessing blindly — the root cause of
+        read_file file-not-found spirals (#886).
+        """
         dir_path = os.path.dirname(path) or "."
         filename = os.path.basename(path)
         basename_no_ext = os.path.splitext(filename)[0]
@@ -1215,11 +1223,13 @@ class ShellFileOperations(FileOperations):
         ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
         ls_result = self._exec(ls_cmd)
 
+        dir_entries: list[str] = []
         scored: list = []  # (score, filepath) — higher is better
         if ls_result.exit_code == 0 and ls_result.stdout.strip():
             for f in ls_result.stdout.strip().split('\n'):
                 if not f:
                     continue
+                dir_entries.append(f)
                 lf = f.lower()
                 score = 0
 
@@ -1250,8 +1260,58 @@ class ShellFileOperations(FileOperations):
         scored.sort(key=lambda x: -x[0])
         similar = [fp for _, fp in scored[:5]]
 
+        # ── Anti-spiral fallback (#886) ──────────────────────────────
+        # When no similar files were found, list what IS available so the
+        # agent stops guessing and uses a real path.  When the parent
+        # directory itself doesn't exist, walk up to the nearest existing
+        # ancestor and list *its* contents (including subdirectories) so
+        # the agent can see which path components are valid.
+        hint_parts: list[str] = []
+        if not similar and dir_entries:
+            # Directory exists but nothing scored — show all entries.
+            available = sorted(dir_entries[:20])
+            hint_parts.append(
+                f"No similar files found in {dir_path}. "
+                f"Available files: {', '.join(available)}"
+            )
+        elif not similar and not dir_entries:
+            # Parent directory doesn't exist (or is empty) — walk up to
+            # the nearest existing ancestor and list its contents.
+            ancestor = dir_path
+            ancestor_entries: list[str] = []
+            while ancestor and ancestor != "/" and ancestor != ".":
+                check_cmd = f"ls -1 {self._escape_shell_arg(ancestor)} 2>/dev/null | head -30"
+                check_result = self._exec(check_cmd)
+                if check_result.exit_code == 0 and check_result.stdout.strip():
+                    ancestor_entries = [
+                        e for e in check_result.stdout.strip().split('\n') if e
+                    ]
+                    break
+                parent = os.path.dirname(ancestor)
+                if parent == ancestor:
+                    break
+                ancestor = parent
+
+            if ancestor_entries:
+                ancestor_display = ancestor if ancestor != dir_path else "parent directory"
+                hint_parts.append(
+                    f"Directory {dir_path} does not exist. "
+                    f"Contents of nearest existing ancestor ({ancestor_display}): "
+                    f"{', '.join(sorted(ancestor_entries[:20]))}"
+                )
+            else:
+                hint_parts.append(
+                    f"File not found: {path}. "
+                    f"The path {dir_path} does not exist and no ancestor "
+                    f"directory was found. Verify the path before retrying."
+                )
+
+        error_msg = f"File not found: {path}"
+        if hint_parts:
+            error_msg += "\n\n" + "\n".join(hint_parts)
+
         return ReadResult(
-            error=f"File not found: {path}",
+            error=error_msg,
             similar_files=similar
         )
     
@@ -1569,7 +1629,22 @@ class ShellFileOperations(FileOperations):
         new_content, match_count, _strategy, error = fuzzy_find_and_replace(
             content, old_string, new_string, replace_all
         )
-        
+
+        # ── Identical-strings no-op (#889) ────────────────────────────
+        # When old_string == new_string, the fuzzy matcher returns a
+        # sentinel (strategy="identical") so we can surface a clean
+        # "no changes needed" message instead of a hard error.  This
+        # eliminates the 14 identical-edit failures observed in the
+        # introspection data where the agent accidentally submitted a
+        # no-op edit and then wasted turns retrying.
+        if _strategy == "identical":
+            return PatchResult(
+                error=(
+                    "old_string and new_string are identical — no changes "
+                    "needed. The file content is already in the desired state."
+                )
+            )
+
         if error or match_count == 0:
             err_msg = error or f"Could not find match for old_string in {path}"
             try:

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -67,7 +67,11 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string cannot be empty"
 
     if old_string == new_string:
-        return content, 0, None, "old_string and new_string are identical"
+        # No-op edit — return a sentinel so callers can surface a clean
+        # "no changes needed" message instead of a hard error (#889).
+        # Using a distinct return shape (match_count=0, strategy="identical")
+        # lets callers distinguish "nothing to do" from a genuine failure.
+        return content, 0, "identical", "old_string and new_string are identical"
 
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
@@ -88,8 +92,16 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         if matches:
             # Found matches with this strategy
             if len(matches) > 1 and not replace_all:
+                # Include line numbers for each match location so the agent
+                # can narrow its old_string with surrounding context (#889).
+                line_nums: List[str] = []
+                for (start, _end) in matches[:10]:
+                    line_no = content.count('\n', 0, start) + 1
+                    line_nums.append(str(line_no))
+                locs = ', '.join(line_nums)
                 return content, 0, None, (
-                    f"Found {len(matches)} matches for old_string. "
+                    f"Found {len(matches)} matches for old_string"
+                    f"{f' at lines {locs}' if line_nums else ''}. "
                     f"Provide more context to make it unique, or use replace_all=True."
                 )
 


### PR DESCRIPTION
Automated evolution PR for issues #886 and #889.

## #886: read_file file-not-found spirals

**Problem:** 381 file-not-found failures across 202 sessions — agent guesses paths repeatedly instead of seeing what's on disk.

**Fix:** Enhanced `_suggest_similar_files` in `tools/file_operations.py`:
- When the parent directory exists but no similar files match, lists all available files in that directory
- When the parent directory doesn't exist, walks up to the nearest existing ancestor and lists its contents
- This gives the agent real path data to work with instead of guessing blindly

## #889: patch no-match/identical/ambiguous failures

**Problem:** 73% of patch failures from three fixable patterns (27 no-match + 14 identical + 12 ambiguous).

**Fixes:**
1. **Identical-strings no-op:** `fuzzy_find_and_replace` now returns a `strategy="identical"` sentinel; `patch_replace` surfaces a clean "no changes needed" message instead of a hard error
2. **Ambiguous-match line numbers:** When multiple matches are found, the error now includes line numbers so the agent can narrow its context
3. **No-match hint:** Already existed via `format_no_match_hint` — confirmed gating still correct

## Tests
- `tests/tools/test_read_patch_resilience.py` — 11 tests covering all three fix areas
- All existing tests pass (218 total across fuzzy_match, file_operations, patch_parser)

Closes #886
Closes #889

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>