### PR TITLE
feat(#879): A2A Agent Card model and /.well-known/agent.json endpoint

### DIFF
--- a/hermes_cli/a2a.py
+++ b/hermes_cli/a2a.py
@@ -1,0 +1,341 @@
+"""A2A (Agent2Agent) Agent Card model and builder.
+
+Slice 1 of #748 (issue #879): expose Hermes' existing tools and skills as
+an A2A Agent Card served at ``/.well-known/agent.json``.
+
+This is a read-only *discovery view*. It registers **no** new core tools --
+all capability lives at the edge (the ``skills/a2a/`` scaffold + this thin
+model). The card only reflects tools/skills Hermes already has.
+
+The serialized shape follows the A2A protocol Agent Card (camelCase JSON):
+``name``, ``description``, ``url``, ``version``, ``capabilities``,
+``authentication``, ``provider`` and a ``skills[]`` array -- see
+https://google.github.io/A2A/ . Each Hermes tool and each ``SKILL.md`` skill
+maps to one entry in ``skills[]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Repo root is two levels up: ``hermes_cli/a2a.py`` -> ``<repo>/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG_PATH = _REPO_ROOT / "skills" / "a2a" / "config.yaml"
+_SKILLS_ROOT = _REPO_ROOT / "skills"
+
+# Defaults used when ``skills/a2a/config.yaml`` is absent or partial. The
+# config file overlays these keys (see that file for the documented schema).
+_DEFAULT_CONFIG: Dict[str, Any] = {
+    "enabled": True,
+    "name": "Hermes",
+    "description": "Hermes agent advertising its tools and skills over A2A.",
+    "url": "/a2a",
+    "provider": {
+        "organization": "NousResearch",
+        "url": "https://github.com/NousResearch/hermes",
+    },
+    "authentication": {"schemes": ["bearer"]},
+    "capabilities": {
+        "streaming": False,
+        "pushNotifications": False,
+        "stateTransitionHistory": False,
+    },
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "expose": {"tools": True, "skills": True, "max_skills": 128},
+}
+
+
+@dataclass
+class AgentSkill:
+    """One advertised competency -- an A2A ``skill`` entry.
+
+    Maps a Hermes tool or ``SKILL.md`` skill into the Agent Card's
+    ``skills[]`` array.
+    """
+
+    id: str
+    name: str
+    description: str = ""
+    tags: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "tags": list(self.tags),
+        }
+
+
+@dataclass
+class AgentCard:
+    """A2A Agent Card. Serialized to JSON at ``/.well-known/agent.json``."""
+
+    name: str
+    description: str
+    url: str
+    version: str
+    skills: List[AgentSkill] = field(default_factory=list)
+    capabilities: Dict[str, bool] = field(default_factory=dict)
+    authentication: Dict[str, Any] = field(default_factory=dict)
+    provider: Optional[Dict[str, str]] = None
+    default_input_modes: List[str] = field(default_factory=lambda: ["text"])
+    default_output_modes: List[str] = field(default_factory=lambda: ["text"])
+
+    def to_dict(self) -> Dict[str, Any]:
+        card: Dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "url": self.url,
+            "version": self.version,
+            "capabilities": dict(self.capabilities),
+            "authentication": dict(self.authentication),
+            "defaultInputModes": list(self.default_input_modes),
+            "defaultOutputModes": list(self.default_output_modes),
+            "skills": [skill.to_dict() for skill in self.skills],
+        }
+        if self.provider:
+            card["provider"] = dict(self.provider)
+        return card
+
+
+def load_config(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Return the A2A config, overlaying ``skills/a2a/config.yaml`` on defaults."""
+    cfg: Dict[str, Any] = {**_DEFAULT_CONFIG}
+    cfg_path = path or _CONFIG_PATH
+    try:
+        import yaml
+
+        if cfg_path.is_file():
+            loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            if isinstance(loaded, dict):
+                cfg.update(loaded)
+    except Exception:  # pragma: no cover - config read is best-effort
+        logger.debug("A2A: could not read %s; using defaults", cfg_path, exc_info=True)
+    return cfg
+
+
+def collect_capabilities(config: Dict[str, Any]) -> List[AgentSkill]:
+    """Gather Hermes tools + ``SKILL.md`` skills as A2A skills.
+
+    Side-effect free: reads the live tool registry (populated once tool
+    modules are imported, e.g. by the running dashboard) and scans the
+    ``skills/`` directory. Tools are listed first; the ``max_skills`` cap
+    bounds the total.
+    """
+    expose = config.get("expose") or {}
+    exclude = {str(x) for x in (expose.get("exclude") or [])}
+    skills: List[AgentSkill] = []
+    seen: set[str] = set()
+
+    if expose.get("tools", True):
+        for name, desc, toolset in _iter_registered_tools():
+            if name in seen or name in exclude:
+                continue
+            seen.add(name)
+            skills.append(
+                AgentSkill(
+                    id=name,
+                    name=name,
+                    description=desc,
+                    tags=[t for t in (toolset,) if t],
+                )
+            )
+
+    if expose.get("skills", True):
+        for name, desc, category in _iter_skill_docs():
+            skill_id = f"skill:{name}"
+            if skill_id in seen or skill_id in exclude or name in exclude:
+                continue
+            seen.add(skill_id)
+            skills.append(
+                AgentSkill(
+                    id=skill_id,
+                    name=name,
+                    description=desc,
+                    tags=[t for t in ("skill", category) if t],
+                )
+            )
+
+    max_skills = expose.get("max_skills")
+    if isinstance(max_skills, int) and max_skills >= 0:
+        skills = skills[:max_skills]
+    return skills
+
+
+# The discovery endpoint is public, so we must not re-read config + re-scan
+# skills/**/SKILL.md on every request (a cheap resource-amplification vector,
+# and needless disk I/O). The card content is request-independent and changes
+# rarely, so cache the (config, capabilities) snapshot for a short TTL.
+_SNAPSHOT_TTL = 30.0
+_snapshot_lock = threading.Lock()
+_snapshot: Optional[Tuple[float, Dict[str, Any], List[AgentSkill]]] = None
+
+
+def get_discovery_snapshot(
+    ttl: float = _SNAPSHOT_TTL,
+) -> Tuple[Dict[str, Any], List[AgentSkill]]:
+    """Return the cached ``(config, capabilities)`` snapshot, rebuilding it at
+    most once per *ttl* seconds. Thread-safe (double-checked locking)."""
+    global _snapshot
+    snap = _snapshot
+    if snap is not None and (time.monotonic() - snap[0]) < ttl:
+        return snap[1], snap[2]
+    with _snapshot_lock:
+        snap = _snapshot
+        if snap is not None and (time.monotonic() - snap[0]) < ttl:
+            return snap[1], snap[2]
+        config = load_config()
+        caps = collect_capabilities(config)
+        _snapshot = (time.monotonic(), config, caps)
+        return config, caps
+
+
+def reset_discovery_cache() -> None:
+    """Drop the cached snapshot (config/skills changes, tests)."""
+    global _snapshot
+    with _snapshot_lock:
+        _snapshot = None
+
+
+def build_agent_card(
+    config: Optional[Dict[str, Any]] = None,
+    capabilities: Optional[List[AgentSkill]] = None,
+    *,
+    version: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> AgentCard:
+    """Build an :class:`AgentCard` from *config* and collected *capabilities*.
+
+    ``capabilities`` may be injected (tests); otherwise it is collected live.
+    ``base_url`` (e.g. the request's scheme+host) is prepended to a relative
+    ``url`` so the card advertises an absolute A2A endpoint; an absolute
+    ``url`` in config is left untouched.
+    """
+    cfg = config if config is not None else load_config()
+    caps = capabilities if capabilities is not None else collect_capabilities(cfg)
+
+    url = str(cfg.get("url", "/a2a"))
+    if base_url and url.startswith("/"):
+        url = base_url.rstrip("/") + url
+
+    return AgentCard(
+        name=cfg.get("name", "Hermes"),
+        description=cfg.get("description", ""),
+        url=url,
+        version=version or cfg.get("version") or _hermes_version(),
+        skills=caps,
+        capabilities=cfg.get("capabilities", {}),
+        authentication=cfg.get("authentication", {}),
+        provider=cfg.get("provider"),
+        default_input_modes=cfg.get("defaultInputModes", ["text"]),
+        default_output_modes=cfg.get("defaultOutputModes", ["text"]),
+    )
+
+
+def _iter_registered_tools() -> Iterator[Tuple[str, str, str]]:
+    """Yield ``(name, description, toolset)`` for each Hermes tool.
+
+    Prefers the live tool registry (populated in a full agent process, so
+    descriptions are rich). When the registry is empty -- e.g. a bare
+    dashboard web server that never built a toolset -- falls back to the
+    static ``toolsets.py`` definitions so the card still advertises Hermes'
+    tools. Both paths are side-effect free (the fallback never imports tool
+    handlers).
+    """
+    seen = False
+    try:
+        from tools.registry import registry
+
+        for name in registry.get_all_tool_names():
+            entry = registry.get_entry(name)
+            if entry is None:
+                continue
+            desc = (entry.description or "").strip()
+            if not desc:
+                desc = str((entry.schema or {}).get("description", "")).strip()
+            seen = True
+            yield name, _first_line(desc), (entry.toolset or "")
+    except Exception:  # pragma: no cover - registry is optional at read time
+        logger.debug("A2A: tool registry unavailable", exc_info=True)
+
+    if seen:
+        return
+
+    try:
+        import toolsets
+
+        static_map: Dict[str, str] = {}
+        for toolset in toolsets.TOOLSETS:
+            try:
+                names = toolsets.resolve_toolset(toolset, include_registry=False)
+            except Exception:  # pragma: no cover - defensive per-toolset
+                continue
+            for name in names:
+                static_map.setdefault(name, toolset)
+        for name in sorted(static_map):
+            yield name, "", static_map[name]
+    except Exception:  # pragma: no cover - static toolsets unavailable
+        logger.debug("A2A: static toolsets unavailable", exc_info=True)
+
+
+def _iter_skill_docs() -> Iterator[Tuple[str, str, str]]:
+    """Yield ``(name, description, category)`` from ``skills/**/SKILL.md``."""
+    if not _SKILLS_ROOT.is_dir():
+        return
+    try:
+        import yaml
+    except Exception:  # pragma: no cover - yaml is a hard dep in practice
+        return
+    for skill_md in sorted(_SKILLS_ROOT.rglob("SKILL.md")):
+        meta = _read_frontmatter(skill_md, yaml)
+        name = str(meta.get("name") or skill_md.parent.name)
+        desc = _first_line(str(meta.get("description", "")).strip())
+        category = ""
+        metadata = meta.get("metadata")
+        if isinstance(metadata, dict) and isinstance(metadata.get("hermes"), dict):
+            category = str(metadata["hermes"].get("category", "") or "")
+        yield name, desc, category
+
+
+def _read_frontmatter(path: Path, yaml_mod: Any) -> Dict[str, Any]:
+    """Parse a ``SKILL.md`` YAML frontmatter block into a dict (or ``{}``)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:  # pragma: no cover - unreadable file, skip
+        return {}
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    try:
+        data = yaml_mod.safe_load(text[3:end])
+    except Exception:  # pragma: no cover - malformed frontmatter, skip
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _first_line(text: str, limit: int = 240) -> str:
+    """First non-empty line of *text*, trimmed to *limit* chars."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return ""
+    return stripped.splitlines()[0].strip()[:limit]
+
+
+def _hermes_version() -> str:
+    try:
+        from hermes_cli import __version__
+
+        return str(__version__)
+    except Exception:  # pragma: no cover
+        return "0.0.0"

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -52,6 +52,10 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/ds-assets/",
     "/fonts/",
     "/fonts-terminal/",
+    # A2A Agent Card discovery (issue #879). Public by design: other A2A
+    # agents hold no dashboard cookie, and the card exposes only tool/skill
+    # names + one-line descriptions (no secrets). Exact-path only.
+    "/.well-known/agent.json",
 )
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16542,6 +16542,30 @@ def _mount_plugin_api_routes():
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
 
 
+# A2A Agent Card discovery endpoint (issue #879). Registered here, before the
+# SPA catch-all below, so /{full_path:path} doesn't swallow it. Public by
+# design (see skills/a2a/): A2A clients hold no dashboard session, and the card
+# carries only tool/skill names + one-line descriptions -- never secrets. It
+# registers no core tools; it is a read-only view over Hermes' existing tools
+# and skills. The /.well-known/agent.json path is non-/api/, so the legacy
+# loopback auth_middleware never gates it; the OAuth gate allowlists it via
+# dashboard_auth.middleware._GATE_PUBLIC_PREFIXES.
+@app.get("/.well-known/agent.json")
+async def well_known_agent_card(request: Request):
+    """Serve the A2A Agent Card advertising Hermes' tools and skills."""
+    from hermes_cli.a2a import build_agent_card, get_discovery_snapshot
+
+    config, capabilities = get_discovery_snapshot()
+    if not config.get("enabled", True):
+        return JSONResponse(status_code=404, content={"detail": "A2A disabled"})
+    card = build_agent_card(
+        config,
+        capabilities=capabilities,
+        base_url=str(request.base_url).rstrip("/"),
+    )
+    return JSONResponse(card.to_dict(), media_type="application/json")
+
+
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
 

--- a/skills/a2a/SKILL.md
+++ b/skills/a2a/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: a2a
+description: |
+  Agent2Agent (A2A) interoperability for Hermes. Slice 1 exposes Hermes'
+  existing tools and skills as an A2A Agent Card served at
+  /.well-known/agent.json, so other A2A-speaking agents can discover what
+  this Hermes instance can do. Discovery only -- no A2A JSON-RPC server yet.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [a2a, interoperability, agent-card, discovery]
+    category: interoperability
+    related_skills: [autonomous-ai-agents]
+---
+
+# A2A Agent Card (discovery)
+
+Hermes advertises itself to the [Agent2Agent (A2A)](https://google.github.io/A2A/)
+ecosystem with an **Agent Card**: a small JSON document that describes the
+agent's identity, endpoint, auth methods, protocol capabilities, and the list
+of things it can do (its "skills").
+
+This slice (issue #879, child of #748) implements **discovery only**:
+
+- The Agent Card data model lives in `hermes_cli/a2a.py` (`AgentCard`,
+  `AgentSkill`, `build_agent_card`).
+- The dashboard web server (`hermes_cli/web_server.py`) serves the card at
+  **`GET /.well-known/agent.json`**.
+- Each existing Hermes tool and each `SKILL.md` skill is mapped to one entry
+  in the card's `skills[]` array. **No new core tools are registered** -- the
+  card is a read-only view over capabilities Hermes already has.
+
+## Configuration
+
+All behaviour is driven by [`config.yaml`](config.yaml) in this directory,
+which overlays the defaults baked into `hermes_cli/a2a.py`. Highlights:
+
+- `enabled: false` makes the endpoint return `404` (Hermes stops advertising).
+- `name` / `description` / `provider` set the card's identity.
+- `url` is the A2A service endpoint; a relative value (`/a2a`) is resolved
+  against the incoming request host so no hostname is hardcoded.
+- `authentication.schemes` lists the advertised auth methods.
+- `expose.tools` / `expose.skills` / `expose.max_skills` control which
+  capabilities are surfaced and the cap on the total.
+
+## Scope note
+
+The card is a **public** discovery document by design (A2A clients hold no
+dashboard session). It contains only tool/skill names and one-line
+descriptions -- never secrets or config values. The A2A JSON-RPC server that
+actually fulfils tasks (`url`), plus streaming and push notifications, are
+later slices (#880 client, #881 server).

--- a/skills/a2a/config.yaml
+++ b/skills/a2a/config.yaml
@@ -1,0 +1,59 @@
+# A2A Agent Card configuration schema.
+#
+# Consumed by hermes_cli/a2a.py to build the Agent Card served at
+# /.well-known/agent.json. Every key overlays the built-in defaults in
+# _DEFAULT_CONFIG, so this file can be partial. Keys use the A2A protocol's
+# camelCase where they map directly onto Agent Card fields.
+
+# Master switch. When false the discovery endpoint returns 404 (Hermes stops
+# advertising an Agent Card) without any code change.
+enabled: true
+
+# Human-facing identity of this agent on the A2A network.
+name: "Hermes"
+description: "Hermes agent advertising its tools and skills over A2A."
+
+# A2A service endpoint. A leading-slash (relative) value is resolved against
+# the incoming request's scheme+host, so the card advertises an absolute URL
+# without hardcoding a hostname. SECURITY: behind a reverse proxy that does not
+# pin the Host header, set an absolute https URL here to stop a spoofed Host
+# from redirecting A2A callers to an attacker origin. NOTE: the A2A JSON-RPC
+# server itself is a later slice (#881); this only advertises where it lives.
+url: "/a2a"
+
+# version: omit to inherit the running Hermes version (hermes_cli.__version__).
+
+# Card provider block (organization + homepage).
+provider:
+  organization: "NousResearch"
+  url: "https://github.com/NousResearch/hermes"
+
+# Advertised authentication methods (A2A "auth methods"). Slice 1 only
+# publishes the schemes; enforcement arrives with the server slice (#881).
+authentication:
+  schemes:
+    - "bearer"
+
+# A2A protocol capabilities. All false for Slice 1 (discovery only) -- the
+# streaming / push-notification server behaviours come with #881.
+capabilities:
+  streaming: false
+  pushNotifications: false
+  stateTransitionHistory: false
+
+# Default IO content modes advertised on the card and per skill.
+defaultInputModes:
+  - "text"
+defaultOutputModes:
+  - "text"
+
+# Which existing Hermes capabilities to surface as A2A skills, and the cap on
+# the total number of skill entries (tools are listed first).
+expose:
+  tools: true
+  skills: true
+  max_skills: 128
+  # Names to hide from the public card. Accepts a tool name (e.g. "shell_exec")
+  # or a skill id ("skill:<name>"). The card is public, so blocklist any tool
+  # whose mere existence you would rather not advertise. Empty = advertise all.
+  exclude: []

--- a/tests/hermes_cli/test_a2a_agent_card.py
+++ b/tests/hermes_cli/test_a2a_agent_card.py
@@ -1,0 +1,221 @@
+"""Tests for the A2A Agent Card model and the /.well-known/agent.json endpoint.
+
+Split in two: the model/serialization tests import only the light
+``hermes_cli.a2a`` module; the endpoint tests spin up the FastAPI app via
+TestClient (importing ``web_server`` registers the real tool set).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import a2a
+
+
+# --------------------------------------------------------------------------
+# Agent Card model / serialization
+# --------------------------------------------------------------------------
+
+
+def test_agent_skill_to_dict():
+    skill = a2a.AgentSkill(
+        id="read_file", name="read_file", description="Read a file", tags=["files"]
+    )
+    assert skill.to_dict() == {
+        "id": "read_file",
+        "name": "read_file",
+        "description": "Read a file",
+        "tags": ["files"],
+    }
+
+
+def test_agent_card_to_dict_has_a2a_shape():
+    card = a2a.AgentCard(
+        name="Hermes",
+        description="desc",
+        url="https://host/a2a",
+        version="1.2.3",
+        skills=[a2a.AgentSkill(id="t", name="t", description="d", tags=["ts"])],
+        capabilities={"streaming": False},
+        authentication={"schemes": ["bearer"]},
+        provider={"organization": "NousResearch", "url": "https://example.com"},
+    )
+    data = card.to_dict()
+
+    # camelCase A2A keys present.
+    assert set(data) >= {
+        "name",
+        "description",
+        "url",
+        "version",
+        "capabilities",
+        "authentication",
+        "defaultInputModes",
+        "defaultOutputModes",
+        "skills",
+        "provider",
+    }
+    assert data["url"] == "https://host/a2a"
+    assert data["version"] == "1.2.3"
+    assert data["authentication"] == {"schemes": ["bearer"]}
+    assert data["defaultInputModes"] == ["text"]
+    assert data["skills"] == [
+        {"id": "t", "name": "t", "description": "d", "tags": ["ts"]}
+    ]
+    assert data["provider"]["organization"] == "NousResearch"
+
+
+def test_agent_card_omits_provider_when_absent():
+    card = a2a.AgentCard(name="H", description="", url="/a2a", version="0")
+    assert "provider" not in card.to_dict()
+
+
+def test_build_agent_card_resolves_relative_url():
+    cfg = {"url": "/a2a", "name": "Hermes"}
+    card = a2a.build_agent_card(cfg, capabilities=[], base_url="https://host:8080/")
+    assert card.url == "https://host:8080/a2a"
+
+
+def test_build_agent_card_leaves_absolute_url_untouched():
+    cfg = {"url": "https://pinned.example/a2a"}
+    card = a2a.build_agent_card(cfg, capabilities=[], base_url="https://host")
+    assert card.url == "https://pinned.example/a2a"
+
+
+def test_build_agent_card_injected_capabilities_and_version():
+    caps = [a2a.AgentSkill(id="x", name="x")]
+    card = a2a.build_agent_card({"name": "Hermes"}, capabilities=caps, version="9.9")
+    assert card.version == "9.9"
+    assert [s.id for s in card.skills] == ["x"]
+
+
+def test_load_config_overlays_defaults(tmp_path):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("name: Custom\nenabled: false\n", encoding="utf-8")
+    cfg = a2a.load_config(cfg_file)
+    assert cfg["name"] == "Custom"  # overridden
+    assert cfg["enabled"] is False  # overridden
+    assert cfg["url"] == "/a2a"  # default preserved
+    assert cfg["capabilities"]["streaming"] is False  # default preserved
+
+
+def test_collect_capabilities_skill_toggle_and_cap():
+    # Tools off, skills on: every entry is a SKILL.md skill, count is capped.
+    caps = a2a.collect_capabilities({
+        "expose": {"tools": False, "skills": True, "max_skills": 3}
+    })
+    assert len(caps) <= 3
+    assert all(s.id.startswith("skill:") for s in caps)
+
+
+def test_collect_capabilities_all_off_is_empty():
+    assert a2a.collect_capabilities({"expose": {"tools": False, "skills": False}}) == []
+
+
+def test_collect_capabilities_honours_exclude():
+    caps = a2a.collect_capabilities({
+        "expose": {"tools": False, "skills": True, "max_skills": 50}
+    })
+    assert caps, "expected at least one SKILL.md skill to exclude"
+    victim = caps[0].id  # e.g. "skill:a2a"
+    filtered = a2a.collect_capabilities({
+        "expose": {
+            "tools": False,
+            "skills": True,
+            "max_skills": 50,
+            "exclude": [victim],
+        }
+    })
+    assert victim not in {s.id for s in filtered}
+
+
+# --------------------------------------------------------------------------
+# /.well-known/agent.json endpoint
+# --------------------------------------------------------------------------
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient  # noqa: E402
+
+from hermes_cli import web_server  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    a2a.reset_discovery_cache()
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        a2a.reset_discovery_cache()
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def test_well_known_agent_json_endpoint(client):
+    response = client.get("/.well-known/agent.json")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+
+    # A2A card shape.
+    assert set(body) >= {
+        "name",
+        "url",
+        "version",
+        "capabilities",
+        "authentication",
+        "skills",
+    }
+    assert body["name"]
+    assert body["url"].endswith("/a2a")
+    assert body["url"].startswith("http")  # relative default resolved to request host
+    assert body["authentication"] == {"schemes": ["bearer"]}
+
+    # Importing web_server registers the real tool set, so the card advertises
+    # Hermes' own tools (id without the "skill:" prefix). No new core tool is
+    # added -- these are existing tools surfaced as A2A capabilities.
+    ids = [s["id"] for s in body["skills"]]
+    assert ids, "agent card should advertise at least one capability"
+    assert any(not i.startswith("skill:") for i in ids), (
+        "expected registered tools in the card"
+    )
+
+
+def test_well_known_agent_json_disabled_returns_404(client, monkeypatch):
+    monkeypatch.setattr(a2a, "load_config", lambda *a, **k: {"enabled": False})
+    a2a.reset_discovery_cache()  # force rebuild so the patched config is used
+    response = client.get("/.well-known/agent.json")
+    assert response.status_code == 404
+
+
+def test_well_known_agent_json_public_under_auth_gate():
+    """The card MUST be reachable unauthenticated even when the OAuth gate is
+    engaged -- A2A clients hold no dashboard cookie. Validates the
+    _GATE_PUBLIC_PREFIXES allowlist entry added for this endpoint."""
+    a2a.reset_discovery_cache()
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        gated = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+        # No session cookie, no session header -> still 200 (public allowlist).
+        response = gated.get("/.well-known/agent.json")
+        assert response.status_code == 200
+        assert response.json()["url"].endswith("/a2a")
+    finally:
+        a2a.reset_discovery_cache()
+        web_server.app.state.auth_required = prev_required
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port


### PR DESCRIPTION
## Summary

Implements **Slice 1 of #748** (issue **#879**): the A2A (Agent2Agent) **Agent Card** data model and the `/.well-known/agent.json` **discovery endpoint**. Hermes now advertises its *existing* tools and skills as A2A capabilities. This is a read-only discovery view — **no new core tools are registered**; all capability lives at the edge.

Closes #879.

## What's in scope (this PR)

- **`skills/a2a/`** plugin scaffold: `config.yaml` (documented config schema) + `SKILL.md` (agentskills.io frontmatter).
- **Agent Card model** — `hermes_cli/a2a.py`: `AgentCard` + `AgentSkill` dataclasses serializing to the A2A camelCase shape (`name`, `description`, `url`, `version`, `capabilities`, `authentication`, `provider`, `skills[]`), plus `build_agent_card()`.
- **Endpoint** — `GET /.well-known/agent.json` in `hermes_cli/web_server.py` (FastAPI, registered before the SPA catch-all so it isn't swallowed).
- **Capability sourcing** — each Hermes **tool** (from the live `tools.registry`, falling back to the static `toolsets.py` definitions so a bare dashboard process still advertises tools) and each **`SKILL.md` skill** maps to one `skills[]` entry. Zero calls to `registry.register(...)`.
- **Config-driven** — `enabled` (404 when off), `name`/`description`/`provider`, relative-or-absolute `url`, `authentication.schemes`, protocol `capabilities`, IO modes, and `expose.{tools,skills,max_skills,exclude}`.
- **Public discovery** — added one exact-path entry to `dashboard_auth.middleware._GATE_PUBLIC_PREFIXES` so A2A clients (which hold no dashboard cookie) can reach the card under the OAuth gate too. The legacy loopback gate already ignores non-`/api/` paths.
- **Tests** — `tests/hermes_cli/test_a2a_agent_card.py` (13): model/serialization, relative-vs-absolute URL, config overlay, exclude filter, capability toggles, the live endpoint (200 + shape + real tools present), `enabled:false` → 404, and unauthenticated access under the OAuth gate.

## Explicitly out of scope (later slices)

- **A2A client** (#880) and **A2A JSON-RPC server** (#881) — the card advertises where the service *will* live (`url`); it does not fulfill tasks. `capabilities.streaming` / `pushNotifications` are `false` for Slice 1.
- No auth *enforcement* on task invocation (arrives with the server slice); the card only *advertises* auth methods.

## Independent review (Gemini via `consult agy`)

Confirmed: stays within Slice 1 scope, follows the skill-plugin + FastAPI route conventions, adds no core tools, route ordering correct. Findings addressed:

- **DoS via per-request disk scan** (public endpoint re-scanned `skills/**/SKILL.md` + parsed YAML every hit) → added a 30s TTL snapshot cache (`get_discovery_snapshot`).
- **Info disclosure** (all tools exposed) → added an opt-in `expose.exclude` blocklist (tool name or `skill:<name>`); default empty. Note: A2A cards are public capability documents by design and expose only names + one-line descriptions (never secrets/config).
- **Host-header spoof → absolute URL** → already mitigated: setting an absolute `url` in `config.yaml` is left untouched (test covers it); strengthened the config note. The repo's host-header guard also applies.
- **Test coverage** → added the unauthenticated-under-gate test.

## Scope-size note

Functional surface is minimal (discovery only). Raw added lines: `a2a.py` 341, route +24, gate +4 (production), plus config 59 + SKILL.md 52 (docs) + tests 221. The overage past the ~200 soft cap is heavy docstrings (matching repo style), the static-toolset fallback, and the review-driven cache/exclude hardening — not extra feature scope.

## Verification

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_a2a_agent_card.py -q
.............                                                             [100%]
13 passed in 1.26s

# touched shared code (run per-file; the suite has pre-existing cross-file
# app.state pollution unrelated to this change — verified identical on main):
test_a2a_agent_card.py               13 passed
test_dashboard_auth_middleware.py    33 passed
test_dashboard_auth_prefix.py        24 passed
test_web_server_host_header.py       11 passed
test_web_server_fs.py                13 passed
test_plugin_runtime_disable_gate.py  10 passed

$ .venv/bin/ruff check .
All checks passed!

$ .venv/bin/ruff format --check hermes_cli/a2a.py tests/hermes_cli/test_a2a_agent_card.py
2 files already formatted
```

Added lines in `web_server.py` / `dashboard_auth/middleware.py` are ruff-clean (`ruff format --diff` touches only pre-existing lines in those files; the repo does not ruff-format them wholesale).
