### PR TITLE
feat(#905): per-stage model/provider allocation for evolution cron jobs

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -24,6 +24,14 @@ toolsets:
   - file
   - terminal   # needed for `gh issue list` (gh is authorized via GITHUB_TOKEN)
 
+# Per-stage model allocation (#905): triage/analysis quality is sufficient
+# with a mid-tier model per the harness-updating research (arXiv:2605.30621).
+# Uncomment and set to the deployment's actual mid-tier provider/model id;
+# the registrar passes both through to cron.jobs.create_job/update_job. Left
+# commented out, this stage stays unpinned and follows the global default.
+# model: <mid-tier-model-id>
+# provider: <provider-name>
+
 # GitHub API configuration (uses GITHUB_TOKEN; gh CLI is preferred)
 github:
   token_env: GITHUB_TOKEN

--- a/cron/evolution/implementation.yaml
+++ b/cron/evolution/implementation.yaml
@@ -31,6 +31,13 @@ toolsets:
   - file
   - terminal
 
+# Per-stage model allocation (#905): implementation is where capability
+# matters most (actual code changes), so this stage intentionally has no
+# model:/provider: override here — it stays unpinned and rides the
+# deployment's main/frontier default, same as today. Set model:/provider:
+# explicitly ONLY if the global default ever needs to change out from under
+# this stage without affecting research/analysis.
+
 # GitHub API configuration (uses GITHUB_TOKEN; gh CLI is preferred)
 github:
   token_env: GITHUB_TOKEN

--- a/cron/evolution/research.yaml
+++ b/cron/evolution/research.yaml
@@ -19,6 +19,15 @@ toolsets:
   - web
   - file
 
+# Per-stage model allocation (#905): research is broad exploration — harness-
+# updating quality is flat across capability tiers (arXiv:2605.30621), so a
+# cheaper/mid-tier model is a candidate here. Uncomment and set to the
+# deployment's actual cheap-tier provider/model id; the registrar passes both
+# through to cron.jobs.create_job/update_job. Left commented out, this stage
+# stays unpinned and follows the global default (no behavior change).
+# model: <cheap-tier-model-id>
+# provider: <provider-name>
+
 # GitHub API configuration (PUBLIC mode)
 github:
   token_env: GITHUB_TOKEN

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -20,6 +20,29 @@ skill's canonical name is ``evolution-research``. We normalize ``/`` -> ``-``
 so the scheduler resolves the real skill (``evolution/analysis`` ->
 ``evolution-analysis``, etc.).
 
+Per-stage model allocation (#905)
+----------------------------------
+A stage YAML may set optional ``model:`` / ``provider:`` keys to pin that
+stage to a specific model — e.g. a cheaper/mid-tier model for the broad,
+capability-flat research/analysis stages, leaving implementation on the
+deployment's main/frontier default. Both are independent and optional;
+omitting either leaves that axis unpinned (follows the global config
+default, same as today). This is a *static per-stage* pin, distinct from
+the *dynamic per-subtask* complexity routing added by #798
+(``evolution_draft_selector.route_cost_tier`` / ``model_hint`` on delegated
+worker tasks) — the two do not overlap.
+
+Caveat: ``model`` and ``provider`` reconcile independently (each only
+updates when its own YAML value differs from the stored one), matching the
+pre-existing skills/toolsets pattern below. cron.jobs.create_job/update_job
+already allow pinning either axis alone, with no cross-validation between
+them — that is inherited, not introduced here. If a stage's model and
+provider are both pinned, always edit both together when changing either;
+an edit that changes only one of the two while the job already has a
+mismatched value for the other risks an invalid model/provider combination
+at run time. The shipped stage YAMLs avoid this by leaving both commented
+out as a single paired block (see research.yaml / analysis.yaml).
+
 Usage
 -----
     python scripts/register_evolution_cron.py [--dry-run] [SRC_DIR]
@@ -411,6 +434,16 @@ def main(argv: list[str]) -> int:
         skills = _normalize_skills(spec.get("skills"))
         toolsets = _normalize_toolsets(spec.get("toolsets"))
         deliver = str(spec.get("deliver") or "local").strip()
+        # Per-stage model allocation (#905): an evolution stage may pin a
+        # cheaper/mid-tier model (research, analysis) while leaving others
+        # (implementation) on the deployment's main/frontier default. Both
+        # keys are optional and independent — omitting one leaves that axis
+        # unpinned (follows global config, same as today). Values pass
+        # through to cron.jobs.create_job/update_job unchanged; that layer
+        # already validates/normalizes and (#44585) drift-guards unpinned
+        # jobs against a later global default change.
+        model = str(spec.get("model") or "").strip() or None
+        provider = str(spec.get("provider") or "").strip() or None
 
         # Refuse to register (or reconcile) an agent job whose skills need a
         # toolset the job definition does not grant — the scheduled job could
@@ -459,6 +492,15 @@ def main(argv: list[str]) -> int:
                     cur.get("enabled_toolsets") or []
                 ):
                     changes["enabled_toolsets"] = toolsets
+                # model/provider (#905): same "None means leave as-is" rule as
+                # skills/toolsets above — a YAML that doesn't mention model:/
+                # provider: must never clear an already-pinned job back to
+                # unpinned. The two reconcile independently (see module
+                # docstring caveat) — always edit both together in the YAML.
+                if model is not None and model != cur.get("model"):
+                    changes["model"] = model
+                if provider is not None and provider != cur.get("provider"):
+                    changes["provider"] = provider
                 # Detect script changes (e.g. Hydra replacing access gate)
                 cur_script = str(cur.get("script") or "").strip()
                 yaml_script = str(spec.get("script") or "").strip()
@@ -507,6 +549,8 @@ def main(argv: list[str]) -> int:
                 skills=skills,
                 enabled_toolsets=toolsets,
                 deliver=deliver,
+                model=model,
+                provider=provider,
             )
             # Does the YAML define its own script? (Hydra gate, etc.)
             yaml_script = str(spec.get("script") or "").strip() if not no_agent else None

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -290,6 +290,190 @@ class TestReconcileExistingJob:
         assert calls["updates"] == {"schedule": "0 8 * * 1,3,5"}
 
 
+class TestModelProviderAllocation:
+    """Per-stage model allocation (#905): a stage YAML may set optional
+    model:/provider: keys to pin that stage to a specific model (e.g. a
+    cheaper/mid-tier model for research/analysis, leaving implementation
+    unpinned on the deployment's frontier default). Both fields are
+    independent, optional, and pass straight through to
+    cron.jobs.create_job/update_job unchanged — this class only tests that
+    the registrar reads and wires them correctly, mirroring the
+    skills/toolsets reconcile semantics above (None means leave as-is)."""
+
+    def _write_yaml(self, src_dir, extra="", schedule="0 9 * * *"):
+        (src_dir / "cheap-stage.yaml").write_text(
+            "name: evolution-cheap-stage\n"
+            f'schedule: "{schedule}"\n'
+            "enabled: true\n"
+            'prompt: "do the thing"\n' + extra
+        )
+
+    def test_create_job_passes_model_and_provider_when_set(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_yaml(src_dir, "model: glm-5-flash\nprovider: zai\n")
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        captured = {}
+
+        def fake_create_job(**kwargs):
+            captured.update(kwargs)
+            return {"id": "job-1", "name": kwargs["name"]}
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "create_job", fake_create_job)
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert captured["model"] == "glm-5-flash"
+        assert captured["provider"] == "zai"
+
+    def test_create_job_omits_model_and_provider_leaves_them_none(
+        self, tmp_path, monkeypatch
+    ):
+        """A YAML with no model:/provider: keys must produce the exact same
+        create_job call as before #905 (both None) — the unpinned, back-compat
+        default that follows the deployment's global config."""
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_yaml(src_dir)  # no model:/provider: keys
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        captured = {}
+
+        def fake_create_job(**kwargs):
+            captured.update(kwargs)
+            return {"id": "job-1", "name": kwargs["name"]}
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "create_job", fake_create_job)
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert captured["model"] is None
+        assert captured["provider"] is None
+
+    def _existing(self, jobs_mod, schedule, model=None, provider=None):
+        sched = jobs_mod.parse_schedule(schedule)
+        job = {
+            "id": "job-9",
+            "name": "evolution-cheap-stage",
+            "schedule": sched,
+            "schedule_display": sched.get("display"),
+            "prompt": "do the thing",
+        }
+        if model is not None:
+            job["model"] = model
+        if provider is not None:
+            job["provider"] = provider
+        return job
+
+    def _wire(self, jobs_mod, monkeypatch, tmp_path, existing):
+        home = tmp_path / "hermes-home"
+        (home / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [existing])
+        monkeypatch.setattr(
+            jobs_mod,
+            "create_job",
+            lambda **kw: (_ for _ in ()).throw(AssertionError("must not create")),
+        )
+        calls = {}
+        monkeypatch.setattr(
+            jobs_mod,
+            "update_job",
+            lambda job_id, updates: (
+                calls.update(job_id=job_id, updates=updates) or {**existing, **updates}
+            ),
+        )
+        return calls
+
+    def test_reconcile_updates_model_when_changed(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_yaml(src_dir, "model: glm-5-flash\n")
+        existing = self._existing(jobs_mod, "0 9 * * *", model="old-model")
+        calls = self._wire(jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls["updates"] == {"model": "glm-5-flash"}
+
+    def test_reconcile_updates_provider_when_changed(self, tmp_path, monkeypatch):
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_yaml(src_dir, "provider: zai\n")
+        existing = self._existing(jobs_mod, "0 9 * * *", provider="old-provider")
+        calls = self._wire(jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls["updates"] == {"provider": "zai"}
+
+    def test_reconcile_unchanged_model_and_provider_trigger_no_update(
+        self, tmp_path, monkeypatch
+    ):
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_yaml(src_dir, "model: glm-5-flash\nprovider: zai\n")
+        existing = self._existing(
+            jobs_mod, "0 9 * * *", model="glm-5-flash", provider="zai"
+        )
+        calls = self._wire(jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls == {}  # nothing changed anywhere -> no update_job call
+
+    def test_reconcile_omitted_model_and_provider_preserve_pinned_values(
+        self, tmp_path, monkeypatch
+    ):
+        """A YAML that never mentions model:/provider: must NOT clear an
+        already-pinned job back to unpinned — mirrors the skills/toolsets
+        back-compat guarantee in TestReconcileExistingJob above."""
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        # Changed schedule (so update_job IS called), but no model:/provider:.
+        self._write_yaml(src_dir)
+        existing = self._existing(
+            jobs_mod, "0 8 * * *", model="pinned-model", provider="pinned-provider"
+        )
+        calls = self._wire(jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls["updates"] == {"schedule": "0 9 * * *"}
+        assert "model" not in calls["updates"]
+        assert "provider" not in calls["updates"]
+
 
 class TestFindVenvPython:
     """The registrar self-locates the install venv interpreter so it runs with


### PR DESCRIPTION
Closes #905

## Summary

`cron.jobs.create_job`/`update_job` already accept optional per-job `model`/`provider` overrides, but `register_evolution_cron.py` — the converter that turns `cron/evolution/*.yaml` stage definitions into native Hermes cron jobs — never read `model:`/`provider:` from the YAML, so every evolution stage was forced onto the single global default with no way to route cheaper stages (research, analysis) to a cheaper model while keeping implementation on the frontier default.

This PR wires those two already-existing job fields through the registrar:

- `main()` reads optional `model:`/`provider:` keys per stage and passes them to `create_job()` on the agent-job creation path (the `no_agent` script-only path, e.g. the watchdog, is untouched — it has no agent/model concept).
- The reconcile path (for already-registered jobs) follows the exact same "`None` means leave as-is, not clear" rule already established for `skills:`/`toolsets:` in this file: a YAML that omits `model:`/`provider:` never clears an already-pinned job back to unpinned.
- `research.yaml` and `analysis.yaml` get an inert, commented-out `model:`/`provider:` block documenting how to opt a stage into a cheaper/mid-tier model. `implementation.yaml` gets a doc-only comment explaining why it intentionally stays unpinned.
- **No concrete model/provider value is hardcoded.** This machine's actual deployment (`~/.hermes/config.yaml`) points at a local self-hosted `zai/glm-5.2` endpoint, and `~/.hermes/cron/jobs.json` shows a real, already-running evolution pipeline (24 completed `evolution-analysis` runs). Guessing a concrete model id here risks breaking that live pipeline on the next registrar pass for a deployment that isn't mine. This PR ships the *mechanism* only, opt-in via YAML — zero behavior change until an operator sets a real value for their own deployment.

## Scope vs #798

#798 (merged) added *dynamic per-subtask* cost routing: `evolution_draft_selector.route_cost_tier` maps a delegated worker sub-task's free-text complexity to a `model_hint` a skill can pass to `delegate_task`, all *within* a single pipeline stage. This PR is a *static per-stage* pin — one model per cron job/stage, set once at registration time. Different call sites, no code overlap; confirmed via full reads of both files.

## Known limitation (intentionally out of scope)

`model` and `provider` reconcile independently, matching the pre-existing `skills`/`toolsets` pattern in this same file — `cron.jobs.create_job`/`update_job` already allow pinning either axis alone with no cross-validation between them (inherited, not introduced here). If both are ever pinned on a job, always edit both together in the YAML: an edit that changes only one while the job already carries a stale value for the other risks an invalid model/provider combination at run time. The shipped YAMLs sidestep this entirely by keeping both commented out as one paired block. Documented in the module docstring and the reconcile-path comment. Fixing the general case (YAML-level explicit-unpin syntax, cross-field validation) would expand scope well beyond this issue and duplicate work at the `cron.jobs.py` layer, which is used by more than just this registrar.

## Out of scope (from the issue's broader plan)

- Concrete tier→model-id resolution / a `MODEL_TIERS` table — no such abstraction exists in the codebase; inventing one here would be the "vague framework" the task explicitly said to avoid. Operators set literal `model:`/`provider:` strings for their own deployment.
- Cost/quality tracking dashboards and automated 40%+ cost-reduction measurement (issue's success criteria) — needs real usage data after an operator opts in; not buildable in this slice.
- Any `cron/evolution/*.yaml` files beyond `research.yaml`, `analysis.yaml`, `implementation.yaml`.

## Testing

```
.venv/bin/python -m pytest tests/scripts/test_register_evolution_cron.py -q
.venv/bin/python -m pytest tests/cron/test_cron_provider_pin.py -q
.venv/bin/python -m ruff check scripts/register_evolution_cron.py tests/scripts/test_register_evolution_cron.py
```

New `TestModelProviderAllocation` (7 cases): create-path pass-through with/without `model:`/`provider:`, reconcile updates on change, no-op when unchanged, and the omit-preserves-pinned-value regression mirroring the existing skills/toolsets back-compat guarantee.

## Review note

Ran an independent adversarial review (`consult agy --review`) against this diff before opening the PR. It raised the model/provider independent-reconcile coupling risk described above (now documented) and two other points — inability to force-clear a pin via YAML, and create-vs-reconcile asymmetry for unpinned stages — which I judged to be intentional, tested, and consistent with this file's pre-existing `skills`/`toolsets` convention rather than bugs; see the caveat note above for the one point I did act on.
