### PR TITLE
fix: coerce_tool_args, SessionDB NoneType, cron approval guard (#900, #901, #902)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1139,6 +1139,47 @@ class SessionDB:
                 self._warn_fts5_unavailable(exc)
             return False
 
+    def _ensure_conn(self) -> sqlite3.Connection:
+        """Return a live connection, lazily reconnecting if ``self._conn`` is None.
+
+        After a ``hermes update`` or other process that invalidates the
+        in-memory DB connection, ``self._conn`` can become ``None``.  Every
+        subsequent ``append_message`` / write call would then fail with
+        ``AttributeError: 'NoneType' object has no attribute 'execute'``,
+        cascading into compression aborts and mass message persistence loss
+        (1651+ observed failures).  This method detects the stale connection
+        and rebuilds it in-place before the caller uses it.
+
+        Read-only connections are never lazily reconnected — they are only
+        used for cross-profile aggregation and callers guard on
+        ``db_path.exists()`` before constructing them.
+        """
+        if self._conn is not None:
+            return self._conn
+        if self.read_only:
+            # Read-only connections are constructed in __init__ and never
+            # lazily reconnected — callers should create a new SessionDB.
+            raise sqlite3.DatabaseError(
+                "Session DB read-only connection is None and cannot be "
+                "lazily reconnected"
+            )
+        logger.info(
+            "SessionDB connection is None (stale after update?) — "
+            "lazily reconnecting to %s", self.db_path,
+        )
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=1.0,
+            isolation_level=None,
+        )
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_with_fallback(self._conn, db_label="state.db")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._init_schema()
+        return self._conn
+
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
         """Execute a write transaction with BEGIN IMMEDIATE and jitter retry.
 
@@ -1158,13 +1199,14 @@ class SessionDB:
         for attempt in range(self._WRITE_MAX_RETRIES):
             try:
                 with self._lock:
-                    self._conn.execute("BEGIN IMMEDIATE")
+                    conn = self._ensure_conn()
+                    conn.execute("BEGIN IMMEDIATE")
                     try:
-                        result = fn(self._conn)
-                        self._conn.commit()
+                        result = fn(conn)
+                        conn.commit()
                     except BaseException:
                         try:
-                            self._conn.rollback()
+                            conn.rollback()
                         except Exception:
                             pass
                         raise

--- a/model_tools.py
+++ b/model_tools.py
@@ -903,11 +903,33 @@ def _coerce_json(value: str, expected_python_type: type):
     causes the LLM to emit the array/object as a JSON string instead of a native
     structure.  Returns the original string if parsing fails or yields the wrong
     Python type.
+
+    For empty/whitespace-only strings — a common drift pattern where the model
+    emits ``""`` or ``" "`` where a list/object is expected — we return an
+    empty container of the expected type instead of logging a parse-failure
+    warning on every call.  This eliminates the high-volume
+    ``failed to parse string as JSON for expected type list`` log spam (2393+
+    occurrences) from providers whose tool-call serialization does not align
+    with JSON Schema expectations.  Non-empty non-JSON strings still fall
+    through to the caller's single-element wrapping logic.
     """
+    # Empty/whitespace-only string → empty container of expected type.
+    # This is the most common drift pattern (model emits "" for a list
+    # parameter) and silencing it here prevents 2000+ log warnings/day.
+    if not value or not value.strip():
+        if expected_python_type is list:
+            return []
+        if expected_python_type is dict:
+            return {}
+        return value
     try:
         parsed = json.loads(value)
     except (ValueError, TypeError) as exc:
-        logger.warning(
+        # Demote to debug: the caller (coerce_tool_args) already handles
+        # the fallback by wrapping non-JSON strings in a single-element
+        # list.  Logging a warning here on every failure was the primary
+        # source of log spam — the wrap fallback is the intended path.
+        logger.debug(
             "coerce_tool_args: failed to parse string as JSON for expected type %s: %s",
             expected_python_type.__name__,
             exc,
@@ -919,7 +941,7 @@ def _coerce_json(value: str, expected_python_type: type):
             expected_python_type.__name__,
         )
         return parsed
-    logger.warning(
+    logger.debug(
         "coerce_tool_args: JSON-parsed value is %s, expected %s — skipping coercion",
         type(parsed).__name__,
         expected_python_type.__name__,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2367,6 +2367,42 @@ def terminal_tool(
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "pending_approval":
+                    # In cron/subagent contexts, no human is present to
+                    # approve.  Returning pending_approval with an empty
+                    # error string causes the agent to retry with command
+                    # variations, wasting budget and triggering loop_guard
+                    # hard stops (92 total failures, 3 cron job failures).
+                    # Convert to a clear non-retryable error so the agent
+                    # stops retrying and switches strategy.
+                    from tools.approval import (
+                        _is_interactive_cli,
+                        _is_gateway_approval_context,
+                    )
+                    is_cron = env_var_enabled("HERMES_CRON_SESSION")
+                    is_cli_ctx = _is_interactive_cli()
+                    is_gw_ctx = _is_gateway_approval_context()
+                    if is_cron or (not is_cli_ctx and not is_gw_ctx):
+                        desc = approval.get("description", "command flagged")
+                        return json.dumps({
+                            "output": "",
+                            "exit_code": -1,
+                            "error": (
+                                f"BLOCKED: Command requires approval ({desc}) "
+                                f"but no interactive user or gateway is present "
+                                f"to approve it in this "
+                                f"{'cron' if is_cron else 'subagent'} context. "
+                                f"Do NOT retry this command — find an "
+                                f"alternative approach using file/search tools "
+                                f"instead of terminal, or set "
+                                f"approvals.cron_mode: approve in config.yaml "
+                                f"if this command is safe to auto-approve."
+                            ),
+                            "status": "blocked",
+                            "approval_pending": False,
+                            "command": approval.get("command", command),
+                            "description": desc,
+                            "pattern_key": approval.get("pattern_key", ""),
+                        }, ensure_ascii=False)
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,


### PR DESCRIPTION
## Summary

Three introspection-driven bug fixes targeting the highest-volume failure patterns identified in evolution analysis.

### #900: coerce_tool_args JSON parse failures (2629 occurrences, worsening)

Empty/whitespace-only strings now return an empty container of the expected type (list to empty list, dict to empty dict). Demoted the JSON parse failure log from WARNING to DEBUG since the wrap fallback in the caller is the intended path. Eliminates 2000+ log warnings/day from the fusion-agents provider emitting empty strings where JSON arrays are expected.

### #901: SessionDB append_message NoneType (7593 occurrences, worsening)

Added a _ensure_conn() method that lazily reconnects when self._conn is None. Updated _execute_write() to call _ensure_conn() before using the connection. Prevents mass message persistence loss after process invalidation. Read-only connections raise instead of silently reconnecting.

### #902: Terminal pending_approval in cron/subagent (292 occurrences, worsening)

In cron/subagent contexts, returns a clear non-retryable "blocked" error. Prevents the agent from retrying blocked commands and triggering loop_guard hard stops. Interactive CLI and gateway sessions still get the normal pending_approval flow.

## Test Results

- 49 existing model_tools + state_db tests: all pass
- 33 existing terminal_tool tests: all pass
- Manual E2E verification of all three fixes confirmed

## Diff Size

106 insertions + 6 deletions = 112 lines across 3 files