### PR TITLE
feat(#929): pre-flight provider/model validation for model_not_found

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -526,6 +526,7 @@ def _user_actionable_provider_guidance(
     *,
     provider: str,
     model: str,
+    phase: str = "abort",
 ) -> Optional[str]:
     """Concise, actionable recovery text for a user-fixable provider error.
 
@@ -535,13 +536,29 @@ def _user_actionable_provider_guidance(
     covers. Only the two reasons in ``_USER_ACTIONABLE_ABORT_REASONS`` are
     handled here — the rest keep their existing dedicated branches. See
     issue #758.
+
+    ``phase`` selects only the *opening sentence* so the same single-sourced
+    recovery steps are reused by both callers (never forked):
+      * ``"abort"`` (default) — the reactive #758 path, AFTER the provider
+        rejected the model. Byte-for-byte identical to the original wording.
+      * ``"preflight"`` — the proactive #929 path, caught BEFORE any request
+        was sent, so the lead is phrased accordingly.
     """
     _provider = provider or "the provider"
     if reason == FailoverReason.model_not_found:
+        if phase == "preflight":
+            _lead = (
+                f"💡 Pre-flight check: '{model}' is not a usable model name for "
+                f"{_provider}, so no request was sent. This fails the same way "
+                "every time until the model name is fixed.\n"
+            )
+        else:
+            _lead = (
+                f"💡 The model '{model}' was rejected by {_provider} — not found or "
+                "not available on this endpoint. Retrying will not help.\n"
+            )
         return (
-            f"💡 The model '{model}' was rejected by {_provider} — not found or "
-            "not available on this endpoint. Retrying will not help.\n"
-            "What you can do:\n"
+            _lead + "What you can do:\n"
             "  • Check the model name for typos, or run `hermes model` to pick a valid one.\n"
             "  • Add a fallback model so this routes automatically: `hermes fallback add`."
         )
@@ -558,6 +575,87 @@ def _user_actionable_provider_guidance(
             "schema your client expects."
         )
     return None
+
+
+def _preflight_model_validation_result(agent, messages):
+    """Early turn-result if the configured model is structurally unresolvable (#929).
+
+    Runs once per turn, BEFORE the first provider request. Complements #758's
+    reactive path: instead of burning a full round trip on a model name the
+    provider can never serve (and, in unattended cron/subagent contexts,
+    risking a cascade into provider connection exhaustion), catch the
+    deterministic failures locally and fail fast with the SAME actionable
+    guidance style — reusing ``_user_actionable_provider_guidance`` with
+    ``phase="preflight"`` rather than forking the message.
+
+    Returns a turn-result ``dict`` (``api_calls == 0``, ``user_actionable``)
+    on a validation miss, or ``None`` to proceed normally. LOCAL-only; see
+    ``agent/model_preflight.py`` for the validation-source boundary. The check
+    must never itself break a run, so any unexpected error fails open.
+    """
+    try:
+        from agent.model_preflight import check_model
+    except Exception:
+        return None
+
+    provider = str(getattr(agent, "provider", "") or "")
+    model = getattr(agent, "model", "")
+    base_url = str(getattr(agent, "base_url", "") or "")
+
+    # ACP/relay transports don't route through a conventional model catalog —
+    # their "model" is managed by the subprocess. Skip to avoid false positives.
+    _base_l = base_url.lower()
+    if (
+        provider in {"copilot-acp"}
+        or _base_l.startswith("acp://")
+        or _base_l.startswith("acp+tcp://")
+    ):
+        return None
+
+    try:
+        miss = check_model(provider, model, base_url)
+    except Exception:
+        return None
+    if miss is None:
+        return None
+
+    guidance = _user_actionable_provider_guidance(
+        FailoverReason.model_not_found,
+        provider=provider,
+        model=str(model),
+        phase="preflight",
+    )
+    _parts = [guidance] if guidance else []
+    if miss.suggestions:
+        _parts.append(
+            f"  • Known-good models for {provider or 'this provider'}: "
+            f"{', '.join(miss.suggestions)}."
+        )
+    final_response = (
+        "\n".join(_parts) if _parts else f"Model pre-flight failed: {miss.detail}."
+    )
+
+    # Console guidance for CLI users; bot/gateway users read ``final_response``.
+    for _line in final_response.splitlines():
+        agent._vprint(f"{agent.log_prefix}   {_line}", force=True)
+    logger.error(
+        "%sPre-flight model validation failed (no request sent): %s "
+        "(provider=%s model=%r)",
+        agent.log_prefix,
+        miss.detail,
+        provider,
+        model,
+    )
+
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": 0,
+        "completed": False,
+        "failed": True,
+        "error": f"model_preflight: {miss.detail}",
+        "user_actionable": True,
+    }
 
 
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
@@ -742,6 +840,16 @@ def _run_conversation_impl(
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+
+    # Pre-flight provider/model validation (#929): catch a structurally
+    # unresolvable model config BEFORE the first provider request, so the turn
+    # fails fast with actionable guidance instead of burning a round trip on a
+    # model the provider can never serve. Skipped for MOA (multi-model routing
+    # has its own dispatch). Complements #758's reactive recovery path.
+    if moa_config is None:
+        _preflight_result = _preflight_model_validation_result(agent, messages)
+        if _preflight_result is not None:
+            return _preflight_result
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/agent/model_preflight.py
+++ b/agent/model_preflight.py
@@ -1,0 +1,192 @@
+"""Pre-flight provider/model validation (issue #929).
+
+Proactive companion to #758 (PR #923).  #758 handles the *reactive* case: when
+a provider rejects a model with ``model_not_found`` the user gets an actionable
+recovery message instead of a silent abort.  #929 catches the same class of
+failure *before* the first provider request, so a run does not burn a round
+trip — and, in unattended cron/subagent contexts, does not risk cascading into
+provider connection exhaustion — on a model name the provider can never serve.
+
+Validation-source boundary (deliberate — documented in the PR)
+--------------------------------------------------------------
+The codebase maintains a LOCAL provider registry
+(``providers.get_provider_profile`` / ``model_metadata._PROVIDER_PREFIXES``)
+and per-provider *curated* ``fallback_models`` lists, but it has NO cheap,
+authoritative, EXHAUSTIVE local catalog of every model each provider currently
+serves.  Enumerating that requires a network call
+(``ProviderProfile.fetch_models`` / models.dev / OpenRouter's ``/models``),
+which must NOT run on every turn.
+
+So this pre-flight fails-closed ONLY on model strings that are *structurally*
+unresolvable — model ids no provider can ever route:
+
+  * a bare provider prefix with nothing after the colon (``"openrouter:"``)
+  * an id containing internal whitespace (``"gpt 4o"`` — a pasted display name),
+    but ONLY for a recognised hosted provider — unknown custom/corporate
+    gateways fail open (their id convention is unknown to us)
+
+Those deterministically produce ``model_not_found`` (HTTP 400/404) at every
+provider and are knowable with zero network and essentially zero false
+positives.  Deliberately NOT rejected here:
+
+  * an EMPTY / blank model — that is a legitimate "use the provider default"
+    state elsewhere in the codebase (exercised by existing tests), so failing
+    it closed would block valid runs.
+  * a well-formed-but-currently-unavailable model (e.g. an OpenRouter slug the
+    catalog has dropped) — no cheap local signal distinguishes it from a valid
+    one, so it stays on #758's reactive path.
+
+The provider's ``fallback_models`` are consulted only to SUGGEST known-good
+names, never to reject.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class PreflightMiss:
+    """A structurally-unresolvable model config caught before any request.
+
+    ``detail`` is a short, log-friendly reason.  ``suggestions`` is a curated
+    (non-exhaustive, LOCAL) list of known-good model names for the provider,
+    used only to enrich the user-facing guidance.
+    """
+
+    detail: str
+    suggestions: tuple[str, ...] = ()
+
+
+def _known_good_models(provider: str, base_url: str) -> tuple[str, ...]:
+    """Best-effort curated known-good models for *provider* — LOCAL only.
+
+    Reads the provider profile's ``fallback_models`` (a curated, non-exhaustive
+    list).  Never triggers a network fetch.  Returns ``()`` when nothing local
+    is available.
+    """
+    try:
+        from providers import get_provider_profile
+    except Exception:
+        return ()
+
+    profile = None
+    try:
+        if provider:
+            profile = get_provider_profile(provider)
+        if profile is None and base_url:
+            # Fall back to URL->provider inference for custom-labelled providers.
+            from agent.model_metadata import _infer_provider_from_url
+
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                profile = get_provider_profile(inferred)
+    except Exception:
+        return ()
+
+    if profile is None:
+        return ()
+    return tuple(profile.fallback_models or ())[:5]
+
+
+def _is_local_or_custom(provider: str, base_url: str) -> bool:
+    """True for local/custom endpoints, whose ad-hoc model ids we can't assume.
+
+    Their ``/models`` catalog can expose identifiers we don't control (LM
+    Studio, Ollama, bespoke relays), so the whitespace heuristic is skipped
+    for them to stay false-positive-free.
+    """
+    prov = (provider or "").strip().lower()
+    if prov in {"local", "custom", "lmstudio", "ollama"}:
+        return True
+    try:
+        from agent.model_metadata import is_local_endpoint
+
+        return bool(is_local_endpoint(base_url))
+    except Exception:
+        return False
+
+
+def _is_known_hosted_provider(provider: str, base_url: str) -> bool:
+    """True only when provider/base_url resolve to a RECOGNISED hosted provider.
+
+    The whitespace heuristic fires exclusively for these. For an unrecognised
+    custom or corporate gateway we cannot assume the model-id convention (a
+    bespoke relay could, in principle, expose space-bearing ids), so those fail
+    open. This keeps the check false-positive-free for private endpoints.
+    """
+    prov = (provider or "").strip().lower()
+    try:
+        from providers import get_provider_profile
+
+        if prov and get_provider_profile(prov) is not None:
+            return True
+    except Exception:
+        pass
+    try:
+        from agent.model_metadata import _PROVIDER_PREFIXES, _infer_provider_from_url
+
+        if prov and prov in _PROVIDER_PREFIXES and prov not in {"custom", "local"}:
+            return True
+        if base_url and _infer_provider_from_url(base_url):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def check_model(
+    provider: str, model: str, base_url: str = ""
+) -> Optional[PreflightMiss]:
+    """Return a :class:`PreflightMiss` iff *model* is structurally unresolvable.
+
+    LOCAL-ONLY, no network.  ``None`` means "nothing provably wrong locally —
+    proceed with the request".  See the module docstring for the boundary and
+    the deliberately-excluded cases (empty model, unavailable-but-well-formed).
+    """
+    raw = model if isinstance(model, str) else ("" if model is None else str(model))
+    stripped = raw.strip()
+
+    # Empty / blank is intentionally allowed (provider-default state). Nothing
+    # structural to check on an empty string anyway.
+    if not stripped:
+        return None
+
+    # 1. A bare recognised provider prefix with no model after the ':' —
+    #    e.g. "openrouter:", "anthropic:". The prefix is not itself a model.
+    #    Guard against URLs (a base-url-shaped model carries a "://").
+    if ":" in stripped and not raw.startswith("http"):
+        prefix, _, suffix = stripped.partition(":")
+        prefix_l = prefix.strip().lower()
+        try:
+            from agent.model_metadata import _PROVIDER_PREFIXES
+        except Exception:
+            _PROVIDER_PREFIXES = frozenset()
+        if prefix_l in _PROVIDER_PREFIXES and not suffix.strip():
+            return PreflightMiss(
+                detail=(
+                    f"the model name '{stripped}' is a bare '{prefix_l}:' provider "
+                    "prefix with no model after the colon"
+                ),
+                suggestions=_known_good_models(provider or prefix_l, base_url),
+            )
+
+    # 2. Internal whitespace — no hosted provider accepts a model id with a
+    #    space (a common paste of a display name, e.g. "gpt 4o"). Fires ONLY for
+    #    recognised hosted providers; unknown custom/corporate gateways and
+    #    local endpoints fail open (we can't assume their id convention).
+    if (
+        any(ch.isspace() for ch in stripped)
+        and _is_known_hosted_provider(provider, base_url)
+        and not _is_local_or_custom(provider, base_url)
+    ):
+        return PreflightMiss(
+            detail=(
+                f"the model name '{stripped}' contains whitespace, which no "
+                "hosted provider accepts as an identifier"
+            ),
+            suggestions=_known_good_models(provider, base_url),
+        )
+
+    return None

--- a/tests/agent/test_model_preflight_929.py
+++ b/tests/agent/test_model_preflight_929.py
@@ -1,0 +1,221 @@
+"""Tests for #929: pre-flight provider/model validation.
+
+#758 (PR #923) added the *reactive* recovery path — when a provider rejects a
+model with ``model_not_found`` the turn ends with actionable guidance. #929
+adds the *proactive* half: a structurally-unresolvable model config is caught
+BEFORE the first provider request, so the run fails fast without burning a
+round trip.
+
+Two layers are covered:
+  • unit — ``agent.model_preflight.check_model`` structural verdicts and the
+    deliberate boundary (empty model and well-formed-unavailable are allowed).
+  • behavioral — driving ``run_conversation`` proves an unresolvable model is
+    caught pre-flight with NO provider call, a resolvable model proceeds
+    untouched, and the empty-model default (a valid state) is unaffected.
+
+The behavioral harness mirrors ``test_provider_error_recovery_758.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.conversation_loop import (
+    FailoverReason,
+    _user_actionable_provider_guidance,
+)
+from agent.model_preflight import PreflightMiss, check_model
+from run_agent import AIAgent
+
+_OPENROUTER = "https://openrouter.ai/api/v1"
+
+
+# ── Unit: structural verdicts ────────────────────────────────────────────
+
+
+def test_resolvable_model_passes_silently():
+    # A well-formed slug: no colon-prefix, no whitespace → proceed (None).
+    assert check_model("openrouter", "anthropic/claude-sonnet-4.6", _OPENROUTER) is None
+    assert (
+        check_model(
+            "anthropic", "claude-sonnet-4-5-20250929", "https://api.anthropic.com"
+        )
+        is None
+    )
+    # Ollama-style model:tag is a real id — the suffix is non-empty.
+    assert check_model("ollama", "qwen:0.5b", "http://localhost:11434/v1") is None
+
+
+def test_empty_model_is_allowed_by_design():
+    # Empty/blank == "use provider default" elsewhere; must NOT be failed closed.
+    assert check_model("openrouter", "", _OPENROUTER) is None
+    assert check_model("openrouter", "   ", _OPENROUTER) is None
+    assert check_model("openrouter", None, _OPENROUTER) is None
+
+
+def test_bare_provider_prefix_is_caught_with_suggestions():
+    miss = check_model("openrouter", "openrouter:", _OPENROUTER)
+    assert isinstance(miss, PreflightMiss)
+    assert "bare" in miss.detail and "openrouter:" in miss.detail
+    # Suggestions come from the LOCAL curated openrouter fallback_models.
+    assert miss.suggestions, "expected curated fallback_models as suggestions"
+
+
+def test_internal_whitespace_is_caught():
+    miss = check_model("openrouter", "gpt 4o", _OPENROUTER)
+    assert isinstance(miss, PreflightMiss)
+    assert "whitespace" in miss.detail
+
+
+def test_whitespace_skipped_for_local_endpoint():
+    # Local/custom endpoints may expose ad-hoc ids — don't second-guess them.
+    assert check_model("local", "my local model", "http://localhost:1234/v1") is None
+    assert check_model("custom", "some model", "http://127.0.0.1:8080/v1") is None
+
+
+def test_well_formed_unknown_model_is_not_rejected():
+    # No cheap local signal proves a well-formed slug is unavailable → allow it
+    # (that stays on #758's reactive path). Boundary guard.
+    assert (
+        check_model("openrouter", "vendor/model-that-was-dropped-v9", _OPENROUTER)
+        is None
+    )
+
+
+# ── Unit: guidance reuse (not fork) ──────────────────────────────────────
+
+
+def test_guidance_default_phase_is_byte_identical_to_758():
+    # The reactive #758 message must be unchanged when ``phase`` is omitted.
+    abort = _user_actionable_provider_guidance(
+        FailoverReason.model_not_found, provider="openrouter", model="foo/bar-v9"
+    )
+    assert abort == (
+        "💡 The model 'foo/bar-v9' was rejected by openrouter — not found or "
+        "not available on this endpoint. Retrying will not help.\n"
+        "What you can do:\n"
+        "  • Check the model name for typos, or run `hermes model` to pick a valid one.\n"
+        "  • Add a fallback model so this routes automatically: `hermes fallback add`."
+    )
+
+
+def test_preflight_phase_reuses_steps_with_a_preflight_lead():
+    pre = _user_actionable_provider_guidance(
+        FailoverReason.model_not_found,
+        provider="openrouter",
+        model="openrouter:",
+        phase="preflight",
+    )
+    # Pre-flight-accurate lead ("no request was sent")...
+    assert "Pre-flight check" in pre
+    assert "no request was sent" in pre
+    # ...but the SAME single-sourced recovery steps as #758.
+    assert "hermes model" in pre
+    assert "hermes fallback add" in pre
+
+
+# ── Behavioral: drive run_conversation ───────────────────────────────────
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(max_iterations: int = 10) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url=_OPENROUTER,
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.provider = "openrouter"
+    return agent
+
+
+def _run(agent, prompt="hello"):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+def test_unresolvable_model_caught_preflight_without_provider_call():
+    agent = _make_agent()
+    agent.model = "openrouter:"  # bare provider prefix — structurally invalid
+    # Safety net: if pre-flight failed to short-circuit, this would be consumed.
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="should-not-be-reached")
+    ]
+
+    result = _run(agent)
+
+    assert result["failed"] is True
+    assert result.get("user_actionable") is True
+    assert result["api_calls"] == 0
+    fr = result["final_response"]
+    assert "Pre-flight check" in fr
+    assert "hermes model" in fr
+    assert "hermes fallback add" in fr
+    assert result["error"].startswith("model_preflight:")
+    # The provider was NEVER contacted — the whole point of #929.
+    assert agent.client.chat.completions.create.call_count == 0
+
+
+def test_whitespace_model_caught_preflight_without_provider_call():
+    agent = _make_agent()
+    agent.model = "Claude Sonnet 4.5"  # pasted display name (spaces)
+
+    result = _run(agent)
+
+    assert result["failed"] is True
+    assert result.get("user_actionable") is True
+    assert result["api_calls"] == 0
+    assert agent.client.chat.completions.create.call_count == 0
+
+
+def test_resolvable_model_proceeds_to_provider():
+    agent = _make_agent()
+    agent.model = "anthropic/claude-sonnet-4.6"  # valid slug
+    agent.client.chat.completions.create.side_effect = [_mock_response(content="ok")]
+
+    result = _run(agent)
+
+    # Pre-flight is silent for a valid model — the turn runs normally.
+    assert result.get("failed") is not True
+    assert result.get("user_actionable") is not True
+    assert result["final_response"] == "ok"
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_empty_model_default_is_unaffected_regression_guard():
+    # The empty-model "use provider default" state (as in the #758 harness)
+    # must reach the provider exactly as before — pre-flight adds nothing.
+    agent = _make_agent()
+    agent.model = ""
+    agent.client.chat.completions.create.side_effect = [_mock_response(content="ok")]
+
+    result = _run(agent)
+
+    assert result.get("failed") is not True
+    assert result.get("user_actionable") is not True
+    assert result["final_response"] == "ok"
+    assert agent.client.chat.completions.create.call_count == 1


### PR DESCRIPTION
Closes #929.

## What #758 (PR #923, already merged) covered — NOT duplicated here
#758 added the **reactive** recovery path: once a provider *rejects* a model
with `model_not_found`/`format_error`, `agent/conversation_loop.py`'s terminal
abort handler calls `_user_actionable_provider_guidance(...)` and returns that
actionable text as `final_response` (so Telegram/Discord bot users, who only
see `final_response`, get a concrete next step instead of a silent abort).
`agent/error_classifier.py` classifies `model_not_found`. That is the
**after-the-provider-rejects** path.

## What this PR adds — the proactive half (#929)
Catch a structurally-unresolvable model config **before** the first provider
request, so a run does not burn a full LLM round trip (and, in unattended
cron/subagent contexts, does not risk cascading into provider connection
exhaustion) on a model name the provider can never serve.

- **New `agent/model_preflight.py`** — local-only `check_model(provider, model,
  base_url)` returns a `PreflightMiss` for a model that is *structurally*
  unresolvable:
  - a bare provider prefix with nothing after the colon (`"openrouter:"`), or
  - an id containing internal whitespace (`"gpt 4o"` — a pasted display name),
    **only** for a recognised hosted provider (unknown custom/corporate
    gateways and local endpoints fail open).
- **Reuse, not fork, of #758's message** — `_user_actionable_provider_guidance`
  gains a `phase` param. Default `"abort"` keeps #758's wording **byte-for-byte**
  (a test asserts this); `"preflight"` swaps only the opening sentence and
  reuses the same single-sourced "What you can do" recovery steps.
- **Wiring** — one call per turn in `_run_conversation_impl`, after the
  codex-app-server short-circuit and **before** the main loop that makes the
  first request. Skipped for MOA (own multi-model dispatch) and ACP relays.
  On a miss it returns the same turn-result dict shape as #758's user-actionable
  abort, but with `api_calls == 0` (no request sent) and `user_actionable=True`.
  The provider's curated `fallback_models` enrich the guidance with known-good
  suggestions (local; never a network fetch).

## Validation-source boundary (deliberate)
The codebase maintains a **local provider registry**
(`providers.get_provider_profile` / `model_metadata._PROVIDER_PREFIXES`) and
per-provider **curated** `fallback_models`, but it has **no cheap, authoritative,
exhaustive local catalog** of every model each provider currently serves —
enumerating that requires a network call (`ProviderProfile.fetch_models` /
models.dev / OpenRouter `/models`), which must **not** run on every turn. So
this pre-flight fails-closed **only** on structurally-unresolvable strings.
Deliberately **not** rejected:
- an **empty/blank** model — a legitimate "use provider default" state exercised
  by existing tests; failing it closed would block valid runs.
- a **well-formed-but-currently-unavailable** model (e.g. an OpenRouter slug the
  catalog dropped) — no cheap local signal distinguishes it from a valid one, so
  it stays on **#758's reactive path**.

No slow per-run network probe is added.

## Independent review
Reviewed by Gemini (`consult agy`, independent provider). It confirmed the hook
location/timing, the byte-for-byte #758 reuse, and the no-network property, and
flagged two items which are addressed in this PR: (1) tightened the whitespace
rule to fire only for *recognised hosted* providers so a custom corporate
gateway with space-bearing model ids can't be false-flagged; (2) removed a dead
`_turn_exit_reason` assignment on the early-return path (never consumed there).

## Tests / lint
- `pytest tests/agent/test_error_classifier.py
  tests/agent/test_provider_error_recovery_758.py
  tests/agent/test_model_preflight_929.py -q` → **219 passed**
- `ruff check .` → **All checks passed!**
- `ruff format --check agent/model_preflight.py
  tests/agent/test_model_preflight_929.py` → **2 files already formatted**
  (the pre-existing `conversation_loop.py` is not `ruff format`-clean at
  baseline — the repo enforces only `ruff check` — so it is intentionally left
  unreformatted to avoid a large unrelated diff; no new format deviations were
  introduced in the edited regions).

New tests prove: a resolvable model passes pre-flight silently; a bare-prefix /
whitespace model is caught **pre-flight** with the actionable message and makes
**zero** provider calls (`api_calls == 0`); the empty-model default and valid
configs are unaffected (regression guards); and #758's default guidance is
unchanged.
