### PR TITLE
feat(#904): deterministic tool-argument schema (required/enum) contract enforcement

### DIFF
--- a/agent/tool_arg_contract.py
+++ b/agent/tool_arg_contract.py
@@ -1,0 +1,204 @@
+"""Deterministic tool-argument contract enforcement.
+
+Issue #904 ("From Prompts to Contracts"). Every tool ships a JSON Schema
+(the ``parameters`` block of its definition) declaring which arguments are
+``required`` and which are constrained to an ``enum`` of allowed values.
+That schema is sent to the model as part of its contract — but until now
+nothing in the dispatch path actually re-checked a call against it before
+running the tool handler. A call missing a required argument, or using a
+value outside a declared ``enum``, either silently reaches a handler that
+happens to tolerate it (inconsistent, handler by handler) or raises deep
+inside the handler and gets flattened by
+:meth:`tools.registry.ToolRegistry.dispatch`'s catch-all ``except Exception``
+into a generic ``Tool execution failed: KeyError: '...'`` message — which
+tells the model *that* something broke but not *what contract* it broke or
+*how* to fix the call.
+
+This module moves that contract from "documentation the model may or may
+not honor" into code: :func:`check_tool_args_contract` re-checks a call's
+final arguments against the tool's own registered schema right at the
+composition boundary — after argument coercion and request middleware have
+run, and before :meth:`tools.registry.ToolRegistry.dispatch` invokes the
+handler — and returns a structured, deterministic verdict instead of
+letting an under-specified call reach the tool at all.
+
+Design mirrors :mod:`agent.verify_policy` / :mod:`agent.policy_interceptors`
+intentionally: frozen dataclasses, a pure check function, opt-in via an
+env var / config flag (default **OFF** — see :func:`tool_arg_contract_enabled`),
+fail-open whenever the tool has no schema or the schema is malformed. Only
+``required`` presence and ``enum`` membership are checked; this is
+deliberately narrower than full JSON Schema validation (no type/format/
+min-max/pattern checks) — type mismatches are already handled by coercion
+in ``model_tools.coerce_tool_args``, which runs earlier in the same
+composition boundary and is intentionally forgiving rather than rejecting.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ArgContractViolation:
+    """One concrete way a tool call's arguments failed to satisfy the schema."""
+
+    kind: str  # "missing_required" | "invalid_enum"
+    param: str
+    detail: str
+
+    @classmethod
+    def missing_required(cls, param: str) -> "ArgContractViolation":
+        return cls(
+            kind="missing_required",
+            param=param,
+            detail=f"missing required parameter '{param}'",
+        )
+
+    @classmethod
+    def invalid_enum(
+        cls, param: str, value: Any, allowed: Tuple[Any, ...]
+    ) -> "ArgContractViolation":
+        allowed_repr = ", ".join(repr(v) for v in allowed)
+        return cls(
+            kind="invalid_enum",
+            param=param,
+            detail=f"'{param}'={value!r} is not one of the allowed values: {allowed_repr}",
+        )
+
+
+@dataclass(frozen=True)
+class ArgContractOutcome:
+    """Result of checking one tool call's arguments against its schema."""
+
+    tool_name: str
+    violations: Tuple[ArgContractViolation, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+    def error_message(self) -> str:
+        """Render one actionable error string covering every violation."""
+        details = "; ".join(v.detail for v in self.violations)
+        return f"Invalid arguments for '{self.tool_name}': {details}."
+
+
+def _allows_null(schema: Any) -> bool:
+    """Return True when a JSON Schema fragment explicitly permits null.
+
+    Small, self-contained duplicate of ``model_tools._schema_allows_null``
+    (kept local so this module stays dependency-free like its siblings
+    ``agent.verify_policy`` / ``agent.policy_interceptors``). Only used to
+    avoid flagging a ``required`` parameter that the schema itself declares
+    nullable — a call that explicitly passes ``None`` for such a parameter
+    is satisfying the contract, not violating it.
+    """
+    if not isinstance(schema, Mapping):
+        return False
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    if schema.get("nullable") is True:
+        return True
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, Mapping) and variant.get("type") == "null":
+                return True
+    return False
+
+
+def check_tool_args_contract(
+    tool_name: str,
+    args: Mapping[str, Any],
+    schema: Optional[Mapping[str, Any]],
+) -> ArgContractOutcome:
+    """Check *args* against *schema*'s ``required``/``enum`` contract.
+
+    Fail-open by design: a missing/malformed schema, or a schema with no
+    ``parameters``/``properties``, always yields ``ok``. This never invents
+    a stricter contract than the tool itself declared, and it never rejects
+    a param it doesn't recognize (unknown keys are the coercion layer's
+    concern, not this one's).
+    """
+    if not isinstance(args, Mapping):
+        args = {}
+    if not isinstance(schema, Mapping):
+        return ArgContractOutcome(tool_name=tool_name)
+    parameters = schema.get("parameters")
+    if not isinstance(parameters, Mapping):
+        return ArgContractOutcome(tool_name=tool_name)
+    properties = parameters.get("properties")
+    if not isinstance(properties, Mapping):
+        properties = {}
+
+    violations: list[ArgContractViolation] = []
+
+    required = parameters.get("required")
+    if isinstance(required, (list, tuple)):
+        for param in required:
+            if not isinstance(param, str):
+                continue
+            if param in args and args.get(param) is not None:
+                continue
+            if param in args and _allows_null(properties.get(param)):
+                continue  # explicit None on a nullable required field is fine
+            violations.append(ArgContractViolation.missing_required(param))
+
+    for param, prop_schema in properties.items():
+        if param not in args or args.get(param) is None:
+            continue
+        if not isinstance(prop_schema, Mapping):
+            continue
+        allowed = prop_schema.get("enum")
+        if not isinstance(allowed, (list, tuple)) or not allowed:
+            continue
+        value = args.get(param)
+        if value not in allowed:
+            violations.append(
+                ArgContractViolation.invalid_enum(param, value, tuple(allowed))
+            )
+
+    return ArgContractOutcome(tool_name=tool_name, violations=tuple(violations))
+
+
+_TOOL_ARG_CONTRACT_ENV = "HERMES_TOOL_ARG_CONTRACT"
+
+
+def tool_arg_contract_enabled() -> bool:
+    """Whether deterministic tool-argument contract enforcement is active.
+
+    Default **OFF**. Enabled by setting ``HERMES_TOOL_ARG_CONTRACT`` to a
+    truthy value (``1``/``true``/``yes``/``on``), or via the
+    ``tool_arg_contract.enabled`` key in ``config.yaml``. Reads the env var
+    first so a session can flip it without editing config. Any failure
+    resolving config -> OFF (safe default). Mirrors
+    :func:`agent.verify_policy.verify_policy_enabled` exactly.
+    """
+    env = os.environ.get(_TOOL_ARG_CONTRACT_ENV)
+    if env is not None:
+        return env.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config() or {}
+    except Exception:
+        return False
+    section = cfg.get("tool_arg_contract") if isinstance(cfg, dict) else None
+    if isinstance(section, dict) and "enabled" in section:
+        return bool(section.get("enabled"))
+    return False
+
+
+__all__ = [
+    "ArgContractViolation",
+    "ArgContractOutcome",
+    "check_tool_args_contract",
+    "tool_arg_contract_enabled",
+]

--- a/model_tools.py
+++ b/model_tools.py
@@ -1252,6 +1252,42 @@ def handle_function_call(
             except Exception:
                 pass  # file_tools may not be loaded yet
 
+        # Deterministic tool-argument contract check (issue #904). Re-checks
+        # the final, post-coercion/post-middleware arguments against the
+        # tool's own registered schema (``required`` fields, ``enum``
+        # values) right at the composition boundary, before dispatch()
+        # invokes the handler. Opt-in and fail-open — see
+        # agent.tool_arg_contract for rationale and default-OFF gating.
+        try:
+            from agent.tool_arg_contract import (
+                check_tool_args_contract,
+                tool_arg_contract_enabled,
+            )
+            if tool_arg_contract_enabled():
+                _contract_outcome = check_tool_args_contract(
+                    function_name, function_args, registry.get_schema(function_name)
+                )
+                if not _contract_outcome.ok:
+                    _contract_error = _contract_outcome.error_message()
+                    result = json.dumps({"error": _contract_error}, ensure_ascii=False)
+                    _emit_post_tool_call_hook(
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=result,
+                        task_id=task_id,
+                        session_id=session_id,
+                        tool_call_id=tool_call_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        status="blocked",
+                        error_type="arg_contract_violation",
+                        error_message=_contract_error,
+                        middleware_trace=list(_tool_middleware_trace),
+                    )
+                    return result
+        except Exception as _contract_check_err:
+            logger.debug("tool_arg_contract check error: %s", _contract_check_err)
+
         # Measure tool dispatch latency so post_tool_call and
         # transform_tool_result hooks can observe per-tool duration.
         # Inspired by Claude Code 2.1.119, which added ``duration_ms`` to

--- a/tests/agent/test_tool_arg_contract.py
+++ b/tests/agent/test_tool_arg_contract.py
@@ -1,0 +1,250 @@
+"""Tests for deterministic tool-argument contract enforcement (issue #904).
+
+check_tool_args_contract() re-checks a tool call's arguments against the
+tool's own registered JSON Schema (``required`` fields, ``enum`` values)
+right before dispatch, so a call violating the schema the model was given
+gets a clean, actionable error instead of either silently reaching a
+handler that happens to tolerate it or raising deep inside the handler.
+"""
+
+import pytest
+
+from agent.tool_arg_contract import (
+    ArgContractOutcome,
+    ArgContractViolation,
+    check_tool_args_contract,
+    tool_arg_contract_enabled,
+)
+
+
+# ── ArgContractViolation ─────────────────────────────────────────────────────
+
+
+def test_missing_required_violation_shape():
+    violation = ArgContractViolation.missing_required("path")
+    assert violation.kind == "missing_required"
+    assert violation.param == "path"
+    assert "path" in violation.detail
+
+
+def test_invalid_enum_violation_shape():
+    violation = ArgContractViolation.invalid_enum("mode", "bogus", ("replace", "patch"))
+    assert violation.kind == "invalid_enum"
+    assert violation.param == "mode"
+    assert "bogus" in violation.detail
+    assert "replace" in violation.detail
+    assert "patch" in violation.detail
+
+
+# ── ArgContractOutcome ───────────────────────────────────────────────────────
+
+
+def test_outcome_ok_when_no_violations():
+    outcome = ArgContractOutcome(tool_name="read_file")
+    assert outcome.ok is True
+
+
+def test_outcome_not_ok_with_violations():
+    outcome = ArgContractOutcome(
+        tool_name="read_file",
+        violations=(ArgContractViolation.missing_required("path"),),
+    )
+    assert outcome.ok is False
+
+
+def test_outcome_error_message_covers_every_violation():
+    outcome = ArgContractOutcome(
+        tool_name="patch",
+        violations=(
+            ArgContractViolation.missing_required("path"),
+            ArgContractViolation.invalid_enum("mode", "bogus", ("replace", "patch")),
+        ),
+    )
+    msg = outcome.error_message()
+    assert "patch" in msg
+    assert "path" in msg
+    assert "mode" in msg
+    assert "bogus" in msg
+
+
+# ── check_tool_args_contract: fail-open cases ───────────────────────────────
+
+
+def test_no_schema_is_ok():
+    outcome = check_tool_args_contract("mystery_tool", {}, None)
+    assert outcome.ok is True
+
+
+def test_schema_without_parameters_is_ok():
+    outcome = check_tool_args_contract("mystery_tool", {}, {"name": "mystery_tool"})
+    assert outcome.ok is True
+
+
+def test_schema_without_properties_is_ok():
+    schema = {"parameters": {"type": "object", "required": []}}
+    outcome = check_tool_args_contract("mystery_tool", {}, schema)
+    assert outcome.ok is True
+
+
+def test_non_mapping_args_treated_as_empty():
+    schema = {
+        "parameters": {"properties": {"path": {"type": "string"}}, "required": ["path"]}
+    }
+    outcome = check_tool_args_contract("read_file", None, schema)
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "missing_required"
+
+
+# ── required-field enforcement ──────────────────────────────────────────────
+
+
+READ_FILE_SCHEMA = {
+    "name": "read_file",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "offset": {"type": "integer", "default": 1},
+        },
+        "required": ["path"],
+    },
+}
+
+
+def test_required_field_present_is_ok():
+    outcome = check_tool_args_contract("read_file", {"path": "a.txt"}, READ_FILE_SCHEMA)
+    assert outcome.ok is True
+
+
+def test_required_field_missing_is_violation():
+    outcome = check_tool_args_contract("read_file", {"offset": 5}, READ_FILE_SCHEMA)
+    assert outcome.ok is False
+    assert len(outcome.violations) == 1
+    assert outcome.violations[0].kind == "missing_required"
+    assert outcome.violations[0].param == "path"
+
+
+def test_required_field_explicit_none_is_violation():
+    """None means "no value supplied" for a non-nullable required field."""
+    outcome = check_tool_args_contract("read_file", {"path": None}, READ_FILE_SCHEMA)
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "missing_required"
+
+
+def test_required_nullable_field_explicit_none_is_ok():
+    schema = {
+        "parameters": {
+            "properties": {"path": {"type": ["string", "null"]}},
+            "required": ["path"],
+        }
+    }
+    outcome = check_tool_args_contract("read_file", {"path": None}, schema)
+    assert outcome.ok is True
+
+
+def test_multiple_required_fields_all_missing_reported():
+    schema = {
+        "parameters": {
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        }
+    }
+    outcome = check_tool_args_contract("write_file", {}, schema)
+    assert len(outcome.violations) == 2
+    params = {v.param for v in outcome.violations}
+    assert params == {"path", "content"}
+
+
+def test_non_string_required_entries_are_skipped_defensively():
+    schema = {
+        "parameters": {
+            "properties": {"path": {"type": "string"}},
+            "required": ["path", 123, None],
+        }
+    }
+    outcome = check_tool_args_contract("read_file", {"path": "a.txt"}, schema)
+    assert outcome.ok is True
+
+
+# ── enum enforcement ─────────────────────────────────────────────────────────
+
+
+PATCH_SCHEMA = {
+    "name": "patch",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "mode": {"type": "string", "enum": ["replace", "patch"]},
+        },
+        "required": ["path"],
+    },
+}
+
+
+def test_enum_valid_value_is_ok():
+    outcome = check_tool_args_contract(
+        "patch", {"path": "a.txt", "mode": "replace"}, PATCH_SCHEMA
+    )
+    assert outcome.ok is True
+
+
+def test_enum_invalid_value_is_violation():
+    outcome = check_tool_args_contract(
+        "patch", {"path": "a.txt", "mode": "bogus"}, PATCH_SCHEMA
+    )
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "invalid_enum"
+    assert outcome.violations[0].param == "mode"
+
+
+def test_enum_field_omitted_is_ok():
+    """An optional enum field the model didn't supply is not a violation."""
+    outcome = check_tool_args_contract("patch", {"path": "a.txt"}, PATCH_SCHEMA)
+    assert outcome.ok is True
+
+
+def test_enum_field_none_is_ok():
+    outcome = check_tool_args_contract(
+        "patch", {"path": "a.txt", "mode": None}, PATCH_SCHEMA
+    )
+    assert outcome.ok is True
+
+
+def test_missing_required_and_invalid_enum_both_reported():
+    outcome = check_tool_args_contract("patch", {"mode": "bogus"}, PATCH_SCHEMA)
+    kinds = {v.kind for v in outcome.violations}
+    assert kinds == {"missing_required", "invalid_enum"}
+
+
+# ── enable gate (opt-in, default OFF) ────────────────────────────────────────
+
+
+def test_tool_arg_contract_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
+    )
+    assert tool_arg_contract_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_tool_arg_contract_env_enables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", val)
+    assert tool_arg_contract_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+def test_tool_arg_contract_env_disables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", val)
+    assert tool_arg_contract_enabled() is False
+
+
+def test_tool_arg_contract_config_enables_when_env_absent(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {"tool_arg_contract": {"enabled": True}},
+        raising=False,
+    )
+    assert tool_arg_contract_enabled() is True

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -369,6 +369,155 @@ class TestPreToolCallBlocking:
 
 
 # =========================================================================
+# Deterministic tool-argument contract enforcement (issue #904)
+# =========================================================================
+
+class TestArgContractEnforcement:
+    """handle_function_call() re-checks args against the tool's own schema
+    at the composition boundary, right before dispatch — but only when
+    agent.tool_arg_contract.tool_arg_contract_enabled() opts in (default OFF,
+    matching agent.verify_policy's gating convention)."""
+
+    def test_disabled_by_default_lets_invalid_call_through_to_dispatch(
+        self, monkeypatch
+    ):
+        """With the feature off (the default), a call missing a required
+        arg still reaches dispatch unchanged — no new blocking behavior
+        for anyone who hasn't opted in."""
+        monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.get_schema",
+            lambda name: {
+                "parameters": {
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True})
+        )
+
+        result = json.loads(handle_function_call("read_file", {}, task_id="t1"))
+        assert result == {"ok": True}
+
+    def test_enabled_blocks_missing_required_arg_before_dispatch(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        monkeypatch.setattr(
+            "model_tools.registry.get_schema",
+            lambda name: {
+                "parameters": {
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                }
+            },
+        )
+
+        def fake_dispatch(*args, **kwargs):
+            raise AssertionError("dispatch should not run when contract is violated")
+
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("read_file", {}, task_id="t1"))
+        assert "error" in result
+        assert "path" in result["error"]
+
+    def test_enabled_blocks_invalid_enum_before_dispatch(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        monkeypatch.setattr(
+            "model_tools.registry.get_schema",
+            lambda name: {
+                "parameters": {
+                    "properties": {
+                        "path": {"type": "string"},
+                        "mode": {"type": "string", "enum": ["replace", "patch"]},
+                    },
+                    "required": ["path"],
+                }
+            },
+        )
+
+        def fake_dispatch(*args, **kwargs):
+            raise AssertionError("dispatch should not run when contract is violated")
+
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(
+            handle_function_call(
+                "patch", {"path": "a.txt", "mode": "bogus"}, task_id="t1"
+            )
+        )
+        assert "error" in result
+        assert "mode" in result["error"]
+
+    def test_enabled_allows_conforming_call_through_to_dispatch(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        monkeypatch.setattr(
+            "model_tools.registry.get_schema",
+            lambda name: {
+                "parameters": {
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True})
+        )
+
+        result = json.loads(
+            handle_function_call("read_file", {"path": "a.txt"}, task_id="t1")
+        )
+        assert result == {"ok": True}
+
+    def test_enabled_fires_post_tool_call_hook_with_blocked_status(self, monkeypatch):
+        hook_calls = []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
+            return []
+
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "model_tools.registry.get_schema",
+            lambda name: {
+                "parameters": {
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not run")),
+        )
+
+        handle_function_call("read_file", {}, task_id="t1")
+
+        post_call = next(c for c in hook_calls if c[0] == "post_tool_call")
+        assert post_call[1]["status"] == "blocked"
+        assert post_call[1]["error_type"] == "arg_contract_violation"
+        assert "path" in post_call[1]["error_message"]
+
+    def test_enabled_fail_open_when_tool_has_no_schema(self, monkeypatch):
+        """A tool with no registered schema is out of scope for this check —
+        it can't invent a stricter contract than none at all."""
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        monkeypatch.setattr("model_tools.registry.get_schema", lambda name: None)
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True})
+        )
+
+        result = json.loads(handle_function_call("read_file", {}, task_id="t1"))
+        assert result == {"ok": True}
+
+
+# =========================================================================
 # Legacy toolset map
 # =========================================================================
 


### PR DESCRIPTION
Closes #904

## What & why

Issue #904 ("From Prompts to Contracts") asks to move behavioral contracts that today rely on a prompt instruction into deterministic, code-level enforcement at the composition boundary "between model output parsing and tool dispatch." This PR ships the smallest valuable, tested slice of that idea.

**The one contract chosen:** every tool ships a JSON Schema (its `parameters` block) declaring which arguments are `required` and which are constrained to an `enum`. That schema is part of the contract handed to the model — but nothing in the dispatch path re-checked a call against it before running the handler. A call missing a required arg, or using an out-of-enum value, either silently reached a handler that happened to tolerate it (inconsistent, handler by handler) or raised deep inside the handler and got flattened by `tools.registry.ToolRegistry.dispatch`'s catch-all `except Exception` into a generic `Tool execution failed: TypeError: ...` — telling the model *that* something broke but not *what contract* it broke or *how* to fix the call.

## How

- **New `agent/tool_arg_contract.py`** — pure `check_tool_args_contract()` re-validates a call's final (post-coercion, post-middleware) arguments against the tool's own registered schema: **`required` presence and `enum` membership only**, deliberately narrower than full JSON Schema validation. Frozen dataclasses, fail-open on any missing/malformed schema, opt-in and **default OFF** via `HERMES_TOOL_ARG_CONTRACT` env var or `tool_arg_contract.enabled` in `config.yaml`. Mirrors the existing `agent.verify_policy` / `agent.policy_interceptors` guardrail conventions exactly (one file per guardrail concern, env-then-config gate).
- **Wired into `model_tools.handle_function_call()`** — the single composition boundary all model-issued tool calls pass through — right before `registry.dispatch()` invokes the handler. A violation short-circuits dispatch and returns a structured, actionable `{"error": ...}` instead of an opaque exception, and fires the `post_tool_call` hook with `status="blocked"`, `error_type="arg_contract_violation"`.

## Tests

- `tests/agent/test_tool_arg_contract.py` — unit coverage of the dataclasses, the check function's required/enum/nullable/fail-open paths (incl. explicit-None on nullable vs non-nullable required fields, defensive non-string `required` entries), and the enable gate (default-OFF, env truthy/falsy parametrized, config-enables-when-env-absent).
- `TestArgContractEnforcement` in `tests/test_model_tools.py` — integration coverage proving dispatch is **skipped** on violation when enabled (and reached when disabled or conforming), and that the blocked-status hook fires.

Local results: my 38 dedicated tests pass. The broader `tests/agent/` + `tests/test_model_tools.py` + `tests/test_sanitize_tool_error.py` + `tests/run_agent/test_tool_arg_coercion.py` sweep shows **135 pre-existing failures that are byte-identical on clean `main` (parent commit) and on this branch** — they are environment-dependent (no network / credentials / web-search provider configured in this sandbox) and test-ordering artifacts, none touched by this diff (diff of the two failure sets is empty in both directions). `ruff check .` (the CI-blocking gate) passes clean.

## Intentionally out of scope

- Full JSON Schema validation (type/format/min-max/pattern) — type mismatches are already handled by the pre-existing, intentionally-forgiving `coerce_tool_args` coercion layer that runs earlier in the same boundary.
- Any agent-level special-cased tools that bypass `handle_function_call`, and the plugin-invoked (non-model) `registry.dispatch` path in `hermes_cli/plugins.py`.
- Other prompt-only contracts in the codebase (e.g. the `delegate_tool.py` "verbatim artifact" contract).
- **Default-OFF is a deliberate rollout choice**, consistent with sibling guardrail modules — flip `HERMES_TOOL_ARG_CONTRACT=1` (or config) to enable; a follow-up can flip the default after a rollout audit.