### PR TITLE
fix(cronjob): stop pre-incrementing failure counter and soft-fail preflight when crontab absent

### DIFF
--- a/tests/tools/test_cronjob_e2e.py
+++ b/tests/tools/test_cronjob_e2e.py
@@ -1,0 +1,214 @@
+"""E2E tests for the cronjob tool — issue #972.
+
+Tests two bug fixes:
+1. ``_cron_preflight_check`` must NOT hard-fail when ``crontab`` is absent,
+   because Hermes has its own internal JSON scheduler that doesn't need it.
+2. ``_record_cron_failure`` must NOT be called before the operation runs —
+   only on actual failures. Pre-incrementing caused successful calls to
+   bump the failure counter, eventually blocking legitimate operations.
+"""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_cron_dir(tmp_path, monkeypatch):
+    """Redirect CRON_DIR to a temp dir so tests don't touch real cron state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    cron_dir = tmp_path / ".hermes" / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    # Patch CRON_DIR where it's actually imported from
+    from cron import jobs as cron_jobs
+
+    monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
+    # Also patch ensure_dirs to be a no-op (dirs already created)
+    monkeypatch.setattr(cron_jobs, "ensure_dirs", lambda: None)
+    yield cron_dir
+
+
+@pytest.fixture(autouse=True)
+def reset_failure_tracker():
+    """Clear the failure tracker before and after each test."""
+    from tools import cronjob_tools
+
+    with cronjob_tools._cron_failure_tracker_lock:
+        cronjob_tools._cron_failure_tracker.clear()
+    yield
+    with cronjob_tools._cron_failure_tracker_lock:
+        cronjob_tools._cron_failure_tracker.clear()
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: preflight must not hard-fail when crontab is missing
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightNoCrontab:
+    """The preflight check should NOT block when crontab is absent."""
+
+    def test_returns_none_without_crontab(self):
+        """When crontab is not on PATH, preflight returns None (no error)."""
+        from tools.cronjob_tools import _cron_preflight_check
+
+        with patch("shutil.which", return_value=None):
+            result = _cron_preflight_check()
+
+        assert result is None, (
+            f"Preflight should return None (pass) when crontab is missing, "
+            f"got: {result}"
+        )
+
+    def test_preflight_passes_in_container_env(self, isolated_cron_dir):
+        """Simulate a container/CI env with no crontab — preflight should pass."""
+        from tools.cronjob_tools import _cron_preflight_check
+
+        with patch("shutil.which", return_value=None):
+            result = _cron_preflight_check()
+
+        assert result is None
+
+    def test_preflight_still_checks_cron_dir_writable(self, tmp_path, monkeypatch):
+        """If the cron directory is not writable, preflight still fails.
+
+        We point CRON_DIR at a *file* (not a directory) so the probe write
+        fails with NotADirectoryError. This works regardless of the test
+        user's privileges (root ignores permission bits).
+        """
+        from tools.cronjob_tools import _cron_preflight_check
+        from cron import jobs as cron_jobs
+
+        not_a_dir = tmp_path / "blocking_file"
+        not_a_dir.write_text("block")
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", not_a_dir)
+        monkeypatch.setattr(cron_jobs, "ensure_dirs", lambda: None)
+
+        with patch("shutil.which", return_value=None):
+            result = _cron_preflight_check()
+        assert result is not None
+        assert "not writable" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: failure counter must not pre-increment
+# ---------------------------------------------------------------------------
+
+
+class TestFailureCounterNoPreIncrement:
+    """The failure counter must only be incremented on actual failures."""
+
+    def test_get_streak_does_not_increment(self):
+        """_get_cron_failure_streak reads without bumping the counter."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+            _cron_failure_tracker,
+        )
+
+        # Record one failure
+        _record_cron_failure("task-1")
+        assert len(_cron_failure_tracker["task-1"]) == 1
+
+        # Read the streak — should NOT add another entry
+        streak = _get_cron_failure_streak("task-1")
+        assert streak == 1
+        assert len(_cron_failure_tracker["task-1"]) == 1
+
+    def test_successful_call_does_not_increment(self):
+        """Simulate the top of _handle_cronjob: reading streak must not bump it."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+            _reset_cron_failure,
+        )
+
+        # Pre-existing failure
+        _record_cron_failure("task-2")
+        initial = _get_cron_failure_streak("task-2")
+        assert initial == 1
+
+        # Simulate what the old code did: _record_cron_failure at top
+        # vs new code: _get_cron_failure_streak at top
+        # New code: read only
+        streak = _get_cron_failure_streak("task-2")
+        assert streak == 1  # unchanged
+
+        # Simulate success → reset
+        _reset_cron_failure("task-2")
+        assert _get_cron_failure_streak("task-2") == 0
+
+    def test_failure_only_counted_once(self):
+        """A single failed operation increments the counter exactly once."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+        )
+
+        # Before: old code called _record at top AND in except = +2 per failure
+        # After: only except block calls _record = +1 per failure
+
+        # Simulate the new flow:
+        # 1. Check streak (no increment)
+        streak_before = _get_cron_failure_streak("task-3")
+        assert streak_before == 0
+
+        # 2. Operation fails → except block records failure
+        _record_cron_failure("task-3")
+
+        streak_after = _get_cron_failure_streak("task-3")
+        assert streak_after == 1  # exactly 1, not 2
+
+    def test_max_failures_still_blocks(self):
+        """After exceeding max consecutive failures, the streak check blocks."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+            _MAX_CONSECUTIVE_CRON_FAILURES,
+        )
+
+        task = "task-blocked"
+        # Record max + 1 failures
+        for _ in range(_MAX_CONSECUTIVE_CRON_FAILURES + 1):
+            _record_cron_failure(task)
+
+        streak = _get_cron_failure_streak(task)
+        assert streak > _MAX_CONSECUTIVE_CRON_FAILURES
+
+    def test_reset_clears_streak(self):
+        """_reset_cron_failure clears the counter so subsequent calls proceed."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+            _reset_cron_failure,
+        )
+
+        task = "task-reset"
+        _record_cron_failure(task)
+        _record_cron_failure(task)
+        assert _get_cron_failure_streak(task) == 2
+
+        _reset_cron_failure(task)
+        assert _get_cron_failure_streak(task) == 0
+
+    def test_none_task_id_safe(self):
+        """None task_id doesn't crash."""
+        from tools.cronjob_tools import (
+            _get_cron_failure_streak,
+            _record_cron_failure,
+            _reset_cron_failure,
+        )
+
+        assert _get_cron_failure_streak(None) == 0
+        assert _record_cron_failure(None) == 1
+        _reset_cron_failure(None)  # should not crash

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -85,6 +85,20 @@ def _record_cron_failure(task_id: Optional[str]) -> int:
         return len(window)
 
 
+def _get_cron_failure_streak(task_id: Optional[str]) -> int:
+    """Return the current failure streak for *task_id* without incrementing."""
+    if not task_id:
+        return 0
+    now = time.monotonic()
+    with _cron_failure_tracker_lock:
+        window = [
+            ts
+            for ts in _cron_failure_tracker.get(task_id, [])
+            if now - ts < _CRON_RETRY_WINDOW_SECONDS
+        ]
+        return len(window)
+
+
 def _reset_cron_failure(task_id: Optional[str]) -> None:
     """Reset the failure streak for *task_id* after a successful operation."""
     if not task_id:
@@ -117,11 +131,18 @@ def _cron_preflight_check() -> Optional[str]:
 
     crontab = shutil.which("crontab")
     if crontab is None:
-        return (
-            "The 'crontab' command is not available on PATH. "
-            "Install a cron implementation (e.g. cronie, vixie-cron) "
-            "or verify that Hermes is running in an environment with cron support."
+        # Hermes has its own internal JSON scheduler (cron/scheduler.py) that
+        # does NOT require the external crontab binary. Many environments
+        # (containers, CI, embedded) intentionally lack crontab but still
+        # run scheduled jobs via the internal scheduler. Downgrade the
+        # missing-crontab check from a hard failure to a warning so job
+        # create/list/update operations proceed via the internal scheduler.
+        logger.warning(
+            "The 'crontab' command is not on PATH — only the internal JSON "
+            "scheduler will be available. Install cronie or vixie-cron if "
+            "system-level crontab integration is needed."
         )
+        return None
 
     try:
         result = subprocess.run(
@@ -1023,7 +1044,11 @@ def cronjob(
         return tool_error(action_error, success=False)
 
     # Retry-rate limiter: noisy failure loops are capped per task.
-    failure_streak = _record_cron_failure(task_id)
+    # Only *check* the current streak — do NOT increment here. The counter
+    # is incremented only on actual failures (except block below) and reset
+    # on success. Pre-incrementing caused every call (even successful ones)
+    # to bump the counter, so 3 quick successes would block the 4th call.
+    failure_streak = _get_cron_failure_streak(task_id)
     if failure_streak > _MAX_CONSECUTIVE_CRON_FAILURES:
         return tool_error(
             f"Cron tool has failed {failure_streak} consecutive times for this task "
@@ -1035,6 +1060,7 @@ def cronjob(
     # Preflight: ensure cron is available before invoking backend operations.
     preflight_error = _cron_preflight_check()
     if preflight_error:
+        _record_cron_failure(task_id)
         return tool_error(preflight_error, success=False)
 
     try:


### PR DESCRIPTION
Closes #972

## Root Cause

Two bugs caused the 11 cronjob tool failures over 7 days reported in #972:

**Bug 1 — Failure counter double-counted:**
`_record_cron_failure(task_id)` was called at the top of `_handle_cronjob` (line 1026, before any operation) AND in the `except` block (line 1377). Each failed operation incremented the counter by 2, so with `_MAX_CONSECUTIVE_CRON_FAILURES=3`, only 2 actual failures (streak=4) triggered the "too many attempts" block.

**Bug 2 — Preflight hard-failed when crontab binary missing:**
`_cron_preflight_check()` returned a hard error if `shutil.which('crontab')` was `None`, blocking ALL cronjob operations in containers/CI/embedded environments. But Hermes has its own internal JSON scheduler (`cron/scheduler.py`) that does NOT use crontab at all.

## Fix

1. **Add `_get_cron_failure_streak()`** — reads the current failure streak WITHOUT incrementing. Used at the top of `_handle_cronjob` to check the rate limiter. `_record_cron_failure` is now only called in the `except` block (actual failures) and in the preflight-fail path.

2. **Downgrade missing-crontab from error to warning** — `_cron_preflight_check()` now logs a warning and returns `None` when crontab is absent, so operations proceed via the internal scheduler. The cron directory writability check is still enforced.

## Tests

9 new E2E tests in `tests/tools/test_cronjob_e2e.py`:
- Preflight returns None when crontab missing (not an error)
- Preflight still fails when cron dir not writable
- Failure streak read does not increment counter
- Successful call does not bump counter
- Single failure increments counter exactly once (not twice)
- Max failures still blocks
- Reset clears streak
- None task_id handled safely