### PR TITLE
fix: search_files spiral guardrail, memory circuit breaker, tool_describe fuzzy matching (#973 #977 #978)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2254,7 +2254,31 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 next_args,
             )
     elif function_name == "memory":
+        # #977 — memory circuit breaker: after 3 consecutive failures the
+        # memory tool returns a "proceed without persistence" directive so
+        # the agent continues the task instead of looping on a broken
+        # storage backend. Uses a dedicated breaker (threshold=3) separate
+        # from the generic tool breaker (threshold=5) because memory
+        # failures are cheaper to route around — the agent can work
+        # without persistence — so we trip sooner.
+        from agent.tool_error_recovery import get_breaker as _get_mem_breaker
+        _mem_breaker = _get_mem_breaker("memory", threshold=3)
+
         def _execute(next_args: dict) -> Any:
+            # If the breaker is already open, short-circuit with a directive.
+            if _mem_breaker.should_trip():
+                _mem_breaker_count = _mem_breaker._consecutive_failures
+                _mem_msg = (
+                    f"Memory is unavailable — proceed without persistence. "
+                    f"Memory tool has failed {_mem_breaker_count} consecutive "
+                    f"times. Continue the task without reading or writing "
+                    f"memory. Do not retry the memory tool."
+                )
+                logger.warning("memory circuit breaker open after %d failures", _mem_breaker_count)
+                return _finish_agent_tool(
+                    json.dumps({"success": False, "error": _mem_msg}, ensure_ascii=False),
+                    next_args,
+                )
             target = next_args.get("target", "memory")
             operations = next_args.get("operations")
             from tools.memory_tool import memory_tool as _memory_tool
@@ -2266,10 +2290,25 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 operations=operations,
                 store=agent._memory_store,
             )
+            # Track success/failure for the memory breaker.
+            try:
+                _parsed = json.loads(result) if isinstance(result, str) else result
+                _ok = bool(_parsed.get("success", True)) if isinstance(_parsed, dict) else True
+            except Exception:
+                _ok = True
+            if _ok:
+                _mem_breaker.record_success()
+            else:
+                _mem_breaker.record_failure()
+                if _mem_breaker.should_trip():
+                    logger.warning(
+                        "memory circuit breaker tripped — returning "
+                        "proceed-without-persistence directive"
+                    )
             # Mirror successful built-in memory writes to external providers.
             # All gating/op-expansion lives behind the manager interface
             # (MemoryManager.notify_memory_tool_write).
-            if agent._memory_manager:
+            if agent._memory_manager and _ok:
                 agent._memory_manager.notify_memory_tool_write(
                     result,
                     next_args,

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -103,6 +103,13 @@ _EXPLORATION_ALTERNATIVE_HINT = {
         "far cheaper than many narrow searches (Python codebases only). "
         "For a batch of searches you already know you need, `delegate_task` a "
         "subagent to run them and report back, keeping this context lean."
+        # #973 — regex/glob parse errors are deterministic: a near-identical
+        # retry reproduces them. Route to repo_map or read_file instead of
+        # re-issuing the same failing pattern.
+        " If search_files is returning regex/glob parse errors, the pattern is "
+        "likely invalid — use `search_files target='files'` with a glob pattern "
+        "instead of a content regex, or switch to `repo_map` for a structured "
+        "overview."
     ),
 }
 
@@ -238,6 +245,15 @@ _MUTATING_FAIL_THRESHOLD = 2
 _IDEMPOTENT_FAIL_THRESHOLD = 4
 _MUTATING_ESCALATE_THRESHOLD = 8
 _IDEMPOTENT_ESCALATE_THRESHOLD = 15
+
+# #973 — Per-tool fail threshold overrides. ``search_files`` failures are
+# typically regex/glob parse errors — deterministic and cheap to route
+# around (switch to repo_map or read_file). Trip one call sooner than the
+# generic idempotent threshold so the agent gets the diversion hint before
+# burning another iteration on the same broken pattern.
+_TOOL_FAIL_THRESHOLD_OVERRIDE: dict[str, int] = {
+    "search_files": 3,
+}
 
 # Monitoring/polling tools whose whole PURPOSE is to be called repeatedly to
 # observe a long-running background job (CI runs, `hermes update`, a spawned
@@ -463,6 +479,8 @@ def maybe_nudge(
             if (is_mutating or is_unknown)
             else _IDEMPOTENT_FAIL_THRESHOLD
         )
+        # #973 — per-tool override (e.g. search_files trips sooner).
+        fail_threshold = _TOOL_FAIL_THRESHOLD_OVERRIDE.get(tool, fail_threshold)
     escalate_threshold = (
         _MUTATING_ESCALATE_THRESHOLD
         if (is_mutating or is_unknown)

--- a/tests/agent/test_loop_guard_search_files_threshold.py
+++ b/tests/agent/test_loop_guard_search_files_threshold.py
@@ -1,0 +1,81 @@
+"""Tests for search_files fail threshold override (#973).
+
+The loop-guard should trip for ``search_files`` failures at a lower
+threshold (3) than the generic idempotent default (4), so the agent
+gets the repo_map diversion hint sooner when search_files keeps
+failing with regex/glob parse errors.
+"""
+
+import json
+
+from agent.loop_guard import maybe_nudge
+
+
+def _assistant_tool_call(tool_name: str, args: dict | None = None) -> dict:
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": json.dumps(args or {}),
+                },
+            }
+        ],
+    }
+
+
+def _tool_result(content: str) -> dict:
+    return {"role": "tool", "tool_call_id": "call_search_files", "content": content}
+
+
+def _search_files_fail_run(n: int) -> list[dict]:
+    """Build a message list of ``n`` consecutive failed search_files calls."""
+    msgs: list[dict] = []
+    for i in range(n):
+        msgs.append(
+            _assistant_tool_call(
+                "search_files",
+                {"pattern": f"broken_regex_{i}", "target": "content"},
+            )
+        )
+        msgs.append(
+            _tool_result(
+                "Error: regex parse error at position 0: unexpected metacharacter"
+            )
+        )
+    return msgs
+
+
+class TestSearchFilesFailThreshold:
+    """search_files should trip at 3 consecutive failures (#973)."""
+
+    def test_trips_at_3_failures(self):
+        """At 3 failures, the nudge should fire (was 4 before #973)."""
+        msgs = _search_files_fail_run(3)
+        nudge = maybe_nudge(msgs)
+        assert nudge is not None
+        assert "search_files" in nudge
+
+    def test_no_trip_at_2_failures(self):
+        """At 2 failures, the nudge should NOT fire yet."""
+        msgs = _search_files_fail_run(2)
+        nudge = maybe_nudge(msgs)
+        assert nudge is None
+
+    def test_nudge_includes_repo_map_hint(self):
+        """The nudge should include the repo_map diversion hint."""
+        msgs = _search_files_fail_run(4)
+        nudge = maybe_nudge(msgs)
+        assert nudge is not None
+        assert "repo_map" in nudge
+
+    def test_nudge_includes_regex_error_advice(self):
+        """The nudge should include advice about regex/glob parse errors."""
+        msgs = _search_files_fail_run(4)
+        nudge = maybe_nudge(msgs)
+        assert nudge is not None
+        # The #973 hint mentions glob patterns or parse errors.
+        assert "glob" in nudge.lower() or "regex" in nudge.lower()

--- a/tests/agent/test_memory_circuit_breaker.py
+++ b/tests/agent/test_memory_circuit_breaker.py
@@ -1,0 +1,68 @@
+"""Tests for memory circuit breaker (#977).
+
+After 3 consecutive memory tool failures, the breaker opens and
+returns a "proceed without persistence" directive instead of
+attempting another failing call.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tool_error_recovery import CircuitBreaker, get_breaker
+
+
+class TestMemoryCircuitBreaker:
+    """Circuit breaker for the memory tool (threshold=3)."""
+
+    def test_breaker_trips_after_3_failures(self):
+        """After 3 consecutive failures, should_trip() returns True."""
+        breaker = CircuitBreaker(threshold=3)
+        breaker.record_failure()
+        breaker.record_failure()
+        assert not breaker.should_trip()
+        breaker.record_failure()
+        assert breaker.should_trip()
+
+    def test_breaker_resets_on_success(self):
+        """A success resets the failure counter."""
+        breaker = CircuitBreaker(threshold=3)
+        breaker.record_failure()
+        breaker.record_failure()
+        breaker.record_success()
+        breaker.record_failure()
+        breaker.record_failure()
+        assert not breaker.should_trip()
+
+    def test_memory_breaker_uses_threshold_3(self):
+        """The memory breaker should be configured with threshold=3."""
+        breaker = get_breaker("memory", threshold=3)
+        assert breaker.threshold == 3
+
+    def test_directive_message_after_breaker_open(self):
+        """When the breaker is open, the memory tool should return a
+        proceed-without-persistence directive."""
+        breaker = get_breaker("memory", threshold=3)
+        # Force the breaker open by recording 3 failures.
+        breaker.record_failure()
+        breaker.record_failure()
+        breaker.record_failure()
+        assert breaker.should_trip()
+        # Verify the directive message content structure.
+        # The actual dispatch is in agent_runtime_helpers.invoke_tool, but
+        # we can verify the breaker state and the directive would fire.
+        assert breaker._consecutive_failures >= 3
+
+    def test_breaker_stays_open_until_success(self):
+        """Once open, the breaker stays open until explicitly reset."""
+        breaker = CircuitBreaker(threshold=3)
+        for _ in range(3):
+            breaker.record_failure()
+        assert breaker.should_trip()
+        # Even more failures keep it open.
+        breaker.record_failure()
+        assert breaker.should_trip()
+        # Only success resets it.
+        breaker.record_success()
+        assert not breaker.should_trip()

--- a/tests/tools/test_tool_describe_fuzzy.py
+++ b/tests/tools/test_tool_describe_fuzzy.py
@@ -1,0 +1,135 @@
+"""Tests for fuzzy name matching in tool_describe (#978).
+
+When the model calls ``tool_describe`` with a slightly wrong tool name,
+the response should include ``suggestions`` with the closest matches
+instead of a bare "not available" error, so the agent can self-correct
+without a separate ``tool_search`` round-trip.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.tool_search import dispatch_tool_describe, _fuzzy_tool_names
+
+
+# ── _fuzzy_tool_names unit tests ─────────────────────────────────────────
+
+
+class TestFuzzyToolNames:
+    def test_empty_query_returns_empty(self):
+        assert _fuzzy_tool_names("", ["a", "b"]) == []
+
+    def test_empty_available_returns_empty(self):
+        assert _fuzzy_tool_names("query", []) == []
+
+    def test_exact_substring_match(self):
+        result = _fuzzy_tool_names("github", ["github_create_issue", "github_list_repos", "web_search"])
+        assert "github_create_issue" in result
+        assert "github_list_repos" in result
+        assert "web_search" not in result
+
+    def test_substring_match_respects_limit(self):
+        result = _fuzzy_tool_names("a", ["a1", "a2", "a3", "a4"], limit=2)
+        assert len(result) <= 2
+
+    def test_edit_distance_near_miss(self):
+        """A single-character typo should still produce a suggestion."""
+        result = _fuzzy_tool_names("web_serch", ["web_search", "web_extract", "read_file"])
+        assert "web_search" in result
+
+    def test_no_match_when_too_far(self):
+        """Completely unrelated names should not produce suggestions."""
+        result = _fuzzy_tool_names("zzzzz", ["web_search", "read_file", "terminal"])
+        assert result == []
+
+
+# ── dispatch_tool_describe integration tests ────────────────────────────
+
+
+def _make_tool_def(name: str, description: str = "test tool") -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+class TestDispatchToolDescribeFuzzy:
+    """Integration: dispatch_tool_describe returns suggestions on miss."""
+
+    @patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+    def test_exact_match_returns_description(self, _mock):
+        defs = [_make_tool_def("my_tool")]
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "my_tool"},
+                current_tool_defs=defs,
+                config=None,
+            )
+        )
+        assert result.get("name") == "my_tool"
+        assert "description" in result
+
+    @patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+    def test_typo_returns_suggestions(self, _mock):
+        defs = [
+            _make_tool_def("github_create_issue"),
+            _make_tool_def("web_search"),
+        ]
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "github_create"},  # substring of the real name
+                current_tool_defs=defs,
+                config=None,
+            )
+        )
+        assert "error" in result
+        assert "suggestions" in result
+        assert "github_create_issue" in result["suggestions"]
+
+    def test_non_deferrable_typo_returns_suggestions(self):
+        """Even when the name is not deferrable, if a deferrable tool name
+        is close, suggest it (#978 non-deferrable branch)."""
+        defs = [_make_tool_def("mcp_search_web")]
+        with patch(
+            "tools.tool_search.is_deferrable_tool_name",
+            side_effect=lambda name, config=None: name == "mcp_search_web",
+        ):
+            result = json.loads(
+                dispatch_tool_describe(
+                    {"name": "mcp_search"},  # close to "mcp_search_web"
+                    current_tool_defs=defs,
+                    config=None,
+                )
+            )
+            assert "error" in result
+            assert "suggestions" in result
+            assert "mcp_search_web" in result["suggestions"]
+
+    def test_completely_wrong_name_no_suggestions(self):
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "zzzzzzzzzz"},
+                current_tool_defs=[_make_tool_def("web_search")],
+                config=None,
+            )
+        )
+        assert "error" in result
+        # Should NOT have suggestions for a completely unrelated name.
+        assert "suggestions" not in result
+
+    def test_empty_name_returns_error(self):
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": ""},
+                current_tool_defs=[],
+                config=None,
+            )
+        )
+        assert "error" in result
+        assert "required" in result["error"]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -733,6 +733,41 @@ def dispatch_tool_search(args: Dict[str, Any],
     }, ensure_ascii=False)
 
 
+def _fuzzy_tool_names(query: str, available: List[str], limit: int = 3) -> List[str]:
+    """Return up to ``limit`` tool names closest to ``query`` by substring /
+    edit-distance. Used so ``tool_describe`` can suggest the right name when
+    the model's requested name is slightly wrong (#978), avoiding a separate
+    ``tool_search`` round-trip."""
+    q = query.lower()
+    if not q or not available:
+        return []
+    # Fast path: substring match (catches typos like "github_create" →
+    # "github_create_issue").
+    sub = [n for n in available if q in n.lower()]
+    if sub:
+        return sorted(sub, key=len)[:limit]
+
+    # Edit-distance fallback for near-misses.
+    def _dist(a: str, b: str) -> int:
+        """Simple Levenshtein distance (small strings, no dep needed)."""
+        a, b = a.lower(), b.lower()
+        if len(a) < len(b):
+            a, b = b, a
+        if not b:
+            return len(a)
+        prev = list(range(len(b) + 1))
+        for i, ca in enumerate(a, 1):
+            cur = [i]
+            for j, cb in enumerate(b, 1):
+                cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (ca != cb)))
+            prev = cur
+        return prev[-1]
+
+    scored = sorted(available, key=lambda n: _dist(q, n))[:limit]
+    # Only suggest if reasonably close (distance ≤ 3 for short names).
+    return [n for n in scored if _dist(q, n) <= max(3, len(q) // 3)]
+
+
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
                            current_tool_defs: List[Dict[str, Any]],
@@ -744,6 +779,25 @@ def dispatch_tool_describe(args: Dict[str, Any],
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
     if not is_deferrable_tool_name(name, config):
+        # #978 — fuzzy name matching even for non-deferrable names: the
+        # model may have slightly misspelled a deferrable tool. Suggest
+        # close matches from the current tool defs so it can self-correct
+        # without a separate tool_search round-trip.
+        _, deferrable = classify_tools(current_tool_defs, config)
+        available_names = [
+            (td.get("function") or {}).get("name", "")
+            for td in deferrable
+        ]
+        suggestions = _fuzzy_tool_names(name, available_names)
+        if suggestions:
+            return json.dumps({
+                "error": (
+                    f"'{name}' is not a deferrable tool. Did you mean one of: "
+                    f"{', '.join(suggestions)}? Use the exact name with "
+                    f"tool_describe or tool_call."
+                ),
+                "suggestions": suggestions,
+            }, ensure_ascii=False)
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
@@ -759,6 +813,22 @@ def dispatch_tool_describe(args: Dict[str, Any],
                 "description": fn.get("description", ""),
                 "parameters": fn.get("parameters", {}),
             }, ensure_ascii=False)
+    # #978 — fuzzy name matching: suggest closest matches so the agent can
+    # self-correct without a separate tool_search round-trip.
+    available_names = [
+        (td.get("function") or {}).get("name", "")
+        for td in deferrable
+    ]
+    suggestions = _fuzzy_tool_names(name, available_names)
+    if suggestions:
+        return json.dumps({
+            "error": (
+                f"'{name}' is not currently available. Did you mean one of: "
+                f"{', '.join(suggestions)}? Use the exact name with tool_describe "
+                f"or tool_call."
+            ),
+            "suggestions": suggestions,
+        }, ensure_ascii=False)
     return json.dumps({
         "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
     }, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Implements 3 issues from the 2026-07-14 evolution analysis (total effort: 1.1, budget: 3.0).

### #973 — search_files repeated loops and failures (effort 0.4)
- **Problem:** 7 failures (+133% vs prior cycle), 8 sessions with ≥5 consecutive search_files calls (max 15). Regex/glob parse errors and repeated identical queries.
- **Fix:** Per-tool fail threshold override for search_files (3, down from default 4) so the loop guard trips sooner. Extended the exploration hint with regex/glob error advice routing to  or .
- **Files:** 

### #977 — memory tool wrapper fails repeatedly (effort 0.4)
- **Problem:** 58 failures across 16 sessions, max 11 consecutive retries. Memory failures break cross-session continuity.
- **Fix:** Wire the existing  (threshold=3) into the memory tool dispatch path. After 3 consecutive failures, return a 'proceed without persistence' directive instead of another failing call. Failure counter resets on success.
- **Files:** 

### #978 — tool_describe fuzzy name matching (effort 0.3)
- **Problem:** 65 combined failures (46 tool_call + 19 tool_describe) across 7 sessions. Agent calls with wrong tool names.
- **Fix:** New  helper using substring + edit-distance matching. When tool_describe gets a near-miss name, return  with closest matches so the agent self-corrects without a separate tool_search round-trip. Applied to both the deferrable and non-deferrable branches.
- **Files:** 

## Test Plan
- 20 new tests added (all passing):
  -  (11 tests)
  -  (4 tests)
  -  (5 tests)
- 122 existing tests still green (loop_guard, tool_search, cron_enforcement)
- Total: 128 source insertions (within 200-line self-merge cap)

## Verification
```bash
scripts/run_tests.sh tests/agent/test_loop_guard.py tests/tools/test_tool_search.py tests/agent/test_loop_guard_cron_enforcement.py tests/agent/test_loop_guard_force_switch.py tests/tools/test_tool_describe_fuzzy.py tests/agent/test_loop_guard_search_files_threshold.py tests/agent/test_memory_circuit_breaker.py -q
# 142 tests passed, 0 failed
```