### PR TITLE
fix(#758): route provider-layer errors to recovery/actionable messaging

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -494,6 +494,72 @@ def _content_policy_blocked_result(
     }
 
 
+# ── User-actionable provider-error guidance (issue #758) ─────────────────
+#
+# A subset of provider-layer failures are deterministic for the current
+# (provider, model, request) tuple — they fail identically on every retry —
+# but are *user-fixable* when surfaced clearly. Historically these fell
+# through the terminal ``is_client_error`` abort with only a generic
+# "retrying won't help" line and a returned ``final_response`` that was the
+# raw provider summary. For a CLI user that's merely unhelpful; for a
+# gateway/bot user (Telegram/Discord) the raw summary with no next step made
+# the session look like it ended silently.
+#
+# Unlike ``auth`` / ``billing`` / ``content_policy_blocked`` /
+# ``ssl_cert_verification`` — which already have dedicated actionable branches
+# in the abort handler — these two reasons had none:
+#   • model_not_found — wrong/unavailable model slug → correct it or fall back
+#   • format_error   — BadRequestError / ValidationException, usually a schema
+#                      or parameter mismatch between the client and endpoint
+#
+# The guidance is keyed on the classifier's ``FailoverReason`` so the
+# classification is CONSUMED by the recovery/messaging path (not merely
+# logged — the prior gap this closes). See issue #758.
+_USER_ACTIONABLE_ABORT_REASONS = frozenset({
+    FailoverReason.model_not_found,
+    FailoverReason.format_error,
+})
+
+
+def _user_actionable_provider_guidance(
+    reason: FailoverReason,
+    *,
+    provider: str,
+    model: str,
+) -> Optional[str]:
+    """Concise, actionable recovery text for a user-fixable provider error.
+
+    Returns a short multi-line hint (first line prefixed with ``💡`` so it
+    slots into both the console ``_vprint`` guidance and the returned
+    ``final_response``) or ``None`` when ``reason`` is not one this helper
+    covers. Only the two reasons in ``_USER_ACTIONABLE_ABORT_REASONS`` are
+    handled here — the rest keep their existing dedicated branches. See
+    issue #758.
+    """
+    _provider = provider or "the provider"
+    if reason == FailoverReason.model_not_found:
+        return (
+            f"💡 The model '{model}' was rejected by {_provider} — not found or "
+            "not available on this endpoint. Retrying will not help.\n"
+            "What you can do:\n"
+            "  • Check the model name for typos, or run `hermes model` to pick a valid one.\n"
+            "  • Add a fallback model so this routes automatically: `hermes fallback add`."
+        )
+    if reason == FailoverReason.format_error:
+        return (
+            f"💡 {_provider} rejected the request as malformed (bad request / "
+            "validation error). Retrying the same request will not help — this "
+            "usually means a schema or parameter mismatch between the client and "
+            "this endpoint.\n"
+            "What you can do:\n"
+            "  • Switch to a compatible model/provider with `hermes model`, or add "
+            "a fallback: `hermes fallback add`.\n"
+            "  • If this is a local or test endpoint, verify it implements the API "
+            "schema your client expects."
+        )
+    return None
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -3999,6 +4065,16 @@ def _run_conversation_impl(
                             agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
                             if base_url_host_matches(str(_base), "openrouter.ai"):
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                    elif classified.reason in _USER_ACTIONABLE_ABORT_REASONS:
+                        # model_not_found / format_error: user-fixable and
+                        # deterministic — surface the concrete next step instead
+                        # of the generic "retrying won't help" line. Wires the
+                        # classification into the user-facing message (#758).
+                        _actionable_guidance = _user_actionable_provider_guidance(
+                            classified.reason, provider=_provider, model=_model,
+                        )
+                        for _line in (_actionable_guidance or "").splitlines():
+                            agent._vprint(f"{agent.log_prefix}   {_line}", force=True)
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                     # Content-policy blocks deserve their own actionable
@@ -4087,6 +4163,31 @@ def _run_conversation_impl(
                             final_response=_policy_response,
                             error_detail=_nonretryable_summary,
                         )
+                    if classified.reason in _USER_ACTIONABLE_ABORT_REASONS:
+                        # User-fixable, deterministic provider error. Return the
+                        # actionable guidance AS the ``final_response`` so bot /
+                        # gateway users (Telegram/Discord) — who only ever see
+                        # ``final_response``, not the console ``_vprint`` lines —
+                        # get a concrete next step instead of a bare provider
+                        # summary. Keep the raw summary in ``error`` for
+                        # logs/telemetry. (#758)
+                        _actionable_guidance = _user_actionable_provider_guidance(
+                            classified.reason, provider=_provider, model=_model,
+                        )
+                        _actionable_final = (
+                            f"{_actionable_guidance}\n\nProvider message: {_nonretryable_summary}"
+                            if _actionable_guidance
+                            else _nonretryable_summary
+                        )
+                        return {
+                            "final_response": _actionable_final,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _nonretryable_summary,
+                            "user_actionable": True,
+                        }
                     return {
                         "final_response": _nonretryable_summary,
                         "messages": messages,

--- a/tests/agent/test_provider_error_recovery_758.py
+++ b/tests/agent/test_provider_error_recovery_758.py
@@ -1,0 +1,243 @@
+"""Runtime tests for #758: provider-layer errors must route by class.
+
+Two routes:
+  • USER-ACTIONABLE (model_not_found, format_error/BadRequestError/
+    ValidationException) — deterministic and user-fixable. The turn must end
+    immediately (no generic retry spin) with a concise, actionable
+    ``final_response`` telling the user what failed and what to do, not a bare
+    provider summary.
+  • RECOVERABLE (timeout, connection drop) — must stay on the existing
+    retry/fallback path and NOT be diverted into the user-actionable abort.
+
+These drive ``run_conversation`` through mocked API errors and assert on the
+returned turn result, proving the classification is CONSUMED by the
+recovery/messaging path (the gap #758 fixes) rather than merely logged.
+The harness mirrors ``test_rate_limit_fail_fast.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.conversation_loop import (
+    FailoverReason,
+    _USER_ACTIONABLE_ABORT_REASONS,
+    _user_actionable_provider_guidance,
+)
+from run_agent import AIAgent
+
+
+# ── Test doubles ─────────────────────────────────────────────────────────
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class _ModelNotFoundError(Exception):
+    """404 that ``classify_api_error`` maps to ``model_not_found``."""
+
+    def __init__(self):
+        super().__init__(
+            "The model `foo/bar-v9` does not exist or you do not have access to it"
+        )
+        self.status_code = 404
+
+
+class _BadRequestError(Exception):
+    """400 with an unknown-parameter signal → ``format_error``."""
+
+    def __init__(self):
+        super().__init__("Invalid request: unknown parameter 'reasoning_effort'")
+        self.status_code = 400
+
+
+class _TimeoutError(Exception):
+    """No status code, message-classified as ``timeout`` (recoverable)."""
+
+    def __init__(self):
+        super().__init__("Request timed out after 60s")
+
+
+def _make_agent(max_iterations: int = 10) -> AIAgent:
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _fast_backoff_patches():
+    """Make backoff instant so the tests don't sleep on the retry path."""
+    return (
+        patch("agent.conversation_loop.jittered_backoff", return_value=0.01),
+        patch(
+            "agent.conversation_loop.adaptive_rate_limit_backoff",
+            side_effect=lambda retry_count, **kw: (0.01, None),
+        ),
+    )
+
+
+def _run(agent, prompt="hello"):
+    jb, arb = _fast_backoff_patches()
+    with (
+        jb,
+        arb,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+# ── Unit: the guidance helper ────────────────────────────────────────────
+
+
+def test_guidance_helper_covers_only_user_actionable_reasons():
+    assert _USER_ACTIONABLE_ABORT_REASONS == frozenset({
+        FailoverReason.model_not_found,
+        FailoverReason.format_error,
+    })
+
+    model_hint = _user_actionable_provider_guidance(
+        FailoverReason.model_not_found, provider="openrouter", model="foo/bar-v9"
+    )
+    assert model_hint is not None
+    assert "foo/bar-v9" in model_hint
+    assert "hermes model" in model_hint
+    assert "hermes fallback add" in model_hint
+
+    fmt_hint = _user_actionable_provider_guidance(
+        FailoverReason.format_error, provider="local", model="test/model"
+    )
+    assert fmt_hint is not None
+    assert "schema" in fmt_hint.lower()
+    assert "hermes model" in fmt_hint
+
+    # Reasons with their own dedicated branches (or recoverable ones) are not
+    # handled here — helper returns None so the caller keeps existing behavior.
+    assert (
+        _user_actionable_provider_guidance(FailoverReason.auth, provider="x", model="y")
+        is None
+    )
+    assert (
+        _user_actionable_provider_guidance(
+            FailoverReason.timeout, provider="x", model="y"
+        )
+        is None
+    )
+
+
+# ── Behavioral: USER-ACTIONABLE errors abort with guidance, no retry ─────
+
+
+def test_model_not_found_surfaces_actionable_message_without_retry():
+    agent = _make_agent()
+    # Safety-net successes: if the loop wrongly retried instead of aborting,
+    # call_count would exceed 1 and the assertions below flag it.
+    agent.client.chat.completions.create.side_effect = [
+        _ModelNotFoundError(),
+        _mock_response(content="should-not-be-reached"),
+    ]
+
+    result = _run(agent)
+
+    assert result["failed"] is True
+    assert result.get("user_actionable") is True
+    fr = result["final_response"]
+    assert "hermes model" in fr
+    assert "hermes fallback add" in fr
+    # Deterministic error → aborted on the first classification, no retry spin.
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_bad_request_surfaces_actionable_message_without_retry():
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _BadRequestError(),
+        _mock_response(content="should-not-be-reached"),
+    ]
+
+    result = _run(agent)
+
+    assert result["failed"] is True
+    assert result.get("user_actionable") is True
+    fr = result["final_response"].lower()
+    assert "schema" in fr
+    assert "hermes model" in fr
+    # Raw provider summary preserved for logs/telemetry.
+    assert "unknown parameter" in result["error"].lower()
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+# ── Behavioral: RECOVERABLE errors stay on the retry path ────────────────
+
+
+def test_recoverable_timeout_retries_then_completes():
+    """A timeout is recoverable — it must route to retry (not the
+    user-actionable abort). One transient timeout then success completes the
+    turn normally with no ``user_actionable`` flag."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _TimeoutError(),
+        _mock_response(content="done"),
+    ]
+
+    result = _run(agent)
+
+    assert result.get("failed") is not True
+    assert result.get("user_actionable") is not True
+    assert result["final_response"] == "done"
+    # Retried the same call once, then succeeded — it did NOT abort on the
+    # first error the way a user-actionable error does.
+    assert agent.client.chat.completions.create.call_count == 2
+
+
+def test_recoverable_timeout_is_not_diverted_to_user_actionable_abort():
+    """A persistent timeout must exhaust the retry/fallback path — never the
+    single-shot user-actionable abort. Contrast with model_not_found, which
+    ends after exactly one call."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = _TimeoutError()
+
+    result = _run(agent)
+
+    # Recoverable errors are never tagged user_actionable...
+    assert result.get("user_actionable") is not True
+    # ...and they burn multiple retries rather than aborting on the first call.
+    assert agent.client.chat.completions.create.call_count > 1


### PR DESCRIPTION
Fixes #758.

## Problem
Provider-layer errors abort sessions before any recovery. The classifier
(`agent/error_classifier.py::classify_api_error`) already returns a structured
`ClassifiedError(reason, retryable, should_fallback, …)`, but **`should_fallback`
was only logged, never consumed** by `conversation_loop`. For the terminal
non-retryable abort path, `auth` / `billing` / `content_policy_blocked` /
`ssl_cert_verification` had dedicated actionable guidance, but two deterministic,
**user-fixable** classes fell through to a bare "retrying won't help" console line
and returned the **raw provider summary** as `final_response`:

- `model_not_found` (wrong/unavailable model slug)
- `format_error` — `BadRequestError` / `ValidationException` (schema/param mismatch)

For gateway/bot users (Telegram/Discord), who only ever see `final_response`, that
read as a silent abort with no next step — exactly the failure shape in the issue.

## In scope (this bounded slice)
Wires the classification into the recovery/messaging path (the value the issue asks
for — not more classification fields):

1. `_USER_ACTIONABLE_ABORT_REASONS = {model_not_found, format_error}` +
   `_user_actionable_provider_guidance(reason, provider, model)` helper producing
   concise, actionable recovery text.
2. Terminal abort handler: `model_not_found` / `format_error` now print actionable
   console guidance (instead of the generic line) **and** return that guidance as
   `final_response` (raw summary preserved in `error`, plus `user_actionable=True`),
   so gateway users get a concrete next step (`hermes model`, `hermes fallback add`,
   verify the endpoint schema).
3. **Recoverable** errors (timeout, connection drop → `reason=timeout`,
   `retryable=True`) are unchanged: they never reach the abort block and stay on the
   existing retry-then-fallback path. No retry spiral (bounded by `max_retries`, then
   pool rebuild → fallback chain → terminal failure).

`auth`/`billing`/`content_policy_blocked`/`ssl_cert_verification` branches are
untouched.

## Deferred (noted for follow-up)
- **Pre-flight provider/model health check** (issue item 3) — out of scope for this
  slice; would need a probe before the main loop for newly-selected/local endpoints.
- **Reduced-toolset / plain-chat fallback for schema-rejecting providers** (issue
  item 4) — larger change to request assembly; deferred.
- **auth/billing actionable text in `final_response` for gateway users** — raised by
  the independent review (agy/Gemini). Legitimate but pre-existing: auth/billing
  already emit extensive *console* guidance (they do NOT abort silently), and folding
  their provider-specific guidance into `final_response` would touch the large,
  heavily-tested auth path. Deferred to keep this diff bounded and reviewable.

## Tests
New `tests/agent/test_provider_error_recovery_758.py` (drives `run_conversation`
through mocked provider errors, mirrors `test_rate_limit_fail_fast.py`):
- `model_not_found` / bad-request → `failed=True`, `user_actionable=True`, actionable
  `final_response`, **exactly 1 API call** (no retry spin).
- recoverable timeout → retries then completes (`call_count==2`), never tagged
  `user_actionable`; a persistent timeout burns multiple retries (contrast with the
  single-shot user-actionable abort).
- unit test of the guidance helper (covers only the two reasons; returns `None` for
  auth/timeout).

## Verification
```
pytest tests/agent/test_error_classifier.py tests/agent/test_rate_limit_fail_fast.py \
       tests/agent/test_nous_oauth_401_guidance.py \
       tests/agent/test_provider_error_recovery_758.py -q
  213 passed

ruff check .            → All checks passed!
ruff format --check tests/agent/test_provider_error_recovery_758.py → already formatted
```
(`ruff format` on `agent/conversation_loop.py` reports pre-existing non-conformance —
pristine HEAD is already format-dirty; the repo enforces only `ruff check`/PLW1514 on
that file. The added lines are format-clean; unrelated code was intentionally NOT
reformatted.)

## Independent review
`consult agy` (Gemini, independent) confirmed the classification is consumed on the
recovery/messaging path, user-actionable errors now surface an actionable message
instead of a silent abort, and recoverable errors stay bounded with no retry spiral.
It flagged the auth/billing gateway gap (deferred above) and a comment inaccuracy that
was a false positive from a stale shallow checkout (`ssl_cert_verification` IS in the
enum and DOES have dedicated abort branches in this tree — verified).
