### PR TITLE
fix(cron): run gateway cron LLM calls inline to avoid deadlock (#62151)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -215,6 +215,112 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
+def should_use_direct_api_call(agent) -> bool:
+    """True when the LLM call must run inline instead of on the interrupt worker.
+
+    ``interruptible_api_call`` / ``interruptible_streaming_api_call`` run every
+    request on a spawned daemon worker so the conversation loop can poll for an
+    interactive interrupt during the blocking HTTP round-trip. Cron jobs execute
+    their turn inside the gateway's *nested* thread pools (cron-scheduler →
+    per-job ``ThreadPoolExecutor`` → ``run_conversation``); stacking the
+    interrupt worker on top of that wedges before the socket even opens on the
+    2nd+ call of a tool-using turn (#62151), while the identical job runs fine
+    via ``hermes cron tick`` (foreground, no nested gateway pools). Cron has no
+    interactive interrupt surface — its only stop signal is the scheduler's
+    inactivity watchdog, which fires from the outer thread — so running inline
+    removes the deadlock class without giving anything up. This predicate is the
+    single extension point for any future non-interactive, nested-pool context.
+    """
+    return getattr(agent, "platform", None) == "cron"
+
+
+def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+    """Run one non-streaming LLM request for the active api_mode and return it.
+
+    Shared by the interrupt-worker path (``interruptible_api_call``) and the
+    inline path (``direct_api_call``) so the per-api_mode dispatch — codex /
+    anthropic / bedrock / MoA / OpenAI-compatible — lives in exactly one place.
+
+    ``make_client(reason)`` builds the per-request OpenAI client for the codex
+    and OpenAI-compatible branches; the worker path uses it to register the
+    client with its stranger-thread abort machinery, the inline path uses it to
+    capture the client for its own ``finally`` close. The anthropic / bedrock /
+    MoA branches manage their own clients and never call it. All interrupt,
+    abort, cancellation, and close semantics stay in the callers — this helper
+    only issues the request.
+    """
+    if agent.api_mode == "codex_responses":
+        request_client = make_client("codex_stream_request")
+        return agent._run_codex_stream(
+            api_kwargs,
+            client=request_client,
+            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+        )
+    if agent.api_mode == "anthropic_messages":
+        return agent._anthropic_messages_create(api_kwargs)
+    if agent.api_mode == "bedrock_converse":
+        # Bedrock uses boto3 directly — no OpenAI client needed.
+        # normalize_converse_response produces an OpenAI-compatible
+        # SimpleNamespace so the rest of the agent loop can treat
+        # bedrock responses like chat_completions responses.
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            invalidate_runtime_client,
+            is_stale_connection_error,
+            normalize_converse_response,
+        )
+
+        region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+        api_kwargs.pop("__bedrock_converse__", None)
+        client = _get_bedrock_runtime_client(region)
+        try:
+            raw_response = client.converse(**api_kwargs)
+        except Exception as _bedrock_exc:
+            # Evict the cached client on stale-connection failures
+            # so the outer retry loop builds a fresh client/pool.
+            if is_stale_connection_error(_bedrock_exc):
+                invalidate_runtime_client(region)
+            raise
+        return normalize_converse_response(raw_response)
+    if agent.provider == "moa":
+        # MoA is a virtual chat-completions provider backed by the
+        # in-process MoAClient facade. Do not rebuild a request-local
+        # OpenAI client from the virtual runtime metadata.
+        return agent.client.chat.completions.create(**api_kwargs)
+    request_client = make_client("chat_completion_request")
+    return request_client.chat.completions.create(**api_kwargs)
+
+
+def direct_api_call(agent, api_kwargs: dict):
+    """Run a non-streaming LLM call inline on the conversation thread.
+
+    Used when ``should_use_direct_api_call`` is True. Skips the interrupt worker
+    (whose only job is interactive-interrupt responsiveness, which this context
+    does not have) so the nested-pool deadlock (#62151) cannot occur. Because the
+    request runs in-flight normally, the per-request OpenAI client's own httpx
+    timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
+    a genuinely hung provider — the same bound interactive calls already rely on.
+    """
+    _check_stale_giveup(agent)
+    agent._touch_activity("waiting for non-streaming API response")
+    request_client_holder = {"client": None}
+
+    def _make_client(reason: str):
+        client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
+        request_client_holder["client"] = client
+        return client
+
+    try:
+        return _dispatch_nonstreaming_api_request(
+            agent, api_kwargs, make_client=_make_client
+        )
+    finally:
+        if request_client_holder["client"] is not None:
+            agent._close_request_openai_client(
+                request_client_holder["client"], reason="request_complete"
+            )
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
@@ -229,6 +335,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    # Cron and other non-interactive, nested-pool contexts must not spawn the
+    # interrupt worker — it wedges before the socket opens on the 2nd+ call
+    # (#62151). Run inline instead. See should_use_direct_api_call.
+    if should_use_direct_api_call(agent):
+        return direct_api_call(agent, api_kwargs)
+
     result = {"response": None, "error": None}
 
     # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
@@ -292,59 +404,20 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
     def _call():
         try:
-            if agent.api_mode == "codex_responses":
-                request_client = _set_request_client(
+            # Shared per-api_mode dispatch (codex / anthropic / bedrock / MoA /
+            # OpenAI-compatible). ``_set_request_client`` registers each
+            # per-request OpenAI client with the stranger-thread abort machinery
+            # above so the interrupt / stale-call detectors can force-close the
+            # worker's connection. (#62151 — shared with the inline direct path.)
+            result["response"] = _dispatch_nonstreaming_api_request(
+                agent,
+                api_kwargs,
+                make_client=lambda reason: _set_request_client(
                     agent._create_request_openai_client(
-                        reason="codex_stream_request",
-                        api_kwargs=api_kwargs,
+                        reason=reason, api_kwargs=api_kwargs
                     )
-                )
-                result["response"] = agent._run_codex_stream(
-                    api_kwargs,
-                    client=request_client,
-                    on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-                )
-            elif agent.api_mode == "anthropic_messages":
-                result["response"] = agent._anthropic_messages_create(api_kwargs)
-            elif agent.api_mode == "bedrock_converse":
-                # Bedrock uses boto3 directly — no OpenAI client needed.
-                # normalize_converse_response produces an OpenAI-compatible
-                # SimpleNamespace so the rest of the agent loop can treat
-                # bedrock responses like chat_completions responses.
-                from agent.bedrock_adapter import (
-                    _get_bedrock_runtime_client,
-                    invalidate_runtime_client,
-                    is_stale_connection_error,
-                    normalize_converse_response,
-                )
-
-                region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-                api_kwargs.pop("__bedrock_converse__", None)
-                client = _get_bedrock_runtime_client(region)
-                try:
-                    raw_response = client.converse(**api_kwargs)
-                except Exception as _bedrock_exc:
-                    # Evict the cached client on stale-connection failures
-                    # so the outer retry loop builds a fresh client/pool.
-                    if is_stale_connection_error(_bedrock_exc):
-                        invalidate_runtime_client(region)
-                    raise
-                result["response"] = normalize_converse_response(raw_response)
-            elif agent.provider == "moa":
-                # MoA is a virtual chat-completions provider backed by the
-                # in-process MoAClient facade. Do not rebuild a request-local
-                # OpenAI client from the virtual runtime metadata.
-                result["response"] = agent.client.chat.completions.create(**api_kwargs)
-            else:
-                request_client = _set_request_client(
-                    agent._create_request_openai_client(
-                        reason="chat_completion_request",
-                        api_kwargs=api_kwargs,
-                    )
-                )
-                result["response"] = request_client.chat.completions.create(
-                    **api_kwargs
-                )
+                ),
+            )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
             # handler, the transport error is the expected consequence of our
@@ -2031,6 +2104,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     """
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
+
+    # Cron and other non-interactive, nested-pool contexts deadlock on the
+    # spawned worker thread (#62151). They also have no stream consumer, so the
+    # deltas this path produces go nowhere. Delegate to the non-streaming entry
+    # (which runs inline via should_use_direct_api_call) exactly like the codex
+    # branch below — routing through the _interruptible_api_call method keeps the
+    # outer loop's per-request retry/refresh seam intact.
+    if should_use_direct_api_call(agent):
+        return agent._interruptible_api_call(api_kwargs)
 
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1626,6 +1626,13 @@ def _run_conversation_impl(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
+                    from agent.chat_completion_helpers import (
+                        direct_api_call,
+                        should_use_direct_api_call,
+                    )
+
+                    if should_use_direct_api_call(agent):
+                        return direct_api_call(agent, next_api_kwargs)
                     return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -1,0 +1,105 @@
+"""Regression guard for #62151 — gateway cron must not wedge on the 2nd+ call.
+
+Gateway-fired cron jobs hung forever on the 2nd+ API call because both the
+non-streaming (``interruptible_api_call``) and the default streaming
+(``interruptible_streaming_api_call``) paths run the request on a spawned
+daemon worker thread. Inside the gateway's nested cron thread pools that extra
+worker wedged before the socket opened; the same job succeeded via ``hermes
+cron tick`` (foreground, no nested pools). Cron has no interactive interrupt
+surface, so both paths now run inline on the conversation thread for the
+``cron`` platform.
+
+These tests pin: (1) the inline gate is cron-only, (2) the inline call runs on
+the *calling* thread — no worker is spawned — for both entry points, and (3)
+the shared dispatch closes the per-request client.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    direct_api_call,
+    interruptible_api_call,
+    interruptible_streaming_api_call,
+    should_use_direct_api_call,
+)
+
+
+def _make_agent(*, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent._interrupt_requested = False
+    agent._consecutive_stale_streams = 0
+    agent._touch_activity = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def test_should_use_direct_api_call_only_for_cron_platform():
+    assert should_use_direct_api_call(_make_agent(platform="cron")) is True
+    assert should_use_direct_api_call(_make_agent(platform="cli")) is False
+    assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
+    assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+
+def test_direct_api_call_runs_inline_and_closes_client():
+    agent = _make_agent()
+    caller_tid = threading.get_ident()
+    ran_on = {}
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        ran_on["tid"] = threading.get_ident()
+        return fake_client
+
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="resp")
+    agent._create_request_openai_client.side_effect = _create
+
+    resp = direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert resp.id == "resp"
+    # Inline: the request ran on the calling thread, no worker was spawned.
+    assert ran_on["tid"] == caller_tid
+    assert agent._close_request_openai_client.call_count == 1
+
+
+def test_interruptible_api_call_routes_cron_inline_no_worker_thread():
+    agent = _make_agent()
+    caller_tid = threading.get_ident()
+    fake_client = MagicMock()
+    ran_on = {}
+
+    def _create(**_kwargs):
+        ran_on["tid"] = threading.get_ident()
+        return fake_client
+
+    fake_client.chat.completions.create.return_value = SimpleNamespace(id="first")
+    agent._create_request_openai_client.side_effect = _create
+
+    resp = interruptible_api_call(agent, {"model": "m", "messages": []})
+
+    assert resp.id == "first"
+    assert ran_on["tid"] == caller_tid  # no daemon worker thread
+
+
+def test_interruptible_streaming_api_call_routes_cron_via_nonstream_method():
+    """Streaming is the default even for cron — the gate must catch it too.
+
+    It delegates to the ``_interruptible_api_call`` method (which itself runs
+    inline for cron) rather than calling ``direct_api_call`` directly, so the
+    outer loop's per-request retry/refresh seam — which patches that method —
+    stays intact (regression from the codex 401-refresh path).
+    """
+    agent = _make_agent()
+    sentinel = SimpleNamespace(id="via-nonstream")
+    agent._interruptible_api_call = MagicMock(return_value=sentinel)
+
+    resp = interruptible_streaming_api_call(
+        agent, {"model": "m", "messages": []}, on_first_delta=lambda: None
+    )
+
+    assert resp is sentinel
+    agent._interruptible_api_call.assert_called_once()

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -1,0 +1,60 @@
+"""Regression guard for #62151 — gateway cron must not wedge on 2nd+ API call.
+
+Gateway-fired cron jobs hung forever on the 2nd+ non-streaming API call when
+``interruptible_api_call`` spawned a daemon worker inside nested cron thread
+pools. The worker logged client creation but never opened a TCP connection.
+The same job succeeded via ``hermes cron tick``. Cron has no interactive
+interrupt surface, so the fix routes cron through a synchronous direct call on
+the conversation thread instead of the interrupt worker.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    direct_api_call,
+    should_use_direct_api_call,
+)
+
+
+def _make_agent(*, platform="cron"):
+    agent = MagicMock()
+    agent.platform = platform
+    agent.api_mode = "chat_completions"
+    agent._touch_activity = MagicMock()
+    agent._create_request_openai_client = MagicMock()
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def test_should_use_direct_api_call_only_for_cron_platform():
+    assert should_use_direct_api_call(_make_agent(platform="cron")) is True
+    assert should_use_direct_api_call(_make_agent(platform="cli")) is False
+    assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
+    assert should_use_direct_api_call(_make_agent(platform=None)) is False
+
+
+def test_direct_api_call_runs_two_sequential_requests_on_same_thread():
+    """Mirror the 2nd+ call failure mode: two back-to-back completions.create."""
+    agent = _make_agent()
+    calls = {"n": 0}
+    fake_client = MagicMock()
+
+    def _create(**_kwargs):
+        calls["n"] += 1
+        return fake_client
+
+    fake_client.chat.completions.create.side_effect = [
+        SimpleNamespace(id="first"),
+        SimpleNamespace(id="second"),
+    ]
+    agent._create_request_openai_client.side_effect = _create
+
+    first = direct_api_call(agent, {"model": "m", "messages": []})
+    second = direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert first.id == "first"
+    assert second.id == "second"
+    assert calls["n"] == 2
+    assert fake_client.chat.completions.create.call_count == 2
+    assert agent._close_request_openai_client.call_count == 2


### PR DESCRIPTION
## Backport: upstream #62151 — cron → gateway deadlock fix

Backports **nousresearch/hermes-agent #62151** into our fork.

### Why it matters to our cron + gateway pipeline
Our self-improving pipeline fires cron jobs **inside the gateway process**. The cron
scheduler builds `AIAgent(platform="cron")` and submits `agent.run_conversation(prompt)`
to a per-job `ThreadPoolExecutor(max_workers=1)` (`cron/scheduler.py:3832`). That means an
LLM turn runs inside *nested* thread pools:

```
gateway → cron-scheduler → per-job ThreadPoolExecutor → run_conversation
        → _perform_api_call → _interruptible_api_call / _interruptible_streaming_api_call
        → spawns ANOTHER daemon worker thread for the HTTP round-trip
```

That extra nested daemon worker **wedges before the socket even opens on the 2nd+ API call**
of a tool-using turn — the job hangs forever. The identical job succeeds via `hermes cron tick`
(foreground, no nested pools). Cron has no interactive-interrupt surface (its only stop signal
is the scheduler's inactivity watchdog, which fires from the *outer* thread), so the interrupt
worker buys nothing here. Fix: for `platform == "cron"`, run the LLM call **inline on the
conversation thread**.

### Clean cherry-pick vs re-implemented — RE-IMPLEMENTED BY HAND
`git cherry-pick -x 5c5dd6b7e d00c15c0c 1234f39e3` **conflicts**. Two reasons:
1. The stated order is the reverse of upstream topological order — `d00c15c0c` is the
   ancestor that *introduces* `direct_api_call`/`should_use_direct_api_call`, and `5c5dd6b7e`
   *refactors* them; picking the refactor first has nothing to modify.
2. More fundamentally, this fork's `agent/chat_completion_helpers.py` has **diverged ~630 lines**
   from upstream's base (different upstream base + fork-specific worker machinery:
   stranger-thread abort, TLS-FD-recycle guard, codex TTFB/idle watchdogs). The raw diffs do
   not apply.

So the fix was **re-implemented by hand** onto our fork's actual functions, reproducing
upstream's *final* design:

| Element | Source |
|---|---|
| `should_use_direct_api_call(agent)` → `platform == "cron"` | re-implemented (upstream 5c5dd6b7e docstring) |
| `_dispatch_nonstreaming_api_request(agent, kwargs, *, make_client)` — shared per-api_mode dispatch | re-implemented (upstream 5c5dd6b7e) |
| `direct_api_call(agent, kwargs)` — inline call, closes client in `finally` | re-implemented (upstream 5c5dd6b7e) |
| inline gate in `interruptible_api_call` | re-implemented |
| inline gate in `interruptible_streaming_api_call` → delegates to `agent._interruptible_api_call` | re-implemented |
| worker `_call()` dispatch rewritten onto the shared helper (behavior-preserving) | re-implemented |
| `conversation_loop.py` `_perform_api_call` cron gate | re-implemented (upstream d00c15c0c) |
| `tests/agent/test_cron_inline_api_call_62151.py` | **verbatim** from 5c5dd6b7e |
| `tests/cron/test_cron_direct_api_call_62151.py` | **verbatim** from 1234f39e3 |

Upstream commits (recorded here in lieu of `-x`):
`5c5dd6b7e`, `d00c15c0c`, `1234f39e3` — all (#62151).

### Verification
- **New #62151 tests** — `test_cron_inline_api_call_62151.py` + `test_cron_direct_api_call_62151.py`: **6 passed**.
- **Worker-path regression set** (guards the shared-dispatch extraction is behavior-preserving) —
  cascading-interrupt, openai-client-lifecycle, interrupt-propagation, stream-stale-breaker,
  codex-ttfb-watchdog, tls-fd-recycle, cron codex-execution-paths: **44 passed**.
- **Broader sweep** — full `tests/cron/` + streaming + codex-responses: **897 passed** (0 failures).
- **`ruff check .`** — passes (repo enforces only `ruff check`; `select = ["PLW1514"]`).
- **`ruff format --check`** — new test files already formatted; my `conversation_loop.py` additions
  are format-clean. The two heavily-diverged fork files report "would be reformatted" from
  **pre-existing** pervasive deviations (no line-length rule is enforced; my one 90-char line is
  verbatim upstream and matches the fork's prevailing >88 style). Not a repo gate.

### Independent review
`consult agy` (Gemini) hung with no response across two attempts (240s, 420s) — environment issue.
Fell back to `consult grok` (xAI, non-Claude). Verdict: the change **correctly prevents the deadlock
on this fork's cron path**, the dispatch unification is **behavior-preserving for non-cron**, client
lifecycle is correct, and **all referenced symbols exist/are consistent** in this fork — **no real
bugs, no missing symbols, no hard regressions**.

### Known, accepted trade-off (matches upstream)
The inline path touches activity once up front rather than every ~30s like the worker's poll loop,
and it does not run the inner stale/TTFB/codex-idle watchdogs. A genuinely hung provider under cron
is therefore bounded by the per-request httpx timeout (`request_timeout_seconds` / `HERMES_API_TIMEOUT`)
and the scheduler's outer inactivity watchdog, instead of an early stale-kill+retry. This is upstream's
deliberate design for the non-interactive cron context — a bounded timeout replacing an unbounded
deadlock — and is strictly better than the wedge it removes.

**Do not merge** — opened for review.
