### PR TITLE
feat(#924): per-chat and per-cron-job display verbosity overrides

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -234,6 +234,34 @@ def _normalize_approval_mode(value: Optional[str]) -> Optional[str]:
 # into output writes/deletes.
 _IMMUTABLE_JOB_FIELDS = frozenset({"id"})
 
+# Per-job cron delivery verbosity levels (issue #924). Absent/None on a job
+# means "full" (current behavior) for backward compatibility.
+#   full        — deliver the content as produced (current behavior)
+#   result_only — deliver only the final response (reasoning/trace stripped)
+#   summary     — one-line status + final response trimmed to N chars
+#   silent      — no delivery on success (errors are always delivered)
+DELIVERY_VERBOSITY_LEVELS = ("full", "result_only", "summary", "silent")
+
+
+def _normalize_delivery_verbosity(value: Any) -> Optional[str]:
+    """Normalize/validate a per-job ``delivery_verbosity`` value.
+
+    Returns the canonical lowercase level, or None for an empty/unset value
+    (which readers treat as ``full``). Raises ``ValueError`` for an unknown
+    level so the caller can surface a clear error.
+    """
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text not in DELIVERY_VERBOSITY_LEVELS:
+        raise ValueError(
+            "delivery_verbosity must be one of "
+            f"{', '.join(DELIVERY_VERBOSITY_LEVELS)} (got {value!r})"
+        )
+    return text
+
 
 def _job_output_dir(job_id: str) -> Path:
     """Resolve a job's output directory, rejecting any path-escape attempt.
@@ -953,6 +981,7 @@ def create_job(
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
     approval_mode: Optional[str] = None,
+    delivery_verbosity: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1001,6 +1030,11 @@ def create_job(
                 Values "approve" / "allow" / "yes" / "off" auto-approve dangerous
                 commands within this job; any other explicit value denies them.
                 When omitted, the global ``approvals.cron_mode`` applies.
+        delivery_verbosity: Optional per-job delivery verbosity (issue #924).
+                One of "full" (default — current behavior), "result_only"
+                (final response only, reasoning/trace stripped), "summary"
+                (one-line status + trimmed final response), or "silent" (no
+                delivery on success; failures always deliver). Absent = "full".
 
     Returns:
         The created job dict
@@ -1042,6 +1076,7 @@ def create_job(
         attach_to_session if isinstance(attach_to_session, bool) else None
     )
     normalized_approval = _normalize_approval_mode(approval_mode)
+    normalized_delivery_verbosity = _normalize_delivery_verbosity(delivery_verbosity)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1143,6 +1178,9 @@ def create_job(
         job["approval_mode"] = normalized_approval
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    # Absent delivery_verbosity = "full" (back-compat); only persist when set.
+    if normalized_delivery_verbosity is not None:
+        job["delivery_verbosity"] = normalized_delivery_verbosity
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -302,6 +302,7 @@ from cron.jobs import (
     advance_next_run,
     claim_dispatch,
     update_job,
+    DELIVERY_VERBOSITY_LEVELS,
 )
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -1455,7 +1456,105 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _summarize_job_result(content: str, *, limit: int = 280) -> str:
+    """One-line-ish status + trimmed final response for delivery_verbosity=summary.
+
+    Strips any leading reasoning trace, then truncates to *limit* chars with an
+    ellipsis. The cron wrap header (``Cronjob Response: <name>``) already carries
+    the run identity, so this keeps the body to a short digestible tail.
+    """
+    text = strip_reasoning_for_delivery(content or "").strip()
+    if not text:
+        return text
+    if len(text) > limit:
+        text = text[:limit].rstrip() + "…"
+    return text
+
+
+def _resolve_delivery_verbosity(job: dict, target_chat_ids, user_cfg: dict) -> str:
+    """Resolve the effective cron delivery verbosity level.
+
+    Order (issue #924):
+      1. per-job ``delivery_verbosity``
+      2. per-chat override at the delivery target(s)
+         (``mode: quiet``/``quiet_chats`` ⇒ ``result_only``;
+          ``mode: silent`` ⇒ ``silent``; verbose/normal ⇒ ``full``)
+      3. default ``full`` (per-platform display tiers carry no delivery-content
+         equivalent, so the effective fallback is byte-identical to prior
+         behavior).
+
+    Multi-target jobs (``deliver: all`` / fan-out) share ONE delivered
+    ``content``, so the per-chat layer resolves to the MOST RESTRICTIVE shaping
+    across targets — the full trace is never delivered to a chat that asked to
+    be quiet/silent. ``silent`` (full suppression) is only chosen when EVERY
+    resolvable target is silent; a mix of silent + others degrades to
+    ``result_only`` (deliver the final answer everywhere, leak nothing) rather
+    than suppressing delivery to the non-silent targets.
+
+    Returns one of ``DELIVERY_VERBOSITY_LEVELS``.
+    """
+    raw = job.get("delivery_verbosity")
+    if raw:
+        norm = str(raw).strip().lower()
+        if norm in DELIVERY_VERBOSITY_LEVELS:
+            return norm
+
+    try:
+        from gateway.display_config import resolve_chat_mode
+    except Exception:
+        return "full"
+
+    modes = [
+        resolve_chat_mode(user_cfg, str(chat_id))
+        for chat_id in (target_chat_ids or [])
+        if chat_id is not None
+    ]
+    configured = [m for m in modes if m]
+    if not configured:
+        return "full"
+    # Every resolvable target wants silence → suppress. (Only when there are no
+    # unconfigured targets that would otherwise expect a delivery.)
+    if all(m == "silent" for m in modes):
+        return "silent"
+    # Any quiet/silent target present → never leak the full trace to it.
+    if any(m in ("silent", "quiet") for m in modes):
+        return "result_only"
+    return "full"
+
+
+def _apply_delivery_verbosity(
+    verbosity: str,
+    content: str,
+    *,
+    success: bool = True,
+    summary_limit: int = 280,
+) -> Optional[str]:
+    """Transform delivery content per verbosity level.
+
+    Returns the (possibly transformed) content, or ``None`` to SUPPRESS delivery
+    entirely. Error deliveries (``success=False``) are NEVER transformed or
+    suppressed — a failing job always delivers its full failure summary so
+    ``silent``/``result_only``/``summary`` can't swallow error alerts.
+    """
+    if not success:
+        return content
+    if verbosity == "silent":
+        return None
+    if verbosity == "result_only":
+        return strip_reasoning_for_delivery(content)
+    if verbosity == "summary":
+        return _summarize_job_result(content, limit=summary_limit)
+    return content  # "full" (default) — unchanged
+
+
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    success: bool = True,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1487,6 +1586,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         msg = f"no delivery target resolved for deliver={deliver_value}"
         logger.warning("Job '%s': %s", job["id"], msg)
         return msg
+
+    # ── Delivery verbosity (issue #924) ──────────────────────────────────
+    # Resolve per-job → per-chat@target → default 'full', then shape the
+    # content. Error deliveries (success=False) always pass through untouched
+    # so silent/result_only/summary can never swallow a failure alert.
+    try:
+        _verbosity_cfg = load_config() or {}
+    except Exception:
+        _verbosity_cfg = {}
+    _verbosity = _resolve_delivery_verbosity(
+        job, [t.get("chat_id") for t in targets], _verbosity_cfg
+    )
+    _shaped = _apply_delivery_verbosity(_verbosity, content, success=success)
+    if _shaped is None:
+        logger.info(
+            "Job '%s': delivery suppressed (delivery_verbosity=silent on success)",
+            job.get("name", job.get("id", "?")),
+        )
+        return None
+    content = _shaped
 
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
@@ -4178,7 +4297,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         if should_deliver:
             try:
                 delivery_error = _deliver_result(
-                    job, deliver_content, adapters=adapters, loop=loop
+                    job, deliver_content, adapters=adapters, loop=loop, success=success
                 )
             except Exception as de:
                 delivery_error = str(de)

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -4,10 +4,22 @@ Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
 
 Resolution order (first non-None wins):
+    0. ``display.chat_overrides.<chat_id>`` / ``display.quiet_chats``
+                                               — per-chat verbosity override
+                                               (only when a ``chat_id`` is passed)
     1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
     2. ``display.<key>``                       — global user setting
     3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
     4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+
+Per-chat overrides (step 0) let a single platform mix verbosity per chat/topic:
+a customer-facing group can run ``mode: quiet`` (final answer only) while a DM
+runs ``mode: verbose`` (full tool/reasoning detail).  A chat entry may set a
+shorthand ``mode`` preset and/or individual setting keys (explicit keys win over
+the preset).  ``display.quiet_chats`` is a convenience list of chat ids that
+implies ``mode: quiet``.  Step 0 is inert unless the caller passes a ``chat_id``
+— every existing call site omits it, so their resolution is byte-for-byte
+unchanged.
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
@@ -162,11 +174,141 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
+# ---------------------------------------------------------------------------
+# Per-chat verbosity modes (shorthand presets)
+# ---------------------------------------------------------------------------
+# A chat entry (``display.chat_overrides.<chat_id>``) can set ``mode: <name>``
+# as a shorthand for a bundle of individual display settings.  The table below
+# is the source of truth for the modes documented in the SKILL/issue:
+#
+#   Mode     | tool_progress | interim | long_running | busy_ack | reasoning
+#   ---------|:-------------:|:-------:|:------------:|:--------:|:--------:
+#   verbose  |     all       |  True   |    True      |  True    |  True
+#   normal   | (fall through to the existing per-platform chain — no override)
+#   quiet    |     off       |  False  |    False     |  False   |  False
+#   silent   |     off       |  False  |    False     |  False   |  False
+#
+# ``silent`` resolves identically to ``quiet`` for per-setting display; its
+# EXTRA meaning — suppress delivery entirely — is expressed via
+# ``chat_delivery_suppressed()``, NOT a pseudo-setting key.  Keeping delivery
+# suppression out of the preset dict avoids leaking a fake "_suppress_delivery"
+# key into the normal setting-resolution path.
+_VERBOSE_PRESET: dict[str, Any] = {
+    "tool_progress": "all",
+    "interim_assistant_messages": True,
+    "long_running_notifications": True,
+    "busy_ack_detail": True,
+    "show_reasoning": True,
+}
+
+_QUIET_PRESET: dict[str, Any] = {
+    "tool_progress": "off",
+    "interim_assistant_messages": False,
+    "long_running_notifications": False,
+    "busy_ack_detail": False,
+    "show_reasoning": False,
+}
+
+# silent == quiet for per-setting resolution (delivery suppression is separate).
+_SILENT_PRESET: dict[str, Any] = dict(_QUIET_PRESET)
+
+_MODE_PRESETS: dict[str, dict[str, Any] | None] = {
+    "verbose": _VERBOSE_PRESET,
+    "normal": None,  # None → fall through to the existing per-platform chain
+    "quiet": _QUIET_PRESET,
+    "silent": _SILENT_PRESET,
+}
+
+# Sentinel: distinguishes "per-chat layer produced no value for this setting"
+# (fall through to the platform chain) from a legitimately resolved ``None``.
+_CHAT_UNSET = object()
+
+
+def _chat_override_entry(display_cfg: dict, chat_id: str) -> Any:
+    """Look up ``chat_overrides.<chat_id>`` tolerating non-string keys.
+
+    YAML/JSON often parse numeric chat ids as ints (e.g. ``12345`` or
+    ``-1001234567890``), so a plain ``dict.get(str_chat_id)`` would silently
+    miss them.  ``chat_id`` is always a str here; match on the stringified key.
+    """
+    overrides = display_cfg.get("chat_overrides")
+    if not isinstance(overrides, dict):
+        return None
+    entry = overrides.get(chat_id)
+    if entry is None:
+        for key, value in overrides.items():
+            if str(key) == chat_id:
+                return value
+    return entry
+
+
+def _chat_mode_for(display_cfg: dict, chat_id: str) -> str | None:
+    """Resolve the effective verbosity *mode* for a chat, or None.
+
+    Priority: an explicit ``chat_overrides.<chat_id>.mode`` beats the
+    ``quiet_chats`` shorthand.  Returns a canonical lowercase mode name
+    (``verbose``/``normal``/``quiet``/``silent``) or None when the chat has no
+    mode configured.
+    """
+    chat_cfg = _chat_override_entry(display_cfg, chat_id)
+    if isinstance(chat_cfg, dict):
+        mode = chat_cfg.get("mode")
+        if isinstance(mode, str):
+            mode_norm = mode.strip().lower()
+            if mode_norm in _MODE_PRESETS:
+                return mode_norm
+    quiet_chats = display_cfg.get("quiet_chats")
+    if isinstance(quiet_chats, (list, tuple, set)):
+        if chat_id in {str(c) for c in quiet_chats}:
+            return "quiet"
+    return None
+
+
+def _resolve_chat_override(display_cfg: dict, chat_id: str, setting: str) -> Any:
+    """Return a per-chat value for *setting*, or ``_CHAT_UNSET`` to fall through.
+
+    An explicit individual key on the chat entry beats the mode preset (e.g.
+    ``mode: quiet`` with an explicit ``show_reasoning: true`` still shows
+    reasoning in that chat).  ``mode: normal`` (or any preset that does not
+    define *setting*) yields ``_CHAT_UNSET`` so the existing platform chain runs
+    unchanged.
+    """
+    chat_cfg = _chat_override_entry(display_cfg, chat_id)
+    if isinstance(chat_cfg, dict) and setting != "mode" and setting in chat_cfg:
+        return chat_cfg[setting]
+    mode = _chat_mode_for(display_cfg, chat_id)
+    if mode:
+        preset = _MODE_PRESETS.get(mode)
+        if preset is not None and setting in preset:
+            return preset[setting]
+    return _CHAT_UNSET
+
+
+def resolve_chat_mode(user_config: dict, chat_id: str | None) -> str | None:
+    """Public helper: the resolved verbosity mode for a chat, or None.
+
+    Used by the cron delivery path (``cron/scheduler.py``) to map a delivery
+    target's per-chat mode onto a ``delivery_verbosity`` level.
+    """
+    if chat_id is None:
+        return None
+    display_cfg = user_config.get("display") or {}
+    if not isinstance(display_cfg, dict):
+        return None
+    return _chat_mode_for(display_cfg, str(chat_id))
+
+
+def chat_delivery_suppressed(user_config: dict, chat_id: str | None) -> bool:
+    """True when the chat's resolved mode is ``silent`` (suppress delivery)."""
+    return resolve_chat_mode(user_config, chat_id) == "silent"
+
+
 def resolve_display_setting(
     user_config: dict,
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    chat_id: str | None = None,
 ) -> Any:
     """Resolve a display setting with per-platform override support.
 
@@ -181,12 +323,29 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_id : str | None
+        When set, the per-chat override layer (step 0) runs first: a resolved
+        ``chat_overrides.<chat_id>`` key / mode-preset value (or a
+        ``quiet_chats`` membership) short-circuits the platform chain.  When
+        None (every existing call site), step 0 is skipped and resolution is
+        identical to before.
 
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
+    if not isinstance(display_cfg, dict):
+        display_cfg = {}
+
+    # 0. Per-chat override (display.chat_overrides.<chat_id> / quiet_chats).
+    # Inert unless a chat_id is supplied — preserves existing behaviour exactly
+    # for every caller that omits it.  ``mode: normal`` and presets that do not
+    # define this setting fall through to the platform chain UNCHANGED.
+    if chat_id is not None:
+        chat_val = _resolve_chat_override(display_cfg, str(chat_id), setting)
+        if chat_val is not _CHAT_UNSET:
+            return _normalise(setting, chat_val)
 
     # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -508,6 +508,18 @@ def _has_platform_display_override(user_config: dict, platform_key: str, setting
     return isinstance(platform_cfg, dict) and setting in platform_cfg
 
 
+def _display_chat_id_for(source: Any) -> Optional[str]:
+    """Per-chat display-override key for a message source, or None.
+
+    Feeds ``resolve_display_setting(..., chat_id=...)`` so a chat/topic listed
+    under ``display.chat_overrides`` / ``display.quiet_chats`` can override
+    verbosity independently of the platform default.  Returns None when there is
+    no chat context (the resolver then behaves exactly as before).
+    """
+    cid = getattr(source, "chat_id", None)
+    return str(cid) if cid is not None else None
+
+
 def _resolve_gateway_display_bool(
     user_config: dict,
     platform_key: str,
@@ -516,6 +528,7 @@ def _resolve_gateway_display_bool(
     default: bool = False,
     platform: Any = None,
     require_platform_override_for: set[Any] | None = None,
+    chat_id: str | None = None,
 ) -> bool:
     """Resolve a boolean display setting with optional platform-only opt-in.
 
@@ -523,6 +536,10 @@ def _resolve_gateway_display_bool(
     user-facing output.  For high-noise threaded chat surfaces such as
     Mattermost, a global opt-in is too broad: they must be enabled with an
     explicit display.platforms.<platform>.<setting> override.
+
+    ``chat_id`` (optional) threads the per-chat verbosity override layer through
+    to ``resolve_display_setting``; callers that have a chat context pass
+    ``str(source.chat_id)``, everything else leaves it None (identical behaviour).
     """
     current_platform = _gateway_platform_value(platform or platform_key)
     platform_only = {
@@ -537,7 +554,9 @@ def _resolve_gateway_display_bool(
 
     from gateway.display_config import resolve_display_setting
 
-    value = resolve_display_setting(user_config, platform_key, setting, default)
+    value = resolve_display_setting(
+        user_config, platform_key, setting, default, chat_id=chat_id
+    )
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -5415,6 +5434,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         from gateway.display_config import resolve_display_setting
         platform_key = _platform_config_key(event.source.platform)
+        _display_chat_id = _display_chat_id_for(event.source)
 
         # In steer mode the user's text has already been injected into the
         # active run. Some mobile chat setups want that steering to be silent,
@@ -5431,6 +5451,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_key,
                         "busy_steer_ack_enabled",
                         True,
+                        chat_id=_display_chat_id,
                     )
                 )
             if not steer_ack_enabled:
@@ -5446,9 +5467,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         busy_ack_detail_enabled = bool(
             resolve_display_setting(
                 _load_gateway_config(),
-                _platform_config_key(event.source.platform),
+                platform_key,
                 "busy_ack_detail",
                 True,
+                chat_id=_display_chat_id,
             )
         )
 
@@ -11466,6 +11488,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     default=bool(getattr(self, "_show_reasoning", False)),
                     platform=source.platform,
                     require_platform_override_for={Platform.MATTERMOST},
+                    chat_id=_display_chat_id_for(source),
                 )
             except Exception:
                 _show_reasoning_effective = (
@@ -11493,6 +11516,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _platform_config_key(source.platform),
                             "reasoning_style",
                             "code",
+                            chat_id=_display_chat_id_for(source),
                         )
                     except Exception:
                         _reasoning_style = "code"
@@ -16404,7 +16428,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config, platform_key, "streaming", chat_id=_display_chat_id_for(source)
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -16718,6 +16742,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        # Per-chat verbosity override key (display.chat_overrides / quiet_chats).
+        # None when the source carries no chat_id — resolution then matches the
+        # prior per-platform-only behaviour exactly.
+        _display_chat_id = _display_chat_id_for(source)
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -16736,7 +16764,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0, chat_id=_display_chat_id)
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
@@ -16744,18 +16772,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Apply friendly tool labels config (default on) — per-platform aware
         try:
             from agent.display import set_friendly_tool_labels
-            _ftl = resolve_display_setting(user_config, platform_key, "friendly_tool_labels", True)
+            _ftl = resolve_display_setting(user_config, platform_key, "friendly_tool_labels", True, chat_id=_display_chat_id)
             set_friendly_tool_labels(bool(_ftl))
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress", chat_id=_display_chat_id)
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
+        # A per-chat override that pins tool_progress (mode quiet/verbose/silent
+        # or an explicit tool_progress key) counts as "configured" so the
+        # HERMES_TOOL_PROGRESS_MODE env fallback does not clobber it.
+        _chat_tp_configured = False
+        if _display_chat_id is not None:
+            from gateway.display_config import resolve_chat_mode as _resolve_chat_mode
+            _chat_mode = _resolve_chat_mode(user_config, _display_chat_id)
+            _chat_entry = (_display_cfg.get("chat_overrides") or {}).get(_display_chat_id)
+            _chat_tp_configured = (
+                _chat_mode in {"quiet", "verbose", "silent"}
+                or (isinstance(_chat_entry, dict) and "tool_progress" in _chat_entry)
+            )
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
             or (
@@ -16766,6 +16806,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 isinstance(_legacy_tp_overrides, dict)
                 and platform_key in _legacy_tp_overrides
             )
+            or _chat_tp_configured
         )
         progress_mode = (
             _env_tp
@@ -16773,7 +16814,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
-        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping", chat_id=_display_chat_id) or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
         _generic_status_catalog = resolve_status_phrase_catalog(user_config, platform_key)
@@ -16797,7 +16838,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and not _has_platform_display_override(user_config, platform_key, setting)
                 ):
                     return "off"
-            value = resolve_display_setting(user_config, platform_key, setting, default)
+            value = resolve_display_setting(user_config, platform_key, setting, default, chat_id=_display_chat_id)
             if isinstance(value, str) and value.strip().lower() == "generic":
                 return "generic" if allow_generic else "off"
             return "raw" if bool(value) else "off"
@@ -16906,7 +16947,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
-            resolve_display_setting(user_config, platform_key, "cleanup_progress")
+            resolve_display_setting(user_config, platform_key, "cleanup_progress", chat_id=_display_chat_id)
         )
         _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
         if _cleanup_adapter is not None and (
@@ -17726,7 +17767,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
             _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming"
+                user_config, platform_key, "streaming", chat_id=_display_chat_id
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (
@@ -19055,6 +19096,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_key,
                         "busy_ack_detail",
                         True,
+                        chat_id=_display_chat_id,
                     )
                 )
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1884,6 +1884,21 @@ DEFAULT_CONFIG = {
             "telegram": {"streaming": True},
             "discord": {"streaming": False},
         },
+        # Per-chat verbosity overrides (issue #924). Each key is a chat id
+        # (Telegram/Discord/etc. chat, topic, or DM id, as a string) mapping to
+        # either a shorthand ``mode`` preset (verbose|normal|quiet|silent) and/or
+        # individual display keys that override the per-platform value for THAT
+        # chat only. Explicit keys win over the mode preset. Applies to both
+        # interactive sessions AND cron deliveries to that chat. Empty by default
+        # (absent = per-platform behavior, unchanged). Example:
+        #   chat_overrides:
+        #     "-1001234567890": {mode: quiet}      # customer-facing group
+        #     "256875587":      {mode: verbose}    # private DM, full detail
+        "chat_overrides": {},
+        # Convenience shorthand: a list of chat ids that implies ``mode: quiet``
+        # (final answer only — no tool progress, interim messages, reasoning, or
+        # heartbeats). Equivalent to a chat_overrides entry with mode: quiet.
+        "quiet_chats": [],
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders
         # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
@@ -3272,7 +3287,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================
@@ -6009,6 +6024,15 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     "delegation.max_concurrent_children now caps background "
                     "delegations too."
                 )
+
+    # ── Version 33 → 34: per-chat display verbosity keys (issue #924) ──
+    # display.chat_overrides / display.quiet_chats are added to DEFAULT_CONFIG
+    # with empty defaults ({} / []). Per the migration invariant, pure schema
+    # defaults are NOT materialised to disk — load_config()'s deep-merge supplies
+    # them at read time, so absent keys mean "no per-chat override" (identical to
+    # prior per-platform behavior). No data transform is needed; the version bump
+    # below records the schema change and get_missing_config_fields() surfaces the
+    # new options in `hermes update`.
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──
     # Users can hand-edit mcp_servers, and older installs may already contain a

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -389,7 +389,7 @@ Edit with `hermes config edit` or `hermes config set section.key value`.
 | `agent` | `max_turns` (90), `tool_use_enforcement` |
 | `terminal` | `backend` (local/docker/ssh/modal), `cwd`, `timeout` (180) |
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
-| `display` | `skin`, `interface` (cli/tui), `tool_progress`, `show_reasoning`, `show_cost`, `language` |
+| `display` | `skin`, `interface` (cli/tui), `tool_progress`, `show_reasoning`, `show_cost`, `language`, `chat_overrides`, `quiet_chats` (see Display verbosity below) |
 | `stt` | `enabled`, `provider` (local/groq/openai/mistral) |
 | `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts) |
 | `memory` | `memory_enabled`, `user_profile_enabled`, `provider` |
@@ -399,6 +399,71 @@ Edit with `hermes config edit` or `hermes config set section.key value`.
 | `curator` | `enabled`, `consolidate` (false — opt-in aux-model skill consolidation), `interval_hours`, `stale_after_days` |
 
 Full config reference: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
+
+### Display verbosity (per-platform · per-chat · per-cron-job)
+
+Hermes controls how much of the agent's intermediate work (tool calls,
+reasoning, "still working" heartbeats, interim status messages) is shown. There
+are three layers, each narrower than the last:
+
+1. **Per-platform** — `display.platforms.<platform>.*` (e.g. quiet Telegram, verbose Discord).
+2. **Per-chat** — `display.chat_overrides.<chat_id>` / `display.quiet_chats` — override verbosity for one chat/topic/DM, even on a platform whose default differs. Applies to interactive sessions **and** cron deliveries into that chat.
+3. **Per-cron-job** — `delivery_verbosity` on a job — controls how much of a cron run's output is delivered.
+
+**Verbosity modes** (used by `chat_overrides.<id>.mode` and `quiet_chats`):
+
+| Mode | tool_progress | interim messages | heartbeats | reasoning | delivery |
+|------|:---:|:---:|:---:|:---:|---|
+| `verbose` | all | yes | yes | yes | full |
+| `normal` | (falls through to the platform default — no override) | | | | full |
+| `quiet` | off | no | no | no | final answer only |
+| `silent` | off | no | no | no | nothing (cron: no delivery on success) |
+
+Explicit individual keys on a chat entry win over its `mode` preset (e.g.
+`mode: quiet` + `show_reasoning: true` keeps reasoning in that one chat).
+
+**Resolution order — interactive:** per-chat override → per-platform setting → built-in platform tier → global default. (`mode: normal`, or a preset that doesn't define a setting, falls through unchanged.)
+
+**Resolution order — cron delivery:** per-job `delivery_verbosity` → per-chat override at the delivery target (`mode: quiet`/`quiet_chats` ⇒ `result_only`; `mode: silent` ⇒ `silent`) → default `full`.
+
+**Per-cron-job `delivery_verbosity`** values: `full` (default — output as produced), `result_only` (final answer only, reasoning/trace stripped), `summary` (one-line status + final answer trimmed to ~280 chars), `silent` (deliver nothing on success — but **failures always deliver** so a broken job can't fail silently).
+
+#### Config example — mixed public/private Telegram
+
+```yaml
+# config.yaml
+display:
+  platforms:
+    telegram:
+      tool_progress: "off"          # platform-wide default
+  chat_overrides:
+    "-1001234567890":               # customer-facing group → clean answers only
+      mode: quiet
+    "256875587":                    # your private DM → full detail
+      mode: verbose
+    "-1009876543210":               # team dev channel, mostly quiet…
+      mode: quiet
+      show_reasoning: true          # …but keep reasoning visible here
+  quiet_chats:                      # shorthand: these chat ids imply mode: quiet
+    - "-1005550000000"
+```
+
+#### Cron example — mail check delivers only the result
+
+```jsonc
+// jobs.json (or via the cronjob tool: cronjob(action='create', ..., delivery_verbosity='result_only'))
+{
+  "id": "3c5220ab270e",
+  "name": "Mailbox check",
+  "schedule": "every 15m",
+  "deliver": "origin",
+  "delivery_verbosity": "result_only"   // final answer only; the tool-call trace is dropped
+}
+```
+
+Set it from the tool: `cronjob(action='update', job_id='3c5220ab270e', delivery_verbosity='silent')` (pass an empty string to clear back to `full`). A cron job whose delivery target chat is `mode: quiet` automatically delivers `result_only` even without a per-job value; a `silent` target suppresses successful deliveries.
+
+Both features are backward-compatible: absent `chat_overrides`/`quiet_chats` and absent `delivery_verbosity` mean exactly the current per-platform behavior.
 
 ### Providers
 

--- a/tests/cron/test_delivery_verbosity.py
+++ b/tests/cron/test_delivery_verbosity.py
@@ -1,0 +1,274 @@
+"""Tests for per-cron-job delivery verbosity (issue #924).
+
+Covers the ``delivery_verbosity`` job field end-to-end: schema normalization in
+``cron/jobs.py``, the resolver/transform helpers in ``cron/scheduler.py``, and
+integration through ``_deliver_result`` for full / result_only / summary /
+silent — including the guarantee that error deliveries are never transformed or
+suppressed.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cron.jobs import (
+    create_job,
+    get_job,
+    _normalize_delivery_verbosity,
+    DELIVERY_VERBOSITY_LEVELS,
+)
+from cron.scheduler import (
+    _deliver_result,
+    _resolve_delivery_verbosity,
+    _apply_delivery_verbosity,
+    _summarize_job_result,
+)
+
+
+@pytest.fixture
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate the on-disk cron job store to a tempdir."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Schema normalization (cron/jobs.py)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeDeliveryVerbosity:
+    def test_levels_exact(self):
+        assert DELIVERY_VERBOSITY_LEVELS == ("full", "result_only", "summary", "silent")
+
+    @pytest.mark.parametrize("level", DELIVERY_VERBOSITY_LEVELS)
+    def test_valid_levels_pass(self, level):
+        assert _normalize_delivery_verbosity(level) == level
+        assert _normalize_delivery_verbosity(level.upper()) == level
+        assert _normalize_delivery_verbosity(f"  {level} ") == level
+
+    def test_none_and_empty(self):
+        assert _normalize_delivery_verbosity(None) is None
+        assert _normalize_delivery_verbosity("") is None
+        assert _normalize_delivery_verbosity("   ") is None
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            _normalize_delivery_verbosity("loud")
+
+
+class TestCreateJobPersistence:
+    def test_persists_when_set(self, tmp_cron_dir):
+        job = create_job(
+            prompt="check mail",
+            schedule="15m",
+            deliver="local",
+            delivery_verbosity="result_only",
+        )
+        assert job["delivery_verbosity"] == "result_only"
+        assert get_job(job["id"])["delivery_verbosity"] == "result_only"
+
+    def test_absent_by_default(self, tmp_cron_dir):
+        # Back-compat: omitted → key not persisted → readers default to "full".
+        job = create_job(prompt="x", schedule="15m", deliver="local")
+        assert "delivery_verbosity" not in job
+
+    def test_invalid_rejected_at_create(self, tmp_cron_dir):
+        with pytest.raises(ValueError):
+            create_job(prompt="x", schedule="15m", deliver="local", delivery_verbosity="bogus")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_delivery_verbosity — resolution order
+# ---------------------------------------------------------------------------
+
+class TestResolveDeliveryVerbosity:
+    def test_per_job_wins(self):
+        assert _resolve_delivery_verbosity({"delivery_verbosity": "summary"}, ["chat"], {}) == "summary"
+
+    def test_per_job_invalid_falls_through(self):
+        # A bogus per-job value is ignored, falling to the default.
+        assert _resolve_delivery_verbosity({"delivery_verbosity": "bogus"}, ["chat"], {}) == "full"
+
+    def test_chat_quiet_implies_result_only(self):
+        cfg = {"display": {"chat_overrides": {"g": {"mode": "quiet"}}}}
+        assert _resolve_delivery_verbosity({}, ["g"], cfg) == "result_only"
+
+    def test_chat_quiet_via_quiet_chats(self):
+        cfg = {"display": {"quiet_chats": ["g"]}}
+        assert _resolve_delivery_verbosity({}, ["g"], cfg) == "result_only"
+
+    def test_chat_silent_implies_silent(self):
+        cfg = {"display": {"chat_overrides": {"s": {"mode": "silent"}}}}
+        assert _resolve_delivery_verbosity({}, ["s"], cfg) == "silent"
+
+    def test_chat_verbose_and_normal_are_full(self):
+        cfg = {"display": {"chat_overrides": {"v": {"mode": "verbose"}, "n": {"mode": "normal"}}}}
+        assert _resolve_delivery_verbosity({}, ["v"], cfg) == "full"
+        assert _resolve_delivery_verbosity({}, ["n"], cfg) == "full"
+
+    def test_per_job_overrides_chat(self):
+        cfg = {"display": {"chat_overrides": {"s": {"mode": "silent"}}}}
+        # Explicit per-job full beats a silent target chat.
+        assert _resolve_delivery_verbosity({"delivery_verbosity": "full"}, ["s"], cfg) == "full"
+
+    def test_default_full(self):
+        assert _resolve_delivery_verbosity({}, ["unknown"], {}) == "full"
+        assert _resolve_delivery_verbosity({}, [], {}) == "full"
+
+    def test_none_chat_id_skipped(self):
+        assert _resolve_delivery_verbosity({}, [None], {}) == "full"
+
+    def test_multi_target_most_restrictive_wins(self):
+        # Fan-out sharing ONE content: a verbose first target must NOT leak the
+        # full trace to a silent/quiet later target.
+        cfg = {
+            "display": {
+                "chat_overrides": {
+                    "v": {"mode": "verbose"},
+                    "s": {"mode": "silent"},
+                    "q": {"mode": "quiet"},
+                }
+            }
+        }
+        # verbose + silent → don't suppress the verbose target, don't leak to
+        # the silent one → result_only (final answer everywhere).
+        assert _resolve_delivery_verbosity({}, ["v", "s"], cfg) == "result_only"
+        # verbose + quiet → result_only.
+        assert _resolve_delivery_verbosity({}, ["v", "q"], cfg) == "result_only"
+
+    def test_multi_target_all_silent_suppresses(self):
+        cfg = {"display": {"chat_overrides": {"s1": {"mode": "silent"}, "s2": {"mode": "silent"}}}}
+        assert _resolve_delivery_verbosity({}, ["s1", "s2"], cfg) == "silent"
+
+    def test_multi_target_silent_plus_unconfigured_degrades_not_suppresses(self):
+        # A silent target mixed with an unconfigured one must still deliver
+        # (result_only) to the unconfigured target — never suppress it.
+        cfg = {"display": {"chat_overrides": {"s": {"mode": "silent"}}}}
+        assert _resolve_delivery_verbosity({}, ["s", "unconfigured"], cfg) == "result_only"
+
+
+# ---------------------------------------------------------------------------
+# _apply_delivery_verbosity — content transform & suppression
+# ---------------------------------------------------------------------------
+
+class TestApplyDeliveryVerbosity:
+    def test_full_unchanged(self):
+        assert _apply_delivery_verbosity("full", "body", success=True) == "body"
+
+    def test_result_only_strips_reasoning(self):
+        out = _apply_delivery_verbosity("result_only", "<think>secret</think>\nFinal answer", success=True)
+        assert out == "Final answer"
+
+    def test_summary_truncates(self):
+        out = _apply_delivery_verbosity("summary", "A" * 400, success=True)
+        assert out.endswith("…")
+        assert len(out) <= 281
+
+    def test_silent_suppresses_on_success(self):
+        assert _apply_delivery_verbosity("silent", "body", success=True) is None
+
+    def test_error_delivery_never_transformed(self):
+        # success=False → every level passes the content through untouched.
+        for level in DELIVERY_VERBOSITY_LEVELS:
+            assert _apply_delivery_verbosity(level, "ERR trace", success=False) == "ERR trace"
+
+    def test_summarize_helper_empty_safe(self):
+        assert _summarize_job_result("") == ""
+        assert _summarize_job_result("   ") == ""
+
+    def test_summarize_short_content_unchanged(self):
+        assert _summarize_job_result("short") == "short"
+
+
+# ---------------------------------------------------------------------------
+# Integration through _deliver_result
+# ---------------------------------------------------------------------------
+
+def _telegram_gateway_cfg():
+    from gateway.config import Platform
+
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    pconfig.extra = {}
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    return mock_cfg
+
+
+def _sent_text(send_mock):
+    return send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+
+
+class TestDeliverResultVerbosityIntegration:
+    JOB = {
+        "id": "job1",
+        "name": "mail-check",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "123"},
+    }
+
+    def _run(self, job, content, user_cfg, *, success=True):
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_gateway_cfg()), \
+             patch("cron.scheduler.load_config", return_value=user_cfg), \
+             patch(
+                 "tools.send_message_tool._send_to_platform",
+                 new=AsyncMock(return_value={"success": True}),
+             ) as send_mock:
+            result = _deliver_result(job, content, success=success)
+        return result, send_mock
+
+    def test_full_delivers_whole_content(self):
+        job = {**self.JOB, "delivery_verbosity": "full"}
+        _, send = self._run(job, "line1\nline2", {"cron": {"wrap_response": False}})
+        assert _sent_text(send) == "line1\nline2"
+
+    def test_result_only_strips_trace(self):
+        job = {**self.JOB, "delivery_verbosity": "result_only"}
+        _, send = self._run(
+            job, "<think>reasoning</think>\nThe result", {"cron": {"wrap_response": False}}
+        )
+        assert _sent_text(send) == "The result"
+
+    def test_summary_truncates(self):
+        job = {**self.JOB, "delivery_verbosity": "summary"}
+        _, send = self._run(job, "B" * 400, {"cron": {"wrap_response": False}})
+        sent = _sent_text(send)
+        assert sent.endswith("…") and len(sent) <= 281
+
+    def test_silent_suppresses_delivery_on_success(self):
+        job = {**self.JOB, "delivery_verbosity": "silent"}
+        result, send = self._run(job, "quiet result", {"cron": {"wrap_response": False}})
+        assert result is None
+        send.assert_not_called()
+
+    def test_silent_still_delivers_on_failure(self):
+        job = {**self.JOB, "delivery_verbosity": "silent"}
+        _, send = self._run(
+            job, "ERROR: job blew up", {"cron": {"wrap_response": False}}, success=False
+        )
+        send.assert_called_once()
+        assert _sent_text(send) == "ERROR: job blew up"
+
+    def test_per_chat_quiet_target_forces_result_only(self):
+        # No per-job verbosity; the delivery target chat is mode: quiet.
+        cfg = {
+            "cron": {"wrap_response": False},
+            "display": {"chat_overrides": {"123": {"mode": "quiet"}}},
+        }
+        _, send = self._run(self.JOB, "<think>x</think>\nJust the answer", cfg)
+        assert _sent_text(send) == "Just the answer"
+
+    def test_per_chat_silent_target_suppresses(self):
+        cfg = {
+            "cron": {"wrap_response": False},
+            "display": {"chat_overrides": {"123": {"mode": "silent"}}},
+        }
+        result, send = self._run(self.JOB, "nothing to see", cfg)
+        assert result is None
+        send.assert_not_called()
+
+    def test_no_verbosity_is_unchanged_default(self):
+        # No per-job field, no chat override → full (byte-identical to before).
+        _, send = self._run(self.JOB, "plain output", {"cron": {"wrap_response": False}})
+        assert _sent_text(send) == "plain output"

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -27,7 +27,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, *, success=True):
         calls.append(("deliver", job["id"]))
         return None
 

--- a/tests/gateway/test_chat_verbosity.py
+++ b/tests/gateway/test_chat_verbosity.py
@@ -1,0 +1,227 @@
+"""Tests for per-chat display verbosity overrides (issue #924).
+
+Covers ``resolve_display_setting(..., chat_id=...)`` step-0 resolution, the
+verbosity mode presets, the ``quiet_chats`` shorthand, the
+``resolve_chat_mode`` / ``chat_delivery_suppressed`` helpers, and the strict
+regression guarantee that ``chat_id=None`` leaves existing resolution
+byte-for-byte identical.
+"""
+
+import pytest
+
+from gateway.display_config import (
+    resolve_display_setting,
+    resolve_chat_mode,
+    chat_delivery_suppressed,
+    _MODE_PRESETS,
+    _QUIET_PRESET,
+    _VERBOSE_PRESET,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mode preset values match the issue's verbosity-modes table
+# ---------------------------------------------------------------------------
+
+class TestModePresets:
+    def test_verbose_preset_values(self):
+        assert _VERBOSE_PRESET["tool_progress"] == "all"
+        assert _VERBOSE_PRESET["interim_assistant_messages"] is True
+        assert _VERBOSE_PRESET["long_running_notifications"] is True
+        assert _VERBOSE_PRESET["show_reasoning"] is True
+
+    def test_quiet_preset_values(self):
+        assert _QUIET_PRESET["tool_progress"] == "off"
+        assert _QUIET_PRESET["interim_assistant_messages"] is False
+        assert _QUIET_PRESET["long_running_notifications"] is False
+        assert _QUIET_PRESET["busy_ack_detail"] is False
+        assert _QUIET_PRESET["show_reasoning"] is False
+
+    def test_normal_falls_through(self):
+        # normal is None so the per-platform chain runs unchanged.
+        assert _MODE_PRESETS["normal"] is None
+
+    def test_silent_matches_quiet_for_settings(self):
+        # silent resolves identically to quiet for per-setting display; its
+        # extra delivery-suppression is expressed via chat_delivery_suppressed.
+        assert _MODE_PRESETS["silent"] == _QUIET_PRESET
+
+    def test_verbose_is_inverse_of_quiet(self):
+        # Same key set, opposite values — predictable, symmetric presets.
+        assert set(_VERBOSE_PRESET) == set(_QUIET_PRESET)
+
+
+# ---------------------------------------------------------------------------
+# Per-chat override resolution (step 0)
+# ---------------------------------------------------------------------------
+
+class TestChatOverrideResolution:
+    def test_quiet_group_hides_progress_and_reasoning(self):
+        cfg = {"display": {"chat_overrides": {"-100grp": {"mode": "quiet"}}}}
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="-100grp") == "off"
+        assert resolve_display_setting(cfg, "telegram", "show_reasoning", chat_id="-100grp") is False
+        assert resolve_display_setting(cfg, "telegram", "interim_assistant_messages", chat_id="-100grp") is False
+
+    def test_verbose_dm_shows_everything(self):
+        cfg = {"display": {"chat_overrides": {"dm1": {"mode": "verbose"}}}}
+        # Telegram default tool_progress is "off"; verbose chat flips it to "all".
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="dm1") == "all"
+        assert resolve_display_setting(cfg, "telegram", "show_reasoning", chat_id="dm1") is True
+
+    def test_explicit_key_beats_mode_preset(self):
+        # mode: quiet but explicit show_reasoning: true → reasoning still shows.
+        cfg = {"display": {"chat_overrides": {"mix": {"mode": "quiet", "show_reasoning": True}}}}
+        assert resolve_display_setting(cfg, "telegram", "show_reasoning", chat_id="mix") is True
+        # Non-overridden keys still follow the quiet preset.
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="mix") == "off"
+
+    def test_mode_normal_falls_through_to_platform_default(self):
+        cfg = {"display": {"chat_overrides": {"n": {"mode": "normal"}}}}
+        # Falls through unchanged: telegram platform default is "off".
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="n") == "off"
+        # And discord's platform default "all" is preserved too.
+        assert resolve_display_setting(cfg, "discord", "tool_progress", chat_id="n") == "all"
+
+    def test_preset_without_this_setting_falls_through(self):
+        # tool_preview_length is not in any mode preset → falls through to the
+        # platform default even inside a quiet chat.
+        cfg = {"display": {"chat_overrides": {"g": {"mode": "quiet"}}}}
+        assert resolve_display_setting(cfg, "slack", "tool_preview_length", chat_id="g") == 40
+
+    def test_unknown_mode_falls_through(self):
+        cfg = {"display": {"chat_overrides": {"g": {"mode": "bogus"}}}}
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="g") == "off"
+
+    def test_chat_value_normalised(self):
+        # Explicit per-chat string values pass through _normalise like any other.
+        cfg = {"display": {"chat_overrides": {"g": {"tool_progress": "false"}}}}
+        assert resolve_display_setting(cfg, "discord", "tool_progress", chat_id="g") == "off"
+        cfg2 = {"display": {"chat_overrides": {"g": {"show_reasoning": "yes"}}}}
+        assert resolve_display_setting(cfg2, "telegram", "show_reasoning", chat_id="g") is True
+
+    def test_int_chat_id_coerced_to_str(self):
+        cfg = {"display": {"chat_overrides": {"12345": {"mode": "quiet"}}}}
+        # Caller may pass an int chat id.
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id=12345) == "off"
+
+    def test_int_keyed_chat_overrides_matched(self):
+        # YAML/JSON may parse an unquoted numeric chat id as an int KEY.
+        cfg = {"display": {"chat_overrides": {12345: {"mode": "quiet"}}}}
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="12345") == "off"
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id=12345) == "off"
+        # Negative Telegram supergroup id as an int key.
+        cfg2 = {"display": {"chat_overrides": {-1001234567890: {"mode": "verbose"}}}}
+        assert resolve_display_setting(cfg2, "telegram", "tool_progress", chat_id="-1001234567890") == "all"
+
+    def test_full_fallback_chain_chat_then_platform_then_tier_then_global(self):
+        # A chat override for one setting doesn't leak into other settings /
+        # other chats: the rest of the chain (platform → tier → global) still runs.
+        cfg = {
+            "display": {
+                "chat_overrides": {"g": {"mode": "quiet"}},
+                "platforms": {"discord": {"reasoning_style": "blockquote"}},
+            }
+        }
+        # chat layer (quiet) for a covered key
+        assert resolve_display_setting(cfg, "discord", "tool_progress", chat_id="g") == "off"
+        # platform layer (explicit) for an uncovered key
+        assert resolve_display_setting(cfg, "discord", "reasoning_style", chat_id="g") == "blockquote"
+        # tier default for another uncovered key
+        assert resolve_display_setting(cfg, "discord", "tool_preview_length", chat_id="g") == 40
+        # global default for a key with no platform/tier entry
+        assert resolve_display_setting(cfg, "discord", "tool_progress_grouping", chat_id="g") == "accumulate"
+
+
+# ---------------------------------------------------------------------------
+# quiet_chats shorthand
+# ---------------------------------------------------------------------------
+
+class TestQuietChatsShorthand:
+    def test_membership_implies_quiet(self):
+        cfg = {"display": {"quiet_chats": ["-100q", "-200q"]}}
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="-100q") == "off"
+        assert resolve_display_setting(cfg, "telegram", "interim_assistant_messages", chat_id="-200q") is False
+
+    def test_non_member_unaffected(self):
+        cfg = {"display": {"quiet_chats": ["-100q"]}}
+        # discord default is "all"; a non-listed chat keeps it.
+        assert resolve_display_setting(cfg, "discord", "tool_progress", chat_id="other") == "all"
+
+    def test_explicit_mode_beats_quiet_chats(self):
+        cfg = {
+            "display": {
+                "quiet_chats": ["dm"],
+                "chat_overrides": {"dm": {"mode": "verbose"}},
+            }
+        }
+        # chat_overrides.mode wins over quiet_chats membership.
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="dm") == "all"
+
+    def test_int_members_coerced(self):
+        cfg = {"display": {"quiet_chats": [12345]}}
+        assert resolve_display_setting(cfg, "telegram", "tool_progress", chat_id="12345") == "off"
+
+
+# ---------------------------------------------------------------------------
+# resolve_chat_mode / chat_delivery_suppressed helpers
+# ---------------------------------------------------------------------------
+
+class TestChatModeHelpers:
+    def test_resolve_chat_mode(self):
+        cfg = {
+            "display": {
+                "chat_overrides": {"g": {"mode": "quiet"}, "v": {"mode": "VERBOSE"}},
+                "quiet_chats": ["q"],
+            }
+        }
+        assert resolve_chat_mode(cfg, "g") == "quiet"
+        assert resolve_chat_mode(cfg, "v") == "verbose"  # case-insensitive
+        assert resolve_chat_mode(cfg, "q") == "quiet"  # via quiet_chats
+        assert resolve_chat_mode(cfg, "unknown") is None
+        assert resolve_chat_mode(cfg, None) is None
+
+    def test_chat_delivery_suppressed(self):
+        cfg = {"display": {"chat_overrides": {"s": {"mode": "silent"}, "g": {"mode": "quiet"}}}}
+        assert chat_delivery_suppressed(cfg, "s") is True
+        # quiet is NOT silent — quiet still delivers (final answer only).
+        assert chat_delivery_suppressed(cfg, "g") is False
+        assert chat_delivery_suppressed(cfg, "unknown") is False
+        assert chat_delivery_suppressed(cfg, None) is False
+
+    def test_helpers_tolerate_missing_display(self):
+        assert resolve_chat_mode({}, "g") is None
+        assert chat_delivery_suppressed({}, "g") is False
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: chat_id=None is byte-for-byte identical to before
+# ---------------------------------------------------------------------------
+
+class TestChatIdNoneRegression:
+    # (config, platform, setting) cases spanning every resolution layer.
+    CASES = [
+        ({}, "telegram", "tool_progress"),                       # platform default
+        ({}, "discord", "tool_progress"),                        # tier default
+        ({}, "unknown_platform", "tool_progress"),               # global default
+        ({}, "telegram", "streaming"),                           # None sentinel
+        ({}, "slack", "tool_preview_length"),                    # int
+        ({"display": {"tool_progress": "new"}}, "telegram", "tool_progress"),  # global user
+        ({"display": {"platforms": {"telegram": {"tool_progress": "verbose"}}}}, "telegram", "tool_progress"),  # platform override
+        ({"display": {"tool_progress_overrides": {"signal": "off"}}}, "signal", "tool_progress"),  # legacy
+        ({"display": {"reasoning_style": "subtext"}}, "telegram", "reasoning_style"),
+    ]
+
+    @pytest.mark.parametrize("cfg,platform,setting", CASES)
+    def test_none_matches_no_arg(self, cfg, platform, setting):
+        # Passing chat_id=None must equal omitting it entirely.
+        assert (
+            resolve_display_setting(cfg, platform, setting)
+            == resolve_display_setting(cfg, platform, setting, chat_id=None)
+        )
+
+    def test_chat_overrides_present_but_no_chat_id_is_inert(self):
+        # Even with chat_overrides configured, omitting chat_id must ignore them.
+        cfg = {"display": {"chat_overrides": {"g": {"mode": "verbose"}}, "quiet_chats": ["g"]}}
+        # telegram default stays "off" — the per-chat layer never runs.
+        assert resolve_display_setting(cfg, "telegram", "tool_progress") == "off"
+        assert resolve_display_setting(cfg, "telegram", "show_reasoning") is False

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -27,6 +27,7 @@ from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,
     create_job,
+    DELIVERY_VERBOSITY_LEVELS,
     get_job,
     list_jobs,
     mark_job_run,
@@ -937,6 +938,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("delivery_verbosity"):
+        result["delivery_verbosity"] = job["delivery_verbosity"]
     return result
 
 
@@ -1010,6 +1013,7 @@ def cronjob(
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     approval_mode: Optional[str] = None,
+    delivery_verbosity: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -1072,6 +1076,15 @@ def cronjob(
             if base_url_error:
                 return tool_error(base_url_error, success=False)
 
+            # Validate delivery_verbosity (issue #924) before persisting.
+            if delivery_verbosity is not None and str(delivery_verbosity).strip():
+                if str(delivery_verbosity).strip().lower() not in DELIVERY_VERBOSITY_LEVELS:
+                    return tool_error(
+                        "delivery_verbosity must be one of "
+                        f"{', '.join(DELIVERY_VERBOSITY_LEVELS)}",
+                        success=False,
+                    )
+
             # Validate context_from references existing jobs
             if context_from:
                 from cron.jobs import get_job as _get_job
@@ -1105,6 +1118,7 @@ def cronjob(
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
                 approval_mode=approval_mode,
+                delivery_verbosity=delivery_verbosity,
             )
             _reset_cron_failure(task_id)
             _notify_provider_jobs_changed_safe()
@@ -1308,6 +1322,17 @@ def cronjob(
                 updates["approval_mode"] = (
                     _normalize_optional_job_value(approval_mode) or None
                 )
+            if delivery_verbosity is not None:
+                # Empty string clears the override (restores "full"); otherwise
+                # validate against the known levels before persisting (#924).
+                _dv = str(delivery_verbosity).strip().lower()
+                if _dv and _dv not in DELIVERY_VERBOSITY_LEVELS:
+                    return tool_error(
+                        "delivery_verbosity must be one of "
+                        f"{', '.join(DELIVERY_VERBOSITY_LEVELS)}",
+                        success=False,
+                    )
+                updates["delivery_verbosity"] = _dv or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1477,6 +1502,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
+            },
+            "delivery_verbosity": {
+                "type": "string",
+                "enum": ["full", "result_only", "summary", "silent"],
+                "description": "Optional per-job delivery verbosity (issue #924). Controls how much of the run's output is delivered to the target chat: 'full' (default — the response as produced), 'result_only' (final answer only, any reasoning/trace stripped — ideal for mail/health checks that flood a channel), 'summary' (one-line status + final answer trimmed to ~280 chars), or 'silent' (deliver nothing on success; failures ALWAYS deliver so a broken job can't fail silently). Absent = 'full'. Note: a delivery target chat configured with display.chat_overrides mode 'quiet' implies 'result_only' and 'silent' implies 'silent' unless this per-job value overrides it. On update, pass an empty string to clear (restore 'full')."
             },
         },
         "required": ["action"],


### PR DESCRIPTION
Closes #924.

Adds a **per-chat** verbosity layer on top of the existing per-platform display system, plus a **per-cron-job** `delivery_verbosity` control. A single platform can now mix verbosity per chat/topic/DM (customer-facing group → clean answers only; private DM → full detail), and cron jobs can deliver only the result (or nothing) instead of the full execution trace.

## Scope (what changed per file)

| File | Change |
|---|---|
| `gateway/display_config.py` | `resolve_display_setting()` gains optional `chat_id` as resolution **STEP 0** (`display.chat_overrides` / `display.quiet_chats`). Mode presets `verbose`/`normal`/`quiet`/`silent`. New public helpers `resolve_chat_mode()` / `chat_delivery_suppressed()`. Int-keyed configs tolerated. |
| `gateway/run.py` | Threads `str(source.chat_id)` into every display resolution in the interactive turn path (tool_progress, interim messages, reasoning, heartbeats, streaming, busy-ack, previews, cleanup). `HERMES_TOOL_PROGRESS_MODE` no longer clobbers a chat's `mode`. |
| `cron/scheduler.py` | `_deliver_result(...)` gains `delivery_verbosity` shaping (`full`/`result_only`/`summary`/`silent`) via `_resolve_delivery_verbosity` + `_apply_delivery_verbosity` + `_summarize_job_result`. |
| `cron/jobs.py` | Persist/validate `delivery_verbosity` job field (absent = `full`, back-compat). |
| `tools/cronjob_tools.py` | `cronjob(..., delivery_verbosity=...)` param, create/update wiring, schema + `_format_job` output. |
| `hermes_cli/config.py` | `display.chat_overrides` / `display.quiet_chats` defaults; `_config_version` 33→34 (deep-merge supplies defaults; migration invariant strips pure defaults on disk). |
| **`skills/.../hermes-agent/SKILL.md`** | **New "Display verbosity (per-platform · per-chat · per-cron-job)" section** — mode table, both resolution orders, copy-paste YAML + jobs.json examples. Config-table `display` row updated. |
| `tests/gateway/test_chat_verbosity.py`, `tests/cron/test_delivery_verbosity.py` | New focused suites. `tests/cron/test_run_one_job.py` mock signature updated for the new `success` kwarg. |

## Verbosity modes

| Mode | tool_progress | interim | heartbeats | reasoning | delivery |
|------|:---:|:---:|:---:|:---:|---|
| `verbose` | all | yes | yes | yes | full |
| `normal` | (falls through to platform default) | | | | full |
| `quiet` | off | no | no | no | final answer only |
| `silent` | off | no | no | no | nothing (cron: no delivery on success) |

Explicit per-chat keys win over the `mode` preset. `silent`'s delivery suppression is expressed via `chat_delivery_suppressed()`, **not** a pseudo-setting key.

## Resolution orders

- **Interactive:** per-chat override → per-platform → built-in tier → global default. (`chat_id=None` skips STEP 0 → byte-for-byte identical to before.)
- **Cron delivery:** per-job `delivery_verbosity` → per-chat override at the delivery target (`quiet`/`quiet_chats` ⇒ `result_only`; `silent` ⇒ `silent`) → default `full`. Multi-target fan-out resolves to the **most-restrictive** shaping so the full trace never leaks to a quiet/silent target; **error deliveries (`success=False`) are never transformed or suppressed**.

## SKILL.md doc update (first-class deliverable)

New **"Display verbosity"** subsection under Config Sections documents what the feature is, the config shape (`display.chat_overrides`, `display.quiet_chats`, per-job `delivery_verbosity`), the mode table, both resolution orders, and copy-paste examples (customer group → `quiet`, DM → `verbose`, cron mail-check → `result_only`). AGENTS.md / `docs/` do not enumerate display keys, so no updates needed there.

## Backward compatibility

Absent `chat_overrides`/`quiet_chats` and absent `delivery_verbosity` mean exactly the current per-platform behavior. `chat_id=None` (every pre-existing caller) preserves resolution byte-for-byte (regression-guard test asserts this across every layer, and a pristine-tree stash comparison confirmed a pre-existing unrelated flaky test is not caused by this change).

## Verification

- **Tests:** `711 passed` across the affected suites (`test_chat_verbosity`, `test_delivery_verbosity`, `test_display_config`, `test_scheduler`, `test_jobs`, `test_run_one_job`, `test_strip_reasoning_delivery`, `test_cronjob_tools`, `test_config`, `test_config_drift`).
- **Lint:** `ruff check .` → *All checks passed!* (repo-wide). The repo enforces only `ruff check`; `ruff format` is not clean repo-wide (sibling test files use the same compact long-line style), so unrelated pre-existing files were not reformatted.
- **Independent review:** `consult agy` (Gemini). Confirmed all five correctness questions (additive `chat_id=None`, presets match spec, error deliveries not dropped, resolution order, no per-platform regression). Two legitimate findings fixed: (1) int-keyed `chat_overrides` from YAML/JSON now matched; (2) multi-target cron fan-out now picks the most-restrictive shaping instead of the first target's.
