### PR TITLE
fix(#910): split evolution-analysis local triage from private-repo dispatch

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -3,18 +3,33 @@ schedule: "0 1,5,9,13,17,21 * * *"  # Every 4h (was daily 21:00). Raises process
 enabled: true
 mode: PRIVATE
 
+# #910: analysis has a token-free LOCAL triage half (Phase 0, reads
+# issues/introspection/research sidecars, writes analysis/YYYY-MM-DD.json)
+# and a GitHub-dependent full pass (Phase 1). Without this dedicated gate,
+# the job fell back to the generic access-gate default, which skipped the
+# ENTIRE run — Phase 0 included — whenever GitHub write access was
+# unavailable. evolution_analysis_gate.sh always runs Phase 0's local
+# triage first (best-effort, never blocking), then gates only the LLM
+# agent wake decision on GitHub write access, same as every other stage.
+script: evolution_analysis_gate.sh
+
 prompt: |
   You are Hermes Evolution Analyzer.
-  
+
   Your task: Analyze all open issues and PRs to prioritize implementation.
-  
+
   Use the evolution-analysis skill for instructions.
-  
+
   Output to: ~/.hermes/evolution/analysis/{current_date}.json
-  
-  CRITICAL: Verify `gh auth status` works before proceeding — the gh CLI is
-  the primary auth mechanism. GITHUB_TOKEN is set as fallback. If neither
-  gh CLI auth nor GITHUB_TOKEN is available, ABORT immediately.
+
+  NOTE: The wake-gate script already ran Phase 0 (local, token-free triage)
+  before you were woken, so analysis/{current_date}.json already exists with
+  at least a local-triage baseline. You were only woken because GitHub write
+  access is confirmed — proceed with Phase 1 (the full, GitHub-aware pass)
+  per the evolution-analysis skill, refining/superseding the local-only
+  baseline. If mid-run `gh auth status` / GITHUB_TOKEN turns out to be
+  unavailable after all, ABORT Phase 1 only — the local-triage baseline
+  already on disk still stands as this cycle's output.
 
 skills:
   - evolution/analysis

--- a/scripts/evolution_analysis_gate.sh
+++ b/scripts/evolution_analysis_gate.sh
@@ -55,6 +55,17 @@ fi
 # environment. The subshell's stdout still flows straight through to ours,
 # so its last line is still the `{"wakeAgent": ...}` JSON this script's
 # contract requires as ITS last line too.
+#
+# `exit 0` here (NOT `exit $?`) is deliberate, not exit-code masking: the
+# scheduler's wake-gate contract (cron/scheduler.py `_run_job_script` +
+# `_parse_wake_gate`) treats a NONZERO/failed script run as "gate could not
+# run" and wakes the agent UNCONDITIONALLY, ignoring any JSON it printed —
+# the opposite of fail-closed. Propagating a hypothetical future nonzero
+# exit from evolution_access_gate.sh (today it always ends in a successful
+# `echo`, so this is currently moot) would flip a real failure from "don't
+# wake" into "wake anyway", which is the one outcome this whole gate exists
+# to prevent. Exiting 0 unconditionally keeps the printed JSON — not the
+# process exit code — as the single source of truth for the wake decision.
 if [ -f "$SCRIPT_DIR/evolution_access_gate.sh" ]; then
     # shellcheck disable=SC1090
     ( source "$SCRIPT_DIR/evolution_access_gate.sh" )

--- a/scripts/evolution_analysis_gate.sh
+++ b/scripts/evolution_analysis_gate.sh
@@ -44,20 +44,29 @@ else
 fi
 
 # Phase 1 gate — reuse the generic write-access wake-gate verbatim so the
-# decision logic (and its tests) live in exactly one place. `source` (not
-# `exec bash ...`) on purpose: spawning a nested `bash` would need to resolve
-# the `bash` binary via PATH, which can be empty/restricted (e.g. under a
-# locked-down cron PATH, or this script's own test harness) — sourcing runs
-# it in THIS already-running interpreter, no new process, no PATH lookup.
-# Its own last stdout line is the `{"wakeAgent": ...}` JSON this script's
+# decision logic (and its tests) live in exactly one place. `source` inside
+# a `( ... )` subshell (not `exec bash ...`, not a bare top-level `source`):
+# a subshell forks THIS already-running interpreter (no execve, no PATH
+# lookup needed — unlike spawning a nested `bash` binary, which would need
+# to resolve `bash` via PATH, possibly empty/restricted under a locked-down
+# cron PATH or this script's own test harness), while also containing the
+# access gate's `.env` exports (it sources `$HERMES_HOME/.env` with `set -a`)
+# to the subshell instead of leaking them into this script's own remaining
+# environment. The subshell's stdout still flows straight through to ours,
+# so its last line is still the `{"wakeAgent": ...}` JSON this script's
 # contract requires as ITS last line too.
 if [ -f "$SCRIPT_DIR/evolution_access_gate.sh" ]; then
     # shellcheck disable=SC1090
-    source "$SCRIPT_DIR/evolution_access_gate.sh"
+    ( source "$SCRIPT_DIR/evolution_access_gate.sh" )
     exit 0
 fi
 
-# Fallback: no access gate installed alongside us — default to waking the
-# agent (matches the scheduler's "gate absent -> wake" contract).
-echo "evolution-analysis-gate: evolution_access_gate.sh not found — defaulting to wake" >&2
-echo '{"wakeAgent": true}'
+# Fallback: the generic write-access gate isn't installed alongside us — a
+# degraded install (register_evolution_cron.py's _install_access_gate runs
+# unconditionally on every registration, so this should always be present).
+# We cannot confirm write access without it, so fail CLOSED: do not wake the
+# LLM agent. Phase 0's local-triage output above already stands as this
+# cycle's result, and no tokens are spent on work that might not even be
+# pushable.
+echo "evolution-analysis-gate: evolution_access_gate.sh not found — cannot confirm write access, not waking" >&2
+echo '{"wakeAgent": false}'

--- a/scripts/evolution_analysis_gate.sh
+++ b/scripts/evolution_analysis_gate.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Evolution-analysis wake-gate (#910).
+#
+# WHY: evolution-analysis has two independent halves — a LOCAL, file-based
+# triage pass (reads issues/introspection/research sidecars, writes
+# analysis/YYYY-MM-DD.json) that needs no GitHub token at all, and a
+# GitHub-dependent full pass (Phase 1: `gh issue list`, triage/reject/close)
+# that needs write access to the repo. Before this fix, evolution-analysis
+# was registered WITHOUT its own gate script, so it fell back to the generic
+# `evolution_access_gate.sh` default: a job-wide wake-gate that skips the
+# LLM agent entirely whenever GitHub write access is unavailable. That meant
+# the local-only triage pass never even got a chance to run — the pipeline
+# accumulated backlog but produced no analysis/*.json output on days the
+# private token was missing/scoped-down (the exact MERGED_ZERO symptom this
+# issue reports).
+#
+# HOW: this gate ALWAYS runs the local triage script first (unconditionally,
+# best-effort — a failure here must never block the wake-gate decision below),
+# so `analysis/YYYY-MM-DD.json` exists for today regardless of GitHub access.
+# It then delegates the wake decision to the same write-access check every
+# other evolution stage uses: wake the LLM agent (for the richer, GitHub-
+# dependent Phase 1 pass) only when write access is confirmed; otherwise the
+# local-only pass already written stands as this cycle's output.
+set +e
+
+# Resolve our own directory using bash parameter expansion only — NOT
+# `dirname`/`cd`/`pwd` (external commands that need PATH resolution). This
+# script must locate its sibling scripts even when PATH is empty/restricted
+# (the same isolated-PATH convention `tests/scripts/test_evolution_access_gate.py`
+# uses), so no external binary can be on the critical path here.
+_src="${BASH_SOURCE[0]}"
+case "$_src" in
+    */*) SCRIPT_DIR="${_src%/*}" ;;
+    *) SCRIPT_DIR="." ;;
+esac
+
+# Phase 0 — local (file-based) triage. No GitHub API calls, no token
+# required. Runs unconditionally, before the write-access check, so it can
+# never be skipped by a missing/scoped-down token.
+if command -v python3 >/dev/null 2>&1 && [ -f "$SCRIPT_DIR/evolution_local_triage.py" ]; then
+    python3 "$SCRIPT_DIR/evolution_local_triage.py" 2>&1 || true
+else
+    echo "evolution-analysis-gate: python3 or evolution_local_triage.py unavailable — skipping local triage" >&2
+fi
+
+# Phase 1 gate — reuse the generic write-access wake-gate verbatim so the
+# decision logic (and its tests) live in exactly one place. `source` (not
+# `exec bash ...`) on purpose: spawning a nested `bash` would need to resolve
+# the `bash` binary via PATH, which can be empty/restricted (e.g. under a
+# locked-down cron PATH, or this script's own test harness) — sourcing runs
+# it in THIS already-running interpreter, no new process, no PATH lookup.
+# Its own last stdout line is the `{"wakeAgent": ...}` JSON this script's
+# contract requires as ITS last line too.
+if [ -f "$SCRIPT_DIR/evolution_access_gate.sh" ]; then
+    # shellcheck disable=SC1090
+    source "$SCRIPT_DIR/evolution_access_gate.sh"
+    exit 0
+fi
+
+# Fallback: no access gate installed alongside us — default to waking the
+# agent (matches the scheduler's "gate absent -> wake" contract).
+echo "evolution-analysis-gate: evolution_access_gate.sh not found — defaulting to wake" >&2
+echo '{"wakeAgent": true}'

--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -385,17 +385,22 @@ def main(argv: list[str]) -> int:
 
         name = str(spec.get("name") or yaml_file.stem).strip()
 
-        # Refresh installed no_agent scripts on EVERY run — including for
-        # already-registered jobs — mirroring the access gate above:
-        # `hermes update` refreshes the repo checkout, but the scheduler
-        # executes the copy in HERMES_HOME/scripts; without this refresh the
-        # installed script stays frozen at whatever version existed when the
-        # job was first registered.
-        if (
-            spec.get("no_agent")
-            and str(spec.get("script") or "").strip()
-            and not dry_run
-        ):
+        # Refresh any YAML-declared script on EVERY run — no_agent AND
+        # per-job agent-gate scripts (Hydra's evolution_hydra_gate.py,
+        # evolution-analysis's evolution_analysis_gate.sh, etc.) alike —
+        # including for already-registered jobs, mirroring the access gate
+        # above: `hermes update` refreshes the repo checkout, but the
+        # scheduler executes the copy in HERMES_HOME/scripts. Without this
+        # refresh, two things go stale: (a) the installed script's CONTENT
+        # stays frozen at whatever version existed when the job was first
+        # registered, and (b) worse, on a script NAME change (e.g. #910's
+        # evolution_access_gate.sh -> evolution_analysis_gate.sh) the
+        # reconcile branch below only updates the job record's `script`
+        # field — it does NOT install the file — so the job would end up
+        # pointing at a script that was never copied into
+        # HERMES_HOME/scripts/ at all. Installing here, unconditionally and
+        # before that reconcile runs, covers both cases for every job kind.
+        if str(spec.get("script") or "").strip() and not dry_run:
             _install_script(repo_root, str(spec["script"]).strip())
 
         schedule = str(spec.get("schedule") or "").strip()

--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -441,7 +441,17 @@ Save to `~/.hermes/evolution/analysis/YYYY-MM-DD.json`:
 
 ## Security
 
-Verify `gh auth status` works before proceeding — the gh CLI is the primary
-auth mechanism. If gh CLI auth is unavailable AND GITHUB_TOKEN is not set,
-**ABORT**. Do NOT export tokens into the environment — `gh` handles auth via
-its own stored credentials.
+**This ABORT applies to Phase 1 only — it never applies to Phase 0.** Phase 0
+(local triage, see above) reads only local sidecar files and makes no GitHub
+API calls, so it has nothing to abort: it always runs and always produces
+`analysis/YYYY-MM-DD.json`, private-tool availability notwithstanding (#910 —
+this stage previously conflated "no private-repo access" with "cannot do
+local triage", aborting the whole run and leaving no output at all on days
+the private token was unavailable).
+
+Before starting Phase 1, verify `gh auth status` works — the gh CLI is the
+primary auth mechanism. If gh CLI auth is unavailable AND GITHUB_TOKEN is not
+set, **ABORT Phase 1 only**: skip the GitHub-dependent triage/reject/close
+work and leave Phase 0's local-triage output (already written, per above) as
+this cycle's result. Do NOT export tokens into the environment — `gh` handles
+auth via its own stored credentials.

--- a/tests/scripts/test_evolution_analysis_gate.py
+++ b/tests/scripts/test_evolution_analysis_gate.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/evolution_analysis_gate.sh (#910).
+
+evolution-analysis has two independent halves:
+
+* Phase 0 — a LOCAL, file-based triage pass (``evolution_local_triage.py``)
+  that reads issues/introspection/research sidecars and writes
+  ``analysis/YYYY-MM-DD.json``. It needs no GitHub token or ``gh`` at all.
+* Phase 1 — a GitHub-dependent full pass (``gh issue list``, triage/reject/
+  close) that needs WRITE access to the repo.
+
+Before this fix, evolution-analysis had no gate script of its own, so it
+inherited the generic ``evolution_access_gate.sh`` default: a job-wide
+wake-gate that skips the *entire* agent run — Phase 0 included — whenever
+GitHub write access is unavailable. That meant the token-free local triage
+pass never ran on days the private token was missing/scoped-down, even
+though it needs no GitHub access whatsoever.
+
+This suite asserts the fix's two guarantees independently:
+
+1. ``analysis/YYYY-MM-DD.json`` (local triage output) is written regardless
+   of GitHub write-access outcome — with push access, without push access,
+   and with no ``gh``/token at all.
+2. The wake-gate decision (last stdout line) still correctly reflects
+   write access, exactly like ``evolution_access_gate.sh`` alone.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE = REPO_ROOT / "scripts" / "evolution_analysis_gate.sh"
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _write_fake_gh(bin_dir: Path, *, perms: str | None, authed: bool = True) -> None:
+    """Install a fake `gh` that answers `api user` and `api repos/...`."""
+    if perms is None:
+        perms = "{}"
+    user_branch = 'echo "tester"\n  exit 0' if authed else "exit 1"
+    script = f"""#!/bin/bash
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  {user_branch}
+fi
+if [ "$1" = "api" ]; then
+  case "$2" in
+    repos/*) printf '%s' '{perms}'; exit 0 ;;
+  esac
+fi
+exit 1
+"""
+    gh = bin_dir / "gh"
+    gh.write_text(script)
+    gh.chmod(gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run_gate(tmp_path: Path, bin_dir: Path) -> tuple[str, Path]:
+    """Run the gate; return (last stdout line, evolution dir).
+
+    Unlike ``test_evolution_access_gate.py`` (which tests a script with no
+    dependency beyond ``gh``/``curl``), this gate also runs
+    ``evolution_local_triage.py`` via ``python3`` — so PATH here PREPENDS
+    ``bin_dir`` (our fake ``gh``, or nothing) onto the real, inherited PATH
+    rather than replacing it. That keeps the real ``python3`` (and whatever
+    interpreter/shim mechanism it needs on the host) resolvable exactly as
+    it would be in production, while still fully controlling which ``gh``
+    the gate sees — the fake one in ``bin_dir`` always shadows any real one.
+    """
+    home = tmp_path / "hermes_home"
+    evolution_dir = home / "evolution"
+    evolution_dir.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+    env["HERMES_HOME"] = str(home)
+    env["GITHUB_EVOLUTION_REPO"] = "Owner/repo"
+    for k in ("GITHUB_TOKEN", "GITHUB_PRIVATE_TOKEN"):
+        env.pop(k, None)
+    proc = subprocess.run(
+        [BASH, str(GATE)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip().splitlines()[-1], evolution_dir
+
+
+def _wakes(line: str) -> bool:
+    return json.loads(line) == {"wakeAgent": True}
+
+
+def _analysis_json(evolution_dir: Path) -> dict:
+    analysis_dir = evolution_dir / "analysis"
+    files = list(analysis_dir.glob("*.json"))
+    assert len(files) == 1, f"expected exactly one analysis file, found {files}"
+    return json.loads(files[0].read_text(encoding="utf-8"))
+
+
+def test_push_access_wakes_and_writes_local_triage(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(
+        bin_dir, perms='{"admin":false,"maintain":false,"push":true,"pull":true}'
+    )
+    line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert _wakes(line)
+    result = _analysis_json(evo_dir)
+    assert result["local_triage"] is True
+
+
+def test_read_only_account_does_not_wake_but_still_writes_local_triage(
+    tmp_path: Path,
+) -> None:
+    """The exact bug this issue reports: reachable but push:false must still
+    let Phase 0 (local triage) produce output — only the wake decision (Phase
+    1, the LLM agent) should be gated on write access."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(
+        bin_dir, perms='{"admin":false,"maintain":false,"push":false,"pull":true}'
+    )
+    line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert not _wakes(line)
+    result = _analysis_json(evo_dir)
+    assert result["local_triage"] is True
+
+
+def test_no_gh_no_token_does_not_wake_but_still_writes_local_triage(
+    tmp_path: Path,
+) -> None:
+    """No gh on PATH and no env token: cannot confirm write access, so the
+    agent must not wake — but local triage needs neither and must still run.
+    This is the core regression this issue is about (#910)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()  # deliberately empty: no gh, no curl
+    line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert not _wakes(line)
+    result = _analysis_json(evo_dir)
+    assert result["local_triage"] is True
+
+
+def test_unauthenticated_does_not_wake_but_still_writes_local_triage(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms="{}", authed=False)
+    line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert not _wakes(line)
+    result = _analysis_json(evo_dir)
+    assert result["local_triage"] is True
+
+
+def test_local_triage_reflects_real_sidecars(tmp_path: Path) -> None:
+    """End-to-end: a filed issue in the issues/ sidecar surfaces in the
+    gate-produced analysis JSON even when GitHub write access is denied."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, perms='{"push":false}')
+    home = tmp_path / "hermes_home"
+    issues_dir = home / "evolution" / "issues"
+    issues_dir.mkdir(parents=True)
+    (issues_dir / "2026-07-08.json").write_text(
+        json.dumps({
+            "date": "2026-07-08",
+            "proposals": [
+                {
+                    "title": "Alpha",
+                    "decision": "filed",
+                    "issue": 100,
+                    "priority_score": 1.5,
+                    "impact": 0.8,
+                    "effort": 0.3,
+                }
+            ],
+        })
+    )
+    line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert not _wakes(line)
+    result = _analysis_json(evo_dir)
+    nums = [s["issue_number"] for s in result["selected_for_implementation"]]
+    assert 100 in nums

--- a/tests/scripts/test_evolution_analysis_gate.py
+++ b/tests/scripts/test_evolution_analysis_gate.py
@@ -59,7 +59,7 @@ exit 1
     gh.chmod(gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _run_gate(tmp_path: Path, bin_dir: Path) -> tuple[str, Path]:
+def _run_gate(tmp_path: Path, bin_dir: Path, gate: Path = GATE) -> tuple[str, Path]:
     """Run the gate; return (last stdout line, evolution dir).
 
     Unlike ``test_evolution_access_gate.py`` (which tests a script with no
@@ -70,6 +70,10 @@ def _run_gate(tmp_path: Path, bin_dir: Path) -> tuple[str, Path]:
     interpreter/shim mechanism it needs on the host) resolvable exactly as
     it would be in production, while still fully controlling which ``gh``
     the gate sees — the fake one in ``bin_dir`` always shadows any real one.
+
+    ``gate`` defaults to the real ``scripts/evolution_analysis_gate.sh`` but
+    can point at a copy in an isolated directory (e.g. to test behavior when
+    a sibling script like ``evolution_access_gate.sh`` is deliberately absent).
     """
     home = tmp_path / "hermes_home"
     evolution_dir = home / "evolution"
@@ -81,7 +85,7 @@ def _run_gate(tmp_path: Path, bin_dir: Path) -> tuple[str, Path]:
     for k in ("GITHUB_TOKEN", "GITHUB_PRIVATE_TOKEN"):
         env.pop(k, None)
     proc = subprocess.run(
-        [BASH, str(GATE)],
+        [BASH, str(gate)],
         capture_output=True,
         text=True,
         env=env,
@@ -151,6 +155,29 @@ def test_unauthenticated_does_not_wake_but_still_writes_local_triage(
     bin_dir.mkdir()
     _write_fake_gh(bin_dir, perms="{}", authed=False)
     line, evo_dir = _run_gate(tmp_path, bin_dir)
+    assert not _wakes(line)
+    result = _analysis_json(evo_dir)
+    assert result["local_triage"] is True
+
+
+def test_missing_access_gate_fails_closed(tmp_path: Path) -> None:
+    """If evolution_access_gate.sh is somehow absent (a degraded install —
+    register_evolution_cron.py's _install_access_gate runs unconditionally,
+    so this should never normally happen), we cannot confirm write access.
+    The gate must fail CLOSED (not wake) rather than default to waking the
+    agent — waking unconditionally would defeat the entire point of the
+    write-access gate."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_scripts = tmp_path / "fake_scripts"
+    fake_scripts.mkdir()
+    shutil.copy(GATE, fake_scripts / GATE.name)
+    shutil.copy(
+        REPO_ROOT / "scripts" / "evolution_local_triage.py",
+        fake_scripts / "evolution_local_triage.py",
+    )
+    # Deliberately do NOT copy evolution_access_gate.sh alongside it.
+    line, evo_dir = _run_gate(tmp_path, bin_dir, gate=fake_scripts / GATE.name)
     assert not _wakes(line)
     result = _analysis_json(evo_dir)
     assert result["local_triage"] is True

--- a/tests/scripts/test_register_evolution_cron.py
+++ b/tests/scripts/test_register_evolution_cron.py
@@ -266,6 +266,54 @@ class TestReconcileExistingJob:
             'prompt: "sync upstream"\n'
         )
 
+    def _write_agent_yaml_with_script(self, src_dir, schedule, script_name):
+        (src_dir / "upstream-sync.yaml").write_text(
+            "name: evolution-upstream-sync\n"
+            f'schedule: "{schedule}"\n'
+            "enabled: true\n"
+            'prompt: "sync upstream"\n'
+            "skills:\n"
+            "  - evolution/upstream-sync\n"
+            "toolsets:\n"
+            "  - web\n"
+            "  - file\n"
+            "  - terminal\n"
+            f"script: {script_name}\n"
+        )
+
+    def test_changed_script_reconciles_record_and_installs_file(
+        self, tmp_path, monkeypatch
+    ):
+        """CRITICAL regression (#910 review finding): reconciling an already-
+        registered AGENT job's YAML-declared `script:` field (e.g. evolution-
+        analysis moving from the generic evolution_access_gate.sh to its own
+        evolution_analysis_gate.sh) must not just flip the DB record via
+        update_job() — the new script file must actually be installed into
+        HERMES_HOME/scripts/, or the scheduler ends up pointing at a file
+        that was never copied and the wake-gate silently stops running."""
+        mod = _import_module()
+        import cron.jobs as jobs_mod
+
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        self._write_agent_yaml_with_script(
+            src_dir, "0 8 * * 1,3,5", "evolution_analysis_gate.sh"
+        )
+        existing = self._existing(mod, jobs_mod, "0 8 * * 1,3,5")  # schedule matches
+        existing["script"] = "evolution_access_gate.sh"  # stale script name
+        calls = self._wire(mod, jobs_mod, monkeypatch, tmp_path, existing)
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        assert calls["updates"] == {"script": "evolution_analysis_gate.sh"}
+        home = tmp_path / "hermes-home"
+        installed = home / "scripts" / "evolution_analysis_gate.sh"
+        assert installed.is_file(), (
+            "reconcile updated the job record but never installed the new "
+            "script file into HERMES_HOME/scripts/"
+        )
+
     def test_existing_agent_job_without_skills_does_not_crash(self, tmp_path, monkeypatch):
         """Regression: _normalize_skills(None) returns None; reconcile must not
         call list(None) — that TypeError silently aborted EVERY re-register (and


### PR DESCRIPTION
Closes #910

## What

evolution-analysis has two independent halves:
- **Phase 0** — a LOCAL, file-based triage pass (`evolution_local_triage.py`, #783) that reads `issues/`/`introspection/`/`research/` sidecars and writes `analysis/YYYY-MM-DD.json`. Needs no GitHub token at all.
- **Phase 1** — a GitHub-dependent full pass (`gh issue list`, triage/reject/close) that needs WRITE access to the repo.

Before this fix, evolution-analysis had no gate script of its own, so it inherited the generic `evolution_access_gate.sh` default: a job-wide wake-gate that skips the **entire** agent run — Phase 0 included — whenever GitHub write access is unavailable. That's the reported symptom: `GITHUB_PRIVATE_TOKEN not set; gh CLI unavailable; cannot access private repo in PRIVATE mode`, aborting even the token-free local triage.

## Why / how

- New `scripts/evolution_analysis_gate.sh`: always runs Phase 0's local triage first (best-effort, never blocking), then delegates the wake decision to the same write-access check every other evolution stage uses — so the LLM agent (Phase 1) only wakes when write access is confirmed, while the local-only pass still produces `analysis/*.json` regardless.
- Wired it into `cron/evolution/analysis.yaml` (`script:` field) and rewrote the prompt/`skills/evolution/evolution-analysis/SKILL.md` Security section to scope the "ABORT" language to Phase 1 only, removing the contradiction with Phase 0 running token-free.
- Follow-up commits (after an adversarial second-opinion review, see below) fix two gaps the review caught:
  - **CRITICAL**: `register_evolution_cron.py`'s reconcile path (already-registered jobs) only updated the job record's `script` field on a name change — it never copied the new file into `HERMES_HOME/scripts/`. Since evolution-analysis is presumably already registered in any real deployment, this would have silently no-op'd the whole fix. Widened the existing no_agent-only script-refresh to cover every job with a YAML-declared `script:`, installed unconditionally before reconcile runs.
  - **MINOR**: the new gate's fallback (if its sibling `evolution_access_gate.sh` is somehow missing — a degraded install) now fails CLOSED (`wakeAgent: false`) instead of defaulting to waking the agent, matching the whole point of the gate.
  - **NIT**: the sourced `evolution_access_gate.sh` exports `$HERMES_HOME/.env` (`set -a`); wrapped the source in a subshell so those exports stay contained instead of leaking into the caller's environment, with no added PATH dependency.

## Tests

Added `tests/scripts/test_evolution_analysis_gate.py` (6 tests) and `test_changed_script_reconciles_record_and_installs_file` / a fallback test in `tests/scripts/test_register_evolution_cron.py`, covering: local triage always runs regardless of GitHub access outcome (push access / read-only / no gh / unauthenticated), the fail-closed fallback, and the reconcile-path install-miss regression.

```
93 passed (test_evolution_analysis_gate, test_evolution_access_gate,
test_evolution_local_triage, test_register_evolution_cron,
test_evolution_analysis_audit, test_evolution_skill_integrity)
```

`ruff check` and `ruff format --check` clean on all touched files (pre-existing formatting drift on unrelated lines of `register_evolution_cron.py` / `test_register_evolution_cron.py` / `evolution_skill_lint.py` left untouched — out of scope for this fix).

## Review

Adversarial review via `consult hermes --review` (GLM-5.2, non-Claude) on the core fix caught the CRITICAL reconcile-install gap above. A follow-up review via `consult agy` (Gemini) on the fix-up commit raised a question about `exit 0` after the subshell possibly masking a failing sourced script; verified against `cron/scheduler.py`'s actual wake-gate contract (`_run_job_script`/`_parse_wake_gate`) that `exit 0` is the deliberate, correct choice — a nonzero exit there would cause the scheduler to wake the agent *unconditionally* on failure, the opposite of fail-closed — and documented this in a comment.

## Limitations

- Not merging this PR per task instructions — leaving it for review/CI.