### PR TITLE
feat(#906): deterministic, bounded meta-editing primitive for the evolution pipeline

### DIFF
--- a/cron/evolution/meta-analysis.yaml
+++ b/cron/evolution/meta-analysis.yaml
@@ -1,0 +1,29 @@
+name: evolution-meta-analysis
+# 08:50 daily — after the postmortem miner (06:00) and well before research
+# (09:00), so a fresh proposal record exists before the pipeline's first LLM
+# stage of the day runs. Off the :00 mark per the funnel/rubric-judge/watchdog
+# convention (avoids cron-stampede contention on the round marks).
+schedule: "50 8 * * *"
+enabled: true
+mode: PRIVATE
+
+# Deterministic meta-analysis pass — NO LLM agent (issue #906 / AEvo). Reads
+# the funnel's accumulated evidence (metrics.jsonl) and proposes AT MOST one
+# bounded adjustment per registered tunable parameter (see TUNABLE_PARAMS in
+# scripts/evolution_meta_editor.py). Writes a proposal record to
+# evolution/meta/{date}.json — advisory only. This script NEVER edits
+# cron/evolution/*.yaml itself; applying a proposal is a separate,
+# human-reviewed action.
+no_agent: true
+script: evolution_meta_editor.py
+
+# Keep on disk for the owner to review; a procedure-adjustment PROPOSAL is
+# advisory data, not an alert — nothing is delivered to channels.
+deliver: local
+
+prompt: |
+  Deterministic meta-analysis pass (no LLM). Aggregates the funnel's
+  accumulated evidence (reject rate, merged-zero streak, halt state) into a
+  process-level state snapshot and proposes bounded, registry-validated
+  adjustments to the pipeline's own min_priority_score quality bars — NEVER
+  applied automatically. See scripts/evolution_meta_editor.py (issue #906).

--- a/scripts/evolution_meta_editor.py
+++ b/scripts/evolution_meta_editor.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Evolution meta-editor — bounded, deterministic procedure-adjustment proposals.
+
+Issue #906 (AEvo): the evolution pipeline already computes signals about its
+own health (``metrics.jsonl`` via ``evolution_funnel``), but that history is
+archival — nothing in the pipeline's own PROCEDURE (e.g. the ``min_priority_score``
+quality bar each stage's YAML hardcodes) ever reacts to it. This module gives
+the pipeline ONE narrow, machine-checked lever: a deterministic aggregator that
+reads that existing evidence and proposes a bounded adjustment to an explicit,
+tiny registry of tunable parameters.
+
+Deliberately narrow scope — this is NOT the "meta-agent rewrites its own
+pipeline" framework the research issue sketches. That would require an LLM
+judging procedure changes against held-out historical performance, which is
+unsound to ship as auto-merged, auto-applied code (no sound way to validate an
+LLM's own procedure edits before they run for real). Instead:
+
+  * NO LLM. Every function here is a pure, deterministic transform of evidence
+    the pipeline already writes (``metrics.jsonl``, read via
+    ``evolution_funnel.summarize``).
+  * NO auto-apply. This script only aggregates state and WRITES a proposal
+    record to ``<evolution_dir>/meta/{date}.json`` — it never edits
+    ``cron/evolution/*.yaml`` itself. Applying a proposal is a separate,
+    human-reviewed action (mirrors ``evolution_postmortem_miner`` writing
+    advisory rules, and ``evolution_ci_diagnosis`` opening child issues for
+    complex cases instead of auto-fixing them).
+  * Registry-bounded. ``propose_edits()`` can only ever suggest a field
+    explicitly declared in ``TUNABLE_PARAMS``, each with a hard min/max/step
+    that ``validate_proposal()`` enforces INDEPENDENTLY of the proposer's own
+    arithmetic — a bug in ``propose_edits`` cannot produce a proposal that
+    escapes the bound the registry declares.
+
+Out of scope for this first increment (left for follow-up issues once this
+primitive has real-world signal to justify it):
+  * Consuming rubric-scorecard.jsonl / postmortem-rules.json as additional
+    evidence (this increment reads only the funnel, the pipeline's most
+    load-bearing existing signal).
+  * A cooldown/hysteresis window to damp oscillating proposals — harmless
+    today because nothing auto-applies a proposal, but would matter before
+    any future auto-apply path.
+  * An ``--apply`` mode that edits the YAML. Deliberately NOT built: applying
+    a bounded proposal is exactly the step that turns "safe advisory data"
+    into "pipeline behavior changed autonomously", which is the auto-merge
+    risk this increment is scoped to avoid.
+
+Pure functions + explicit IO boundary so it is import-safe and unit-testable,
+matching the rest of the ``evolution_*`` script family.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from evolution_funnel import (  # noqa: E402
+    _resolve_repo_dir,
+    is_evolution_halted,
+    load_records,
+    summarize,
+)
+
+# ---------------------------------------------------------------------------
+# The registry — the ONLY edits this module may ever propose.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TunableParam:
+    """One (file, section, key) triple this module is allowed to touch.
+
+    ``min_value``/``max_value``/``step`` are the hard bound: a proposal that
+    would move the value outside them, or by more than one ``step``, is
+    invalid (see ``validate_proposal``) regardless of what proposed it.
+    ``default`` is the fallback used when the live YAML value cannot be read
+    (missing file, unparsable, key absent) — the registry's own last resort,
+    never a network call or an LLM guess.
+    """
+
+    stage: str
+    yaml_file: str
+    section: str
+    key: str
+    min_value: float
+    max_value: float
+    step: float
+    default: float
+
+
+# All four stages share the same ``min_priority_score`` quality-bar concept
+# (see cron/evolution/{research,issues,introspection}.yaml `limits.` and
+# analysis.yaml `safety.` — same field name, different top-level section).
+# Bounds [0.5, 0.9] keep the bar from ever falling to "accept anything" or
+# rising to "accept almost nothing"; step 0.05 caps how much any single
+# cycle's proposal can move it.
+TUNABLE_PARAMS: Dict[str, TunableParam] = {
+    "research.min_priority_score": TunableParam(
+        "research", "research.yaml", "limits", "min_priority_score", 0.5, 0.9, 0.05, 0.7
+    ),
+    "issues.min_priority_score": TunableParam(
+        "issues", "issues.yaml", "limits", "min_priority_score", 0.5, 0.9, 0.05, 0.7
+    ),
+    "introspection.min_priority_score": TunableParam(
+        "introspection",
+        "introspection.yaml",
+        "limits",
+        "min_priority_score",
+        0.5,
+        0.9,
+        0.05,
+        0.7,
+    ),
+    "analysis.min_priority_score": TunableParam(
+        "analysis", "analysis.yaml", "safety", "min_priority_score", 0.5, 0.9, 0.05, 0.7
+    ),
+}
+
+# Same reject_rate threshold evolution_funnel.summarize() already uses for its
+# HIGH_REJECT_RATE flag — one number, one meaning, across the pipeline.
+_HIGH_REJECT_RATE = 0.70
+# New for this module: a low-reject-rate signal that the bar may be too
+# strict. Deliberately conservative (well below the high threshold) so the
+# two triggers can never both fire for the same state.
+_LOW_REJECT_RATE = 0.20
+# Require several cycles of evidence before proposing anything — a single
+# noisy cycle must never justify moving a pipeline-wide threshold. Slightly
+# higher than evolution_metrics.compute_health's >=3 (which only surfaces a
+# flag for a human to read); this module computes a concrete number, so it
+# asks for one more cycle of confidence.
+_MIN_CYCLES_FOR_PROPOSAL = 5
+
+
+def aggregate_state(evolution_dir: Path, last: int = 14) -> Dict[str, Any]:
+    """Process-level state snapshot: the evidence this module reasons over.
+
+    Deliberately minimal for this increment — reads only the funnel, the
+    pipeline's most load-bearing existing signal. ``cycles`` reflects how much
+    evidence backs the snapshot; callers must not propose edits when it is
+    below ``_MIN_CYCLES_FOR_PROPOSAL``.
+    """
+    records = load_records(evolution_dir / "metrics.jsonl")
+    summary = summarize(records, last)
+    return {
+        "cycles": summary["cycles"],
+        "reject_rate": summary["reject_rate"],
+        "merged_zero_streak": summary["merged_zero_streak"],
+        "flags": summary["flags"],
+        "halted": bool(is_evolution_halted(evolution_dir)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reading the CURRENT value of a tunable parameter out of the live YAML.
+# ---------------------------------------------------------------------------
+
+
+def read_current_value(
+    repo_root: Optional[Path], param: TunableParam
+) -> Optional[float]:
+    """Read ``param``'s current value from its cron YAML. None on any failure
+    (missing repo, missing file, unparsable YAML, missing key) — callers fall
+    back to ``param.default`` so a read failure never crashes the job."""
+    if repo_root is None:
+        return None
+    path = repo_root / "cron" / "evolution" / param.yaml_file
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, ValueError):
+        return None
+    except Exception:
+        return None
+    section = data.get(param.section)
+    if not isinstance(section, dict):
+        return None
+    value = section.get(param.key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+# ---------------------------------------------------------------------------
+# Proposing edits — pure function of (state, current values, registry).
+# ---------------------------------------------------------------------------
+
+
+def propose_edits(
+    state: Dict[str, Any],
+    current_values: Dict[str, Optional[float]],
+    params: Dict[str, TunableParam] = TUNABLE_PARAMS,
+) -> List[Dict[str, Any]]:
+    """Return zero or more bounded edit proposals for the given state.
+
+    An empty list is the normal, expected outcome most cycles ("procedure
+    looks fine, no changes proposed") — this is advisory data, not a job that
+    must always produce output.
+    """
+    proposals: List[Dict[str, Any]] = []
+
+    if state.get("halted"):
+        return proposals  # a halted pipeline has a bigger problem than tuning
+    if int(state.get("cycles", 0) or 0) < _MIN_CYCLES_FOR_PROPOSAL:
+        return proposals
+
+    reject_rate = state.get("reject_rate")
+    if reject_rate is None:
+        return proposals
+
+    if reject_rate > _HIGH_REJECT_RATE:
+        direction = "increase"
+        reason = (
+            f"reject_rate {reject_rate:.0%} > {_HIGH_REJECT_RATE:.0%} over "
+            f"{state['cycles']} cycles — raise the quality bar"
+        )
+    elif (
+        reject_rate < _LOW_REJECT_RATE
+        and int(state.get("merged_zero_streak", 0) or 0) == 0
+    ):
+        direction = "decrease"
+        reason = (
+            f"reject_rate {reject_rate:.0%} < {_LOW_REJECT_RATE:.0%} over "
+            f"{state['cycles']} cycles and merges are healthy — the bar may "
+            "be filtering out viable proposals; ease it"
+        )
+    else:
+        return proposals
+
+    for name in sorted(params):
+        param = params[name]
+        current = current_values.get(name)
+        if current is None:
+            current = param.default
+        if direction == "increase":
+            candidate = _clamp(current + param.step, param.min_value, param.max_value)
+        else:
+            candidate = _clamp(current - param.step, param.min_value, param.max_value)
+        candidate = round(candidate, 4)
+        if candidate == current:
+            continue  # already at the bound, or no-op — nothing to propose
+
+        proposal = {
+            "name": name,
+            "stage": param.stage,
+            "yaml_file": param.yaml_file,
+            "section": param.section,
+            "key": param.key,
+            "current": current,
+            "proposed": candidate,
+            "delta": round(candidate - current, 4),
+            "reason": reason,
+            "evidence": {
+                "cycles": state["cycles"],
+                "reject_rate": reject_rate,
+                "merged_zero_streak": state.get("merged_zero_streak"),
+            },
+        }
+        ok, err = validate_proposal(proposal, param)
+        if ok:
+            proposals.append(proposal)
+        # An invalid proposal here would be a bug in this very function (the
+        # candidate is already clamped) — silently dropping it is defense in
+        # depth, not the expected path. Tests cover both sides directly.
+
+    return proposals
+
+
+# ---------------------------------------------------------------------------
+# Validation gate — independent of propose_edits' own arithmetic.
+# ---------------------------------------------------------------------------
+
+
+def validate_proposal(
+    proposal: Dict[str, Any], param: TunableParam
+) -> Tuple[bool, Optional[str]]:
+    """Check ``proposal`` against ``param``'s declared bounds. Returns
+    ``(True, None)`` when valid, ``(False, reason)`` otherwise. This is the
+    module's validation gate: it re-checks bounds from scratch rather than
+    trusting whatever computed the proposal."""
+    if (
+        proposal.get("stage") != param.stage
+        or proposal.get("yaml_file") != param.yaml_file
+        or proposal.get("section") != param.section
+        or proposal.get("key") != param.key
+    ):
+        return False, "proposal identity does not match the declared TunableParam"
+
+    proposed = proposal.get("proposed")
+    if not isinstance(proposed, (int, float)) or isinstance(proposed, bool):
+        return False, "proposed value is not numeric"
+    if proposed < param.min_value or proposed > param.max_value:
+        return False, (
+            f"proposed {proposed} outside bounds [{param.min_value}, {param.max_value}]"
+        )
+
+    current = proposal.get("current")
+    if not isinstance(current, (int, float)) or isinstance(current, bool):
+        return False, "current value is not numeric"
+    if abs(proposed - current) > param.step + 1e-9:
+        return False, (
+            f"proposed change {abs(proposed - current):.4f} exceeds the bounded "
+            f"step {param.step}"
+        )
+    if proposed == current:
+        return False, "proposal is a no-op"
+
+    return True, None
+
+
+def validate_proposal_against_registry(
+    proposal: Dict[str, Any], params: Dict[str, TunableParam] = TUNABLE_PARAMS
+) -> Tuple[bool, Optional[str]]:
+    """Top-level validation gate: is ``proposal["name"]`` even a registered,
+    legal edit target? Then defers to ``validate_proposal`` for the bounds
+    check. Any name outside the registry is rejected outright — the registry
+    is the only source of truth for what may ever be proposed."""
+    name = proposal.get("name")
+    param = params.get(name) if isinstance(name, str) else None
+    if param is None:
+        return False, f"'{name}' is not a registered tunable parameter"
+    return validate_proposal(proposal, param)
+
+
+# ---------------------------------------------------------------------------
+# Rendering + persistence.
+# ---------------------------------------------------------------------------
+
+
+def format_proposals(
+    date: str, state: Dict[str, Any], proposals: List[Dict[str, Any]]
+) -> str:
+    """One-line, log/agent-friendly rendering, matching the funnel/health
+    sidecar convention (readable by stages without a terminal toolset)."""
+    if not proposals:
+        return (
+            f"[evolution-meta] {date}: {state['cycles']} cycles, "
+            f"reject_rate={_pct(state.get('reject_rate'))} — no procedure "
+            "changes proposed"
+        )
+    parts = [f"{p['name']}: {p['current']}->{p['proposed']}" for p in proposals]
+    return (
+        f"[evolution-meta] {date}: {state['cycles']} cycles, "
+        f"reject_rate={_pct(state.get('reject_rate'))} — proposing " + ", ".join(parts)
+    )
+
+
+def _pct(x: Optional[float]) -> str:
+    return "n/a" if x is None else f"{x:.0%}"
+
+
+def write_meta_record(evolution_dir: Path, date: str, record: Dict[str, Any]) -> Path:
+    """Write the proposal record for ``date``, overwriting any prior run for
+    the same date (idempotent re-runs), matching the date-keyed stage report
+    convention (analysis/{date}.json etc.)."""
+    out_dir = evolution_dir / "meta"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{date}.json"
+    out_path.write_text(json.dumps(record, indent=2, sort_keys=True), encoding="utf-8")
+    return out_path
+
+
+def main(argv: List[str]) -> int:
+    evolution_dir = Path(
+        os.environ.get(
+            "EVOLUTION_PROFILE_DIR",
+            str(Path.home() / ".hermes" / "evolution"),
+        )
+    )
+
+    date = argv[1] if len(argv) > 1 and not argv[1].startswith("-") else ""
+    date = date or os.environ.get("EVOLUTION_META_DATE", "")
+    if not date:
+        date = datetime.now(timezone.utc).date().isoformat()
+
+    state = aggregate_state(evolution_dir)
+
+    repo_root = _resolve_repo_dir()
+    current_values = {
+        name: read_current_value(repo_root, param)
+        for name, param in TUNABLE_PARAMS.items()
+    }
+
+    proposals = propose_edits(state, current_values)
+    # Independent re-validation before anything touches disk — defense in
+    # depth so a future refactor of propose_edits cannot silently smuggle an
+    # out-of-bounds proposal into the written record.
+    proposals = [p for p in proposals if validate_proposal_against_registry(p)[0]]
+
+    record = {"date": date, "state": state, "proposals": proposals}
+    out_path = write_meta_record(evolution_dir, date, record)
+
+    summary_line = format_proposals(date, state, proposals)
+    try:
+        (evolution_dir / "meta-proposals.txt").write_text(
+            summary_line + "\n", encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+    print(f"{summary_line} (wrote {out_path})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_meta_editor.py
+++ b/scripts/evolution_meta_editor.py
@@ -59,11 +59,34 @@ from typing import Any, Dict, List, Optional, Tuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from evolution_funnel import (  # noqa: E402
-    _resolve_repo_dir,
     is_evolution_halted,
     load_records,
     summarize,
 )
+
+
+def _resolve_repo_dir() -> Optional[Path]:
+    """Locate the git repo to read the live cron/evolution/*.yaml values from.
+
+    Duplicated locally rather than imported (matches evolution_watchdog's own
+    copy, not evolution_funnel's): this script runs as a COPY under
+    HERMES_HOME/scripts, outside the repo, so it cannot rely on importing
+    another script's private helper staying in sync. Env override, then the
+    in-tree location (when run from the repo), then the common server
+    install / agent-clone paths. Returns None when none is a git repo — the
+    caller then falls back to each TunableParam's registry default.
+    """
+    candidates = [
+        os.environ.get("EVOLUTION_REPO_DIR"),
+        str(Path(__file__).resolve().parent.parent),  # scripts/ -> repo root (in-tree)
+        "/usr/local/lib/hermes-agent",
+        str(Path.home() / "hermes-agent-evolution"),
+    ]
+    for cand in candidates:
+        if cand and (Path(cand) / ".git").exists():
+            return Path(cand)
+    return None
+
 
 # ---------------------------------------------------------------------------
 # The registry — the ONLY edits this module may ever propose.

--- a/tests/scripts/test_evolution_meta_editor.py
+++ b/tests/scripts/test_evolution_meta_editor.py
@@ -1,0 +1,421 @@
+"""Tests for scripts/evolution_meta_editor.py (#906 — AEvo meta-editing slice).
+
+Covers the deterministic, bounded procedure-adjustment primitive: process-level
+state aggregation, reading current YAML values, proposing bounded edits, and
+the independent validation gate. No LLM, no network — every function here is
+pure or takes explicit paths, matching the rest of the evolution_* family.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_meta_editor import (  # noqa: E402
+    TUNABLE_PARAMS,
+    TunableParam,
+    aggregate_state,
+    format_proposals,
+    main,
+    propose_edits,
+    read_current_value,
+    validate_proposal,
+    validate_proposal_against_registry,
+    write_meta_record,
+)
+
+
+def _write_funnel_records(metrics_file: Path, records):
+    metrics_file.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(r) for r in records]
+    metrics_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _cycle(date, selected=2, rejected=1, merged=1, created=3):
+    return {
+        "date": date,
+        "issues_created": created,
+        "selected": selected,
+        "rejected": rejected,
+        "merged": merged,
+        "skipped": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# aggregate_state
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateState:
+    def test_no_history_is_empty_but_safe(self, tmp_path):
+        state = aggregate_state(tmp_path)
+        assert state["cycles"] == 0
+        assert state["reject_rate"] == 0.0
+        assert state["merged_zero_streak"] == 0
+        assert state["halted"] is False
+
+    def test_high_reject_rate_reflected(self, tmp_path):
+        records = [
+            _cycle(f"2026-06-{10 + i:02d}", selected=1, rejected=9, merged=1)
+            for i in range(6)
+        ]
+        _write_funnel_records(tmp_path / "metrics.jsonl", records)
+        state = aggregate_state(tmp_path)
+        assert state["cycles"] == 6
+        assert state["reject_rate"] > 0.7
+
+    def test_halted_flag_from_halt_file(self, tmp_path):
+        (tmp_path).mkdir(parents=True, exist_ok=True)
+        (tmp_path / "halt-state.txt").write_text("# halted\n", encoding="utf-8")
+        state = aggregate_state(tmp_path)
+        assert state["halted"] is True
+
+    def test_merged_zero_streak_reflected(self, tmp_path):
+        records = [
+            _cycle(f"2026-06-{10 + i:02d}", selected=1, rejected=0, merged=0)
+            for i in range(4)
+        ]
+        _write_funnel_records(tmp_path / "metrics.jsonl", records)
+        state = aggregate_state(tmp_path)
+        assert state["merged_zero_streak"] == 4
+
+
+# ---------------------------------------------------------------------------
+# read_current_value
+# ---------------------------------------------------------------------------
+
+
+class TestReadCurrentValue:
+    PARAM = TUNABLE_PARAMS["research.min_priority_score"]
+
+    def test_reads_nested_section_key(self, tmp_path):
+        cron_dir = tmp_path / "cron" / "evolution"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "research.yaml").write_text(
+            "name: evolution-research\nlimits:\n  min_priority_score: 0.75\n",
+            encoding="utf-8",
+        )
+        value = read_current_value(tmp_path, self.PARAM)
+        assert value == 0.75
+
+    def test_missing_repo_root_is_none(self):
+        assert read_current_value(None, self.PARAM) is None
+
+    def test_missing_file_is_none(self, tmp_path):
+        assert read_current_value(tmp_path, self.PARAM) is None
+
+    def test_malformed_yaml_is_none(self, tmp_path):
+        cron_dir = tmp_path / "cron" / "evolution"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "research.yaml").write_text(
+            "not: [valid: yaml: at all\n", encoding="utf-8"
+        )
+        assert read_current_value(tmp_path, self.PARAM) is None
+
+    def test_missing_key_is_none(self, tmp_path):
+        cron_dir = tmp_path / "cron" / "evolution"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "research.yaml").write_text(
+            "name: evolution-research\nlimits:\n  max_proposals_per_day: 20\n",
+            encoding="utf-8",
+        )
+        assert read_current_value(tmp_path, self.PARAM) is None
+
+    def test_non_numeric_value_is_none(self, tmp_path):
+        cron_dir = tmp_path / "cron" / "evolution"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "research.yaml").write_text(
+            "name: evolution-research\nlimits:\n  min_priority_score: true\n",
+            encoding="utf-8",
+        )
+        assert read_current_value(tmp_path, self.PARAM) is None
+
+
+# ---------------------------------------------------------------------------
+# propose_edits
+# ---------------------------------------------------------------------------
+
+
+class TestProposeEdits:
+    def _state(self, **overrides):
+        base = {
+            "cycles": 6,
+            "reject_rate": 0.5,
+            "merged_zero_streak": 0,
+            "flags": [],
+            "halted": False,
+        }
+        base.update(overrides)
+        return base
+
+    def test_not_enough_cycles_no_proposal(self):
+        state = self._state(cycles=2, reject_rate=0.9)
+        proposals = propose_edits(state, {})
+        assert proposals == []
+
+    def test_halted_no_proposal(self):
+        state = self._state(reject_rate=0.9, halted=True)
+        proposals = propose_edits(state, {})
+        assert proposals == []
+
+    def test_high_reject_rate_proposes_increase(self):
+        state = self._state(reject_rate=0.85)
+        current = {name: 0.7 for name in TUNABLE_PARAMS}
+        proposals = propose_edits(state, current)
+        assert len(proposals) == len(TUNABLE_PARAMS)
+        by_name = {p["name"]: p for p in proposals}
+        for name, param in TUNABLE_PARAMS.items():
+            p = by_name[name]
+            assert p["current"] == 0.7
+            assert p["proposed"] == pytest.approx(0.75)
+            assert p["delta"] == pytest.approx(0.05)
+            assert "raise the quality bar" in p["reason"]
+
+    def test_low_reject_rate_and_healthy_merges_proposes_decrease(self):
+        state = self._state(reject_rate=0.1, merged_zero_streak=0)
+        current = {name: 0.7 for name in TUNABLE_PARAMS}
+        proposals = propose_edits(state, current)
+        assert len(proposals) == len(TUNABLE_PARAMS)
+        for p in proposals:
+            assert p["proposed"] == pytest.approx(0.65)
+            assert p["delta"] == pytest.approx(-0.05)
+            assert "ease it" in p["reason"]
+
+    def test_low_reject_rate_but_merges_stuck_no_proposal(self):
+        """Don't loosen the quality bar while integration itself looks broken."""
+        state = self._state(reject_rate=0.05, merged_zero_streak=3)
+        current = {name: 0.7 for name in TUNABLE_PARAMS}
+        proposals = propose_edits(state, current)
+        assert proposals == []
+
+    def test_moderate_reject_rate_no_proposal(self):
+        state = self._state(reject_rate=0.5)
+        current = {name: 0.7 for name in TUNABLE_PARAMS}
+        proposals = propose_edits(state, current)
+        assert proposals == []
+
+    def test_clamped_at_max_bound_produces_no_op(self):
+        state = self._state(reject_rate=0.85)
+        current = {name: 0.9 for name in TUNABLE_PARAMS}  # already at max
+        proposals = propose_edits(state, current)
+        assert proposals == []
+
+    def test_clamped_at_min_bound_produces_no_op(self):
+        state = self._state(reject_rate=0.1, merged_zero_streak=0)
+        current = {name: 0.5 for name in TUNABLE_PARAMS}  # already at min
+        proposals = propose_edits(state, current)
+        assert proposals == []
+
+    def test_missing_current_value_falls_back_to_default(self):
+        state = self._state(reject_rate=0.85)
+        proposals = propose_edits(state, {name: None for name in TUNABLE_PARAMS})
+        assert len(proposals) == len(TUNABLE_PARAMS)
+        for p in proposals:
+            assert p["current"] == 0.7  # the registry default
+
+    def test_every_proposal_passes_the_registry_validation_gate(self):
+        state = self._state(reject_rate=0.85)
+        current = {name: 0.7 for name in TUNABLE_PARAMS}
+        proposals = propose_edits(state, current)
+        for p in proposals:
+            ok, err = validate_proposal_against_registry(p)
+            assert ok, err
+
+
+# ---------------------------------------------------------------------------
+# validate_proposal / validate_proposal_against_registry
+# ---------------------------------------------------------------------------
+
+
+class TestValidateProposal:
+    PARAM = TUNABLE_PARAMS["research.min_priority_score"]
+
+    def _valid(self, **overrides):
+        base = {
+            "name": "research.min_priority_score",
+            "stage": "research",
+            "yaml_file": "research.yaml",
+            "section": "limits",
+            "key": "min_priority_score",
+            "current": 0.7,
+            "proposed": 0.75,
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_proposal_passes(self):
+        ok, err = validate_proposal(self._valid(), self.PARAM)
+        assert ok is True
+        assert err is None
+
+    def test_exceeds_step_rejected(self):
+        proposal = self._valid(proposed=0.9)  # step is 0.05, current 0.7
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "step" in err
+
+    def test_exceeds_max_bound_rejected(self):
+        proposal = self._valid(current=0.88, proposed=0.93)
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "bounds" in err
+
+    def test_below_min_bound_rejected(self):
+        proposal = self._valid(current=0.52, proposed=0.47)
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "bounds" in err
+
+    def test_no_op_rejected(self):
+        proposal = self._valid(proposed=0.7)
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "no-op" in err
+
+    def test_mismatched_identity_rejected(self):
+        proposal = self._valid(yaml_file="issues.yaml")
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "identity" in err
+
+    def test_non_numeric_proposed_rejected(self):
+        proposal = self._valid(proposed="0.75")
+        ok, err = validate_proposal(proposal, self.PARAM)
+        assert ok is False
+        assert "numeric" in err
+
+
+class TestValidateProposalAgainstRegistry:
+    def test_unregistered_name_rejected(self):
+        proposal = {
+            "name": "not.a.real.param",
+            "stage": "research",
+            "yaml_file": "research.yaml",
+            "section": "limits",
+            "key": "min_priority_score",
+            "current": 0.7,
+            "proposed": 0.75,
+        }
+        ok, err = validate_proposal_against_registry(proposal)
+        assert ok is False
+        assert "not a registered" in err
+
+    def test_registered_name_delegates_to_validate_proposal(self):
+        proposal = {
+            "name": "research.min_priority_score",
+            "stage": "research",
+            "yaml_file": "research.yaml",
+            "section": "limits",
+            "key": "min_priority_score",
+            "current": 0.7,
+            "proposed": 0.75,
+        }
+        ok, err = validate_proposal_against_registry(proposal)
+        assert ok is True
+        assert err is None
+
+
+# ---------------------------------------------------------------------------
+# format_proposals / write_meta_record
+# ---------------------------------------------------------------------------
+
+
+class TestFormatProposals:
+    def test_empty_proposals_reads_as_no_change(self):
+        state = {"cycles": 6, "reject_rate": 0.5}
+        line = format_proposals("2026-07-12", state, [])
+        assert "no procedure changes proposed" in line
+
+    def test_proposals_are_summarized(self):
+        state = {"cycles": 6, "reject_rate": 0.85}
+        proposals = [
+            {"name": "research.min_priority_score", "current": 0.7, "proposed": 0.75}
+        ]
+        line = format_proposals("2026-07-12", state, proposals)
+        assert "research.min_priority_score: 0.7->0.75" in line
+
+
+class TestWriteMetaRecord:
+    def test_writes_and_overwrites_idempotently(self, tmp_path):
+        record1 = {"date": "2026-07-12", "state": {}, "proposals": []}
+        path = write_meta_record(tmp_path, "2026-07-12", record1)
+        assert path == tmp_path / "meta" / "2026-07-12.json"
+        assert json.loads(path.read_text(encoding="utf-8"))["proposals"] == []
+
+        record2 = {"date": "2026-07-12", "state": {}, "proposals": [{"name": "x"}]}
+        write_meta_record(tmp_path, "2026-07-12", record2)
+        assert json.loads(path.read_text(encoding="utf-8"))["proposals"] == [
+            {"name": "x"}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# main() — end-to-end wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _make_repo(self, tmp_path, min_priority_score=0.7):
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        cron_dir = repo / "cron" / "evolution"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "research.yaml").write_text(
+            f"name: evolution-research\nlimits:\n  min_priority_score: {min_priority_score}\n",
+            encoding="utf-8",
+        )
+        (cron_dir / "issues.yaml").write_text(
+            f"name: evolution-issues\nlimits:\n  min_priority_score: {min_priority_score}\n",
+            encoding="utf-8",
+        )
+        (cron_dir / "introspection.yaml").write_text(
+            f"name: evolution-introspection\nlimits:\n  min_priority_score: {min_priority_score}\n",
+            encoding="utf-8",
+        )
+        (cron_dir / "analysis.yaml").write_text(
+            f"name: evolution-analysis\nsafety:\n  min_priority_score: {min_priority_score}\n",
+            encoding="utf-8",
+        )
+        return repo
+
+    def test_end_to_end_no_history_writes_empty_proposals(self, tmp_path, monkeypatch):
+        evolution_dir = tmp_path / "evolution"
+        repo = self._make_repo(tmp_path)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evolution_dir))
+        monkeypatch.setenv("EVOLUTION_REPO_DIR", str(repo))
+
+        rc = main(["evolution_meta_editor.py", "2026-07-12"])
+        assert rc == 0
+
+        out = json.loads((evolution_dir / "meta" / "2026-07-12.json").read_text())
+        assert out["date"] == "2026-07-12"
+        assert out["proposals"] == []
+        assert (evolution_dir / "meta-proposals.txt").is_file()
+
+    def test_end_to_end_high_reject_rate_writes_proposals(self, tmp_path, monkeypatch):
+        evolution_dir = tmp_path / "evolution"
+        repo = self._make_repo(tmp_path, min_priority_score=0.7)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evolution_dir))
+        monkeypatch.setenv("EVOLUTION_REPO_DIR", str(repo))
+
+        records = [
+            _cycle(f"2026-07-{1 + i:02d}", selected=1, rejected=9, merged=1)
+            for i in range(6)
+        ]
+        _write_funnel_records(evolution_dir / "metrics.jsonl", records)
+
+        rc = main(["evolution_meta_editor.py", "2026-07-12"])
+        assert rc == 0
+
+        out = json.loads((evolution_dir / "meta" / "2026-07-12.json").read_text())
+        assert len(out["proposals"]) == len(TUNABLE_PARAMS)
+        for p in out["proposals"]:
+            assert p["current"] == 0.7
+            assert p["proposed"] == pytest.approx(0.75)
+
+        sidecar = (evolution_dir / "meta-proposals.txt").read_text()
+        assert "proposing" in sidecar


### PR DESCRIPTION
Closes #906

## Summary

Issue #906 (AEvo) proposes a broad "meta-agent rewrites its own evolution
procedure" framework — LLM-judged procedure changes validated against
held-out historical performance, then auto-applied. That's unsound to ship
as auto-merged code today: there's no sound way to validate an LLM's own
procedure edits before they run for real, and nothing in this repo currently
validates procedure changes against historical performance.

This PR ships the smallest valuable, well-scoped, deterministic slice of the
idea instead:

- **Process-level state aggregation**: `aggregate_state()` reads the
  pipeline's existing funnel evidence (`metrics.jsonl` via
  `evolution_funnel.load_records`/`summarize`) into a state snapshot (reject
  rate, merged-zero streak, halt state, cycle count).
- **Bounded procedure-adjustment proposals**: `propose_edits()` is a pure
  function that proposes AT MOST one step-bounded adjustment per registered
  tunable parameter — currently the four stages' `min_priority_score` quality
  bars (`research`/`issues`/`introspection`/`analysis`) — raising the bar on
  sustained high reject rate, easing it on sustained low reject rate with
  healthy merges, and doing nothing otherwise (including once already
  clamped at a bound).
- **A validated editing primitive**: every field this module may ever touch
  is declared upfront in a `TUNABLE_PARAMS` registry (file, section, key,
  min/max/step). `validate_proposal()` / `validate_proposal_against_registry()`
  independently re-check every proposal against that registry — a bug in the
  proposer's arithmetic cannot produce a proposal that escapes the declared
  bound.
- **No LLM, no auto-apply**: this is a new `no_agent` cron stage
  (`cron/evolution/meta-analysis.yaml`, 08:50 daily). It only aggregates
  evidence and writes an advisory record to `evolution/meta/{date}.json` (plus
  a plain-text sidecar). It never edits `cron/evolution/*.yaml` itself —
  applying a proposal remains a separate, human-reviewed action, mirroring
  how `evolution_postmortem_miner` writes advisory rules rather than
  auto-patching anything.

## Files

- `scripts/evolution_meta_editor.py` — new no_agent script (pure functions +
  explicit IO boundary, matching the rest of the `evolution_*` family).
- `cron/evolution/meta-analysis.yaml` — registers the new stage; no changes
  needed to `evolution_watchdog.py` (STAGES dict covers a different, audited
  subset), `evolution_skill_lint.py` (skips `no_agent` stages), or
  `register_evolution_cron.py` (auto-installs the whole `evolution_*.py`
  family via glob).
- `tests/scripts/test_evolution_meta_editor.py` — 34 tests covering state
  aggregation, YAML value reads (valid/missing/malformed/missing key),
  every proposal-generation branch (not enough cycles, halted, high/low/
  moderate reject rate, already-at-bound, missing current value falls back
  to registry default), both validation gates, formatting, record writing,
  and an end-to-end `main()` integration test.

## Verification

```
.venv/bin/python -m pytest tests/scripts/test_evolution_meta_editor.py -q
# 34 passed

.venv/bin/python -m pytest tests/scripts/test_evolution_funnel.py tests/scripts/test_evolution_watchdog.py tests/cron -q
# 823 passed (no regressions)

.venv/bin/ruff check .
# All checks passed!

.venv/bin/ruff format --check scripts/evolution_meta_editor.py tests/scripts/test_evolution_meta_editor.py
# 2 files already formatted
```

Independent second-opinion review (`consult agy`, Gemini — different
provider from the one implementing this) returned `VERDICT: PASS` on
scope-soundness and flagged one real convention mismatch (importing
`evolution_funnel`'s private `_resolve_repo_dir` instead of duplicating it
locally, the way `evolution_watchdog.py` does, since `no_agent` scripts run
as standalone copies under `HERMES_HOME/scripts`) — fixed in a follow-up
commit on this branch, re-verified with the same test/lint commands.

## Out of scope (left for follow-up issues once this primitive has
real-world signal to justify them)

- Consuming `rubric-scorecard.jsonl` / `postmortem-rules.json` as additional
  evidence — this increment reads only the funnel, the pipeline's most
  load-bearing existing signal.
- A cooldown/hysteresis window to damp oscillating proposals — harmless
  today since nothing auto-applies a proposal, but would matter before any
  future auto-apply path.
- An `--apply` mode that would edit the YAML autonomously. Deliberately NOT
  built: applying a bounded proposal is exactly the step that turns "safe
  advisory data" into "pipeline behavior changed autonomously," which is the
  auto-merge risk this increment is scoped to avoid. A real validation gate
  against historical performance (per the issue's success criteria) doesn't
  exist yet either, so auto-apply isn't safe to build until it does.
