### PR TITLE
fix(gateway): mark planned exit-75 restart as clean via SuccessExitStatus

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2732,6 +2732,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2766,6 +2767,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -427,6 +427,12 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        # SuccessExitStatus must ALSO list the planned-restart code so a graceful
+        # exit-75 (SIGUSR1 restart / stale-code respawn / /restart) is recorded
+        # as a CLEAN stop, not "Failed with result 'exit-code'". Without it every
+        # planned restart pollutes systemctl status/journal as a bogus failure,
+        # masking real crashes and misreading as instability.
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
@@ -538,6 +544,12 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        # SuccessExitStatus must ALSO list the planned-restart code so a graceful
+        # exit-75 (SIGUSR1 restart / stale-code respawn / /restart) is recorded
+        # as a CLEAN stop, not "Failed with result 'exit-code'". Without it every
+        # planned restart pollutes systemctl status/journal as a bogus failure,
+        # masking real crashes and misreading as instability.
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.


### PR DESCRIPTION
## Problem
The gateway exits with code **75** for a *planned* service restart (graceful SIGUSR1 restart, stale-code respawn, `/restart`). The systemd unit sets `RestartForceExitStatus=75` (so the restart happens) but **not** `SuccessExitStatus=75`, so systemd records every planned restart as `Failed with result 'exit-code'`.

Observed on the production server: **7 such 'failures' in 24h** — all benign planned restarts. This pollutes `systemctl status`/journal, masks genuine crashes, and reads as gateway instability (it is not — `Restart=always` + `StartLimitIntervalSec=0` always recover it).

## Fix
Add `SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}` (=75) to **both** unit templates (user + system) in `generate_systemd_unit()`. A planned exit-75 is now a CLEAN stop; `Restart=always` still restarts it; real crashes (exit≠75) still surface as failures.

## Tests
Extended `test_user_unit_...` and `test_system_unit_...` to assert `SuccessExitStatus=75` in the generated unit. `ruff check` clean. (6 unrelated systemd-routing tests fail on macOS dev = no user-systemd; verified they fail identically on baseline — they pass in Linux CI.)

## Review
Independent peer review (Gemini): confirmed correct/safe — restart still fires under `Restart=always`, no conflict with `RestartForceExitStatus`, no start-limit impact given `StartLimitIntervalSec=0`.

Deploy note: the gateway refreshes its unit on every boot, so the fix applies on the next `hermes gateway restart`.