### PR TITLE
feat(#975): wire refusal taxonomy into agent loop as recovery directive

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -819,6 +819,7 @@ def _run_conversation_impl(
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+    agent._refusal_nudged_this_turn = False  # Reset per-turn (#975)
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
@@ -5640,6 +5641,36 @@ def _run_conversation_impl(
                     logger.debug("pre_verify nudge issued (attempt %d)",
                                  agent._pre_verify_nudges)
                     continue
+
+                # ── Refusal recovery nudge (#975) ───────────────────
+                # If the final text response contains refusal language
+                # ("I can't", "I don't have access", etc.), give the model
+                # one chance to course-correct before accepting the refusal.
+                # Mirrors the tool-spiral nudge pattern but for text-only
+                # responses.  Only fires once per turn to avoid spamming.
+                if not getattr(agent, "_refusal_nudged_this_turn", False):
+                    try:
+                        _refusal_nudge = _loop_guard.maybe_refusal_nudge(
+                            messages,
+                            already_nudged=False,
+                        )
+                    except Exception:
+                        _refusal_nudge = None
+                    if _refusal_nudge:
+                        agent._refusal_nudged_this_turn = True
+                        final_msg["finish_reason"] = "refusal_nudge"
+                        final_msg["_refusal_nudge_synthetic"] = True
+                        messages.append(final_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": _refusal_nudge,
+                            "_refusal_nudge_synthetic": True,
+                        })
+                        agent._session_messages = messages
+                        logger.debug(
+                            "refusal nudge issued: %s", _refusal_nudge[:80]
+                        )
+                        continue
 
                 messages.append(final_msg)
                 

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -30,6 +30,13 @@ requires the model to explain progress before continuing (#432).
 
 Pure functions over the ``messages`` list -> fully unit-testable, no agent state
 required (the caller tracks "already nudged this run" to avoid spamming).
+
+Refusal detection (#975): assistant text responses containing refusal language
+("I can't", "I don't have access", "I'm unable to") are classified via a
+lightweight taxonomy and a recovery directive is returned.  The caller injects
+it as a user-role nudge so the model gets one chance to course-correct before
+the refusal is accepted as the final answer.  Mirrors the tool-spiral nudge
+pattern but for text-only responses.
 """
 
 from __future__ import annotations
@@ -718,3 +725,122 @@ def run_warrants_cron_hard_stop(messages: List[Dict[str, Any]]) -> bool:
         return True
 
     return False
+
+
+# ── Refusal taxonomy and recovery (#975) ──────────────────────────────
+# Lightweight inline taxonomy — mirrors scripts/evolution_refusal_taxonomy.py
+# but lives in the agent core so the conversation loop can call it without a
+# subprocess.  Classifies refusal language in assistant text responses and
+# returns a recovery directive the caller injects as a user-role nudge.
+
+_REFUSAL_PAT = re.compile(
+    "|".join([  # fmt: skip
+        r"i can'?t",
+        r"i can not",
+        r"i don'?t have (?:access|permission)",
+        r"no access",
+        r"i'?m unable to",
+        r"i don'?t have (?:a |the )?(?:tool|skill|feature|plugin|ability|capability)",
+        r"i cannot (?:help|assist|do|provide|access)",
+        r"not (?:able|allowed) to",
+    ]),
+    re.IGNORECASE,
+)
+# Rhetorical false positives — "I can't stress this enough" etc.
+_FP_REFUSAL_PAT = re.compile(
+    r"i can'?t (?:stress|emphasize|overstate|imagine|believe|say|thank|praise|wait)",
+    re.IGNORECASE,
+)
+
+_REFUSAL_CATEGORIES = {
+    "true_capability_gap": (
+        r"don'?t have (?:a |the )?(?:tool|skill|plugin|feature)",
+        "A capability gap was cited. Check whether the capability exists "
+        "locally (use `hermes tools` or check skills) before accepting the "
+        "refusal. If a tool/skill is available, use it directly. If genuinely "
+        "missing, suggest how to install or configure it rather than stopping.",
+    ),
+    "permission_boundary": (
+        r"permission|security|unauthorized|forbidden",
+        "A permission/security boundary was cited. Verify this is a genuine "
+        "security boundary and not an over-refusal — check whether the "
+        "action is safe and permitted in the current context. If legitimate, "
+        "explain the boundary and suggest an alternative approach.",
+    ),
+    "over_refusal": (
+        r"",
+        "The capability likely exists locally. Before accepting this refusal, "
+        "re-check available tools and skills — the requested action may be "
+        "achievable with the tools already configured. Use them directly.",
+    ),
+}
+
+
+def _classify_refusal(text: str) -> str:
+    """Classify a refusal snippet into a category, or empty string if spurious."""
+    # Check false-positive pattern first
+    if _FP_REFUSAL_PAT.search(text):
+        return ""
+    # Check each category in priority order
+    for cat, (pat, _) in _REFUSAL_CATEGORIES.items():
+        if pat and re.search(pat, text, re.IGNORECASE):
+            return cat
+    return "over_refusal"
+
+
+def maybe_refusal_nudge(
+    messages: List[Dict[str, Any]],
+    *,
+    already_nudged: bool = False,
+) -> Optional[str]:
+    """Return a recovery directive if the last assistant message contains
+    refusal language, else None.
+
+    Called from the conversation loop when the assistant produces a text-only
+    response (no tool calls).  If the text matches refusal patterns, a
+    taxonomy-specific recovery nudge is returned for injection as a user
+    message — giving the model one chance to course-correct before the
+    refusal is accepted as the final answer.
+
+    ``already_nudged`` prevents double-nudging the same refusal (the caller
+    tracks this, mirroring the tool-spiral nudge pattern).
+    """
+    if already_nudged:
+        return None
+    # Find the last assistant message with text content
+    last_assistant_text = None
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        # Skip synthetic/recovery messages
+        if msg.get("_empty_terminal_sentinel") or msg.get("_thinking_prefill"):
+            continue
+        last_assistant_text = content
+        break
+    if not last_assistant_text:
+        return None
+    # Detect refusal language
+    refusals = [
+        m for m in _REFUSAL_PAT.finditer(last_assistant_text)
+        if not _FP_REFUSAL_PAT.match(last_assistant_text[m.start():m.start() + 40])
+    ]
+    if not refusals:
+        return None
+    # Classify using the context around the first refusal
+    first = refusals[0]
+    snippet = last_assistant_text[first.start():first.start() + 120]
+    category = _classify_refusal(snippet)
+    if not category:
+        return None
+    # Build recovery directive
+    _, recovery = _REFUSAL_CATEGORIES.get(category, _REFUSAL_CATEGORIES["over_refusal"])
+    return (
+        f"[loop-guard] Refusal detected ({category}). {recovery} "
+        f"Do not simply repeat the refusal — take concrete action or "
+        f"explain specifically what is needed to proceed."
+    )

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -12,6 +12,7 @@ from agent.loop_guard import (
     CRON_LOOP_GUARD_HARD_STOP_THRESHOLD,
     current_run_signature,
     maybe_nudge,
+    maybe_refusal_nudge,
     run_warrants_cron_hard_stop,
     should_cron_hard_stop,
 )
@@ -564,3 +565,110 @@ class TestRunWarrantsCronHardStop:
     def test_distinct_process_calls_do_not_warrant(self):
         # Even distinct successful process calls (varied handles) are fine.
         assert run_warrants_cron_hard_stop(_distinct_run("process", 8)) is False
+
+
+# ── Refusal nudge tests (#975) ─────────────────────────────────────────
+
+
+def _asst_text(content: str) -> dict:
+    """Build an assistant text-only message (no tool calls)."""
+    return {"role": "assistant", "content": content}
+
+
+class TestMaybeRefusalNudge:
+    """Tests for maybe_refusal_nudge — refusal detection in assistant text."""
+
+    def test_no_refusal_returns_none(self):
+        msgs = [
+            {"role": "user", "content": "do the task"},
+            _asst_text("I'll help you with that. Let me start by running the tests."),
+        ]
+        assert maybe_refusal_nudge(msgs) is None
+
+    def test_over_refusal_detected(self):
+        msgs = [
+            {"role": "user", "content": "run the build"},
+            _asst_text("I can't do that right now."),
+        ]
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        assert "over_refusal" in nudge
+        assert "[loop-guard]" in nudge
+
+    def test_capability_gap_detected(self):
+        msgs = [
+            {"role": "user", "content": "deploy to kubernetes"},
+            _asst_text("I don't have a tool for that."),
+        ]
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        assert "true_capability_gap" in nudge
+
+    def test_permission_boundary_detected(self):
+        msgs = [
+            {"role": "user", "content": "read /etc/shadow"},
+            _asst_text("I don't have permission to access that file."),
+        ]
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        assert "permission_boundary" in nudge
+
+    def test_rhetorical_false_positive_ignored(self):
+        """'I can't stress this enough' is NOT a refusal."""
+        msgs = [
+            {"role": "user", "content": "review the code"},
+            _asst_text("I can't stress this enough — the code looks great!"),
+        ]
+        assert maybe_refusal_nudge(msgs) is None
+
+    def test_already_nudged_returns_none(self):
+        msgs = [
+            {"role": "user", "content": "do the thing"},
+            _asst_text("I can't help with that."),
+        ]
+        assert maybe_refusal_nudge(msgs, already_nudged=True) is None
+
+    def test_no_assistant_message_returns_none(self):
+        msgs = [
+            {"role": "user", "content": "hello"},
+        ]
+        assert maybe_refusal_nudge(msgs) is None
+
+    def test_empty_assistant_content_returns_none(self):
+        msgs = [
+            {"role": "user", "content": "hello"},
+            _asst_text(""),
+        ]
+        assert maybe_refusal_nudge(msgs) is None
+
+    def test_synthetic_sentinel_skipped(self):
+        """Empty terminal sentinel messages are skipped when looking for text."""
+        msgs = [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "I can't do that.", "role": "assistant"},
+            {"role": "assistant", "content": "(empty)", "_empty_terminal_sentinel": True},
+        ]
+        # Should find the real refusal text, not the sentinel
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        assert "over_refusal" in nudge
+
+    def test_nudge_contains_recovery_directive(self):
+        msgs = [
+            {"role": "user", "content": "build the project"},
+            _asst_text("I'm unable to build the project."),
+        ]
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        assert "Do not simply repeat the refusal" in nudge
+        assert "concrete action" in nudge
+
+    def test_multiple_refusals_still_nudges_once(self):
+        msgs = [
+            {"role": "user", "content": "do x and y"},
+            _asst_text("I can't do x. I also don't have access to y."),
+        ]
+        nudge = maybe_refusal_nudge(msgs)
+        assert nudge is not None
+        # Should classify the first refusal
+        assert "[loop-guard]" in nudge


### PR DESCRIPTION
## Summary

Closes #975.

865 sessions exhibited refusal/access-denied language (23% of sessions, up 7.5x) despite an existing `refusal_taxonomy` module. The module classified refusals but the conversation loop never consumed its output — no recovery directive was ever issued.

## Changes

**`agent/loop_guard.py`** (+126 lines):
- Add `maybe_refusal_nudge()` — detects refusal language in the last assistant text response using a lightweight inline taxonomy (mirrors `scripts/evolution_refusal_taxonomy.py` but in-process)
- Three categories: `true_capability_gap`, `permission_boundary`, `over_refusal`
- False-positive filtering for rhetorical uses ("I can't stress this enough")
- Returns a taxonomy-specific recovery directive string

**`agent/conversation_loop.py`** (+31 lines):
- Wire `maybe_refusal_nudge()` into the final-response path, right before the refusal would be accepted as the final answer
- If refusal language detected, inject a user-role nudge with recovery guidance — giving the model one chance to course-correct
- Per-turn guard (`_refusal_nudged_this_turn`) prevents double-nudging
- Synthetic message flags (`_refusal_nudge_synthetic`) prevent persistence in transcript

**`tests/agent/test_loop_guard.py`** (+108 lines):
- 11 new tests covering: all three refusal categories, false-positive filtering, already-nudged guard, no-assistant-message, empty content, synthetic sentinel skipping, recovery directive content, multiple refusals

## Test Results

- 75/75 `test_loop_guard.py` tests pass (64 existing + 11 new)
- 85/85 total across loop_guard + cron enforcement + refusal taxonomy tests
- No regressions in any related test file

## Design Notes

- Mirrors the tool-spiral `maybe_nudge()` pattern but for text-only responses
- Advisory only — injects a user message, never blocks
- One nudge per turn to avoid spamming
- Inline taxonomy avoids subprocess overhead while staying consistent with the CLI script