### PR TITLE
feat(#908): detect conflicting memory claims (topic/value contradictions)

### DIFF
--- a/agent/memory_conflicts.py
+++ b/agent/memory_conflicts.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Conflict-preserving memory detection for tqmemory notes (#908).
+
+Hermes's memory (``MEMORY.md``, ``USER.md``, structured memories) can
+accumulate *contradictory* claims across sessions — one session records
+"the deploy target is staging", a later one records "the deploy target is
+production", and both entries sit side by side with no indication that they
+disagree. The built-in memory store's ``add()`` is append-only (it never
+overwrites), so nothing is silently lost — but nothing surfaces the
+disagreement either, and an agent reading the corpus has no way to tell that
+two entries are in conflict rather than simply about related topics.
+
+This module is a *side-effect-free* analysis pass, mirroring
+``agent/memory_staleness.py``: it never mutates the notes it inspects and
+never calls any memory API. It detects pairs of notes that make a claim
+about the same *topic* but disagree on the *value*, and returns a
+:class:`ConflictReport` — an explicit, queryable record of the disagreement
+— that the caller surfaces (CLI report, system-prompt note, etc.) rather
+than silently picking a winner.
+
+Detection is a deterministic heuristic, not semantic understanding:
+
+1. Each note's title is split into a ``(topic, value)`` pair on the first
+   matching separator (``:``, ``" is "``, ``" are "``, ``"="``,
+   ``" prefers "``) via :func:`split_claim`. Notes whose title has no
+   recognizable separator are not claims and are skipped — this mirrors
+   ``detect_contradictions`` in ``memory_staleness.py`` skipping notes
+   without timestamps: the detector only operates on notes it can
+   structurally interpret.
+2. Two claims *conflict* when their topics are near-identical (Jaccard
+   word-set similarity at/above ``topic_similarity_threshold``) but their
+   values are substantially different (Jaccard word-set similarity *below*
+   ``value_similarity_threshold``). Same topic + same value is a duplicate
+   (out of scope here — see ``detect_duplicates``); same topic + different
+   value is a conflict.
+
+The module depends only on the Python standard library (plus reusing the
+``Note`` model and ``jaccard_similarity`` helper from ``memory_staleness``),
+is import-safe, and is unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional, Tuple
+
+from agent.memory_staleness import Note, jaccard_similarity
+
+__all__ = [
+    "Note",
+    "MemoryConflict",
+    "ConflictReport",
+    "DEFAULT_CONFIG",
+    "split_claim",
+    "detect_conflicts",
+    "analyze_conflicts",
+    "render_conflict_report",
+]
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+#: Default configuration. Values are intentionally conservative so the
+#: analysis is useful out-of-the-box; every threshold is overridable via
+#: :func:`analyze_conflicts`'s ``config`` argument.
+DEFAULT_CONFIG: dict[str, Any] = {
+    # Topic word-set Jaccard similarity at/above this fraction means "same topic".
+    "topic_similarity_threshold": 0.6,
+    # Value word-set Jaccard similarity below this fraction means "different
+    # value" (a same-topic pair at/above this is a near-duplicate claim, not
+    # a conflict — that's DUPLICATE territory, handled by memory_staleness).
+    "value_similarity_threshold": 0.5,
+}
+
+
+# ---------------------------------------------------------------------------
+# Claim splitting
+# ---------------------------------------------------------------------------
+
+# Ordered by priority: the first pattern that splits the title into two
+# non-empty parts wins. Colon-delimited claims ("Deploy target: staging")
+# are the most common and least ambiguous form in real memory entries, so
+# they take priority over the looser natural-language separators.
+_SEPARATOR_PATTERNS: Tuple[re.Pattern, ...] = (
+    re.compile(r"\s*:\s*"),
+    re.compile(r"\s+is\s+", re.IGNORECASE),
+    re.compile(r"\s+are\s+", re.IGNORECASE),
+    re.compile(r"\s*=\s*"),
+    re.compile(r"\s+prefers\s+", re.IGNORECASE),
+)
+
+_WORD_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _word_set(text: str) -> set[str]:
+    """Normalized word set for Jaccard comparison (lowercase, alnum runs)."""
+    return {w for w in _WORD_RE.split(text.lower()) if w}
+
+
+def split_claim(text: str) -> Optional[Tuple[str, str]]:
+    """Split ``text`` into a ``(topic, value)`` pair on the first matching separator.
+
+    Tries each separator in :data:`_SEPARATOR_PATTERNS` in priority order and
+    returns the first split that yields two non-empty, stripped parts.
+    Returns ``None`` when no separator matches (or a match produces an empty
+    topic or value) — the text is not a recognizable key/value claim.
+    """
+    for pattern in _SEPARATOR_PATTERNS:
+        parts = pattern.split(text, maxsplit=1)
+        if len(parts) != 2:
+            continue
+        topic, value = parts[0].strip(), parts[1].strip()
+        if topic and value:
+            return topic, value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Conflict model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MemoryConflict:
+    """A pair of memory entries that claim different values for the same topic.
+
+    Both notes are left untouched by this module — the conflict is a
+    *finding*, not a mutation. ``note_a_id``/``note_b_id`` are always ordered
+    so results are deterministic regardless of input or traversal order (the
+    lexicographically smaller id is always ``note_a_id``).
+
+    Attributes:
+        note_a_id: The first note's id (lexicographically smaller of the pair).
+        note_b_id: The second note's id.
+        topic_a: The topic phrase extracted from ``note_a``'s claim.
+        topic_b: The topic phrase extracted from ``note_b``'s claim.
+        value_a: The value phrase extracted from ``note_a``'s claim.
+        value_b: The value phrase extracted from ``note_b``'s claim.
+        topic_similarity: Jaccard similarity of the two topic word sets.
+        value_similarity: Jaccard similarity of the two value word sets.
+        detail: Human-readable explanation (used verbatim in the report).
+    """
+
+    note_a_id: str
+    note_b_id: str
+    topic_a: str
+    topic_b: str
+    value_a: str
+    value_b: str
+    topic_similarity: float
+    value_similarity: float
+    detail: str = ""
+
+
+def detect_conflicts(
+    notes: Iterable[Note],
+    *,
+    config: dict[str, Any] | None = None,
+) -> list[MemoryConflict]:
+    """Flag pairs of notes that claim different values for the same topic.
+
+    Only notes whose title splits cleanly into a ``(topic, value)`` pair (via
+    :func:`split_claim`) are considered — free-form notes with no recognizable
+    claim structure are skipped. Deprecated notes are skipped (already
+    actioned). A pair conflicts when its topic similarity is at/above
+    ``topic_similarity_threshold`` and its value similarity is *below*
+    ``value_similarity_threshold``; pairs where either value has no words at
+    all (an empty value after the separator) are skipped — there is no value
+    to compare.
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    topic_threshold = float(cfg["topic_similarity_threshold"])
+    value_threshold = float(cfg["value_similarity_threshold"])
+
+    claims: list[tuple[Note, str, str, set[str], set[str]]] = []
+    for note in notes:
+        if note.deprecated:
+            continue
+        split = split_claim(note.title)
+        if split is None:
+            continue
+        topic, value = split
+        topic_words = _word_set(topic)
+        value_words = _word_set(value)
+        if not topic_words or not value_words:
+            continue
+        claims.append((note, topic, value, topic_words, value_words))
+
+    conflicts: list[MemoryConflict] = []
+    for i, (note_a, topic_a, value_a, topic_words_a, value_words_a) in enumerate(
+        claims
+    ):
+        for note_b, topic_b, value_b, topic_words_b, value_words_b in claims[i + 1 :]:
+            topic_sim = jaccard_similarity(topic_words_a, topic_words_b)
+            if topic_sim < topic_threshold:
+                continue
+            value_sim = jaccard_similarity(value_words_a, value_words_b)
+            if value_sim >= value_threshold:
+                continue
+
+            # Canonical ordering so results are independent of input order.
+            if note_a.id <= note_b.id:
+                first = (note_a.id, topic_a, value_a)
+                second = (note_b.id, topic_b, value_b)
+            else:
+                first = (note_b.id, topic_b, value_b)
+                second = (note_a.id, topic_a, value_a)
+
+            conflicts.append(
+                MemoryConflict(
+                    note_a_id=first[0],
+                    note_b_id=second[0],
+                    topic_a=first[1],
+                    topic_b=second[1],
+                    value_a=first[2],
+                    value_b=second[2],
+                    topic_similarity=topic_sim,
+                    value_similarity=value_sim,
+                    detail=(
+                        f"Same topic ('{first[1]}' ~ '{second[1]}', "
+                        f"similarity {topic_sim:.2f}) but different values: "
+                        f"'{first[2]}' vs '{second[2]}' "
+                        f"(value similarity {value_sim:.2f}). Both entries "
+                        f"are preserved — resolve manually."
+                    ),
+                )
+            )
+    return conflicts
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConflictReport:
+    """Full output of :func:`analyze_conflicts`.
+
+    Attributes:
+        total_notes: Count of notes inspected.
+        total_claims: Count of notes whose title split into a claim
+            (topic, value) pair — the subset actually eligible for
+            conflict detection.
+        conflicts: All detected conflicts.
+        config: The configuration used to produce the report (for audit).
+    """
+
+    total_notes: int
+    total_claims: int
+    conflicts: list[MemoryConflict]
+    config: dict[str, Any]
+
+
+def analyze_conflicts(
+    notes: Iterable[Note],
+    *,
+    config: dict[str, Any] | None = None,
+) -> ConflictReport:
+    """Run conflict detection over ``notes`` and assemble a :class:`ConflictReport`.
+
+    This is the single entry point a caller uses. It is pure: it does not
+    mutate ``notes`` or touch any external state.
+    """
+    effective_config = {**DEFAULT_CONFIG, **(config or {})}
+    materialized = list(notes)
+    total = len(materialized)
+    total_claims = sum(
+        1 for n in materialized if not n.deprecated and split_claim(n.title) is not None
+    )
+
+    conflicts = detect_conflicts(materialized, config=effective_config)
+
+    return ConflictReport(
+        total_notes=total,
+        total_claims=total_claims,
+        conflicts=conflicts,
+        config=effective_config,
+    )
+
+
+def render_conflict_report(report: ConflictReport) -> str:
+    """Render a :class:`ConflictReport` as human-readable markdown.
+
+    The report has two sections — summary and flagged conflicts — so a human
+    (or the agent) can scan it without re-running the analysis.
+    """
+    lines: list[str] = []
+    lines.append("# Memory Conflict Report")
+    lines.append("")
+    lines.append(f"- Total notes inspected: **{report.total_notes}**")
+    lines.append(f"- Notes with a recognizable claim: **{report.total_claims}**")
+    lines.append(f"- Conflicts detected: **{len(report.conflicts)}**")
+    lines.append("")
+
+    lines.append("## Conflicts")
+    if not report.conflicts:
+        lines.append("")
+        lines.append("_No conflicting claims detected._")
+    else:
+        for conflict in report.conflicts:
+            lines.append("")
+            lines.append(
+                f"### ⚠ CONFLICT: `{conflict.note_a_id}` vs `{conflict.note_b_id}`"
+            )
+            lines.append(
+                f"- Topic: `{conflict.topic_a}` ~ `{conflict.topic_b}`"
+                f" (similarity {conflict.topic_similarity:.2f})"
+            )
+            lines.append(f"- `{conflict.note_a_id}` claims: **{conflict.value_a}**")
+            lines.append(f"- `{conflict.note_b_id}` claims: **{conflict.value_b}**")
+            lines.append(f"- Value similarity: {conflict.value_similarity:.2f}")
+            lines.append(f"- {conflict.detail}")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/agent/memory_conflicts.py
+++ b/agent/memory_conflicts.py
@@ -155,6 +155,33 @@ class MemoryConflict:
     detail: str = ""
 
 
+def _extract_claims(
+    notes: Iterable[Note],
+) -> list[tuple[Note, str, str, set[str], set[str]]]:
+    """Return the subset of ``notes`` usable as a ``(topic, value)`` claim.
+
+    Skips deprecated notes, notes with no recognizable claim structure (see
+    :func:`split_claim`), and notes whose topic or value tokenizes to an
+    empty word set (nothing to compare, e.g. a value of ``"---"``). Shared by
+    :func:`detect_conflicts` and :func:`analyze_conflicts` so "notes with a
+    recognizable claim" means exactly the same thing in both places.
+    """
+    claims: list[tuple[Note, str, str, set[str], set[str]]] = []
+    for note in notes:
+        if note.deprecated:
+            continue
+        split = split_claim(note.title)
+        if split is None:
+            continue
+        topic, value = split
+        topic_words = _word_set(topic)
+        value_words = _word_set(value)
+        if not topic_words or not value_words:
+            continue
+        claims.append((note, topic, value, topic_words, value_words))
+    return claims
+
+
 def detect_conflicts(
     notes: Iterable[Note],
     *,
@@ -170,24 +197,16 @@ def detect_conflicts(
     ``value_similarity_threshold``; pairs where either value has no words at
     all (an empty value after the separator) are skipped — there is no value
     to compare.
+
+    The returned list is sorted by ``(note_a_id, note_b_id)`` so the report is
+    fully deterministic regardless of the input notes' traversal order (not
+    just the per-pair id ordering within each :class:`MemoryConflict`).
     """
     cfg = {**DEFAULT_CONFIG, **(config or {})}
     topic_threshold = float(cfg["topic_similarity_threshold"])
     value_threshold = float(cfg["value_similarity_threshold"])
 
-    claims: list[tuple[Note, str, str, set[str], set[str]]] = []
-    for note in notes:
-        if note.deprecated:
-            continue
-        split = split_claim(note.title)
-        if split is None:
-            continue
-        topic, value = split
-        topic_words = _word_set(topic)
-        value_words = _word_set(value)
-        if not topic_words or not value_words:
-            continue
-        claims.append((note, topic, value, topic_words, value_words))
+    claims = _extract_claims(notes)
 
     conflicts: list[MemoryConflict] = []
     for i, (note_a, topic_a, value_a, topic_words_a, value_words_a) in enumerate(
@@ -228,6 +247,7 @@ def detect_conflicts(
                     ),
                 )
             )
+    conflicts.sort(key=lambda c: (c.note_a_id, c.note_b_id))
     return conflicts
 
 
@@ -268,9 +288,9 @@ def analyze_conflicts(
     effective_config = {**DEFAULT_CONFIG, **(config or {})}
     materialized = list(notes)
     total = len(materialized)
-    total_claims = sum(
-        1 for n in materialized if not n.deprecated and split_claim(n.title) is not None
-    )
+    # Same eligibility rule detect_conflicts() uses, so "notes with a
+    # recognizable claim" in the report matches what was actually compared.
+    total_claims = len(_extract_claims(materialized))
 
     conflicts = detect_conflicts(materialized, config=effective_config)
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1215,6 +1215,42 @@ class MemoryManager:
 
         return render_report(self.check_staleness(config=config))
 
+    # -- Conflict detection (#908) -------------------------------------------
+
+    def detect_memory_conflicts(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> "ConflictReport":
+        """Run conflict detection over the current memory corpus (#908).
+
+        This is the real consumer of :func:`agent.memory_conflicts.analyze_conflicts`:
+        it collects notes from the on-disk memory store (the same
+        :meth:`collect_notes` used by :meth:`check_staleness`) and flags pairs
+        of notes that claim different values for the same topic. Both notes
+        stay exactly as they are — this is analysis only, not a mutation —
+        so a caller can surface the disagreement (CLI report, system-prompt
+        note) instead of an agent silently trusting whichever entry it read
+        last.
+
+        Pass ``config`` to override the default similarity thresholds.
+        """
+        from agent.memory_conflicts import ConflictReport, analyze_conflicts
+
+        notes = self.collect_notes()
+        return analyze_conflicts(notes, config=config)
+
+    def render_memory_conflicts(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """Run :meth:`detect_memory_conflicts` and render the result as markdown.
+
+        Convenience wrapper for the CLI ``hermes memory conflicts`` subcommand
+        and any caller that wants a human-readable string rather than the
+        structured :class:`~agent.memory_conflicts.ConflictReport`.
+        """
+        from agent.memory_conflicts import render_conflict_report
+
+        return render_conflict_report(self.detect_memory_conflicts(config=config))
+
     def on_delegation(self, task: str, result: str, *,
                       child_session_id: str = "", **kwargs) -> None:
         """Notify all providers that a subagent completed."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12699,6 +12699,22 @@ def cmd_memory(args):
         mm = MemoryManager()
         report = mm.render_staleness_report(config=config or None)
         print(report)
+    elif sub == "conflicts":
+        # Conflict detection (#908): analyze the on-disk memory corpus and
+        # print a markdown report of notes that claim different values for
+        # the same topic. This is the CLI entry point for the conflict
+        # detector wired into MemoryManager.detect_memory_conflicts().
+        from agent.memory_manager import MemoryManager
+
+        config = {}
+        if getattr(args, "topic_similarity_threshold", None) is not None:
+            config["topic_similarity_threshold"] = args.topic_similarity_threshold
+        if getattr(args, "value_similarity_threshold", None) is not None:
+            config["value_similarity_threshold"] = args.value_similarity_threshold
+
+        mm = MemoryManager()
+        report = mm.render_memory_conflicts(config=config or None)
+        print(report)
     else:
         from hermes_cli.memory_setup import memory_command
 

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -70,6 +70,27 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         default=None,
         help="Override the Jaccard similarity threshold for DUPLICATE flags.",
     )
+
+    # Conflict detection (#908): flag pairs of notes that claim different
+    # values for the same topic instead of silently letting the agent trust
+    # whichever one it read last.
+    _conflicts_parser = memory_sub.add_parser(
+        "conflicts",
+        help="Detect memory notes with contradictory claims about the same topic",
+    )
+    _conflicts_parser.add_argument(
+        "--topic-similarity-threshold",
+        type=float,
+        default=None,
+        help="Override the Jaccard similarity threshold for 'same topic' (default 0.6).",
+    )
+    _conflicts_parser.add_argument(
+        "--value-similarity-threshold",
+        type=float,
+        default=None,
+        help="Override the Jaccard similarity threshold below which values "
+        "count as 'different' (default 0.5).",
+    )
     _reset_parser = memory_sub.add_parser(
         "reset",
         help="Erase all built-in memory (MEMORY.md and USER.md)",

--- a/tests/agent/test_memory_conflicts.py
+++ b/tests/agent/test_memory_conflicts.py
@@ -1,0 +1,306 @@
+"""Tests for conflict-preserving memory detection (#908).
+
+Covers the pure analysis in ``agent/memory_conflicts`` and the real wiring
+into ``agent/memory_manager.MemoryManager``.
+
+Only stdlib + pytest + unittest.mock. No live network calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.memory_conflicts import (  # noqa: E402
+    DEFAULT_CONFIG,
+    ConflictReport,
+    MemoryConflict,
+    Note,
+    analyze_conflicts,
+    detect_conflicts,
+    render_conflict_report,
+    split_claim,
+)
+
+
+# ── split_claim ────────────────────────────────────────────────────────────────────
+
+
+def test_split_claim_colon():
+    assert split_claim("Deploy target: staging") == ("Deploy target", "staging")
+
+
+def test_split_claim_is():
+    assert split_claim("Favorite color is blue") == ("Favorite color", "blue")
+
+
+def test_split_claim_are():
+    assert split_claim("Tests are passing") == ("Tests", "passing")
+
+
+def test_split_claim_equals():
+    assert split_claim("timeout = 30s") == ("timeout", "30s")
+
+
+def test_split_claim_prefers():
+    assert split_claim("User prefers dark mode") == ("User", "dark mode")
+
+
+def test_split_claim_colon_priority_over_is():
+    # Colon is tried first even when "is" also appears.
+    assert split_claim("Status: build is green") == ("Status", "build is green")
+
+
+def test_split_claim_no_separator():
+    assert split_claim("A plain sentence with no structure") is None
+
+
+def test_split_claim_empty_topic():
+    assert split_claim(": staging") is None
+
+
+def test_split_claim_empty_value():
+    assert split_claim("Deploy target:") is None
+
+
+def test_split_claim_empty_string():
+    assert split_claim("") is None
+
+
+# ── detect_conflicts ─────────────────────────────────────────────────────────────
+
+
+def test_detect_conflicts_flags_same_topic_different_value():
+    a = Note(id="a", title="Deploy target: staging", content="")
+    b = Note(id="b", title="Deploy target: production", content="")
+    conflicts = detect_conflicts([a, b])
+    assert len(conflicts) == 1
+    c = conflicts[0]
+    assert c.note_a_id == "a"
+    assert c.note_b_id == "b"
+    assert c.value_a == "staging"
+    assert c.value_b == "production"
+    assert c.topic_similarity >= DEFAULT_CONFIG["topic_similarity_threshold"]
+    assert c.value_similarity < DEFAULT_CONFIG["value_similarity_threshold"]
+
+
+def test_detect_conflicts_is_order_independent():
+    a = Note(id="z-note", title="Deploy target: staging", content="")
+    b = Note(id="a-note", title="Deploy target: production", content="")
+    forward = detect_conflicts([a, b])
+    backward = detect_conflicts([b, a])
+    assert len(forward) == len(backward) == 1
+    # note_a_id is always the lexicographically smaller id, regardless of
+    # traversal order.
+    assert forward[0].note_a_id == "a-note"
+    assert backward[0].note_a_id == "a-note"
+
+
+def test_detect_conflicts_same_value_is_not_a_conflict():
+    # Same topic, same value (a near-duplicate claim, not a conflict) — that's
+    # memory_staleness.detect_duplicates' territory, not this module's.
+    a = Note(id="a", title="Deploy target: staging", content="")
+    b = Note(id="b", title="Deploy target: staging", content="")
+    assert detect_conflicts([a, b]) == []
+
+
+def test_detect_conflicts_different_topic_no_conflict():
+    a = Note(id="a", title="Deploy target: staging", content="")
+    b = Note(id="b", title="Favorite color: blue", content="")
+    assert detect_conflicts([a, b]) == []
+
+
+def test_detect_conflicts_skips_notes_without_claim_structure():
+    a = Note(id="a", title="Deploy target: staging", content="")
+    b = Note(id="b", title="A free-form note with no structure", content="")
+    assert detect_conflicts([a, b]) == []
+
+
+def test_detect_conflicts_skips_deprecated():
+    a = Note(id="a", title="Deploy target: staging", content="", deprecated=True)
+    b = Note(id="b", title="Deploy target: production", content="")
+    assert detect_conflicts([a, b]) == []
+
+
+def test_detect_conflicts_skips_empty_value_word_set():
+    # "---" strips to a non-empty string (passes split_claim) but tokenizes
+    # to an empty word set (no alnum characters) — nothing to compare.
+    a = Note(id="a", title="Deploy target: ---", content="")
+    b = Note(id="b", title="Deploy target: production", content="")
+    assert detect_conflicts([a, b]) == []
+
+
+def test_detect_conflicts_no_pair_among_single_note():
+    a = Note(id="a", title="Deploy target: staging", content="")
+    assert detect_conflicts([a]) == []
+
+
+def test_detect_conflicts_config_overrides_thresholds():
+    a = Note(id="a", title="Deploy target: staging", content="")
+    b = Note(id="b", title="Deploy target: production", content="")
+    # An absurdly high value_similarity_threshold makes even very different
+    # values fail to register as a conflict (nothing is "different enough").
+    conflicts = detect_conflicts([a, b], config={"value_similarity_threshold": 0.0})
+    assert conflicts == []
+
+
+# ── analyze_conflicts ────────────────────────────────────────────────────────────
+
+
+def test_analyze_conflicts_returns_report():
+    notes = [
+        Note(id="a", title="Deploy target: staging", content=""),
+        Note(id="b", title="Deploy target: production", content=""),
+        Note(id="c", title="A free-form note", content=""),
+    ]
+    report = analyze_conflicts(notes)
+    assert isinstance(report, ConflictReport)
+    assert report.total_notes == 3
+    assert report.total_claims == 2
+    assert len(report.conflicts) == 1
+
+
+def test_analyze_conflicts_empty():
+    report = analyze_conflicts([])
+    assert report.total_notes == 0
+    assert report.total_claims == 0
+    assert report.conflicts == []
+
+
+def test_analyze_conflicts_passes_config_through():
+    notes = [
+        Note(id="a", title="Deploy target: staging", content=""),
+        Note(id="b", title="Deploy target: production", content=""),
+    ]
+    report = analyze_conflicts(notes, config={"value_similarity_threshold": 0.0})
+    assert report.conflicts == []
+    assert report.config["value_similarity_threshold"] == 0.0
+
+
+# ── render_conflict_report ───────────────────────────────────────────────────────
+
+
+def test_render_conflict_report_contains_sections():
+    notes = [
+        Note(id="a", title="Deploy target: staging", content=""),
+        Note(id="b", title="Deploy target: production", content=""),
+    ]
+    report = analyze_conflicts(notes)
+    md = render_conflict_report(report)
+    assert "# Memory Conflict Report" in md
+    assert "## Conflicts" in md
+    assert "CONFLICT" in md
+    assert "`a`" in md and "`b`" in md
+
+
+def test_render_conflict_report_empty_corpus():
+    report = analyze_conflicts([])
+    md = render_conflict_report(report)
+    assert "# Memory Conflict Report" in md
+    assert "Total notes inspected: **0**" in md
+
+
+def test_render_conflict_report_no_conflicts():
+    notes = [Note(id="a", title="Deploy target: staging", content="")]
+    report = analyze_conflicts(notes)
+    md = render_conflict_report(report)
+    assert "No conflicting claims detected" in md
+
+
+# ── MemoryManager wiring (#908) ───────────────────────────────────────────────────
+#
+# These verify the REAL call site: MemoryManager.detect_memory_conflicts() must
+# actually invoke agent.memory_conflicts.analyze_conflicts() on notes collected
+# from the on-disk memory store — not just import it.
+
+
+def test_detect_memory_conflicts_invokes_analyze_on_real_notes(monkeypatch):
+    """detect_memory_conflicts() must call analyze_conflicts() with collected notes."""
+    from agent.memory_manager import MemoryManager
+    import agent.memory_conflicts as mc
+
+    mm = MemoryManager()
+
+    fake_notes = [
+        Note(id="memory-0", title="Deploy target: staging", content=""),
+        Note(id="memory-1", title="Deploy target: production", content=""),
+    ]
+
+    captured: dict = {}
+    real_analyze = mc.analyze_conflicts  # save before monkeypatching
+
+    def fake_analyze(notes, *, config=None):
+        captured["notes"] = list(notes)
+        captured["config"] = config
+        return real_analyze(notes, config=config)
+
+    monkeypatch.setattr(mm, "collect_notes", lambda: fake_notes)
+    monkeypatch.setattr(mc, "analyze_conflicts", fake_analyze)
+
+    report = mm.detect_memory_conflicts()
+    assert isinstance(report, ConflictReport)
+    assert captured["notes"] == fake_notes
+    assert report.total_notes == 2
+    assert len(report.conflicts) == 1
+
+
+def test_detect_memory_conflicts_passes_config_through(monkeypatch):
+    from agent.memory_manager import MemoryManager
+    import agent.memory_conflicts as mc
+
+    mm = MemoryManager()
+    captured: dict = {}
+    real_analyze = mc.analyze_conflicts  # save before monkeypatching
+
+    def fake_analyze(notes, *, config=None):
+        captured["config"] = config
+        return real_analyze(notes, config=config)
+
+    monkeypatch.setattr(mm, "collect_notes", lambda: [])
+    monkeypatch.setattr(mc, "analyze_conflicts", fake_analyze)
+
+    mm.detect_memory_conflicts(config={"topic_similarity_threshold": 0.9})
+    assert captured["config"] == {"topic_similarity_threshold": 0.9}
+
+
+def test_detect_memory_conflicts_empty_corpus(monkeypatch):
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    monkeypatch.setattr(mm, "collect_notes", lambda: [])
+    report = mm.detect_memory_conflicts()
+    assert report.total_notes == 0
+    assert report.conflicts == []
+
+
+def test_render_memory_conflicts_produces_markdown(monkeypatch):
+    """render_memory_conflicts() must call detect_memory_conflicts() and render markdown."""
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    monkeypatch.setattr(
+        mm,
+        "collect_notes",
+        lambda: [
+            Note(id="memory-0", title="Deploy target: staging", content=""),
+            Note(id="memory-1", title="Deploy target: production", content=""),
+        ],
+    )
+    md = mm.render_memory_conflicts()
+    assert "# Memory Conflict Report" in md
+    assert "CONFLICT" in md
+
+
+def test_collect_notes_reused_by_conflict_detection(monkeypatch):
+    """detect_memory_conflicts() must read the real on-disk store, not a stub."""
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+
+    class _FakeStore:
+        memory_entries = ["Deploy target: staging", "Deploy target: production"]
+        user_entries = []
+
+    monkeypatch.setattr("tools.memory_tool.load_on_disk_store", lambda: _FakeStore())
+    report = mm.detect_memory_conflicts()
+    assert report.total_notes == 2
+    assert len(report.conflicts) == 1

--- a/tests/agent/test_memory_conflicts.py
+++ b/tests/agent/test_memory_conflicts.py
@@ -95,6 +95,24 @@ def test_detect_conflicts_is_order_independent():
     assert backward[0].note_a_id == "a-note"
 
 
+def test_detect_conflicts_list_is_sorted_regardless_of_traversal_order():
+    # With more than one conflict, the *list* itself must also be
+    # order-independent, not just the id ordering within each MemoryConflict.
+    notes_forward = [
+        Note(id="c-note", title="Deploy target: staging", content=""),
+        Note(id="d-note", title="Deploy target: production", content=""),
+        Note(id="a-note", title="Favorite color: blue", content=""),
+        Note(id="b-note", title="Favorite color: red", content=""),
+    ]
+    notes_backward = list(reversed(notes_forward))
+    forward = detect_conflicts(notes_forward)
+    backward = detect_conflicts(notes_backward)
+    assert len(forward) == len(backward) == 2
+    forward_pairs = [(c.note_a_id, c.note_b_id) for c in forward]
+    backward_pairs = [(c.note_a_id, c.note_b_id) for c in backward]
+    assert forward_pairs == backward_pairs == sorted(forward_pairs)
+
+
 def test_detect_conflicts_same_value_is_not_a_conflict():
     # Same topic, same value (a near-duplicate claim, not a conflict) — that's
     # memory_staleness.detect_duplicates' territory, not this module's.
@@ -137,8 +155,9 @@ def test_detect_conflicts_no_pair_among_single_note():
 def test_detect_conflicts_config_overrides_thresholds():
     a = Note(id="a", title="Deploy target: staging", content="")
     b = Note(id="b", title="Deploy target: production", content="")
-    # An absurdly high value_similarity_threshold makes even very different
-    # values fail to register as a conflict (nothing is "different enough").
+    # Jaccard similarity is always >= 0.0, so a value_similarity_threshold of
+    # 0.0 means "value_sim >= 0.0" is always true — no pair can ever be
+    # "different enough" to register as a conflict.
     conflicts = detect_conflicts([a, b], config={"value_similarity_threshold": 0.0})
     assert conflicts == []
 
@@ -174,6 +193,19 @@ def test_analyze_conflicts_passes_config_through():
     report = analyze_conflicts(notes, config={"value_similarity_threshold": 0.0})
     assert report.conflicts == []
     assert report.config["value_similarity_threshold"] == 0.0
+
+
+def test_analyze_conflicts_total_claims_excludes_empty_word_set():
+    # "Deploy target: ---" passes split_claim (non-empty topic/value strings)
+    # but "---" tokenizes to an empty word set, so detect_conflicts() cannot
+    # use it as a claim. total_claims must reflect that same exclusion
+    # rather than counting it as a usable claim.
+    notes = [
+        Note(id="a", title="Deploy target: staging", content=""),
+        Note(id="b", title="Deploy target: ---", content=""),
+    ]
+    report = analyze_conflicts(notes)
+    assert report.total_claims == 1
 
 
 # ── render_conflict_report ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #908

## Summary

Implements the smallest well-scoped, tested slice of #908's "conflict-preserving memory" proposal: **deterministic detection of contradictory memory claims**, surfaced instead of silently lost.

- `agent/memory_conflicts.py` (new): a pure, side-effect-free analysis module mirroring `agent/memory_staleness.py`'s established pattern. Splits each note's title into a `(topic, value)` pair on a recognized separator (`:`, ` is `, ` are `, `=`, ` prefers `), then flags a pair as conflicting when topic word-set Jaccard similarity is ≥ 0.6 but value similarity is < 0.5 (e.g. `"Deploy target: staging"` vs `"Deploy target: production"`). Both notes are always left untouched — this is analysis only, never a mutation. Conflict pairs use canonical `(note_a_id, note_b_id)` ordering and the returned list is sorted, so results are fully deterministic regardless of input traversal order.
- `agent/memory_manager.py`: wires it in as a real consumer — `MemoryManager.detect_memory_conflicts()` (collects notes via the existing `collect_notes()`, same source `check_staleness()` uses) and `render_memory_conflicts()` (markdown rendering), following the exact pattern of the existing staleness methods.
- `hermes_cli/subcommands/memory.py` + `hermes_cli/main.py`: new `hermes memory conflicts` CLI subcommand (with `--topic-similarity-threshold` / `--value-similarity-threshold` overrides), matching the `hermes memory stale` subcommand's parser/dispatch convention exactly (including the same lack of `[0,1]` bounds validation on threshold args, since `stale`'s `--duplicate-jaccard-threshold` has none either).
- `tests/agent/test_memory_conflicts.py` (new, 32 tests): `split_claim` separator priority/edge cases; `detect_conflicts` (order-independence of both individual pairs and the full multi-conflict list, same-value-is-not-a-conflict, different-topic, deprecated notes skipped, empty-value-word-set edge case, config overrides); `analyze_conflicts`; `render_conflict_report`; and `MemoryManager` wiring tests that monkeypatch `collect_notes()`/`analyze_conflicts()` to prove the real call chain down to the on-disk store loader (not just an import).

## A note on the issue's framing

The issue states conflicts are "resolved by silent overwrite (last write wins)." Reading `tools/memory_tool.py` shows `MemoryStore.add()` is strictly append-only and never overwrites — only `replace()` does, and only via explicit `old_text` substring matching. So nothing is silently *lost* today. The actual gap — which this PR closes — is that contradictory entries sit side-by-side on disk with no signal that they disagree; an agent (or human) reading the corpus has no way to tell "conflict" from "two unrelated notes."

## Verification

- `pytest tests/agent/test_memory_conflicts.py -q` → **32 passed**
- Targeted regression (every memory-related test module + the CLI subcommand smoke test): `pytest tests/agent/test_memory_async_sync.py tests/agent/test_memory_conflicts.py tests/agent/test_memory_importance.py tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py tests/agent/test_memory_skill_scaffolding.py tests/agent/test_memory_staleness.py tests/agent/test_memory_user_id.py tests/agent/test_memory_write_bridge.py tests/hermes_cli/test_subcommands_followup.py -q` → **293 passed**
- `ruff check` on all changed/new files → **All checks passed!**
- `ruff format` applied to the two new files only (pre-existing files were left untouched — `ruff format --diff` showed only pre-existing, unrelated formatting drift in `agent/memory_manager.py`/`hermes_cli/main.py` that this PR does not touch; CI's blocking lint job only runs `ruff check .`, not `ruff format --check`).
- Manual CLI smoke test: `python -m hermes_cli.main memory conflicts` runs cleanly against the real on-disk memory store.
- Independent peer review (`consult --panel agy,grok --review` on the initial diff; grok's session hit a 403 auth error, agy/Gemini returned PASS) caught two real issues, both fixed in a follow-up commit: `total_claims` was using a looser eligibility filter than `detect_conflicts()` (now shares one `_extract_claims()` helper), and the conflicts list wasn't fully sorted for multi-conflict determinism (now sorted by `(note_a_id, note_b_id)`). Also fixed an inverted test comment the review caught.

## Out of scope

- Live write-path integration into `MemoryStore.add()`/`replace()` (this PR is read-time analysis only, by design — matches the "smallest valuable slice" scope).
- Semantic/embedding-based topic matching beyond the Jaccard word-set heuristic (documented limitation: e.g. `"30s"` vs `"30 seconds"` won't match).
- The full StateFuse framework from the issue (`claim_id` fields, correction handles, projection-time resolution, safer abstention, CRDT/OpSet foundation) — explicitly out of scope per the task brief; this PR ships the detection primitive the rest of that framework would build on.