### PR TITLE
feat(#740): core evidence-tree model and replay API

### DIFF
--- a/agent/recursive_evidence.py
+++ b/agent/recursive_evidence.py
@@ -1,0 +1,294 @@
+"""Core evidence-tree model and replay API for recursive evidence reasoning.
+
+This module is a standalone, import-safe data model. It records *claims* and
+the *supporting passages* that back them as nodes in a tree, where each node
+links to the parent claim it refines and to the child claims derived from it.
+``EvidenceReplayBuffer`` builds those nodes directly from real tool-result
+turns (the OpenAI-style ``{"role": "tool", "name": ..., "content": ...}`` shape
+produced by :func:`agent.tool_dispatch_helpers.make_tool_result_message`), so
+the buffer never invents its own turn shape.
+
+``replay_evidence_path`` answers the reasoning question "why do we believe this
+claim?" by returning the minimal chain from a matching claim back to the root
+evidence it descends from.
+
+Nothing here touches the live conversation loop — wiring is a follow-up. The
+model is pure and unit-testable:
+
+    buffer = EvidenceReplayBuffer()
+    root = buffer.add_claim("investigation start")
+    node = buffer.ingest_tool_result(turn, "grep found the bug", parent_id=root.node_id)
+    chain = buffer.replay_evidence_path("the bug")  # [node, root]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from agent.message_content import flatten_message_text
+
+
+def _clamp01(value: float) -> float:
+    """Clamp a confidence score into the inclusive ``[0.0, 1.0]`` range."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if score < 0.0:
+        return 0.0
+    if score > 1.0:
+        return 1.0
+    return score
+
+
+@dataclass
+class EvidenceNode:
+    """A single claim in the evidence tree.
+
+    Attributes
+    ----------
+    node_id:
+        Stable identifier, unique within a single buffer.
+    claim:
+        The assertion this node represents.
+    supporting_passages:
+        Text passages (typically extracted from a tool result) that back the
+        claim. May be empty for a purely structural / intermediate claim.
+    parent_id:
+        ``node_id`` of the claim this one refines, or ``None`` for a root.
+    children_ids:
+        ``node_id`` of each claim derived from this one. Maintained by the
+        owning :class:`EvidenceReplayBuffer`; do not mutate directly.
+    confidence:
+        How strongly the passages support the claim, clamped to ``[0.0, 1.0]``.
+    source:
+        Optional provenance label, e.g. the name of the tool whose result
+        produced the node.
+    """
+
+    node_id: str
+    claim: str
+    supporting_passages: list[str] = field(default_factory=list)
+    parent_id: Optional[str] = None
+    children_ids: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    source: Optional[str] = None
+
+    @property
+    def is_root(self) -> bool:
+        """True when this node has no parent claim."""
+        return self.parent_id is None
+
+
+def _passages_from_turn(turn: dict[str, Any]) -> list[str]:
+    """Extract supporting passages from a tool-result turn's content.
+
+    Mirrors how the rest of the codebase reads message content: string content
+    becomes a single passage; list content (multimodal parts) yields one
+    passage per non-empty text part, skipping image/audio parts. Uses
+    :func:`agent.message_content.flatten_message_text` so the extraction stays
+    consistent with the provider-facing shape.
+    """
+    content = turn.get("content")
+    if isinstance(content, list):
+        passages: list[str] = []
+        for part in content:
+            # Wrap each part in a one-element list so flatten_message_text
+            # routes it through its list branch, which drops non-text parts
+            # (images/audio) instead of stringifying them.
+            text = flatten_message_text([part]).strip()
+            if text:
+                passages.append(text)
+        return passages
+    text = flatten_message_text(content).strip()
+    return [text] if text else []
+
+
+class EvidenceReplayBuffer:
+    """A lightweight, in-memory evidence tree.
+
+    Nodes are keyed by ``node_id`` and linked into one or more trees (a forest
+    is allowed — each node whose ``parent_id`` is ``None`` roots its own tree).
+    Insertion order is preserved so replay is deterministic.
+    """
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, EvidenceNode] = {}
+        self._order: list[str] = []
+        self._counter: int = 0
+
+    # ── inserts ──────────────────────────────────────────────────────────
+
+    def _next_id(self) -> str:
+        self._counter += 1
+        return f"node-{self._counter}"
+
+    def add_claim(
+        self,
+        claim: str,
+        *,
+        parent_id: Optional[str] = None,
+        node_id: Optional[str] = None,
+        supporting_passages: Optional[list[str]] = None,
+        confidence: float = 1.0,
+        source: Optional[str] = None,
+    ) -> EvidenceNode:
+        """Insert a claim node and link it under ``parent_id`` (if given).
+
+        Parameters
+        ----------
+        claim:
+            The assertion to record.
+        parent_id:
+            Existing node to attach under; ``None`` makes this a root.
+        node_id:
+            Explicit id; auto-generated when omitted.
+        supporting_passages:
+            Backing passages. Copied so the caller's list is not aliased.
+        confidence:
+            Clamped into ``[0.0, 1.0]``.
+        source:
+            Optional provenance label.
+
+        Raises
+        ------
+        ValueError
+            If ``node_id`` already exists, or ``parent_id`` is unknown.
+        """
+        if node_id is None:
+            node_id = self._next_id()
+        elif node_id in self._nodes:
+            raise ValueError(f"duplicate node_id: {node_id!r}")
+
+        if parent_id is not None and parent_id not in self._nodes:
+            raise ValueError(f"unknown parent_id: {parent_id!r}")
+
+        node = EvidenceNode(
+            node_id=node_id,
+            claim=claim,
+            supporting_passages=list(supporting_passages or []),
+            parent_id=parent_id,
+            confidence=_clamp01(confidence),
+            source=source,
+        )
+        self._nodes[node_id] = node
+        self._order.append(node_id)
+        if parent_id is not None:
+            self._nodes[parent_id].children_ids.append(node_id)
+        return node
+
+    def ingest_tool_result(
+        self,
+        turn: dict[str, Any],
+        claim: str,
+        *,
+        parent_id: Optional[str] = None,
+        node_id: Optional[str] = None,
+        confidence: float = 1.0,
+    ) -> EvidenceNode:
+        """Build a node from a tool-result turn, backing ``claim``.
+
+        ``turn`` must be a tool-result message (``role == "tool"``), the shape
+        emitted by :func:`agent.tool_dispatch_helpers.make_tool_result_message`.
+        Its content becomes the node's supporting passages and its tool name
+        becomes the node's ``source``.
+
+        Raises
+        ------
+        ValueError
+            If ``turn`` is not a tool-result turn.
+        """
+        if not isinstance(turn, dict) or turn.get("role") != "tool":
+            raise ValueError(
+                "ingest_tool_result expects a tool-result turn (role='tool')"
+            )
+
+        source = turn.get("name") or turn.get("tool_name")
+        return self.add_claim(
+            claim,
+            parent_id=parent_id,
+            node_id=node_id,
+            supporting_passages=_passages_from_turn(turn),
+            confidence=confidence,
+            source=str(source) if source is not None else None,
+        )
+
+    # ── accessors ────────────────────────────────────────────────────────
+
+    def get(self, node_id: str) -> Optional[EvidenceNode]:
+        """Return the node for ``node_id`` or ``None`` if absent."""
+        return self._nodes.get(node_id)
+
+    def roots(self) -> list[EvidenceNode]:
+        """Return every root node, in insertion order."""
+        return [self._nodes[nid] for nid in self._order if self._nodes[nid].is_root]
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def __contains__(self, node_id: object) -> bool:
+        return node_id in self._nodes
+
+    # ── replay ───────────────────────────────────────────────────────────
+
+    def _path_to_root(self, node: EvidenceNode) -> list[EvidenceNode]:
+        """Walk parent links from ``node`` up to its root.
+
+        Returns ``[node, parent, ..., root]``. Guards against cycles so a
+        corrupted ``parent_id`` chain cannot loop forever.
+        """
+        path: list[EvidenceNode] = []
+        seen: set[str] = set()
+        current: Optional[EvidenceNode] = node
+        while current is not None and current.node_id not in seen:
+            path.append(current)
+            seen.add(current.node_id)
+            if current.parent_id is None:
+                break
+            current = self._nodes.get(current.parent_id)
+        return path
+
+    def _matching_nodes(self, query: str) -> list[EvidenceNode]:
+        """Return claim nodes matching ``query``, in insertion order.
+
+        A node matches when the normalized query is contained in the normalized
+        claim (case-insensitive; substring covers exact equality). Empty queries
+        match nothing.
+        """
+        needle = (query or "").strip().casefold()
+        if not needle:
+            return []
+        matches: list[EvidenceNode] = []
+        for nid in self._order:
+            node = self._nodes[nid]
+            claim = node.claim.strip().casefold()
+            if needle in claim:
+                matches.append(node)
+        return matches
+
+    def replay_evidence_path(self, query: str) -> list[EvidenceNode]:
+        """Return the minimal claim-to-root chain for a claim matching ``query``.
+
+        The chain is ordered ``[matched_claim, parent, ..., root]``. When the
+        query matches claims in several branches, the shortest chain to a root
+        wins (ties broken by insertion order). Returns an empty list when the
+        buffer is empty or nothing matches.
+        """
+        best: Optional[list[EvidenceNode]] = None
+        for node in self._matching_nodes(query):
+            path = self._path_to_root(node)
+            if best is None or len(path) < len(best):
+                best = path
+        return best if best is not None else []
+
+
+def replay_evidence_path(
+    buffer: EvidenceReplayBuffer, query: str
+) -> list[EvidenceNode]:
+    """Module-level replay API: the minimal claim-to-root chain in ``buffer``.
+
+    Thin wrapper over :meth:`EvidenceReplayBuffer.replay_evidence_path` for
+    callers that prefer a free function over a method.
+    """
+    return buffer.replay_evidence_path(query)

--- a/tests/agent/test_recursive_evidence.py
+++ b/tests/agent/test_recursive_evidence.py
@@ -1,0 +1,247 @@
+"""Tests for agent.recursive_evidence — evidence-tree model and replay API."""
+
+import pytest
+
+from agent.recursive_evidence import (
+    EvidenceNode,
+    EvidenceReplayBuffer,
+    replay_evidence_path,
+)
+
+
+def _tool_turn(content, name="grep", tool_call_id="call-1"):
+    """Build a tool-result turn matching make_tool_result_message's shape."""
+    return {
+        "role": "tool",
+        "name": name,
+        "tool_name": name,
+        "content": content,
+        "tool_call_id": tool_call_id,
+    }
+
+
+# ── EvidenceNode ─────────────────────────────────────────────────────────
+
+
+class TestEvidenceNode:
+    def test_defaults(self):
+        node = EvidenceNode(node_id="n1", claim="a claim")
+        assert node.supporting_passages == []
+        assert node.children_ids == []
+        assert node.parent_id is None
+        assert node.confidence == 1.0
+        assert node.source is None
+
+    def test_is_root(self):
+        root = EvidenceNode(node_id="n1", claim="root")
+        child = EvidenceNode(node_id="n2", claim="child", parent_id="n1")
+        assert root.is_root is True
+        assert child.is_root is False
+
+
+# ── Tree construction ────────────────────────────────────────────────────
+
+
+class TestTreeConstruction:
+    def test_add_claim_returns_node_and_is_retrievable(self):
+        buf = EvidenceReplayBuffer()
+        node = buf.add_claim("root claim")
+        assert isinstance(node, EvidenceNode)
+        assert buf.get(node.node_id) is node
+        assert len(buf) == 1
+        assert node.node_id in buf
+
+    def test_auto_ids_are_unique(self):
+        buf = EvidenceReplayBuffer()
+        a = buf.add_claim("a")
+        b = buf.add_claim("b")
+        assert a.node_id != b.node_id
+        assert len(buf) == 2
+
+    def test_parent_child_links_are_bidirectional(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("root")
+        child = buf.add_claim("child", parent_id=root.node_id)
+        assert child.parent_id == root.node_id
+        assert child.node_id in root.children_ids
+
+    def test_confidence_is_clamped(self):
+        buf = EvidenceReplayBuffer()
+        assert buf.add_claim("hi", confidence=2.5).confidence == 1.0
+        assert buf.add_claim("lo", confidence=-1.0).confidence == 0.0
+        assert buf.add_claim("mid", confidence=0.4).confidence == 0.4
+
+    def test_supporting_passages_are_copied_not_aliased(self):
+        buf = EvidenceReplayBuffer()
+        passages = ["p1"]
+        node = buf.add_claim("c", supporting_passages=passages)
+        passages.append("p2")
+        assert node.supporting_passages == ["p1"]
+
+    def test_explicit_node_id(self):
+        buf = EvidenceReplayBuffer()
+        node = buf.add_claim("c", node_id="custom")
+        assert node.node_id == "custom"
+
+    def test_duplicate_node_id_raises(self):
+        buf = EvidenceReplayBuffer()
+        buf.add_claim("c", node_id="dup")
+        with pytest.raises(ValueError, match="duplicate node_id"):
+            buf.add_claim("c2", node_id="dup")
+
+    def test_unknown_parent_raises(self):
+        buf = EvidenceReplayBuffer()
+        with pytest.raises(ValueError, match="unknown parent_id"):
+            buf.add_claim("orphan", parent_id="ghost")
+
+    def test_roots_lists_only_roots_in_insertion_order(self):
+        buf = EvidenceReplayBuffer()
+        r1 = buf.add_claim("root one")
+        buf.add_claim("child", parent_id=r1.node_id)
+        r2 = buf.add_claim("root two")
+        roots = buf.roots()
+        assert [n.node_id for n in roots] == [r1.node_id, r2.node_id]
+
+
+# ── Building nodes from tool-result turns ────────────────────────────────
+
+
+class TestIngestToolResult:
+    def test_string_content_becomes_single_passage(self):
+        buf = EvidenceReplayBuffer()
+        turn = _tool_turn("match found at foo.py:42", name="grep")
+        node = buf.ingest_tool_result(turn, "the bug is in foo.py")
+        assert node.supporting_passages == ["match found at foo.py:42"]
+        assert node.source == "grep"
+        assert node.claim == "the bug is in foo.py"
+
+    def test_multimodal_content_yields_one_passage_per_text_part(self):
+        buf = EvidenceReplayBuffer()
+        content = [
+            {"type": "text", "text": "line one"},
+            {"type": "image_url", "image_url": {"url": "data:..."}},
+            {"type": "text", "text": "line two"},
+        ]
+        node = buf.ingest_tool_result(_tool_turn(content), "claim")
+        assert node.supporting_passages == ["line one", "line two"]
+
+    def test_empty_content_yields_no_passages(self):
+        buf = EvidenceReplayBuffer()
+        node = buf.ingest_tool_result(_tool_turn(""), "claim")
+        assert node.supporting_passages == []
+
+    def test_source_falls_back_to_tool_name_key(self):
+        buf = EvidenceReplayBuffer()
+        turn = {"role": "tool", "tool_name": "read_file", "content": "data"}
+        node = buf.ingest_tool_result(turn, "claim")
+        assert node.source == "read_file"
+
+    def test_ingest_links_under_parent(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("investigation")
+        node = buf.ingest_tool_result(
+            _tool_turn("evidence"), "derived claim", parent_id=root.node_id
+        )
+        assert node.parent_id == root.node_id
+        assert node.node_id in root.children_ids
+
+    def test_non_tool_turn_raises(self):
+        buf = EvidenceReplayBuffer()
+        with pytest.raises(ValueError, match="tool-result turn"):
+            buf.ingest_tool_result({"role": "assistant", "content": "x"}, "claim")
+
+    def test_non_dict_turn_raises(self):
+        buf = EvidenceReplayBuffer()
+        with pytest.raises(ValueError, match="tool-result turn"):
+            buf.ingest_tool_result("not a turn", "claim")
+
+
+# ── Path replay ──────────────────────────────────────────────────────────
+
+
+class TestReplayEvidencePath:
+    def test_empty_buffer_returns_empty(self):
+        buf = EvidenceReplayBuffer()
+        assert buf.replay_evidence_path("anything") == []
+
+    def test_no_match_returns_empty(self):
+        buf = EvidenceReplayBuffer()
+        buf.add_claim("the sky is blue")
+        assert buf.replay_evidence_path("quantum gravity") == []
+
+    def test_empty_query_returns_empty(self):
+        buf = EvidenceReplayBuffer()
+        buf.add_claim("some claim")
+        assert buf.replay_evidence_path("") == []
+        assert buf.replay_evidence_path("   ") == []
+
+    def test_single_chain_returns_claim_to_root(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("investigation root")
+        mid = buf.add_claim("intermediate step", parent_id=root.node_id)
+        leaf = buf.add_claim("the target file was modified", parent_id=mid.node_id)
+
+        path = buf.replay_evidence_path("target file")
+        assert [n.node_id for n in path] == [leaf.node_id, mid.node_id, root.node_id]
+        # claim first, root last
+        assert path[0].claim == "the target file was modified"
+        assert path[-1].is_root is True
+
+    def test_matching_root_returns_single_node(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("root evidence claim")
+        path = buf.replay_evidence_path("root evidence")
+        assert [n.node_id for n in path] == [root.node_id]
+
+    def test_case_insensitive_match(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("The Bug Is In Parser")
+        path = buf.replay_evidence_path("bug is in parser")
+        assert path and path[0].node_id == root.node_id
+
+    def test_multi_branch_returns_minimal_path(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("investigation root")
+        # Shallow branch: match at depth 2 (node -> root).
+        shallow = buf.add_claim("search shows the target file", parent_id=root.node_id)
+        # Deep branch: match at depth 3 (node -> mid -> root).
+        mid = buf.add_claim("first drill down", parent_id=root.node_id)
+        deep = buf.add_claim("the target file was patched", parent_id=mid.node_id)
+
+        path = buf.replay_evidence_path("target file")
+        # Both `shallow` and `deep` claims contain "target file"; the shorter
+        # chain (shallow -> root) must win.
+        assert [n.node_id for n in path] == [shallow.node_id, root.node_id]
+        assert deep.node_id not in {n.node_id for n in path}
+
+    def test_module_level_function_delegates(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("root")
+        leaf = buf.add_claim("a distinctive claim", parent_id=root.node_id)
+        path = replay_evidence_path(buf, "distinctive")
+        assert [n.node_id for n in path] == [leaf.node_id, root.node_id]
+
+    def test_cycle_in_parent_links_does_not_hang(self):
+        # Defensive: a corrupted parent chain must not loop forever.
+        buf = EvidenceReplayBuffer()
+        a = buf.add_claim("node a")
+        b = buf.add_claim("node b cyclic", parent_id=a.node_id)
+        a.parent_id = b.node_id  # force a cycle
+        path = buf.replay_evidence_path("cyclic")
+        ids = [n.node_id for n in path]
+        assert len(ids) == len(set(ids))  # each node visited at most once
+
+    def test_replay_over_tool_result_nodes(self):
+        buf = EvidenceReplayBuffer()
+        root = buf.add_claim("root question")
+        buf.ingest_tool_result(
+            _tool_turn("grep: hit in auth.py"),
+            "auth.py contains the vulnerability",
+            parent_id=root.node_id,
+        )
+        path = buf.replay_evidence_path("vulnerability")
+        assert [n.claim for n in path] == [
+            "auth.py contains the vulnerability",
+            "root question",
+        ]
+        assert path[0].supporting_passages == ["grep: hit in auth.py"]


### PR DESCRIPTION
## Summary

Implements the "core model + replay API" slice of #740 (child of #736): a standalone, import-safe evidence-tree data model plus a replay API for recursive evidence reasoning. Model only — deliberately **not** wired into the live conversation loop (that is a follow-up).

New file `agent/recursive_evidence.py`:

- **`EvidenceNode`** dataclass — `claim`, `supporting_passages`, `parent_id` / `children_ids` links, clamped `confidence` score, optional `source` provenance. Plain mutable dataclass matching sibling modules (`VerificationIssue`, `SkillNode`).
- **`EvidenceReplayBuffer`** — a lightweight in-memory tree/forest. `add_claim(...)` inserts and maintains bidirectional parent/child links; `ingest_tool_result(turn, claim, ...)` builds a node from a **real tool-result turn** (the `{"role": "tool", "name": ..., "content": ...}` shape from `agent.tool_dispatch_helpers.make_tool_result_message`), extracting supporting passages via the existing `agent.message_content.flatten_message_text` helper — so the buffer never invents its own turn shape.
- **`replay_evidence_path(query)`** — returns the minimal claim-to-root chain (`[matched_claim, parent, ..., root]`). When a query matches claims across multiple branches at different depths, the shortest chain wins (ties broken by insertion order). Cycle-guarded. Available as a `EvidenceReplayBuffer` method and a module-level convenience wrapper.

## Scope notes

- Pure, import-safe, no new dependencies.
- Does **not** touch the conversation loop / runtime — standalone model + tests only, per the issue's "keep it small and self-contained" (Effort 0.4 / Impact 0.5).

## Tests / lint

- `python -m pytest tests/agent/test_recursive_evidence.py -q` → **28 passed**. Covers tree construction (links, clamping, dup/unknown-parent errors, tool-result ingestion incl. multimodal parts) and path replay edge cases: empty buffer, no-match, empty query, matching root, case-insensitive match, multi-branch minimal path, cycle guard, module-level delegation.
- `ruff check .` → **All checks passed** (repo enforces PLW1514).
- `ruff format --check` on both new files → **already formatted**.

## Independent review

Cross-checked with Gemini (`consult agy`): confirmed the minimal-path logic is correct, all edge cases handled, no blocking bugs. Applied its one legitimate finding (removed a redundant equality check in claim matching, since substring covers it).

Refs #740. Does not close it on its own if the parent tracks further wiring — this is the core-model slice.
