### PR TITLE
feat(#909): model-diverse fact-checking for /verify adversarial verification

### DIFF
--- a/agent/adversarial_verification.py
+++ b/agent/adversarial_verification.py
@@ -289,6 +289,163 @@ def format_verification_result(result: VerificationResult) -> str:
     return "\n".join(lines)
 
 
+# ── Model-family diversity (#909) ────────────────────────────────────────
+
+# Deterministic, offline keyword classifier — no network call, no models.dev
+# lookup. Mirrors the family buckets used by optional-skills/security/godmode/
+# scripts/auto_jailbreak.py::_detect_model_family, but returns the
+# provider/lab name (anthropic/openai/...) rather than a short nickname, so it
+# lines up with the provider names used elsewhere in config (delegation.*,
+# moa.presets.*.reference_models).
+_MODEL_FAMILY_KEYWORDS: list[tuple[str, str]] = [
+    ("claude", "anthropic"),
+    ("anthropic", "anthropic"),
+    ("gpt-", "openai"),
+    ("gpt5", "openai"),
+    ("openai", "openai"),
+    ("o1-", "openai"),
+    ("o3-", "openai"),
+    ("gemini", "google"),
+    ("google", "google"),
+    ("grok", "xai"),
+    ("x-ai", "xai"),
+    ("llama", "meta"),
+    ("meta-llama", "meta"),
+    ("deepseek", "deepseek"),
+    ("qwen", "qwen"),
+    ("mistral", "mistral"),
+    ("mixtral", "mistral"),
+    ("kimi", "moonshot"),
+    ("moonshot", "moonshot"),
+    ("glm", "zhipu"),
+    ("zhipu", "zhipu"),
+    ("minimax", "minimax"),
+    # "luminous" (Aleph Alpha) must precede "nous" — "nous" is a substring of
+    # "luminous", so ordering here prevents a luminous model being misfiled as
+    # the Nous Research family.
+    ("luminous", "alephalpha"),
+    ("nous", "nous"),
+    ("hermes", "nous"),
+]
+
+
+def detect_model_family(model: Optional[str]) -> str:
+    """Classify a model id string by training lab / provider family.
+
+    Deterministic keyword matching on the model id (no network lookup) — a
+    model is in the same family regardless of which provider/base_url routes
+    it (e.g. "anthropic/claude-opus-4.8" via OpenRouter and "claude-opus-4-6"
+    via the native Anthropic API are both family "anthropic"). Returns
+    "unknown" for unrecognized or empty model ids.
+    """
+    if not model:
+        return "unknown"
+    model_lower = model.lower()
+    for keyword, family in _MODEL_FAMILY_KEYWORDS:
+        if keyword in model_lower:
+            return family
+    return "unknown"
+
+
+def resolve_verifier_model(
+    generator_model: Optional[str], verifier_config: Optional[dict] = None
+) -> dict:
+    """Resolve whether adversarial verification will run cross-family (#909).
+
+    Same-model-family generator+verifier pairs share blind spots: research
+    shows cross-family verification catches ~45% of harmful approvals vs ~6%
+    for same-family, and raw self-consistency/agreement is a weak correctness
+    signal (rho 0.20-0.59), worst for frontier models (77% agreement, 48%
+    wrong on GPQA). This inspects the ``auxiliary.adversarial_verification``
+    config the caller passes to ``call_llm(task="adversarial_verification",
+    ...)`` and reports whether the resulting call is expected to land on the
+    SAME model family as the solution's generator, so the caller can surface
+    a warning.
+
+    This function does not itself pick a model or resolve credentials — that
+    stays in ``agent.auxiliary_client.call_llm`` /
+    ``hermes_cli.runtime_provider.resolve_runtime_provider``, the existing
+    single source of truth for provider/model/base_url resolution. It only
+    answers "will this probably be the same family?" from the configured
+    values, matching how that resolver treats an empty model as "inherit the
+    main runtime" (i.e. the same model as the generator).
+
+    Parameters
+    ----------
+    generator_model : str, optional
+        The model id that produced the solution under verification.
+    verifier_config : dict, optional
+        The ``auxiliary.adversarial_verification`` config section (only
+        ``model``/``provider`` are read; other keys are ignored here).
+
+    Returns
+    -------
+    dict
+        ``model`` (the configured override, "" if none), ``provider`` (the
+        configured override, "" if none), ``generator_family``,
+        ``verifier_family`` ("unknown" when it can't be determined), and
+        ``cross_family`` (True/False, or None when it can't be determined —
+        e.g. an explicit multi-model provider override such as "openrouter"
+        with no explicit model, whose default model's family is unknown
+        without a live provider lookup).
+    """
+    cfg = verifier_config or {}
+    configured_model = str(cfg.get("model") or "").strip()
+    configured_provider = str(cfg.get("provider") or "").strip()
+    generator_family = detect_model_family(generator_model)
+
+    if configured_model:
+        verifier_family = detect_model_family(configured_model)
+        if generator_model and configured_model.lower() == str(generator_model).lower():
+            # Same exact model string — same blind spots — regardless of
+            # whether we recognize the family (catches identical unrecognized
+            # models that both classify as "unknown").
+            cross_family = False
+        elif verifier_family != "unknown" and generator_family != "unknown":
+            cross_family = verifier_family != generator_family
+        else:
+            cross_family = None
+        return {
+            "model": configured_model,
+            "provider": configured_provider,
+            "generator_family": generator_family,
+            "verifier_family": verifier_family,
+            "cross_family": cross_family,
+        }
+
+    if configured_provider and configured_provider.lower() != "auto":
+        # A provider override with no explicit model: the real call uses that
+        # provider's default model. For single-family providers the provider
+        # name itself identifies the family (e.g. "anthropic", "openai",
+        # "google"); multi-model aggregators (e.g. "openrouter") classify as
+        # "unknown" and degrade to cross_family=None rather than a guess.
+        verifier_family = detect_model_family(configured_provider)
+        cross_family = (
+            verifier_family != generator_family
+            if verifier_family != "unknown" and generator_family != "unknown"
+            else None
+        )
+        return {
+            "model": "",
+            "provider": configured_provider,
+            "generator_family": generator_family,
+            "verifier_family": verifier_family,
+            "cross_family": cross_family,
+        }
+
+    # No override at all ("auto"/empty): the auxiliary task resolver inherits
+    # the main runtime, i.e. the SAME model as the generator. That is
+    # same-family whenever a generator model exists at all — even if its family
+    # is unrecognized, since the verifier runs on that exact same model.
+    return {
+        "model": "",
+        "provider": "",
+        "generator_family": generator_family,
+        "verifier_family": generator_family,
+        "cross_family": False if generator_model else None,
+    }
+
+
 # ── Public API ───────────────────────────────────────────────────────────
 
 

--- a/cli.py
+++ b/cli.py
@@ -9235,9 +9235,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _handle_verify_command(self):
         """Run adversarial verification on the last agent response.
 
-        Spawns a verifier subagent via delegate_task with an adversarial
-        system prompt. The verifier reviews the last agent response for
-        flaws and reports a verdict.
+        Runs a one-shot LLM call with an adversarial system prompt against
+        the last agent response, routed through the
+        ``auxiliary.adversarial_verification`` config (see call_llm) so it
+        can run on a different model/provider than the one that generated
+        the response — same-model-family verification shares blind spots
+        with the solution it's checking (#909).
         """
         # Find the last assistant message in conversation history
         last_response = ""
@@ -9273,6 +9276,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 get_verifier_system_prompt,
                 parse_verifier_output,
                 format_verification_result,
+                resolve_verifier_model,
             )
         except ImportError:
             self._console_print("  (x) Adversarial verification module not available.")
@@ -9286,10 +9290,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         )
         verifier_system = get_verifier_system_prompt()
 
-        # Use the agent's chat method to get a verification — this runs
-        # a fresh LLM call with the adversarial system prompt, which is
-        # the simplest way to get a verification without touching the
-        # agent loop's tool-calling machinery.
+        # A one-shot LLM call with the adversarial system prompt, deliberately
+        # bypassing the agent loop's tool-calling machinery (see call_llm below).
         if not self.agent:
             self._console_print("  (x) No active agent to run verification.")
             return
@@ -9297,32 +9299,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._console_print("  (⚡) Running adversarial verification...")
 
         try:
-            # Save the current system prompt and temporarily swap it
-            # for the adversarial verifier prompt. This gives the
-            # verifier a fresh context with opposing incentives.
-            # We use a simple chat() call (no tools) to get the verdict.
-            original_system = getattr(self.agent, "system_message", None)
-
             # Build a minimal conversation for the verifier
             verify_messages = [
                 {"role": "system", "content": verifier_system},
                 {"role": "user", "content": verifier_prompt},
             ]
 
-            # Use the agent's client directly for a one-shot verification
-            # call — no tool calling, no iteration, just a verdict.
-            import json as _json
-            client = self.agent._get_client() if hasattr(self.agent, "_get_client") else None
-            if client is None:
-                # Fall back to chat() which is simpler but may include tools
-                verdict_text = self.agent.chat(verifier_prompt)
-            else:
-                response = client.chat.completions.create(
-                    model=self.agent.model,
-                    messages=verify_messages,
-                    temperature=0.3,  # low temp for focused analysis
+            # Resolve whether verification will run same-family as the
+            # generator (#909) and warn the user when it will — same-family
+            # verification shares blind spots with the solution it's
+            # checking (research: ~6% harmful-approval reduction same-family
+            # vs ~45% cross-family).
+            verifier_cfg = CLI_CONFIG.get("auxiliary", {}).get(
+                "adversarial_verification", {}
+            )
+            resolution = resolve_verifier_model(
+                getattr(self.agent, "model", None), verifier_cfg
+            )
+            if resolution["cross_family"] is False:
+                self._console_print(
+                    "  (!) Verifier is running on the SAME model family as the "
+                    f"generator ({resolution['generator_family']}) — same-family "
+                    "verification misses more issues than cross-family (#909). Set "
+                    "auxiliary.adversarial_verification.model to a different "
+                    "provider's model to strengthen this check."
                 )
-                verdict_text = response.choices[0].message.content or ""
+
+            # One-shot verification call — no tool calling, no iteration, just
+            # a verdict. Routed through call_llm's auxiliary-task resolution so
+            # auxiliary.adversarial_verification.{provider,model,base_url,
+            # api_key} can point the verifier at a different model/provider
+            # than the one that generated the solution being checked.
+            from agent.auxiliary_client import call_llm
+
+            response = call_llm(
+                task="adversarial_verification",
+                messages=verify_messages,
+                temperature=0.3,  # low temp for focused analysis
+            )
+            verdict_text = response.choices[0].message.content or ""
 
             # Parse the verdict
             result = parse_verifier_output(verdict_text)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1693,8 +1693,28 @@ DEFAULT_CONFIG = {
             "timeout": 900,
             "extra_body": {},
         },
+        # Adversarial verification (/verify, #825) — model-diverse fact-
+        # checking (#909). Generator and verifier sharing a model family
+        # share blind spots: research shows cross-family verification
+        # catches ~45% of harmful approvals vs ~6% for same-family, and raw
+        # self-consistency is a weak correctness signal (worst for frontier
+        # models: 77% agreement, 48% wrong on GPQA). "auto"/"" (default)
+        # keeps today's behavior — verification runs on the main chat model.
+        # Set model/provider to a DIFFERENT model family (e.g. provider
+        # "openrouter", model "google/gemini-3-flash-preview" when the main
+        # model is Claude/GPT) to get cross-family verification;
+        # agent.adversarial_verification.resolve_verifier_model() detects
+        # same-family setups so the /verify command can warn about them.
+        "adversarial_verification": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+            "extra_body": {},
+        },
     },
-    
+
     "display": {
         "compact": False,
         "personality": "",

--- a/tests/agent/test_adversarial_verification.py
+++ b/tests/agent/test_adversarial_verification.py
@@ -7,10 +7,12 @@ from agent.adversarial_verification import (
     VerificationResult,
     VerificationSeverity,
     VerificationVerdict,
+    detect_model_family,
     format_verification_result,
     generate_verifier_prompt,
     get_verifier_system_prompt,
     parse_verifier_output,
+    resolve_verifier_model,
 )
 
 
@@ -223,3 +225,157 @@ class TestEnums:
     def test_all_verdicts_have_values(self):
         for verdict in VerificationVerdict:
             assert isinstance(verdict.value, str)
+
+
+# ── Model-family diversity tests (#909) ─────────────────────────────────
+
+
+class TestDetectModelFamily:
+    def test_claude_models(self):
+        assert detect_model_family("anthropic/claude-opus-4.8") == "anthropic"
+        assert detect_model_family("claude-sonnet-4-6") == "anthropic"
+
+    def test_openai_models(self):
+        assert detect_model_family("gpt-5.5") == "openai"
+        assert detect_model_family("openai/gpt-4o") == "openai"
+
+    def test_google_models(self):
+        assert detect_model_family("google/gemini-3-flash-preview") == "google"
+
+    def test_xai_models(self):
+        assert detect_model_family("x-ai/grok-4") == "xai"
+
+    def test_meta_models(self):
+        assert detect_model_family("meta-llama/llama-4") == "meta"
+
+    def test_deepseek_models(self):
+        assert detect_model_family("deepseek/deepseek-v4-pro") == "deepseek"
+
+    def test_qwen_models(self):
+        assert detect_model_family("qwen/qwen3-max") == "qwen"
+
+    def test_mistral_models(self):
+        assert detect_model_family("mistralai/mixtral-8x22b") == "mistral"
+
+    def test_nous_hermes_models(self):
+        assert detect_model_family("nousresearch/hermes-4-70b") == "nous"
+
+    def test_luminous_not_misfiled_as_nous(self):
+        # "nous" is a substring of "luminous" (Aleph Alpha) — ordering in the
+        # keyword table must classify it as its own family, not Nous Research.
+        assert detect_model_family("luminous-supreme") == "alephalpha"
+
+    def test_unknown_model(self):
+        assert detect_model_family("some-obscure-local-model") == "unknown"
+
+    def test_empty_or_none(self):
+        assert detect_model_family("") == "unknown"
+        assert detect_model_family(None) == "unknown"
+
+    def test_case_insensitive(self):
+        assert detect_model_family("CLAUDE-Opus-4.8") == "anthropic"
+
+
+class TestResolveVerifierModel:
+    def test_explicit_cross_family_model(self):
+        result = resolve_verifier_model(
+            "anthropic/claude-opus-4.8",
+            {"model": "google/gemini-3-flash-preview", "provider": "openrouter"},
+        )
+        assert result["model"] == "google/gemini-3-flash-preview"
+        assert result["provider"] == "openrouter"
+        assert result["generator_family"] == "anthropic"
+        assert result["verifier_family"] == "google"
+        assert result["cross_family"] is True
+
+    def test_explicit_same_family_model(self):
+        result = resolve_verifier_model(
+            "anthropic/claude-opus-4.8",
+            {"model": "claude-sonnet-4-6", "provider": ""},
+        )
+        assert result["cross_family"] is False
+        assert result["generator_family"] == "anthropic"
+        assert result["verifier_family"] == "anthropic"
+
+    def test_explicit_model_unknown_family(self):
+        result = resolve_verifier_model(
+            "anthropic/claude-opus-4.8",
+            {"model": "some-local-model"},
+        )
+        assert result["cross_family"] is None
+        assert result["verifier_family"] == "unknown"
+
+    def test_provider_only_override_is_unknown(self):
+        result = resolve_verifier_model(
+            "anthropic/claude-opus-4.8",
+            {"provider": "openrouter", "model": ""},
+        )
+        assert result["cross_family"] is None
+        assert result["model"] == ""
+        assert result["provider"] == "openrouter"
+
+    def test_no_config_is_same_family(self):
+        result = resolve_verifier_model("anthropic/claude-opus-4.8", None)
+        assert result["cross_family"] is False
+        assert result["generator_family"] == "anthropic"
+        assert result["verifier_family"] == "anthropic"
+
+    def test_auto_provider_no_config_is_same_family(self):
+        result = resolve_verifier_model("gpt-5.5", {"provider": "auto", "model": ""})
+        assert result["cross_family"] is False
+        assert result["generator_family"] == "openai"
+
+    def test_no_config_unrecognized_generator_still_same_family(self):
+        # Auto/empty config inherits the generator's exact model, so it is
+        # same-family even when we don't recognize the family (#909 review).
+        result = resolve_verifier_model("some-local-model", {})
+        assert result["cross_family"] is False
+        assert result["generator_family"] == "unknown"
+
+    def test_empty_generator_model(self):
+        result = resolve_verifier_model(None, {})
+        assert result["generator_family"] == "unknown"
+        assert result["cross_family"] is None
+
+    def test_identical_unrecognized_models_are_same_family(self):
+        # Same exact unrecognized model string on both sides — same blind
+        # spots — must be flagged same-family even though the family is
+        # "unknown" (#909 review, false-negative fix).
+        result = resolve_verifier_model(
+            "some-local-model", {"model": "some-local-model"}
+        )
+        assert result["cross_family"] is False
+        assert result["generator_family"] == "unknown"
+        assert result["verifier_family"] == "unknown"
+
+    def test_luminous_vs_nous_is_cross_family(self):
+        # Regression guard for the substring collision: a luminous generator
+        # and a nous verifier are different families, not the same.
+        result = resolve_verifier_model("luminous-supreme", {"model": "nous-hermes-2"})
+        assert result["generator_family"] == "alephalpha"
+        assert result["verifier_family"] == "nous"
+        assert result["cross_family"] is True
+
+    def test_single_family_provider_override_detects_family(self):
+        # Provider-only override on a single-family provider identifies the
+        # family from the provider name (#909 review, false-negative fix).
+        cross = resolve_verifier_model(
+            "openai/gpt-4o", {"provider": "anthropic", "model": ""}
+        )
+        assert cross["verifier_family"] == "anthropic"
+        assert cross["cross_family"] is True
+
+        same = resolve_verifier_model(
+            "anthropic/claude-opus-4.8", {"provider": "anthropic", "model": ""}
+        )
+        assert same["verifier_family"] == "anthropic"
+        assert same["cross_family"] is False
+
+    def test_multi_model_provider_override_stays_unknown(self):
+        # Aggregators like openrouter can't be pinned to one family — degrade
+        # to None rather than guessing.
+        result = resolve_verifier_model(
+            "anthropic/claude-opus-4.8", {"provider": "openrouter", "model": ""}
+        )
+        assert result["verifier_family"] == "unknown"
+        assert result["cross_family"] is None

--- a/tests/cli/test_cli_verify_command.py
+++ b/tests/cli/test_cli_verify_command.py
@@ -1,0 +1,127 @@
+"""Tests for the /verify command's model-diverse verification wiring (#909).
+
+Adversarial verification (#825) is only valuable if the verifier isn't
+sharing the generator's blind spots. _handle_verify_command now routes the
+verifier call through call_llm(task="adversarial_verification", ...), which
+honors auxiliary.adversarial_verification.{provider,model} — a config seam
+that lets the verifier run on a different model/provider than the one that
+produced the solution being checked — and warns the user when it can tell
+verification is running same-family.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_response(content):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+_APPROVED_JSON = (
+    '```json\n{"verdict": "approved", "confidence": 0.9, '
+    '"summary": "ok", "issues": []}\n```'
+)
+
+
+class TestHandleVerifyCommand(unittest.TestCase):
+    def _make_cli(self, *, agent_model="anthropic/claude-opus-4.8"):
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.conversation_history = [
+            {"role": "user", "content": "please implement X"},
+            {"role": "assistant", "content": "here is my solution"},
+        ]
+        cli.agent = SimpleNamespace(model=agent_model)
+        cli._console_print = MagicMock()
+        return cli
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_calls_call_llm_with_adversarial_verification_task(self, mock_call_llm):
+        mock_call_llm.return_value = _make_response(_APPROVED_JSON)
+        cli = self._make_cli()
+
+        with patch.dict("cli.CLI_CONFIG", {"auxiliary": {}}, clear=False):
+            cli._handle_verify_command()
+
+        self.assertEqual(mock_call_llm.call_count, 1)
+        _, kwargs = mock_call_llm.call_args
+        self.assertEqual(kwargs["task"], "adversarial_verification")
+        messages = kwargs["messages"]
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertIn("here is my solution", messages[1]["content"])
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_warns_when_verification_runs_same_family(self, mock_call_llm):
+        mock_call_llm.return_value = _make_response(_APPROVED_JSON)
+        cli = self._make_cli(agent_model="anthropic/claude-opus-4.8")
+
+        with patch.dict(
+            "cli.CLI_CONFIG",
+            {
+                "auxiliary": {
+                    "adversarial_verification": {"provider": "auto", "model": ""}
+                }
+            },
+            clear=False,
+        ):
+            cli._handle_verify_command()
+
+        warned = any(
+            "#909" in str(call.args[0]) and "SAME model family" in str(call.args[0])
+            for call in cli._console_print.call_args_list
+        )
+        self.assertTrue(warned, "expected a same-family warning to be printed")
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_no_warning_when_cross_family_model_configured(self, mock_call_llm):
+        mock_call_llm.return_value = _make_response(_APPROVED_JSON)
+        cli = self._make_cli(agent_model="anthropic/claude-opus-4.8")
+
+        with patch.dict(
+            "cli.CLI_CONFIG",
+            {
+                "auxiliary": {
+                    "adversarial_verification": {
+                        "provider": "openrouter",
+                        "model": "google/gemini-3-flash-preview",
+                    }
+                }
+            },
+            clear=False,
+        ):
+            cli._handle_verify_command()
+
+        warned = any(
+            "#909" in str(call.args[0]) for call in cli._console_print.call_args_list
+        )
+        self.assertFalse(
+            warned, "should not warn when verifier is configured cross-family"
+        )
+
+    def test_no_last_response_skips_verification(self):
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.conversation_history = []
+        cli.agent = SimpleNamespace(model="anthropic/claude-opus-4.8")
+        cli._console_print = MagicMock()
+
+        with patch("agent.auxiliary_client.call_llm") as mock_call_llm:
+            cli._handle_verify_command()
+            mock_call_llm.assert_not_called()
+
+        self.assertTrue(
+            any(
+                "No agent response to verify" in str(call.args[0])
+                for call in cli._console_print.call_args_list
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #909

## Problem

Adversarial verification (#825) added a separate-prompt/incentive `/verify`
pass, but the actual verdict LLM call was still same-model. In
`_handle_verify_command` the "raw client" branch called
`self.agent._get_client()` — a method that does not exist on `Agent`
(`hasattr` always False) — so execution fell through to
`self.agent.chat(verifier_prompt)`, which runs the **full** agent loop
(`run_conversation`, tools + iteration), directly contradicting the code's own
"one-shot... no tool calling, no iteration" comment. Either path ran the
verifier on the same model that generated the solution, sharing its blind
spots.

Research cited in #909: cross-family verification catches ~45% of harmful
approvals vs ~6% for same-family, and raw self-consistency is a weak
correctness signal (rho 0.20-0.59, worst for frontier models: 77% agreement,
48% wrong on GPQA).

## What changed

- **`agent/adversarial_verification.py`** — `detect_model_family()`, a
  deterministic offline keyword classifier (anthropic/openai/google/xai/meta/
  deepseek/qwen/mistral/moonshot/zhipu/minimax/nous/alephalpha), and
  `resolve_verifier_model()`, which compares the generator's family to the
  configured verifier model/provider and reports
  `cross_family` (True / False / None-when-undeterminable).
- **`hermes_cli/config.py`** — new `auxiliary.adversarial_verification` block
  (`provider`/`model`/`base_url`/`api_key`/`timeout`/`extra_body`), matching
  the exact shape of the ~14 sibling `auxiliary.*` task entries. Default
  `"auto"`/`""` preserves today's same-model behavior.
- **`cli.py`** — `_handle_verify_command` now routes the verdict through
  `agent.auxiliary_client.call_llm(task="adversarial_verification", ...)` —
  the codebase's existing, tested seam for auxiliary LLM calls that can target
  a different provider/model than the main runtime (the same mechanism MoA's
  `reference_models`/`aggregator` slots use). This replaces both the dead
  `_get_client()` branch and the full-agent-loop `chat()` fallback with a real
  one-shot call. When the resolved verifier is same-family as the generator,
  the command prints a warning pointing at the new config key.

## Why this shape, not something bigger

- Not `delegate_task`: spawning a full subagent (tools + iteration budget) for
  a one-shot text-in/text-out verdict is disproportionate and changes far more
  than #909 asks.
- Not a new top-level config section: `auxiliary.*` is the established,
  already-tested seam for "auxiliary LLM call that may target a different
  provider" — reusing it avoids duplicating the provider/credential resolution
  `call_llm` already owns.

## Relationship to #825

#825 (merged) solved "different agent instance / incentives / context" — that
is untouched. #909 layers on top by making the verifier **model** itself
independently configurable, and surfaces the same-family case to the user
instead of silently assuming it.

## Out of scope

- No automatic model-family auto-discovery / catalog lookup. Multi-model
  provider-only overrides (e.g. `openrouter`) report `cross_family: None`
  rather than guessing; users opt into cross-family checks by setting
  `auxiliary.adversarial_verification.model`/`provider`.
- No changes to `scripts/evolution_qc_review.py` or other QC/approval paths
  beyond the `/verify` slash command.

## Review

Independently reviewed by a different model family (Gemini, via `consult
agy`). It confirmed `call_llm` is the correct seam over `delegate_task`, and
flagged four `resolve_verifier_model` edge cases — all fixed here with tests:
substring collision (`nous` inside `luminous`), identical unrecognized model
strings, auto/empty inheritance with an unrecognized generator, and
single-family provider-only overrides.

## Testing

```
.venv/bin/python -m pytest tests/agent/test_adversarial_verification.py \
    tests/cli/test_cli_verify_command.py -q
# 50 passed

.venv/bin/python -m ruff check .
# All checks passed!   (the blocking CI gate — .github/workflows/lint.yml)
```

Every line added or changed in this PR is `ruff format`-clean. (Whole-file
`ruff format --check` still reports pre-existing formatting debt in cli.py /
config.py / adversarial_verification.py that predates this PR; CI does not run
`ruff format --check`, only `ruff check .`, so that unrelated debt was left
untouched to keep the diff scoped to #909.)
