### PR TITLE
feat(patch): structured error context for self-correction (#996)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3286,6 +3286,15 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # Patch tool self-correction settings (issue #996).
+    # Controls how many consecutive patch failures on the same file are
+    # allowed before the error is classified as "permanent" and the model
+    # is instructed to stop retrying and use an alternative strategy
+    # (re-read the file, use write_file, etc.).  1–5; default 3.
+    "patch": {
+        "self_correction_retries": 3,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 34,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.2"
+version = "0.18.3"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/tools/test_patch_failure_tracking.py
+++ b/tests/tools/test_patch_failure_tracking.py
@@ -95,6 +95,9 @@ class TestPatchFailureEscalation:
             last_hint = d.get("_hint", "") or ""
 
         assert "failure #3" in last_hint, repr(last_hint)
+        assert "PERMANENT FAILURE" in last_hint, (
+            "Escalating hint should classify as PERMANENT FAILURE"
+        )
         assert "Stop retrying" in last_hint
         assert "write_file" in last_hint, (
             "Escalating hint should mention write_file fallback"

--- a/tests/tools/test_patch_self_correction.py
+++ b/tests/tools/test_patch_self_correction.py
@@ -1,0 +1,317 @@
+"""Tests for structured error context in patch self-correction (issue #996).
+
+The structured error package gives the model everything it needs to produce
+a corrected patch on its next turn WITHOUT re-reading the file:
+
+- Error type classification (no_match, ambiguous, identical, escape_drift)
+- The closest matching region with line numbers (±5 lines)
+- A recovery suggestion matched to the error type
+
+This file tests the pure functions in ``tools.fuzzy_match`` — the functions
+that build the structured error context.  Integration through the full
+``_handle_patch`` pipeline is tested in ``test_patch_failure_tracking.py``.
+"""
+
+import json
+
+import pytest
+
+from tools.fuzzy_match import (
+    classify_error,
+    format_structured_error,
+    _format_file_context_snippet,
+    ERROR_TYPES,
+)
+
+
+class TestClassifyError:
+    def test_no_match(self):
+        assert classify_error("Could not find a match for old_string", None) == "no_match"
+
+    def test_no_match_variant(self):
+        assert classify_error("Could not find match for old_string in file.py", None) == "no_match"
+
+    def test_ambiguous(self):
+        assert classify_error("Found 3 matches for old_string", None) == "ambiguous"
+
+    def test_identical_via_strategy(self):
+        assert classify_error("some error", "identical") == "identical"
+
+    def test_identical_via_text(self):
+        assert classify_error("old_string and new_string are identical", None) == "identical"
+
+    def test_escape_drift(self):
+        assert classify_error("Escape-drift detected: backslash issue", None) == "escape_drift"
+
+    def test_escape_drift_no_hyphen(self):
+        assert classify_error("Escape drift detected in old_string", None) == "escape_drift"
+
+    def test_permission(self):
+        assert classify_error("Write denied: protected path", None) == "permission"
+
+    def test_read_failed(self):
+        assert classify_error("Failed to read file: /tmp/x.py", None) == "read_failed"
+
+    def test_write_failed(self):
+        assert classify_error("Failed to write changes to file", None) == "write_failed"
+
+    def test_unknown(self):
+        assert classify_error("something weird happened", None) == "unknown"
+
+    def test_none_error(self):
+        assert classify_error(None, None) == "unknown"
+
+
+class TestFormatFileContextSnippet:
+    def test_finds_closest_region(self):
+        content = "line1\nline2\ndef foo():\n    return 1\nline5\nline6\n"
+        old_string = "def foo():\n    return 2"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=2)
+        assert "def foo" in snippet
+        assert "return 1" in snippet
+        # Line numbers should be present
+        assert "   3" in snippet  # line 3 is def foo()
+
+    def test_marks_best_match_line(self):
+        content = "a\nb\ndef target():\n    pass\ne\nf\n"
+        old_string = "def target():\n    pass"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=1)
+        # The >> marker should be on the best-matching line
+        assert ">>" in snippet
+
+    def test_empty_for_no_similar_content(self):
+        content = "completely different content here\n"
+        old_string = "def totally_unrelated():\n    pass"
+        snippet = _format_file_context_snippet(content, old_string)
+        assert snippet == ""
+
+    def test_empty_for_empty_inputs(self):
+        assert _format_file_context_snippet("", "old") == ""
+        assert _format_file_context_snippet("content", "") == ""
+
+    def test_context_lines_respected(self):
+        content = "\n".join(f"line{i}" for i in range(1, 21))
+        old_string = "line10\nline11"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=3)
+        # Should include lines 7 through ~14 (3 before line 10, 3 after the block)
+        assert "line7" in snippet
+        assert "line14" in snippet or "line13" in snippet
+        # Should NOT include lines too far away — check by line number prefix,
+        # not substring ("line1" is a substring of "line10" through "line19").
+        snippet_lines = snippet.split("\n")
+        # Extract line numbers from the snippet (format: "   N>>| content" or "   N  | content")
+        line_nums = set()
+        for sl in snippet_lines:
+            # Strip leading whitespace, take digits before >> or |
+            stripped = sl.strip()
+            if stripped:
+                num_part = stripped.split("|")[0].rstrip(">")
+                try:
+                    line_nums.add(int(num_part.strip()))
+                except ValueError:
+                    pass
+        assert 1 not in line_nums, f"line 1 should not be in snippet, got lines: {sorted(line_nums)}"
+        assert 20 not in line_nums, f"line 20 should not be in snippet, got lines: {sorted(line_nums)}"
+
+
+class TestFormatStructuredError:
+    def test_no_match_includes_error_type_and_snippet(self):
+        content = "def foo():\n    return 1\n\ndef bar():\n    return 2\n"
+        old_string = "def foo():\n    return 99"
+        new_string = "def foo():\n    return 42"
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, old_string, new_string, content,
+            file_path="/tmp/test.py",
+        )
+        assert "Error type: no_match" in result
+        assert "File: /tmp/test.py" in result
+        # Should include the closest matching region
+        assert "return 1" in result
+        # Should include a recovery suggestion
+        assert "Recovery:" in result
+
+    def test_ambiguous_includes_error_type_and_recovery(self):
+        content = "aaa bbb aaa\n"
+        old_string = "aaa"
+        new_string = "ccc"
+        result = format_structured_error(
+            "Found 2 matches for old_string",
+            0, old_string, new_string, content,
+            file_path="/tmp/test.py",
+        )
+        assert "Error type: ambiguous" in result
+        assert "replace_all=True" in result
+
+    def test_identical_includes_error_type_and_recovery(self):
+        result = format_structured_error(
+            "old_string and new_string are identical",
+            0, "foo", "foo", "foo bar\n",
+            strategy="identical",
+        )
+        assert "Error type: identical" in result
+        assert "no action needed" in result.lower()
+
+    def test_escape_drift_includes_error_type_and_recovery(self):
+        result = format_structured_error(
+            "Escape-drift detected: backslash issue",
+            0, "old\\'", "new\\'", "content\n",
+        )
+        assert "Error type: escape_drift" in result
+        assert "read_file" in result
+
+    def test_silent_on_permission_error(self):
+        result = format_structured_error(
+            "Write denied: protected path",
+            0, "old", "new", "content\n",
+        )
+        assert result == ""
+
+    def test_silent_on_unknown_error(self):
+        result = format_structured_error(
+            "something weird",
+            0, "old", "new", "content\n",
+        )
+        assert result == ""
+
+    def test_silent_on_none_error(self):
+        result = format_structured_error(None, 0, "old", "new", "content\n")
+        assert result == ""
+
+    def test_no_match_no_snippet_falls_back_to_generic_recovery(self):
+        """When no similar content exists, still provide a generic recovery hint."""
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, "totally_unique_xyzzy", "replacement",
+            "completely different content\n",
+        )
+        assert "Error type: no_match" in result
+        assert "read_file" in result
+
+    def test_file_path_optional(self):
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, "foo", "bar", "def foo():\n    pass\n",
+        )
+        assert "Error type: no_match" in result
+        # Should still work without file_path
+        assert "File:" not in result
+
+
+class TestPatchResultStructuredError:
+    """Verify that PatchResult carries structured_error through to_dict."""
+
+    def test_to_dict_includes_diagnostic_when_set(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(
+            error="Could not find a match for old_string",
+            structured_error="Error type: no_match — old_string not found in file",
+        )
+        d = result.to_dict()
+        assert "_diagnostic" in d
+        assert "no_match" in d["_diagnostic"]
+
+    def test_to_dict_omits_diagnostic_when_none(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(error="some error")
+        d = result.to_dict()
+        assert "_diagnostic" not in d
+
+    def test_to_dict_omits_diagnostic_on_success(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(success=True, diff="--- a\n+++ b\n")
+        d = result.to_dict()
+        assert "_diagnostic" not in d
+
+
+class TestSelfCorrectionConfigGate:
+    """Verify the config gate for self-correction retry threshold."""
+
+    def test_default_value(self, monkeypatch):
+        """When config is unavailable, the default of 3 is returned."""
+        import tools.file_tools as ft
+        # Reset the cache
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        # Force the config load to fail
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: (_ for _ in ()).throw(Exception("no config")))
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_clamps_to_max(self, monkeypatch):
+        """Values above 5 are rejected in favor of the default."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 99}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_clamps_to_min(self, monkeypatch):
+        """Values below 1 are rejected in favor of the default."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 0}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_valid_value_used(self, monkeypatch):
+        """A valid value (1-5) is used as-is."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 5}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 5
+
+
+class TestPatchFailureEscalationWithDiagnostic:
+    """Verify that the structured _diagnostic suppresses redundant _hint."""
+
+    @pytest.fixture
+    def hermes_home(self, monkeypatch, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        yield home
+        try:
+            from tools.file_tools import clear_file_ops_cache
+            clear_file_ops_cache()
+        except Exception:
+            pass
+
+    @pytest.fixture
+    def fresh_tracker(self):
+        from tools.file_tools import _patch_failure_tracker, _patch_failure_lock
+        with _patch_failure_lock:
+            _patch_failure_tracker.clear()
+        yield
+        with _patch_failure_lock:
+            _patch_failure_tracker.clear()
+
+    def test_first_failure_has_diagnostic_not_generic_hint(
+        self, hermes_home, tmp_path, fresh_tracker, monkeypatch
+    ):
+        """On the first no-match failure, the structured _diagnostic should
+        be present and the generic _hint should be suppressed (since the
+        diagnostic is strictly more useful)."""
+        from tools.file_tools import _handle_patch
+        # Reset the config cache so we get the default threshold
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+
+        target = tmp_path / "f.py"
+        target.write_text("def foo():\n    return 1\n")
+
+        result = _handle_patch(
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "class TOTALLY_NONEXISTENT_BANANA_XYZQQQ:\n    pass",
+                "new_string": "x",
+            },
+            task_id="diag_t1",
+        )
+        d = json.loads(result)
+        # Should have an error (no match)
+        assert d.get("error"), f"Expected error for non-matching old_string, got: {d}"
+        # Should have the structured diagnostic
+        assert "_diagnostic" in d, f"Missing _diagnostic in {list(d.keys())}"
+        assert "no_match" in d["_diagnostic"]

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -272,6 +272,13 @@ class PatchResult:
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
+    # Structured error context for self-correction (#996).  Contains
+    # error-type classification, the closest matching region with line
+    # numbers, and a recovery suggestion.  Populated by patch_replace
+    # on match failures; consumed by patch_tool to add a ``_diagnostic``
+    # field to the tool result so the model can correct on its next
+    # turn without re-reading the file.
+    structured_error: Optional[str] = None
     
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -292,6 +299,8 @@ class PatchResult:
             hit = classify_file_error(self.error)
             if hit:
                 result["error_class"], result["recovery"] = hit
+        if self.structured_error:
+            result["_diagnostic"] = self.structured_error
         return result
 
 
@@ -1653,12 +1662,30 @@ class ShellFileOperations(FileOperations):
 
         if error or match_count == 0:
             err_msg = error or f"Could not find match for old_string in {path}"
+            # Build structured error context for self-correction (#996).
+            # This gives the model the closest matching region with line
+            # numbers and a classified error type so it can produce a
+            # corrected patch without re-reading the file.
+            structured_err = ""
             try:
-                from tools.fuzzy_match import format_no_match_hint
-                err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+                from tools.fuzzy_match import format_structured_error
+                structured_err = format_structured_error(
+                    error, match_count, old_string, new_string, content,
+                    file_path=path, strategy=_strategy,
+                )
             except Exception:
                 pass
-            return PatchResult(error=err_msg)
+            # Append the legacy "Did you mean?" hint only when the
+            # structured error didn't already produce a richer context
+            # snippet (the structured error is strictly more useful
+            # because it includes line numbers and a recovery hint).
+            if not structured_err:
+                try:
+                    from tools.fuzzy_match import format_no_match_hint
+                    err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+                except Exception:
+                    pass
+            return PatchResult(error=err_msg, structured_error=structured_err or None)
 
         # ── Line-ending preservation ──────────────────────────────────
         # Models nearly always send old_string/new_string with bare LF

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -84,6 +84,35 @@ def _get_max_read_chars() -> int:
     return _max_read_chars_cached
 
 
+# ── Self-correction retry threshold (issue #996) ─────────────────────────
+# Controls how many consecutive patch failures on the same file are allowed
+# before the error is classified as "permanent" and the model is told to
+# stop retrying.  Read from ``patch.self_correction_retries`` in config.yaml
+# on first call, cached for the process lifetime.  Default 3, max 5.
+_DEFAULT_SELF_CORRECTION_RETRIES = 3
+_MAX_SELF_CORRECTION_RETRIES = 5
+_self_correction_retries_cached: int | None = None
+
+
+def _get_self_correction_retries() -> int:
+    """Return the configured self-correction retry threshold for patches."""
+    global _self_correction_retries_cached
+    if _self_correction_retries_cached is not None:
+        return _self_correction_retries_cached
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        patch_cfg = cfg.get("patch", {})
+        val = patch_cfg.get("self_correction_retries")
+        if isinstance(val, (int, float)) and 1 <= int(val) <= _MAX_SELF_CORRECTION_RETRIES:
+            _self_correction_retries_cached = int(val)
+            return _self_correction_retries_cached
+    except Exception:
+        pass
+    _self_correction_retries_cached = _DEFAULT_SELF_CORRECTION_RETRIES
+    return _self_correction_retries_cached
+
+
 def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bool]:
     """Trim line-numbered ``read_file`` content to fit a char budget.
 
@@ -1874,10 +1903,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # ("Found N matches") failures — both cause the same spiral
         # pattern where the agent retries with slight variations.
         # Suppressed when patch_replace already attached a rich "Did you mean?"
-        # snippet (which is strictly more useful than the generic hint).
+        # snippet or a structured _diagnostic (#996) — both are strictly
+        # more useful than the generic hint.
         err_str = str(result_dict.get("error") or "")
         is_no_match = "Could not find" in err_str
         is_ambiguous = "Found" in err_str and "matches" in err_str and "old_string" in err_str
+        has_diagnostic = bool(result_dict.get("_diagnostic"))
         if err_str and (is_no_match or is_ambiguous):
             # Track per-file consecutive failures for replace mode.  The
             # ``path`` arg only exists for replace mode; for V4A patches
@@ -1888,7 +1919,13 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 resolved = _path_to_resolved.get(path) or path
                 failure_count = _record_patch_failure(task_id, resolved)
 
-            if failure_count >= 3:
+            # Config-gated retry threshold (#996).  After this many
+            # consecutive failures on the same file, classify the failure
+            # as "permanent" and instruct the model to stop retrying and
+            # use an alternative strategy (re-read or write_file).
+            retry_threshold = _get_self_correction_retries()
+
+            if failure_count >= retry_threshold:
                 # Escalating hint after multiple consecutive failures on the
                 # same path.  Most common cause is a stale view of the file —
                 # the model is retrying with the same old_string against
@@ -1896,15 +1933,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # so the model recognises it's in a loop and breaks out by
                 # re-reading or falling back to write_file.
                 result_dict["_hint"] = (
-                    f"This is failure #{failure_count} patching {path!r}. "
-                    "Stop retrying with variations of the same old_string. "
-                    "Either: (1) re-read the file fresh to verify current "
-                    "content, (2) use a longer / more unique old_string with "
-                    "surrounding context lines, or (3) use write_file to "
-                    "replace the entire file if the targeted region is hard "
-                    "to anchor."
+                    f"PERMANENT FAILURE: This is failure #{failure_count} "
+                    f"patching {path!r}, exceeding the retry threshold of "
+                    f"{retry_threshold}. Stop retrying with variations of "
+                    f"the same old_string. Either: (1) re-read the file fresh "
+                    f"to verify current content, (2) use a longer / more "
+                    f"unique old_string with surrounding context lines, or "
+                    f"(3) use write_file to replace the entire file if the "
+                    f"targeted region is hard to anchor."
                 )
-            elif is_ambiguous:
+            elif is_ambiguous and not has_diagnostic:
                 result_dict["_hint"] = (
                     "Multiple matches found. Use read_file to see the "
                     "surrounding context at each match location, then "
@@ -1912,7 +1950,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "the target. The error message above shows the line "
                     "content at each match."
                 )
-            elif "Did you mean one of these sections?" not in err_str:
+            elif not has_diagnostic and "Did you mean one of these sections?" not in err_str:
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -965,3 +965,211 @@ def format_no_match_hint(error: Optional[str], match_count: int,
     if not hint:
         return ""
     return "\n\nDid you mean one of these sections?\n" + hint
+
+
+# ---------------------------------------------------------------------------
+# Structured error context for self-correction (issue #996)
+#
+# The functions below build a rich, structured error package that gives the
+# model everything it needs to produce a corrected patch on its next turn
+# WITHOUT re-reading the file: the error type, the closest matching lines
+# with line numbers, and the surrounding file content near the best match.
+#
+# This is the "Aider-style self-correction reflection loop" adapted to
+# Hermes's architecture: rather than re-invoking the LLM from inside the
+# tool handler (which would break the conversation loop, prompt caching,
+# and the narrow-waist principle), we enrich the tool-result error so the
+# model naturally self-corrects on its next turn.  The model already retries
+# failed patches — it just needs better information to guide the retry.
+# ---------------------------------------------------------------------------
+
+# Error-type classification labels.  These appear in the structured error
+# package so the model can reason about WHY the patch failed and choose the
+# right recovery strategy (re-read, add context, fix escapes, etc.).
+ERROR_TYPES = {
+    "no_match": "old_string not found in file",
+    "ambiguous": "multiple matches found — old_string is not unique",
+    "identical": "old_string and new_string are identical — no change needed",
+    "escape_drift": "escape-drift detected — likely tool-call serialization artifact",
+    "permission": "permission denied or protected path",
+    "read_failed": "could not read the file",
+    "write_failed": "could not write changes to the file",
+    "unknown": "unclassified failure",
+}
+
+
+def classify_error(error: Optional[str], strategy: Optional[str]) -> str:
+    """Classify a patch error string into a known error type.
+
+    Returns one of the keys from ``ERROR_TYPES``.
+    """
+    if not error:
+        return "unknown"
+    err = error.lower()
+    if strategy == "identical" or "identical" in err:
+        return "identical"
+    if "escape-drift" in err or "escape drift" in err:
+        return "escape_drift"
+    if "found" in err and "matches" in err:
+        return "ambiguous"
+    if "could not find" in err or "not find a match" in err:
+        return "no_match"
+    if "permission" in err or "denied" in err or "protected" in err:
+        return "permission"
+    if "failed to read" in err:
+        return "read_failed"
+    if "failed to write" in err:
+        return "write_failed"
+    return "unknown"
+
+
+def _format_file_context_snippet(
+    content: str,
+    old_string: str,
+    context_lines: int = 5,
+) -> str:
+    """Return a snippet of ``content`` around the best-matching region.
+
+    Uses the same line-similarity scoring as ``find_closest_lines`` to
+    locate the region of the file most similar to ``old_string``, then
+    returns ``±context_lines`` lines of file content with line numbers
+    so the model can see exactly what's there and craft a corrected
+    ``old_string`` without needing to re-read.
+
+    Returns an empty string when no useful snippet can be produced.
+    """
+    if not old_string or not content:
+        return ""
+
+    old_lines = old_string.splitlines()
+    content_lines = content.splitlines()
+
+    if not old_lines or not content_lines:
+        return ""
+
+    # Use first non-blank line of old_string as anchor
+    anchor = ""
+    for line in old_lines:
+        if line.strip():
+            anchor = line.strip()
+            break
+    if not anchor:
+        return ""
+
+    # Score each line by similarity to anchor
+    best_ratio = 0.0
+    best_idx = -1
+    for i, line in enumerate(content_lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        ratio = SequenceMatcher(None, anchor, stripped).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_idx = i
+
+    if best_idx < 0 or best_ratio < 0.3:
+        return ""
+
+    # Build the ±context_lines snippet around the best match
+    start = max(0, best_idx - context_lines)
+    end = min(len(content_lines), best_idx + len(old_lines) + context_lines)
+
+    snippet_lines = []
+    for j in range(start, end):
+        marker = ">>" if j == best_idx else "  "
+        snippet_lines.append(f"{j + 1:4d}{marker}| {content_lines[j]}")
+
+    return "\n".join(snippet_lines)
+
+
+def format_structured_error(
+    error: Optional[str],
+    match_count: int,
+    old_string: str,
+    new_string: str,
+    content: str,
+    file_path: str = "",
+    strategy: Optional[str] = None,
+) -> str:
+    """Build a structured error context for patch failures (issue #996).
+
+    Returns a multi-section diagnostic string containing:
+    - Error type classification
+    - The file path (when provided)
+    - The closest matching region with line numbers (±5 lines)
+    - A recovery suggestion matched to the error type
+
+    Returns an empty string when the error doesn't warrant structured
+    context (e.g. successful operations).
+    """
+    if not error:
+        return ""
+
+    error_type = classify_error(error, strategy)
+
+    # Don't add structured context for non-match failures that already
+    # have clear messages (permission, read/write failures).
+    if error_type in ("permission", "read_failed", "write_failed", "unknown"):
+        return ""
+
+    sections: List[str] = []
+    sections.append(f"Error type: {error_type} — {ERROR_TYPES.get(error_type, '')}")
+    if file_path:
+        sections.append(f"File: {file_path}")
+
+    # For no-match: show the closest matching region so the model can
+    # see what's actually there and craft a corrected old_string.
+    if error_type == "no_match":
+        snippet = _format_file_context_snippet(content, old_string, context_lines=5)
+        if snippet:
+            sections.append(
+                "Closest matching region in the file (>> marks best match):\n"
+                + snippet
+            )
+
+    # For ambiguous: the error message already lists the match locations,
+    # so we just add a recovery hint.
+    if error_type == "ambiguous":
+        sections.append(
+            "Recovery: provide a longer old_string with more surrounding "
+            "context lines to make the match unique, or use replace_all=True "
+            "if you intend to replace all occurrences."
+        )
+
+    # For escape-drift: the error already explains the issue; add a
+    # concise recovery hint.
+    if error_type == "escape_drift":
+        sections.append(
+            "Recovery: re-read the file with read_file, then pass "
+            "old_string/new_string without backslash-escaping apostrophe "
+            "or quote characters."
+        )
+
+    # For identical: just confirm no action needed.
+    if error_type == "identical":
+        sections.append(
+            "Recovery: no action needed — the file is already in the "
+            "desired state. Proceed with the next step."
+        )
+
+    # For no-match with a snippet, add a general recovery hint.
+    if error_type == "no_match":
+        snippet = _format_file_context_snippet(content, old_string, context_lines=5)
+        if snippet:
+            sections.append(
+                "Recovery: use the closest matching region above to craft "
+                "a corrected old_string that exactly matches the file's "
+                "current content (including indentation). Alternatively, "
+                "use read_file to see the full file, or use write_file to "
+                "replace the entire file if the targeted region is hard to "
+                "anchor."
+            )
+        else:
+            # No snippet found — fall back to the generic hint
+            sections.append(
+                "Recovery: use read_file to verify the current file "
+                "content, or search_files to locate the text."
+            )
+
+    return "\n\n".join(sections)


### PR DESCRIPTION
## Summary

Enriches patch-failure error output with structured error context so the model can self-correct on its next turn without re-reading the file.

## Problem (Issue #996)

When a patch fails, the model receives a bare error string like `Could not find match for old_string` with no context about what's actually in the file. This causes retry loops where the model makes slight variations of the same incorrect old_string, wasting turns and tokens.

Issue #996 proposed an "automatic guided retry" that re-invokes the LLM from inside the tool handler. This was **deliberately not implemented** — it would violate the narrow-waist principle, break conversation loop tracking, break prompt caching, and create circular dependencies between the tool layer and model layer.

## Solution

Instead of re-invoking the LLM, we **enrich the tool-result error** so the model naturally self-corrects on its next turn. The model already retries failed patches — it just needs better information to guide the retry.

### Error package contents
1. **Error type classification** — `no_match`, `ambiguous`, `identical`, `escape_drift`, `permission`, etc.
2. **Closest matching region** — ±5 lines of file content with line numbers around the best match, so the model can see what's actually there
3. **Recovery suggestion** — matched to the error type (re-read, add context, use replace_all, fix escapes, etc.)

### Config gate
```yaml
patch:
  self_correction_retries: 3  # 1-5, default 3
```

Controls how many consecutive patch failures on the same file before the error is classified as `PERMANENT FAILURE` and the model is instructed to stop retrying.

## Files changed
- `tools/fuzzy_match.py` — `classify_error()`, `_format_file_context_snippet()`, `format_structured_error()`
- `tools/file_operations.py` — `PatchResult.structured_error` field; `patch_replace` builds structured context on failure
- `tools/file_tools.py` — `patch_tool` consumes `_diagnostic`; config-gated retry threshold; `PERMANENT FAILURE` classification
- `hermes_cli/config.py` — `patch.self_correction_retries` in DEFAULT_CONFIG
- `tests/tools/test_patch_self_correction.py` — 34 new tests
- `tests/tools/test_patch_failure_tracking.py` — updated escalation assertion

## Test results
```
12 files, 407 tests passed, 0 failed
```

Closes #996