### PR TITLE
feat(#913): gate expensive LLM evolution stages on halt-state.txt

### DIFF
--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -11,6 +11,7 @@ useful input instead of failing silently.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -78,20 +79,26 @@ def _evolution_dir(hermes_home: Optional[Path] = None) -> Path:
 def _halt_state_active(hermes_home: Optional[Path] = None) -> bool:
     """Return whether the evolution pipeline halt-state file is present.
 
-    Same file, same directory resolution (:func:`_evolution_dir`) as the rest
-    of this module — i.e. the same evolution dir the scheduler already
-    resolves for ``load_digest_as_fallback``/``find_latest_digest``. Mirrors
-    ``scripts/evolution_funnel.py::is_evolution_halted()`` and
-    ``scripts/evolution_hydra_gate.py::_check_halt()``, which independently
-    do the same trivial existence check (those run as standalone script
+    ``scripts/evolution_funnel.py::is_evolution_halted()`` (the writer) and
+    ``scripts/evolution_hydra_gate.py::_check_halt()`` resolve their
+    directory as ``EVOLUTION_PROFILE_DIR`` if set, else ``~/.hermes/evolution``
+    — independently of ``HERMES_HOME``, since those run as standalone script
     copies under ``HERMES_HOME/scripts`` and cannot rely on importing this
-    package, so the check is intentionally duplicated rather than shared).
+    package. Check that exact location FIRST so a custom evolution profile
+    (``EVOLUTION_PROFILE_DIR``) still gates correctly, then fall back to
+    :func:`_evolution_dir` — the same ``HERMES_HOME``-based resolution the
+    scheduler already uses for ``load_digest_as_fallback``/
+    ``find_latest_digest``, and which matches the writer's own default when
+    neither ``EVOLUTION_PROFILE_DIR`` nor ``HERMES_HOME`` is overridden.
 
-    Fail-safe: ANY error while resolving the path or checking existence is
+    Fail-safe: ANY error while resolving a path or checking existence is
     treated as NOT halted — a broken halt check must never wrongly skip a
     job (#913).
     """
     try:
+        profile_dir = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+        if profile_dir and (Path(profile_dir) / "halt-state.txt").exists():
+            return True
         return (_evolution_dir(hermes_home) / "halt-state.txt").exists()
     except OSError:
         return False

--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -84,12 +84,16 @@ def _halt_state_active(hermes_home: Optional[Path] = None) -> bool:
     directory as ``EVOLUTION_PROFILE_DIR`` if set, else ``~/.hermes/evolution``
     — independently of ``HERMES_HOME``, since those run as standalone script
     copies under ``HERMES_HOME/scripts`` and cannot rely on importing this
-    package. Check that exact location FIRST so a custom evolution profile
-    (``EVOLUTION_PROFILE_DIR``) still gates correctly, then fall back to
-    :func:`_evolution_dir` — the same ``HERMES_HOME``-based resolution the
-    scheduler already uses for ``load_digest_as_fallback``/
-    ``find_latest_digest``, and which matches the writer's own default when
-    neither ``EVOLUTION_PROFILE_DIR`` nor ``HERMES_HOME`` is overridden.
+    package. Mirror that resolution EXACTLY (not "check both"): if
+    ``EVOLUTION_PROFILE_DIR`` is set, it is the writer's one and only
+    location, so it is the one and only location checked here too — falling
+    through to :func:`_evolution_dir` in that case would risk a false
+    "halted" from an unrelated stale ``halt-state.txt`` left over in a
+    different ``HERMES_HOME`` tree. Only when ``EVOLUTION_PROFILE_DIR`` is
+    unset do we fall back to :func:`_evolution_dir` — the same
+    ``HERMES_HOME``-based resolution the scheduler already uses for
+    ``load_digest_as_fallback``/``find_latest_digest``, and which matches
+    the writer's own default in that case.
 
     Fail-safe: ANY error while resolving a path or checking existence is
     treated as NOT halted — a broken halt check must never wrongly skip a
@@ -97,9 +101,11 @@ def _halt_state_active(hermes_home: Optional[Path] = None) -> bool:
     """
     try:
         profile_dir = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
-        if profile_dir and (Path(profile_dir) / "halt-state.txt").exists():
-            return True
-        return (_evolution_dir(hermes_home) / "halt-state.txt").exists()
+        if profile_dir:
+            halt_dir = Path(profile_dir).expanduser().resolve()
+        else:
+            halt_dir = _evolution_dir(hermes_home)
+        return (halt_dir / "halt-state.txt").exists()
     except OSError:
         return False
     except Exception as exc:  # pragma: no cover - defense in depth

--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -31,6 +31,19 @@ _EVOLUTION_STAGES = {
     "integration": ".md",
 }
 
+# Stages that spawn an expensive LLM agent and must respect the pipeline
+# halt-state file written by scripts/evolution_funnel.py (merged=0 for 5+
+# cycles AND selected=0 for 3+ cycles). `funnel` is a deterministic no_agent
+# job that MUST keep running every cycle regardless of halt state — it is
+# what measures recovery and clears halt-state.txt once metrics improve.
+# `integration` is intentionally left ungated for now (#913).
+_HALT_GATED_STAGES = frozenset({
+    "introspection",
+    "analysis",
+    "implementation",
+    "research",
+})
+
 
 def evolution_job_stage(job: Dict[str, Any]) -> Optional[str]:
     """Return the evolution stage for a cron job, or None if it is not an
@@ -60,6 +73,50 @@ def evolution_job_stage(job: Dict[str, Any]) -> Optional[str]:
 def _evolution_dir(hermes_home: Optional[Path] = None) -> Path:
     home = (hermes_home or get_hermes_home()).resolve()
     return home / "evolution"
+
+
+def _halt_state_active(hermes_home: Optional[Path] = None) -> bool:
+    """Return whether the evolution pipeline halt-state file is present.
+
+    Same file, same directory resolution (:func:`_evolution_dir`) as the rest
+    of this module — i.e. the same evolution dir the scheduler already
+    resolves for ``load_digest_as_fallback``/``find_latest_digest``. Mirrors
+    ``scripts/evolution_funnel.py::is_evolution_halted()`` and
+    ``scripts/evolution_hydra_gate.py::_check_halt()``, which independently
+    do the same trivial existence check (those run as standalone script
+    copies under ``HERMES_HOME/scripts`` and cannot rely on importing this
+    package, so the check is intentionally duplicated rather than shared).
+
+    Fail-safe: ANY error while resolving the path or checking existence is
+    treated as NOT halted — a broken halt check must never wrongly skip a
+    job (#913).
+    """
+    try:
+        return (_evolution_dir(hermes_home) / "halt-state.txt").exists()
+    except OSError:
+        return False
+    except Exception as exc:  # pragma: no cover - defense in depth
+        logger.debug("Halt-state check failed, treating as not halted: %s", exc)
+        return False
+
+
+def should_skip_for_halt(
+    stage: Optional[str], hermes_home: Optional[Path] = None
+) -> bool:
+    """Return True if a cron job for ``stage`` should be skipped because the
+    evolution pipeline is structurally halted.
+
+    Only the expensive LLM-agent stages in :data:`_HALT_GATED_STAGES`
+    (introspection, analysis, implementation, research) are gated — this
+    extends the halt-state gate that already covers the Hydra orchestrator
+    (``evolution_hydra_gate.py``) to the individual stage crons that spawn
+    their own agents directly, so a structurally-halted pipeline stops
+    burning tokens on every stage, not only Hydra (#913). ``funnel`` and
+    ``integration`` are never skipped here.
+    """
+    if stage not in _HALT_GATED_STAGES:
+        return False
+    return _halt_state_active(hermes_home)
 
 
 def _preflight_timeout_seconds(cfg: Optional[Any] = None) -> float:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3410,6 +3410,44 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # so downstream evolution jobs still have stale-but-structured input
         # instead of failing silently during retries. (#486)
         stage = evolution_preflight.evolution_job_stage(job)
+
+        # Halt-state gate (#913): scripts/evolution_funnel.py writes
+        # halt-state.txt once the pipeline has produced zero merged PRs for
+        # 5+ consecutive cycles AND zero selections for 3+ consecutive
+        # cycles. evolution_hydra_gate.py already sleeps on this file, but
+        # the individual research/analysis/implementation/introspection cron
+        # jobs spawn their own LLM agents directly and never consulted it —
+        # so a structurally-halted pipeline kept burning tokens on every
+        # scheduled stage run. Check BEFORE the provider ping (cheaper) and
+        # before any agent construction. `funnel` (deterministic, no_agent)
+        # is never gated — it is what clears the halt once metrics recover.
+        if stage and evolution_preflight.should_skip_for_halt(
+            stage, _get_hermes_home()
+        ):
+            logger.warning(
+                "Job '%s' (evolution-%s): SKIPPED — evolution pipeline is "
+                "halted (halt-state.txt present). No LLM agent was spawned. "
+                "The pipeline resumes automatically once the funnel job "
+                "clears the halt (merged/selected recover), or the file can "
+                "be removed manually.",
+                job_id,
+                stage,
+            )
+            now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {now_iso}\n"
+                f"**Status:** silent (evolution pipeline halted)\n\n"
+                "The evolution pipeline is halted (zero merged PRs for 5+ "
+                "cycles and zero selections for 3+ cycles — see "
+                "scripts/evolution_funnel.py). This expensive LLM stage was "
+                "skipped to avoid burning tokens on a structurally blocked "
+                "pipeline. `funnel` keeps running and will clear the halt "
+                "automatically once metrics recover.\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
+
         if stage and evolution_preflight._preflight_enabled(_cfg):
             # ROOT-FIX (#486): resolve_runtime_provider() does NOT populate
             # runtime["model"] — the model is resolved into the local ``model``

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2957,10 +2957,33 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # path `stage` can be known. `funnel` (deterministic, no_agent) is
     # never gated — it already returned above and is what clears the
     # halt once metrics recover.
+    #
+    # The whole classification+check is wrapped here too (not just the
+    # leaf `_halt_state_active` existence check): stage classification or
+    # `_get_hermes_home()` blowing up must never turn into "silently skip
+    # a job" or "crash the run" — fail-safe means falling through to the
+    # normal, ungated LLM path below, exactly as it would for a job that
+    # isn't part of the evolution pipeline at all.
     from cron import evolution_preflight
 
-    stage = evolution_preflight.evolution_job_stage(job)
-    if stage and evolution_preflight.should_skip_for_halt(stage, _get_hermes_home()):
+    stage: Optional[str] = None
+    halted_for_gate = False
+    try:
+        stage = evolution_preflight.evolution_job_stage(job)
+        halted_for_gate = bool(stage) and evolution_preflight.should_skip_for_halt(
+            stage, _get_hermes_home()
+        )
+    except Exception as exc:  # pragma: no cover - defense in depth
+        logger.debug(
+            "Job '%s': halt-state gate classification failed, proceeding "
+            "without it: %s",
+            job_id,
+            exc,
+        )
+        stage = None
+        halted_for_gate = False
+
+    if halted_for_gate:
         # info, not warning: halt is an expected, potentially long-lived
         # state (can persist for days), not an anomaly — this line would
         # otherwise spam the log on every tick of every gated stage.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2943,6 +2943,51 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # at module top keeps no_agent ticks from paying for AIAgent / SessionDB
     # construction costs.
     # ---------------------------------------------------------------
+
+    # Halt-state gate (#913): scripts/evolution_funnel.py writes
+    # halt-state.txt once the pipeline has produced zero merged PRs for
+    # 5+ consecutive cycles AND zero selections for 3+ consecutive
+    # cycles. evolution_hydra_gate.py already sleeps on this file, but
+    # the individual research/analysis/implementation/introspection cron
+    # jobs spawn their own LLM agents directly and never consulted it —
+    # so a structurally-halted pipeline kept burning tokens on every
+    # scheduled stage run. Checked here, before SessionDB/AIAgent
+    # construction, any prerun script, config/model resolution, or
+    # provider/credential resolution — the earliest point in the LLM
+    # path `stage` can be known. `funnel` (deterministic, no_agent) is
+    # never gated — it already returned above and is what clears the
+    # halt once metrics recover.
+    from cron import evolution_preflight
+
+    stage = evolution_preflight.evolution_job_stage(job)
+    if stage and evolution_preflight.should_skip_for_halt(stage, _get_hermes_home()):
+        # info, not warning: halt is an expected, potentially long-lived
+        # state (can persist for days), not an anomaly — this line would
+        # otherwise spam the log on every tick of every gated stage.
+        logger.info(
+            "Job '%s' (evolution-%s): SKIPPED — evolution pipeline is "
+            "halted (halt-state.txt present). No LLM agent was spawned. "
+            "The pipeline resumes automatically once the funnel job "
+            "clears the halt (merged/selected recover), or the file can "
+            "be removed manually.",
+            job_id,
+            stage,
+        )
+        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        silent_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {now_iso}\n"
+            f"**Status:** silent (evolution pipeline halted)\n\n"
+            "The evolution pipeline is halted (zero merged PRs for 5+ "
+            "cycles and zero selections for 3+ cycles — see "
+            "scripts/evolution_funnel.py). This expensive LLM stage was "
+            "skipped to avoid burning tokens on a structurally blocked "
+            "pipeline. `funnel` keeps running and will clear the halt "
+            "automatically once metrics recover.\n"
+        )
+        return True, silent_doc, SILENT_MARKER, None
+
     from run_agent import AIAgent
 
     # Initialize SQLite session store so cron job messages are persisted
@@ -3347,7 +3392,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             format_runtime_provider_error,
         )
         from hermes_cli.auth import AuthError
-        from cron import evolution_preflight
+
+        # evolution_preflight was already imported above (halt-state gate,
+        # #913) — reused here for _preflight_enabled()/preflight_provider().
 
         # F8 runtime backstop: never resolve a stored provider/base_url pair that
         # would ship a named provider's stored credential to an off-host endpoint
@@ -3409,45 +3456,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # build an agent. If it fails, return the most recent on-disk digest
         # so downstream evolution jobs still have stale-but-structured input
         # instead of failing silently during retries. (#486)
-        stage = evolution_preflight.evolution_job_stage(job)
-
-        # Halt-state gate (#913): scripts/evolution_funnel.py writes
-        # halt-state.txt once the pipeline has produced zero merged PRs for
-        # 5+ consecutive cycles AND zero selections for 3+ consecutive
-        # cycles. evolution_hydra_gate.py already sleeps on this file, but
-        # the individual research/analysis/implementation/introspection cron
-        # jobs spawn their own LLM agents directly and never consulted it —
-        # so a structurally-halted pipeline kept burning tokens on every
-        # scheduled stage run. Check BEFORE the provider ping (cheaper) and
-        # before any agent construction. `funnel` (deterministic, no_agent)
-        # is never gated — it is what clears the halt once metrics recover.
-        if stage and evolution_preflight.should_skip_for_halt(
-            stage, _get_hermes_home()
-        ):
-            logger.warning(
-                "Job '%s' (evolution-%s): SKIPPED — evolution pipeline is "
-                "halted (halt-state.txt present). No LLM agent was spawned. "
-                "The pipeline resumes automatically once the funnel job "
-                "clears the halt (merged/selected recover), or the file can "
-                "be removed manually.",
-                job_id,
-                stage,
-            )
-            now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {now_iso}\n"
-                f"**Status:** silent (evolution pipeline halted)\n\n"
-                "The evolution pipeline is halted (zero merged PRs for 5+ "
-                "cycles and zero selections for 3+ cycles — see "
-                "scripts/evolution_funnel.py). This expensive LLM stage was "
-                "skipped to avoid burning tokens on a structurally blocked "
-                "pipeline. `funnel` keeps running and will clear the halt "
-                "automatically once metrics recover.\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
-
+        #
+        # `stage` and the halt-state gate (#913) were already resolved
+        # earlier in this function, right after the no_agent short-circuit —
+        # before SessionDB/AIAgent construction, prerun scripts, and this
+        # provider resolution — so a halted job never reaches this point.
         if stage and evolution_preflight._preflight_enabled(_cfg):
             # ROOT-FIX (#486): resolve_runtime_provider() does NOT populate
             # runtime["model"] — the model is resolved into the local ``model``

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -106,6 +106,39 @@ class TestHaltGate:
         (evo_dir / "halt-state.txt").write_text("halted")
         assert ep.should_skip_for_halt("research", tmp_path) is True
 
+    def test_evolution_profile_dir_set_is_exclusive_not_additive(
+        self, tmp_path, monkeypatch
+    ):
+        # When EVOLUTION_PROFILE_DIR is set, the writer (evolution_funnel.py)
+        # uses that location EXCLUSIVELY — it never also looks at
+        # HERMES_HOME/evolution. The gate must mirror that: a stale
+        # halt-state.txt left over in the HERMES_HOME tree (e.g. from a
+        # previous deployment/profile) must NOT cause a false "halted" when
+        # the active EVOLUTION_PROFILE_DIR itself is clear (#913 follow-up).
+        profile_dir = tmp_path / "custom-profile"
+        profile_dir.mkdir()
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(profile_dir))
+
+        stale_home = tmp_path / "stale-hermes-home"
+        stale_evo = stale_home / "evolution"
+        stale_evo.mkdir(parents=True)
+        (stale_evo / "halt-state.txt").write_text("stale halt from another profile")
+
+        assert ep.should_skip_for_halt("research", stale_home) is False
+
+    def test_evolution_profile_dir_expands_user_and_relative(
+        self, tmp_path, monkeypatch
+    ):
+        # The writer's own resolution is a raw Path(env_var); real deployments
+        # may still set it to a `~`-relative value, so the gate should not be
+        # any less permissive than a literal, resolved path would be.
+        profile_dir = tmp_path / "custom-profile"
+        profile_dir.mkdir()
+        (profile_dir / "halt-state.txt").write_text("halted")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", "~/custom-profile")
+        assert ep.should_skip_for_halt("research", tmp_path / "unused-home") is True
+
 
 class TestPreflightConfig:
     def test_preflight_timeout_default(self):
@@ -652,6 +685,48 @@ class TestSchedulerHaltGate:
             success, _output, final_response, _error = _run_job_impl(job)
 
         assert success is True
+        assert final_response == "ok"
+        mock_agent_cls.assert_called_once()
+
+    def test_gate_classification_error_proceeds_normally_not_skipped(self, tmp_path):
+        """Fail-safe (#913 follow-up): if stage classification or the halt
+        check itself raises for any reason, the job must proceed through the
+        normal LLM path — never silently skipped and never crashed. A broken
+        gate must fail OPEN (run the job), not closed (skip it)."""
+        from cron.scheduler import _run_job_impl
+
+        self._write_halt_file(tmp_path)  # even with halt active...
+        job = self._make_job("research")
+        with (
+            patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=MagicMock()),
+            patch(
+                "cron.evolution_preflight.evolution_job_stage",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "model": "openrouter/model",
+                },
+            ),
+            patch("cron.evolution_preflight.preflight_provider", return_value=None),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            # ...classification blowing up must not raise out of _run_job_impl.
+            success, _output, final_response, error = _run_job_impl(job)
+
+        assert success is True
+        assert error is None
         assert final_response == "ok"
         mock_agent_cls.assert_called_once()
 

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -81,6 +81,31 @@ class TestHaltGate:
         with patch.object(ep, "_evolution_dir", side_effect=RuntimeError("boom")):
             assert ep._halt_state_active(tmp_path) is False
 
+    def test_evolution_profile_dir_checked_first(self, tmp_path, monkeypatch):
+        # scripts/evolution_funnel.py (the writer) resolves its directory via
+        # EVOLUTION_PROFILE_DIR when set, independently of HERMES_HOME. The
+        # gate must check that exact location too, or a custom-profile
+        # deployment's halt file would never be seen (#913 follow-up).
+        profile_dir = tmp_path / "custom-profile"
+        profile_dir.mkdir()
+        (profile_dir / "halt-state.txt").write_text("halted")
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(profile_dir))
+
+        # hermes_home points somewhere else entirely and has no halt file —
+        # the EVOLUTION_PROFILE_DIR match must still win.
+        other_home = tmp_path / "other-hermes-home"
+        (other_home / "evolution").mkdir(parents=True)
+        assert ep.should_skip_for_halt("research", other_home) is True
+
+    def test_evolution_profile_dir_unset_falls_back_to_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("EVOLUTION_PROFILE_DIR", raising=False)
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir()
+        (evo_dir / "halt-state.txt").write_text("halted")
+        assert ep.should_skip_for_halt("research", tmp_path) is True
+
 
 class TestPreflightConfig:
     def test_preflight_timeout_default(self):

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -35,6 +35,53 @@ class TestEvolutionJobStage:
         )
 
 
+class TestHaltGate:
+    """Halt-state gate (#913): expensive LLM stages must skip when the
+    evolution pipeline is structurally halted (scripts/evolution_funnel.py's
+    halt-state.txt)."""
+
+    def test_no_halt_file_not_skipped(self, tmp_path):
+        (tmp_path / "evolution").mkdir()
+        assert ep.should_skip_for_halt("research", tmp_path) is False
+
+    def test_halt_file_present_gated_stage_skipped(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir()
+        (evo_dir / "halt-state.txt").write_text("halted")
+        for stage in ("research", "analysis", "implementation", "introspection"):
+            assert ep.should_skip_for_halt(stage, tmp_path) is True
+
+    def test_halt_file_present_funnel_not_gated(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir()
+        (evo_dir / "halt-state.txt").write_text("halted")
+        assert ep.should_skip_for_halt("funnel", tmp_path) is False
+
+    def test_halt_file_present_integration_not_gated(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir()
+        (evo_dir / "halt-state.txt").write_text("halted")
+        assert ep.should_skip_for_halt("integration", tmp_path) is False
+
+    def test_none_stage_never_skipped(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir()
+        (evo_dir / "halt-state.txt").write_text("halted")
+        assert ep.should_skip_for_halt(None, tmp_path) is False
+
+    def test_missing_evolution_dir_not_halted(self, tmp_path):
+        # No evolution/ dir at all yet — must not raise, must not skip.
+        assert ep.should_skip_for_halt("research", tmp_path) is False
+
+    def test_halt_check_fail_safe_on_error(self, tmp_path):
+        # Any error resolving/reading the halt file must be treated as
+        # NOT halted — a broken check must never wrongly skip a job.
+        with patch.object(ep, "_evolution_dir", side_effect=OSError("boom")):
+            assert ep._halt_state_active(tmp_path) is False
+        with patch.object(ep, "_evolution_dir", side_effect=RuntimeError("boom")):
+            assert ep._halt_state_active(tmp_path) is False
+
+
 class TestPreflightConfig:
     def test_preflight_timeout_default(self):
         with patch("hermes_cli.config.load_config_readonly", return_value={}):
@@ -465,4 +512,152 @@ class TestSchedulerIntegration:
         assert success is True
         assert final_response == "ok"
         mock_preflight.assert_not_called()
+        mock_agent_cls.assert_called_once()
+
+
+class TestSchedulerHaltGate:
+    """Scheduler-level wiring for the halt-state gate (#913): a job for a
+    gated stage must be skipped BEFORE any provider ping or agent
+    construction when scripts/evolution_funnel.py's halt-state.txt is
+    present, and jobs for ungated stages (funnel is no_agent and never
+    reaches this code path; integration is left ungated) must proceed."""
+
+    def _make_job(self, stage):
+        return {
+            "id": f"evolution-{stage}",
+            "name": f"evolution-{stage}",
+            "prompt": "do work",
+        }
+
+    def _write_halt_file(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir(parents=True, exist_ok=True)
+        (evo_dir / "halt-state.txt").write_text("halted")
+
+    def test_halted_gated_stage_skips_without_agent_or_preflight(self, tmp_path):
+        from cron.scheduler import _run_job_impl
+
+        self._write_halt_file(tmp_path)
+        job = self._make_job("analysis")
+        with (
+            patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=MagicMock()),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "model": "openrouter/model",
+                },
+            ),
+            patch("cron.evolution_preflight.preflight_provider") as mock_preflight,
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
+            success, output, final_response, error = _run_job_impl(job)
+
+        assert success is True
+        assert final_response == "[SILENT]"
+        assert error is None
+        assert "pipeline halted" in output
+        mock_preflight.assert_not_called()
+        mock_agent_cls.assert_not_called()
+
+    def test_halted_all_four_gated_stages_skip(self, tmp_path):
+        from cron.scheduler import _run_job_impl
+
+        self._write_halt_file(tmp_path)
+        for stage in ("research", "analysis", "implementation", "introspection"):
+            job = self._make_job(stage)
+            with (
+                patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+                patch("cron.scheduler._resolve_origin", return_value=None),
+                patch("dotenv.load_dotenv"),
+                patch("hermes_state.SessionDB", return_value=MagicMock()),
+                patch(
+                    "hermes_cli.runtime_provider.resolve_runtime_provider",
+                    return_value={
+                        "api_key": "test-key",
+                        "base_url": "https://example.invalid/v1",
+                        "provider": "openrouter",
+                        "api_mode": "chat_completions",
+                        "model": "openrouter/model",
+                    },
+                ),
+                patch("run_agent.AIAgent") as mock_agent_cls,
+            ):
+                success, _output, final_response, _error = _run_job_impl(job)
+            assert success is True
+            assert final_response == "[SILENT]"
+            mock_agent_cls.assert_not_called()
+
+    def test_halted_integration_stage_not_gated(self, tmp_path):
+        """Integration is intentionally left ungated: gating it too would
+        deadlock the halt (merged=0 triggers halt; integration is what
+        performs merges, so it must keep running to let the pipeline
+        recover on its own)."""
+        from cron.scheduler import _run_job_impl
+
+        self._write_halt_file(tmp_path)
+        job = self._make_job("integration")
+        with (
+            patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=MagicMock()),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "model": "openrouter/model",
+                },
+            ),
+            patch("cron.evolution_preflight.preflight_provider", return_value=None),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, final_response, _error = _run_job_impl(job)
+
+        assert success is True
+        assert final_response == "ok"
+        mock_agent_cls.assert_called_once()
+
+    def test_no_halt_file_gated_stage_proceeds_normally(self, tmp_path):
+        from cron.scheduler import _run_job_impl
+
+        (tmp_path / "evolution").mkdir(parents=True, exist_ok=True)
+        job = self._make_job("research")
+        with (
+            patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=MagicMock()),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "model": "openrouter/model",
+                },
+            ),
+            patch("cron.evolution_preflight.preflight_provider", return_value=None),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, final_response, _error = _run_job_impl(job)
+
+        assert success is True
+        assert final_response == "ok"
         mock_agent_cls.assert_called_once()


### PR DESCRIPTION
Closes #913

## Problem

`scripts/evolution_funnel.py` writes `halt-state.txt` once the evolution
pipeline has produced zero merged PRs for 5+ consecutive cycles AND zero
selections for 3+ consecutive cycles. `scripts/evolution_hydra_gate.py`
already sleeps on this file before waking the Hydra orchestrator, but the
individual `research`/`analysis`/`implementation`/`introspection` cron jobs
spawn their own LLM agents directly and never consulted it — so a
structurally-halted pipeline kept burning tokens on every scheduled stage
run, not just via Hydra.

## Fix

Added the halt-gate to the scheduler's evolution pre-flight path instead of
touching `evolution_access_gate.sh` (that script only gates the Hydra
orchestrator entry point, not the per-stage crons):

- `cron/evolution_preflight.py`: new `should_skip_for_halt(stage, hermes_home)`
  + `_halt_state_active()` helper. Only the four LLM-agent stages named in
  the issue are gated (`_HALT_GATED_STAGES`); `funnel` (deterministic,
  `no_agent`, the only thing that can clear the halt) and `integration`
  (performs the merges that clear `merged=0` — gating it would deadlock the
  halt) are intentionally left ungated.
- `cron/scheduler.py`: `_run_job_impl` checks the gate at the earliest
  possible point in the LLM path — right after the `no_agent` short-circuit,
  before `AIAgent`/`SessionDB` construction, any prerun wake-gate script,
  config/model resolution, or provider/credential resolution. A gated,
  halted job returns a silent success (`SILENT_MARKER`) with no agent spawned
  and an `info`-level log line (halt can persist for days — not an anomaly
  worth `warning` spam).
- Directory resolution matches the same `HERMES_HOME`-based resolution the
  scheduler already uses (`load_digest_as_fallback`/`find_latest_digest`),
  reused via `_evolution_dir()`. It also checks `EVOLUTION_PROFILE_DIR`
  first when set — the standalone `scripts/evolution_*.py` writer/gate
  resolve their directory that way, independently of `HERMES_HOME` (they
  run as standalone copies outside the package). When set, it is the
  *exclusive* location checked (mirroring the writer exactly), not an
  additional location — an "or" check would risk a false "halted" from an
  unrelated stale file in a different `HERMES_HOME` tree.
- The whole gate (stage classification + halt check) is wrapped fail-safe
  at both the leaf (`_halt_state_active`) and call-site level in
  `scheduler.py`: any resolution/read/classification error is treated as
  "not halted, not an evolution job" and the job proceeds through the
  normal, ungated LLM path — a broken check must never wrongly skip or
  crash a job.

This diff went through two rounds of independent adversarial review
(`consult grok --review`, a non-Claude peer AI) before being sealed. The
first round caught: the halt-gate being placed after `resolve_runtime_provider()`
rather than truly first, a `WARNING`-level log for an expected long-lived
state, and the missing `EVOLUTION_PROFILE_DIR` handling — all fixed in the
first fixup commit. The second round caught the "or" vs. "exclusive"
`EVOLUTION_PROFILE_DIR` semantics bug and the call-site (not just leaf)
fail-safe gap — both fixed in the second fixup commit, each with a
regression test.

## Testing

- `tests/cron/test_evolution_preflight.py`: 43 passed (10 new tests added
  across both fixups, covering the gate itself, `EVOLUTION_PROFILE_DIR`
  exclusivity/expansion, fail-safe error handling, and scheduler wiring for
  all four gated stages plus the `funnel`/`integration` non-gating).
- `tests/cron/` (full suite): 726 passed, 1 skipped — no regressions.
- `ruff check` (blocking CI gate): clean on all 3 changed files.
- `ruff format --check`: flags only pre-existing, unrelated lines in
  `cron/scheduler.py` and the test file (verified against the pre-change
  baseline) — zero new formatting nits from this change.

## Limitations

- `integration` is deliberately left ungated (see above) — this is a
  judgment call, not an oversight.
- The `EVOLUTION_PROFILE_DIR` fallback closes the gap for the one override
  mechanism the standalone evolution scripts already document, but it does
  not fully unify `HERMES_HOME` vs. `EVOLUTION_PROFILE_DIR` resolution
  across the whole `scripts/evolution_*.py` family. A deployment that
  overrides `HERMES_HOME` alone (without also setting `EVOLUTION_PROFILE_DIR`)
  will still see the scheduler's `_evolution_dir()` and the standalone
  scripts' default (`~/.hermes/evolution`) diverge. This is a pre-existing
  architectural inconsistency (it already affected the digest-fallback
  mechanism before this issue) and a full fix is out of scope here.

Do not merge — CI needs to pass first.