### PR TITLE
fix: add config-drift validation for unpinned evolution cron jobs (#938)

### DIFF
--- a/scripts/register_evolution_cron.py
+++ b/scripts/register_evolution_cron.py
@@ -595,6 +595,60 @@ def main(argv: list[str]) -> int:
     for name, err in failed:
         print(f"  ! {name}: {err}")
 
+    # Config-drift validation (#938): warn when an agent-stage job has BOTH
+    # model and provider unpinned (both None), meaning it inherits the global
+    # inference config and is vulnerable to config drift that caused a mass
+    # blackout in July 2026. no_agent jobs (deterministic scripts) do not use
+    # model/provider and are excluded from this check.
+    def _is_unpinned_yaml(yaml_path: Path) -> bool | None:
+        """Check if a YAML file defines an unpinned agent job.
+        Returns True if unpinned, False if pinned, None if no_agent or not found."""
+        if not yaml_path.exists():
+            return None
+        try:
+            spec = _load_yaml(yaml_path)
+        except Exception:
+            return None
+        if bool(spec.get("no_agent")):
+            return None
+        yaml_model = str(spec.get("model") or "").strip() or None
+        yaml_provider = str(spec.get("provider") or "").strip() or None
+        return yaml_model is None and yaml_provider is None
+
+    def _check_unpinned(name: str, src_dir: Path) -> bool:
+        """Check if a named job is unpinned in its YAML definition."""
+        stem = name.replace("evolution-", "")
+        yaml_path = src_dir / f"{stem}.yaml"
+        result = _is_unpinned_yaml(yaml_path)
+        if result is True:
+            return True
+        if result is None and not yaml_path.exists():
+            # Fallback: search all YAMLs
+            for candidate in sorted(src_dir.glob("*.yaml")):
+                r = _is_unpinned_yaml(candidate)
+                if r is not None:
+                    return r
+        return False
+
+    unpinned: list[str] = []
+    all_processed: list[str] = []
+    all_processed.extend(n for n, _ in created)
+    all_processed.extend(n for n, _ in updated)
+    all_processed.extend(skipped)  # skipped is list[str]
+    for name in all_processed:
+        if _check_unpinned(name, src_dir):
+            unpinned.append(name)
+
+    if unpinned:
+        print(
+            "[evolution-cron] warning: the following agent jobs have unpinned "
+            "model AND provider — they are vulnerable to global inference config "
+            "drift. Set model:/provider: in their YAML to pin them to a specific "
+            f"deployment model (see #938).\n"
+            f"  unpinned: {', '.join(sorted(set(unpinned)))}",
+            file=sys.stderr,
+        )
+
     return 2 if failed else 0
 
 

--- a/tests/scripts/test_config_drift.py
+++ b/tests/scripts/test_config_drift.py
@@ -1,0 +1,132 @@
+"""Tests for config-drift validation in scripts.register_evolution_cron."""
+
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "register_evolution_cron.py"
+
+
+def _import_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("register_evolution_cron", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["register_evolution_cron"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestConfigDriftValidation:
+    """Config-drift validation (#938): warn when agent-stage jobs have both
+    model and provider unpinned. no_agent jobs are excluded."""
+
+    def test_warns_when_unpinned(self, tmp_path, monkeypatch, capsys):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        (src_dir / "analysis.yaml").write_text(
+            "name: evolution-analysis\n"
+            'schedule: "0 9 * * *"\n'
+            "enabled: true\n"
+            'prompt: "do analysis"\n'
+        )
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(mod, "_ensure_evolution_labels", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_install_access_gate", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_install_evolution_helpers", lambda *a, **k: [])
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(
+            jobs_mod, "create_job", lambda **kw: {"id": "j1", "name": kw["name"]}
+        )
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "unpinned" in captured.err
+        assert "evolution-analysis" in captured.err
+
+    def test_silent_when_pinned_or_no_agent(self, tmp_path, monkeypatch, capsys):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        (src_dir / "analysis.yaml").write_text(
+            "name: evolution-analysis\n"
+            'schedule: "0 9 * * *"\n'
+            "enabled: true\n"
+            'prompt: "do analysis"\n'
+            "model: glm-5-flash\n"
+            "provider: zai\n"
+        )
+        (src_dir / "funnel.yaml").write_text(
+            "name: evolution-funnel\n"
+            'schedule: "40 7 * * *"\n'
+            "enabled: true\n"
+            "no_agent: true\n"
+            "script: evolution_funnel.py\n"
+            'prompt: "deterministic script"\n'
+        )
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(mod, "_ensure_evolution_labels", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_install_access_gate", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_install_evolution_helpers", lambda *a, **k: [])
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(
+            jobs_mod, "create_job", lambda **kw: {"id": "j1", "name": kw["name"]}
+        )
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "unpinned" not in captured.err
+
+    def test_mixed_jobs(self, tmp_path, monkeypatch, capsys):
+        mod = _import_module()
+        src_dir = tmp_path / "cron-src"
+        src_dir.mkdir()
+        (src_dir / "research.yaml").write_text(
+            "name: evolution-research\n"
+            'schedule: "0 9 * * *"\n'
+            "enabled: true\n"
+            'prompt: "research"\n'
+            "model: glm-5-flash\n"
+            "provider: zai\n"
+        )
+        (src_dir / "analysis.yaml").write_text(
+            "name: evolution-analysis\n"
+            'schedule: "0 10 * * *"\n'
+            "enabled: true\n"
+            'prompt: "analysis"\n'
+        )
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(mod, "_ensure_evolution_labels", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "_install_access_gate", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_install_evolution_helpers", lambda *a, **k: [])
+
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(
+            jobs_mod, "create_job", lambda **kw: {"id": "j1", "name": kw["name"]}
+        )
+        monkeypatch.setattr(jobs_mod, "load_jobs", lambda: [])
+
+        rc = mod.main(["register_evolution_cron.py", str(src_dir)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "evolution-analysis" in captured.err
+        assert "evolution-research" not in captured.err


### PR DESCRIPTION
Automated evolution PR for issue #938.

Adds post-registration validation in register_evolution_cron.py: after
processing all YAML files, the registrar scans for agent-stage jobs that
have BOTH model and provider unpinned (both None/omitted). Such jobs
inherit the global inference config and are vulnerable to config drift
that caused a total 11-hour system blackout in July 2026.

The check is a warning only — it does not change the exit code. no_agent
jobs (deterministic scripts like the funnel, watchdog) are excluded since
they do not use model/provider.

The per-stage pinning infrastructure already exists (#905); this change
adds the observability layer to tell operators which jobs are unpinned
and need explicit model:/provider: set in their YAML.

Files changed:
- `scripts/register_evolution_cron.py` (+54 lines): post-loop unpinned check
- `tests/scripts/test_config_drift.py` (+132 lines): 3 tests covering
  unpinned warning, pinned+no_agent silence, and mixed-job filtering

Landability: 186 lines (≤200 cap), no breaking changes, no new deps.