### PR TITLE
fix(#745): align browser tool failure taxonomy and add guardrail caps

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -80,6 +80,14 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    # #745 — browser tools spiral expensively (each call drives a real browser)
+    # and their deterministic failures (CDP down, nav timeout, missing tool) do
+    # not recover on a blind retry. Cap consecutive same-browser-tool failures
+    # this turn and HALT regardless of ``hard_stop_enabled`` — mirroring the
+    # always-on per-URL cap in ``tools/browser_navigate_fallback`` — so a browser
+    # retry spiral is bounded even in the default (hard-stop-off) mode. ``0``
+    # disables the browser cap (falls back to the generic same-tool behaviour).
+    browser_failure_cap: int = 3
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -123,6 +131,10 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            browser_failure_cap=_non_negative_int(
+                data.get("browser_failure_cap"),
+                defaults.browser_failure_cap,
             ),
         )
 
@@ -339,6 +351,35 @@ class ToolCallGuardrailController:
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
 
+            # #745 — browser tools get an always-on per-tool failure cap that
+            # halts REGARDLESS of ``hard_stop_enabled``. Browser retries are
+            # expensive and their deterministic failures (CDP down, nav timeout,
+            # missing tool) do not recover on a blind retry, so bound the spiral
+            # even in the default hard-stop-off mode. This mirrors the per-URL
+            # cap in ``tools/browser_navigate_fallback`` and does NOT change the
+            # generic hard_stop circuit breaker for native tools below.
+            if (
+                self.config.browser_failure_cap >= 1
+                and _is_browser_tool(tool_name)
+                and same_count >= self.config.browser_failure_cap
+            ):
+                decision = ToolGuardrailDecision(
+                    action="halt",
+                    code="browser_tool_failure_cap",
+                    message=(
+                        f"Stopped {tool_name}: it failed {same_count} times this turn, "
+                        f"reaching the browser retry cap ({self.config.browser_failure_cap}). "
+                        "Browser retries are expensive and this failure is deterministic — "
+                        "stop re-driving the browser and use the fallback."
+                    ),
+                    tool_name=tool_name,
+                    count=same_count,
+                    signature=signature,
+                    fallback_directive=_fallback_directive_for(tool_name),
+                )
+                self._halt_decision = decision
+                return decision
+
             if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
                     action="halt",
@@ -495,12 +536,36 @@ _TOOL_FALLBACK_DIRECTIVE: dict[str, str] = {
     "image_generate": "report the visual blocker and supply a text description/placeholder instead of retrying, or verify the prompt and image-provider configuration",
     "video_analyze": "verify the video path and format with read_file, or work from a text summary of the video instead of retrying",
     "video_generate": "report the visual blocker and supply a text placeholder instead of retrying, or verify the prompt and video-provider configuration",
+    # #745 — browser tools: a deterministic browser failure (backend down, nav
+    # timeout, stale ref) does not recover on a blind retry. Route to the
+    # web_extract/web_search text fallback or a fresh snapshot instead of
+    # re-driving the browser.
+    "browser_navigate": "use web_extract or web_search for this URL instead of re-navigating; the page-text fallback is in the last result",
+    "browser_click": "re-run browser_snapshot to refresh element refs, or extract the page text with web_extract instead of retrying the same ref",
+    "browser_type": "re-run browser_snapshot to refresh element refs, or extract the page text with web_extract instead of retrying the same ref",
+    "browser_console": "the JS eval failed deterministically; read values via browser_snapshot or extract the page with web_extract instead of re-evaluating",
 }
+
+# #745 — generic fallback for any browser_* tool not explicitly listed above.
+_BROWSER_FALLBACK_DIRECTIVE = (
+    "stop re-driving the browser; use web_extract/web_search on the target URL, "
+    "or work from the page text already retrieved, instead of retrying"
+)
+
+
+def _is_browser_tool(tool_name: str) -> bool:
+    """Whether ``tool_name`` is a browser tool subject to the browser retry cap."""
+    return tool_name.startswith("browser_")
 
 
 def _fallback_directive_for(tool_name: str) -> str:
     """Return a concise fallback directive for a failing tool, or empty string."""
-    return _TOOL_FALLBACK_DIRECTIVE.get(tool_name, "")
+    directive = _TOOL_FALLBACK_DIRECTIVE.get(tool_name)
+    if directive is not None:
+        return directive
+    if _is_browser_tool(tool_name):
+        return _BROWSER_FALLBACK_DIRECTIVE
+    return ""
 
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
@@ -549,6 +614,18 @@ def _positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 1 else default
+
+
+def _non_negative_int(value: Any, default: int) -> int:
+    """Like ``_positive_int`` but allows ``0`` (used to DISABLE the browser
+    failure cap). Negative values fall back to the default."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
 
 
 def _sha256(value: str) -> str:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -46,6 +46,7 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
     assert cfg.exact_failure_block_after == 5
     assert cfg.same_tool_failure_halt_after == 8
     assert cfg.no_progress_block_after == 5
+    assert cfg.browser_failure_cap == 3
 
 
 def test_config_parses_nested_warn_and_hard_stop_thresholds():
@@ -457,3 +458,152 @@ def test_append_guidance_no_directive_for_allow_decision():
     )
     result = append_toolguard_guidance("output", decision)
     assert result == "output"
+
+
+# ── #745: browser tool retry-spiral cap (always-on, hard_stop-independent) ─────
+
+
+def test_browser_failure_cap_halts_spiral_with_hard_stop_off():
+    """A browser tool spiral halts at the browser cap even with hard_stop OFF.
+
+    This is the core #745 regression: the 15-consecutive browser_navigate /
+    10-consecutive browser_console spirals from the trace must be bounded in the
+    default (hard-stop-off) mode, not only when the generic circuit breaker is on.
+    """
+    controller = ToolCallGuardrailController()  # defaults: hard_stop_enabled=False
+    assert controller.config.hard_stop_enabled is False
+    assert controller.config.browser_failure_cap == 3
+
+    # Simulate a cross-iteration spiral: same browser tool, varying args (a
+    # broken backend fails regardless of URL), each result a failure.
+    decisions = []
+    for i in range(6):
+        # before_call would still allow (hard_stop off), but the after_call cap
+        # records a halt that ends the turn.
+        assert controller.before_call("browser_navigate", {"url": f"https://x/{i}"}).allows_execution
+        decisions.append(
+            controller.after_call(
+                "browser_navigate",
+                {"url": f"https://x/{i}"},
+                '{"success": false, "error": "Could not connect to Chrome backend"}',
+                failed=True,
+            )
+        )
+
+    # First two failures do not hit the cap (cap=3); the third halts and the
+    # spiral is stopped — no unbounded 15-in-a-row.
+    assert decisions[0].action == "allow"
+    halt = decisions[2]
+    assert halt.action == "halt"
+    assert halt.should_halt is True
+    assert halt.code == "browser_tool_failure_cap"
+    assert halt.count == 3
+    assert halt.fallback_directive != ""
+    assert controller.halt_decision is not None
+    assert controller.halt_decision.code == "browser_tool_failure_cap"
+
+
+def test_browser_failure_cap_applies_to_console_and_click():
+    """The cap covers every browser_* tool, not just navigate (browser_console
+    spiraled 10× in the trace)."""
+    for tool in ("browser_console", "browser_click", "browser_type"):
+        controller = ToolCallGuardrailController()
+        last = None
+        for _ in range(3):
+            last = controller.after_call(
+                tool, {"x": 1}, '{"success": false, "error": "boom"}', failed=True
+            )
+        assert last.action == "halt", tool
+        assert last.code == "browser_tool_failure_cap", tool
+        assert last.tool_name == tool
+
+
+def test_browser_cap_does_not_fire_before_threshold():
+    """Below the cap, browser failures only warn — the cap does not over-trigger."""
+    controller = ToolCallGuardrailController()
+    first = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    second = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    assert first.action == "allow"
+    assert second.action == "warn"  # exact_failure_warn_after == 2
+    assert controller.halt_decision is None
+
+
+def test_browser_cap_can_be_disabled():
+    """browser_failure_cap=0 disables the browser cap; spirals then follow the
+    generic same-tool behaviour (warn-only when hard_stop is off)."""
+    controller = ToolCallGuardrailController(ToolCallGuardrailConfig(browser_failure_cap=0))
+    decisions = [
+        controller.after_call(
+            "browser_navigate", {"url": f"u{i}"}, '{"error":"boom"}', failed=True
+        )
+        for i in range(6)
+    ]
+    assert all(d.action != "halt" for d in decisions)
+    assert controller.halt_decision is None
+
+
+def test_browser_cap_leaves_native_tool_hard_stop_semantics_unchanged():
+    """The always-on browser cap must not leak into native tools: with hard_stop
+    OFF, a native same-tool failure spiral still only warns (never halts)."""
+    controller = ToolCallGuardrailController()  # hard_stop off
+    decisions = [
+        controller.after_call(
+            "terminal", {"command": f"cmd-{i}"}, '{"exit_code":1}', failed=True
+        )
+        for i in range(10)
+    ]
+    assert all(d.action != "halt" for d in decisions)
+    assert controller.halt_decision is None
+
+
+def test_browser_cap_success_resets_streak():
+    """A successful browser call clears the failure streak, so the cap only
+    fires on a genuine consecutive spiral."""
+    controller = ToolCallGuardrailController()
+    controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    # A success resets the same-tool failure count.
+    controller.after_call("browser_navigate", {"url": "u"}, '{"success": true}', failed=False)
+    # Two more failures should NOT reach the cap (streak restarted at 1, 2).
+    d1 = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    d2 = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    assert d1.action != "halt"
+    assert d2.action != "halt"
+    assert controller.halt_decision is None
+
+
+def test_browser_cap_reset_for_turn_clears_streak():
+    """Per-turn reset clears the browser failure streak (no cross-turn leakage)."""
+    controller = ToolCallGuardrailController()
+    for _ in range(3):
+        controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    assert controller.halt_decision is not None
+    controller.reset_for_turn()
+    assert controller.halt_decision is None
+    d = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    assert d.action == "allow"
+
+
+def test_browser_failure_cap_parsed_from_mapping():
+    cfg = ToolCallGuardrailConfig.from_mapping({"browser_failure_cap": 5})
+    assert cfg.browser_failure_cap == 5
+    # 0 is honoured (disables); negative falls back to default.
+    assert ToolCallGuardrailConfig.from_mapping({"browser_failure_cap": 0}).browser_failure_cap == 0
+    assert ToolCallGuardrailConfig.from_mapping({"browser_failure_cap": -3}).browser_failure_cap == 3
+    assert ToolCallGuardrailConfig.from_mapping({}).browser_failure_cap == 3
+
+
+def test_browser_fallback_directive_for_all_browser_tools():
+    """Every browser_* tool resolves a non-empty fallback directive (explicit or
+    the generic browser default)."""
+    from agent.tool_guardrails import _fallback_directive_for
+
+    assert "web_extract" in _fallback_directive_for("browser_navigate")
+    assert "snapshot" in _fallback_directive_for("browser_click")
+    # An unlisted browser tool still gets the generic browser directive.
+    assert _fallback_directive_for("browser_get_images") == (
+        "stop re-driving the browser; use web_extract/web_search on the target URL, "
+        "or work from the page text already retrieved, instead of retrying"
+    )
+    # Non-browser unknown tools remain empty (unchanged behaviour).
+    assert _fallback_directive_for("mcp_custom_tool") == ""

--- a/tests/tools/test_browser_failure_taxonomy.py
+++ b/tests/tools/test_browser_failure_taxonomy.py
@@ -1,0 +1,88 @@
+"""Browser console/click/type failure paths surface the shared taxonomy (#745).
+
+Step 2 of #745: browser_click / browser_type / browser_console failure results
+must carry a ``failure_class`` drawn from the shared ``agent/tool_diagnostics``
+categories (via ``browser_navigate_fallback.classify_browser_error``), the same
+way ``browser_navigate`` already does — no parallel browser-only taxonomy.
+"""
+
+import json
+from unittest.mock import patch
+
+import agent.tool_diagnostics as td
+import tools.browser_tool as bt
+
+_SHARED_CATEGORIES = {cat for _pat, cat, _hint in td._RULES}
+
+
+class TestFailureTaggingHelpers:
+    def test_annotate_adds_shared_failure_class(self):
+        resp = bt._annotate_browser_failure(
+            {"success": False, "error": "Could not connect to Chrome backend"}
+        )
+        assert resp["failure_class"] == "provider_dead"
+        assert resp["failure_class"] in _SHARED_CATEGORIES
+
+    def test_annotate_is_noop_on_success(self):
+        resp = bt._annotate_browser_failure({"success": True, "result": "ok"})
+        assert "failure_class" not in resp
+
+    def test_annotate_preserves_existing_failure_class(self):
+        resp = bt._annotate_browser_failure(
+            {"success": False, "error": "x", "failure_class": "timeout"}
+        )
+        assert resp["failure_class"] == "timeout"
+
+    def test_tag_string_adds_failure_class(self):
+        tagged = bt._tag_browser_failure_class(
+            json.dumps({"success": False, "error": "navigation timed out"})
+        )
+        assert json.loads(tagged)["failure_class"] == "timeout"
+
+    def test_tag_string_noop_on_success_or_garbage(self):
+        ok = json.dumps({"success": True, "result": 1})
+        assert bt._tag_browser_failure_class(ok) == ok
+        assert bt._tag_browser_failure_class("not json") == "not json"
+
+
+class TestClickTypeConsoleFailurePaths:
+    def test_browser_click_failure_has_failure_class(self):
+        failed = {"success": False, "error": "Could not connect to Chrome backend"}
+        with patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._last_session_key", return_value="t"), \
+             patch("tools.browser_tool._blocked_private_page_action", return_value=None), \
+             patch("tools.browser_tool._run_browser_command", return_value=failed):
+            out = json.loads(bt.browser_click("@e5"))
+        assert out["success"] is False
+        assert out["failure_class"] == "provider_dead"
+
+    def test_browser_type_failure_has_failure_class(self):
+        failed = {"success": False, "error": "navigation timed out"}
+        with patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._last_session_key", return_value="t"), \
+             patch("tools.browser_tool._blocked_private_page_action", return_value=None), \
+             patch("tools.browser_tool._run_browser_command", return_value=failed):
+            out = json.loads(bt.browser_type("@e3", "hello"))
+        assert out["success"] is False
+        assert out["failure_class"] == "timeout"
+
+    def test_browser_console_eval_failure_has_failure_class(self):
+        failed = {"success": False, "error": "Could not connect to Chrome backend"}
+        with patch("tools.browser_tool._enforce_browser_eval_policy", return_value=None), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._last_session_key", return_value="t"), \
+             patch("tools.browser_tool._eval_ssrf_guard_active", return_value=False), \
+             patch("tools.browser_tool._run_browser_command", return_value=failed):
+            out = json.loads(bt.browser_console(expression="document.title"))
+        assert out["success"] is False
+        assert out["failure_class"] == "provider_dead"
+
+    def test_browser_click_success_has_no_failure_class(self):
+        ok = {"success": True}
+        with patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool._last_session_key", return_value="t"), \
+             patch("tools.browser_tool._blocked_private_page_action", return_value=None), \
+             patch("tools.browser_tool._run_browser_command", return_value=ok):
+            out = json.loads(bt.browser_click("@e5"))
+        assert out["success"] is True
+        assert "failure_class" not in out

--- a/tests/tools/test_browser_navigate_fallback.py
+++ b/tests/tools/test_browser_navigate_fallback.py
@@ -1,31 +1,66 @@
-"""Tests for tools/browser_navigate_fallback.py (#234/#213)."""
+"""Tests for tools/browser_navigate_fallback.py (#234/#213/#745).
 
+Since #745 the browser failure classes are the SHARED ``agent/tool_diagnostics``
+categories (no parallel browser-only taxonomy): CDP/backend down -> provider_dead,
+navigation timeout -> timeout, absent tool set -> missing_command, DOM read
+failure / generic -> runtime_error.
+"""
+
+import agent.tool_diagnostics as td
 import tools.browser_navigate_fallback as bnf
 
 
-class TestClassify:
-    def test_cdp_unavailable(self):
-        assert bnf.classify_navigation_error("CDP command timed out: Page.navigate") in (
-            "cdp_unavailable", "navigation_timeout")  # both are valid; timeout wins by order
+# Every class the browser classifier can return must be a real tool_diagnostics
+# category — this is what "no parallel taxonomy" means concretely.
+_SHARED_CATEGORIES = {cat for _pat, cat, _hint in td._RULES}
 
-    def test_pure_cdp(self):
-        assert bnf.classify_navigation_error("Could not connect to Chrome backend") == "cdp_unavailable"
+
+class TestClassify:
+    def test_cdp_timed_out_is_provider_dead_or_timeout(self):
+        # "CDP ... timed out" matches both the CDP (provider_dead) and timeout
+        # signals; the CDP rule is ordered first, so provider_dead wins.
+        assert bnf.classify_browser_error("CDP command timed out: Page.navigate") in (
+            "provider_dead", "timeout"
+        )
+
+    def test_pure_cdp_is_provider_dead(self):
+        assert bnf.classify_browser_error("Could not connect to Chrome backend") == "provider_dead"
 
     def test_timeout(self):
-        assert bnf.classify_navigation_error("navigation timed out after 60s") == "navigation_timeout"
+        assert bnf.classify_browser_error("navigation timed out after 60s") == "timeout"
 
-    def test_tool_not_present(self):
-        assert bnf.classify_navigation_error("Tool does not exist. Available tools: open, click") == "tool_not_present"
+    def test_tool_not_present_is_missing_command(self):
+        assert bnf.classify_browser_error(
+            "Tool does not exist. Available tools: open, click"
+        ) == "missing_command"
 
-    def test_dom_error(self):
-        assert bnf.classify_navigation_error("Could not compute box model") == "dom_error"
+    def test_dom_error_is_runtime_error(self):
+        assert bnf.classify_browser_error("Could not compute box model") == "runtime_error"
 
-    def test_generic(self):
-        assert bnf.classify_navigation_error("something weird happened") == "navigation_error"
+    def test_generic_is_runtime_error(self):
+        assert bnf.classify_browser_error("something weird happened") == "runtime_error"
 
-    def test_empty(self):
-        assert bnf.classify_navigation_error(None) == "navigation_error"
-        assert bnf.classify_navigation_error("") == "navigation_error"
+    def test_empty_is_runtime_error(self):
+        assert bnf.classify_browser_error(None) == "runtime_error"
+        assert bnf.classify_browser_error("") == "runtime_error"
+
+    def test_navigation_alias_matches_browser_error(self):
+        # Back-compat alias returns the same shared category.
+        assert bnf.classify_navigation_error("navigation timed out") == "timeout"
+
+    def test_all_outputs_are_shared_categories(self):
+        samples = [
+            "Could not connect to Chrome backend",
+            "navigation timed out after 60s",
+            "Tool does not exist. Available tools: open",
+            "Could not compute box model",
+            "something weird happened",
+            "permission denied writing profile",
+            None,
+            "",
+        ]
+        for s in samples:
+            assert bnf.classify_browser_error(s) in _SHARED_CATEGORIES
 
 
 class TestFailureCounter:
@@ -59,7 +94,8 @@ class TestBuildNavigationFailure:
         monkeypatch.setattr(bnf, "web_extract_fallback", lambda url: (None, "extract boom"))
         r = bnf.build_navigation_failure("https://x", "Could not connect to Chrome")
         assert r["fallback_used"] is None
-        assert r["failure_class"] == "cdp_unavailable"
+        assert r["failure_class"] == "provider_dead"
+        assert r["failure_class"] in _SHARED_CATEGORIES
         assert r["fallback_error"] == "extract boom"
         assert "web_search" in r["recovery"] or "extracted" in r["recovery"]
 
@@ -70,3 +106,4 @@ class TestBuildNavigationFailure:
         r = bnf.build_navigation_failure("https://x", "timeout")
         assert r["nav_failures_for_url"] == bnf.MAX_NAV_FAILURES
         assert "cap" in r["recovery"].lower() and "STOP" in r["recovery"]
+

--- a/tools/browser_navigate_fallback.py
+++ b/tools/browser_navigate_fallback.py
@@ -1,9 +1,19 @@
-"""Fallback + failure-taxonomy helpers for ``browser_navigate`` (#234/#213).
+"""Fallback + failure-taxonomy helpers for browser tools (#234/#213/#745).
 
 When navigation fails the agent used to retry ``browser_navigate`` up to 15× in
-a row with no recovery. This module gives the failure a small, stable TAXONOMY
-and an active fallback to ``web_extract`` (text retrieval of the same URL), plus
-a per-URL retry cap so a broken page/backend can't drive an unbounded spiral.
+a row with no recovery. This module gives the failure an active fallback to
+``web_extract`` (text retrieval of the same URL) plus a per-URL retry cap so a
+broken page/backend can't drive an unbounded spiral.
+
+Failure classification reuses the SHARED taxonomy in ``agent/tool_diagnostics``
+rather than defining a parallel one (#745): ``classify_browser_error`` returns
+one of the global ``tool_diagnostics`` categories (``timeout``, ``permission``,
+``missing_command``, ``limit``, ``provider_dead``, ``not_found``,
+``runtime_error``) so browser failures carry the same ``failure_class`` the
+native tools and ``loop_guard`` already use. Browser-specific error strings the
+generic classifier does not recognise (CDP/Chrome backend down, an absent tool
+set, box-model/DOM read failures) are routed to the closest shared category
+first, then anything else defers to ``tool_diagnostics.classify()``.
 
 Kept in its own module to avoid a top-level import cycle between
 ``tools.browser_tool`` and ``tools.web_tools`` — ``browser_tool`` imports it
@@ -18,6 +28,8 @@ import logging
 import re
 from typing import Optional, Tuple
 
+from agent.tool_diagnostics import classify as _diagnostics_classify
+
 logger = logging.getLogger(__name__)
 
 # Per-URL consecutive navigation-failure counts. After ``MAX_NAV_FAILURES`` the
@@ -27,40 +39,76 @@ logger = logging.getLogger(__name__)
 _nav_failures: dict[str, int] = {}
 MAX_NAV_FAILURES = 3
 
-# Ordered most-specific first; first match wins. (regex, taxonomy_class).
-_NAV_ERROR_RULES: tuple[tuple[re.Pattern, str], ...] = (
+# Browser-specific error signals the generic ``tool_diagnostics`` regexes do not
+# recognise (or would misclassify), mapped onto the SHARED taxonomy categories.
+# Ordered most-specific first; first match wins. Each RHS is a real
+# ``agent/tool_diagnostics`` category name — NOT a browser-only class (#745).
+_BROWSER_ERROR_RULES: tuple[tuple[re.Pattern, str], ...] = (
+    # A browser backend that exposes a different / absent tool set is a missing
+    # command: the requested browser command is not available here. ``classify``
+    # would call this ``not_found`` (change-and-retry); ``missing_command`` is
+    # the deterministic non-retryable class, which is the correct signal.
     (re.compile(r"tool does not exist|available tools:|unknown ref|no such tool", re.I),
-     "tool_not_present"),
-    (re.compile(r"\bCDP\b|chrome devtools|websocketdebugger|could not connect to (chrome|browser)|browser (backend|session) (unavailable|not)", re.I),
-     "cdp_unavailable"),
+     "missing_command"),
+    # CDP / Chrome backend down or unreachable is a dead provider: retrying the
+    # same navigation keeps failing — route to the web_extract / web_search
+    # fallback instead of re-driving a backend that is not there.
+    (re.compile(
+        r"\bCDP\b|chrome devtools|websocketdebugger|could not connect to (chrome|browser)"
+        r"|browser (backend|session) (unavailable|not)",
+        re.I,
+    ),
+     "provider_dead"),
+    # Navigation / page timeouts.
     (re.compile(r"timed out|timeout|deadline exceeded|navigation timeout|Page\.navigate", re.I),
-     "navigation_timeout"),
+     "timeout"),
+    # DOM / selector read failures are runtime errors against the live page.
     (re.compile(r"could not compute box model|detached|stale element|DOM|selector|element not found", re.I),
-     "dom_error"),
+     "runtime_error"),
 )
 
+# Browser-context recovery hints keyed by the SHARED ``tool_diagnostics``
+# category. The category is shared; the hint text is browser-flavoured (it
+# points at the web_extract / web_search fallback instead of the generic
+# advice). Categories without a browser-specific hint fall back to
+# ``_DEFAULT_HINT``.
 _TAXONOMY_HINT = {
-    "tool_not_present": "The browser backend exposed a different tool set. Do NOT repeat the same "
-                        "call — use the extracted text below, web_search, or report the gap.",
-    "cdp_unavailable": "The browser backend (CDP/Chrome) is unavailable. Retrying navigation will "
-                       "keep failing — use the extracted text below or web_search for this URL.",
-    "navigation_timeout": "Navigation timed out. This is deterministic for a slow/blocked page — "
-                          "use the extracted text below or web_search instead of re-navigating.",
-    "dom_error": "The page DOM could not be read. Use the extracted text below, or fetch via "
-                 "web_extract/web_search rather than re-driving the browser.",
-    "navigation_error": "Navigation failed. Use the extracted text below or web_search for this URL "
-                        "rather than repeating browser_navigate.",
+    "missing_command": "The browser backend exposed a different tool set. Do NOT repeat the same "
+                       "call — use the extracted text below, web_search, or report the gap.",
+    "provider_dead": "The browser backend (CDP/Chrome) is unavailable. Retrying navigation will "
+                     "keep failing — use the extracted text below or web_search for this URL.",
+    "timeout": "Navigation timed out. This is deterministic for a slow/blocked page — "
+               "use the extracted text below or web_search instead of re-navigating.",
+    "runtime_error": "The page could not be read/navigated. Use the extracted text below, or fetch "
+                     "via web_extract/web_search rather than re-driving the browser.",
 }
+_DEFAULT_HINT = _TAXONOMY_HINT["runtime_error"]
 
 
-def classify_navigation_error(error: Optional[str]) -> str:
-    """Map a navigation error string to a stable taxonomy class."""
+def classify_browser_error(error: Optional[str]) -> str:
+    """Map a browser tool error string to a shared ``agent/tool_diagnostics``
+    failure category.
+
+    Reuses the global taxonomy rather than a parallel one (#745). Browser-only
+    signals the generic classifier does not recognise are routed to the closest
+    shared category first; otherwise defers to ``tool_diagnostics.classify()``;
+    an unrecognised or empty failure defaults to ``runtime_error`` (the shared
+    catch-all).
+    """
     if not isinstance(error, str) or not error.strip():
-        return "navigation_error"
-    for pattern, klass in _NAV_ERROR_RULES:
+        return "runtime_error"
+    for pattern, category in _BROWSER_ERROR_RULES:
         if pattern.search(error):
-            return klass
-    return "navigation_error"
+            return category
+    hit = _diagnostics_classify(error)
+    if hit:
+        return hit[0]
+    return "runtime_error"
+
+
+# Back-compat alias: navigation-specific callers keep the old name, but it now
+# returns a shared ``tool_diagnostics`` category rather than a browser-only class.
+classify_navigation_error = classify_browser_error
 
 
 def record_nav_failure(url: str) -> int:
@@ -112,10 +160,10 @@ def web_extract_fallback(url: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def build_navigation_failure(url: str, error: Optional[str]) -> dict:
-    """Build the structured browser_navigate failure result (#234/#213):
-    classify, count toward the per-URL cap, attempt the web_extract fallback,
-    and attach an actionable recovery directive."""
-    klass = classify_navigation_error(error)
+    """Build the structured browser_navigate failure result (#234/#213/#745):
+    classify with the shared taxonomy, count toward the per-URL cap, attempt the
+    web_extract fallback, and attach an actionable recovery directive."""
+    klass = classify_browser_error(error)
     failures = record_nav_failure(url)
     capped = failures >= MAX_NAV_FAILURES
 
@@ -137,7 +185,7 @@ def build_navigation_failure(url: str, error: Optional[str]) -> dict:
     else:
         response["fallback_used"] = None
         response["fallback_error"] = fb_error
-        hint = _TAXONOMY_HINT.get(klass, _TAXONOMY_HINT["navigation_error"])
+        hint = _TAXONOMY_HINT.get(klass, _DEFAULT_HINT)
         if capped:
             hint = (
                 f"Reached the {MAX_NAV_FAILURES}-attempt cap for this URL. STOP "

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -987,6 +987,42 @@ def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Di
     return target
 
 
+def _annotate_browser_failure(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Tag a failed browser tool response with the shared failure taxonomy.
+
+    Adds a ``failure_class`` drawn from ``agent/tool_diagnostics`` (via
+    ``browser_navigate_fallback.classify_browser_error``) so browser
+    click/type/console failures surface the same categories as
+    ``browser_navigate`` and the native tools (#745/#737). No-op on success or
+    when already tagged; never raises."""
+    if response.get("success") is False and "failure_class" not in response:
+        try:
+            from tools.browser_navigate_fallback import classify_browser_error
+
+            response["failure_class"] = classify_browser_error(response.get("error"))
+        except Exception:  # pragma: no cover - tagging must never break a result
+            pass
+    return response
+
+
+def _tag_browser_failure_class(payload: str) -> str:
+    """String-level variant of ``_annotate_browser_failure`` for call sites that
+    only have the serialized JSON (e.g. delegated ``_browser_eval`` / camofox
+    output). Returns the payload unchanged on success or unparseable input."""
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return payload
+    if not isinstance(data, dict) or data.get("success") is not False:
+        return payload
+    if "failure_class" in data:
+        return payload
+    _annotate_browser_failure(data)
+    if "failure_class" not in data:
+        return payload
+    return json.dumps(data, ensure_ascii=False)
+
+
 def _run_chrome_fallback_command(
     task_id: str,
     command: str,
@@ -3036,12 +3072,12 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
-        return camofox_click(ref, task_id)
+        return _tag_browser_failure_class(camofox_click(ref, task_id))
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "click")
     if blocked is not None:
-        return blocked
+        return _tag_browser_failure_class(blocked)
 
     # Ensure ref starts with @
     if not ref.startswith("@"):
@@ -3060,6 +3096,7 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
             "success": False,
             "error": result.get("error", f"Failed to click {ref}")
         }
+        _annotate_browser_failure(response)
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
@@ -3077,12 +3114,12 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
-        return camofox_type(ref, text, task_id)
+        return _tag_browser_failure_class(camofox_type(ref, text, task_id))
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "type")
     if blocked is not None:
-        return blocked
+        return _tag_browser_failure_class(blocked)
 
     # Ensure ref starts with @
     if not ref.startswith("@"):
@@ -3116,6 +3153,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             "success": False,
             "error": result.get("error", f"Failed to type into {ref}")
         }
+        _annotate_browser_failure(response)
         response = _copy_fallback_warning(response, result)
         response = redact_browser_typed_text_for_display(response, text)
         return json.dumps(response, ensure_ascii=False)
@@ -3292,27 +3330,33 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     if expression is not None:
         policy_error = _enforce_browser_eval_policy(expression)
         if policy_error:
-            return json.dumps({"success": False, "error": policy_error}, ensure_ascii=False)
-        return _browser_eval(expression, task_id)
+            return json.dumps(
+                _annotate_browser_failure({"success": False, "error": policy_error}),
+                ensure_ascii=False,
+            )
+        return _tag_browser_failure_class(_browser_eval(expression, task_id))
 
     # --- Console output mode (original behaviour) ---
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_console
-        return camofox_console(clear, task_id)
+        return _tag_browser_failure_class(camofox_console(clear, task_id))
 
     effective_task_id = _last_session_key(task_id or "default")
 
     if _eval_ssrf_guard_active(effective_task_id):
         _blocked_url = _current_page_private_url(effective_task_id)
         if _blocked_url:
-            return json.dumps({
-                "success": False,
-                "error": (
-                    "Blocked: page URL targets a private or internal address "
-                    f"({_blocked_url}). This may have been caused by a "
-                    "JavaScript navigation via browser_console."
-                ),
-            }, ensure_ascii=False)
+            return json.dumps(
+                _annotate_browser_failure({
+                    "success": False,
+                    "error": (
+                        "Blocked: page URL targets a private or internal address "
+                        f"({_blocked_url}). This may have been caused by a "
+                        "JavaScript navigation via browser_console."
+                    ),
+                }),
+                ensure_ascii=False,
+            )
 
     console_args = ["--clear"] if clear else []
     error_args = ["--clear"] if clear else []


### PR DESCRIPTION
Closes #745 (child of #737).

## Prerequisite check (issue was labeled `blocked`)
The `blocked` label is **stale**. The blocking comment on #745 said implementation was blocked by *environment* tool-read timeouts, not missing prerequisites. All three alignment targets exist and were read before implementing:
- `agent/tool_diagnostics.py` — the shared taxonomy (`missing_command`, `permission`, `timeout`, `limit`, `provider_dead`, `not_found`, `runtime_error`).
- `agent/tool_guardrails.py` — per-tool retry/loop caps for native tools.
- `tools/browser_navigate_fallback.py` — browser navigation classification + per-URL cap.

## Scope
1. **Align `tools/browser_navigate_fallback.py` with the shared taxonomy.** `classify_browser_error` (new canonical name; `classify_navigation_error` kept as a back-compat alias) now returns the shared `agent/tool_diagnostics` categories instead of a parallel browser-only set (`cdp_unavailable`/`navigation_timeout`/`dom_error`/…). Browser-specific signals map to the closest shared category (CDP/backend down → `provider_dead`, nav timeout → `timeout`, absent tool set → `missing_command`, DOM read failure → `runtime_error`); anything else defers to `tool_diagnostics.classify()`; unrecognized/empty → `runtime_error`. Recovery hints are re-keyed by shared category.
2. **Browser console/click/type failure paths use the shared taxonomy.** `browser_click`, `browser_type`, and `browser_console` (eval, camofox, and SSRF/policy blocks) now tag failure results with a `failure_class` from the shared taxonomy via two small helpers (`_annotate_browser_failure`, `_tag_browser_failure_class`). No-ops on success.
3. **Per-tool browser retry cap in `agent/tool_guardrails.py`.** New always-on `browser_failure_cap` (default 3) halts a consecutive same-browser-tool failure spiral **even when `hard_stop_enabled` is off**, mirroring the always-on per-URL cap in `browser_navigate_fallback`. Native tools and `hard_stop` semantics are unchanged (the check is scoped to `browser_*` and sits before the existing hard-stop block). Browser tools also gain fallback directives. Config-driven; `0` disables.
4. **Regression tests** asserting the cap stops a browser retry spiral with hard_stop off, does not leak into native tools, resets on success and per-turn, and that console/click/type failures surface the shared `failure_class`.

## Verification
- `pytest` (new + touched modules): **166 passed** — `tests/tools/test_browser_failure_taxonomy.py` (new), `tests/tools/test_browser_navigate_fallback.py`, `tests/agent/test_tool_guardrails.py`, `tests/agent/test_tool_diagnostics.py`, `tests/tools/test_browser_console.py`, `tests/run_agent/test_agent_guardrails.py`, `tests/run_agent/test_tool_call_guardrail_runtime.py`. Broader `tests/tools -k browser` + guardrail runtime: **543 passed, 22 skipped** (pre-existing binary/network-gated skips).
- `ruff check .`: **All checks passed!** (repo lint gate selects `PLW1514`). Note: the repo does **not** enforce `ruff format` (baseline is non-conformant — untouched files also "would be reformatted"); new/changed code preserves each file's existing style, so `ruff format` was intentionally not applied to avoid reformatting unrelated code.
- Independent review by Gemini (`consult agy`, different provider) traced the full runtime and returned a clean pass: correct reuse of shared categories (no parallel taxonomy), cap stops the spiral before the hard-stop block with no native-tool side-effects, streak/turn integrity intact, circular-import-safe.

Do not merge — opening for review.