### PR TITLE
fix(cron): backport SCHEDULER-FREEZE hardening (re-implemented, preserves delivery_verbosity)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -571,7 +571,7 @@ def _recoverable_oneshot_run_at(
     their requested minute still run on the next tick. Once a one-shot has
     already run, it is never eligible again.
     """
-    if schedule.get("kind") != "once":
+    if not isinstance(schedule, dict) or schedule.get("kind") != "once":
         return None
     if last_run_at:
         return None
@@ -580,7 +580,10 @@ def _recoverable_oneshot_run_at(
     if not run_at:
         return None
 
-    run_at_dt = _ensure_aware(datetime.fromisoformat(run_at))
+    try:
+        run_at_dt = _ensure_aware(datetime.fromisoformat(run_at))
+    except Exception:
+        return None
     if run_at_dt >= now - timedelta(seconds=ONESHOT_GRACE_SECONDS):
         return run_at
     return None
@@ -604,16 +607,18 @@ def _compute_grace_seconds(schedule: dict) -> int:
         return max(MIN_GRACE, min(grace, MAX_GRACE))
 
     if kind == "cron" and HAS_CRONITER:
-        try:
-            now = _hermes_now()
-            cron = croniter(schedule["expr"], now)
-            first = cron.get_next(datetime)
-            second = cron.get_next(datetime)
-            period_seconds = int((second - first).total_seconds())
-            grace = period_seconds // 2
-            return max(MIN_GRACE, min(grace, MAX_GRACE))
-        except Exception:
-            pass
+        expr = schedule.get("expr")
+        if expr:
+            try:
+                now = _hermes_now()
+                cron = croniter(expr, now)
+                first = cron.get_next(datetime)
+                second = cron.get_next(datetime)
+                period_seconds = int((second - first).total_seconds())
+                grace = period_seconds // 2
+                return max(MIN_GRACE, min(grace, MAX_GRACE))
+            except Exception:
+                pass
 
     return MIN_GRACE
 
@@ -628,28 +633,42 @@ def compute_next_run(
     """
     now = _hermes_now()
 
-    if schedule["kind"] == "once":
+    if not isinstance(schedule, dict):
+        return None
+    kind = schedule.get("kind")
+    if kind is None:
+        return None
+
+    if kind == "once":
         return _recoverable_oneshot_run_at(schedule, now, last_run_at=last_run_at)
 
-    elif schedule["kind"] == "interval":
-        minutes = schedule["minutes"]
+    elif kind == "interval":
+        minutes = schedule.get("minutes")
+        if minutes is None:
+            return None
         if last_run_at:
             # Next run is last_run + interval
-            last = _ensure_aware(datetime.fromisoformat(last_run_at))
-            next_run = last + timedelta(minutes=minutes)
+            try:
+                last = _ensure_aware(datetime.fromisoformat(last_run_at))
+                next_run = last + timedelta(minutes=minutes)
+            except Exception:
+                next_run = now + timedelta(minutes=minutes)
         else:
             # First run is now + interval
             next_run = now + timedelta(minutes=minutes)
         return next_run.isoformat()
 
-    elif schedule["kind"] == "cron":
+    elif kind == "cron":
+        expr = schedule.get("expr")
+        if not expr:
+            return None
         if not HAS_CRONITER:
             logger.warning(
                 "Cannot compute next run for cron schedule %r: 'croniter' is "
                 "not installed. croniter is a core dependency as of v0.9.x; "
                 "reinstall hermes-agent or run 'pip install croniter' in your "
                 "runtime env.",
-                schedule.get("expr"),
+                expr,
             )
             return None
         # Use last_run_at as the croniter base when available, consistent
@@ -658,8 +677,11 @@ def compute_next_run(
         # rather than to an arbitrary restart time.
         base_time = now
         if last_run_at:
-            base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+            try:
+                base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+            except Exception:
+                base_time = now
+        cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 
@@ -1530,7 +1552,7 @@ def mark_job_run(
                             "Job '%s' (%s) could not compute next_run_at; "
                             "leaving enabled and marking state=error so the "
                             "job is not silently disabled.",
-                            job.get("name", job["id"]),
+                            job.get("name", job.get("id", "?")),
                             kind,
                         )
                     else:
@@ -1584,7 +1606,7 @@ def claim_dispatch(job_id: str) -> bool:
                 save_jobs(jobs)
                 logger.info(
                     "Job '%s': dispatch limit reached (%d/%d) — removing",
-                    job.get("name", job["id"]),
+                    job.get("name", job.get("id", "?")),
                     completed,
                     times,
                 )
@@ -1594,7 +1616,7 @@ def claim_dispatch(job_id: str) -> bool:
             save_jobs(jobs)
             logger.debug(
                 "Job '%s': claimed dispatch %d/%d",
-                job.get("name", job["id"]),
+                job.get("name", job.get("id", "?")),
                 repeat["completed"],
                 times,
             )
@@ -1803,9 +1825,71 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
+    needs_save = False
+
+    # Repair malformed persisted records at the source, BEFORE they are copied
+    # into ``jobs`` and BEFORE anything keys off ``job["id"]`` /
+    # ``job["schedule"]`` / ``job["next_run_at"]``. A direct jobs.json edit, an
+    # old writer, or on-disk corruption can leave a record that raises mid-tick:
+    #   - missing "id"            -> KeyError (logging helpers + the
+    #                                ``for rj in raw_jobs: if rj["id"] ...``
+    #                                persistence loops index job["id"] eagerly)
+    #   - non-dict "schedule"     -> AttributeError on schedule.get("kind") /
+    #                                schedule["expr"] / ["minutes"]
+    #   - bad "next_run_at"/      -> ValueError from datetime.fromisoformat(...)
+    #     "last_run_at"
+    # Any such raise aborts the whole scan *before* save_jobs() runs, so every
+    # healthy sibling's fast-forwarded next_run_at is recomputed in memory then
+    # discarded on the exception unwind — freezing the entire profile's
+    # scheduler in a per-minute loop. Sanitizing raw_jobs up front (before the
+    # deepcopy below) repairs the whole bug class in one pass and keeps the
+    # in-memory ``jobs`` copies clean too, so no downstream site needs guarding.
+    # Upstream: 26f040ef2 / 8e2ce4352 / c71d19c0e (re-implemented, not
+    # cherry-picked, to preserve our delivery_verbosity field).
+    for rj in raw_jobs:
+        # id-less record: recover the id from a drifted "job_id" key (older
+        # writers used it), else synthesize one.
+        if not rj.get("id"):
+            rj["id"] = rj.pop("job_id", None) or uuid.uuid4().hex[:12]
+            needs_save = True
+
+        # non-dict "schedule" (null / string / etc.): normalize to {} so the
+        # kind/expr/minutes lookups later never raise.
+        if not isinstance(rj.get("schedule"), dict):
+            rj["schedule"] = {}
+            needs_save = True
+
+        # unparseable "next_run_at": strip it so the existing "no next_run_at"
+        # recovery path recomputes a sane value and persists it for this job.
+        nr = rj.get("next_run_at")
+        if nr is not None:
+            if not isinstance(nr, str):
+                rj.pop("next_run_at", None)
+                needs_save = True
+            else:
+                try:
+                    datetime.fromisoformat(nr)
+                except Exception:
+                    rj.pop("next_run_at", None)
+                    needs_save = True
+
+        # unparseable "last_run_at" (used as the base in recovery /
+        # compute_next_run): strip it too.
+        lr = rj.get("last_run_at")
+        if lr is not None:
+            if not isinstance(lr, str):
+                rj.pop("last_run_at", None)
+                needs_save = True
+            else:
+                try:
+                    datetime.fromisoformat(lr)
+                except Exception:
+                    rj.pop("last_run_at", None)
+                    needs_save = True
+
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
-    needs_save = False
+
     # Resolve the one-shot running-claim stale-recovery TTL once per scan
     # (derived from HERMES_CRON_TIMEOUT). See _oneshot_run_claim_ttl_seconds.
     _run_claim_ttl = _oneshot_run_claim_ttl_seconds()
@@ -1862,7 +1946,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             next_run = recovered_next
             logger.info(
                 "Job '%s' had no next_run_at; recovering %s run at %s",
-                job.get("name", job["id"]),
+                job.get("name", job.get("id", "?")),
                 recovery_kind,
                 recovered_next,
             )
@@ -1903,7 +1987,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 logger.info(
                     "Job '%s' next_run_at offset changed (%s -> %s). "
                     "Recomputing cron run to preserve local wall-clock intent: %s",
-                    job.get("name", job["id"]),
+                    job.get("name", job.get("id", "?")),
                     raw_next_run_dt.utcoffset(),
                     now.utcoffset(),
                     new_next,
@@ -1933,7 +2017,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                         "Job '%s' missed its scheduled time (%s, grace=%ds). "
                         "Running now; next run provisionally set to: %s "
                         "(re-anchored on completion)",
-                        job.get("name", job["id"]),
+                        job.get("name", job.get("id", "?")),
                         next_run,
                         grace,
                         new_next,
@@ -1967,7 +2051,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                         logger.info(
                             "Job '%s': one-shot dispatch limit reached (%d/%d) "
                             "— removing stale due entry",
-                            job.get("name", job["id"]),
+                            job.get("name", job.get("id", "?")),
                             completed,
                             times,
                         )

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1602,3 +1602,163 @@ class TestClaimDispatch:
         due = get_due_jobs()
         assert due == []
         assert load_jobs() == []  # cleaned up
+
+
+class TestSchedulerFreezeHardening:
+    """Regression: a single malformed job record must NOT freeze the whole scheduler.
+
+    Re-implemented from upstream 26f040ef2 / 8e2ce4352 / c71d19c0e (hand-ported
+    rather than cherry-picked so our per-job ``delivery_verbosity`` field is
+    preserved). Each freeze case — an id-less record, a non-dict ``schedule``,
+    and a malformed ``next_run_at`` — used to raise mid-tick in
+    ``_get_due_jobs_locked`` BEFORE ``save_jobs()`` ran, discarding every healthy
+    sibling's fast-forwarded ``next_run_at`` on the exception unwind and wedging
+    the entire profile's scheduler in a per-minute loop. The guards must skip /
+    repair the bad record while healthy siblings still load and run.
+    """
+
+    def test_idless_job_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """A job missing its 'id' key must not crash the tick or freeze siblings.
+
+        Direct jobs.json edits (bypassing create_job) sometimes used the key
+        'job_id' instead of 'id'. The logging helpers evaluated
+        ``job.get("name", job["id"])`` -- Python evaluates the default argument
+        ``job["id"]`` eagerly, so an id-less job raised ``KeyError: 'id'``
+        mid-tick, aborting the scan before ``save_jobs()`` ran.
+        """
+        healthy = create_job(prompt="Healthy", schedule="every 1h")
+
+        jobs = load_jobs()
+        # Push the healthy job beyond its grace window so the fast-forward path
+        # (one of the id-less-crash sites) runs.
+        jobs[0]["next_run_at"] = (datetime.now() - timedelta(minutes=35)).isoformat()
+        # A malformed record: no 'id' key, mirroring the real corruption.
+        jobs.append({
+            "name": "idless-job",
+            "schedule": {"kind": "cron", "expr": "0 4 * * *"},
+            "enabled": True,
+            "no_agent": True,
+            "next_run_at": None,
+        })
+        save_jobs(jobs)
+
+        # Must not raise KeyError.
+        due = get_due_jobs()
+
+        # The healthy sibling is still discovered despite the malformed neighbor.
+        assert any(d.get("id") == healthy["id"] for d in due)
+
+        # The id-less record was repaired (given an id) and persisted, not dropped.
+        loaded = load_jobs()
+        assert any(j.get("name") == "idless-job" and j.get("id") for j in loaded)
+
+    def test_bad_schedule_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """A job with a non-dict 'schedule' (null / string / etc.) must not crash.
+
+        ``schedule.get("kind")`` / ``schedule["kind"]`` raises on a non-dict
+        value and aborts the whole scan, so healthy siblings lose their
+        fast-forwarded next_run_at.
+        """
+        past = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+        bad = {
+            "id": "bad-sched",
+            "name": "bad",
+            "enabled": True,
+            "schedule": None,  # poison: not a dict
+            "next_run_at": future,  # not due
+        }
+        good = {
+            "id": "good",
+            "name": "good",
+            "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": past,
+        }
+        save_jobs([bad, good])
+
+        due = get_due_jobs()
+        due_ids = [j["id"] for j in due]
+        assert "good" in due_ids
+        assert "bad-sched" not in due_ids  # bad one ignored, no crash
+
+        # The good job's record survives intact (no corruption from the neighbor).
+        loaded = {j["id"]: j for j in load_jobs()}
+        assert "good" in loaded
+
+    def test_bad_next_run_at_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
+        """A malformed next_run_at must not crash the due scan or starve siblings.
+
+        ``datetime.fromisoformat(next_run)`` raises on an unparseable value and
+        aborts the scan before ``save_jobs()``; the bad record must instead be
+        repaired (next_run_at cleared so recovery can set a sane value).
+        """
+        now = datetime.now(timezone.utc)
+        past = (now - timedelta(seconds=30)).isoformat()
+
+        bad_job = {
+            "id": "bad-next",
+            "schedule": {"kind": "interval", "minutes": 60},
+            "next_run_at": "not-a-valid-iso-timestamp!!!",
+            "enabled": True,
+            "created_at": past,
+        }
+        good_job = {
+            "id": "good-sibling",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": past,
+            "enabled": True,
+            "created_at": past,
+        }
+        save_jobs([bad_job, good_job])
+
+        # Must not raise.
+        due = get_due_jobs()
+
+        ids = [j["id"] for j in due]
+        assert "good-sibling" in ids, f"healthy sibling missing from due jobs: {ids}"
+        # bad one is repaired (recomputed next_run in the future) → not yet due
+        assert "bad-next" not in ids
+
+        repaired = get_job("bad-next")
+        assert repaired is not None
+        nr = repaired.get("next_run_at")
+        if nr is not None:
+            # If present it must now be parseable.
+            datetime.fromisoformat(nr)
+
+        # Re-scanning must remain stable (no crash, sibling still due).
+        due2 = get_due_jobs()
+        assert any(j["id"] == "good-sibling" for j in due2)
+
+    def test_delivery_verbosity_still_works_alongside_guards(self, tmp_cron_dir):
+        """Our per-job delivery_verbosity field is preserved through a due scan.
+
+        Guards against a regression where the hand-ported freeze fixes might
+        strip or ignore our fork-specific field.
+        """
+        job = create_job(
+            prompt="verbose job",
+            schedule="every 1h",
+            delivery_verbosity="result_only",
+        )
+        assert job["delivery_verbosity"] == "result_only"
+
+        # A malformed neighbor triggers all the repair paths in the same scan.
+        jobs = load_jobs()
+        jobs.append({
+            "name": "idless-poison",
+            "schedule": None,
+            "next_run_at": "not-iso",
+            "enabled": True,
+            "no_agent": True,
+        })
+        save_jobs(jobs)
+
+        get_due_jobs()  # must not raise
+
+        # delivery_verbosity survives the scan / save round-trip untouched.
+        persisted = get_job(job["id"])
+        assert persisted is not None
+        assert persisted.get("delivery_verbosity") == "result_only"


### PR DESCRIPTION
## What & why

A single malformed cron record in `jobs.json` used to raise mid-tick inside
`_get_due_jobs_locked` **before** `save_jobs()` ran, discarding every healthy
sibling's fast-forwarded `next_run_at` on the exception unwind and freezing the
**entire** profile's scheduler in a per-minute loop. Because our self-improving
pipeline is itself a set of cron jobs, one bad payload halted all of them.

This backports upstream's three freeze fixes — **re-implemented by hand, not
cherry-picked**, so our fork-only per-job `delivery_verbosity` field is
preserved intact:

| Upstream | Freeze case | Guard |
|---|---|---|
| `c71d19c0e` | id-less job (`KeyError: 'id'`) | recover id from a drifted `job_id` key, else synthesize `uuid4`; logging helpers use `job.get("id", "?")` |
| `8e2ce4352` | non-dict `schedule` (`AttributeError`) | normalize to `{}`; guard `_recoverable_oneshot_run_at` / `_compute_grace_seconds` / `compute_next_run` against non-dict schedule + missing `kind`/`expr`/`minutes` |
| `26f040ef2` | malformed `next_run_at` (`ValueError`) | strip unparseable `next_run_at`/`last_run_at` so the existing recovery path recomputes; defensive `fromisoformat()` parses |

All four repairs run in a **single pass over `raw_jobs` before** the
`copy.deepcopy` + `_apply_skill_fields` list build, so no malformed field can
raise before it is repaired, and the working copies inherit the repaired values.

## delivery_verbosity preserved
`_normalize_delivery_verbosity`, the `create_job(delivery_verbosity=...)` param,
and the persist block are untouched. The guards only add normalization/skip
logic in the due-jobs scan plus defensive ISO parses — no field is dropped. A
dedicated test (`test_delivery_verbosity_still_works_alongside_guards`) proves
the field survives a scan that triggers every repair path.

## Tests
New `tests/cron/test_jobs.py::TestSchedulerFreezeHardening` — one regression
test per freeze case (each verified **red on the pre-fix baseline, green with
the fix**) plus the delivery_verbosity guard test.

- `.venv/bin/python -m pytest tests/cron -q` → **770 passed**
- `.venv/bin/ruff check .` → **All checks passed!**
- Independent review: `consult agy` (Gemini) on the diff — flagged the
  pre-deepcopy ordering; fixed in this PR (single pre-copy sanitization pass).

## Not cherry-picked
Re-implemented by hand to preserve `delivery_verbosity`; see commit body.
Refs upstream `nousresearch/hermes-agent` 26f040ef2 / 8e2ce4352 / c71d19c0e.
