### PR TITLE
feat(#880): A2A task lifecycle client (send, SSE subscribe, cancel)

### DIFF
--- a/hermes_cli/a2a_client.py
+++ b/hermes_cli/a2a_client.py
@@ -1,0 +1,475 @@
+"""A2A (Agent2Agent) task lifecycle *client*.
+
+Slice 2 of #748 (issue #880). Complements the discovery view from #879
+(``hermes_cli/a2a.py``, which advertises *this* Hermes as an Agent Card):
+this module lets Hermes act as an A2A *caller* -- discover a remote agent's
+Agent Card, send it a task, observe the task's state transitions over
+Server-Sent Events (SSE), and cancel a running task.
+
+It rides Hermes' existing outbound-HTTP seam (``httpx`` -- already a core
+dependency and the transport used throughout ``hermes_cli/web_server.py``),
+so it adds **no** new dependency and registers **no** new core tool. An A2A
+client is a capability at the edge, driven by the ``skills/a2a`` skill.
+
+Wire protocol: A2A speaks JSON-RPC 2.0 over HTTP. The task methods used here
+are ``tasks/send`` (run one turn), ``tasks/sendSubscribe`` (same, but the
+response is an SSE stream of ``TaskStatusUpdateEvent`` / ``TaskArtifactUpdate``
+frames), ``tasks/get`` (poll) and ``tasks/cancel``. Task state flows through
+``submitted -> working -> (input-required) -> completed`` or is short-circuited
+to ``canceled`` / ``failed``. See https://google.github.io/A2A/ .
+"""
+
+from __future__ import annotations
+
+import enum
+import itertools
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import httpx
+
+from hermes_cli.a2a import AgentSkill
+
+logger = logging.getLogger(__name__)
+
+WELL_KNOWN_PATH = "/.well-known/agent.json"
+_DEFAULT_TIMEOUT = 30.0
+# SSE streams are long-lived; bound a *silent* server so subscribe() cannot
+# hang forever waiting for the next frame, while still allowing slow work.
+_DEFAULT_STREAM_READ_TIMEOUT = 120.0
+# Hard cap on frames consumed from one subscription -- defends against a
+# server that streams forever without ever marking a frame ``final``.
+_MAX_STREAM_EVENTS = 10_000
+# Cap on ``data:`` lines buffered for a *single* SSE event. A conformant
+# server terminates every event with a blank line; a peer that streams endless
+# ``data:`` lines without one would otherwise grow this buffer without bound
+# (each line resets the read timeout), so cap it and abort.
+_MAX_DATA_LINES_PER_EVENT = 100_000
+
+
+class A2AClientError(RuntimeError):
+    """Base class for A2A client failures (transport, HTTP, decode)."""
+
+
+class A2AProtocolError(A2AClientError):
+    """A JSON-RPC ``error`` object was returned by the remote agent."""
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        self.code = code
+        self.data = data
+        super().__init__(f"A2A JSON-RPC error {code}: {message}")
+
+
+class TaskState(str, enum.Enum):
+    """A2A task lifecycle states.
+
+    The five states called out by #880 -- ``submitted``, ``working``,
+    ``input-required``, ``completed``, ``canceled`` (cancelled) -- plus
+    ``failed`` and an ``unknown`` sentinel so an unexpected wire value never
+    crashes the state machine.
+    """
+
+    SUBMITTED = "submitted"
+    WORKING = "working"
+    INPUT_REQUIRED = "input-required"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_wire(cls, value: Any) -> "TaskState":
+        """Coerce a wire value to a member.
+
+        Accepts both the A2A spelling ``canceled`` and the British
+        ``cancelled`` for the cancelled state; anything unrecognised maps to
+        :attr:`UNKNOWN` rather than raising.
+        """
+        text = str(value or "").strip().lower()
+        if text in ("cancelled", "canceled"):
+            return cls.CANCELED
+        try:
+            return cls(text)
+        except ValueError:
+            return cls.UNKNOWN
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in _TERMINAL_STATES
+
+
+_TERMINAL_STATES = frozenset({
+    TaskState.COMPLETED,
+    TaskState.CANCELED,
+    TaskState.FAILED,
+})
+
+
+@dataclass
+class TaskStatus:
+    """The ``status`` block of an A2A task (state + optional agent message)."""
+
+    state: TaskState
+    message: Optional[Dict[str, Any]] = None
+    timestamp: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "TaskStatus":
+        data = data or {}
+        return cls(
+            state=TaskState.from_wire(data.get("state")),
+            message=data.get("message"),
+            timestamp=data.get("timestamp"),
+        )
+
+
+@dataclass
+class Task:
+    """A snapshot of a remote A2A task (result of tasks/send|get|cancel)."""
+
+    id: str
+    status: TaskStatus
+    session_id: Optional[str] = None
+    artifacts: List[Dict[str, Any]] = field(default_factory=list)
+    history: List[Dict[str, Any]] = field(default_factory=list)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def state(self) -> TaskState:
+        return self.status.state
+
+    @classmethod
+    def from_result(cls, result: Dict[str, Any]) -> "Task":
+        return cls(
+            id=str(result.get("id", "")),
+            status=TaskStatus.from_dict(result.get("status")),
+            session_id=result.get("sessionId"),
+            artifacts=list(result.get("artifacts") or []),
+            history=list(result.get("history") or []),
+            raw=result,
+        )
+
+
+@dataclass
+class TaskStatusUpdate:
+    """One SSE ``TaskStatusUpdateEvent`` frame observed during subscribe()."""
+
+    task_id: str
+    status: TaskStatus
+    final: bool = False
+
+    @property
+    def state(self) -> TaskState:
+        return self.status.state
+
+
+@dataclass
+class DiscoveredAgent:
+    """Parsed remote Agent Card plus the resolved JSON-RPC endpoint."""
+
+    name: str
+    endpoint: str
+    card: Dict[str, Any]
+    skills: List[AgentSkill] = field(default_factory=list)
+
+    @property
+    def supports_streaming(self) -> bool:
+        caps = self.card.get("capabilities") or {}
+        return bool(caps.get("streaming"))
+
+
+def text_message(text: str, role: str = "user") -> Dict[str, Any]:
+    """Build an A2A ``Message`` with a single text part."""
+    return {"role": role, "parts": [{"type": "text", "text": text}]}
+
+
+def _new_task_id() -> str:
+    return uuid.uuid4().hex
+
+
+class A2AClient:
+    """Client for the A2A task lifecycle against one remote agent.
+
+    ``base_url`` is the remote agent's origin (e.g. ``https://peer.example``).
+    The JSON-RPC endpoint is taken from the discovered Agent Card's ``url``;
+    :meth:`discover` runs lazily on first use if not called explicitly, so a
+    bare ``send_task`` still performs discover -> invoke.
+
+    ``transport`` is injectable so tests drive a fully in-memory mock A2A
+    server via :class:`httpx.MockTransport` -- no real network.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        auth_token: Optional[str] = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+        stream_read_timeout: float = _DEFAULT_STREAM_READ_TIMEOUT,
+        transport: Optional[httpx.BaseTransport] = None,
+        max_stream_events: int = _MAX_STREAM_EVENTS,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.auth_token = auth_token
+        self.timeout = timeout
+        self.stream_read_timeout = stream_read_timeout
+        self._transport = transport
+        self._max_stream_events = max_stream_events
+        self._endpoint: Optional[str] = None
+        self._ids = itertools.count(1)
+
+    # -- discovery --------------------------------------------------------
+
+    def discover(self) -> DiscoveredAgent:
+        """Fetch and parse the remote ``/.well-known/agent.json`` card."""
+        url = self.base_url + WELL_KNOWN_PATH
+        with self._client() as client:
+            card = self._decode_json(self._send(client, "GET", url))
+        if not isinstance(card, dict):
+            raise A2AClientError(f"Agent Card at {url} was not a JSON object")
+        raw_endpoint = str(card.get("url") or "").strip()
+        # A relative endpoint is resolved against the discovery origin; an
+        # absolute one is left untouched.
+        self._endpoint = (
+            urljoin(self.base_url + "/", raw_endpoint)
+            if raw_endpoint
+            else self.base_url
+        )
+        skills = [
+            AgentSkill(
+                id=str(s.get("id", "")),
+                name=str(s.get("name", "")),
+                description=str(s.get("description", "")),
+                tags=list(s.get("tags") or []),
+            )
+            for s in (card.get("skills") or [])
+            if isinstance(s, dict)
+        ]
+        return DiscoveredAgent(
+            name=str(card.get("name", "")),
+            endpoint=self._endpoint,
+            card=card,
+            skills=skills,
+        )
+
+    @property
+    def endpoint(self) -> str:
+        """The JSON-RPC endpoint, discovering it lazily on first access."""
+        if self._endpoint is None:
+            self.discover()
+        assert self._endpoint is not None
+        return self._endpoint
+
+    # -- task lifecycle ---------------------------------------------------
+
+    def send_task(
+        self,
+        message: Dict[str, Any],
+        *,
+        task_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> Task:
+        """Send one task turn (``tasks/send``) and return the resulting Task."""
+        params: Dict[str, Any] = {"id": task_id or _new_task_id(), "message": message}
+        if session_id:
+            params["sessionId"] = session_id
+        return Task.from_result(self._rpc("tasks/send", params))
+
+    def get_task(self, task_id: str, *, history_length: Optional[int] = None) -> Task:
+        """Poll a task's current state (``tasks/get``)."""
+        params: Dict[str, Any] = {"id": task_id}
+        if history_length is not None:
+            params["historyLength"] = history_length
+        return Task.from_result(self._rpc("tasks/get", params))
+
+    def cancel_task(self, task_id: str) -> Task:
+        """Request cancellation of a running task (``tasks/cancel``)."""
+        return Task.from_result(self._rpc("tasks/cancel", {"id": task_id}))
+
+    def subscribe(
+        self,
+        message: Dict[str, Any],
+        *,
+        task_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> Iterator[TaskStatusUpdate]:
+        """Send a task and yield its status transitions from the SSE stream.
+
+        This is a generator. The underlying HTTP stream is closed when it is
+        exhausted, when the caller stops early (``GeneratorExit`` via
+        ``.close()`` or ``break``), or on error -- the ``with`` blocks below
+        guarantee it. Iteration stops after a frame marked ``final`` or one
+        carrying a terminal state, and is hard-capped at ``max_stream_events``
+        frames, so a misbehaving server cannot hang the caller indefinitely.
+        """
+        endpoint = self.endpoint  # lazy-discover before opening the stream
+        params: Dict[str, Any] = {"id": task_id or _new_task_id(), "message": message}
+        if session_id:
+            params["sessionId"] = session_id
+        payload = self._jsonrpc("tasks/sendSubscribe", params)
+        # Overall connect budget from ``timeout``; per-frame read budget is the
+        # (larger) stream read timeout so slow work does not trip a false hang.
+        timeout = httpx.Timeout(self.timeout, read=self.stream_read_timeout)
+        with self._client(timeout=timeout) as client:
+            with client.stream(
+                "POST",
+                endpoint,
+                json=payload,
+                headers={"Accept": "text/event-stream"},
+            ) as response:
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise A2AClientError(
+                        f"A2A subscribe -> HTTP {exc.response.status_code}"
+                    ) from exc
+                lines = response.iter_lines()
+                for _event, data in _iter_sse(lines, self._max_stream_events):
+                    update = self._parse_stream_frame(data)
+                    if update is None:
+                        continue
+                    yield update
+                    if update.final or update.state.is_terminal:
+                        return
+
+    # -- internals --------------------------------------------------------
+
+    def _jsonrpc(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": next(self._ids),
+            "method": method,
+            "params": params,
+        }
+
+    def _rpc(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._jsonrpc(method, params)
+        with self._client() as client:
+            response = self._send(client, "POST", self.endpoint, json_body=payload)
+        return self._extract_result(self._decode_json(response))
+
+    def _extract_result(self, body: Any) -> Dict[str, Any]:
+        if not isinstance(body, dict):
+            raise A2AClientError("A2A response was not a JSON-RPC object")
+        error = body.get("error")
+        if error:
+            raise A2AProtocolError(
+                int(error.get("code", 0)),
+                str(error.get("message", "")),
+                error.get("data"),
+            )
+        result = body.get("result")
+        if not isinstance(result, dict):
+            raise A2AClientError("A2A JSON-RPC response missing 'result'")
+        return result
+
+    def _parse_stream_frame(self, data: str) -> Optional[TaskStatusUpdate]:
+        try:
+            frame = json.loads(data)
+        except json.JSONDecodeError:
+            logger.debug("A2A: skipping non-JSON SSE frame: %r", data[:120])
+            return None
+        if not isinstance(frame, dict):
+            return None
+        error = frame.get("error")
+        if error:
+            raise A2AProtocolError(
+                int(error.get("code", 0)),
+                str(error.get("message", "")),
+                error.get("data"),
+            )
+        result = frame.get("result")
+        # Only TaskStatusUpdateEvent frames carry a ``status``; artifact-update
+        # and other frame types have no state to observe, so skip them.
+        if not isinstance(result, dict) or "status" not in result:
+            return None
+        return TaskStatusUpdate(
+            task_id=str(result.get("id", "")),
+            status=TaskStatus.from_dict(result.get("status")),
+            final=bool(result.get("final")),
+        )
+
+    def _client(self, *, timeout: Optional[httpx.Timeout] = None) -> httpx.Client:
+        return httpx.Client(
+            transport=self._transport,
+            timeout=timeout or httpx.Timeout(self.timeout),
+            headers=self._headers(),
+        )
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"User-Agent": "Hermes-Agent/a2a-client"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        return headers
+
+    def _send(
+        self,
+        client: httpx.Client,
+        method: str,
+        url: str,
+        *,
+        json_body: Any = None,
+    ) -> httpx.Response:
+        try:
+            response = client.request(method, url, json=json_body)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as exc:
+            raise A2AClientError(
+                f"A2A {method} {url} -> HTTP {exc.response.status_code}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise A2AClientError(f"A2A {method} {url} failed: {exc}") from exc
+
+    @staticmethod
+    def _decode_json(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise A2AClientError("A2A response was not valid JSON") from exc
+
+
+def _iter_sse(
+    lines: Iterator[str], max_events: int
+) -> Iterator[Tuple[Optional[str], str]]:
+    """Parse an SSE line stream into ``(event, data)`` tuples.
+
+    ``lines`` is an iterator of newline-stripped lines (httpx
+    ``iter_lines()``). Multiple ``data:`` lines within one event are joined
+    with newlines per the SSE spec; comment lines (``:`` prefix) are ignored;
+    a value's single leading space after the colon is stripped. Emits at most
+    ``max_events`` frames, then stops.
+    """
+    data: List[str] = []
+    event: Optional[str] = None
+    emitted = 0
+    for raw in lines:
+        line = raw.rstrip("\r")
+        if line == "":
+            if data:
+                yield event, "\n".join(data)
+                emitted += 1
+                data, event = [], None
+                if emitted >= max_events:
+                    return
+            continue
+        if line.startswith(":"):
+            continue  # comment / keep-alive
+        field_name, sep, value = line.partition(":")
+        if sep and value.startswith(" "):
+            value = value[1:]
+        if field_name == "data":
+            data.append(value)
+            if len(data) > _MAX_DATA_LINES_PER_EVENT:
+                raise A2AClientError(
+                    "A2A SSE event exceeded the data-line buffer cap "
+                    f"({_MAX_DATA_LINES_PER_EVENT}); aborting stream"
+                )
+        elif field_name == "event":
+            event = value
+    if data:  # flush a final event not terminated by a blank line
+        yield event, "\n".join(data)

--- a/tests/hermes_cli/test_a2a_client.py
+++ b/tests/hermes_cli/test_a2a_client.py
@@ -1,0 +1,492 @@
+"""Tests for the A2A task lifecycle client (``hermes_cli/a2a_client.py``).
+
+Everything runs against an in-memory mock A2A server built on
+:class:`httpx.MockTransport` -- no real network. The mock server implements
+the A2A JSON-RPC surface the client speaks (``tasks/send``, ``tasks/get``,
+``tasks/cancel`` and the SSE ``tasks/sendSubscribe``) plus the
+``/.well-known/agent.json`` discovery document, records every request, and
+lets each test script the exact state sequence it wants to observe.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+import pytest
+
+from hermes_cli.a2a import AgentSkill
+from hermes_cli.a2a_client import (
+    A2AClient,
+    A2AClientError,
+    A2AProtocolError,
+    Task,
+    TaskState,
+    TaskStatusUpdate,
+    _iter_sse,
+    text_message,
+)
+
+BASE_URL = "http://peer.test"
+
+
+# --------------------------------------------------------------------------
+# In-memory mock A2A server
+# --------------------------------------------------------------------------
+
+
+def _sse(*frames: Dict[str, Any]) -> bytes:
+    """Serialise JSON-RPC result frames as an SSE ``text/event-stream`` body."""
+    chunks = []
+    for frame in frames:
+        chunks.append("data: " + json.dumps(frame) + "\n\n")
+    return "".join(chunks).encode("utf-8")
+
+
+def _status_frame(
+    request_id: Any, task_id: str, state: str, *, final: bool = False
+) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {"id": task_id, "status": {"state": state}, "final": final},
+    }
+
+
+class MockA2AServer:
+    """Scriptable A2A peer served through an ``httpx.MockTransport`` handler.
+
+    ``send_result`` / ``get_result`` / ``cancel_result`` return the JSON-RPC
+    ``result`` object for the matching method; ``stream_body`` returns the raw
+    SSE bytes for ``tasks/sendSubscribe``. Each is overridable per test.
+    """
+
+    def __init__(self) -> None:
+        self.requests: List[httpx.Request] = []
+        self.bodies: List[Dict[str, Any]] = []
+        self.card: Dict[str, Any] = {
+            "name": "PeerBot",
+            "url": "/a2a",  # relative -> resolved against BASE_URL
+            "version": "1.0.0",
+            "capabilities": {"streaming": True},
+            "authentication": {"schemes": ["bearer"]},
+            "skills": [
+                {
+                    "id": "echo",
+                    "name": "echo",
+                    "description": "Echo text",
+                    "tags": ["x"],
+                }
+            ],
+        }
+        self.send_result: Callable[[str, Dict[str, Any]], Dict[str, Any]] = (
+            lambda tid, params: {"id": tid, "status": {"state": "completed"}}
+        )
+        self.get_result: Callable[[str, Dict[str, Any]], Dict[str, Any]] = (
+            lambda tid, params: {"id": tid, "status": {"state": "working"}}
+        )
+        self.cancel_result: Callable[[str, Dict[str, Any]], Dict[str, Any]] = (
+            lambda tid, params: {"id": tid, "status": {"state": "canceled"}}
+        )
+        self.stream_body: Optional[Callable[[Any, str], bytes]] = None
+        self.card_status: int = 200
+
+    @property
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self._handle)
+
+    def client(self, **kwargs: Any) -> A2AClient:
+        return A2AClient(BASE_URL, transport=self.transport, **kwargs)
+
+    # -- request dispatch --------------------------------------------------
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if request.url.path == "/.well-known/agent.json":
+            if self.card_status != 200:
+                return httpx.Response(self.card_status, text="nope")
+            return httpx.Response(200, json=self.card)
+
+        body = json.loads(request.content.decode("utf-8"))
+        self.bodies.append(body)
+        method = body.get("method")
+        params = body.get("params") or {}
+        request_id = body.get("id")
+        task_id = str(params.get("id", ""))
+
+        if method == "tasks/send":
+            return self._result(request_id, self.send_result(task_id, params))
+        if method == "tasks/get":
+            return self._result(request_id, self.get_result(task_id, params))
+        if method == "tasks/cancel":
+            return self._result(request_id, self.cancel_result(task_id, params))
+        if method == "tasks/sendSubscribe":
+            builder = self.stream_body or self._default_stream
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=builder(request_id, task_id),
+            )
+        return self._error(request_id, -32601, f"method not found: {method}")
+
+    def _default_stream(self, request_id: Any, task_id: str) -> bytes:
+        return _sse(
+            _status_frame(request_id, task_id, "submitted"),
+            _status_frame(request_id, task_id, "working"),
+            _status_frame(request_id, task_id, "completed", final=True),
+        )
+
+    @staticmethod
+    def _result(request_id: Any, result: Dict[str, Any]) -> httpx.Response:
+        return httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": request_id, "result": result}
+        )
+
+    @staticmethod
+    def _error(request_id: Any, code: int, message: str) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": code, "message": message},
+            },
+        )
+
+
+@pytest.fixture
+def server() -> MockA2AServer:
+    return MockA2AServer()
+
+
+# --------------------------------------------------------------------------
+# Pure helpers: state coercion + SSE parsing
+# --------------------------------------------------------------------------
+
+
+def test_task_state_from_wire_normalises_spellings():
+    assert TaskState.from_wire("submitted") is TaskState.SUBMITTED
+    assert TaskState.from_wire("input-required") is TaskState.INPUT_REQUIRED
+    # Both the A2A ("canceled") and British ("cancelled") spellings map home.
+    assert TaskState.from_wire("canceled") is TaskState.CANCELED
+    assert TaskState.from_wire("cancelled") is TaskState.CANCELED
+    assert TaskState.from_wire("  WORKING ") is TaskState.WORKING
+    # Unknown / empty never raises -- it degrades to the sentinel.
+    assert TaskState.from_wire("wat") is TaskState.UNKNOWN
+    assert TaskState.from_wire(None) is TaskState.UNKNOWN
+
+
+def test_task_state_terminal_flags():
+    assert TaskState.COMPLETED.is_terminal
+    assert TaskState.CANCELED.is_terminal
+    assert TaskState.FAILED.is_terminal
+    assert not TaskState.WORKING.is_terminal
+    assert not TaskState.INPUT_REQUIRED.is_terminal
+
+
+def test_iter_sse_multiline_comments_and_compact():
+    lines = iter([
+        ": keep-alive comment",
+        "event: status",
+        "data: line-one",
+        "data: line-two",
+        "",  # dispatch first event
+        'data:{"compact":true}',  # no space after colon
+        "",  # dispatch second event
+    ])
+    events = list(_iter_sse(lines, max_events=100))
+    assert events[0] == ("status", "line-one\nline-two")
+    assert events[1] == (None, '{"compact":true}')
+
+
+def test_iter_sse_flushes_trailing_event_without_blank_line():
+    events = list(_iter_sse(iter(["data: only\r"]), max_events=100))
+    assert events == [(None, "only")]
+
+
+def test_iter_sse_respects_max_events():
+    lines = iter(["data: a", "", "data: b", "", "data: c", ""])
+    assert list(_iter_sse(lines, max_events=2)) == [(None, "a"), (None, "b")]
+
+
+def test_iter_sse_aborts_on_unterminated_event_buffer():
+    from hermes_cli import a2a_client
+
+    # A peer that streams endless ``data:`` lines with no blank line would grow
+    # the buffer without bound; the per-event cap turns that into a clean abort.
+    def endless():
+        while True:
+            yield "data: x"
+
+    original = a2a_client._MAX_DATA_LINES_PER_EVENT
+    a2a_client._MAX_DATA_LINES_PER_EVENT = 5
+    try:
+        with pytest.raises(A2AClientError):
+            list(_iter_sse(endless(), max_events=100))
+    finally:
+        a2a_client._MAX_DATA_LINES_PER_EVENT = original
+
+
+def test_text_message_shape():
+    assert text_message("hi") == {
+        "role": "user",
+        "parts": [{"type": "text", "text": "hi"}],
+    }
+
+
+# --------------------------------------------------------------------------
+# Discovery
+# --------------------------------------------------------------------------
+
+
+def test_discover_parses_card_and_resolves_relative_endpoint(server):
+    agent = server.client().discover()
+    assert agent.name == "PeerBot"
+    assert agent.endpoint == "http://peer.test/a2a"  # relative -> absolute
+    assert agent.supports_streaming is True
+    assert agent.skills == [
+        AgentSkill(id="echo", name="echo", description="Echo text", tags=["x"])
+    ]
+
+
+def test_discover_leaves_absolute_endpoint_untouched(server):
+    server.card["url"] = "https://pinned.example/rpc"
+    agent = server.client().discover()
+    assert agent.endpoint == "https://pinned.example/rpc"
+
+
+def test_discover_http_error_raises_client_error(server):
+    server.card_status = 500
+    with pytest.raises(A2AClientError):
+        server.client().discover()
+
+
+# --------------------------------------------------------------------------
+# discover -> invoke
+# --------------------------------------------------------------------------
+
+
+def test_send_task_auto_discovers_then_invokes(server):
+    """A bare send_task must first GET the card, then POST tasks/send."""
+    task = server.client().send_task(text_message("ping"), task_id="t-1")
+
+    assert isinstance(task, Task)
+    assert task.state is TaskState.COMPLETED
+    assert task.id == "t-1"
+
+    paths = [r.url.path for r in server.requests]
+    assert paths == ["/.well-known/agent.json", "/a2a"]  # discover then invoke
+
+    sent = server.bodies[0]
+    assert sent["method"] == "tasks/send"
+    assert sent["jsonrpc"] == "2.0"
+    assert sent["params"]["id"] == "t-1"
+    assert sent["params"]["message"] == text_message("ping")
+
+
+def test_send_task_attaches_bearer_token(server):
+    server.client(auth_token="secret-abc").send_task(text_message("hi"), task_id="t")
+    invoke = [r for r in server.requests if r.url.path == "/a2a"][0]
+    assert invoke.headers["Authorization"] == "Bearer secret-abc"
+
+
+def test_send_task_reuses_discovered_endpoint(server):
+    client = server.client()
+    client.discover()
+    client.send_task(text_message("a"), task_id="t-a")
+    client.send_task(text_message("b"), task_id="t-b")
+    # One discovery, two invokes -- endpoint cached after first discover.
+    paths = [r.url.path for r in server.requests]
+    assert paths.count("/.well-known/agent.json") == 1
+    assert paths.count("/a2a") == 2
+
+
+def test_send_task_input_required_state(server):
+    server.send_result = lambda tid, params: {
+        "id": tid,
+        "status": {"state": "input-required", "message": {"role": "agent"}},
+    }
+    task = server.client().send_task(text_message("need more"), task_id="t")
+    assert task.state is TaskState.INPUT_REQUIRED
+    assert task.status.message == {"role": "agent"}
+
+
+# --------------------------------------------------------------------------
+# SSE subscribe: observable state transitions
+# --------------------------------------------------------------------------
+
+
+def test_subscribe_observes_full_transition_sequence(server):
+    updates = list(server.client().subscribe(text_message("go"), task_id="job-1"))
+    assert [u.state for u in updates] == [
+        TaskState.SUBMITTED,
+        TaskState.WORKING,
+        TaskState.COMPLETED,
+    ]
+    assert all(isinstance(u, TaskStatusUpdate) for u in updates)
+    assert all(u.task_id == "job-1" for u in updates)
+    assert updates[-1].final is True
+
+    # The subscribe call went to the JSON-RPC endpoint with the SSE method.
+    subscribe_body = server.bodies[-1]
+    assert subscribe_body["method"] == "tasks/sendSubscribe"
+
+
+def test_subscribe_stops_on_terminal_state_without_final_flag(server):
+    # Server never sets ``final``; the client must still stop on ``canceled``.
+    def stream(request_id, task_id):
+        return _sse(
+            _status_frame(request_id, task_id, "working"),
+            _status_frame(request_id, task_id, "canceled"),
+            _status_frame(request_id, task_id, "working"),  # must never surface
+        )
+
+    server.stream_body = stream
+    updates = list(server.client().subscribe(text_message("go"), task_id="j"))
+    assert [u.state for u in updates] == [TaskState.WORKING, TaskState.CANCELED]
+
+
+def test_subscribe_skips_artifact_frames_without_status(server):
+    def stream(request_id, task_id):
+        artifact = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"id": task_id, "artifact": {"parts": []}},
+        }
+        return (
+            _sse(_status_frame(request_id, task_id, "working"))
+            + _sse(artifact)
+            + _sse(_status_frame(request_id, task_id, "completed", final=True))
+        )
+
+    server.stream_body = stream
+    updates = list(server.client().subscribe(text_message("go"), task_id="j"))
+    assert [u.state for u in updates] == [TaskState.WORKING, TaskState.COMPLETED]
+
+
+def test_subscribe_early_break_closes_stream_without_hang(server):
+    def stream(request_id, task_id):
+        return _sse(
+            _status_frame(request_id, task_id, "submitted"),
+            _status_frame(request_id, task_id, "working"),
+            _status_frame(request_id, task_id, "completed", final=True),
+        )
+
+    server.stream_body = stream
+    gen = server.client().subscribe(text_message("go"), task_id="j")
+    first = next(gen)
+    assert first.state is TaskState.SUBMITTED
+    # Closing the generator early must tear down the stream cleanly (the
+    # generator's ``with`` blocks run on GeneratorExit) -- no exception, no hang.
+    gen.close()
+
+
+def test_subscribe_max_events_cap_prevents_unbounded_stream(server):
+    def stream(request_id, task_id):
+        # 5 non-final ``working`` frames -- a server that never terminates.
+        return _sse(*[_status_frame(request_id, task_id, "working") for _ in range(5)])
+
+    server.stream_body = stream
+    client = server.client(max_stream_events=3)
+    updates = list(client.subscribe(text_message("go"), task_id="j"))
+    assert len(updates) == 3  # hard cap, not all 5
+
+
+def test_subscribe_protocol_error_frame_raises(server):
+    def stream(request_id, task_id):
+        return _sse({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32000, "message": "boom"},
+        })
+
+    server.stream_body = stream
+    with pytest.raises(A2AProtocolError) as exc:
+        list(server.client().subscribe(text_message("go"), task_id="j"))
+    assert exc.value.code == -32000
+
+
+def test_subscribe_http_error_raises_client_error(server):
+    def broken_transport(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/.well-known/agent.json":
+            return httpx.Response(200, json=server.card)
+        return httpx.Response(503, text="unavailable")
+
+    client = A2AClient(BASE_URL, transport=httpx.MockTransport(broken_transport))
+    with pytest.raises(A2AClientError):
+        list(client.subscribe(text_message("go"), task_id="j"))
+
+
+# --------------------------------------------------------------------------
+# Cancel
+# --------------------------------------------------------------------------
+
+
+def test_cancel_task_transitions_to_canceled(server):
+    task = server.client().cancel_task("t-9")
+    assert task.state is TaskState.CANCELED
+    body = server.bodies[-1]
+    assert body["method"] == "tasks/cancel"
+    assert body["params"] == {"id": "t-9"}
+
+
+def test_cancel_task_accepts_british_spelling(server):
+    server.cancel_result = lambda tid, params: {
+        "id": tid,
+        "status": {"state": "cancelled"},  # British spelling on the wire
+    }
+    task = server.client().cancel_task("t-9")
+    assert task.state is TaskState.CANCELED
+
+
+# --------------------------------------------------------------------------
+# JSON-RPC / HTTP error handling on unary calls
+# --------------------------------------------------------------------------
+
+
+def test_rpc_jsonrpc_error_raises_protocol_error(server):
+    server.send_result = lambda tid, params: (_ for _ in ()).throw(
+        AssertionError("should not be called")
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/.well-known/agent.json":
+            return httpx.Response(200, json=server.card)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32602, "message": "bad params", "data": {"x": 1}},
+            },
+        )
+
+    client = A2AClient(BASE_URL, transport=httpx.MockTransport(handler))
+    with pytest.raises(A2AProtocolError) as exc:
+        client.send_task(text_message("hi"), task_id="t")
+    assert exc.value.code == -32602
+    assert exc.value.data == {"x": 1}
+
+
+def test_rpc_http_error_raises_client_error(server):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/.well-known/agent.json":
+            return httpx.Response(200, json=server.card)
+        return httpx.Response(500, text="kaboom")
+
+    client = A2AClient(BASE_URL, transport=httpx.MockTransport(handler))
+    with pytest.raises(A2AClientError):
+        client.send_task(text_message("hi"), task_id="t")
+
+
+def test_rpc_result_missing_raises_client_error(server):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/.well-known/agent.json":
+            return httpx.Response(200, json=server.card)
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1})  # no result
+
+    client = A2AClient(BASE_URL, transport=httpx.MockTransport(handler))
+    with pytest.raises(A2AClientError):
+        client.get_task("t")


### PR DESCRIPTION
## Slice 2 of #748 — A2A task lifecycle **client**

Closes #880.

Builds on the #879 discovery foundation (`hermes_cli/a2a.py`,
`GET /.well-known/agent.json`). This slice lets Hermes act as an A2A
**caller**: discover a remote agent's Agent Card, send it a task, observe the
task's state transitions over Server-Sent Events (SSE), and cancel a running
task.

### What's here
- **New module `hermes_cli/a2a_client.py`** — all client code lives here.
  It imports read-only from `hermes_cli/a2a.py` (reuses `AgentSkill`) and does
  **not** touch `a2a.py`, `web_server.py`, or `dashboard_auth/middleware.py`
  (owned by #879/#881), so it will not conflict with the parallel #881 server.
- `A2AClient` over Hermes' existing outbound-HTTP seam (`httpx` — already a
  core dependency and the transport used throughout `web_server.py`). **No new
  dependency; no new core tool registered** — the A2A client is an edge
  capability driven by the `skills/a2a` skill, not wired into `tools/registry`.
- JSON-RPC 2.0 methods: `tasks/send`, `tasks/get`, `tasks/cancel`, and the SSE
  `tasks/sendSubscribe`. `discover()` runs lazily on first use, so a bare
  `send_task` still performs discover -> invoke.
- **All five task states**: `submitted`, `working`, `input-required`,
  `completed`, `canceled`/`cancelled` (plus `failed` and an `unknown`
  sentinel). `TaskState.from_wire` normalises both the A2A (`canceled`) and
  British (`cancelled`) spellings and never raises on an unexpected value.
- **Robust SSE parser** (`_iter_sse`): multi-line `data:`, comment/keep-alive
  lines, CRLF, compact `data:{...}` (no space), and a trailing event with no
  closing blank line. Subscription is bounded three ways so a misbehaving peer
  cannot hang the caller: (a) `with client.stream(...)` closes the stream on
  exhaustion / early `break` / error, (b) a per-subscription frame cap
  (`max_stream_events`), (c) a per-event `data:`-line buffer cap, and it stops
  on the first `final` frame or terminal state.

### Tests — mock A2A server, no real network
`tests/hermes_cli/test_a2a_client.py` drives an in-memory `MockA2AServer` built
on `httpx.MockTransport`. Covers: discover -> invoke ordering, relative/absolute
endpoint resolution, Bearer auth, the full SSE transition sequence
(submitted -> working -> completed), stop-on-terminal-without-`final`, artifact
frames skipped, early-break stream teardown, the frame/buffer caps, cancel
(both spellings), and JSON-RPC / HTTP / malformed-response error paths.

### Verification
```
$ pytest tests/hermes_cli/test_a2a_client.py -q
26 passed in 0.59s

$ ruff check .
All checks passed!

$ ruff format --check hermes_cli/a2a_client.py tests/hermes_cli/test_a2a_client.py
2 files already formatted
```

### Independent review
`consult agy` (Gemini) was attempted twice for an independent second opinion;
both runs timed out without returning (inconclusive). Proceeding on green
tests + ruff and a self-review that proactively added the unbounded-SSE-buffer
guard the review question probes for. Happy to fold in findings if a later
review lands.

### Not in scope (later slices)
- The A2A JSON-RPC **server** that fulfils tasks (#881, in parallel).
- Push notifications / richer artifact handling.
