### PR TITLE
feat(#976): enrich patch tool error responses with line content and ambiguous-match classification

### DIFF
--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -34,6 +34,15 @@ class TestClassifyFileError:
         klass, rec = classify_file_error("search block did not match the file content")
         assert klass == "fuzzy_match" and "EXACT" in rec
 
+    def test_ambiguous_match_is_classified(self):
+        """'Found N matches' errors get a specific error_class and recovery (#976)."""
+        klass, rec = classify_file_error(
+            "Found 3 matches for old_string at:\n  Line 10: def foo()\n"
+            "Provide more context to make it unique, or use replace_all=True."
+        )
+        assert klass == "ambiguous_match"
+        assert "replace_all" in rec or "context" in rec
+
     def test_verification(self):
         klass, _ = classify_file_error("Post-write verification failed: could not re-read x")
         assert klass == "verification"
@@ -60,6 +69,16 @@ class TestResultToDict:
     def test_patch_result_error_classified(self):
         d = PatchResult(success=False, error="Failed to parse patch: x").to_dict()
         assert d["error_class"] == "patch_parse" and "recovery" in d
+
+    def test_patch_result_ambiguous_match_classified(self):
+        """PatchResult with ambiguous-match error gets error_class (#976)."""
+        d = PatchResult(
+            success=False,
+            error="Found 3 matches for old_string at:\n  Line 10: x\n"
+            "Provide more context to make it unique, or use replace_all=True.",
+        ).to_dict()
+        assert d["error_class"] == "ambiguous_match"
+        assert "replace_all" in d["recovery"] or "context" in d["recovery"]
 
     def test_patch_result_success_clean(self):
         d = PatchResult(success=True, diff="--- a").to_dict()

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -666,3 +666,55 @@ class TestEscapeNormalizedNewString:
         assert count == 1
         assert "return 2" in new
 
+
+class TestAmbiguousMatchEnrichment:
+    """Tests for the enriched ambiguous-match error (#976).
+
+    The error must include the actual line content at each match location,
+    not just bare line numbers, so the agent can disambiguate without
+    re-reading the file.
+    """
+
+    def test_ambiguous_error_includes_line_content(self):
+        """The 'Found N matches' error shows the actual line text at each match."""
+        content = "def foo():\n    pass\ndef bar():\n    return 1\n"
+        _, count, _, err = fuzzy_find_and_replace(
+            content, "def ", "x ", replace_all=False
+        )
+        assert count == 0
+        assert "Found 2 matches" in err
+        # Line content (first line at each match) must appear, not just numbers
+        assert "def foo():" in err
+        assert "def bar():" in err
+
+    def test_ambiguous_error_includes_line_numbers(self):
+        """Line numbers are still present in the enriched format."""
+        content = "x = 1\nx = 1\n"
+        _, count, _, err = fuzzy_find_and_replace(
+            content, "x = 1\n", "x = 2\n", replace_all=False
+        )
+        assert count == 0
+        assert "Line 1" in err
+        assert "Line 2" in err
+
+    def test_ambiguous_error_format_is_multiline(self):
+        """The enriched error uses a multi-line format for readability."""
+        content = "aaa\naaa\naaa\n"
+        _, count, _, err = fuzzy_find_and_replace(
+            content, "aaa\n", "bbb\n", replace_all=False
+        )
+        assert count == 0
+        assert "Found 3 matches" in err
+        # The format should use newlines to separate match locations
+        assert "\n  " in err
+
+    def test_ambiguous_error_still_says_provide_more_context(self):
+        """The recovery guidance is still present."""
+        content = "aaa bbb aaa\n"
+        _, count, _, err = fuzzy_find_and_replace(
+            content, "aaa", "ccc", replace_all=False
+        )
+        assert count == 0
+        assert "Provide more context" in err
+        assert "replace_all=True" in err
+

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -192,6 +192,12 @@ def classify_file_error(
             "The write succeeded but re-read verification failed. Re-read the file to "
             "see actual state before editing again."
         )
+    if "found" in low and "matches" in low and "old_string" in low:
+        return "ambiguous_match", (
+            "Multiple matches found. Include more surrounding context lines in "
+            "old_string to make it unique, or use replace_all=True if you want "
+            "all occurrences replaced."
+        )
     if "did not match" in low or "no match" in low or ("match" in low and "block" in low):
         return "fuzzy_match", (
             "The search block didn't match the file. Re-read the file and copy the EXACT "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1867,11 +1867,18 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 _reset_patch_failures(task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
-        # Hint when old_string not found — saves iterations where the agent
-        # retries with stale content instead of re-reading the file.
+        # Hint when patch fails — saves iterations where the agent retries
+        # with stale content or an ambiguous old_string instead of
+        # re-reading the file or providing more context.
+        # Covers both no-match ("Could not find") and ambiguous-match
+        # ("Found N matches") failures — both cause the same spiral
+        # pattern where the agent retries with slight variations.
         # Suppressed when patch_replace already attached a rich "Did you mean?"
         # snippet (which is strictly more useful than the generic hint).
-        if result_dict.get("error") and "Could not find" in str(result_dict["error"]):
+        err_str = str(result_dict.get("error") or "")
+        is_no_match = "Could not find" in err_str
+        is_ambiguous = "Found" in err_str and "matches" in err_str and "old_string" in err_str
+        if err_str and (is_no_match or is_ambiguous):
             # Track per-file consecutive failures for replace mode.  The
             # ``path`` arg only exists for replace mode; for V4A patches
             # we'd need to walk the headers, but in practice V4A failures
@@ -1897,7 +1904,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "replace the entire file if the targeted region is hard "
                     "to anchor."
                 )
-            elif "Did you mean one of these sections?" not in str(result_dict["error"]):
+            elif is_ambiguous:
+                result_dict["_hint"] = (
+                    "Multiple matches found. Use read_file to see the "
+                    "surrounding context at each match location, then "
+                    "provide a longer old_string that uniquely identifies "
+                    "the target. The error message above shows the line "
+                    "content at each match."
+                )
+            elif "Did you mean one of these sections?" not in err_str:
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -92,16 +92,21 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         if matches:
             # Found matches with this strategy
             if len(matches) > 1 and not replace_all:
-                # Include line numbers for each match location so the agent
-                # can narrow its old_string with surrounding context (#889).
-                line_nums: List[str] = []
+                # Include line numbers AND the actual line content at each
+                # match location so the agent can see what's there and pick
+                # the right one without re-reading the file (#976).
+                content_lines = content.splitlines()
+                location_parts: List[str] = []
                 for (start, _end) in matches[:10]:
                     line_no = content.count('\n', 0, start) + 1
-                    line_nums.append(str(line_no))
-                locs = ', '.join(line_nums)
+                    # Show the actual line content (first line of the match)
+                    line_idx = line_no - 1
+                    line_text = content_lines[line_idx].strip() if 0 <= line_idx < len(content_lines) else ""
+                    location_parts.append(f"Line {line_no}: {line_text}")
+                locs_block = "\n  ".join(location_parts)
                 return content, 0, None, (
                     f"Found {len(matches)} matches for old_string"
-                    f"{f' at lines {locs}' if line_nums else ''}. "
+                    f" at:\n  {locs_block}\n"
                     f"Provide more context to make it unique, or use replace_all=True."
                 )
 


### PR DESCRIPTION
## Summary

Addresses issue #976: 105 patch failures across 13 sessions, max 17 consecutive retries. Three failure shapes identified: no-match, identical no-op, and ambiguous N matches.

## Changes

### 1. Ambiguous-match error enrichment (`tools/fuzzy_match.py`)
When multiple matches are found for `old_string`, the error now includes the **actual line content** at each match location, not just bare line numbers. This lets the agent see what's at each position and pick the right one without re-reading the file.

**Before:**
```
Found 3 matches for old_string at lines 10, 45, 78. Provide more context...
```

**After:**
```
Found 3 matches for old_string at:
  Line 10: def foo(self):
  Line 45: def foo(self, x):
  Line 78: def foo(self, x, y):
Provide more context to make it unique, or use replace_all=True.
```

### 2. Error classification (`tools/file_operations.py`)
`classify_file_error` now recognizes `"Found N matches for old_string"` as `ambiguous_match` error_class with specific recovery guidance, instead of falling through to the generic `"error"` class that says "CHANGE the call" without telling the agent HOW to change it.

### 3. Failure tracking and escalation hints (`tools/file_tools.py`)
The patch tool's failure tracking and `_hint` escalation now cover **both** no-match ("Could not find") **and** ambiguous-match ("Found N matches") errors. Previously, the agent could loop on ambiguous matches 17 times without getting any escalation hint — the failure counter only tracked "Could not find" errors.

### No-match and identical no-op (already enriched, unchanged)
- No-match: `format_no_match_hint` already provides "Did you mean one of these sections?" with closest matching lines
- Identical no-op: already returns a clean "no changes needed" message (#889)

## Test Coverage

- 4 new tests in `test_fuzzy_match.py` (`TestAmbiguousMatchEnrichment`): verify line content in error, line numbers present, multi-line format, recovery guidance preserved
- 2 new tests in `test_file_error_classification.py`: verify `ambiguous_match` classification and `PatchResult.to_dict()` integration
- All 374 related tests pass (fuzzy_match, file_operations, file_tools, file_error_classification, read_patch_resilience, acp tools, agent insights, last_reasoning)

## Files Changed
- `tools/fuzzy_match.py` — enriched ambiguous-match error with line content
- `tools/file_operations.py` — added `ambiguous_match` to `classify_file_error`
- `tools/file_tools.py` — extended failure tracking to ambiguous matches
- `tests/tools/test_fuzzy_match.py` — 4 new tests
- `tests/tools/test_file_error_classification.py` — 2 new tests