### PR TITLE
feat(#881): minimal A2A server endpoint mapping tasks to tool calls

### DIFF
--- a/hermes_cli/a2a_server.py
+++ b/hermes_cli/a2a_server.py
@@ -1,0 +1,445 @@
+"""A2A (Agent2Agent) server: accept JSON-RPC task submissions and map each to a
+Hermes tool call.
+
+Slice 3 of #748 (issue #881). Builds on the Slice-1 discovery view
+(``hermes_cli/a2a.py`` + ``/.well-known/agent.json``): this module turns an
+incoming A2A ``message/send`` / ``message/stream`` into a single dispatch
+through the *existing* Hermes tool registry (``tools.registry.registry``). It
+adds **no** core tools -- it is a thin JSON-RPC front over tools Hermes already
+has.
+
+Security posture (the route wiring in ``web_server.py`` owns transport auth):
+  * The route calls ``_require_token`` so unauthenticated callers never reach
+    task execution (loopback: session token/bearer; non-loopback: the OAuth
+    gate 401/302s first). This module assumes the caller is already authorized.
+  * Even for an authorized caller, only tools **advertised on the Agent Card**
+    are dispatchable (:func:`_authorize_tool`). This honours the card's
+    ``expose``/``exclude`` blocklist, so a tool Hermes deliberately hid is not
+    reachable over A2A. Unknown/hidden tools are indistinguishable (no oracle).
+  * Requests are size-capped (route) and each tool runs under a wall-clock
+    timeout (:data:`TOOL_TIMEOUT_S`) in a worker thread, so a slow/hung tool
+    can't block the event loop or hold an SSE stream open forever.
+
+Task state lives here (the "shared task-state type" for this wave):
+:class:`A2ATask` + the in-memory bounded :class:`TaskStore`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# JSON-RPC 2.0 error codes (+ the A2A TaskNotFound extension, -32001).
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+TASK_NOT_FOUND = -32001
+
+# Resource caps. MAX_REQUEST_BYTES is enforced by the route on the raw body;
+# it is exported here so both sides share one number.
+MAX_REQUEST_BYTES = 256 * 1024
+TOOL_TIMEOUT_S = 60.0
+MAX_TASKS = 256
+
+# A2A TaskState values we use.
+SUBMITTED = "submitted"
+WORKING = "working"
+COMPLETED = "completed"
+CANCELED = "canceled"
+FAILED = "failed"
+TERMINAL = frozenset({COMPLETED, CANCELED, FAILED})
+
+
+class A2AError(Exception):
+    """A JSON-RPC error carrying a ``code``/``message`` (and optional ``data``)."""
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+@dataclass
+class A2ATask:
+    """One A2A task = one mapped Hermes tool call, plus its state history."""
+
+    id: str
+    context_id: str
+    tool: str
+    arguments: Dict[str, Any]
+    state: str = SUBMITTED
+    result: Optional[str] = None
+    error: Optional[str] = None
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize as an A2A ``Task`` object (camelCase)."""
+        status: Dict[str, Any] = {"state": self.state, "timestamp": _now_iso()}
+        if self.error:
+            status["message"] = _agent_text(self.error)
+        task: Dict[str, Any] = {
+            "id": self.id,
+            "contextId": self.context_id,
+            "kind": "task",
+            "status": status,
+            "history": list(self.history),
+            "artifacts": _artifacts(self),
+        }
+        return task
+
+
+class TaskStore:
+    """Thread-safe, bounded in-memory task store (FIFO eviction)."""
+
+    def __init__(self, max_tasks: int = MAX_TASKS) -> None:
+        self._tasks: "OrderedDict[str, A2ATask]" = OrderedDict()
+        self._lock = Lock()
+        self._max = max_tasks
+
+    def put(self, task: A2ATask) -> None:
+        with self._lock:
+            self._tasks[task.id] = task
+            self._tasks.move_to_end(task.id)
+            while len(self._tasks) > self._max:
+                self._tasks.popitem(last=False)
+
+    def get(self, task_id: str) -> Optional[A2ATask]:
+        with self._lock:
+            return self._tasks.get(task_id)
+
+
+# Process-wide default store. Tests may pass their own.
+_STORE = TaskStore()
+
+
+# --------------------------------------------------------------------------
+# JSON-RPC entry points (consumed by the web_server route)
+# --------------------------------------------------------------------------
+
+
+async def handle_rpc(payload: Any, store: Optional[TaskStore] = None) -> Dict[str, Any]:
+    """Handle a non-streaming JSON-RPC call, returning a response envelope.
+
+    Supports ``message/send`` (create + run a task to completion),
+    ``tasks/get`` and ``tasks/cancel``.
+    """
+    store = store or _STORE
+    rid, method, params, err = _parse_envelope(payload)
+    if err is not None:
+        return _rpc_error(rid, err)
+    try:
+        if method == "message/send":
+            task = _new_task(params)
+            await _execute(task, store)
+            return _rpc_result(rid, task.to_dict())
+        if method == "tasks/get":
+            return _rpc_result(rid, _lookup(params, store).to_dict())
+        if method == "tasks/cancel":
+            task = _lookup(params, store)
+            if task.state not in TERMINAL:
+                _set_state(task, CANCELED)
+            return _rpc_result(rid, task.to_dict())
+        raise A2AError(METHOD_NOT_FOUND, f"unknown method: {method}")
+    except A2AError as exc:
+        return _rpc_error(rid, exc)
+    except Exception:  # pragma: no cover - defensive: never leak a traceback
+        logger.exception("A2A: internal error handling %r", method)
+        return _rpc_error(rid, A2AError(INTERNAL_ERROR, "internal error"))
+
+
+async def sse_stream(
+    payload: Any, store: Optional[TaskStore] = None
+) -> AsyncIterator[str]:
+    """Handle ``message/stream``, yielding SSE frames for each state transition.
+
+    Emits ``submitted`` -> ``working`` -> terminal (``completed``/``failed``),
+    each as a JSON-RPC result wrapping an A2A ``status-update`` event. The
+    generator ALWAYS terminates (terminal frame then return), so the stream is
+    never left open.
+    """
+    store = store or _STORE
+    rid, method, params, err = _parse_envelope(payload)
+    if err is not None:
+        yield _sse(_rpc_error(rid, err))
+        return
+    if method != "message/stream":
+        yield _sse(
+            _rpc_error(rid, A2AError(METHOD_NOT_FOUND, f"unknown method: {method}"))
+        )
+        return
+    try:
+        task = _new_task(params)
+    except A2AError as exc:
+        yield _sse(_rpc_error(rid, exc))
+        return
+
+    store.put(task)
+    yield _sse(_rpc_result(rid, _status_event(task, final=False)))
+    _set_state(task, WORKING)
+    yield _sse(_rpc_result(rid, _status_event(task, final=False)))
+    await _run(task)
+    yield _sse(_rpc_result(rid, _status_event(task, final=True)))
+
+
+def parse_error_response() -> Dict[str, Any]:
+    """Envelope for an unparseable request body (id is null per JSON-RPC)."""
+    return _rpc_error(None, A2AError(PARSE_ERROR, "parse error"))
+
+
+# --------------------------------------------------------------------------
+# Task creation / execution
+# --------------------------------------------------------------------------
+
+
+def _new_task(params: Dict[str, Any]) -> A2ATask:
+    """Build a task from ``message/send`` params, authorizing the mapped tool."""
+    message = params.get("message")
+    tool, args = _extract_tool_call(message)
+    _authorize_tool(tool)
+    context_id = ""
+    if isinstance(message, dict):
+        context_id = str(message.get("contextId") or "")
+    context_id = context_id or str(params.get("contextId") or "") or _new_id()
+    return A2ATask(id=_new_id(), context_id=context_id, tool=tool, arguments=args)
+
+
+async def _execute(task: A2ATask, store: TaskStore) -> None:
+    """Store the task, mark it working, run its tool to a terminal state."""
+    store.put(task)
+    _set_state(task, WORKING)
+    await _run(task)
+
+
+async def _run(task: A2ATask) -> None:
+    """Dispatch the task's tool in a worker thread under a wall-clock timeout."""
+    try:
+        ok, payload = await asyncio.wait_for(
+            asyncio.to_thread(_run_tool, task), TOOL_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        _finish(task, FAILED, error=f"tool timed out after {int(TOOL_TIMEOUT_S)}s")
+        return
+    except Exception as exc:  # pragma: no cover - defensive
+        _finish(task, FAILED, error=f"{type(exc).__name__}: {exc}")
+        return
+    if ok:
+        _finish(task, COMPLETED, result=payload)
+    else:
+        _finish(task, FAILED, error=payload)
+
+
+def _finish(
+    task: A2ATask,
+    state: str,
+    *,
+    result: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Apply a terminal outcome UNLESS the task already reached a terminal state.
+
+    A concurrent ``tasks/cancel`` may have moved the task to ``canceled`` while
+    its tool was still running in the worker thread (which can't be preempted).
+    Guarding here keeps that cancellation authoritative instead of letting the
+    late tool result overwrite it.
+    """
+    if task.state in TERMINAL:
+        return
+    if result is not None:
+        task.result = result
+    if error is not None:
+        task.error = error
+    _set_state(task, state)
+
+
+def _run_tool(task: A2ATask) -> Tuple[bool, str]:
+    """Execute the tool via the registry dispatch seam. Returns (ok, payload).
+
+    ``registry.dispatch`` already catches handler exceptions, sanitizes error
+    strings, bridges async handlers, and returns a JSON string -- so this is
+    the single seam through which A2A reaches tools. No new tool logic here.
+    """
+    from tools.registry import registry
+
+    if registry.get_entry(task.tool) is None:
+        return False, f"tool not available: {task.tool}"
+    raw = registry.dispatch(task.tool, dict(task.arguments))
+    dispatch_err = _dispatch_error(raw)
+    if dispatch_err is not None:
+        return False, dispatch_err
+    return True, raw
+
+
+def _dispatch_error(raw: str) -> Optional[str]:
+    """Return the error string if ``raw`` is a ``{"error": ...}``-only envelope."""
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        return None
+    if isinstance(obj, dict) and set(obj) == {"error"}:
+        return str(obj["error"])
+    return None
+
+
+# --------------------------------------------------------------------------
+# Parsing / authorization / serialization helpers
+# --------------------------------------------------------------------------
+
+
+def _parse_envelope(
+    payload: Any,
+) -> Tuple[Any, str, Dict[str, Any], Optional[A2AError]]:
+    """Validate the JSON-RPC envelope. Returns (id, method, params, error)."""
+    if not isinstance(payload, dict):
+        return None, "", {}, A2AError(INVALID_REQUEST, "request must be a JSON object")
+    rid = payload.get("id")
+    if payload.get("jsonrpc") != "2.0":
+        return rid, "", {}, A2AError(INVALID_REQUEST, "jsonrpc must be '2.0'")
+    method = payload.get("method")
+    if not isinstance(method, str) or not method:
+        return (
+            rid,
+            "",
+            {},
+            A2AError(INVALID_REQUEST, "method must be a non-empty string"),
+        )
+    params = payload.get("params")
+    if params is None:
+        params = {}
+    if not isinstance(params, dict):
+        return rid, method, {}, A2AError(INVALID_PARAMS, "params must be an object")
+    return rid, method, params, None
+
+
+def _extract_tool_call(message: Any) -> Tuple[str, Dict[str, Any]]:
+    """Pull ``(tool, arguments)`` out of an A2A message.
+
+    Two carriers, in priority order: a ``data`` part
+    (``{"kind": "data", "data": {"tool": ..., "arguments": {...}}}``) or the
+    message-level ``metadata``. Both are explicit structured mappings -- we do
+    NOT parse free-text into a tool call, which would be an injection surface.
+    """
+    if not isinstance(message, dict):
+        raise A2AError(INVALID_PARAMS, "'message' must be an object")
+    for part in message.get("parts") or []:
+        if isinstance(part, dict) and part.get("kind") == "data":
+            data = part.get("data")
+            if isinstance(data, dict) and "tool" in data:
+                return _validate_call(data)
+    metadata = message.get("metadata")
+    if isinstance(metadata, dict) and "tool" in metadata:
+        return _validate_call(metadata)
+    raise A2AError(
+        INVALID_PARAMS,
+        "message carries no tool mapping (expected a data part or metadata "
+        "with a 'tool' field)",
+    )
+
+
+def _validate_call(data: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    tool = data.get("tool")
+    if not isinstance(tool, str) or not tool:
+        raise A2AError(INVALID_PARAMS, "'tool' must be a non-empty string")
+    args = data.get("arguments", {})
+    if args is None:
+        args = {}
+    if not isinstance(args, dict):
+        raise A2AError(INVALID_PARAMS, "'arguments' must be an object")
+    return tool, args
+
+
+def _authorize_tool(tool: str) -> None:
+    """Reject any tool not advertised on the Agent Card (honours ``exclude``)."""
+    if tool not in _advertised_tools():
+        # Same code/shape as a genuinely unknown tool: no existence oracle.
+        raise A2AError(METHOD_NOT_FOUND, f"tool not found: {tool}")
+
+
+def _advertised_tools() -> set:
+    """The set of tool ids currently advertised on the Agent Card (no skills)."""
+    from hermes_cli.a2a import get_discovery_snapshot
+
+    _config, capabilities = get_discovery_snapshot()
+    return {c.id for c in capabilities if not c.id.startswith("skill:")}
+
+
+def _set_state(task: A2ATask, state: str) -> None:
+    """Record the current status in history, then move to ``state``."""
+    task.history.append({"state": task.state, "timestamp": _now_iso()})
+    task.state = state
+
+
+def _lookup(params: Dict[str, Any], store: TaskStore) -> A2ATask:
+    task_id = params.get("id")
+    if not isinstance(task_id, str) or not task_id:
+        raise A2AError(INVALID_PARAMS, "'id' is required")
+    task = store.get(task_id)
+    if task is None:
+        raise A2AError(TASK_NOT_FOUND, f"task not found: {task_id}")
+    return task
+
+
+def _status_event(task: A2ATask, *, final: bool) -> Dict[str, Any]:
+    """An A2A ``status-update`` streaming event for ``task``'s current state."""
+    status: Dict[str, Any] = {"state": task.state, "timestamp": _now_iso()}
+    if final and task.error:
+        status["message"] = _agent_text(task.error)
+    event: Dict[str, Any] = {
+        "taskId": task.id,
+        "contextId": task.context_id,
+        "kind": "status-update",
+        "status": status,
+        "final": final,
+    }
+    if final:
+        event["artifacts"] = _artifacts(task)
+    return event
+
+
+def _artifacts(task: A2ATask) -> List[Dict[str, Any]]:
+    if task.result is None:
+        return []
+    return [
+        {
+            "artifactId": f"{task.id}-result",
+            "parts": [{"kind": "text", "text": task.result}],
+        }
+    ]
+
+
+def _agent_text(text: str) -> Dict[str, Any]:
+    return {"role": "agent", "parts": [{"kind": "text", "text": text}]}
+
+
+def _rpc_result(rid: Any, result: Dict[str, Any]) -> Dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+
+def _rpc_error(rid: Any, err: A2AError) -> Dict[str, Any]:
+    error: Dict[str, Any] = {"code": err.code, "message": err.message}
+    if err.data is not None:
+        error["data"] = err.data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
+
+
+def _sse(obj: Dict[str, Any]) -> str:
+    return f"data: {json.dumps(obj)}\n\n"
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16566,6 +16566,73 @@ async def well_known_agent_card(request: Request):
     return JSONResponse(card.to_dict(), media_type="application/json")
 
 
+# A2A JSON-RPC server endpoint (issue #881, Slice 3 of #748). Lives at the
+# path the Agent Card advertises (config ``url``, default ``/a2a``) and turns
+# an incoming A2A task into a single dispatch through Hermes' existing tool
+# registry -- it registers NO new core tools.
+#
+# AUTH (this is the security boundary; the discovery card above is public, this
+# is NOT): unlike ``/.well-known/agent.json`` this route is deliberately absent
+# from every public allowlist. ``_require_token`` gates it exactly like the
+# dashboard's other sensitive endpoints:
+#   * loopback / --insecure bind -> the ephemeral ``_SESSION_TOKEN`` (sent as
+#     ``Authorization: Bearer`` or ``X-Hermes-Session-Token``), matching the
+#     card's advertised ``authentication.schemes: [bearer]``;
+#   * non-loopback bind -> the OAuth ``gated_auth_middleware`` runs first and
+#     302/401s any cookieless caller before this handler; ``_require_token``
+#     then confirms the verified session.
+# So an unauthenticated caller can never reach tool execution. A second layer
+# in a2a_server only dispatches tools ADVERTISED on the card (honouring the
+# ``exclude`` blocklist); requests are size-capped here and each tool runs
+# under a wall-clock timeout in a worker thread (no event-loop / stream stall).
+@app.post("/a2a")
+async def a2a_rpc(request: Request):
+    """Accept an A2A JSON-RPC task submission and map it to a Hermes tool call."""
+    from hermes_cli import a2a_server
+    from hermes_cli.a2a import get_discovery_snapshot
+
+    _require_token(request)
+
+    config, _capabilities = get_discovery_snapshot()
+    if not config.get("enabled", True):
+        return JSONResponse(status_code=404, content={"detail": "A2A disabled"})
+
+    # Read the body with a hard cap. Checking Content-Length first rejects an
+    # honestly-declared oversized body cheaply; the streaming accumulator then
+    # also bounds a chunked / spoofed-length body so a client can't OOM us by
+    # streaming an unbounded payload into request.body().
+    try:
+        declared = int(request.headers.get("content-length") or 0)
+    except ValueError:
+        declared = 0
+    if declared > a2a_server.MAX_REQUEST_BYTES:
+        return JSONResponse(status_code=413, content={"detail": "request too large"})
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > a2a_server.MAX_REQUEST_BYTES:
+            return JSONResponse(status_code=413, content={"detail": "request too large"})
+        chunks.append(chunk)
+    raw = b"".join(chunks)
+    try:
+        payload = json.loads(raw or b"{}")
+    except Exception:
+        # JSON-RPC transport convention: 200 with a parse-error envelope.
+        return JSONResponse(a2a_server.parse_error_response())
+
+    method = payload.get("method") if isinstance(payload, dict) else None
+    if method == "message/stream":
+        from fastapi.responses import StreamingResponse
+
+        return StreamingResponse(
+            a2a_server.sse_stream(payload),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+        )
+    return JSONResponse(await a2a_server.handle_rpc(payload))
+
+
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
 

--- a/tests/hermes_cli/test_a2a_server.py
+++ b/tests/hermes_cli/test_a2a_server.py
@@ -1,0 +1,384 @@
+"""Tests for the A2A JSON-RPC server (issue #881, Slice 3 of #748).
+
+Three layers:
+
+* pure unit tests over ``hermes_cli.a2a_server`` helpers (envelope parsing,
+  tool-call extraction, authorization, serialization) -- no web server, no
+  registry;
+* execution tests that register a STUB tool in the real
+  ``tools.registry.registry`` and drive ``handle_rpc`` / ``sse_stream``
+  directly (submit -> execute -> state), asserting no new *core* tool is
+  needed -- the A2A layer only dispatches through the existing registry seam;
+* an end-to-end test through the FastAPI route via ``TestClient`` covering
+  submit -> execute -> state-over-SSE and the auth posture (a request without
+  the session token is rejected 401 before any tool runs).
+
+Two live Hermes instances are impractical in unit time, so the e2e maps to a
+stub tool over the real route + real registry rather than a second process.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli import a2a, a2a_server
+from tools.registry import registry
+
+STUB_TOOL = "a2a_stub_echo"
+
+
+def _stub_handler(args, **kwargs):
+    """Echo args back as a JSON string (a tool handler returns JSON text)."""
+    return json.dumps({"echo": args})
+
+
+def _stub_error_handler(args, **kwargs):
+    return json.dumps({"error": "boom"})
+
+
+@pytest.fixture(autouse=True)
+def _register_stub_tool():
+    """Register the stub in the real registry and advertise it on the card."""
+    registry.register(
+        name=STUB_TOOL,
+        toolset="a2a-test",
+        schema={"name": STUB_TOOL, "description": "echo stub"},
+        handler=_stub_handler,
+        override=True,
+    )
+    a2a.reset_discovery_cache()  # so _advertised_tools() sees the stub
+    yield
+    a2a.reset_discovery_cache()
+
+
+def _send_payload(tool=STUB_TOOL, arguments=None, method="message/send", rid=1):
+    return {
+        "jsonrpc": "2.0",
+        "id": rid,
+        "method": method,
+        "params": {
+            "message": {
+                "role": "user",
+                "messageId": "m1",
+                "parts": [
+                    {
+                        "kind": "data",
+                        "data": {"tool": tool, "arguments": arguments or {}},
+                    }
+                ],
+            }
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Envelope / params parsing
+# --------------------------------------------------------------------------
+
+
+def test_parse_envelope_valid():
+    rid, method, params, err = a2a_server._parse_envelope({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tasks/get",
+        "params": {"id": "x"},
+    })
+    assert err is None
+    assert (rid, method, params) == (7, "tasks/get", {"id": "x"})
+
+
+def test_parse_envelope_rejects_non_object():
+    _, _, _, err = a2a_server._parse_envelope([1, 2, 3])
+    assert err.code == a2a_server.INVALID_REQUEST
+
+
+def test_parse_envelope_rejects_bad_version():
+    _, _, _, err = a2a_server._parse_envelope({"jsonrpc": "1.0", "method": "m"})
+    assert err.code == a2a_server.INVALID_REQUEST
+
+
+def test_parse_envelope_rejects_missing_method():
+    _, _, _, err = a2a_server._parse_envelope({"jsonrpc": "2.0", "id": 1})
+    assert err.code == a2a_server.INVALID_REQUEST
+
+
+def test_parse_envelope_rejects_non_object_params():
+    _, _, _, err = a2a_server._parse_envelope({
+        "jsonrpc": "2.0",
+        "method": "m",
+        "params": [],
+    })
+    assert err.code == a2a_server.INVALID_PARAMS
+
+
+# --------------------------------------------------------------------------
+# Tool-call extraction
+# --------------------------------------------------------------------------
+
+
+def test_extract_tool_call_from_data_part():
+    msg = {"parts": [{"kind": "data", "data": {"tool": "t", "arguments": {"a": 1}}}]}
+    assert a2a_server._extract_tool_call(msg) == ("t", {"a": 1})
+
+
+def test_extract_tool_call_from_metadata():
+    msg = {"parts": [{"kind": "text", "text": "hi"}], "metadata": {"tool": "t"}}
+    assert a2a_server._extract_tool_call(msg) == ("t", {})
+
+
+def test_extract_tool_call_missing_mapping_raises():
+    with pytest.raises(a2a_server.A2AError) as exc:
+        a2a_server._extract_tool_call({"parts": [{"kind": "text", "text": "hi"}]})
+    assert exc.value.code == a2a_server.INVALID_PARAMS
+
+
+def test_extract_tool_call_rejects_bad_tool_type():
+    with pytest.raises(a2a_server.A2AError):
+        a2a_server._extract_tool_call({"metadata": {"tool": 123}})
+
+
+def test_extract_tool_call_rejects_non_object_arguments():
+    with pytest.raises(a2a_server.A2AError):
+        a2a_server._extract_tool_call({"metadata": {"tool": "t", "arguments": [1]}})
+
+
+# --------------------------------------------------------------------------
+# Task model + store
+# --------------------------------------------------------------------------
+
+
+def test_task_to_dict_shape():
+    task = a2a_server.A2ATask(id="i", context_id="c", tool="t", arguments={})
+    task.result = json.dumps({"ok": True})
+    a2a_server._set_state(task, a2a_server.COMPLETED)
+    data = task.to_dict()
+    assert data["id"] == "i"
+    assert data["contextId"] == "c"
+    assert data["kind"] == "task"
+    assert data["status"]["state"] == "completed"
+    assert data["artifacts"][0]["parts"][0]["text"] == json.dumps({"ok": True})
+    # history captured the pre-completion (submitted) state.
+    assert data["history"][0]["state"] == "submitted"
+
+
+def test_taskstore_evicts_oldest():
+    store = a2a_server.TaskStore(max_tasks=2)
+    ids = []
+    for _ in range(3):
+        task = a2a_server.A2ATask(
+            id=a2a_server._new_id(), context_id="c", tool="t", arguments={}
+        )
+        ids.append(task.id)
+        store.put(task)
+    assert store.get(ids[0]) is None  # first evicted
+    assert store.get(ids[2]) is not None
+
+
+# --------------------------------------------------------------------------
+# Execution via handle_rpc / sse_stream (stub tool)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_send_executes_tool_to_completion():
+    store = a2a_server.TaskStore()
+    resp = await a2a_server.handle_rpc(_send_payload(arguments={"a": 1}), store)
+    task = resp["result"]
+    assert task["status"]["state"] == "completed"
+    echoed = json.loads(task["artifacts"][0]["parts"][0]["text"])
+    assert echoed == {"echo": {"a": 1}}
+    # Retrievable afterwards via tasks/get.
+    got = await a2a_server.handle_rpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tasks/get",
+            "params": {"id": task["id"]},
+        },
+        store,
+    )
+    assert got["result"]["id"] == task["id"]
+
+
+@pytest.mark.asyncio
+async def test_unadvertised_tool_is_rejected():
+    resp = await a2a_server.handle_rpc(
+        _send_payload(tool="definitely_not_registered_xyz"), a2a_server.TaskStore()
+    )
+    assert resp["error"]["code"] == a2a_server.METHOD_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_dispatch_error_envelope_marks_task_failed(monkeypatch):
+    registry.register(
+        name=STUB_TOOL,
+        toolset="a2a-test",
+        schema={"name": STUB_TOOL, "description": "err stub"},
+        handler=_stub_error_handler,
+        override=True,
+    )
+    resp = await a2a_server.handle_rpc(_send_payload(), a2a_server.TaskStore())
+    assert resp["result"]["status"]["state"] == "failed"
+    assert "boom" in resp["result"]["status"]["message"]["parts"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_tasks_cancel_transitions_to_canceled():
+    store = a2a_server.TaskStore()
+    task = a2a_server.A2ATask(id="fixed", context_id="c", tool=STUB_TOOL, arguments={})
+    store.put(task)
+    resp = await a2a_server.handle_rpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tasks/cancel",
+            "params": {"id": "fixed"},
+        },
+        store,
+    )
+    assert resp["result"]["status"]["state"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_tasks_get_unknown_id_returns_task_not_found():
+    resp = await a2a_server.handle_rpc(
+        {"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {"id": "nope"}},
+        a2a_server.TaskStore(),
+    )
+    assert resp["error"]["code"] == a2a_server.TASK_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_returns_method_not_found():
+    resp = await a2a_server.handle_rpc(
+        {"jsonrpc": "2.0", "id": 1, "method": "tasks/frobnicate", "params": {}},
+        a2a_server.TaskStore(),
+    )
+    assert resp["error"]["code"] == a2a_server.METHOD_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_run_timeout_marks_failed(monkeypatch):
+    import time as _time
+
+    def _slow(args, **kwargs):
+        _time.sleep(0.3)
+        return json.dumps({"late": True})
+
+    registry.register(
+        name=STUB_TOOL,
+        toolset="a2a-test",
+        schema={"name": STUB_TOOL, "description": "slow stub"},
+        handler=_slow,
+        override=True,
+    )
+    monkeypatch.setattr(a2a_server, "TOOL_TIMEOUT_S", 0.01)
+    task = a2a_server.A2ATask(id="t", context_id="c", tool=STUB_TOOL, arguments={})
+    await a2a_server._run(task)
+    assert task.state == "failed"
+    assert "timed out" in (task.error or "")
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_overwrite_a_canceled_task():
+    """A cancel that landed while the tool was still running stays authoritative:
+    the late tool result must NOT flip the task back to completed."""
+    task = a2a_server.A2ATask(id="t", context_id="c", tool=STUB_TOOL, arguments={})
+    a2a_server._set_state(task, a2a_server.CANCELED)  # cancel arrived first
+    await a2a_server._run(task)  # tool finishes afterwards
+    assert task.state == "canceled"
+    assert task.result is None
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_emits_submitted_working_completed():
+    frames = []
+    async for frame in a2a_server.sse_stream(
+        _send_payload(method="message/stream", arguments={"k": "v"}),
+        a2a_server.TaskStore(),
+    ):
+        assert frame.startswith("data: ") and frame.endswith("\n\n")
+        frames.append(json.loads(frame[len("data: ") :]))
+    states = [f["result"]["status"]["state"] for f in frames]
+    assert states == ["submitted", "working", "completed"]
+    assert frames[-1]["result"]["final"] is True
+    echoed = json.loads(frames[-1]["result"]["artifacts"][0]["parts"][0]["text"])
+    assert echoed == {"echo": {"k": "v"}}
+
+
+# --------------------------------------------------------------------------
+# End-to-end through the FastAPI route (TestClient)
+# --------------------------------------------------------------------------
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient  # noqa: E402
+
+from hermes_cli import web_server  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    a2a.reset_discovery_cache()
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        a2a.reset_discovery_cache()
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def test_e2e_message_send_over_route(client):
+    resp = client.post("/a2a", json=_send_payload(arguments={"x": 9}))
+    assert resp.status_code == 200
+    task = resp.json()["result"]
+    assert task["status"]["state"] == "completed"
+    echoed = json.loads(task["artifacts"][0]["parts"][0]["text"])
+    assert echoed == {"echo": {"x": 9}}
+
+
+def test_e2e_message_stream_sse_over_route(client):
+    resp = client.post("/a2a", json=_send_payload(method="message/stream"))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    events = [
+        json.loads(chunk[len("data: ") :])
+        for chunk in resp.text.split("\n\n")
+        if chunk.startswith("data: ")
+    ]
+    states = [e["result"]["status"]["state"] for e in events]
+    assert states == ["submitted", "working", "completed"]
+
+
+def test_e2e_requires_auth(client):
+    """A request WITHOUT the session token is rejected before any tool runs."""
+    unauth = TestClient(web_server.app)  # no session header
+    resp = unauth.post("/a2a", json=_send_payload())
+    assert resp.status_code == 401
+
+
+def test_e2e_disabled_returns_404(client, monkeypatch):
+    monkeypatch.setattr(a2a, "load_config", lambda *a, **k: {"enabled": False})
+    a2a.reset_discovery_cache()
+    resp = client.post("/a2a", json=_send_payload())
+    assert resp.status_code == 404
+
+
+def test_e2e_oversized_body_rejected(client):
+    """A body over MAX_REQUEST_BYTES is rejected 413 before any parsing/dispatch."""
+    big = b'{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"x":"'
+    big += b"A" * (a2a_server.MAX_REQUEST_BYTES + 16) + b'"}}'
+    resp = client.post(
+        "/a2a", content=big, headers={"content-type": "application/json"}
+    )
+    assert resp.status_code == 413


### PR DESCRIPTION
## Slice 3 of #748 — closes #881

Minimal A2A **server** endpoint: Hermes accepts an A2A JSON-RPC task and maps it
to a single dispatch through its **existing** tool registry. **No new core
tools.** Builds directly on the #879 foundation (`hermes_cli/a2a.py` Agent Card
+ the public `GET /.well-known/agent.json` route + the auth middleware).

### What's here
- **`hermes_cli/a2a_server.py`** (new) — JSON-RPC handling for `message/send`,
  `message/stream`, `tasks/get`, `tasks/cancel`; the `A2ATask` state type + a
  bounded in-memory `TaskStore`; tool-call extraction; card-scoped tool
  authorization; timeout-bounded execution; SSE event framing.
- **`hermes_cli/web_server.py`** (owned this wave) — `POST /a2a` route,
  registered right after the #879 `/.well-known/agent.json` route and **before**
  the SPA catch-all, following the exact same FastAPI pattern (local import,
  `enabled` → 404, `JSONResponse`). Streaming path returns `StreamingResponse`
  with `media_type="text/event-stream"`.
- **`tests/hermes_cli/test_a2a_server.py`** (new) — 25 tests.

### How a task maps to a tool
The A2A message carries the call as a structured `data` part
(`{"kind":"data","data":{"tool":"<name>","arguments":{...}}}`) or message
`metadata`. We **never** parse free text into a tool call. The mapped tool is
dispatched via the existing `tools.registry.registry.dispatch(name, args)` seam
(which already catches handler exceptions, sanitizes errors, and bridges async).

### SSE state transitions
`message/stream` emits, as JSON-RPC-wrapped A2A `status-update` events:
`submitted → working → completed | failed` (terminal frame carries `final:true`
and the result artifact). The generator always terminates — no unclosed stream.

### Auth posture of the new endpoint (security-relevant)
`POST /a2a` is **NOT** in any public allowlist (unlike the discovery card, which
is public and read-only). It is gated exactly like the dashboard's other
sensitive endpoints via the existing `_require_token(request)`:
- **loopback / `--insecure` bind** → the ephemeral `_SESSION_TOKEN`
  (`Authorization: Bearer …` or `X-Hermes-Session-Token`), matching the card's
  advertised `authentication.schemes: [bearer]`. (The legacy loopback
  `auth_middleware` only gates `/api/*`, so the in-handler `_require_token` is
  the guard for this non-`/api/` path — verified by a test.)
- **non-loopback bind** → the OAuth `gated_auth_middleware` 302/401s any
  cookieless caller *before* the handler; `_require_token` then confirms the
  verified session.

So an unauthenticated caller can **never** reach tool execution. Second layer:
even an authenticated caller may only invoke tools **advertised on the Agent
Card** (`_authorize_tool`, honouring the card's `exclude` blocklist); unknown
and deliberately-hidden tools return the same `-32601` (no existence oracle).
Request bodies are size-capped (256 KiB, checked on `Content-Length` **and** via
a bounded streaming read so a chunked/spoofed-length body can't OOM the process),
and each tool runs under a 60 s wall-clock timeout in a worker thread.

### Independent review (Gemini via `consult agy`)
Confirmed: no unauth path to execution in either bind mode; no tool/prompt
injection (structured extraction only); no `_authorize_tool` bypass; SSE always
terminates. Findings addressed:
1. **State-overwrite bug** — a concurrent `tasks/cancel` landing mid-execution
   could be overwritten by the late tool result. **Fixed:** `_finish` refuses to
   move a task that is already terminal (+ regression test).
2. **Body-buffering OOM** on chunked/no-`Content-Length` requests. **Fixed:**
   bounded streaming read (+ 413 test).
3. Suggested adding `/a2a` to the public allowlist for cookieless external
   agents — **intentionally NOT done**: this endpoint executes tools, so it must
   stay gated (the exact hole #881 forbids). Cross-agent bearer principals are a
   follow-up via the existing `token_auth` seam.

### Known limitations (minimal-slice scope)
- Timed-out tools: Python worker threads can't be preempted, so a hung tool's
  thread runs to completion in the background (task is already `failed`, stream
  closed). Acceptable behind auth for this slice.
- Per-tool argument schemas aren't pre-validated here; we rely on each tool
  handler's own validation via `dispatch`.

### Test coverage
E2E is TestClient-driven against the real route + real registry, mapping to a
registered **stub** tool (two live Hermes processes are impractical in unit
time). Covers submit → execute → state (both `message/send` and SSE
`message/stream`), `tasks/get`/`tasks/cancel`, auth-required (401), disabled
(404), oversized body (413), unadvertised-tool rejection, timeout, and the
cancel-overwrite guard.

### Verification
- `pytest tests/hermes_cli/test_a2a_server.py tests/hermes_cli/test_a2a_agent_card.py -q` → **39 passed**
- `ruff check .` → **All checks passed**
- `ruff format --check hermes_cli/a2a_server.py tests/hermes_cli/test_a2a_server.py` → clean

### Scope note
Module is ~274 code SLOC (+~40 for the route), above the ~200 soft cap; the extra
buys the auth-authorization layer, size/timeout caps, and cancel-guard the review
validated. No new core tools; touches only `web_server.py` (this wave's owner)
plus the two new files — no overlap with the #880 client.
