### PR TITLE
feat(patch): structured error context for self-correction (Closes #996)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -137,6 +137,7 @@ def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
     except Exception:
         pass
 
+
 _IS_WINDOWS = platform.system() == "Windows"
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -180,22 +181,43 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # planting them.
 _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # Loader / linker
-    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG",
-    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
-    "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FALLBACK_FRAMEWORK_PATH",
     # Python
-    "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
-    "PYTHONEXECUTABLE", "PYTHONNOUSERSITE",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE",
+    "PYTHONNOUSERSITE",
     # Node
-    "NODE_OPTIONS", "NODE_PATH",
+    "NODE_OPTIONS",
+    "NODE_PATH",
     # General
-    "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+    "PATH",
+    "SHELL",
+    "BROWSER",
+    "EDITOR",
+    "VISUAL",
+    "PAGER",
     # Git
-    "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+    "GIT_SSH_COMMAND",
+    "GIT_EXEC_PATH",
+    "GIT_SHELL",
     # Hermes runtime location — never via dashboard env writer.
     # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
-    "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+    "HERMES_CONFIG",
+    "HERMES_ENV",
 })
 
 
@@ -215,6 +237,7 @@ def _reject_denylisted_env_var(key: str) -> None:
             "~/.hermes/.env directly."
         )
 
+
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
 # load_config() returns a deepcopy of the cached value when the file
@@ -228,7 +251,9 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # editing the managed-scope config.yaml invalidates the cache (see
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+_LOAD_CONFIG_CACHE: Dict[
+    str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]
+] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -244,46 +269,104 @@ _CONFIG_LOCK = threading.RLock()
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
-    "OPENAI_API_KEY", "OPENAI_BASE_URL",
-    "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
-    "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME",
-    "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME",
-    "SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME",
-    "SIGNAL_ACCOUNT", "SIGNAL_HTTP_URL",
-    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
-    "SIGNAL_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL_NAME",
-    "SMS_HOME_CHANNEL", "SMS_HOME_CHANNEL_NAME",
-    "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
-    "DINGTALK_HOME_CHANNEL", "DINGTALK_HOME_CHANNEL_NAME",
-    "FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_ENCRYPT_KEY", "FEISHU_VERIFICATION_TOKEN",
-    "FEISHU_HOME_CHANNEL", "FEISHU_HOME_CHANNEL_NAME",
-    "YUANBAO_HOME_CHANNEL", "YUANBAO_HOME_CHANNEL_NAME",
-    "WECOM_BOT_ID", "WECOM_SECRET",
-    "WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET", "WECOM_CALLBACK_AGENT_ID",
-    "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_ENCODING_AES_KEY",
-    "WECOM_CALLBACK_HOST", "WECOM_CALLBACK_PORT",
-    "WECOM_HOME_CHANNEL", "WECOM_HOME_CHANNEL_NAME",
-    "WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN", "WEIXIN_BASE_URL", "WEIXIN_CDN_BASE_URL",
-    "WEIXIN_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL_NAME", "WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY",
-    "WEIXIN_ALLOWED_USERS", "WEIXIN_GROUP_ALLOWED_USERS", "WEIXIN_ALLOW_ALL_USERS",
-    "BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD",
-    "BLUEBUBBLES_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL_NAME",
-    "QQ_APP_ID", "QQ_CLIENT_SECRET", "QQBOT_HOME_CHANNEL", "QQBOT_HOME_CHANNEL_NAME",
-    "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
-    "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
-    "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
-    "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
-    "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
-    "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SMS_HOME_CHANNEL",
+    "SMS_HOME_CHANNEL_NAME",
+    "DINGTALK_CLIENT_ID",
+    "DINGTALK_CLIENT_SECRET",
+    "DINGTALK_HOME_CHANNEL",
+    "DINGTALK_HOME_CHANNEL_NAME",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_HOME_CHANNEL",
+    "FEISHU_HOME_CHANNEL_NAME",
+    "YUANBAO_HOME_CHANNEL",
+    "YUANBAO_HOME_CHANNEL_NAME",
+    "WECOM_BOT_ID",
+    "WECOM_SECRET",
+    "WECOM_CALLBACK_CORP_ID",
+    "WECOM_CALLBACK_CORP_SECRET",
+    "WECOM_CALLBACK_AGENT_ID",
+    "WECOM_CALLBACK_TOKEN",
+    "WECOM_CALLBACK_ENCODING_AES_KEY",
+    "WECOM_CALLBACK_HOST",
+    "WECOM_CALLBACK_PORT",
+    "WECOM_HOME_CHANNEL",
+    "WECOM_HOME_CHANNEL_NAME",
+    "WEIXIN_ACCOUNT_ID",
+    "WEIXIN_TOKEN",
+    "WEIXIN_BASE_URL",
+    "WEIXIN_CDN_BASE_URL",
+    "WEIXIN_HOME_CHANNEL",
+    "WEIXIN_HOME_CHANNEL_NAME",
+    "WEIXIN_DM_POLICY",
+    "WEIXIN_GROUP_POLICY",
+    "WEIXIN_ALLOWED_USERS",
+    "WEIXIN_GROUP_ALLOWED_USERS",
+    "WEIXIN_ALLOW_ALL_USERS",
+    "BLUEBUBBLES_SERVER_URL",
+    "BLUEBUBBLES_PASSWORD",
+    "BLUEBUBBLES_HOME_CHANNEL",
+    "BLUEBUBBLES_HOME_CHANNEL_NAME",
+    "QQ_APP_ID",
+    "QQ_CLIENT_SECRET",
+    "QQBOT_HOME_CHANNEL",
+    "QQBOT_HOME_CHANNEL_NAME",
+    "QQ_HOME_CHANNEL",
+    "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
+    "QQ_ALLOWED_USERS",
+    "QQ_GROUP_ALLOWED_USERS",
+    "QQ_ALLOW_ALL_USERS",
+    "QQ_MARKDOWN_SUPPORT",
+    "QQ_STT_API_KEY",
+    "QQ_STT_BASE_URL",
+    "QQ_STT_MODEL",
+    "IRC_SERVER",
+    "IRC_PORT",
+    "IRC_NICKNAME",
+    "IRC_CHANNEL",
+    "IRC_USE_TLS",
+    "IRC_SERVER_PASSWORD",
+    "IRC_NICKSERV_PASSWORD",
+    "TERMINAL_ENV",
+    "TERMINAL_SSH_KEY",
+    "TERMINAL_SSH_PORT",
     # Deprecated tool-progress env vars — replaced by display.tool_progress in
     # config.yaml. Kept known here so .env sanitization/reload still handle
     # them for existing users (gateway reads them as a back-compat fallback),
     # without surfacing them in user-facing OPTIONAL_ENV_VARS listings.
-    "HERMES_TOOL_PROGRESS", "HERMES_TOOL_PROGRESS_MODE",
-    "WHATSAPP_MODE", "WHATSAPP_ENABLED",
-    "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
-    "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
-    "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
+    "HERMES_TOOL_PROGRESS",
+    "HERMES_TOOL_PROGRESS_MODE",
+    "WHATSAPP_MODE",
+    "WHATSAPP_ENABLED",
+    "MATTERMOST_HOME_CHANNEL",
+    "MATTERMOST_HOME_CHANNEL_NAME",
+    "MATTERMOST_REPLY_MODE",
+    "MATRIX_PASSWORD",
+    "MATRIX_ENCRYPTION",
+    "MATRIX_DEVICE_ID",
+    "MATRIX_HOME_ROOM",
+    "MATRIX_REQUIRE_MENTION",
+    "MATRIX_FREE_RESPONSE_ROOMS",
+    "MATRIX_AUTO_THREAD",
+    "MATRIX_DM_AUTO_THREAD",
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable
@@ -494,6 +577,7 @@ def is_uv_tool_install() -> bool:
     ``hermes update`` to upgrade the wrong copy. It would also block on a
     subprocess call (~seconds) just to compute a recommendation string.
     """
+
     def _has_uv_tool_marker(path: str) -> bool:
         norm = os.path.normpath(path).replace(os.sep, "/").lower()
         return "/uv/tools/hermes-agent/" in norm + "/"
@@ -517,6 +601,7 @@ def recommended_update_command_for_method(method: str) -> str:
         if is_uv_tool_install():
             return "uv tool upgrade hermes-agent"
         import shutil
+
         if shutil.which("uv"):
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
@@ -612,6 +697,7 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
         "Use your package manager to upgrade or reinstall Hermes."
     )
 
+
 def managed_error(action: str = "modify configuration"):
     """Print user-friendly error for managed mode."""
     print(format_managed_message(action), file=sys.stderr)
@@ -620,6 +706,7 @@ def managed_error(action: str = "modify configuration"):
 # =============================================================================
 # Container-aware CLI (NixOS container mode)
 # =============================================================================
+
 
 def get_container_exec_info() -> Optional[dict]:
     """Read container mode metadata from HERMES_HOME/.container-mode.
@@ -636,6 +723,7 @@ def get_container_exec_info() -> Optional[dict]:
         return None
 
     from hermes_constants import is_container
+
     if is_container():
         return None
 
@@ -674,17 +762,21 @@ def get_container_exec_info() -> Optional[dict]:
 from hermes_constants import get_hermes_home  # noqa: F811,E402
 from utils import atomic_replace, fast_safe_load
 
+
 def get_config_path() -> Path:
     """Get the main config file path."""
     return get_hermes_home() / "config.yaml"
+
 
 def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""
     return get_hermes_home() / ".env"
 
+
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
 
 def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
     """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.
@@ -795,7 +887,11 @@ def _is_container() -> bool:
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup_content = f.read()
-        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
+        if (
+            "docker" in cgroup_content
+            or "lxc" in cgroup_content
+            or "kubepods" in cgroup_content
+        ):
             return True
     except (OSError, IOError):
         pass
@@ -868,8 +964,16 @@ def ensure_hermes_home():
         home.mkdir(parents=True, exist_ok=True)
         _secure_dir(home)
         for subdir in (
-            "cron", "sessions", "logs", "logs/curator", "memories",
-            "pairing", "hooks", "image_cache", "audio_cache", "skills",
+            "cron",
+            "sessions",
+            "logs",
+            "logs/curator",
+            "memories",
+            "pairing",
+            "hooks",
+            "image_cache",
+            "audio_cache",
+            "skills",
         ):
             d = home / subdir
             d.mkdir(parents=True, exist_ok=True)
@@ -881,15 +985,13 @@ def _ensure_hermes_home_managed(home: Path):
     """Managed-mode variant: verify dirs exist (activation creates them), seed SOUL.md."""
     if not home.is_dir():
         raise RuntimeError(
-            f"HERMES_HOME {home} does not exist. "
-            "Run 'sudo nixos-rebuild switch' first."
+            f"HERMES_HOME {home} does not exist. Run 'sudo nixos-rebuild switch' first."
         )
     for subdir in ("cron", "sessions", "logs", "memories"):
         d = home / subdir
         if not d.is_dir():
             raise RuntimeError(
-                f"{d} does not exist. "
-                "Run 'sudo nixos-rebuild switch' first."
+                f"{d} does not exist. Run 'sudo nixos-rebuild switch' first."
             )
     # Curator reports dir is a sub-path of logs/; create it if missing.
     # In managed mode the activation script may not know about this subdir,
@@ -1112,7 +1214,6 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
     },
-    
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",
@@ -1174,9 +1275,9 @@ DEFAULT_CONFIG = {
         "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         # Container resource limits (docker, singularity, modal, daytona — ignored for local/ssh)
         "container_cpu": 1,
-        "container_memory": 5120,       # MB (default 5GB)
-        "container_disk": 51200,        # MB (default 50GB)
-        "container_persistent": True,   # Persist filesystem across sessions
+        "container_memory": 5120,  # MB (default 5GB)
+        "container_disk": 51200,  # MB (default 50GB)
+        "container_persistent": True,  # Persist filesystem across sessions
         # Docker volume mounts — share host directories with the container.
         # Each entry is "host_path:container_path" (standard Docker -v syntax).
         # Example:
@@ -1191,7 +1292,7 @@ DEFAULT_CONFIG = {
         # Opt-in egress lockdown for Docker terminal sessions. When false,
         # Docker runs with --network=none so commands cannot reach the network.
         "docker_network": True,
-        "docker_extra_args": [],        # Extra flags passed verbatim to docker run
+        "docker_extra_args": [],  # Extra flags passed verbatim to docker run
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)
@@ -1209,15 +1310,13 @@ DEFAULT_CONFIG = {
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
     },
-
     "web": {
-        "backend": "",           # shared fallback — applies to both search and extract
-        "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
-        "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "backend": "",  # shared fallback — applies to both search and extract
+        "search_backend": "",  # per-capability override for web_search (e.g. "searxng")
+        "extract_backend": "",  # per-capability override for web_extract (e.g. "native")
         "search_backend_fallback_chain": "",
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
     },
-
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
@@ -1257,7 +1356,6 @@ DEFAULT_CONFIG = {
             "loopback_host_alias": "host.docker.internal",
         },
     },
-
     # Filesystem checkpoints — automatic snapshots before destructive file ops.
     # When enabled, the agent takes a snapshot of the working directory once
     # per conversation turn (on first write_file/patch call).  Use /rollback
@@ -1296,7 +1394,6 @@ DEFAULT_CONFIG = {
         "delete_orphans": True,
         "min_interval_hours": 24,
     },
-
     # Hard cap (chars) for a single automatic context file such as SOUL.md,
     # AGENTS.md, CLAUDE.md, .hermes.md, or .cursorrules before Hermes applies
     # head/tail truncation. ``null`` (the default) lets the cap scale with the
@@ -1304,12 +1401,10 @@ DEFAULT_CONFIG = {
     # rarely truncate a project doc. Set a positive integer to pin a fixed cap
     # and override the dynamic behavior. Separate from read_file tool limits.
     "context_file_max_chars": None,
-
     # Maximum characters returned by a single read_file call.  Reads that
     # exceed this are rejected with guidance to use offset+limit.
     # 100K chars ≈ 25–35K tokens across typical tokenisers.
     "file_read_max_chars": 100_000,
-
     # Seconds to wait at agent-build time for in-flight MCP server discovery
     # to finish before the agent snapshots its tool list.  MCP discovery runs
     # in a background thread so a slow/dead server can't freeze startup; this
@@ -1324,7 +1419,6 @@ DEFAULT_CONFIG = {
     # (see agent/turn_context.py), so correctness never depends on it.  Keep it
     # small so a slow/dead server adds little to first-response latency.
     "mcp_discovery_timeout": 1.5,
-
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the
     # payload sent to the model (keeping head + tail for terminal,
@@ -1344,7 +1438,6 @@ DEFAULT_CONFIG = {
         "max_lines": 2000,
         "max_line_length": 2000,
     },
-
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
@@ -1362,71 +1455,69 @@ DEFAULT_CONFIG = {
             "idempotent_no_progress": 5,
         },
     },
-
     "compression": {
         "enabled": True,
-        "threshold": 0.50,            # compress when context usage exceeds this ratio
-        "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
-        "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "threshold": 0.50,  # compress when context usage exceeds this ratio
+        "target_ratio": 0.20,  # fraction of threshold to preserve as recent tail
+        "protect_last_n": 20,  # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
-        "protect_first_n": 3,         # non-system head messages always preserved
-                                      # verbatim, in ADDITION to the system prompt
-                                      # (which is always implicitly protected). Set to
-                                      # 0 for long-running rolling-compaction sessions
-                                      # where you want nothing pinned except the
-                                      # system prompt + rolling summary + recent tail.
+        "protect_first_n": 3,  # non-system head messages always preserved
+        # verbatim, in ADDITION to the system prompt
+        # (which is always implicitly protected). Set to
+        # 0 for long-running rolling-compaction sessions
+        # where you want nothing pinned except the
+        # system prompt + rolling summary + recent tail.
         "abort_on_summary_failure": False,  # When True, auto-compression that fails
-                                      # to generate a summary (aux LLM errored / returned
-                                      # non-JSON / timed out) aborts entirely instead of
-                                      # dropping the middle window with a static
-                                      # "summary unavailable" placeholder.  Messages are
-                                      # preserved unchanged and the session "freezes" at
-                                      # its current size until the user runs /compress
-                                      # (which bypasses the failure cooldown) or /new.
-                                      # Default False matches historical behavior; set to
-                                      # True if you'd rather pause than silently lose
-                                      # context turns when your aux model is flaky.
+        # to generate a summary (aux LLM errored / returned
+        # non-JSON / timed out) aborts entirely instead of
+        # dropping the middle window with a static
+        # "summary unavailable" placeholder.  Messages are
+        # preserved unchanged and the session "freezes" at
+        # its current size until the user runs /compress
+        # (which bypasses the failure cooldown) or /new.
+        # Default False matches historical behavior; set to
+        # True if you'd rather pause than silently lose
+        # context turns when your aux model is flaky.
         "codex_gpt55_autoraise": True,  # Historical key name kept for compatibility.
-                                      # When True, gpt-5.4 / gpt-5.5 on the ChatGPT Codex
-                                      # OAuth route raise their compaction trigger to 85%
-                                      # (vs the global `threshold` above). Codex hard-caps
-                                      # both families at a 272K window, so the default 50%
-                                      # would compact at ~136K and waste half the usable
-                                      # context. Set to False to opt back down to the global
-                                      # threshold (e.g. 0.50) for those Codex sessions.
-                                      # Only this exact route is affected — gpt-5.4 / 5.5
-                                      # on OpenAI's direct API, OpenRouter, and Copilot keep
-                                      # the global threshold regardless.
+        # When True, gpt-5.4 / gpt-5.5 on the ChatGPT Codex
+        # OAuth route raise their compaction trigger to 85%
+        # (vs the global `threshold` above). Codex hard-caps
+        # both families at a 272K window, so the default 50%
+        # would compact at ~136K and waste half the usable
+        # context. Set to False to opt back down to the global
+        # threshold (e.g. 0.50) for those Codex sessions.
+        # Only this exact route is affected — gpt-5.4 / 5.5
+        # on OpenAI's direct API, OpenRouter, and Copilot keep
+        # the global threshold regardless.
         "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.4/5.5
-                                      # autoraise banner. Set False to keep the
-                                      # 85% threshold autoraise but suppress the
-                                      # user-facing notice in CLI/gateway output.
+        # autoraise banner. Set False to keep the
+        # 85% threshold autoraise but suppress the
+        # user-facing notice in CLI/gateway output.
         "codex_app_server_auto": "native",  # Codex app-server (codex CLI runtime) thread
-                                      # compaction mode. The codex agent owns the real
-                                      # thread context, so Hermes' summarizer cannot
-                                      # shrink it (#36801). native = codex decides when
-                                      # to compact its own thread (default); hermes =
-                                      # Hermes' compression threshold triggers
-                                      # thread/compact/start; off = never auto-trigger
-                                      # (codex may still compact natively).
-        "in_place": True,             # When True, compaction rewrites the message
-                                      # list and rebuilds the system prompt WITHOUT
-                                      # rotating the session id — the conversation
-                                      # keeps one durable id for its whole life
-                                      # (no parent_session_id chain, no `name #N`
-                                      # renumbering). Eliminates the session-rotation
-                                      # bug cluster (#33618 /goal loss, #14238 lost
-                                      # response, #33907 orphans, #45117 search gaps,
-                                      # #42228 null cwd) — see #38763. Non-destructive:
-                                      # the live context is compacted (lossy for what
-                                      # the model reloads), but the pre-compaction
-                                      # turns are soft-archived under the same id
-                                      # (active=0, compacted=1) — still searchable via
-                                      # session_search and recoverable, not deleted.
-                                      # Default False during rollout; will flip on
-                                      # after live validation.
+        # compaction mode. The codex agent owns the real
+        # thread context, so Hermes' summarizer cannot
+        # shrink it (#36801). native = codex decides when
+        # to compact its own thread (default); hermes =
+        # Hermes' compression threshold triggers
+        # thread/compact/start; off = never auto-trigger
+        # (codex may still compact natively).
+        "in_place": True,  # When True, compaction rewrites the message
+        # list and rebuilds the system prompt WITHOUT
+        # rotating the session id — the conversation
+        # keeps one durable id for its whole life
+        # (no parent_session_id chain, no `name #N`
+        # renumbering). Eliminates the session-rotation
+        # bug cluster (#33618 /goal loss, #14238 lost
+        # response, #33907 orphans, #45117 search gaps,
+        # #42228 null cwd) — see #38763. Non-destructive:
+        # the live context is compacted (lossy for what
+        # the model reloads), but the pre-compaction
+        # turns are soft-archived under the same id
+        # (active=0, compacted=1) — still searchable via
+        # session_search and recoverable, not deleted.
+        # Default False during rollout; will flip on
+        # after live validation.
     },
-
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).
     # See tools/kanban_tools.py and hermes_cli/kanban_db.py for the actual
     # implementations. Per-platform notification opt-out is handled by the
@@ -1441,13 +1532,11 @@ DEFAULT_CONFIG = {
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
     },
-
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
         "cache_ttl": "5m",
     },
-
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).
@@ -1468,14 +1557,13 @@ DEFAULT_CONFIG = {
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
     },
-
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {
         "region": "",  # AWS region for Bedrock API calls (empty = AWS_REGION env var → us-east-1)
         "discovery": {
-            "enabled": True,           # Auto-discover models via ListFoundationModels
-            "provider_filter": [],     # Only show models from these providers (e.g. ["anthropic", "amazon"])
+            "enabled": True,  # Auto-discover models via ListFoundationModels
+            "provider_filter": [],  # Only show models from these providers (e.g. ["anthropic", "amazon"])
             "refresh_interval": 3600,  # Cache discovery results for this many seconds
         },
         "guardrail": {
@@ -1483,12 +1571,11 @@ DEFAULT_CONFIG = {
             # Create a guardrail in the Bedrock console, then set the ID and version here.
             # See: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
             "guardrail_identifier": "",  # e.g. "abc123def456"
-            "guardrail_version": "",     # e.g. "1" or "DRAFT"
+            "guardrail_version": "",  # e.g. "1" or "DRAFT"
             "stream_processing_mode": "async",  # "sync" or "async"
-            "trace": "disabled",         # "enabled", "disabled", or "enabled_full"
+            "trace": "disabled",  # "enabled", "disabled", or "enabled_full"
         },
     },
-
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
@@ -1524,12 +1611,12 @@ DEFAULT_CONFIG = {
         # call.
         "transient_retries": 2,
         "vision": {
-            "provider": "auto",    # auto | openrouter | nous | codex | custom
-            "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
-            "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
-            "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
-            "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
-            "extra_body": {},      # OpenAI-compatible provider-specific request fields
+            "provider": "auto",  # auto | openrouter | nous | codex | custom
+            "model": "",  # e.g. "google/gemini-2.5-flash", "gpt-4o"
+            "base_url": "",  # direct OpenAI-compatible endpoint (takes precedence over provider)
+            "api_key": "",  # API key for base_url (falls back to OPENAI_API_KEY)
+            "timeout": 120,  # seconds — LLM API call timeout; vision payloads need generous timeout
+            "extra_body": {},  # OpenAI-compatible provider-specific request fields
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
         "web_extract": {
@@ -1537,7 +1624,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
+            "timeout": 360,  # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
             "extra_body": {},
         },
         "compression": {
@@ -1545,7 +1632,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 120,  # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —
@@ -1562,7 +1649,7 @@ DEFAULT_CONFIG = {
         },
         "approval": {
             "provider": "auto",
-            "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)
+            "model": "",  # fast/cheap model recommended (e.g. gemini-flash, haiku)
             "base_url": "",
             "api_key": "",
             "timeout": 30,
@@ -1714,7 +1801,6 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
     },
-
     "display": {
         "compact": False,
         "personality": "",
@@ -1722,10 +1808,10 @@ DEFAULT_CONFIG = {
         # Recap tuning for /resume and startup resume. The defaults match the
         # historical hardcoded values; expose them as config so power users can
         # widen or tighten the snapshot to taste.
-        "resume_exchanges": 10,            # max user+assistant pairs to show
-        "resume_max_user_chars": 300,      # truncate user message text
-        "resume_max_assistant_chars": 200, # truncate non-last assistant text
-        "resume_max_assistant_lines": 3,   # truncate non-last assistant lines
+        "resume_exchanges": 10,  # max user+assistant pairs to show
+        "resume_max_user_chars": 300,  # truncate user message text
+        "resume_max_assistant_chars": 200,  # truncate non-last assistant text
+        "resume_max_assistant_lines": 3,  # truncate non-last assistant lines
         # When True (default), assistant entries that are *only* tool calls
         # (no visible text) are skipped in the recap. This prevents the recap
         # from being dominated by `[2 tool calls: terminal, read_file]` lines
@@ -1770,7 +1856,7 @@ DEFAULT_CONFIG = {
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
         "streaming": False,
-        "timestamps": False,      # Show timestamp on user and assistant labels
+        "timestamps": False,  # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
@@ -1782,7 +1868,7 @@ DEFAULT_CONFIG = {
         # clarify) into scrollback so the question and decision survive the
         # panel repaint. Set false to keep scrollback untouched.
         "persist_prompts": True,
-        "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        "inline_diffs": True,  # Show inline diff previews for write actions (write_file, patch, skill_manage)
         # File-mutation verifier footer.  When true (default), the agent
         # appends a one-line advisory to its final response whenever a
         # write_file / patch call failed during the turn and was never
@@ -1803,7 +1889,7 @@ DEFAULT_CONFIG = {
         # iteration/budget limit.  Replaces the bare "(empty)" sentinel so the
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
-        "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "show_cost": False,  # Show $ cost in the status bar (off by default)
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
@@ -1934,7 +2020,6 @@ DEFAULT_CONFIG = {
             "unicode_cols": 0,
         },
     },
-
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
@@ -2036,12 +2121,10 @@ DEFAULT_CONFIG = {
         # the login flow.
         "public_url": "",
     },
-
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
-    
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
@@ -2087,7 +2170,7 @@ DEFAULT_CONFIG = {
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
-            "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
+            "ref_text": "",  # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
         },
@@ -2105,7 +2188,6 @@ DEFAULT_CONFIG = {
             # "normalize_audio": True,
         },
     },
-    
     "stt": {
         "enabled": True,
         # When true, gateway voice messages are transcribed for the agent and
@@ -2130,22 +2212,19 @@ DEFAULT_CONFIG = {
             "diarize": False,
         },
     },
-
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
-        "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
-        "silence_threshold": 200,     # RMS below this = silence (0-32767)
-        "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "beep_enabled": True,  # Play record start/stop beeps in CLI voice mode
+        "silence_threshold": 200,  # RMS below this = silence (0-32767)
+        "silence_duration": 3.0,  # Seconds of silence before auto-stop
     },
-    
     "human_delay": {
         "mode": "off",
         "min_ms": 800,
         "max_ms": 2500,
     },
-    
     # Context engine -- controls how the context window is managed when
     # approaching the model's token limit.
     # "compressor" = built-in lossy summarization (default).
@@ -2155,7 +2234,6 @@ DEFAULT_CONFIG = {
     "context": {
         "engine": "compressor",
     },
-
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,
@@ -2173,28 +2251,27 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 2200,  # ~800 tokens at 2.75 chars/token
+        "user_char_limit": 1375,  # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
     },
-
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
     "delegation": {
-        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
-        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
-        "base_url": "",    # direct OpenAI-compatible endpoint for subagents
-        "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
-        "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",
-                           # "codex_responses", or "anthropic_messages". Empty = auto-detect
-                           # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
-                           # explicitly for non-standard endpoints the heuristic can't detect.
+        "model": "",  # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
+        "provider": "",  # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "base_url": "",  # direct OpenAI-compatible endpoint for subagents
+        "api_key": "",  # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "api_mode": "",  # wire protocol for delegation.base_url: "chat_completions",
+        # "codex_responses", or "anthropic_messages". Empty = auto-detect
+        # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
+        # explicitly for non-standard endpoints the heuristic can't detect.
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these
@@ -2202,7 +2279,7 @@ DEFAULT_CONFIG = {
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
-                               # independent of the parent's max_iterations)
+        # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch
         # fan-out (N children) returns N summaries at once, which can exceed
         # the parent's context window and trigger a compression/429 death
@@ -2218,23 +2295,22 @@ DEFAULT_CONFIG = {
         # instruction). 0 disables the hard ceiling; the dynamic headroom
         # budget still applies.
         "max_summary_chars": 24000,
-
         "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
-                                     # = no timeout: children fail only from real errors
-                                     # (API, tools, iteration budget), never a delegation
-                                     # stopwatch. Set a positive number of seconds
-                                     # (floor 30s) to enforce a hard cap.
+        # = no timeout: children fail only from real errors
+        # (API, tools, iteration budget), never a delegation
+        # stopwatch. Set a positive number of seconds
+        # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
-                                 # "low", "minimal", "none" (empty = inherit parent's level)
+        # "low", "minimal", "none" (empty = inherit parent's level)
         "max_concurrent_children": 3,  # unified concurrency cap: max parallel children per batch
-                                       # AND max concurrent background (background=true)
-                                       # delegation units. New async dispatches beyond the cap
-                                       # fall back to synchronous execution. Floor of 1, no ceiling.
-                                       # (Replaces the deprecated max_async_children.)
+        # AND max concurrent background (background=true)
+        # delegation units. New async dispatches beyond the cap
+        # fall back to synchronous execution. Floor of 1, no ceiling.
+        # (Replaces the deprecated max_async_children.)
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.
-        "max_spawn_depth": 1,        # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
+        "max_spawn_depth": 1,  # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
         "orchestrator_enabled": True,  # kill switch for role="orchestrator"
         # When a subagent hits a dangerous-command approval prompt, the parent's
         # prompt_toolkit TUI owns stdin — a thread-local input() call from the
@@ -2246,12 +2322,10 @@ DEFAULT_CONFIG = {
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
     },
-
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
     "prefill_messages_file": "",
-
     # Goals — persistent cross-turn goals (Ralph-style loop).
     # After every turn, a lightweight judge call asks the auxiliary model
     # whether the active /goal is satisfied by the assistant's last
@@ -2267,7 +2341,6 @@ DEFAULT_CONFIG = {
         # unbounded model spend on fuzzy / unachievable goals.
         "max_turns": 20,
     },
-
     # Mixture of Agents — named presets used by /moa. A preset is an execution
     # mode around the main model, not a provider/model itself: references +
     # aggregator synthesize private guidance before each main-model iteration.
@@ -2288,18 +2361,20 @@ DEFAULT_CONFIG = {
                     {"provider": "openai-codex", "model": "gpt-5.5"},
                     {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
                 ],
-                "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
                 "max_tokens": 4096,
                 "enabled": True,
             }
         },
     },
-
     # Skills — external skill directories for sharing skills across tools/agents.
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
     # always goes to ~/.hermes/skills/.
     "skills": {
-        "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "external_dirs": [],  # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
@@ -2338,7 +2413,6 @@ DEFAULT_CONFIG = {
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
     },
-
     # Curator — background skill maintenance.
     #
     # Periodically reviews AGENT-CREATED skills (never bundled or
@@ -2388,36 +2462,32 @@ DEFAULT_CONFIG = {
             "keep": 5,  # retain last N regular snapshots
         },
     },
-
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
     # This section is only needed for hermes-specific overrides; everything else
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
     "honcho": {},
-
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.
     "timezone": "",
-
     # Slack platform settings (gateway mode)
     "slack": {
-        "require_mention": True,       # Require @mention to respond in channels
+        "require_mention": True,  # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},  # Per-channel ephemeral system prompts
     },
-
     # Discord platform settings (gateway mode)
     "discord": {
-        "require_mention": True,       # Require @mention to respond in server channels
+        "require_mention": True,  # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "auto_thread": True,  # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
-        "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
-        "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
-        "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "history_backfill": True,  # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
+        "history_backfill_limit": 50,  # Max number of recent messages to scan when assembling the backfill block
+        "reactions": True,  # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},  # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
@@ -2455,14 +2525,14 @@ DEFAULT_CONFIG = {
         # stop-and-swap — the Grok-voice-mode feel. discord.py ships no mixer;
         # this is implemented in plugins/platforms/discord/voice_mixer.py.
         "voice_fx": {
-            "enabled": False,         # master switch for the mixer subsystem
+            "enabled": False,  # master switch for the mixer subsystem
             "ambient_enabled": True,  # play the idle "thinking" bed while tools run
-            "ambient_path": "",       # custom loop audio file; "" = synthesised pad
-            "ambient_gain": 0.18,     # idle bed loudness, 0.0–1.0
-            "duck_gain": 0.06,        # ambient loudness while speech plays
-            "speech_gain": 1.0,       # TTS / ack loudness, 0.0–1.0
-            "ack_enabled": True,      # speak a short phrase before the first tool call
-            "ack_phrases": [          # picked at random; set [] to disable phrases
+            "ambient_path": "",  # custom loop audio file; "" = synthesised pad
+            "ambient_gain": 0.18,  # idle bed loudness, 0.0–1.0
+            "duck_gain": 0.06,  # ambient loudness while speech plays
+            "speech_gain": 1.0,  # TTS / ack loudness, 0.0–1.0
+            "ack_enabled": True,  # speak a short phrase before the first tool call
+            "ack_phrases": [  # picked at random; set [] to disable phrases
                 "Let me look into that.",
                 "One moment.",
                 "Checking on that now.",
@@ -2471,7 +2541,6 @@ DEFAULT_CONFIG = {
             ],
         },
     },
-
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.
@@ -2479,33 +2548,29 @@ DEFAULT_CONFIG = {
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
     },
-
     # Telegram platform settings (gateway mode)
     "telegram": {
-        "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
-        "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
-        "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "reactions": False,  # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},  # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "allowed_chats": "",  # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
-            "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
-            "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
+            "rich_messages": False,  # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
+            "rich_drafts": False,  # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
         },
     },
-
     # Mattermost platform settings (gateway mode)
     "mattermost": {
-        "require_mention": True,       # Require @mention to respond in channels
+        "require_mention": True,  # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "allowed_channels": "",  # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},  # Per-channel ephemeral system prompts
     },
-
     # Matrix platform settings (gateway mode)
     "matrix": {
-        "require_mention": True,       # Require @mention to respond in rooms
-        "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
-        "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        "require_mention": True,  # Require @mention to respond in rooms
+        "free_response_rooms": "",  # Comma-separated room IDs where bot responds without mention
+        "allowed_rooms": "",  # If set, bot ONLY responds in these room IDs (whitelist)
     },
-
     # Approval mode for dangerous commands:
     #   manual — always prompt the user (default)
     #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
@@ -2546,12 +2611,10 @@ DEFAULT_CONFIG = {
         # opt out there).
         "destructive_slash_confirm": True,
     },
-
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
-
     # Per-platform system-prompt hint overrides. Lets an admin append to or
     # replace Hermes' built-in platform hint for a single messaging platform
     # (WhatsApp, Slack, Telegram, ...) without affecting other platforms.
@@ -2567,7 +2630,6 @@ DEFAULT_CONFIG = {
     #         When tabular output would be useful, invoke the
     #         table_formatting skill instead of emitting a Markdown table.
     "platform_hints": {},
-
     # Shell-script hooks — declarative bridge that invokes shell scripts
     # on plugin-hook events (pre_tool_call, post_tool_call, pre_llm_call,
     # subagent_stop, etc.).  Each entry maps an event name to a list of
@@ -2576,7 +2638,6 @@ DEFAULT_CONFIG = {
     # stored approval from ~/.hermes/shell-hooks-allowlist.json.
     # See `website/docs/user-guide/features/hooks.md` for schema + examples.
     "hooks": {},
-
     # Auto-accept shell-hook registrations without a TTY prompt.  Also
     # toggleable per-invocation via --accept-hooks or HERMES_ACCEPT_HOOKS=1.
     # Gateway / cron / non-interactive runs need this (or one of the other
@@ -2586,7 +2647,6 @@ DEFAULT_CONFIG = {
     # Supports string format: {"name": "system prompt"}
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
     "personalities": {},
-
     # Pre-exec security scanning via tirith
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
@@ -2616,7 +2676,6 @@ DEFAULT_CONFIG = {
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
     },
-
     "cron": {
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
@@ -2679,7 +2738,6 @@ DEFAULT_CONFIG = {
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
     },
-
     # Kanban multi-agent coordination — controls the dispatcher loop that
     # spawns workers for ready tasks. The dispatcher ticks every N seconds
     # (default 60), reclaims stale claims, promotes dependency-satisfied
@@ -2740,7 +2798,6 @@ DEFAULT_CONFIG = {
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
     },
-
     # execute_code settings — controls the tool used for programmatic tool calls.
     "code_execution": {
         # Execution mode:
@@ -2754,7 +2811,6 @@ DEFAULT_CONFIG = {
         # tool whitelist apply identically in both modes.
         "mode": "project",
     },
-
     # Tool Search (progressive disclosure for large tool surfaces).
     # When the model is connected to many MCP servers or non-core plugin
     # tools, their JSON schemas can consume a substantial fraction of the
@@ -2786,15 +2842,13 @@ DEFAULT_CONFIG = {
             "max_search_limit": 20,
         },
     },
-
     # Logging — controls file logging to ~/.hermes/logs/.
     # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
     "logging": {
-        "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
-        "max_size_mb": 5,      # Max size per log file before rotation
-        "backup_count": 3,     # Number of rotated backup files to keep
+        "level": "INFO",  # Minimum level for agent.log: DEBUG, INFO, WARNING
+        "max_size_mb": 5,  # Max size per log file before rotation
+        "backup_count": 3,  # Number of rotated backup files to keep
     },
-
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches
     # curated model lists for OpenRouter and Nous Portal from this URL,
     # falling back to the in-repo snapshot on network failure.  Lets us
@@ -2815,7 +2869,6 @@ DEFAULT_CONFIG = {
         #       url: https://example.com/my-curation.json
         "providers": {},
     },
-
     # Network settings — workarounds for connectivity issues.
     "network": {
         # Force IPv4 connections.  On servers with broken or unreachable IPv6,
@@ -2823,7 +2876,6 @@ DEFAULT_CONFIG = {
         # before falling back to IPv4.  Set to true to skip IPv6 entirely.
         "force_ipv4": False,
     },
-
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
@@ -2837,14 +2889,12 @@ DEFAULT_CONFIG = {
         # internal HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT env var, which still
         # works as a manual override and wins if set explicitly.
         "platform_connect_timeout": 30,
-
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with
         # external tooling and downgrade safety; set to false to stop
         # producing ~/.hermes/sessions/sessions.json entirely.
         "write_sessions_json": True,
-
         # Scale-to-zero idle detection (Phase 0). The gateway watches for idle
         # and, when an instance is opted in via the NAS "Labs" toggle (carried as
         # the HERMES_SCALE_TO_ZERO env stamp) AND messaging is relay-only/absent
@@ -2856,7 +2906,6 @@ DEFAULT_CONFIG = {
         "scale_to_zero": {
             "idle_timeout_minutes": 5,
         },
-
         # Auto-resume restart-loop breaker (#30719, defense-3). When the
         # gateway is killed mid-turn (SIGTERM) and revived by a supervisor
         # (launchd KeepAlive / systemd Restart=), it auto-resumes the
@@ -2873,7 +2922,6 @@ DEFAULT_CONFIG = {
             "max_restarts": 3,
             "window_seconds": 60,
         },
-
         # Inject a human-readable timestamp prefix (e.g.
         # "[Tue 2026-04-28 13:40:53 CEST]") onto user messages IN THE MODEL'S
         # CONTEXT so the agent has temporal awareness of when each message was
@@ -2884,7 +2932,6 @@ DEFAULT_CONFIG = {
         "message_timestamps": {
             "enabled": False,
         },
-
         # Maximum bytes for an inbound image / audio / video payload the
         # gateway will buffer into memory and cache to disk. Inbound media is
         # read fully into RAM before being written, so an unbounded upload
@@ -2894,7 +2941,6 @@ DEFAULT_CONFIG = {
         # (gateway/platforms/base.py), so the cap holds across every platform
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
-
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,
@@ -2932,7 +2978,6 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
-
         # OpenAI-compatible API server platform
         # (gateway/platforms/api_server.py).
         "api_server": {
@@ -2945,7 +2990,6 @@ DEFAULT_CONFIG = {
             "max_concurrent_runs": 10,
         },
     },
-
     # Real-time token streaming to messaging platforms (Telegram, Discord,
     # Slack, etc.). Read at the top level by the gateway; absent this block the
     # gateway falls back to these same defaults, so adding it here only makes
@@ -2984,7 +3028,6 @@ DEFAULT_CONFIG = {
         # completion time. Telegram only; other platforms ignore it.
         "fresh_final_after_seconds": 0.0,
     },
-
     # Session storage — controls automatic cleanup of ~/.hermes/state.db.
     # state.db accumulates every session, message, tool call, and FTS5 index
     # entry forever.  Without auto-pruning, a heavy user (gateway + cron)
@@ -3021,7 +3064,6 @@ DEFAULT_CONFIG = {
         # tool that consumes the JSON files directly.
         "write_json_snapshots": False,
     },
-
     # Contextual first-touch onboarding hints (see agent/onboarding.py).
     # Each hint is shown once per install and then latched here so it
     # never fires again.  Users can wipe the section to re-see all hints.
@@ -3034,7 +3076,6 @@ DEFAULT_CONFIG = {
         # The offer fires at most once (latched under onboarding.seen).
         "profile_build": "ask",
     },
-
     # ``hermes update`` behaviour.
     "updates": {
         # Run a full ``hermes backup``-style zip of HERMES_HOME before every
@@ -3075,7 +3116,6 @@ DEFAULT_CONFIG = {
         # on non-admin accounts where `/Applications` is not writable.
         "refresh_cua_driver": True,
     },
-
     # Language Server Protocol — semantic diagnostics from real
     # language servers (pyright, gopls, rust-analyzer, etc.) wired
     # into the post-write lint check used by ``write_file`` and
@@ -3092,21 +3132,18 @@ DEFAULT_CONFIG = {
         # subsystem — no servers spawn, no background event loop, no
         # cost.
         "enabled": True,
-
         # Diagnostic-wait mode for the post-write check.
         # ``"document"`` waits up to ``wait_timeout`` seconds for the
         # current file's diagnostics; ``"full"`` additionally requests
         # workspace-wide diagnostics (slower).
         "wait_mode": "document",
         "wait_timeout": 5.0,
-
         # How to handle missing server binaries.
         # ``"auto"`` — try to install via npm/go/pip into
         #              ``<HERMES_HOME>/lsp/bin/`` on first use.
         # ``"manual"`` — only use binaries already on PATH.
         # ``"off"`` — alias for ``manual``.
         "install_strategy": "auto",
-
         # Per-server overrides.  Each key is a server_id from the
         # registry (``pyright``, ``typescript``, ``gopls``,
         # ``rust-analyzer``, etc.) and accepts:
@@ -3122,8 +3159,6 @@ DEFAULT_CONFIG = {
         # setups.
         "servers": {},
     },
-
-
     # X (Twitter) Search via xAI's built-in x_search Responses tool.
     # The tool registers when xAI credentials are available (SuperGrok
     # OAuth or XAI_API_KEY) AND the x_search toolset is enabled in
@@ -3140,7 +3175,6 @@ DEFAULT_CONFIG = {
         # Each retry backs off (1.5x attempt seconds, capped at 5s).
         "retries": 2,
     },
-
     # =========================================================================
     # External secret sources
     # =========================================================================
@@ -3216,7 +3250,6 @@ DEFAULT_CONFIG = {
             "override_existing": True,
         },
     },
-
     # Paste collapse thresholds (TUI + CLI).
     #
     # paste_collapse_threshold (default 5)
@@ -3237,7 +3270,6 @@ DEFAULT_CONFIG = {
     "paste_collapse_threshold": 5,
     "paste_collapse_threshold_fallback": 5,
     "paste_collapse_char_threshold": 2000,
-
     # Computer Use (cua-driver) toolset settings.
     "computer_use": {
         # cua-driver ships with anonymous usage telemetry (PostHog) ENABLED
@@ -3248,7 +3280,6 @@ DEFAULT_CONFIG = {
         # to let cua-driver use its own default (telemetry on).
         "cua_telemetry": False,
     },
-
     # Hermes Desktop (Electron app) launch options. These only affect
     # `hermes desktop`; they do not touch the CLI/gateway.
     "desktop": {
@@ -3266,8 +3297,6 @@ DEFAULT_CONFIG = {
         # Bridged to the HERMES_DESKTOP_DISABLE_GPU env var the Electron app reads.
         "disable_gpu": "auto",
     },
-
-
     # Google Vertex AI provider (Gemini via the OpenAI-compatible endpoint).
     # Auth is OAuth2 (short-lived access tokens minted from a service-account
     # JSON or Application Default Credentials) — NOT a static API key. The
@@ -3285,7 +3314,6 @@ DEFAULT_CONFIG = {
         # (e.g. "us-central1") only if your models are pinned to a region.
         "region": "global",
     },
-
     # Patch tool self-correction settings (issue #996).
     # Controls how many consecutive patch failures on the same file are
     # allowed before the error is classified as "permanent" and the model
@@ -3294,7 +3322,6 @@ DEFAULT_CONFIG = {
     "patch": {
         "self_correction_retries": 3,
     },
-
     # Config schema version - bump this when adding new required fields
     "_config_version": 34,
 }
@@ -3306,10 +3333,21 @@ DEFAULT_CONFIG = {
 # Track which env vars were introduced in each config version.
 # Migration only mentions vars new since the user's previous version.
 ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
-    3: ["FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID", "FAL_KEY"],
+    3: [
+        "FIRECRAWL_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "FAL_KEY",
+    ],
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
-    5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
-        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    5: [
+        "WHATSAPP_ENABLED",
+        "WHATSAPP_MODE",
+        "WHATSAPP_ALLOWED_USERS",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_ALLOWED_USERS",
+    ],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
 }
@@ -3366,10 +3404,10 @@ OPTIONAL_ENV_VARS = {
     },
     "VERTEX_CREDENTIALS_PATH": {
         "description": "Path to a Google Cloud service account JSON for Vertex AI (Gemini). "
-                       "Vertex uses OAuth2, not a static API key — this points at the "
-                       "credentials Hermes mints short-lived tokens from. Falls back to "
-                       "GOOGLE_APPLICATION_CREDENTIALS, then to ADC (gcloud auth "
-                       "application-default login). Set project/region under vertex: in config.yaml.",
+        "Vertex uses OAuth2, not a static API key — this points at the "
+        "credentials Hermes mints short-lived tokens from. Falls back to "
+        "GOOGLE_APPLICATION_CREDENTIALS, then to ADC (gcloud auth "
+        "application-default login). Set project/region under vertex: in config.yaml.",
         "prompt": "Vertex service account JSON path (leave empty to use ADC / GOOGLE_APPLICATION_CREDENTIALS)",
         "url": "https://cloud.google.com/iam/docs/keys-create-delete",
         "password": False,
@@ -3706,7 +3744,6 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
-
     # ── Tool API keys ──
     "EXA_API_KEY": {
         "description": "Exa API key for AI-native web search and contents",
@@ -3831,7 +3868,12 @@ OPTIONAL_ENV_VARS = {
         "description": "Browser engine for local mode: auto (default Chrome), lightpanda (faster, no screenshots), chrome",
         "prompt": "Browser engine (auto/lightpanda/chrome)",
         "url": "https://github.com/vercel-labs/agent-browser",
-        "tools": ["browser_navigate", "browser_snapshot", "browser_click", "browser_vision"],
+        "tools": [
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_vision",
+        ],
         "password": False,
         "category": "tool",
         "advanced": True,
@@ -3899,7 +3941,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-
     # ── Bundled skills (opt-in: only needed if the user uses that skill) ──
     # These use category="skill" (distinct from "tool") so the sandbox
     # env blocklist in tools/environments/local.py does NOT rewrite them —
@@ -3937,7 +3978,6 @@ OPTIONAL_ENV_VARS = {
         "category": "skill",
         "advanced": True,
     },
-
     # ── Honcho ──
     "HONCHO_API_KEY": {
         "description": "Honcho API key for AI-native persistent memory",
@@ -3952,7 +3992,6 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
     },
-
     # ── Hindsight ──
     "HINDSIGHT_API_KEY": {
         "description": "Hindsight API key for graph-aware persistent memory",
@@ -3968,7 +4007,6 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
-
     # ── Supermemory ──
     "SUPERMEMORY_API_KEY": {
         "description": "Supermemory API key for conversation-scoped persistent memory",
@@ -3978,7 +4016,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-
     # ── Mem0 ──
     "MEM0_API_KEY": {
         "description": "Mem0 Platform API key for semantic persistent memory",
@@ -3988,7 +4025,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-
     # ── RetainDB ──
     "RETAINDB_API_KEY": {
         "description": "RetainDB API key for persistent memory",
@@ -4004,7 +4040,6 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
-
     # ── ByteRover ──
     "BRV_API_KEY": {
         "description": "ByteRover API key (optional, for cloud sync — local-first by default)",
@@ -4014,7 +4049,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
-
     # ── OpenViking ──
     "OPENVIKING_API_KEY": {
         "description": "OpenViking API key (leave blank for local dev mode)",
@@ -4029,7 +4063,6 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
-
     # ── Langfuse observability ──
     "HERMES_LANGFUSE_PUBLIC_KEY": {
         "description": "Langfuse project public key (pk-lf-...)",
@@ -4053,7 +4086,6 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
-
     # ── Messaging platforms ──
     "TELEGRAM_BOT_TOKEN": {
         "description": "Telegram bot token from @BotFather",
@@ -4098,8 +4130,8 @@ OPTIONAL_ENV_VARS = {
     },
     "SLACK_BOT_TOKEN": {
         "description": "Slack bot token (xoxb-). Get from OAuth & Permissions after installing your app. "
-                       "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
-                       "im:history, im:read, im:write, mpim:history, mpim:read, users:read, files:read, files:write",
+        "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
+        "im:history, im:read, im:write, mpim:history, mpim:read, users:read, files:read, files:write",
         "prompt": "Slack Bot Token (xoxb-...)",
         "help": "In your Slack app, add the required bot scopes, install the app to the workspace, then copy OAuth & Permissions > Bot User OAuth Token.",
         "url": "https://api.slack.com/apps",
@@ -4108,8 +4140,8 @@ OPTIONAL_ENV_VARS = {
     },
     "SLACK_APP_TOKEN": {
         "description": "Slack app-level token (xapp-) for Socket Mode. Get from Basic Information → "
-                       "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
-                       "message.channels, message.groups, message.mpim, app_mention",
+        "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
+        "message.channels, message.groups, message.mpim, app_mention",
         "prompt": "Slack App Token (xapp-...)",
         "help": "In your Slack app, enable Socket Mode, then create Basic Information > App-Level Tokens with the connections:write scope.",
         "url": "https://api.slack.com/apps",
@@ -4425,7 +4457,6 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "messaging",
     },
-
     # ── Agent settings ──
     # NOTE: MESSAGING_CWD was removed here — use terminal.cwd in config.yaml
     # instead.  The gateway reads TERMINAL_CWD (bridged from terminal.cwd).
@@ -4466,22 +4497,22 @@ OPTIONAL_ENV_VARS = {
 def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     """
     Check which environment variables are missing.
-    
+
     Returns list of dicts with var info for missing variables.
     """
     missing = []
-    
+
     # Check required vars
     for var_name, info in REQUIRED_ENV_VARS.items():
         if not get_env_value(var_name):
             missing.append({"name": var_name, **info, "is_required": True})
-    
+
     # Check optional vars (if not required_only)
     if not required_only:
         for var_name, info in OPTIONAL_ENV_VARS.items():
             if not get_env_value(var_name):
                 missing.append({"name": var_name, **info, "is_required": False})
-    
+
     return missing
 
 
@@ -4566,7 +4597,7 @@ def clear_model_endpoint_credentials(
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
-    
+
     Walks the DEFAULT_CONFIG tree at arbitrary depth and reports any keys
     present in defaults but absent from the user's loaded config.
     """
@@ -4575,7 +4606,7 @@ def get_missing_config_fields() -> List[Dict[str, Any]]:
 
     def _check(defaults: dict, current: dict, prefix: str = ""):
         for key, default_value in defaults.items():
-            if key.startswith('_'):
+            if key.startswith("_"):
                 continue
             full_key = key if not prefix else f"{prefix}.{key}"
             if key not in current:
@@ -4599,7 +4630,10 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     config.yaml.  Returns a list of dicts suitable for prompting.
     """
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, SKILL_CONFIG_PREFIX
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            SKILL_CONFIG_PREFIX,
+        )
     except Exception:
         return []
 
@@ -4610,6 +4644,7 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
         # should never break `hermes update`.  Skill-config prompting is a
         # post-migration nicety, not a blocker.
         import logging
+
         logging.getLogger(__name__).debug(
             "discover_all_skill_config_vars failed: %s", e
         )
@@ -4689,28 +4724,48 @@ def _normalize_custom_provider_entry(
         # into provider entries. Accept it silently so those (self-written)
         # configs don't warn on every load.
         "provider",
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "name",
+        "api",
+        "url",
+        "base_url",
+        "api_key",
+        "key_env",
+        "api_key_env",
+        "api_mode",
+        "transport",
+        "model",
+        "default_model",
+        "models",
+        "context_length",
+        "rate_limit_delay",
+        "request_timeout_seconds",
+        "stale_timeout_seconds",
+        "discover_models",
+        "extra_body",
+        "extra_headers",
+        "ssl_ca_cert",
+        "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
             _warn_once_per_provider(
-                provider_key, f"camel:{camel}",
+                provider_key,
+                f"camel:{camel}",
                 "providers.%s: camelCase key '%s' auto-mapped to '%s' "
                 "(use snake_case to avoid this warning)",
-                provider_key or "?", camel, snake,
+                provider_key or "?",
+                camel,
+                snake,
             )
             entry[snake] = entry[camel]
     unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
     if unknown:
         _warn_once_per_provider(
-            provider_key, "unknown:" + ",".join(sorted(unknown)),
+            provider_key,
+            "unknown:" + ",".join(sorted(unknown)),
             "providers.%s: unknown config keys ignored: %s",
-            provider_key or "?", ", ".join(sorted(unknown)),
+            provider_key or "?",
+            ", ".join(sorted(unknown)),
         )
 
     from urllib.parse import urlparse
@@ -4736,7 +4791,9 @@ def _normalize_custom_provider_entry(
                 logger.warning(
                     "providers.%s: '%s' value '%s' is not a valid URL "
                     "(no scheme or host) — skipped",
-                    provider_key or "?", url_key, candidate,
+                    provider_key or "?",
+                    url_key,
+                    candidate,
                 )
     if not base_url:
         return None
@@ -4796,9 +4853,7 @@ def _normalize_custom_provider_entry(
                 model_id = item.get("name")
             if not isinstance(model_id, str) or not model_id.strip():
                 continue
-            model_meta = {
-                k: v for k, v in item.items() if k not in {"id", "name"}
-            }
+            model_meta = {k: v for k, v in item.items() if k not in {"id", "name"}}
             normalized_models[model_id.strip()] = model_meta
         if normalized_models:
             normalized["models"] = normalized_models
@@ -5074,7 +5129,9 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
 
     SECURITY: values may carry credentials — never log them.
     """
-    extra_headers = get_custom_provider_extra_headers(base_url, custom_providers, config)
+    extra_headers = get_custom_provider_extra_headers(
+        base_url, custom_providers, config
+    )
     if not extra_headers:
         return
     merged = dict(client_kwargs.get("default_headers") or {})
@@ -5196,18 +5253,43 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+    "_config_version",
+    "model",
+    "providers",
+    "fallback_model",
+    "fallback_providers",
+    "credential_pool_strategies",
+    "toolsets",
+    "agent",
+    "terminal",
+    "display",
+    "compression",
+    "delegation",
+    "auxiliary",
+    "moa",
+    "custom_providers",
+    "context",
+    "memory",
+    "gateway",
+    "sessions",
+    "streaming",
+    "updates",
+    "mcp_servers",
 }
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
-    "ssl_ca_cert", "ssl_verify",
+    "name",
+    "base_url",
+    "api_key",
+    "api_mode",
+    "model",
+    "models",
+    "context_length",
+    "rate_limit_delay",
+    "extra_body",
+    "ssl_ca_cert",
+    "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
@@ -5226,7 +5308,9 @@ class ConfigIssue:
     hint: str
 
 
-def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+def validate_config_structure(
+    config: Optional[Dict[str, Any]] = None,
+) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
     Catches common YAML formatting mistakes that produce confusing runtime
@@ -5238,7 +5322,13 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         try:
             config = load_config()
         except Exception:
-            return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
+            return [
+                ConfigIssue(
+                    "error",
+                    "Could not load config.yaml",
+                    "Run 'hermes setup' to create a valid config",
+                )
+            ]
 
     issues: List[ConfigIssue] = []
 
@@ -5246,46 +5336,56 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     cp = config.get("custom_providers")
     if cp is not None:
         if isinstance(cp, dict):
-            issues.append(ConfigIssue(
-                "error",
-                "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
-                "Change to:\n"
-                "  custom_providers:\n"
-                "    - name: my-provider\n"
-                "      base_url: https://...\n"
-                "      api_key: ...",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
+                    "Change to:\n"
+                    "  custom_providers:\n"
+                    "    - name: my-provider\n"
+                    "      base_url: https://...\n"
+                    "      api_key: ...",
+                )
+            )
             # Check if dict keys look like they should be list-entry fields
             cp_keys = set(cp.keys()) if isinstance(cp, dict) else set()
             suspicious = cp_keys & _CUSTOM_PROVIDER_LIKE_FIELDS
             if suspicious:
-                issues.append(ConfigIssue(
-                    "warning",
-                    f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
-                    "These should be indented under a '- name: ...' list entry, not at root level",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
+                        "These should be indented under a '- name: ...' list entry, not at root level",
+                    )
+                )
         elif isinstance(cp, list):
             # Validate each entry in the list
             for i, entry in enumerate(cp):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
-                        "Each entry should have at minimum: name, base_url",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
+                            "Each entry should have at minimum: name, base_url",
+                        )
+                    )
                     continue
                 if not entry.get("name"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'name' field",
-                        "Add a name, e.g.: name: my-provider",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'name' field",
+                            "Add a name, e.g.: name: my-provider",
+                        )
+                    )
                 if not entry.get("base_url"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'base_url' field",
-                        "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'base_url' field",
+                            "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
+                        )
+                    )
 
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
@@ -5294,78 +5394,100 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             # Chain fallback — validate each entry
             for i, entry in enumerate(fb):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "error",
-                        f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
-                        "Each entry needs provider + model",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "error",
+                            f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
+                            "Each entry needs provider + model",
+                        )
+                    )
                 else:
                     if not entry.get("provider"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'provider' field",
-                            "Add: provider: openrouter (or another provider)",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'provider' field",
+                                "Add: provider: openrouter (or another provider)",
+                            )
+                        )
                     if not entry.get("model"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'model' field",
-                            "Add: model: <model-name>",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'model' field",
+                                "Add: model: <model-name>",
+                            )
+                        )
         elif not isinstance(fb, dict):
-            issues.append(ConfigIssue(
-                "error",
-                f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
-                "Change to:\n"
-                "  fallback_model:\n"
-                "    provider: openrouter\n"
-                "    model: anthropic/claude-sonnet-4",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
+                    "Change to:\n"
+                    "  fallback_model:\n"
+                    "    provider: openrouter\n"
+                    "    model: anthropic/claude-sonnet-4",
+                )
+            )
         elif fb:
             if not fb.get("provider"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'provider' field — fallback will be disabled",
-                    "Add: provider: openrouter (or another provider)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'provider' field — fallback will be disabled",
+                        "Add: provider: openrouter (or another provider)",
+                    )
+                )
             if not fb.get("model"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'model' field — fallback will be disabled",
-                    "Add: model: anthropic/claude-sonnet-4 (or another model)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'model' field — fallback will be disabled",
+                        "Add: model: anthropic/claude-sonnet-4 (or another model)",
+                    )
+                )
 
     # ── Check for fallback_model accidentally nested inside custom_providers ──
-    if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
-        issues.append(ConfigIssue(
-            "error",
-            "fallback_model appears inside custom_providers instead of at root level",
-            "Move fallback_model to the top level of config.yaml (no indentation)",
-        ))
+    if (
+        isinstance(cp, dict)
+        and "fallback_model" not in config
+        and "fallback_model" in (cp or {})
+    ):
+        issues.append(
+            ConfigIssue(
+                "error",
+                "fallback_model appears inside custom_providers instead of at root level",
+                "Move fallback_model to the top level of config.yaml (no indentation)",
+            )
+        )
 
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")
     if cp and not model_cfg:
-        issues.append(ConfigIssue(
-            "warning",
-            "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
-            "Add a model section:\n"
-            "  model:\n"
-            "    provider: custom\n"
-            "    default: your-model-name\n"
-            "    base_url: https://...",
-        ))
+        issues.append(
+            ConfigIssue(
+                "warning",
+                "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
+                "Add a model section:\n"
+                "  model:\n"
+                "    provider: custom\n"
+                "    default: your-model-name\n"
+                "    base_url: https://...",
+            )
+        )
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
         if key.startswith("_"):
             continue
         if key not in _KNOWN_ROOT_KEYS and key in _CUSTOM_PROVIDER_LIKE_FIELDS:
-            issues.append(ConfigIssue(
-                "warning",
-                f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
-                f"Move '{key}' under the appropriate section",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "warning",
+                    f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
+                    f"Move '{key}' under the appropriate section",
+                )
+            )
 
     return issues
 
@@ -5463,11 +5585,11 @@ def _persist_migration(config: Dict[str, Any]) -> None:
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
-    
+
     Args:
         interactive: If True, prompt user for missing values
         quiet: If True, suppress output
-        
+
     Returns:
         Dict with migration results: {"env_added": [...], "config_added": [...], "warnings": [...]}
     """
@@ -5483,7 +5605,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check config version
     current_ver, latest_ver = check_config_version()
-    
+
     # ── Version 3 → 4: migrate tool progress from .env to config.yaml ──
     if current_ver < 4:
         config = read_raw_config()
@@ -5495,18 +5617,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             old_mode = get_env_value("HERMES_TOOL_PROGRESS_MODE")
             if old_enabled and old_enabled.lower() in {"false", "0", "no"}:
                 display["tool_progress"] = "off"
-                results["config_added"].append("display.tool_progress=off (from HERMES_TOOL_PROGRESS=false)")
+                results["config_added"].append(
+                    "display.tool_progress=off (from HERMES_TOOL_PROGRESS=false)"
+                )
             elif old_mode and old_mode.lower() in {"new", "all", "verbose"}:
                 display["tool_progress"] = old_mode.lower()
-                results["config_added"].append(f"display.tool_progress={old_mode.lower()} (from HERMES_TOOL_PROGRESS_MODE)")
+                results["config_added"].append(
+                    f"display.tool_progress={old_mode.lower()} (from HERMES_TOOL_PROGRESS_MODE)"
+                )
             else:
                 display["tool_progress"] = "all"
                 results["config_added"].append("display.tool_progress=all (default)")
             config["display"] = display
             _persist_migration(config)
             if not quiet:
-                print(f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}")
-    
+                print(
+                    f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}"
+                )
+
     # ── Version 4 → 5: add timezone field ──
     if current_ver < 5:
         config = read_raw_config()
@@ -5514,7 +5642,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             old_tz = os.getenv("HERMES_TIMEZONE", "")
             if old_tz and old_tz.strip():
                 config["timezone"] = old_tz.strip()
-                results["config_added"].append(f"timezone={old_tz.strip()} (from HERMES_TIMEZONE)")
+                results["config_added"].append(
+                    f"timezone={old_tz.strip()} (from HERMES_TIMEZONE)"
+                )
             else:
                 config["timezone"] = ""
                 results["config_added"].append("timezone= (empty, uses server-local)")
@@ -5548,12 +5678,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if not isinstance(entry, dict):
                     continue
                 old_name = entry.get("name", "")
-                old_url = entry.get("base_url", "") or entry.get("url", "") or entry.get("api", "") or ""
+                old_url = (
+                    entry.get("base_url", "")
+                    or entry.get("url", "")
+                    or entry.get("api", "")
+                    or ""
+                )
                 if not old_url:
                     continue  # skip entries with no URL
 
                 # Generate a kebab-case key from the display name
-                key = old_name.strip().lower().replace(" ", "-").replace("(", "").replace(")", "")
+                key = (
+                    old_name
+                    .strip()
+                    .lower()
+                    .replace(" ", "-")
+                    .replace("(", "")
+                    .replace(")", "")
+                )
                 # Remove consecutive hyphens and trailing hyphens
                 while "--" in key:
                     key = key.replace("--", "-")
@@ -5562,6 +5704,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     # Fallback: derive from URL hostname
                     try:
                         from urllib.parse import urlparse
+
                         parsed = urlparse(old_url)
                         key = (parsed.hostname or "endpoint").replace(".", "-")
                     except Exception:
@@ -5594,7 +5737,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 config.pop("custom_providers", None)
                 _persist_migration(config)
                 if not quiet:
-                    print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
+                    print(
+                        f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section"
+                    )
                     for key in list(providers_dict.keys())[-migrated_count:]:
                         ep = providers_dict[key]
                         print(f"    → {key}: {ep.get('api', '')}")
@@ -5610,7 +5755,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if old_val:
                     save_env_value(dead_var, "")
                     if not quiet:
-                        print(f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)")
+                        print(
+                            f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)"
+                        )
             except Exception:
                 pass
 
@@ -5637,11 +5784,25 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             if provider in {"local", "local_command"}:
                 # Don't migrate an OpenAI model name into the local section
                 _local_models = {
-                    "tiny.en", "tiny", "base.en", "base", "small.en", "small",
-                    "medium.en", "medium", "large-v1", "large-v2", "large-v3",
-                    "large", "distil-large-v2", "distil-medium.en",
-                    "distil-small.en", "distil-large-v3", "distil-large-v3.5",
-                    "large-v3-turbo", "turbo",
+                    "tiny.en",
+                    "tiny",
+                    "base.en",
+                    "base",
+                    "small.en",
+                    "small",
+                    "medium.en",
+                    "medium",
+                    "large-v1",
+                    "large-v2",
+                    "large-v3",
+                    "large",
+                    "distil-large-v2",
+                    "distil-medium.en",
+                    "distil-small.en",
+                    "distil-large-v3",
+                    "distil-large-v3.5",
+                    "large-v3-turbo",
+                    "turbo",
                 }
                 if legacy_model in _local_models:
                     # Check raw config — only set if user didn't already
@@ -5673,7 +5834,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         if "interim_assistant_messages" not in display:
             display["interim_assistant_messages"] = True
             config["display"] = display
-            results["config_added"].append("display.interim_assistant_messages=true (default)")
+            results["config_added"].append(
+                "display.interim_assistant_messages=true (default)"
+            )
             _persist_migration(config)
             if not quiet:
                 print("  ✓ Added display.interim_assistant_messages=true")
@@ -5699,8 +5862,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             _persist_migration(config)
             if not quiet:
                 migrated = ", ".join(f"{p}={m}" for p, m in old_overrides.items())
-                print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
-            results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
+                print(
+                    f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}"
+                )
+            results["config_added"].append(
+                "display.platforms (migrated from tool_progress_overrides)"
+            )
 
     # ── Version 16 → 17: remove legacy compression.summary_* keys ──
     if current_ver < 17:
@@ -5730,12 +5897,19 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if not aux_comp.get("base_url"):
                     aux_comp["base_url"] = str(s_base_url).strip()
                     migrated_keys.append(f"base_url={s_base_url}")
-            if migrated_keys or s_model is not None or s_provider is not None or s_base_url is not None:
+            if (
+                migrated_keys
+                or s_model is not None
+                or s_provider is not None
+                or s_base_url is not None
+            ):
                 config["compression"] = comp
                 _persist_migration(config)
                 if not quiet:
                     if migrated_keys:
-                        print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
+                        print(
+                            f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}"
+                        )
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 
@@ -5848,9 +6022,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             touched = True
 
         # (2) auxiliary.curator task slot
-        _aux_curator_defaults = (
-            DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
-        )
+        _aux_curator_defaults = DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
         raw_aux = config.get("auxiliary")
         if not isinstance(raw_aux, dict):
             raw_aux = {}
@@ -5902,7 +6074,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             _persist_migration(config)
             results["config_added"].append("model_catalog.ttl_hours 24→1")
             if not quiet:
-                print("  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)")
+                print(
+                    "  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)"
+                )
 
     # ── Version 28 → 29: rename memory/skills write_mode → write_approval ──
     # The tri-state write_mode (on|off|approve) was replaced by a clear boolean
@@ -5921,7 +6095,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 continue
             old = sub.pop("write_mode")
             old_norm = old.strip().lower() if isinstance(old, str) else old
-            sub["write_approval"] = (old_norm == "approve")
+            sub["write_approval"] = old_norm == "approve"
             config[subsystem] = sub
             touched = True
             results["config_added"].append(
@@ -5955,9 +6129,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         if not isinstance(raw_agent, dict):
             raw_agent = {}
         cur = raw_agent.get("verify_on_stop")
-        is_auto_sentinel = (
-            isinstance(cur, str) and cur.strip().lower() == "auto"
-        )
+        is_auto_sentinel = isinstance(cur, str) and cur.strip().lower() == "auto"
         # Only flip the non-committal states; leave explicit bool/on/off alone.
         if cur is None or is_auto_sentinel:
             raw_agent["verify_on_stop"] = False
@@ -5967,7 +6139,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             if not quiet:
                 print(
                     "  ✓ Turned off verify-on-stop (agent.verify_on_stop: false). "
-                    "Set it to true to re-enable, or \"auto\" for the legacy "
+                    'Set it to true to re-enable, or "auto" for the legacy '
                     "surface-aware behavior."
                 )
 
@@ -5995,7 +6167,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 print(
                     "  ✓ Turned off verify-on-stop (agent.verify_on_stop: false) — "
                     "the old default was written into your config as a literal "
-                    "true. Set it to true again to re-enable, or \"auto\" for the "
+                    'true. Set it to true again to re-enable, or "auto" for the '
                     "legacy surface-aware behavior."
                 )
 
@@ -6051,7 +6223,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     raw_mcp_servers = config.get("mcp_servers")
     if isinstance(raw_mcp_servers, dict):
         try:
-            from hermes_cli.mcp_security import validate_mcp_server_entry as _validate_mcp_server_entry
+            from hermes_cli.mcp_security import (
+                validate_mcp_server_entry as _validate_mcp_server_entry,
+            )
         except Exception:
             _validate_mcp_server_entry = None
         if _validate_mcp_server_entry:
@@ -6100,40 +6274,43 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check for missing required env vars
     missing_env = get_missing_env_vars(required_only=True)
-    
+
     if missing_env and not quiet:
         print("\n⚠️  Missing required environment variables:")
         for var in missing_env:
             print(f"   • {var['name']}: {var['description']}")
-    
+
     if interactive and missing_env:
         print("\nLet's configure them now:\n")
         for var in missing_env:
             if var.get("url"):
                 print(f"  Get your key at: {var['url']}")
-            
+
             if var.get("password"):
                 value = masked_secret_prompt(f"  {var['prompt']}: ")
             else:
                 value = input(f"  {var['prompt']}: ").strip()
-            
+
             if value:
                 save_env_value(var["name"], value)
                 results["env_added"].append(var["name"])
                 print(f"  ✓ Saved {var['name']}")
             else:
-                results["warnings"].append(f"Skipped {var['name']} - some features may not work")
+                results["warnings"].append(
+                    f"Skipped {var['name']} - some features may not work"
+                )
             print()
-    
+
     # Check for missing optional env vars and offer to configure interactively
     # Skip "advanced" vars (like OPENAI_BASE_URL) -- those are for power users
     missing_optional = get_missing_env_vars(required_only=False)
     required_names = {v["name"] for v in missing_env} if missing_env else set()
     missing_optional = [
-        v for v in missing_optional
+        v
+        for v in missing_optional
         if v["name"] not in required_names and not v.get("advanced")
     ]
-    
+
     # Only offer to configure env vars that are NEW since the user's previous version
     new_var_names = set()
     for ver in range(current_ver + 1, latest_ver + 1):
@@ -6168,7 +6345,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                             f"  {info.get('prompt', name)} (Enter to skip): "
                         )
                     else:
-                        value = input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
+                        value = input(
+                            f"  {info.get('prompt', name)} (Enter to skip): "
+                        ).strip()
                     if value:
                         save_env_value(name, value)
                         results["env_added"].append(name)
@@ -6176,7 +6355,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     print()
             else:
                 print("  Set later with: hermes config set <key> <value>")
-    
+
     # Check for missing config fields.
     #
     # New default keys are NOT materialised to disk: load_config() deep-merges
@@ -6202,7 +6381,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         print(f"\n  {len(missing_skill_config)} skill setting(s) not configured:")
         for var in missing_skill_config:
             skill_name = var.get("skill", "unknown")
-            print(f"    • {var['key']} — {var['description']} (from skill: {skill_name})")
+            print(
+                f"    • {var['key']} — {var['description']} (from skill: {skill_name})"
+            )
         print()
         try:
             answer = input("  Configure skill settings? [y/N]: ").strip().lower()
@@ -6248,11 +6429,7 @@ def _deep_merge(base: dict, override: dict) -> dict:
     """
     result = base.copy()
     for key, value in override.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             result[key] = _deep_merge(result[key], value)
         else:
             result[key] = value
@@ -6356,7 +6533,11 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
     rotation between load and save while still treating mixed literal/template
     string edits as caller-owned once their rendered value diverges.
     """
-    if isinstance(current, str) and isinstance(raw, str) and re.search(r"\${[^}]+}", raw):
+    if (
+        isinstance(current, str)
+        and isinstance(raw, str)
+        and re.search(r"\${[^}]+}", raw)
+    ):
         if current == raw:
             return raw
         if isinstance(loaded_expanded, str) and current == loaded_expanded:
@@ -6388,7 +6569,9 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
                 _preserve_env_ref_templates(
                     item,
                     raw_by_name.get(item.get("name")),
-                    loaded_by_name.get(item.get("name")) if loaded_by_name is not None else None,
+                    loaded_by_name.get(item.get("name"))
+                    if loaded_by_name is not None
+                    else None,
                 )
                 for item in current
             ]
@@ -6640,7 +6823,6 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
     return node
 
 
-
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 
@@ -6840,7 +7022,7 @@ def terminal_config_env_var_for_key(key: str) -> Optional[str]:
     prefix = "terminal."
     if not key.startswith(prefix):
         return None
-    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix):])
+    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix) :])
 
 
 def apply_terminal_config_to_env(
@@ -7119,9 +7301,13 @@ def save_config(
         )
         # ----------------------------------------------------------------
 
-        current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        current_normalized = _normalize_root_model_keys(
+            _normalize_max_turns_config(config)
+        )
         normalized = current_normalized
-        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+        raw_existing = _normalize_root_model_keys(
+            _normalize_max_turns_config(read_raw_config())
+        )
         if raw_existing:
             normalized = _preserve_env_ref_templates(
                 normalized,
@@ -7141,6 +7327,7 @@ def save_config(
         if strip_defaults and effective_preserve_keys:
             # _preserve_env_ref_templates may return Any; cast for type-checker.
             from typing import cast as _cast
+
             normalized = _cast(Dict[str, Any], normalized)
             normalized = _strip_default_values(
                 normalized,  # type: ignore[arg-type]
@@ -7157,7 +7344,9 @@ def save_config(
         fb = normalized.get("fallback_model", {})
         fb_is_valid = False
         if isinstance(fb, list):
-            fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+            fb_is_valid = any(
+                isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb
+            )
         elif isinstance(fb, dict):
             fb_is_valid = bool(fb.get("provider") and fb.get("model"))
         if not fb_is_valid:
@@ -7169,7 +7358,9 @@ def save_config(
             extra_content="".join(parts) if parts else None,
         )
         _secure_file(config_path)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(
+            current_normalized
+        )
 
 
 def _parse_env_value(raw_value: str) -> str:
@@ -7242,13 +7433,13 @@ def load_env() -> Dict[str, str]:
         lines = _sanitize_env_lines(raw_lines)
         for line in lines:
             line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
+            if line and not line.startswith("#") and "=" in line:
                 # Strip the bash-compatible ``export `` prefix so lines like
                 # ``export API_KEY=...`` parse as ``API_KEY`` rather than being
                 # stored under the wrong key ``"export API_KEY"`` (#6659).
-                if line.startswith('export '):
+                if line.startswith("export "):
                     line = line[7:]
-                key, _, value = line.partition('=')
+                key, _, value = line.partition("=")
                 env_vars[key.strip()] = _parse_env_value(value)
 
     if cache_key is not None:
@@ -7262,7 +7453,9 @@ def load_env() -> Dict[str, str]:
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_env_cache: Optional[
+    Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]
+] = None
 
 
 def invalidate_env_cache() -> None:
@@ -7335,10 +7528,10 @@ def _sanitize_env_lines(lines: list) -> list:
                 idx = stripped.find(needle, idx + len(needle))
 
         split_positions = sorted({
-            s for s, e in match_ranges
+            s
+            for s, e in match_ranges
             if not any(
-                s2 <= s and e2 >= e and (s2, e2) != (s, e)
-                for s2, e2 in match_ranges
+                s2 <= s and e2 >= e and (s2, e2) != (s, e) for s2, e2 in match_ranges
             )
         })
 
@@ -7350,9 +7543,13 @@ def _sanitize_env_lines(lines: list) -> list:
         segments: list[str] = []
         if len(split_positions) > 1 and split_positions[0] == 0:
             segments = [
-                stripped[pos:(
-                    split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
-                )]
+                stripped[
+                    pos : (
+                        split_positions[i + 1]
+                        if i + 1 < len(split_positions)
+                        else len(stripped)
+                    )
+                ]
                 for i, pos in enumerate(split_positions)
             ]
             # A genuine concatenation has a simple token value in every segment
@@ -7404,7 +7601,9 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
@@ -7467,10 +7666,7 @@ def _quote_env_value(value: str) -> str:
     if value == "":
         return value
     needs_quoting = (
-        "#" in value
-        or '"' in value
-        or "'" in value
-        or value != value.strip()
+        "#" in value or '"' in value or "'" in value or value != value.strip()
     )
     if not needs_quoting:
         return value
@@ -7532,8 +7728,10 @@ def save_env_value(key: str, value: str):
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
         lines.append(f"{key}={serialized_value}\n")
-    
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     # Preserve original permissions so Docker volume mounts aren't clobbered.
     original_mode = None
     if env_path.exists():
@@ -7542,7 +7740,7 @@ def save_env_value(key: str, value: str):
         except OSError:
             pass
     try:
-        with os.fdopen(fd, 'w', **write_kw) as f:
+        with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(lines)
             f.flush()
             os.fsync(f.fileno())
@@ -7605,7 +7803,9 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
 
     if found:
-        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+        )
         # Preserve original permissions so Docker volume mounts aren't clobbered.
         original_mode = None
         try:
@@ -7613,7 +7813,7 @@ def remove_env_value(key: str) -> bool:
         except OSError:
             pass
         try:
-            with os.fdopen(fd, 'w', **write_kw) as f:
+            with os.fdopen(fd, "w", **write_kw) as f:
                 f.writelines(new_lines)
                 f.flush()
                 os.fsync(f.fileno())
@@ -7668,7 +7868,6 @@ def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
         "stored_as": key,
         "validated": False,
     }
-
 
 
 def reload_env() -> int:
@@ -7734,6 +7933,7 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
 # Config display
 # =============================================================================
 
+
 def redact_key(key: str) -> str:
     """Redact an API key for display.
 
@@ -7741,6 +7941,7 @@ def redact_key(key: str) -> str:
     "(not set)" placeholder in dim color for the empty case.
     """
     from agent.redact import mask_secret
+
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
@@ -7788,7 +7989,12 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if (
+                isinstance(k, str)
+                and k.lower() in _SECRET_CONFIG_KEYS
+                and isinstance(v, str)
+                and v
+            ):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
@@ -7803,9 +8009,19 @@ def show_config():
     config = load_config()
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print(
+        color(
+            "┌─────────────────────────────────────────────────────────┐", Colors.CYAN
+        )
+    )
+    print(
+        color("│              ⚕ Hermes Configuration                    │", Colors.CYAN)
+    )
+    print(
+        color(
+            "└─────────────────────────────────────────────────────────┘", Colors.CYAN
+        )
+    )
 
     # Managed scope: surface that some settings are administrator-pinned so the
     # user understands why their config.yaml value may not be the effective one.
@@ -7816,22 +8032,28 @@ def show_config():
     if _managed_keys or _managed_env:
         _managed_dir = managed_scope.get_managed_dir()
         print()
-        print(color(
-            f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
-            f"and cannot be changed",
-            Colors.YELLOW,
-            Colors.BOLD,
-        ))
+        print(
+            color(
+                f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
+                f"and cannot be changed",
+                Colors.YELLOW,
+                Colors.BOLD,
+            )
+        )
         if _managed_keys:
-            print(color(
-                f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
+                    Colors.YELLOW,
+                )
+            )
         if _managed_env:
-            print(color(
-                f"    Managed env keys: {', '.join(sorted(_managed_env))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed env keys: {', '.join(sorted(_managed_env))}",
+                    Colors.YELLOW,
+                )
+            )
 
     # Paths
     print()
@@ -7839,11 +8061,11 @@ def show_config():
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
-    
+
     # API Keys
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
-    
+
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
@@ -7855,76 +8077,98 @@ def show_config():
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
     ]
-    
+
     for env_key, name in keys:
         value = get_env_value(env_key)
         print(f"  {name:<14} {redact_key(value)}")
     from hermes_cli.auth import get_anthropic_key
+
     anthropic_value = get_anthropic_key()
     print(f"  {'Anthropic':<14} {redact_key(anthropic_value)}")
-    
+
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {redact_config_value(config.get('model', 'not set'))}")
-    _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
+    _cfg_max_turns = config.get("agent", {}).get(
+        "max_turns", DEFAULT_CONFIG["agent"]["max_turns"]
+    )
     print(f"  Max turns:    {_cfg_max_turns}")
     # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with
     # config.yaml (issue #17534). Read the .env FILE directly so we catch the
     # ghost even when the gateway bridge already overrode os.environ.
     try:
         _env_ghost = load_env().get("HERMES_MAX_ITERATIONS")
-        if _env_ghost is not None and str(_env_ghost).strip() != str(_cfg_max_turns).strip():
-            print(color(
-                f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
-                f"(run 'hermes doctor --fix' to remove)",
-                Colors.YELLOW,
-            ))
+        if (
+            _env_ghost is not None
+            and str(_env_ghost).strip() != str(_cfg_max_turns).strip()
+        ):
+            print(
+                color(
+                    f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
+                    f"(run 'hermes doctor --fix' to remove)",
+                    Colors.YELLOW,
+                )
+            )
     except Exception:
         pass
-    
+
     # Display
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
-    display = config.get('display', {})
+    display = config.get("display", {})
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
-    ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
-    ump_first = ump.get('first_lines', 2)
-    ump_last = ump.get('last_lines', 2)
+    print(
+        f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}"
+    )
+    ump = (
+        display.get("user_message_preview", {})
+        if isinstance(display.get("user_message_preview", {}), dict)
+        else {}
+    )
+    ump_first = ump.get("first_lines", 2)
+    ump_last = ump.get("last_lines", 2)
     print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s)")
 
     # Terminal
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
-    terminal = config.get('terminal', {})
+    terminal = config.get("terminal", {})
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
-    
-    if terminal.get('backend') == 'docker':
-        print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'singularity':
-        print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'modal':
-        print(f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        modal_token = get_env_value('MODAL_TOKEN_ID')
+
+    if terminal.get("backend") == "docker":
+        print(
+            f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "singularity":
+        print(
+            f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "modal":
+        print(
+            f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        modal_token = get_env_value("MODAL_TOKEN_ID")
         print(f"  Modal token:  {'configured' if modal_token else '(not set)'}")
-    elif terminal.get('backend') == 'daytona':
-        print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        daytona_key = get_env_value('DAYTONA_API_KEY')
+    elif terminal.get("backend") == "daytona":
+        print(
+            f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        daytona_key = get_env_value("DAYTONA_API_KEY")
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
-    elif terminal.get('backend') == 'ssh':
-        ssh_host = get_env_value('TERMINAL_SSH_HOST')
-        ssh_user = get_env_value('TERMINAL_SSH_USER')
+    elif terminal.get("backend") == "ssh":
+        ssh_host = get_env_value("TERMINAL_SSH_HOST")
+        ssh_user = get_env_value("TERMINAL_SSH_USER")
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
-    
+
     # Timezone
     print()
     print(color("◆ Timezone", Colors.CYAN, Colors.BOLD))
-    tz = config.get('timezone', '')
+    tz = config.get("timezone", "")
     if tz:
         print(f"  Timezone:     {tz}")
     else:
@@ -7933,56 +8177,68 @@ def show_config():
     # Compression
     print()
     print(color("◆ Context Compression", Colors.CYAN, Colors.BOLD))
-    compression = config.get('compression', {})
-    enabled = compression.get('enabled', True)
+    compression = config.get("compression", {})
+    enabled = compression.get("enabled", True)
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
-        print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
+        print(
+            f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved"
+        )
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
-        print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")
-        _aux_comp = config.get('auxiliary', {}).get('compression', {})
-        _sm = _aux_comp.get('model', '') or '(auto)'
+        print(
+            f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages"
+        )
+        _aux_comp = config.get("auxiliary", {}).get("compression", {})
+        _sm = _aux_comp.get("model", "") or "(auto)"
         print(f"  Model:        {_sm}")
-        comp_provider = _aux_comp.get('provider', 'auto')
-        if comp_provider and comp_provider != 'auto':
+        comp_provider = _aux_comp.get("provider", "auto")
+        if comp_provider and comp_provider != "auto":
             print(f"  Provider:     {comp_provider}")
-    
+
     # Auxiliary models
-    auxiliary = config.get('auxiliary', {})
+    auxiliary = config.get("auxiliary", {})
     aux_tasks = {
-        "Vision":      auxiliary.get('vision', {}),
-        "Web extract": auxiliary.get('web_extract', {}),
+        "Vision": auxiliary.get("vision", {}),
+        "Web extract": auxiliary.get("web_extract", {}),
     }
     has_overrides = any(
-        t.get('provider', 'auto') != 'auto' or t.get('model', '')
+        t.get("provider", "auto") != "auto" or t.get("model", "")
         for t in aux_tasks.values()
     )
     if has_overrides:
         print()
         print(color("◆ Auxiliary Models (overrides)", Colors.CYAN, Colors.BOLD))
         for label, task_cfg in aux_tasks.items():
-            prov = task_cfg.get('provider', 'auto')
-            mdl = task_cfg.get('model', '')
-            if prov != 'auto' or mdl:
+            prov = task_cfg.get("provider", "auto")
+            mdl = task_cfg.get("model", "")
+            if prov != "auto" or mdl:
                 parts = [f"provider={prov}"]
                 if mdl:
                     parts.append(f"model={mdl}")
                 print(f"  {label:12s}  {', '.join(parts)}")
-    
+
     # Messaging
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
-    
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
-    
+
+    telegram_token = get_env_value("TELEGRAM_BOT_TOKEN")
+    discord_token = get_env_value("DISCORD_BOT_TOKEN")
+
+    print(
+        f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}"
+    )
+    print(
+        f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}"
+    )
+
     # Skill config
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            resolve_skill_config_values,
+        )
+
         skill_vars = discover_all_skill_config_vars()
         if skill_vars:
             resolved = resolve_skill_config_values(skill_vars)
@@ -7993,7 +8249,9 @@ def show_config():
                 value = resolved.get(key, "")
                 skill_name = var.get("skill", "")
                 display_val = str(value) if value else color("(not set)", Colors.DIM)
-                print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
+                print(
+                    f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}"
+                )
     except Exception:
         pass
 
@@ -8011,14 +8269,14 @@ def edit_config():
         managed_error("edit configuration")
         return
     config_path = get_config_path()
-    
+
     # Ensure config exists
     if not config_path.exists():
         save_config(DEFAULT_CONFIG, strip_defaults=False)
         print(f"Created {config_path}")
-    
+
     # Find editor
-    editor = os.getenv('EDITOR') or os.getenv('VISUAL')
+    editor = os.getenv("EDITOR") or os.getenv("VISUAL")
 
     if not editor:
         # Try common editors — order is platform-aware so Windows users
@@ -8027,20 +8285,21 @@ def edit_config():
         # it's more likely to be present on headless / server systems.
         import shutil
         import sys as _sys
+
         if _sys.platform == "win32":
-            candidates = ['notepad', 'code', 'vim', 'vi', 'nano']
+            candidates = ["notepad", "code", "vim", "vi", "nano"]
         else:
-            candidates = ['nano', 'vim', 'vi', 'code', 'notepad']
+            candidates = ["nano", "vim", "vi", "code", "notepad"]
         for cmd in candidates:
             if shutil.which(cmd):
                 editor = cmd
                 break
-    
+
     if not editor:
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
         return
-    
+
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
 
@@ -8068,22 +8327,44 @@ def set_config_value(key: str, value: str):
         sys.exit(1)
     # Check if it's an API key (goes to .env)
     api_keys = [
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "EXA_API_KEY",
+        "PARALLEL_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "FIRECRAWL_API_URL",
+        "FIRECRAWL_GATEWAY_URL",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_SCHEME",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "TAVILY_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY",
+        "FAL_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
+        "TERMINAL_SSH_KEY",
+        "SUDO_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "GITHUB_TOKEN",
+        "HONCHO_API_KEY",
     ]
-    
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
+
+    if (
+        key.upper() in api_keys
+        or key.upper().endswith(("_API_KEY", "_TOKEN"))
+        or key.upper().startswith("TERMINAL_SSH")
+    ):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
-    
+
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
@@ -8096,20 +8377,20 @@ def set_config_value(key: str, value: str):
                 user_config = fast_safe_load(f) or {}
         except Exception:
             user_config = {}
-    
+
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
     # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
+    if value.lower() in {"true", "yes", "on"}:
         value = True
-    elif value.lower() in {'false', 'no', 'off'}:
+    elif value.lower() in {"false", "no", "off"}:
         value = False
     elif value.isdigit():
         value = int(value)
-    elif value.replace('.', '', 1).isdigit():
+    elif value.replace(".", "", 1).isdigit():
         value = float(value)
 
     _set_nested(user_config, key, value)
@@ -8125,8 +8406,9 @@ def set_config_value(key: str, value: str):
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()
     from utils import atomic_yaml_write
+
     atomic_yaml_write(config_path, user_config, sort_keys=False)
-    
+
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
     env_var = terminal_config_env_var_for_key(key)
@@ -8140,6 +8422,7 @@ def set_config_value(key: str, value: str):
     _leaf_key = key.rsplit(".", 1)[-1].lower()
     if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
         from agent.redact import mask_secret
+
         _display_value = mask_secret(value)
     else:
         _display_value = value
@@ -8150,19 +8433,20 @@ def set_config_value(key: str, value: str):
 # Command handler
 # =============================================================================
 
+
 def config_command(args):
     """Handle config subcommands."""
-    subcmd = getattr(args, 'config_command', None)
-    
+    subcmd = getattr(args, "config_command", None)
+
     if subcmd is None or subcmd == "show":
         show_config()
-    
+
     elif subcmd == "edit":
         edit_config()
-    
+
     elif subcmd == "set":
-        key = getattr(args, 'key', None)
-        value = getattr(args, 'value', None)
+        key = getattr(args, "key", None)
+        value = getattr(args, "value", None)
         if not key or value is None:
             print("Usage: hermes config set <key> <value>")
             print()
@@ -8172,81 +8456,89 @@ def config_command(args):
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             sys.exit(1)
         set_config_value(key, value)
-    
+
     elif subcmd == "path":
         print(get_config_path())
-    
+
     elif subcmd == "env-path":
         print(get_env_path())
-    
+
     elif subcmd == "migrate":
         print()
-        print(color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD))
+        print(
+            color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD)
+        )
         print()
-        
+
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
         current_ver, latest_ver = check_config_version()
-        
+
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
             print()
             return
-        
+
         # Show what needs to be updated
         if current_ver < latest_ver:
             print(f"  Config version: {current_ver} → {latest_ver}")
-        
+
         if missing_config:
-            print(f"\n  {len(missing_config)} new config option(s) will be added with defaults")
-        
+            print(
+                f"\n  {len(missing_config)} new config option(s) will be added with defaults"
+            )
+
         required_missing = [v for v in missing_env if v.get("is_required")]
         optional_missing = [
-            v for v in missing_env
-            if not v.get("is_required") and not v.get("advanced")
+            v for v in missing_env if not v.get("is_required") and not v.get("advanced")
         ]
-        
+
         if required_missing:
             print(f"\n  ⚠️  {len(required_missing)} required API key(s) missing:")
             for var in required_missing:
                 print(f"     • {var['name']}")
-        
+
         if optional_missing:
             print(f"\n  ℹ️  {len(optional_missing)} optional API key(s) not configured:")
             for var in optional_missing:
                 tools = var.get("tools", [])
                 tools_str = f" (enables: {', '.join(tools[:2])})" if tools else ""
                 print(f"     • {var['name']}{tools_str}")
-        
+
         print()
-        
+
         # Run migration
         results = migrate_config(interactive=True, quiet=False)
-        
+
         print()
         if results["env_added"] or results["config_added"]:
             print(color("✓ Configuration updated!", Colors.GREEN))
-        
+
         if results["warnings"]:
             print()
             for warning in results["warnings"]:
                 print(color(f"  ⚠️  {warning}", Colors.YELLOW))
-        
+
         print()
-    
+
     elif subcmd == "check":
         # Non-interactive check for what's missing
         print()
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
-        
+
         current_ver, latest_ver = check_config_version()
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:
-            print(color(f"  Config version: {current_ver} → {latest_ver} (update available)", Colors.YELLOW))
-        
+            print(
+                color(
+                    f"  Config version: {current_ver} → {latest_ver} (update available)",
+                    Colors.YELLOW,
+                )
+            )
+
         print()
         print(color("  Required:", Colors.BOLD))
         for var_name in REQUIRED_ENV_VARS:
@@ -8254,7 +8546,7 @@ def config_command(args):
                 print(f"    ✓ {var_name}")
             else:
                 print(color(f"    ✗ {var_name} (missing)", Colors.RED))
-        
+
         print()
         print(color("  Optional:", Colors.BOLD))
         for var_name, info in OPTIONAL_ENV_VARS.items():
@@ -8264,15 +8556,20 @@ def config_command(args):
                 tools = info.get("tools", [])
                 tools_str = f" → {', '.join(tools[:2])}" if tools else ""
                 print(color(f"    ○ {var_name}{tools_str}", Colors.DIM))
-        
+
         missing_config = get_missing_config_fields()
         if missing_config:
             print()
-            print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
+            print(
+                color(
+                    f"  {len(missing_config)} new config option(s) available",
+                    Colors.YELLOW,
+                )
+            )
             print("    Run 'hermes config migrate' to add them")
-        
+
         print()
-    
+
     else:
         print(f"Unknown config command: {subcmd}")
         print()
@@ -8306,8 +8603,11 @@ def _inject_profile_env_vars() -> None:
     _profile_env_vars_injected = True
     try:
         from providers import list_providers
+
         for _pp in list_providers():
-            if _pp.auth_type not in {"api_key",}:
+            if _pp.auth_type not in {
+                "api_key",
+            }:
                 continue
             for _var in _pp.env_vars:
                 if _var in OPTIONAL_ENV_VARS:
@@ -8410,8 +8710,7 @@ def _inject_platform_plugin_env_vars() -> None:
                     )
                 OPTIONAL_ENV_VARS[name] = {
                     "description": (
-                        meta.get("description")
-                        or f"{label} configuration"
+                        meta.get("description") or f"{label} configuration"
                     ),
                     "prompt": meta.get("prompt") or name,
                     "url": meta.get("url") or None,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3286,6 +3286,15 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # Patch tool self-correction settings (issue #996).
+    # Controls how many consecutive patch failures on the same file are
+    # allowed before the error is classified as "permanent" and the model
+    # is instructed to stop retrying and use an alternative strategy
+    # (re-read the file, use write_file, etc.).  1–5; default 3.
+    "patch": {
+        "self_correction_retries": 3,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 34,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.2"
+version = "0.18.3"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/tools/test_patch_failure_tracking.py
+++ b/tests/tools/test_patch_failure_tracking.py
@@ -24,7 +24,12 @@ def hermes_home(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(home))
     yield home
     try:
-        from tools.file_tools import clear_file_ops_cache, _read_tracker_lock, _read_tracker
+        from tools.file_tools import (
+            clear_file_ops_cache,
+            _read_tracker_lock,
+            _read_tracker,
+        )
+
         clear_file_ops_cache()
         with _read_tracker_lock:
             _read_tracker.clear()
@@ -32,6 +37,7 @@ def hermes_home(monkeypatch, tmp_path):
         pass
     try:
         from tools.terminal_tool import _active_environments, _env_lock
+
         with _env_lock:
             _active_environments.clear()
     except Exception:
@@ -52,7 +58,9 @@ def fresh_tracker():
 
 
 class TestPatchFailureEscalation:
-    def test_first_two_failures_use_normal_hint(self, hermes_home, tmp_path, fresh_tracker):
+    def test_first_two_failures_use_normal_hint(
+        self, hermes_home, tmp_path, fresh_tracker
+    ):
         from tools.file_tools import _handle_patch
 
         target = tmp_path / "f.py"
@@ -74,7 +82,9 @@ class TestPatchFailureEscalation:
                 f"Escalating hint fired too early on attempt {_i + 1}: {hint!r}"
             )
 
-    def test_third_consecutive_failure_escalates(self, hermes_home, tmp_path, fresh_tracker):
+    def test_third_consecutive_failure_escalates(
+        self, hermes_home, tmp_path, fresh_tracker
+    ):
         from tools.file_tools import _handle_patch
 
         target = tmp_path / "f.py"
@@ -184,9 +194,7 @@ class TestPatchFailureEscalation:
         )
         d = json.loads(result)
         hint = d.get("_hint", "") or ""
-        assert "failure #" not in hint, (
-            f"b.py's hint inherited a.py's count: {hint!r}"
-        )
+        assert "failure #" not in hint, f"b.py's hint inherited a.py's count: {hint!r}"
 
     def test_different_tasks_have_independent_counters(
         self, hermes_home, tmp_path, fresh_tracker

--- a/tests/tools/test_patch_failure_tracking.py
+++ b/tests/tools/test_patch_failure_tracking.py
@@ -95,6 +95,9 @@ class TestPatchFailureEscalation:
             last_hint = d.get("_hint", "") or ""
 
         assert "failure #3" in last_hint, repr(last_hint)
+        assert "PERMANENT FAILURE" in last_hint, (
+            "Escalating hint should classify as PERMANENT FAILURE"
+        )
         assert "Stop retrying" in last_hint
         assert "write_file" in last_hint, (
             "Escalating hint should mention write_file fallback"

--- a/tests/tools/test_patch_self_correction.py
+++ b/tests/tools/test_patch_self_correction.py
@@ -1,0 +1,317 @@
+"""Tests for structured error context in patch self-correction (issue #996).
+
+The structured error package gives the model everything it needs to produce
+a corrected patch on its next turn WITHOUT re-reading the file:
+
+- Error type classification (no_match, ambiguous, identical, escape_drift)
+- The closest matching region with line numbers (±5 lines)
+- A recovery suggestion matched to the error type
+
+This file tests the pure functions in ``tools.fuzzy_match`` — the functions
+that build the structured error context.  Integration through the full
+``_handle_patch`` pipeline is tested in ``test_patch_failure_tracking.py``.
+"""
+
+import json
+
+import pytest
+
+from tools.fuzzy_match import (
+    classify_error,
+    format_structured_error,
+    _format_file_context_snippet,
+    ERROR_TYPES,
+)
+
+
+class TestClassifyError:
+    def test_no_match(self):
+        assert classify_error("Could not find a match for old_string", None) == "no_match"
+
+    def test_no_match_variant(self):
+        assert classify_error("Could not find match for old_string in file.py", None) == "no_match"
+
+    def test_ambiguous(self):
+        assert classify_error("Found 3 matches for old_string", None) == "ambiguous"
+
+    def test_identical_via_strategy(self):
+        assert classify_error("some error", "identical") == "identical"
+
+    def test_identical_via_text(self):
+        assert classify_error("old_string and new_string are identical", None) == "identical"
+
+    def test_escape_drift(self):
+        assert classify_error("Escape-drift detected: backslash issue", None) == "escape_drift"
+
+    def test_escape_drift_no_hyphen(self):
+        assert classify_error("Escape drift detected in old_string", None) == "escape_drift"
+
+    def test_permission(self):
+        assert classify_error("Write denied: protected path", None) == "permission"
+
+    def test_read_failed(self):
+        assert classify_error("Failed to read file: /tmp/x.py", None) == "read_failed"
+
+    def test_write_failed(self):
+        assert classify_error("Failed to write changes to file", None) == "write_failed"
+
+    def test_unknown(self):
+        assert classify_error("something weird happened", None) == "unknown"
+
+    def test_none_error(self):
+        assert classify_error(None, None) == "unknown"
+
+
+class TestFormatFileContextSnippet:
+    def test_finds_closest_region(self):
+        content = "line1\nline2\ndef foo():\n    return 1\nline5\nline6\n"
+        old_string = "def foo():\n    return 2"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=2)
+        assert "def foo" in snippet
+        assert "return 1" in snippet
+        # Line numbers should be present
+        assert "   3" in snippet  # line 3 is def foo()
+
+    def test_marks_best_match_line(self):
+        content = "a\nb\ndef target():\n    pass\ne\nf\n"
+        old_string = "def target():\n    pass"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=1)
+        # The >> marker should be on the best-matching line
+        assert ">>" in snippet
+
+    def test_empty_for_no_similar_content(self):
+        content = "completely different content here\n"
+        old_string = "def totally_unrelated():\n    pass"
+        snippet = _format_file_context_snippet(content, old_string)
+        assert snippet == ""
+
+    def test_empty_for_empty_inputs(self):
+        assert _format_file_context_snippet("", "old") == ""
+        assert _format_file_context_snippet("content", "") == ""
+
+    def test_context_lines_respected(self):
+        content = "\n".join(f"line{i}" for i in range(1, 21))
+        old_string = "line10\nline11"
+        snippet = _format_file_context_snippet(content, old_string, context_lines=3)
+        # Should include lines 7 through ~14 (3 before line 10, 3 after the block)
+        assert "line7" in snippet
+        assert "line14" in snippet or "line13" in snippet
+        # Should NOT include lines too far away — check by line number prefix,
+        # not substring ("line1" is a substring of "line10" through "line19").
+        snippet_lines = snippet.split("\n")
+        # Extract line numbers from the snippet (format: "   N>>| content" or "   N  | content")
+        line_nums = set()
+        for sl in snippet_lines:
+            # Strip leading whitespace, take digits before >> or |
+            stripped = sl.strip()
+            if stripped:
+                num_part = stripped.split("|")[0].rstrip(">")
+                try:
+                    line_nums.add(int(num_part.strip()))
+                except ValueError:
+                    pass
+        assert 1 not in line_nums, f"line 1 should not be in snippet, got lines: {sorted(line_nums)}"
+        assert 20 not in line_nums, f"line 20 should not be in snippet, got lines: {sorted(line_nums)}"
+
+
+class TestFormatStructuredError:
+    def test_no_match_includes_error_type_and_snippet(self):
+        content = "def foo():\n    return 1\n\ndef bar():\n    return 2\n"
+        old_string = "def foo():\n    return 99"
+        new_string = "def foo():\n    return 42"
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, old_string, new_string, content,
+            file_path="/tmp/test.py",
+        )
+        assert "Error type: no_match" in result
+        assert "File: /tmp/test.py" in result
+        # Should include the closest matching region
+        assert "return 1" in result
+        # Should include a recovery suggestion
+        assert "Recovery:" in result
+
+    def test_ambiguous_includes_error_type_and_recovery(self):
+        content = "aaa bbb aaa\n"
+        old_string = "aaa"
+        new_string = "ccc"
+        result = format_structured_error(
+            "Found 2 matches for old_string",
+            0, old_string, new_string, content,
+            file_path="/tmp/test.py",
+        )
+        assert "Error type: ambiguous" in result
+        assert "replace_all=True" in result
+
+    def test_identical_includes_error_type_and_recovery(self):
+        result = format_structured_error(
+            "old_string and new_string are identical",
+            0, "foo", "foo", "foo bar\n",
+            strategy="identical",
+        )
+        assert "Error type: identical" in result
+        assert "no action needed" in result.lower()
+
+    def test_escape_drift_includes_error_type_and_recovery(self):
+        result = format_structured_error(
+            "Escape-drift detected: backslash issue",
+            0, "old\\'", "new\\'", "content\n",
+        )
+        assert "Error type: escape_drift" in result
+        assert "read_file" in result
+
+    def test_silent_on_permission_error(self):
+        result = format_structured_error(
+            "Write denied: protected path",
+            0, "old", "new", "content\n",
+        )
+        assert result == ""
+
+    def test_silent_on_unknown_error(self):
+        result = format_structured_error(
+            "something weird",
+            0, "old", "new", "content\n",
+        )
+        assert result == ""
+
+    def test_silent_on_none_error(self):
+        result = format_structured_error(None, 0, "old", "new", "content\n")
+        assert result == ""
+
+    def test_no_match_no_snippet_falls_back_to_generic_recovery(self):
+        """When no similar content exists, still provide a generic recovery hint."""
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, "totally_unique_xyzzy", "replacement",
+            "completely different content\n",
+        )
+        assert "Error type: no_match" in result
+        assert "read_file" in result
+
+    def test_file_path_optional(self):
+        result = format_structured_error(
+            "Could not find a match for old_string in the file",
+            0, "foo", "bar", "def foo():\n    pass\n",
+        )
+        assert "Error type: no_match" in result
+        # Should still work without file_path
+        assert "File:" not in result
+
+
+class TestPatchResultStructuredError:
+    """Verify that PatchResult carries structured_error through to_dict."""
+
+    def test_to_dict_includes_diagnostic_when_set(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(
+            error="Could not find a match for old_string",
+            structured_error="Error type: no_match — old_string not found in file",
+        )
+        d = result.to_dict()
+        assert "_diagnostic" in d
+        assert "no_match" in d["_diagnostic"]
+
+    def test_to_dict_omits_diagnostic_when_none(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(error="some error")
+        d = result.to_dict()
+        assert "_diagnostic" not in d
+
+    def test_to_dict_omits_diagnostic_on_success(self):
+        from tools.file_operations import PatchResult
+        result = PatchResult(success=True, diff="--- a\n+++ b\n")
+        d = result.to_dict()
+        assert "_diagnostic" not in d
+
+
+class TestSelfCorrectionConfigGate:
+    """Verify the config gate for self-correction retry threshold."""
+
+    def test_default_value(self, monkeypatch):
+        """When config is unavailable, the default of 3 is returned."""
+        import tools.file_tools as ft
+        # Reset the cache
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        # Force the config load to fail
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: (_ for _ in ()).throw(Exception("no config")))
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_clamps_to_max(self, monkeypatch):
+        """Values above 5 are rejected in favor of the default."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 99}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_clamps_to_min(self, monkeypatch):
+        """Values below 1 are rejected in favor of the default."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 0}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 3
+
+    def test_valid_value_used(self, monkeypatch):
+        """A valid value (1-5) is used as-is."""
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 5}})
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+        assert ft._get_self_correction_retries() == 5
+
+
+class TestPatchFailureEscalationWithDiagnostic:
+    """Verify that the structured _diagnostic suppresses redundant _hint."""
+
+    @pytest.fixture
+    def hermes_home(self, monkeypatch, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        yield home
+        try:
+            from tools.file_tools import clear_file_ops_cache
+            clear_file_ops_cache()
+        except Exception:
+            pass
+
+    @pytest.fixture
+    def fresh_tracker(self):
+        from tools.file_tools import _patch_failure_tracker, _patch_failure_lock
+        with _patch_failure_lock:
+            _patch_failure_tracker.clear()
+        yield
+        with _patch_failure_lock:
+            _patch_failure_tracker.clear()
+
+    def test_first_failure_has_diagnostic_not_generic_hint(
+        self, hermes_home, tmp_path, fresh_tracker, monkeypatch
+    ):
+        """On the first no-match failure, the structured _diagnostic should
+        be present and the generic _hint should be suppressed (since the
+        diagnostic is strictly more useful)."""
+        from tools.file_tools import _handle_patch
+        # Reset the config cache so we get the default threshold
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
+
+        target = tmp_path / "f.py"
+        target.write_text("def foo():\n    return 1\n")
+
+        result = _handle_patch(
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "class TOTALLY_NONEXISTENT_BANANA_XYZQQQ:\n    pass",
+                "new_string": "x",
+            },
+            task_id="diag_t1",
+        )
+        d = json.loads(result)
+        # Should have an error (no match)
+        assert d.get("error"), f"Expected error for non-matching old_string, got: {d}"
+        # Should have the structured diagnostic
+        assert "_diagnostic" in d, f"Missing _diagnostic in {list(d.keys())}"
+        assert "no_match" in d["_diagnostic"]

--- a/tests/tools/test_patch_self_correction.py
+++ b/tests/tools/test_patch_self_correction.py
@@ -26,10 +26,15 @@ from tools.fuzzy_match import (
 
 class TestClassifyError:
     def test_no_match(self):
-        assert classify_error("Could not find a match for old_string", None) == "no_match"
+        assert (
+            classify_error("Could not find a match for old_string", None) == "no_match"
+        )
 
     def test_no_match_variant(self):
-        assert classify_error("Could not find match for old_string in file.py", None) == "no_match"
+        assert (
+            classify_error("Could not find match for old_string in file.py", None)
+            == "no_match"
+        )
 
     def test_ambiguous(self):
         assert classify_error("Found 3 matches for old_string", None) == "ambiguous"
@@ -38,13 +43,22 @@ class TestClassifyError:
         assert classify_error("some error", "identical") == "identical"
 
     def test_identical_via_text(self):
-        assert classify_error("old_string and new_string are identical", None) == "identical"
+        assert (
+            classify_error("old_string and new_string are identical", None)
+            == "identical"
+        )
 
     def test_escape_drift(self):
-        assert classify_error("Escape-drift detected: backslash issue", None) == "escape_drift"
+        assert (
+            classify_error("Escape-drift detected: backslash issue", None)
+            == "escape_drift"
+        )
 
     def test_escape_drift_no_hyphen(self):
-        assert classify_error("Escape drift detected in old_string", None) == "escape_drift"
+        assert (
+            classify_error("Escape drift detected in old_string", None)
+            == "escape_drift"
+        )
 
     def test_permission(self):
         assert classify_error("Write denied: protected path", None) == "permission"
@@ -110,8 +124,12 @@ class TestFormatFileContextSnippet:
                     line_nums.add(int(num_part.strip()))
                 except ValueError:
                     pass
-        assert 1 not in line_nums, f"line 1 should not be in snippet, got lines: {sorted(line_nums)}"
-        assert 20 not in line_nums, f"line 20 should not be in snippet, got lines: {sorted(line_nums)}"
+        assert 1 not in line_nums, (
+            f"line 1 should not be in snippet, got lines: {sorted(line_nums)}"
+        )
+        assert 20 not in line_nums, (
+            f"line 20 should not be in snippet, got lines: {sorted(line_nums)}"
+        )
 
 
 class TestFormatStructuredError:
@@ -121,7 +139,10 @@ class TestFormatStructuredError:
         new_string = "def foo():\n    return 42"
         result = format_structured_error(
             "Could not find a match for old_string in the file",
-            0, old_string, new_string, content,
+            0,
+            old_string,
+            new_string,
+            content,
             file_path="/tmp/test.py",
         )
         assert "Error type: no_match" in result
@@ -137,7 +158,10 @@ class TestFormatStructuredError:
         new_string = "ccc"
         result = format_structured_error(
             "Found 2 matches for old_string",
-            0, old_string, new_string, content,
+            0,
+            old_string,
+            new_string,
+            content,
             file_path="/tmp/test.py",
         )
         assert "Error type: ambiguous" in result
@@ -146,7 +170,10 @@ class TestFormatStructuredError:
     def test_identical_includes_error_type_and_recovery(self):
         result = format_structured_error(
             "old_string and new_string are identical",
-            0, "foo", "foo", "foo bar\n",
+            0,
+            "foo",
+            "foo",
+            "foo bar\n",
             strategy="identical",
         )
         assert "Error type: identical" in result
@@ -155,7 +182,10 @@ class TestFormatStructuredError:
     def test_escape_drift_includes_error_type_and_recovery(self):
         result = format_structured_error(
             "Escape-drift detected: backslash issue",
-            0, "old\\'", "new\\'", "content\n",
+            0,
+            "old\\'",
+            "new\\'",
+            "content\n",
         )
         assert "Error type: escape_drift" in result
         assert "read_file" in result
@@ -163,14 +193,20 @@ class TestFormatStructuredError:
     def test_silent_on_permission_error(self):
         result = format_structured_error(
             "Write denied: protected path",
-            0, "old", "new", "content\n",
+            0,
+            "old",
+            "new",
+            "content\n",
         )
         assert result == ""
 
     def test_silent_on_unknown_error(self):
         result = format_structured_error(
             "something weird",
-            0, "old", "new", "content\n",
+            0,
+            "old",
+            "new",
+            "content\n",
         )
         assert result == ""
 
@@ -182,7 +218,9 @@ class TestFormatStructuredError:
         """When no similar content exists, still provide a generic recovery hint."""
         result = format_structured_error(
             "Could not find a match for old_string in the file",
-            0, "totally_unique_xyzzy", "replacement",
+            0,
+            "totally_unique_xyzzy",
+            "replacement",
             "completely different content\n",
         )
         assert "Error type: no_match" in result
@@ -191,7 +229,10 @@ class TestFormatStructuredError:
     def test_file_path_optional(self):
         result = format_structured_error(
             "Could not find a match for old_string in the file",
-            0, "foo", "bar", "def foo():\n    pass\n",
+            0,
+            "foo",
+            "bar",
+            "def foo():\n    pass\n",
         )
         assert "Error type: no_match" in result
         # Should still work without file_path
@@ -203,6 +244,7 @@ class TestPatchResultStructuredError:
 
     def test_to_dict_includes_diagnostic_when_set(self):
         from tools.file_operations import PatchResult
+
         result = PatchResult(
             error="Could not find a match for old_string",
             structured_error="Error type: no_match — old_string not found in file",
@@ -213,12 +255,14 @@ class TestPatchResultStructuredError:
 
     def test_to_dict_omits_diagnostic_when_none(self):
         from tools.file_operations import PatchResult
+
         result = PatchResult(error="some error")
         d = result.to_dict()
         assert "_diagnostic" not in d
 
     def test_to_dict_omits_diagnostic_on_success(self):
         from tools.file_operations import PatchResult
+
         result = PatchResult(success=True, diff="--- a\n+++ b\n")
         d = result.to_dict()
         assert "_diagnostic" not in d
@@ -230,34 +274,50 @@ class TestSelfCorrectionConfigGate:
     def test_default_value(self, monkeypatch):
         """When config is unavailable, the default of 3 is returned."""
         import tools.file_tools as ft
+
         # Reset the cache
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
         # Force the config load to fail
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: (_ for _ in ()).throw(Exception("no config")))
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: (_ for _ in ()).throw(Exception("no config")),
+        )
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
         assert ft._get_self_correction_retries() == 3
 
     def test_clamps_to_max(self, monkeypatch):
         """Values above 5 are rejected in favor of the default."""
         import tools.file_tools as ft
+
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 99}})
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"patch": {"self_correction_retries": 99}},
+        )
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
         assert ft._get_self_correction_retries() == 3
 
     def test_clamps_to_min(self, monkeypatch):
         """Values below 1 are rejected in favor of the default."""
         import tools.file_tools as ft
+
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 0}})
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"patch": {"self_correction_retries": 0}},
+        )
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
         assert ft._get_self_correction_retries() == 3
 
     def test_valid_value_used(self, monkeypatch):
         """A valid value (1-5) is used as-is."""
         import tools.file_tools as ft
+
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"patch": {"self_correction_retries": 5}})
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"patch": {"self_correction_retries": 5}},
+        )
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
         assert ft._get_self_correction_retries() == 5
 
@@ -273,6 +333,7 @@ class TestPatchFailureEscalationWithDiagnostic:
         yield home
         try:
             from tools.file_tools import clear_file_ops_cache
+
             clear_file_ops_cache()
         except Exception:
             pass
@@ -280,6 +341,7 @@ class TestPatchFailureEscalationWithDiagnostic:
     @pytest.fixture
     def fresh_tracker(self):
         from tools.file_tools import _patch_failure_tracker, _patch_failure_lock
+
         with _patch_failure_lock:
             _patch_failure_tracker.clear()
         yield
@@ -293,8 +355,10 @@ class TestPatchFailureEscalationWithDiagnostic:
         be present and the generic _hint should be suppressed (since the
         diagnostic is strictly more useful)."""
         from tools.file_tools import _handle_patch
+
         # Reset the config cache so we get the default threshold
         import tools.file_tools as ft
+
         monkeypatch.setattr(ft, "_self_correction_retries_cached", None)
 
         target = tmp_path / "f.py"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -11,16 +11,16 @@ so we wrap the terminal backend's execute() interface to provide a unified file 
 Usage:
     from tools.file_operations import ShellFileOperations
     from tools.terminal_tool import _active_environments
-    
+
     # Get file operations for a terminal environment
     file_ops = ShellFileOperations(terminal_env)
-    
+
     # Read a file
     result = file_ops.read_file("/path/to/file.py")
-    
+
     # Write a file
     result = file_ops.write_file("/path/to/new.py", "print('hello')")
-    
+
     # Search for content
     result = file_ops.search("TODO", path=".", file_glob="*.py")
 """
@@ -134,7 +134,7 @@ def _strip_bom(text: str) -> tuple[str, bool]:
     left alone (it's legitimate data there, not a file marker).
     """
     if text and text.startswith(_UTF8_BOM):
-        return text[len(_UTF8_BOM):], True
+        return text[len(_UTF8_BOM) :], True
     return text, False
 
 
@@ -151,6 +151,7 @@ def _is_write_denied(path: str) -> bool:
 # =============================================================================
 # Result Data Classes
 # =============================================================================
+
 
 def classify_file_error(
     error: Optional[str], *, similar_files: Optional[List[str]] = None
@@ -198,7 +199,11 @@ def classify_file_error(
             "old_string to make it unique, or use replace_all=True if you want "
             "all occurrences replaced."
         )
-    if "did not match" in low or "no match" in low or ("match" in low and "block" in low):
+    if (
+        "did not match" in low
+        or "no match" in low
+        or ("match" in low and "block" in low)
+    ):
         return "fuzzy_match", (
             "The search block didn't match the file. Re-read the file and copy the EXACT "
             "current text into the patch — don't retry the same block."
@@ -219,6 +224,7 @@ def classify_file_error(
 @dataclass
 class ReadResult:
     """Result from reading a file."""
+
     content: str = ""
     total_lines: int = 0
     file_size: int = 0
@@ -243,6 +249,7 @@ class ReadResult:
 @dataclass
 class WriteResult:
     """Result from writing a file."""
+
     bytes_written: int = 0
     dirs_created: bool = False
     lint: Optional[Dict[str, Any]] = None
@@ -263,6 +270,7 @@ class WriteResult:
 @dataclass
 class PatchResult:
     """Result from patching a file."""
+
     success: bool = False
     diff: str = ""
     files_modified: List[str] = field(default_factory=list)
@@ -279,7 +287,7 @@ class PatchResult:
     # field to the tool result so the model can correct on its next
     # turn without re-reading the file.
     structured_error: Optional[str] = None
-    
+
     def to_dict(self) -> dict:
         result = {"success": self.success}
         if self.diff:
@@ -307,6 +315,7 @@ class PatchResult:
 @dataclass
 class SearchMatch:
     """A single search match."""
+
     path: str
     line_number: int
     content: str
@@ -316,6 +325,7 @@ class SearchMatch:
 @dataclass
 class SearchResult:
     """Result from searching."""
+
     matches: List[SearchMatch] = field(default_factory=list)
     files: List[str] = field(default_factory=list)
     counts: Dict[str, int] = field(default_factory=dict)
@@ -324,7 +334,7 @@ class SearchResult:
     limit_reason: Optional[str] = None
     warning: Optional[str] = None
     error: Optional[str] = None
-    
+
     # Densify content-mode matches into a path-grouped text block above this
     # many matches. Below it, the verbose array is already compact enough that
     # the path-grouping header costs more than it saves.
@@ -393,11 +403,12 @@ class SearchResult:
 @dataclass
 class LintResult:
     """Result from linting a file."""
+
     success: bool = True
     skipped: bool = False
     output: str = ""
     message: str = ""
-    
+
     def to_dict(self) -> dict:
         if self.skipped:
             return {"status": "skipped", "message": self.message}
@@ -410,6 +421,7 @@ class LintResult:
 @dataclass
 class ExecuteResult:
     """Result from executing a shell command."""
+
     stdout: str = ""
     exit_code: int = 0
 
@@ -446,7 +458,7 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """
     diagnostics: list[str] = []
     payload: list[str] = []
-    for line in output.split('\n'):
+    for line in output.split("\n"):
         if not line.strip():
             continue
         # Tool diagnostics always carry the "<tool>: " prefix (e.g.
@@ -470,7 +482,7 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
             payload.append(line)
         else:
             diagnostics.append(line)
-    return '\n'.join(diagnostics), '\n'.join(payload)
+    return "\n".join(diagnostics), "\n".join(payload)
 
 
 # A real rg/grep output line starts with a path token and is followed by a
@@ -478,7 +490,7 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
 # diagnostics ("rg: ...", "grep: ...", "error: ...", indented carets) never
 # match because the path token forbids whitespace and a leading tool prefix
 # like "rg" is followed by ": " (space) which the negated class rejects.
-_SEARCH_OUTPUT_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^[^\s:][^\s]*$')
+_SEARCH_OUTPUT_RE = re.compile(r"^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^[^\s:][^\s]*$")
 
 
 def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
@@ -493,26 +505,27 @@ def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
         return None
 
     match = None
-    for candidate in re.finditer(r'-(\d+)-', line):
+    for candidate in re.finditer(r"-(\d+)-", line):
         match = candidate
 
     if match is None:
         return None
 
-    path = line[:match.start()]
+    path = line[: match.start()]
     if not path:
         return None
 
-    return path, int(match.group(1)), line[match.end():]
+    return path, int(match.group(1)), line[match.end() :]
 
 
 # =============================================================================
 # Abstract Interface
 # =============================================================================
 
+
 class FileOperations(ABC):
     """Abstract interface for file operations across terminal backends."""
-    
+
     @abstractmethod
     def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
         """Read a file with pagination support."""
@@ -534,8 +547,9 @@ class FileOperations(ABC):
         ...
 
     @abstractmethod
-    def patch_replace(self, path: str, old_string: str, new_string: str,
-                      replace_all: bool = False) -> PatchResult:
+    def patch_replace(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> PatchResult:
         """Replace text in a file using fuzzy matching."""
         ...
 
@@ -556,7 +570,9 @@ class FileOperations(ABC):
         should override.
         """
         if recursive:
-            return WriteResult(error="Recursive delete not implemented for this backend")
+            return WriteResult(
+                error="Recursive delete not implemented for this backend"
+            )
         return self.delete_file(path)
 
     @abstractmethod
@@ -565,9 +581,17 @@ class FileOperations(ABC):
         ...
 
     @abstractmethod
-    def search(self, pattern: str, path: str = ".", target: str = "content",
-               file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+    def search(
+        self,
+        pattern: str,
+        path: str = ".",
+        target: str = "content",
+        file_glob: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        output_mode: str = "content",
+        context: int = 0,
+    ) -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -577,17 +601,17 @@ class FileOperations(ABC):
 # =============================================================================
 
 # Image extensions (subset of binary that we can return as base64)
-IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico'}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico"}
 
 # Shell-based linters by file extension.  Invoked via _exec() with the
 # filesystem path.  Cover languages where a compile/type check needs an
 # external toolchain (py_compile, node, tsc, go vet, rustfmt).
 LINTERS = {
-    '.py': 'python -m py_compile {file} 2>&1',
-    '.js': 'node --check {file} 2>&1',
-    '.ts': 'npx tsc --noEmit {file} 2>&1',
-    '.go': 'go vet {file} 2>&1',
-    '.rs': 'rustfmt --check {file} 2>&1',
+    ".py": "python -m py_compile {file} 2>&1",
+    ".js": "node --check {file} 2>&1",
+    ".ts": "npx tsc --noEmit {file} 2>&1",
+    ".go": "go vet {file} 2>&1",
+    ".rs": "rustfmt --check {file} 2>&1",
 }
 
 # Extensions where the per-file shell linter is structurally weaker than
@@ -626,7 +650,7 @@ LINTERS = {
 # extensions — the ``lsp_diagnostics`` channel carries the real signal.
 # Everything else in ``LINTERS`` (Python ``py_compile``, ``node --check``)
 # is fast, file-local, and correct, so it runs unconditionally.
-_SHELL_LINTER_LSP_REDUNDANT = frozenset({'.ts', '.go', '.rs'})
+_SHELL_LINTER_LSP_REDUNDANT = frozenset({".ts", ".go", ".rs"})
 
 
 # Patterns that indicate the linter base command exists on PATH but
@@ -640,24 +664,24 @@ _SHELL_LINTER_LSP_REDUNDANT = frozenset({'.ts', '.go', '.rs'})
 #
 # Patterns are matched case-insensitively against linter stdout.
 _LINTER_UNUSABLE_PATTERNS = {
-    'npx': (
+    "npx": (
         # npx prints this banner when the package isn't installed locally
         # AND it can't auto-install (no internet, registry off, etc.) or
         # when the binary it tried to run is the wrong one.
-        'this is not the tsc command you are looking for',
+        "this is not the tsc command you are looking for",
         # npx with --no-install resolution failures
-        'could not determine executable to run',
-        'not found in npm registry',
+        "could not determine executable to run",
+        "not found in npm registry",
     ),
-    'rustfmt': (
+    "rustfmt": (
         # rustfmt outside a Cargo project
-        'no input filename given',
-        'error: not a workspace',
+        "no input filename given",
+        "error: not a workspace",
     ),
-    'go': (
+    "go": (
         # ``go vet`` on a file outside a module / GOPATH
-        'cannot find package',
-        'go: cannot find main module',
+        "cannot find package",
+        "go: cannot find main module",
     ),
 }
 
@@ -681,6 +705,7 @@ def _looks_like_linter_unusable(base_cmd: str, output: str) -> bool:
 def _lint_json_inproc(content: str) -> tuple[bool, str]:
     """In-process JSON syntax check.  Returns (ok, error_message)."""
     import json as _json
+
     try:
         _json.loads(content)
         return True, ""
@@ -734,6 +759,7 @@ def _lint_python_inproc(content: str) -> tuple[bool, str]:
     subprocess overhead and no dependency on a ``python`` in PATH.
     """
     import ast as _ast
+
     try:
         _ast.parse(content)
         return True, ""
@@ -750,11 +776,11 @@ def _lint_python_inproc(content: str) -> tuple[bool, str]:
 # string of ``"__SKIP__"`` signals the linter isn't available (missing
 # dependency) and should be treated as "no linter".
 LINTERS_INPROC = {
-    '.py': _lint_python_inproc,
-    '.json': _lint_json_inproc,
-    '.yaml': _lint_yaml_inproc,
-    '.yml': _lint_yaml_inproc,
-    '.toml': _lint_toml_inproc,
+    ".py": _lint_python_inproc,
+    ".json": _lint_json_inproc,
+    ".yaml": _lint_yaml_inproc,
+    ".yml": _lint_yaml_inproc,
+    ".toml": _lint_toml_inproc,
 }
 
 # Max limits for read operations
@@ -775,8 +801,9 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
-def normalize_read_pagination(offset: Any = DEFAULT_READ_OFFSET,
-                              limit: Any = DEFAULT_READ_LIMIT) -> tuple[int, int]:
+def normalize_read_pagination(
+    offset: Any = DEFAULT_READ_OFFSET, limit: Any = DEFAULT_READ_LIMIT
+) -> tuple[int, int]:
     """Return safe read_file pagination bounds.
 
     Tool schemas declare minimum/maximum values, but not every caller or
@@ -787,6 +814,7 @@ def normalize_read_pagination(offset: Any = DEFAULT_READ_OFFSET,
     config.yaml (defaults to the module-level ``MAX_LINES`` constant).
     """
     from tools.tool_output_limits import get_max_lines
+
     max_lines = get_max_lines()
     normalized_offset = max(1, _coerce_int(offset, DEFAULT_READ_OFFSET))
     normalized_limit = _coerce_int(limit, DEFAULT_READ_LIMIT)
@@ -794,8 +822,9 @@ def normalize_read_pagination(offset: Any = DEFAULT_READ_OFFSET,
     return normalized_offset, normalized_limit
 
 
-def normalize_search_pagination(offset: Any = DEFAULT_SEARCH_OFFSET,
-                                limit: Any = DEFAULT_SEARCH_LIMIT) -> tuple[int, int]:
+def normalize_search_pagination(
+    offset: Any = DEFAULT_SEARCH_OFFSET, limit: Any = DEFAULT_SEARCH_LIMIT
+) -> tuple[int, int]:
     """Return safe search pagination bounds for shell head/tail pipelines."""
     normalized_offset = max(0, _coerce_int(offset, DEFAULT_SEARCH_OFFSET))
     normalized_limit = max(1, _coerce_int(limit, DEFAULT_SEARCH_LIMIT))
@@ -822,10 +851,12 @@ def _is_line_oriented_newline_error(error: Optional[str]) -> bool:
     """Return True for rg's hard error when multiline mode is required."""
     if not error:
         return False
-    return "literal \"\\n\" is not allowed" in error and "--multiline" in error
+    return 'literal "\\n" is not allowed' in error and "--multiline" in error
 
 
-def _maybe_warn_line_oriented_newline_pattern(result: SearchResult, pattern: str) -> SearchResult:
+def _maybe_warn_line_oriented_newline_pattern(
+    result: SearchResult, pattern: str
+) -> SearchResult:
     """Attach a newline-regex warning only when search found no usable results."""
     if result.total_count != 0 or not _pattern_has_regex_newline(pattern):
         return result
@@ -844,11 +875,11 @@ def _maybe_warn_line_oriented_newline_pattern(result: SearchResult, pattern: str
 class ShellFileOperations(FileOperations):
     """
     File operations implemented via shell commands.
-    
+
     Works with ANY terminal backend that has execute(command, cwd) method.
     This includes local, docker, singularity, ssh, modal, and daytona environments.
     """
-    
+
     def __init__(self, terminal_env, cwd: str = None):
         """
         Initialize file operations with a terminal environment.
@@ -878,14 +909,19 @@ class ShellFileOperations(FileOperations):
         # IMPORTANT: do NOT fall back to os.getcwd() -- that's the HOST's local
         # path which doesn't exist inside container/cloud backends (modal, docker).
         # If nothing provides a cwd, use "/" as a safe universal default.
-        self.cwd = cwd or getattr(terminal_env, 'cwd', None) or \
-                   getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
+        self.cwd = (
+            cwd
+            or getattr(terminal_env, "cwd", None)
+            or getattr(getattr(terminal_env, "config", None), "cwd", None)
+            or "/"
+        )
 
         # Cache for command availability checks
         self._command_cache: Dict[str, bool] = {}
-    
-    def _exec(self, command: str, cwd: str = None, timeout: int = None,
-              stdin_data: str = None) -> ExecuteResult:
+
+    def _exec(
+        self, command: str, cwd: str = None, timeout: int = None, stdin_data: str = None
+    ) -> ExecuteResult:
         """Execute command via terminal backend.
 
         Args:
@@ -903,49 +939,49 @@ class ShellFileOperations(FileOperations):
         """
         kwargs = {}
         if timeout:
-            kwargs['timeout'] = timeout
+            kwargs["timeout"] = timeout
         if stdin_data is not None:
-            kwargs['stdin_data'] = stdin_data
+            kwargs["stdin_data"] = stdin_data
 
         # Resolve cwd from the live env so `cd` commands are picked up.
         # Fall through to init-time self.cwd only if the env doesn't track cwd.
-        effective_cwd = cwd or getattr(self.env, 'cwd', None) or self.cwd
+        effective_cwd = cwd or getattr(self.env, "cwd", None) or self.cwd
         result = self.env.execute(command, cwd=effective_cwd, **kwargs)
         return ExecuteResult(
-            stdout=result.get("output", ""),
-            exit_code=result.get("returncode", 0)
+            stdout=result.get("output", ""), exit_code=result.get("returncode", 0)
         )
-    
+
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
         if cmd not in self._command_cache:
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
-            self._command_cache[cmd] = result.stdout.strip() == 'yes'
+            self._command_cache[cmd] = result.stdout.strip() == "yes"
         return self._command_cache[cmd]
-    
+
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
         Check if a file is likely binary.
-        
+
         Uses extension check (fast) + content analysis (fallback).
         """
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
             return True
-        
+
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
-            non_printable = sum(1 for c in content_sample[:1000]
-                               if ord(c) < 32 and c not in '\n\r\t')
+            non_printable = sum(
+                1 for c in content_sample[:1000] if ord(c) < 32 and c not in "\n\r\t"
+            )
             return non_printable / min(len(content_sample), 1000) > 0.30
-        
+
         return False
-    
+
     def _is_image(self, path: str) -> bool:
         """Check if file is an image we can return as base64."""
         ext = os.path.splitext(path)[1].lower()
         return ext in IMAGE_EXTENSIONS
-    
+
     def _add_line_numbers(self, content: str, start_line: int = 1) -> str:
         """Add line numbers to content in ``LINE_NUM|CONTENT`` format.
 
@@ -962,53 +998,54 @@ class ShellFileOperations(FileOperations):
         numbers, just not the padding.
         """
         from tools.tool_output_limits import get_max_line_length
+
         max_line_length = get_max_line_length()
-        lines = content.split('\n')
+        lines = content.split("\n")
         numbered = []
         for i, line in enumerate(lines, start=start_line):
             # Truncate long lines
             if len(line) > max_line_length:
                 line = line[:max_line_length] + "... [truncated]"
             numbered.append(f"{i}|{line}")
-        return '\n'.join(numbered)
-    
+        return "\n".join(numbered)
+
     def _expand_path(self, path: str) -> str:
         """
         Expand shell-style paths like ~ and ~user to absolute paths.
-        
+
         This must be done BEFORE shell escaping, since ~ doesn't expand
         inside single quotes.
         """
         if not path:
             return path
-        
+
         # Handle ~ and ~user
-        if path.startswith('~'):
+        if path.startswith("~"):
             # Get home directory via the terminal environment
             result = self._exec("echo $HOME")
             if result.exit_code == 0 and result.stdout.strip():
                 home = result.stdout.strip()
-                if path == '~':
+                if path == "~":
                     return home
-                elif path.startswith('~/'):
+                elif path.startswith("~/"):
                     return home + path[1:]  # Replace ~ with home
                 # ~username format - extract and validate username before
                 # letting shell expand it (prevent shell injection via
                 # paths like "~; rm -rf /").
                 rest = path[1:]  # strip leading ~
-                slash_idx = rest.find('/')
+                slash_idx = rest.find("/")
                 username = rest[:slash_idx] if slash_idx >= 0 else rest
-                if username and re.fullmatch(r'[a-zA-Z0-9._-]+', username):
+                if username and re.fullmatch(r"[a-zA-Z0-9._-]+", username):
                     # Only expand ~username (not the full path) to avoid shell
                     # injection via path suffixes like "~user/$(malicious)".
                     expand_result = self._exec(f"echo ~{username}")
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
                         user_home = expand_result.stdout.strip()
-                        suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
+                        suffix = path[1 + len(username) :]  # e.g. "/rest/of/path"
                         return user_home + suffix
-        
+
         return path
-    
+
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands."""
         # Use single quotes and escape any single quotes in the string
@@ -1052,7 +1089,7 @@ class ShellFileOperations(FileOperations):
         script = (
             "set -e; "
             f"d={q_parent}; t={q_path}; "
-            'tmp="$(mktemp -p "$d" ' + tmpl + ' 2>/dev/null '
+            'tmp="$(mktemp -p "$d" ' + tmpl + " 2>/dev/null "
             '|| mktemp "$d/.hermes-tmp.$$.XXXXXX" 2>/dev/null '
             '|| { tmp="$d/.hermes-tmp.$$"; : > "$tmp" && echo "$tmp"; })"; '
             '[ -n "$tmp" ] || { echo "atomic write: could not create temp file" >&2; exit 1; }; '
@@ -1068,7 +1105,9 @@ class ShellFileOperations(FileOperations):
         )
         return self._exec(script, stdin_data=content)
 
-    def _detect_file_line_ending(self, path: str, pre_content: Optional[str] = None) -> Optional[str]:
+    def _detect_file_line_ending(
+        self, path: str, pre_content: Optional[str] = None
+    ) -> Optional[str]:
         """Detect the dominant line ending of a file on disk.
 
         If ``pre_content`` is already available (we just read the file
@@ -1105,58 +1144,55 @@ class ShellFileOperations(FileOperations):
             return False
         return _has_bom(head_result.stdout)
 
-
     def _unified_diff(self, old_content: str, new_content: str, filename: str) -> str:
         """Generate unified diff between old and new content."""
         old_lines = old_content.splitlines(keepends=True)
         new_lines = new_content.splitlines(keepends=True)
         diff = difflib.unified_diff(
-            old_lines, new_lines,
-            fromfile=f"a/{filename}",
-            tofile=f"b/{filename}"
+            old_lines, new_lines, fromfile=f"a/{filename}", tofile=f"b/{filename}"
         )
-        return ''.join(diff)
-    
+        return "".join(diff)
+
     # =========================================================================
     # READ Implementation
     # =========================================================================
-    
+
     def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
-        
+
         Args:
             path: File path (absolute or relative to cwd)
             offset: Line number to start from (1-indexed, default 1)
             limit: Maximum lines to return (default 500, max 2000)
-        
+
         Returns:
             ReadResult with content, metadata, or error info
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
         offset, limit = normalize_read_pagination(offset, limit)
-        
+
         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
-        
+
         if stat_result.exit_code != 0:
             # File not found - try to suggest similar files
             return self._suggest_similar_files(path)
-        
+
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
             file_size = int(stat_output.strip())
         except ValueError:
             file_size = 0
-        
+
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
             # Still try to read, but warn
             pass
-        
+
         # Images are never inlined — redirect to the vision tool
         if self._is_image(path):
             return ReadResult(
@@ -1168,24 +1204,24 @@ class ShellFileOperations(FileOperations):
                     "Use vision_analyze with this file path to inspect the image contents."
                 ),
             )
-        
+
         # Read a sample to check for binary content
         sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        
+
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
-                error="Binary file - cannot display as text. Use appropriate tools to handle this file type."
+                error="Binary file - cannot display as text. Use appropriate tools to handle this file type.",
             )
-        
+
         # Read with pagination using sed
         end_line = offset + limit - 1
         read_cmd = f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
         read_result = self._exec(read_cmd)
-        
+
         if read_result.exit_code != 0:
             return ReadResult(error=f"Failed to read file: {read_result.stdout}")
         read_output = _strip_terminal_fence_leaks(read_result.stdout)
@@ -1194,7 +1230,7 @@ class ShellFileOperations(FileOperations):
         # chunk (the marker lives at byte 0); later pages can't carry it.
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
-        
+
         # Get total line count
         wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
         wc_result = self._exec(wc_cmd)
@@ -1203,21 +1239,21 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
-        
+
         # Check if truncated
         truncated = total_lines > end_line
         hint = None
         if truncated:
             hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
-        
+
         return ReadResult(
             content=self._add_line_numbers(read_output, offset),
             total_lines=total_lines,
             file_size=file_size,
             truncated=truncated,
-            hint=hint
+            hint=hint,
         )
-    
+
     def _suggest_similar_files(self, path: str) -> ReadResult:
         """Suggest similar files when the requested file is not found.
 
@@ -1241,7 +1277,7 @@ class ShellFileOperations(FileOperations):
         dir_entries: list[str] = []
         scored: list = []  # (score, filepath) — higher is better
         if ls_result.exit_code == 0 and ls_result.stdout.strip():
-            for f in ls_result.stdout.strip().split('\n'):
+            for f in ls_result.stdout.strip().split("\n"):
                 if not f:
                     continue
                 dir_entries.append(f)
@@ -1295,11 +1331,13 @@ class ShellFileOperations(FileOperations):
             ancestor = dir_path
             ancestor_entries: list[str] = []
             while ancestor and ancestor != "/" and ancestor != ".":
-                check_cmd = f"ls -1 {self._escape_shell_arg(ancestor)} 2>/dev/null | head -30"
+                check_cmd = (
+                    f"ls -1 {self._escape_shell_arg(ancestor)} 2>/dev/null | head -30"
+                )
                 check_result = self._exec(check_cmd)
                 if check_result.exit_code == 0 and check_result.stdout.strip():
                     ancestor_entries = [
-                        e for e in check_result.stdout.strip().split('\n') if e
+                        e for e in check_result.stdout.strip().split("\n") if e
                     ]
                     break
                 parent = os.path.dirname(ancestor)
@@ -1308,7 +1346,9 @@ class ShellFileOperations(FileOperations):
                 ancestor = parent
 
             if ancestor_entries:
-                ancestor_display = ancestor if ancestor != dir_path else "parent directory"
+                ancestor_display = (
+                    ancestor if ancestor != dir_path else "parent directory"
+                )
                 hint_parts.append(
                     f"Directory {dir_path} does not exist. "
                     f"Contents of nearest existing ancestor ({ancestor_display}): "
@@ -1325,11 +1365,8 @@ class ShellFileOperations(FileOperations):
         if hint_parts:
             error_msg += "\n\n" + "\n".join(hint_parts)
 
-        return ReadResult(
-            error=error_msg,
-            similar_files=similar
-        )
-    
+        return ReadResult(error=error_msg, similar_files=similar)
+
     def read_file_raw(self, path: str) -> ReadResult:
         """Read the complete file content as a plain string.
 
@@ -1348,12 +1385,15 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
+        sample_result = self._exec(
+            f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
+        )
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
-                is_binary=True, file_size=file_size,
-                error="Binary file — cannot display as text."
+                is_binary=True,
+                file_size=file_size,
+                error="Binary file — cannot display as text.",
             )
         cat_result = self._exec(f"cat {self._escape_shell_arg(path)}")
         if cat_result.exit_code != 0:
@@ -1426,7 +1466,9 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
 
         if result.exit_code != 0:
-            return WriteResult(error=f"Failed to delete {path}: {(result.stdout or '').strip() or 'unknown error'}")
+            return WriteResult(
+                error=f"Failed to delete {path}: {(result.stdout or '').strip() or 'unknown error'}"
+            )
 
         return WriteResult()
 
@@ -1475,7 +1517,9 @@ class ShellFileOperations(FileOperations):
 
         # Block writes to sensitive paths
         if _is_write_denied(path):
-            return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+            return WriteResult(
+                error=f"Write denied: '{path}' is a protected system/credential file."
+            )
 
         # Capture pre-write content.  Two consumers want it:
         #
@@ -1572,10 +1616,12 @@ class ShellFileOperations(FileOperations):
         try:
             bytes_written = int(stat_result.stdout.strip())
         except ValueError:
-            bytes_written = len(content.encode('utf-8'))
+            bytes_written = len(content.encode("utf-8"))
 
         # Post-write lint with delta refinement.
-        lint_result = self._check_lint_delta(path, pre_content=pre_content, post_content=content)
+        lint_result = self._check_lint_delta(
+            path, pre_content=pre_content, post_content=content
+        )
 
         # Semantic diagnostics from the LSP layer — separate channel.
         # Only fired when the syntax tier reported clean (no point asking
@@ -1597,13 +1643,14 @@ class ShellFileOperations(FileOperations):
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
         )
-    
+
     # =========================================================================
     # PATCH Implementation (Replace Mode)
     # =========================================================================
-    
-    def patch_replace(self, path: str, old_string: str, new_string: str,
-                      replace_all: bool = False) -> PatchResult:
+
+    def patch_replace(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> PatchResult:
         """
         Replace text in a file using fuzzy matching.
 
@@ -1621,15 +1668,17 @@ class ShellFileOperations(FileOperations):
 
         # Block writes to sensitive paths
         if _is_write_denied(path):
-            return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+            return PatchResult(
+                error=f"Write denied: '{path}' is a protected system/credential file."
+            )
 
         # Read current content
         read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
         read_result = self._exec(read_cmd)
-        
+
         if read_result.exit_code != 0:
             return PatchResult(error=f"Failed to read file: {path}")
-        
+
         content = read_result.stdout
         # Strip a leading UTF-8 BOM before matching so the fuzzy matcher and
         # the diff operate on clean content (a phantom U+FEFF before line 1
@@ -1640,7 +1689,7 @@ class ShellFileOperations(FileOperations):
 
         # Import and use fuzzy matching
         from tools.fuzzy_match import fuzzy_find_and_replace
-        
+
         new_content, match_count, _strategy, error = fuzzy_find_and_replace(
             content, old_string, new_string, replace_all
         )
@@ -1669,9 +1718,15 @@ class ShellFileOperations(FileOperations):
             structured_err = ""
             try:
                 from tools.fuzzy_match import format_structured_error
+
                 structured_err = format_structured_error(
-                    error, match_count, old_string, new_string, content,
-                    file_path=path, strategy=_strategy,
+                    error,
+                    match_count,
+                    old_string,
+                    new_string,
+                    content,
+                    file_path=path,
+                    strategy=_strategy,
                 )
             except Exception:
                 pass
@@ -1682,7 +1737,10 @@ class ShellFileOperations(FileOperations):
             if not structured_err:
                 try:
                     from tools.fuzzy_match import format_no_match_hint
-                    err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+
+                    err_msg += format_no_match_hint(
+                        err_msg, match_count, old_string, content
+                    )
                 except Exception:
                     pass
             return PatchResult(error=err_msg, structured_error=structured_err or None)
@@ -1712,7 +1770,9 @@ class ShellFileOperations(FileOperations):
         verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
         verify_result = self._exec(verify_cmd)
         if verify_result.exit_code != 0:
-            return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
+            return PatchResult(
+                error=f"Post-write verification failed: could not re-read {path}"
+            )
         # Normalize line endings before comparing.  On Windows, Python's
         # default text-mode ``open()`` translates ``\n`` → ``\r\n`` on
         # write, so the file on disk legitimately holds CRLFs while our
@@ -1725,16 +1785,20 @@ class ShellFileOperations(FileOperations):
         # matched against, so the comparison must drop it to stay
         # apples-to-apples.
         _verify_bomless, _ = _strip_bom(verify_result.stdout)
-        _verify_stdout_normalized = _verify_bomless.replace("\r\n", "\n").replace("\r", "\n")
+        _verify_stdout_normalized = _verify_bomless.replace("\r\n", "\n").replace(
+            "\r", "\n"
+        )
         _new_content_normalized = new_content.replace("\r\n", "\n").replace("\r", "\n")
         if _verify_stdout_normalized != _new_content_normalized:
-            return PatchResult(error=(
-                f"Post-write verification failed for {path}: on-disk content "
-                f"differs from intended write "
-                f"(wrote {len(_new_content_normalized)} chars, read back "
-                f"{len(_verify_stdout_normalized)} chars after normalizing line endings). "
-                "The patch did not persist. Re-read the file and try again."
-            ))
+            return PatchResult(
+                error=(
+                    f"Post-write verification failed for {path}: on-disk content "
+                    f"differs from intended write "
+                    f"(wrote {len(_new_content_normalized)} chars, read back "
+                    f"{len(_verify_stdout_normalized)} chars after normalizing line endings). "
+                    "The patch did not persist. Re-read the file and try again."
+                )
+            )
 
         # Generate diff
         diff = self._unified_diff(content, new_content, path)
@@ -1742,7 +1806,9 @@ class ShellFileOperations(FileOperations):
         # Auto-lint with delta refinement: only surface errors introduced
         # by this patch, filtering out pre-existing lint failures so the
         # agent isn't distracted by problems that were already there.
-        lint_result = self._check_lint_delta(path, pre_content=content, post_content=new_content)
+        lint_result = self._check_lint_delta(
+            path, pre_content=content, post_content=new_content
+        )
 
         return PatchResult(
             success=True,
@@ -1757,11 +1823,11 @@ class ShellFileOperations(FileOperations):
             # syntax-check ``lint`` so the agent can read both signals.
             lsp_diagnostics=write_result.lsp_diagnostics,
         )
-    
+
     def patch_v4a(self, patch_content: str) -> PatchResult:
         """
         Apply a V4A format patch.
-        
+
         V4A format:
             *** Begin Patch
             *** Update File: path/to/file.py
@@ -1770,24 +1836,24 @@ class ShellFileOperations(FileOperations):
             -removed line
             +added line
             *** End Patch
-        
+
         Args:
             patch_content: V4A format patch string
-        
+
         Returns:
             PatchResult with changes made
         """
         # Import patch parser
         from tools.patch_parser import parse_v4a_patch, apply_v4a_operations
-        
+
         operations, parse_error = parse_v4a_patch(patch_content)
         if parse_error:
             return PatchResult(error=f"Failed to parse patch: {parse_error}")
-        
+
         # Apply operations
         result = apply_v4a_operations(operations, self)
         return result
-    
+
     def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:
         """
         Run syntax check on a file after editing.
@@ -1818,11 +1884,16 @@ class ShellFileOperations(FileOperations):
                 read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
                 read_result = self._exec(read_cmd)
                 if read_result.exit_code != 0:
-                    return LintResult(skipped=True, message=f"Failed to read {path} for lint")
+                    return LintResult(
+                        skipped=True, message=f"Failed to read {path} for lint"
+                    )
                 content = read_result.stdout
             ok, err = inproc(content)
             if err == "__SKIP__":
-                return LintResult(skipped=True, message=f"No linter available for {ext} (missing dependency)")
+                return LintResult(
+                    skipped=True,
+                    message=f"No linter available for {ext} (missing dependency)",
+                )
             return LintResult(success=ok, output="" if ok else err)
 
         # Fall back to shell linter.
@@ -1853,13 +1924,16 @@ class ShellFileOperations(FileOperations):
         cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
         result = self._exec(cmd, timeout=30)
 
-        if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):
+        if result.exit_code != 0 and _looks_like_linter_unusable(
+            base_cmd, result.stdout
+        ):
             # The linter command exists on PATH but couldn't actually run
             # (e.g. ``npx tsc`` when tsc isn't in node_modules; ``rustfmt
             # --check`` without a Cargo project).  This is a tooling gap,
             # not a real lint failure — surface it as ``skipped`` so the
             # write doesn't get flagged AND so the LSP tier still runs.
             from tools.ansi_strip import strip_ansi
+
             cleaned = strip_ansi(result.stdout).strip()
             # Collapse to a single line — the npx banner is multi-line ASCII.
             first_line = next(
@@ -1873,11 +1947,12 @@ class ShellFileOperations(FileOperations):
 
         return LintResult(
             success=result.exit_code == 0,
-            output=result.stdout.strip() if result.stdout.strip() else ""
+            output=result.stdout.strip() if result.stdout.strip() else "",
         )
 
-    def _check_lint_delta(self, path: str, pre_content: Optional[str],
-                          post_content: Optional[str] = None) -> LintResult:
+    def _check_lint_delta(
+        self, path: str, pre_content: Optional[str], post_content: Optional[str] = None
+    ) -> LintResult:
         """
         Run post-write syntax lint with pre-write baseline comparison.
 
@@ -1941,7 +2016,11 @@ class ShellFileOperations(FileOperations):
         # new on top — the agent knows it's inherited state, not fresh
         # damage, without silently dropping the error.
         pre_lines = {ln.strip() for ln in pre.output.splitlines() if ln.strip()}
-        post_lines = [ln for ln in post.output.splitlines() if ln.strip() and ln.strip() not in pre_lines]
+        post_lines = [
+            ln
+            for ln in post.output.splitlines()
+            if ln.strip() and ln.strip() not in pre_lines
+        ]
 
         if not post_lines:
             # Every error in post was also in pre — this edit didn't make
@@ -1958,7 +2037,7 @@ class ShellFileOperations(FileOperations):
             output=(
                 "New lint errors introduced by this edit "
                 "(pre-existing errors filtered out):\n" + "\n".join(post_lines)
-            )
+            ),
         )
 
     def _lsp_local_only(self) -> bool:
@@ -2052,6 +2131,7 @@ class ShellFileOperations(FileOperations):
             return
         try:
             from agent.lsp import get_service
+
             svc = get_service()
         except Exception:  # noqa: BLE001
             return
@@ -2106,38 +2186,54 @@ class ShellFileOperations(FileOperations):
         # remaps baseline diagnostics into post-edit coordinates so
         # the strict (range-aware) delta key matches correctly.
         line_shift = None
-        if pre_content is not None and post_content is not None and pre_content != post_content:
+        if (
+            pre_content is not None
+            and post_content is not None
+            and pre_content != post_content
+        ):
             try:
                 from agent.lsp.range_shift import build_line_shift
+
                 line_shift = build_line_shift(pre_content, post_content)
             except Exception:  # noqa: BLE001
                 line_shift = None
 
         try:
-            diagnostics = svc.get_diagnostics_sync(path, delta=True, line_shift=line_shift)
+            diagnostics = svc.get_diagnostics_sync(
+                path, delta=True, line_shift=line_shift
+            )
         except Exception:  # noqa: BLE001
             return ""
         if not diagnostics:
             return ""
         try:
             from agent.lsp.reporter import report_for_file, truncate
+
             block = report_for_file(path, diagnostics)
             if not block:
                 return ""
             return truncate("LSP diagnostics introduced by this edit:\n" + block)
         except Exception:  # noqa: BLE001
             return ""
-    
+
     # =========================================================================
     # SEARCH Implementation
     # =========================================================================
-    
-    def search(self, pattern: str, path: str = ".", target: str = "content",
-               file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+
+    def search(
+        self,
+        pattern: str,
+        path: str = ".",
+        target: str = "content",
+        file_glob: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        output_mode: str = "content",
+        context: int = 0,
+    ) -> SearchResult:
         """
         Search for content or files.
-        
+
         Args:
             pattern: Regex (for content) or glob pattern (for files)
             path: Directory/file to search (default: cwd)
@@ -2147,7 +2243,7 @@ class ShellFileOperations(FileOperations):
             offset: Skip first N results
             output_mode: "content", "files_only", or "count"
             context: Lines of context around matches
-        
+
         Returns:
             SearchResult with matches or file list
         """
@@ -2155,9 +2251,11 @@ class ShellFileOperations(FileOperations):
 
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
         # Validate that the path exists before searching
-        check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
+        check = self._exec(
+            f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found"
+        )
         if "not_found" in check.stdout:
             # Try to suggest nearby paths
             parent = os.path.dirname(path) or "."
@@ -2174,34 +2272,32 @@ class ShellFileOperations(FileOperations):
                 if ls_result.exit_code == 0 and ls_result.stdout.strip():
                     lower_q = basename_query.lower()
                     candidates = []
-                    for entry in ls_result.stdout.strip().split('\n'):
+                    for entry in ls_result.stdout.strip().split("\n"):
                         if not entry:
                             continue
                         le = entry.lower()
                         if lower_q in le or le in lower_q or le.startswith(lower_q[:3]):
                             candidates.append(os.path.join(parent, entry))
                     if candidates:
-                        hint_parts.append(
-                            "Similar paths: " + ", ".join(candidates[:5])
-                        )
-            return SearchResult(
-                error=". ".join(hint_parts),
-                total_count=0
-            )
-        
+                        hint_parts.append("Similar paths: " + ", ".join(candidates[:5]))
+            return SearchResult(error=". ".join(hint_parts), total_count=0)
+
         if target == "files":
             return self._search_files(pattern, path, limit, offset)
         else:
-            return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
-    
-    def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+            return self._search_content(
+                pattern, path, file_glob, limit, offset, output_mode, context
+            )
+
+    def _search_files(
+        self, pattern: str, path: str, limit: int, offset: int
+    ) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
         # Auto-prepend **/ for recursive search if not already present
-        if not pattern.startswith('**/') and '/' not in pattern:
+        if not pattern.startswith("**/") and "/" not in pattern:
             search_pattern = pattern
         else:
-            search_pattern = pattern.split('/')[-1]
+            search_pattern = pattern.split("/")[-1]
 
         search_root = Path(path)
         has_hidden_path_ancestor = any(
@@ -2212,15 +2308,15 @@ class ShellFileOperations(FileOperations):
         # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
-        if self._has_command('rg'):
+        if self._has_command("rg"):
             return self._search_files_rg(search_pattern, path, limit, offset)
 
         # Fallback: find (slower, no .gitignore awareness)
-        if not self._has_command('find'):
+        if not self._has_command("find"):
             return SearchResult(
                 error="File search requires 'rg' (ripgrep) or 'find'. "
-                      "Install ripgrep for best results: "
-                      "https://github.com/BurntSushi/ripgrep#installation"
+                "Install ripgrep for best results: "
+                "https://github.com/BurntSushi/ripgrep#installation"
             )
 
         # Exclude hidden directories (matching ripgrep's default behavior).
@@ -2234,25 +2330,29 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+        cmd = (
+            f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} "
+            f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+        )
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+            cmd_simple = (
+                f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} "
+                f"2>/dev/null | sort -rn{pagination_expr}"
+            )
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
 
         files = []
-        for line in stdout.strip().split('\n'):
+        for line in stdout.strip().split("\n"):
             if not line:
                 continue
-            parts = line.split(' ', 1)
-            if len(parts) == 2 and parts[0].replace('.', '').isdigit():
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[0].replace(".", "").isdigit():
                 files.append(parts[1])
             else:
                 files.append(line)
@@ -2265,13 +2365,18 @@ class ShellFileOperations(FileOperations):
             filtered_files = []
             for file_path in files:
                 try:
-                    rel_parts = Path(file_path).resolve().relative_to(normalized_root).parts
+                    rel_parts = (
+                        Path(file_path).resolve().relative_to(normalized_root).parts
+                    )
                 except ValueError:
                     rel_parts = Path(file_path).parts
-                if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
+                if any(
+                    part not in {".", ".."} and part.startswith(".")
+                    for part in rel_parts
+                ):
                     continue
                 filtered_files.append(file_path)
-            files = filtered_files[offset:offset + limit]
+            files = filtered_files[offset : offset + limit]
         # pagination for standard roots is already applied in shell
 
         return SearchResult(
@@ -2281,7 +2386,9 @@ class ShellFileOperations(FileOperations):
             limit_reason=limit_reason,
         )
 
-    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files_rg(
+        self, pattern: str, path: str, limit: int, offset: int
+    ) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
         rg --files respects .gitignore and excludes hidden directories by
@@ -2291,7 +2398,7 @@ class ShellFileOperations(FileOperations):
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
-        if '/' not in pattern and not pattern.startswith('*'):
+        if "/" not in pattern and not pattern.startswith("*"):
             glob_pattern = f"*{pattern}"
         else:
             glob_pattern = pattern
@@ -2305,7 +2412,7 @@ class ShellFileOperations(FileOperations):
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.strip().split('\n') if f]
+        all_files = [f for f in stdout.strip().split("\n") if f]
 
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
@@ -2316,9 +2423,9 @@ class ShellFileOperations(FileOperations):
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            all_files = [f for f in stdout.strip().split("\n") if f]
 
-        page = all_files[offset:offset + limit]
+        page = all_files[offset : offset + limit]
 
         return SearchResult(
             files=page,
@@ -2326,55 +2433,73 @@ class ShellFileOperations(FileOperations):
             truncated=len(all_files) >= fetch_limit or bool(limit_reason),
             limit_reason=limit_reason,
         )
-    
-    def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+
+    def _search_content(
+        self,
+        pattern: str,
+        path: str,
+        file_glob: Optional[str],
+        limit: int,
+        offset: int,
+        output_mode: str,
+        context: int,
+    ) -> SearchResult:
         """Search for content inside files (grep-like)."""
         # Try ripgrep first (fast), fallback to grep (slower but works)
-        if self._has_command('rg'):
-            result = self._search_with_rg(pattern, path, file_glob, limit, offset,
-                                          output_mode, context)
-        elif self._has_command('grep'):
-            result = self._search_with_grep(pattern, path, file_glob, limit, offset,
-                                            output_mode, context)
+        if self._has_command("rg"):
+            result = self._search_with_rg(
+                pattern, path, file_glob, limit, offset, output_mode, context
+            )
+        elif self._has_command("grep"):
+            result = self._search_with_grep(
+                pattern, path, file_glob, limit, offset, output_mode, context
+            )
         else:
             # Neither rg nor grep available (Windows without Git Bash, etc.)
             return SearchResult(
                 error="Content search requires ripgrep (rg) or grep. "
-                      "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"
+                "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"
             )
 
         return _maybe_warn_line_oriented_newline_pattern(result, pattern)
-    
-    def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+
+    def _search_with_rg(
+        self,
+        pattern: str,
+        path: str,
+        file_glob: Optional[str],
+        limit: int,
+        offset: int,
+        output_mode: str,
+        context: int,
+    ) -> SearchResult:
         """Search using ripgrep."""
         cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
-        
+
         # Add context if requested
         if context > 0:
             cmd_parts.extend(["-C", str(context)])
-        
+
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
             cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
-        
+
         # Output mode handling
         if output_mode == "files_only":
             cmd_parts.append("-l")  # Files only
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
-        
+
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
-        
+
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
         # so we grab generously and filter in Python.
         fetch_limit = limit + offset + 200 if context > 0 else limit + offset
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
+
         # `set -o pipefail` so rg's exit status propagates through `| head`.
         # Without it the pipeline reports head's status (0), masking rg's
         # error code (2) and making the guard below unreachable. rg handles a
@@ -2402,21 +2527,21 @@ class ShellFileOperations(FileOperations):
         stdout = payload
         # Parse results based on output mode
         if output_mode == "files_only":
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            all_files = [f for f in stdout.strip().split("\n") if f]
             total = len(all_files)
-            page = all_files[offset:offset + limit]
+            page = all_files[offset : offset + limit]
             return SearchResult(
                 files=page,
                 total_count=total,
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
             )
-        
+
         elif output_mode == "count":
             counts = {}
-            for line in stdout.strip().split('\n'):
-                if ':' in line:
-                    parts = line.rsplit(':', 1)
+            for line in stdout.strip().split("\n"):
+                if ":" in line:
+                    parts = line.rsplit(":", 1)
                     if len(parts) == 2:
                         try:
                             counts[parts[0]] = int(parts[1])
@@ -2428,7 +2553,7 @@ class ShellFileOperations(FileOperations):
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
             )
-        
+
         else:
             # Parse content matches and context lines.
             # rg match lines:   "file:lineno:content"  (colon separator)
@@ -2436,73 +2561,85 @@ class ShellFileOperations(FileOperations):
             # rg group seps:    "--"
             # Note: on Windows, paths contain drive letters (e.g. C:\path),
             # so naive split(":") breaks. Use regex to handle both platforms.
-            _match_re = re.compile(r'^([A-Za-z]:)?(.*?):(\d+):(.*)$')
+            _match_re = re.compile(r"^([A-Za-z]:)?(.*?):(\d+):(.*)$")
             matches = []
-            for line in stdout.strip().split('\n'):
+            for line in stdout.strip().split("\n"):
                 if not line or line == "--":
                     continue
-                
+
                 # Try match line first (colon-separated: file:line:content)
                 m = _match_re.match(line)
                 if m:
-                    matches.append(SearchMatch(
-                        path=(m.group(1) or '') + m.group(2),
-                        line_number=int(m.group(3)),
-                        content=m.group(4)[:500]
-                    ))
+                    matches.append(
+                        SearchMatch(
+                            path=(m.group(1) or "") + m.group(2),
+                            line_number=int(m.group(3)),
+                            content=m.group(4)[:500],
+                        )
+                    )
                     continue
-                
+
                 # Try context line (dash-separated: file-line-content)
                 # Only attempt if context was requested to avoid false positives
                 if context > 0:
                     parsed = _parse_search_context_line(line)
                     if parsed:
-                        matches.append(SearchMatch(
-                            path=parsed[0],
-                            line_number=parsed[1],
-                            content=parsed[2][:500]
-                        ))
-            
+                        matches.append(
+                            SearchMatch(
+                                path=parsed[0],
+                                line_number=parsed[1],
+                                content=parsed[2][:500],
+                            )
+                        )
+
             total = len(matches)
-            page = matches[offset:offset + limit]
+            page = matches[offset : offset + limit]
             return SearchResult(
                 matches=page,
                 total_count=total,
                 truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
             )
-    
-    def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
-                          limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+
+    def _search_with_grep(
+        self,
+        pattern: str,
+        path: str,
+        file_glob: Optional[str],
+        limit: int,
+        offset: int,
+        output_mode: str,
+        context: int,
+    ) -> SearchResult:
         """Fallback search using grep."""
         cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
-        
+
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
         cmd_parts.append("--exclude-dir='.*'")
-        
+
         # Add context if requested
         if context > 0:
             cmd_parts.extend(["-C", str(context)])
-        
+
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
             cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
-        
+
         # Output mode handling
         if output_mode == "files_only":
             cmd_parts.append("-l")
         elif output_mode == "count":
             cmd_parts.append("-c")
-        
+
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
-        
+
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
+
         # `set -o pipefail` so grep's exit status propagates through `| head`
         # (without it the pipeline reports head's 0, masking grep's error 2).
         # A truncating head makes grep exit 141 (SIGPIPE) on an otherwise
@@ -2528,21 +2665,21 @@ class ShellFileOperations(FileOperations):
 
         stdout = payload
         if output_mode == "files_only":
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            all_files = [f for f in stdout.strip().split("\n") if f]
             total = len(all_files)
-            page = all_files[offset:offset + limit]
+            page = all_files[offset : offset + limit]
             return SearchResult(
                 files=page,
                 total_count=total,
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
             )
-        
+
         elif output_mode == "count":
             counts = {}
-            for line in stdout.strip().split('\n'):
-                if ':' in line:
-                    parts = line.rsplit(':', 1)
+            for line in stdout.strip().split("\n"):
+                if ":" in line:
+                    parts = line.rsplit(":", 1)
                     if len(parts) == 2:
                         try:
                             counts[parts[0]] = int(parts[1])
@@ -2554,40 +2691,43 @@ class ShellFileOperations(FileOperations):
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
             )
-        
+
         else:
             # grep match lines:   "file:lineno:content" (colon)
             # grep context lines: "file-lineno-content"  (dash)
             # grep group seps:    "--"
             # Note: on Windows, paths contain drive letters (e.g. C:\path),
             # so naive split(":") breaks. Use regex to handle both platforms.
-            _match_re = re.compile(r'^([A-Za-z]:)?(.*?):(\d+):(.*)$')
+            _match_re = re.compile(r"^([A-Za-z]:)?(.*?):(\d+):(.*)$")
             matches = []
-            for line in stdout.strip().split('\n'):
+            for line in stdout.strip().split("\n"):
                 if not line or line == "--":
                     continue
-                
+
                 m = _match_re.match(line)
                 if m:
-                    matches.append(SearchMatch(
-                        path=(m.group(1) or '') + m.group(2),
-                        line_number=int(m.group(3)),
-                        content=m.group(4)[:500]
-                    ))
+                    matches.append(
+                        SearchMatch(
+                            path=(m.group(1) or "") + m.group(2),
+                            line_number=int(m.group(3)),
+                            content=m.group(4)[:500],
+                        )
+                    )
                     continue
-                
+
                 if context > 0:
                     parsed = _parse_search_context_line(line)
                     if parsed:
-                        matches.append(SearchMatch(
-                            path=parsed[0],
-                            line_number=parsed[1],
-                            content=parsed[2][:500]
-                        ))
+                        matches.append(
+                            SearchMatch(
+                                path=parsed[0],
+                                line_number=parsed[1],
+                                content=parsed[2][:500],
+                            )
+                        )
 
-            
             total = len(matches)
-            page = matches[offset:offset + limit]
+            page = matches[offset : offset + limit]
             return SearchResult(
                 matches=page,
                 total_count=total,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -272,6 +272,13 @@ class PatchResult:
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
+    # Structured error context for self-correction (#996).  Contains
+    # error-type classification, the closest matching region with line
+    # numbers, and a recovery suggestion.  Populated by patch_replace
+    # on match failures; consumed by patch_tool to add a ``_diagnostic``
+    # field to the tool result so the model can correct on its next
+    # turn without re-reading the file.
+    structured_error: Optional[str] = None
     
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -292,6 +299,8 @@ class PatchResult:
             hit = classify_file_error(self.error)
             if hit:
                 result["error_class"], result["recovery"] = hit
+        if self.structured_error:
+            result["_diagnostic"] = self.structured_error
         return result
 
 
@@ -1653,12 +1662,30 @@ class ShellFileOperations(FileOperations):
 
         if error or match_count == 0:
             err_msg = error or f"Could not find match for old_string in {path}"
+            # Build structured error context for self-correction (#996).
+            # This gives the model the closest matching region with line
+            # numbers and a classified error type so it can produce a
+            # corrected patch without re-reading the file.
+            structured_err = ""
             try:
-                from tools.fuzzy_match import format_no_match_hint
-                err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+                from tools.fuzzy_match import format_structured_error
+                structured_err = format_structured_error(
+                    error, match_count, old_string, new_string, content,
+                    file_path=path, strategy=_strategy,
+                )
             except Exception:
                 pass
-            return PatchResult(error=err_msg)
+            # Append the legacy "Did you mean?" hint only when the
+            # structured error didn't already produce a richer context
+            # snippet (the structured error is strictly more useful
+            # because it includes line numbers and a recovery hint).
+            if not structured_err:
+                try:
+                    from tools.fuzzy_match import format_no_match_hint
+                    err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+                except Exception:
+                    pass
+            return PatchResult(error=err_msg, structured_error=structured_err or None)
 
         # ── Line-ending preservation ──────────────────────────────────
         # Models nearly always send old_string/new_string with bare LF

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -73,6 +73,7 @@ def _get_max_read_chars() -> int:
         return _max_read_chars_cached
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         val = cfg.get("file_read_max_chars")
         if isinstance(val, (int, float)) and val > 0:
@@ -101,10 +102,14 @@ def _get_self_correction_retries() -> int:
         return _self_correction_retries_cached
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         patch_cfg = cfg.get("patch", {})
         val = patch_cfg.get("self_correction_retries")
-        if isinstance(val, (int, float)) and 1 <= int(val) <= _MAX_SELF_CORRECTION_RETRIES:
+        if (
+            isinstance(val, (int, float))
+            and 1 <= int(val) <= _MAX_SELF_CORRECTION_RETRIES
+        ):
             _self_correction_retries_cached = int(val)
             return _self_correction_retries_cached
     except Exception:
@@ -167,13 +172,21 @@ _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
 # ---------------------------------------------------------------------------
 _BLOCKED_DEVICE_PATHS = frozenset({
     # Infinite output — never reach EOF
-    "/dev/zero", "/dev/random", "/dev/urandom", "/dev/full",
+    "/dev/zero",
+    "/dev/random",
+    "/dev/urandom",
+    "/dev/full",
     # Blocks waiting for input
-    "/dev/stdin", "/dev/tty", "/dev/console",
+    "/dev/stdin",
+    "/dev/tty",
+    "/dev/console",
     # Nonsensical to read
-    "/dev/stdout", "/dev/stderr",
+    "/dev/stdout",
+    "/dev/stderr",
     # fd aliases
-    "/dev/fd/0", "/dev/fd/1", "/dev/fd/2",
+    "/dev/fd/0",
+    "/dev/fd/1",
+    "/dev/fd/2",
 })
 
 
@@ -193,7 +206,12 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPa
 # (gateway/run.py); the file/terminal-tool layer must do likewise so CLI
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona"})
+_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({
+    "docker",
+    "singularity",
+    "modal",
+    "daytona",
+})
 
 
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
@@ -211,7 +229,9 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
         except Exception:
             container_key = task_id
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(
+                task_id
+            )
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -235,6 +255,7 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
 def _uses_container_paths(task_id: str = "default") -> bool:
     try:
         from tools.terminal_tool import _CONTAINER_BACKENDS
+
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
@@ -326,6 +347,7 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     """Return the task's live terminal cwd for bookkeeping when available."""
     try:
         from tools.terminal_tool import _resolve_container_task_id
+
         container_key = _resolve_container_task_id(task_id)
     except Exception:
         container_key = task_id
@@ -348,7 +370,9 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
         from tools.terminal_tool import _active_environments, _env_lock
 
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(
+                task_id
+            )
         live_cwd = _live_cwd_if_owned(env, task_id)
         if live_cwd:
             _remember_last_known_cwd(container_key, live_cwd)
@@ -445,7 +469,9 @@ def _resolve_base_dir(
     return base.resolve()
 
 
-def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path_for_task(
+    filepath: str, task_id: str = "default"
+) -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
@@ -465,7 +491,9 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     return resolved.resolve()
 
 
-def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
+def _path_resolution_warning(
+    filepath: str, resolved: Path, task_id: str = "default"
+) -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
     Surfaces the worktree-cwd divergence the moment it would matter: if the
@@ -512,9 +540,11 @@ def _is_blocked_device_path(path: str) -> bool:
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
-    if normalized.startswith("/proc/") and normalized.endswith(
-        ("/fd/0", "/fd/1", "/fd/2")
-    ):
+    if normalized.startswith("/proc/") and normalized.endswith((
+        "/fd/0",
+        "/fd/1",
+        "/fd/2",
+    )):
         return True
     # /proc/*/environ, /proc/*/cmdline, /proc/*/maps (and the maps variants
     # smaps, smaps_rollup, numa_maps) can leak secrets, command-line args, and
@@ -525,19 +555,17 @@ def _is_blocked_device_path(path: str) -> bool:
     # load addresses — an ASLR oracle on par with maps. /proc/*/pagemap exposes
     # virtual->physical translation. Both are blocked alongside the maps family.
     # endswith matches both /proc/<pid>/X and /proc/<pid>/task/<tid>/X.
-    if normalized.startswith("/proc/") and normalized.endswith(
-        (
-            "/environ",
-            "/cmdline",
-            "/maps",
-            "/smaps",
-            "/smaps_rollup",
-            "/numa_maps",
-            "/mem",
-            "/auxv",
-            "/pagemap",
-        )
-    ):
+    if normalized.startswith("/proc/") and normalized.endswith((
+        "/environ",
+        "/cmdline",
+        "/maps",
+        "/smaps",
+        "/smaps_rollup",
+        "/numa_maps",
+        "/mem",
+        "/auxv",
+        "/pagemap",
+    )):
         return True
     return False
 
@@ -634,8 +662,11 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
-    "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/", "/private/var/",
+    "/etc/",
+    "/boot/",
+    "/usr/lib/systemd/",
+    "/private/etc/",
+    "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
@@ -651,10 +682,13 @@ def _get_hermes_config_resolved() -> str | None:
     _hermes_config_resolved_loaded = True
     try:
         from hermes_cli.config import get_config_path
+
         _hermes_config_resolved = str(get_config_path().resolve())
     except Exception:
         try:
-            _hermes_config_resolved = str(Path(_expand_tilde("~/.hermes/config.yaml")).resolve())
+            _hermes_config_resolved = str(
+                Path(_expand_tilde("~/.hermes/config.yaml")).resolve()
+            )
         except Exception:
             _hermes_config_resolved = None
     return _hermes_config_resolved
@@ -681,9 +715,17 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except Exception:
         _tmp = ""
     _temp_roots = tuple(
-        p for p in (_tmp + os.sep if _tmp else "", "/var/folders/", "/private/var/folders/") if p
+        p
+        for p in (
+            _tmp + os.sep if _tmp else "",
+            "/var/folders/",
+            "/private/var/folders/",
+        )
+        if p
     )
-    in_temp = any(resolved.startswith(s) or normalized.startswith(s) for s in _temp_roots)
+    in_temp = any(
+        resolved.startswith(s) or normalized.startswith(s) for s in _temp_roots
+    )
     if not in_temp:
         for prefix in _SENSITIVE_PATH_PREFIXES:
             if resolved.startswith(prefix) or normalized.startswith(prefix):
@@ -720,7 +762,9 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
 
     try:
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(
+                task_id
+            )
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -843,11 +887,13 @@ def _last_known_cwd_for(task_id: str = "default") -> str | None:
     """
     try:
         from tools.terminal_tool import _resolve_container_task_id
+
         container_key = _resolve_container_task_id(task_id)
     except Exception:
         container_key = task_id
     with _file_ops_lock:
         return _last_known_cwd.get(container_key) or _last_known_cwd.get(task_id)
+
 
 # Track files read per task to detect re-read loops and deduplicate reads.
 # Per task_id we store:
@@ -904,15 +950,16 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
         for rp in resolved_paths:
             task_failures.pop(rp, None)
 
+
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
 # caps, a 10k-read session would accumulate ~1.5MB of dict/set state that
 # is never referenced again (only the most recent reads matter for dedup,
 # loop detection, and external-edit warnings).  Hard caps bound the
 # accretion to a few hundred KB regardless of session length.
-_READ_HISTORY_CAP = 500       # set; used only by get_read_files_summary
-_DEDUP_CAP = 1000             # dict; skip-identical-reread guard
-_READ_TIMESTAMPS_CAP = 1000   # dict; external-edit detection for write/patch
+_READ_HISTORY_CAP = 500  # set; used only by get_read_files_summary
+_DEDUP_CAP = 1000  # dict; skip-identical-reread guard
+_READ_TIMESTAMPS_CAP = 1000  # dict; external-edit detection for write/patch
 _READ_DEDUP_STATUS_MESSAGE = (
     "File unchanged since last read. The content from "
     "the earlier read_file result in this conversation is "
@@ -996,8 +1043,9 @@ def _is_internal_file_status_text(content: str) -> bool:
         return False
     if stripped == _READ_DEDUP_STATUS_MESSAGE:
         return True
-    if _READ_DEDUP_STATUS_MESSAGE in stripped and \
-            len(stripped) <= 2 * len(_READ_DEDUP_STATUS_MESSAGE):
+    if _READ_DEDUP_STATUS_MESSAGE in stripped and len(stripped) <= 2 * len(
+        _READ_DEDUP_STATUS_MESSAGE
+    ):
         return True
     return False
 
@@ -1031,18 +1079,16 @@ def _looks_like_read_file_line_numbered_content(content: str) -> bool:
         return False
 
     consecutive_pairs = sum(
-        1 for prev, current in zip(numbered, numbered[1:])
-        if current == prev + 1
+        1 for prev, current in zip(numbered, numbered[1:]) if current == prev + 1
     )
     return consecutive_pairs >= len(numbered) - 1
 
 
 def _is_internal_file_tool_content(content: str) -> bool:
     """Return True when content is file-tool display text, not intended file bytes."""
-    return (
-        _is_internal_file_status_text(content)
-        or _looks_like_read_file_line_numbered_content(content)
-    )
+    return _is_internal_file_status_text(
+        content
+    ) or _looks_like_read_file_line_numbered_content(content)
 
 
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
@@ -1061,8 +1107,12 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     a registered env override keep their isolation.
     """
     from tools.terminal_tool import (
-        _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
+        _active_environments,
+        _env_lock,
+        _create_environment,
+        _get_env_config,
+        _last_activity,
+        _start_cleanup_thread,
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
@@ -1120,7 +1170,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             if env_type == "docker":
                 image = overrides.get("docker_image") or config["docker_image"]
             elif env_type == "singularity":
-                image = overrides.get("singularity_image") or config["singularity_image"]
+                image = (
+                    overrides.get("singularity_image") or config["singularity_image"]
+                )
             elif env_type == "modal":
                 image = overrides.get("modal_image") or config["modal_image"]
             elif env_type == "daytona":
@@ -1129,7 +1181,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 image = ""
 
             cwd = overrides.get("cwd") or _last_known_cwd.get(task_id) or config["cwd"]
-            logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
+            logger.info(
+                "Creating new %s environment for task %s...", env_type, task_id[:8]
+            )
 
             container_config = None
             if env_type in {"docker", "singularity", "modal", "daytona"}:
@@ -1139,9 +1193,13 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                    "docker_mount_cwd_to_workspace": config.get(
+                        "docker_mount_cwd_to_workspace", False
+                    ),
                     "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                    "docker_run_as_host_user": config.get(
+                        "docker_run_as_host_user", False
+                    ),
                     "docker_network": config.get("docker_network", True),
                 }
 
@@ -1196,7 +1254,9 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str, offset: int = 1, limit: int = 500, task_id: str = "default"
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1204,7 +1264,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        device_base = (
+            None
+            if Path(path).expanduser().is_absolute()
+            else _resolve_base_dir(task_id)
+        )
         if _is_blocked_device(path, base_dir=device_base):
             return json.dumps({
                 "error": (
@@ -1218,7 +1282,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.
         # Malformed documents fall through to the normal path/binary guard.
-        from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
+        from tools.read_extract import (
+            ExtractionError,
+            extract_document_text,
+            is_extractable_document,
+        )
 
         if is_extractable_document(str(_resolved)):
             try:
@@ -1230,9 +1298,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
-                page_text = "\n".join(lines[offset - 1:end_line])
+                page_text = "\n".join(lines[offset - 1 : end_line])
                 result_dict = {
-                    "content": file_ops._add_line_numbers(page_text, offset) if page_text else "",
+                    "content": file_ops._add_line_numbers(page_text, offset)
+                    if page_text
+                    else "",
                     "total_lines": total_lines,
                     "file_size": os.path.getsize(_resolved),
                     "truncated": total_lines > end_line,
@@ -1271,7 +1341,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                             "retrievable via offset."
                         )
                 if result_dict["content"]:
-                    result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                    result_dict["content"] = redact_sensitive_text(
+                        result_dict["content"], file_read=True
+                    )
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1303,11 +1375,17 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
-                "last_key": None, "consecutive": 0,
-                "read_history": set(), "dedup": {},
-                "dedup_hits": {}, "read_timestamps": {},
-            })
+            task_data = _read_tracker.setdefault(
+                task_id,
+                {
+                    "last_key": None,
+                    "consecutive": 0,
+                    "read_history": set(),
+                    "dedup": {},
+                    "dedup_hits": {},
+                    "read_timestamps": {},
+                },
+            )
             # Backward-compat for pre-existing tracker entries that predate
             # dedup_hits/read_timestamps (long-lived task or crossed an
             # upgrade boundary).
@@ -1332,27 +1410,33 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         _cap_read_tracker_data(task_data)
 
                     if hits >= 2:
-                        return json.dumps({
-                            "error": (
-                                f"BLOCKED: You have called read_file on this "
-                                f"exact region {hits + 1} times and the file "
-                                "has NOT changed. STOP calling read_file for "
-                                "this path — the content from your earlier "
-                                "read_file result in this conversation is "
-                                "still current. Proceed with your task using "
-                                "the information you already have."
-                            ),
-                            "path": path,
-                            "already_read": hits + 1,
-                        }, ensure_ascii=False)
+                        return json.dumps(
+                            {
+                                "error": (
+                                    f"BLOCKED: You have called read_file on this "
+                                    f"exact region {hits + 1} times and the file "
+                                    "has NOT changed. STOP calling read_file for "
+                                    "this path — the content from your earlier "
+                                    "read_file result in this conversation is "
+                                    "still current. Proceed with your task using "
+                                    "the information you already have."
+                                ),
+                                "path": path,
+                                "already_read": hits + 1,
+                            },
+                            ensure_ascii=False,
+                        )
 
-                    return json.dumps({
-                        "status": "unchanged",
-                        "message": _READ_DEDUP_STATUS_MESSAGE,
-                        "path": path,
-                        "dedup": True,
-                        "content_returned": False,
-                    }, ensure_ascii=False)
+                    return json.dumps(
+                        {
+                            "status": "unchanged",
+                            "message": _READ_DEDUP_STATUS_MESSAGE,
+                            "path": path,
+                            "dedup": True,
+                            "content_returned": False,
+                        },
+                        ensure_ascii=False,
+                    )
             except OSError:
                 pass  # stat failed — fall through to full read
 
@@ -1410,14 +1494,20 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.
-        if (file_size and file_size > _LARGE_FILE_HINT_BYTES
-                and limit > 200
-                and result_dict.get("truncated")):
-            result_dict.setdefault("_hint", (
-                f"This file is large ({file_size:,} bytes). "
-                "Consider reading only the section you need with offset and limit "
-                "to keep context usage efficient."
-            ))
+        if (
+            file_size
+            and file_size > _LARGE_FILE_HINT_BYTES
+            and limit > 200
+            and result_dict.get("truncated")
+        ):
+            result_dict.setdefault(
+                "_hint",
+                (
+                    f"This file is large ({file_size:,} bytes). "
+                    "Consider reading only the section you need with offset and limit "
+                    "to keep context usage efficient."
+                ),
+            )
 
         # ── Track for consecutive-loop detection ──────────────────────
         read_key = ("read", path, offset, limit)
@@ -1470,15 +1560,18 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         if count >= 4:
             # Hard block: stop returning content to break the loop
-            return json.dumps({
-                "error": (
-                    f"BLOCKED: You have read this exact file region {count} times in a row. "
-                    "The content has NOT changed. You already have this information. "
-                    "STOP re-reading and proceed with your task."
-                ),
-                "path": path,
-                "already_read": count,
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "error": (
+                        f"BLOCKED: You have read this exact file region {count} times in a row. "
+                        "The content has NOT changed. You already have this information. "
+                        "STOP re-reading and proceed with your task."
+                    ),
+                    "path": path,
+                    "already_read": count,
+                },
+                ensure_ascii=False,
+            )
         elif count >= 3:
             result_dict["_warning"] = (
                 f"You have read this exact file region {count} times consecutively. "
@@ -1489,8 +1582,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
-
-
 
 
 def reset_file_dedup(task_id: str = None):
@@ -1659,9 +1750,13 @@ def _mark_verification_stale(
         logger.debug("verification stale marker failed", exc_info=True)
 
 
-def write_file_tool(path: str, content: str, task_id: str = "default",
-                    cross_profile: bool = False,
-                    session_id: str | None = None) -> str:
+def write_file_tool(
+    path: str,
+    content: str,
+    task_id: str = "default",
+    cross_profile: bool = False,
+    session_id: str | None = None,
+) -> str:
     """Write content to a file.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard. The
@@ -1742,10 +1837,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         return tool_error(str(e))
 
 
-def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
-               new_string: str = None, replace_all: bool = False, patch: str = None,
-               task_id: str = "default", cross_profile: bool = False,
-               session_id: str | None = None) -> str:
+def patch_tool(
+    mode: str = "replace",
+    path: str = None,
+    old_string: str = None,
+    new_string: str = None,
+    replace_all: bool = False,
+    patch: str = None,
+    task_id: str = "default",
+    cross_profile: bool = False,
+    session_id: str | None = None,
+) -> str:
     """Patch a file using replace mode or V4A patch format.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard for
@@ -1759,6 +1861,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     if mode == "patch" and patch:
         import re as _re
         from tools.path_security import has_traversal_component
+
         def _reject_v4a_traversal(v4a_path: str) -> str | None:
             # V4A path headers come from patch CONTENT, not the explicit
             # ``path=`` arg — so they're more attacker-influenceable (skill
@@ -1781,7 +1884,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # it accepts ``***Update File:`` with no space after the asterisks
         # (patch_parser.py uses ``\*\*\*\s*Update\s+File:``). Requiring a space
         # here let a no-space header parse + apply while skipping this check.
-        for _m in _re.finditer(r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
+        for _m in _re.finditer(
+            r"^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$", patch, _re.MULTILINE
+        ):
             v4a_path = _m.group(1).strip()
             _err = _reject_v4a_traversal(v4a_path)
             if _err:
@@ -1791,7 +1896,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # but was never extracted, so a Move targeting /etc/crontab skipped the
         # sensitive-path pre-check. Check BOTH endpoints, and run them through
         # the same ``..`` traversal rejection as the other headers.
-        for _m in _re.finditer(r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$', patch, _re.MULTILINE):
+        for _m in _re.finditer(
+            r"^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$", patch, _re.MULTILINE
+        ):
             for v4a_path in (_m.group(1).strip(), _m.group(2).strip()):
                 _err = _reject_v4a_traversal(v4a_path)
                 if _err:
@@ -1825,6 +1932,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # path this degenerates to one lock; on empty list (unresolvable)
         # it's a no-op and execution falls through unchanged.
         from contextlib import ExitStack
+
         with ExitStack() as _locks:
             for _r in _resolved_paths:
                 _locks.enter_context(file_state.lock_path(_r))
@@ -1861,7 +1969,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # path would let the two layers disagree about which file is
                 # being edited.
                 _replace_target = _path_to_resolved.get(path) or path
-                result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
+                result = file_ops.patch_replace(
+                    _replace_target, old_string, new_string, replace_all
+                )
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
@@ -1871,7 +1981,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 
             result_dict = result.to_dict()
             if stale_warnings:
-                result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)
+                result_dict["_warning"] = (
+                    stale_warnings[0]
+                    if len(stale_warnings) == 1
+                    else " | ".join(stale_warnings)
+                )
             # Report the ABSOLUTE path(s) actually patched so a wrong-cwd
             # mismatch (e.g. a worktree session editing the main checkout) is
             # visible in the response instead of silently landing elsewhere.
@@ -1884,7 +1998,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
-                _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
+                _mark_verification_stale(
+                    task_id, _resolved_modified, session_id=session_id
+                )
                 for _p in _paths_to_check:
                     _update_read_timestamp(_p, task_id)
                     _r = _path_to_resolved.get(_p)
@@ -1893,9 +2009,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
-                _reset_patch_failures(task_id, [
-                    _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
-                ])
+                _reset_patch_failures(
+                    task_id,
+                    [
+                        _r
+                        for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check)
+                        if _r
+                    ],
+                )
         # Hint when patch fails — saves iterations where the agent retries
         # with stale content or an ambiguous old_string instead of
         # re-reading the file or providing more context.
@@ -1907,7 +2028,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # more useful than the generic hint.
         err_str = str(result_dict.get("error") or "")
         is_no_match = "Could not find" in err_str
-        is_ambiguous = "Found" in err_str and "matches" in err_str and "old_string" in err_str
+        is_ambiguous = (
+            "Found" in err_str and "matches" in err_str and "old_string" in err_str
+        )
         has_diagnostic = bool(result_dict.get("_diagnostic"))
         if err_str and (is_no_match or is_ambiguous):
             # Track per-file consecutive failures for replace mode.  The
@@ -1950,7 +2073,10 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "the target. The error message above shows the line "
                     "content at each match."
                 )
-            elif not has_diagnostic and "Did you mean one of these sections?" not in err_str:
+            elif (
+                not has_diagnostic
+                and "Did you mean one of these sections?" not in err_str
+            ):
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
@@ -1960,10 +2086,17 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
-def search_tool(pattern: str, target: str = "content", path: str = ".",
-                file_glob: str = None, limit: int = 50, offset: int = 0,
-                output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+def search_tool(
+    pattern: str,
+    target: str = "content",
+    path: str = ".",
+    file_glob: str = None,
+    limit: int = 50,
+    offset: int = 0,
+    output_mode: str = "content",
+    context: int = 0,
+    task_id: str = "default",
+) -> str:
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
@@ -1981,9 +2114,14 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             offset,
         )
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
-                "last_key": None, "consecutive": 0, "read_history": set(),
-            })
+            task_data = _read_tracker.setdefault(
+                task_id,
+                {
+                    "last_key": None,
+                    "consecutive": 0,
+                    "read_history": set(),
+                },
+            )
             if task_data["last_key"] == search_key:
                 task_data["consecutive"] += 1
             else:
@@ -1992,33 +2130,44 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             count = task_data["consecutive"]
 
         if count >= 4:
-            return json.dumps({
-                "error": (
-                    f"BLOCKED: You have run this exact search {count} times in a row. "
-                    "The results have NOT changed. You already have this information. "
-                    "STOP re-searching and proceed with your task."
-                ),
-                "pattern": pattern,
-                "already_searched": count,
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "error": (
+                        f"BLOCKED: You have run this exact search {count} times in a row. "
+                        "The results have NOT changed. You already have this information. "
+                        "STOP re-searching and proceed with your task."
+                    ),
+                    "pattern": pattern,
+                    "already_searched": count,
+                },
+                ensure_ascii=False,
+            )
 
         try:
             resolved_path = _resolve_path_for_task(path, task_id)
         except (OSError, ValueError, RuntimeError):
             resolved_path = None
-        block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
+        block_error = get_read_block_error(
+            str(resolved_path) if resolved_path else path
+        )
         if block_error:
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            pattern=pattern,
+            path=path,
+            target=target,
+            file_glob=file_glob,
+            limit=limit,
+            offset=offset,
+            output_mode=output_mode,
+            context=context,
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
-        if hasattr(result, 'matches'):
+        if hasattr(result, "matches"):
             for m in result.matches:
-                if hasattr(m, 'content') and m.content:
+                if hasattr(m, "content") and m.content:
                     m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
 
@@ -2045,8 +2194,6 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         return tool_error(str(e))
 
 
-
-
 # ---------------------------------------------------------------------------
 # Schemas + Registry
 # ---------------------------------------------------------------------------
@@ -2056,7 +2203,9 @@ from tools.registry import registry, tool_error
 def _check_file_reqs():
     """Lazy wrapper to avoid circular import with tools/__init__.py."""
     from tools import check_file_requirements
+
     return check_file_requirements()
+
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
@@ -2069,11 +2218,21 @@ READ_FILE_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "Path to the file to read (absolute, relative, or ~/path), or a list of up to 10 paths for batch reading",
             },
-            "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "offset": {
+                "type": "integer",
+                "description": "Line number to start reading from (1-indexed, default: 1)",
+                "default": 1,
+                "minimum": 1,
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of lines to read (default: 500, max: 2000)",
+                "default": 500,
+                "maximum": 2000,
+            },
         },
-        "required": ["path"]
-    }
+        "required": ["path"],
+    },
 }
 
 WRITE_FILE_SCHEMA = {
@@ -2082,16 +2241,22 @@ WRITE_FILE_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
-            "content": {"type": "string", "description": "Complete content to write to the file"},
+            "path": {
+                "type": "string",
+                "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)",
+            },
+            "content": {
+                "type": "string",
+                "description": "Complete content to write to the file",
+            },
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
                 "default": False,
             },
         },
-        "required": ["path", "content"]
-    }
+        "required": ["path", "content"],
+    },
 }
 
 PATCH_SCHEMA = {
@@ -2151,17 +2316,49 @@ SEARCH_FILES_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search. When target='content', this is a REGEX (not a glob) — passing '*.py' here will cause a regex parse error; use file_glob to filter by filename pattern instead."},
-            "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
-            "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
-            "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},
-            "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
-            "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
-            "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "pattern": {
+                "type": "string",
+                "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search. When target='content', this is a REGEX (not a glob) — passing '*.py' here will cause a regex parse error; use file_glob to filter by filename pattern instead.",
+            },
+            "target": {
+                "type": "string",
+                "enum": ["content", "files"],
+                "description": "'content' searches inside file contents, 'files' searches for files by name",
+                "default": "content",
+            },
+            "path": {
+                "type": "string",
+                "description": "Directory or file to search in (default: current working directory)",
+                "default": ".",
+            },
+            "file_glob": {
+                "type": "string",
+                "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results to return (default: 50)",
+                "default": 50,
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Skip first N results for pagination (default: 0)",
+                "default": 0,
+            },
+            "output_mode": {
+                "type": "string",
+                "enum": ["content", "files_only", "count"],
+                "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file",
+                "default": "content",
+            },
+            "context": {
+                "type": "integer",
+                "description": "Number of context lines before and after each match (grep mode only)",
+                "default": 0,
+            },
         },
-        "required": ["pattern"]
-    }
+        "required": ["pattern"],
+    },
 }
 
 
@@ -2171,7 +2368,12 @@ def _handle_read_file(args, **kw):
     # #757/#784 — batch mode: read multiple files in one tool call.
     if isinstance(path, list):
         return _handle_read_file_batch(path, args, tid)
-    return read_file_tool(path=path, offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=path,
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+    )
 
 
 _BATCH_READ_MAX_FILES = 10
@@ -2191,7 +2393,10 @@ def _handle_read_file_batch(paths: list, args: dict, tid: str) -> str:
     files = []
     for p in paths:
         if not isinstance(p, str):
-            files.append({"path": str(p), "error": "Invalid path type: expected string"})
+            files.append({
+                "path": str(p),
+                "error": "Invalid path type: expected string",
+            })
             continue
         raw = read_file_tool(path=p, offset=offset, limit=limit, task_id=tid)
         try:
@@ -2228,7 +2433,9 @@ def _handle_write_file(args, **kw):
             f"{type(args['content']).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=args["path"],
+        content=args["content"],
+        task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
     )
@@ -2237,9 +2444,13 @@ def _handle_write_file(args, **kw):
 def _handle_patch(args, **kw):
     tid = kw.get("task_id") or "default"
     return patch_tool(
-        mode=args.get("mode", "replace"), path=args.get("path"),
-        old_string=args.get("old_string"), new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
+        mode=args.get("mode", "replace"),
+        path=args.get("path"),
+        old_string=args.get("old_string"),
+        new_string=args.get("new_string"),
+        replace_all=args.get("replace_all", False),
+        patch=args.get("patch"),
+        task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
     )
@@ -2308,6 +2519,7 @@ def _handle_search_files(args, **kw):
         # contents.  Auto-redirect to file search — that is the correct tool
         # for the job and avoids the regex parse error entirely.
         import json as _json
+
         return _json.dumps({
             "error": (
                 f"Pattern {pattern!r} looks like a shell glob (wildcards), not a regex. "
@@ -2322,12 +2534,51 @@ def _handle_search_files(args, **kw):
         })
 
     return search_tool(
-        pattern=pattern, target=target, path=args.get("path", "."),
-        file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        pattern=pattern,
+        target=target,
+        path=args.get("path", "."),
+        file_glob=args.get("file_glob"),
+        limit=args.get("limit", 50),
+        offset=args.get("offset", 0),
+        output_mode=args.get("output_mode", "content"),
+        context=args.get("context", 0),
+        task_id=tid,
+    )
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
-registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
-registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
-registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)
+registry.register(
+    name="read_file",
+    toolset="file",
+    schema=READ_FILE_SCHEMA,
+    handler=_handle_read_file,
+    check_fn=_check_file_reqs,
+    emoji="📖",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="write_file",
+    toolset="file",
+    schema=WRITE_FILE_SCHEMA,
+    handler=_handle_write_file,
+    check_fn=_check_file_reqs,
+    emoji="✍️",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="patch",
+    toolset="file",
+    schema=PATCH_SCHEMA,
+    handler=_handle_patch,
+    check_fn=_check_file_reqs,
+    emoji="🔧",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="search_files",
+    toolset="file",
+    schema=SEARCH_FILES_SCHEMA,
+    handler=_handle_search_files,
+    check_fn=_check_file_reqs,
+    emoji="🔎",
+    max_result_size_chars=100_000,
+)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -84,6 +84,35 @@ def _get_max_read_chars() -> int:
     return _max_read_chars_cached
 
 
+# ── Self-correction retry threshold (issue #996) ─────────────────────────
+# Controls how many consecutive patch failures on the same file are allowed
+# before the error is classified as "permanent" and the model is told to
+# stop retrying.  Read from ``patch.self_correction_retries`` in config.yaml
+# on first call, cached for the process lifetime.  Default 3, max 5.
+_DEFAULT_SELF_CORRECTION_RETRIES = 3
+_MAX_SELF_CORRECTION_RETRIES = 5
+_self_correction_retries_cached: int | None = None
+
+
+def _get_self_correction_retries() -> int:
+    """Return the configured self-correction retry threshold for patches."""
+    global _self_correction_retries_cached
+    if _self_correction_retries_cached is not None:
+        return _self_correction_retries_cached
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        patch_cfg = cfg.get("patch", {})
+        val = patch_cfg.get("self_correction_retries")
+        if isinstance(val, (int, float)) and 1 <= int(val) <= _MAX_SELF_CORRECTION_RETRIES:
+            _self_correction_retries_cached = int(val)
+            return _self_correction_retries_cached
+    except Exception:
+        pass
+    _self_correction_retries_cached = _DEFAULT_SELF_CORRECTION_RETRIES
+    return _self_correction_retries_cached
+
+
 def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bool]:
     """Trim line-numbered ``read_file`` content to fit a char budget.
 
@@ -1874,10 +1903,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # ("Found N matches") failures — both cause the same spiral
         # pattern where the agent retries with slight variations.
         # Suppressed when patch_replace already attached a rich "Did you mean?"
-        # snippet (which is strictly more useful than the generic hint).
+        # snippet or a structured _diagnostic (#996) — both are strictly
+        # more useful than the generic hint.
         err_str = str(result_dict.get("error") or "")
         is_no_match = "Could not find" in err_str
         is_ambiguous = "Found" in err_str and "matches" in err_str and "old_string" in err_str
+        has_diagnostic = bool(result_dict.get("_diagnostic"))
         if err_str and (is_no_match or is_ambiguous):
             # Track per-file consecutive failures for replace mode.  The
             # ``path`` arg only exists for replace mode; for V4A patches
@@ -1888,7 +1919,13 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 resolved = _path_to_resolved.get(path) or path
                 failure_count = _record_patch_failure(task_id, resolved)
 
-            if failure_count >= 3:
+            # Config-gated retry threshold (#996).  After this many
+            # consecutive failures on the same file, classify the failure
+            # as "permanent" and instruct the model to stop retrying and
+            # use an alternative strategy (re-read or write_file).
+            retry_threshold = _get_self_correction_retries()
+
+            if failure_count >= retry_threshold:
                 # Escalating hint after multiple consecutive failures on the
                 # same path.  Most common cause is a stale view of the file —
                 # the model is retrying with the same old_string against
@@ -1896,15 +1933,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # so the model recognises it's in a loop and breaks out by
                 # re-reading or falling back to write_file.
                 result_dict["_hint"] = (
-                    f"This is failure #{failure_count} patching {path!r}. "
-                    "Stop retrying with variations of the same old_string. "
-                    "Either: (1) re-read the file fresh to verify current "
-                    "content, (2) use a longer / more unique old_string with "
-                    "surrounding context lines, or (3) use write_file to "
-                    "replace the entire file if the targeted region is hard "
-                    "to anchor."
+                    f"PERMANENT FAILURE: This is failure #{failure_count} "
+                    f"patching {path!r}, exceeding the retry threshold of "
+                    f"{retry_threshold}. Stop retrying with variations of "
+                    f"the same old_string. Either: (1) re-read the file fresh "
+                    f"to verify current content, (2) use a longer / more "
+                    f"unique old_string with surrounding context lines, or "
+                    f"(3) use write_file to replace the entire file if the "
+                    f"targeted region is hard to anchor."
                 )
-            elif is_ambiguous:
+            elif is_ambiguous and not has_diagnostic:
                 result_dict["_hint"] = (
                     "Multiple matches found. Use read_file to see the "
                     "surrounding context at each match location, then "
@@ -1912,7 +1950,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "the target. The error message above shows the line "
                     "content at each match."
                 )
-            elif "Did you mean one of these sections?" not in err_str:
+            elif not has_diagnostic and "Did you mean one of these sections?" not in err_str:
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -20,7 +20,7 @@ Multi-occurrence matching is handled via the replace_all flag.
 
 Usage:
     from tools.fuzzy_match import fuzzy_find_and_replace
-    
+
     new_content, match_count, strategy, error = fuzzy_find_and_replace(
         content="def foo():\\n    pass",
         old_string="def foo():",
@@ -34,11 +34,16 @@ from typing import Tuple, Optional, List, Callable
 from difflib import SequenceMatcher
 
 UNICODE_MAP = {
-    "\u201c": '"', "\u201d": '"',  # smart double quotes
-    "\u2018": "'", "\u2019": "'",  # smart single quotes
-    "\u2014": "--", "\u2013": "-", # em/en dashes
-    "\u2026": "...", "\u00a0": " ", # ellipsis and non-breaking space
+    "\u201c": '"',
+    "\u201d": '"',  # smart double quotes
+    "\u2018": "'",
+    "\u2019": "'",  # smart single quotes
+    "\u2014": "--",
+    "\u2013": "-",  # em/en dashes
+    "\u2026": "...",
+    "\u00a0": " ",  # ellipsis and non-breaking space
 }
+
 
 def _unicode_normalize(text: str) -> str:
     """Normalizes Unicode characters to their standard ASCII equivalents."""
@@ -47,8 +52,9 @@ def _unicode_normalize(text: str) -> str:
     return text
 
 
-def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
-                            replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
+def fuzzy_find_and_replace(
+    content: str, old_string: str, new_string: str, replace_all: bool = False
+) -> Tuple[str, int, Optional[str], Optional[str]]:
     """
     Find and replace text using a chain of increasingly fuzzy matching strategies.
 
@@ -97,17 +103,26 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
                 # the right one without re-reading the file (#976).
                 content_lines = content.splitlines()
                 location_parts: List[str] = []
-                for (start, _end) in matches[:10]:
-                    line_no = content.count('\n', 0, start) + 1
+                for start, _end in matches[:10]:
+                    line_no = content.count("\n", 0, start) + 1
                     # Show the actual line content (first line of the match)
                     line_idx = line_no - 1
-                    line_text = content_lines[line_idx].strip() if 0 <= line_idx < len(content_lines) else ""
+                    line_text = (
+                        content_lines[line_idx].strip()
+                        if 0 <= line_idx < len(content_lines)
+                        else ""
+                    )
                     location_parts.append(f"Line {line_no}: {line_text}")
                 locs_block = "\n  ".join(location_parts)
-                return content, 0, None, (
-                    f"Found {len(matches)} matches for old_string"
-                    f" at:\n  {locs_block}\n"
-                    f"Provide more context to make it unique, or use replace_all=True."
+                return (
+                    content,
+                    0,
+                    None,
+                    (
+                        f"Found {len(matches)} matches for old_string"
+                        f" at:\n  {locs_block}\n"
+                        f"Provide more context to make it unique, or use replace_all=True."
+                    ),
                 )
 
             # Escape-drift guard: when the matched strategy is NOT `exact`,
@@ -121,7 +136,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # Block with a helpful error so the model re-reads and retries
             # instead of the caller silently persisting garbage (or not).
             if strategy_name != "exact":
-                drift_err = _detect_escape_drift(content, matches, old_string, new_string)
+                drift_err = _detect_escape_drift(
+                    content, matches, old_string, new_string
+                )
                 if drift_err:
                     return content, 0, None, drift_err
 
@@ -149,7 +166,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # through JSON, and rewriting backslash-n would mangle escape
             # sequences in source code constants far more often than help.
             effective_new = _maybe_unescape_new_string(
-                new_string, content, matches,
+                new_string,
+                content,
+                matches,
             )
             # Unicode-preservation guard: when strategy 7 (unicode_normalized)
             # matched, the file has Unicode characters (em-dashes, smart quotes,
@@ -161,10 +180,15 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # and unchanged portions keep their original characters.
             if strategy_name == "unicode_normalized":
                 effective_new = _preserve_unicode_in_replacement(
-                    content, matches, old_string, effective_new,
+                    content,
+                    matches,
+                    old_string,
+                    effective_new,
                 )
             new_content = _apply_replacements(
-                content, matches, effective_new,
+                content,
+                matches,
+                effective_new,
                 old_string=old_string if strategy_name != "exact" else None,
             )
             return new_content, len(matches), strategy_name, None
@@ -173,8 +197,9 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     return content, 0, None, "Could not find a match for old_string in the file"
 
 
-def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
-                         old_string: str, new_string: str) -> Optional[str]:
+def _detect_escape_drift(
+    content: str, matches: List[Tuple[int, int]], old_string: str, new_string: str
+) -> Optional[str]:
     """Detect tool-call escape-drift artifacts in new_string.
 
     Looks for ``\\'`` or ``\\"`` sequences that are present in both
@@ -199,7 +224,11 @@ def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
     matched_regions = "".join(content[start:end] for start, end in matches)
 
     for suspect in ("\\'", '\\"'):
-        if suspect in new_string and suspect in old_string and suspect not in matched_regions:
+        if (
+            suspect in new_string
+            and suspect in old_string
+            and suspect not in matched_regions
+        ):
             plain = suspect[1]  # "'" or '"'
             return (
                 f"Escape-drift detected: old_string and new_string contain "
@@ -288,7 +317,7 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
         if line_indent.startswith(old_indent):
             # Common case: line has the LLM's base indent (possibly plus
             # extra). Swap base prefix for the file's base prefix.
-            remainder = line[len(old_indent):]
+            remainder = line[len(old_indent) :]
             out_lines.append(file_indent + remainder)
         else:
             # Line is less-indented than the LLM's base — e.g. a dedent at
@@ -297,9 +326,9 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
     return "\n".join(out_lines)
 
 
-def _maybe_unescape_new_string(new_string: str,
-                               content: str,
-                               matches: List[Tuple[int, int]]) -> str:
+def _maybe_unescape_new_string(
+    new_string: str, content: str, matches: List[Tuple[int, int]]
+) -> str:
     """Conditionally unescape ``\\t``/``\\r`` in new_string.
 
     LLMs frequently send the two-character sequences ``\\t`` (backslash + t)
@@ -334,8 +363,10 @@ def _maybe_unescape_new_string(new_string: str,
 
 
 def _preserve_unicode_in_replacement(
-    content: str, matches: List[Tuple[int, int]],
-    old_string: str, new_string: str,
+    content: str,
+    matches: List[Tuple[int, int]],
+    old_string: str,
+    new_string: str,
 ) -> str:
     """Preserve Unicode characters from the file in the replacement string.
 
@@ -385,10 +416,7 @@ def _preserve_unicode_in_replacement(
             # Keep the original file_region text for this span
             orig_start = file_norm_to_orig.get(i1, 0)
             orig_end = orig_start
-            while (
-                orig_end < len(file_region)
-                and file_orig_to_norm[orig_end] < i2
-            ):
+            while orig_end < len(file_region) and file_orig_to_norm[orig_end] < i2:
                 orig_end += 1
             result_parts.append(file_region[orig_start:orig_end])
         elif tag == "replace":
@@ -401,8 +429,12 @@ def _preserve_unicode_in_replacement(
     return "".join(result_parts)
 
 
-def _apply_replacements(content: str, matches: List[Tuple[int, int]],
-                        new_string: str, old_string: Optional[str] = None) -> str:
+def _apply_replacements(
+    content: str,
+    matches: List[Tuple[int, int]],
+    new_string: str,
+    old_string: Optional[str] = None,
+) -> str:
     """
     Apply replacements at the given positions.
 
@@ -437,6 +469,7 @@ def _apply_replacements(content: str, matches: List[Tuple[int, int]],
 # Matching Strategies
 # =============================================================================
 
+
 def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
     """Strategy 1: Exact string match."""
     matches = []
@@ -458,40 +491,42 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
 def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 2: Match with line-by-line whitespace trimming.
-    
+
     Strips leading/trailing whitespace from each line before matching.
     """
     # Normalize pattern and content by trimming each line
-    pattern_lines = [line.strip() for line in pattern.split('\n')]
-    pattern_normalized = '\n'.join(pattern_lines)
-    
-    content_lines = content.split('\n')
+    pattern_lines = [line.strip() for line in pattern.split("\n")]
+    pattern_normalized = "\n".join(pattern_lines)
+
+    content_lines = content.split("\n")
     content_normalized_lines = [line.strip() for line in content_lines]
-    
+
     # Build mapping from normalized positions back to original positions
     return _find_normalized_matches(
-        content, content_lines, content_normalized_lines,
-        pattern, pattern_normalized
+        content, content_lines, content_normalized_lines, pattern, pattern_normalized
     )
 
 
-def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_whitespace_normalized(
+    content: str, pattern: str
+) -> List[Tuple[int, int]]:
     """
     Strategy 3: Collapse multiple whitespace to single space.
     """
+
     def normalize(s):
         # Collapse multiple spaces/tabs to single space, preserve newlines
-        return re.sub(r'[ \t]+', ' ', s)
-    
+        return re.sub(r"[ \t]+", " ", s)
+
     pattern_normalized = normalize(pattern)
     content_normalized = normalize(content)
-    
+
     # Find in normalized, map back to original
     matches_in_normalized = _strategy_exact(content_normalized, pattern_normalized)
-    
+
     if not matches_in_normalized:
         return []
-    
+
     # Map positions back to original content
     return _map_normalized_positions(content, content_normalized, matches_in_normalized)
 
@@ -499,77 +534,81 @@ def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[in
 def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 4: Ignore indentation differences entirely.
-    
+
     Strips all leading whitespace from lines before matching.
     """
-    content_lines = content.split('\n')
+    content_lines = content.split("\n")
     content_stripped_lines = [line.lstrip() for line in content_lines]
-    pattern_lines = [line.lstrip() for line in pattern.split('\n')]
-    
+    pattern_lines = [line.lstrip() for line in pattern.split("\n")]
+
     return _find_normalized_matches(
-        content, content_lines, content_stripped_lines,
-        pattern, '\n'.join(pattern_lines)
+        content,
+        content_lines,
+        content_stripped_lines,
+        pattern,
+        "\n".join(pattern_lines),
     )
 
 
 def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 5: Convert escape sequences to actual characters.
-    
+
     Handles \\n -> newline, \\t -> tab, etc.
     """
+
     def unescape(s):
         # Convert common escape sequences
-        return s.replace('\\n', '\n').replace('\\t', '\t').replace('\\r', '\r')
-    
+        return s.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+
     pattern_unescaped = unescape(pattern)
-    
+
     if pattern_unescaped == pattern:
         # No escapes to convert, skip this strategy
         return []
-    
+
     return _strategy_exact(content, pattern_unescaped)
 
 
 def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 6: Trim whitespace from first and last lines only.
-    
+
     Useful when the pattern boundaries have whitespace differences.
     """
-    pattern_lines = pattern.split('\n')
+    pattern_lines = pattern.split("\n")
     if not pattern_lines:
         return []
-    
+
     # Trim only first and last lines
     pattern_lines[0] = pattern_lines[0].strip()
     if len(pattern_lines) > 1:
         pattern_lines[-1] = pattern_lines[-1].strip()
-    
-    modified_pattern = '\n'.join(pattern_lines)
-    
-    content_lines = content.split('\n')
-    
+
+    modified_pattern = "\n".join(pattern_lines)
+
+    content_lines = content.split("\n")
+
     # Search through content for matching block
     matches = []
     pattern_line_count = len(pattern_lines)
-    
+
     for i in range(len(content_lines) - pattern_line_count + 1):
-        block_lines = content_lines[i:i + pattern_line_count]
-        
+        block_lines = content_lines[i : i + pattern_line_count]
+
         # Trim first and last of this block
         check_lines = block_lines.copy()
         check_lines[0] = check_lines[0].strip()
         if len(check_lines) > 1:
             check_lines[-1] = check_lines[-1].strip()
-        
-        if '\n'.join(check_lines) == modified_pattern:
+
+        if "\n".join(check_lines) == modified_pattern:
             # Found match - calculate original positions
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
@@ -662,30 +701,32 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
     # Normalize both strings for comparison while keeping original content for offset calculation
     norm_pattern = _unicode_normalize(pattern)
     norm_content = _unicode_normalize(content)
-    
-    pattern_lines = norm_pattern.split('\n')
+
+    pattern_lines = norm_pattern.split("\n")
     if len(pattern_lines) < 2:
         return []
-    
+
     first_line = pattern_lines[0].strip()
     last_line = pattern_lines[-1].strip()
-    
+
     # Use normalized lines for matching logic
-    norm_content_lines = norm_content.split('\n')
+    norm_content_lines = norm_content.split("\n")
     # BUT use original lines for calculating start/end positions to prevent index shift
-    orig_content_lines = content.split('\n')
-    
+    orig_content_lines = content.split("\n")
+
     pattern_line_count = len(pattern_lines)
-    
+
     potential_matches = []
     for i in range(len(norm_content_lines) - pattern_line_count + 1):
-        if (norm_content_lines[i].strip() == first_line and 
-            norm_content_lines[i + pattern_line_count - 1].strip() == last_line):
+        if (
+            norm_content_lines[i].strip() == first_line
+            and norm_content_lines[i + pattern_line_count - 1].strip() == last_line
+        ):
             potential_matches.append(i)
-            
+
     matches = []
     candidate_count = len(potential_matches)
-    
+
     # Thresholding logic: 0.50 for unique matches, 0.70 for multiple candidates.
     # Previous values (0.10 / 0.30) were dangerously loose — a 10% middle-section
     # similarity could match completely unrelated blocks.
@@ -696,52 +737,54 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
             similarity = 1.0
         else:
             # Compare normalized middle sections
-            content_middle = '\n'.join(norm_content_lines[i+1:i+pattern_line_count-1])
-            pattern_middle = '\n'.join(pattern_lines[1:-1])
+            content_middle = "\n".join(
+                norm_content_lines[i + 1 : i + pattern_line_count - 1]
+            )
+            pattern_middle = "\n".join(pattern_lines[1:-1])
             similarity = SequenceMatcher(None, content_middle, pattern_middle).ratio()
-        
+
         if similarity >= threshold:
             # Calculate positions using ORIGINAL lines to ensure correct character offsets in the file
             start_pos, end_pos = _calculate_line_positions(
                 orig_content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
 def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 9: Line-by-line similarity with 50% threshold.
-    
+
     Finds blocks where at least 50% of lines have high similarity.
     """
-    pattern_lines = pattern.split('\n')
-    content_lines = content.split('\n')
-    
+    pattern_lines = pattern.split("\n")
+    content_lines = content.split("\n")
+
     if not pattern_lines:
         return []
-    
+
     matches = []
     pattern_line_count = len(pattern_lines)
-    
+
     for i in range(len(content_lines) - pattern_line_count + 1):
-        block_lines = content_lines[i:i + pattern_line_count]
-        
+        block_lines = content_lines[i : i + pattern_line_count]
+
         # Calculate line-by-line similarity
         high_similarity_count = 0
         for p_line, c_line in zip(pattern_lines, block_lines):
             sim = SequenceMatcher(None, p_line.strip(), c_line.strip()).ratio()
             if sim >= 0.80:
                 high_similarity_count += 1
-        
+
         # Need at least 50% of lines to have high similarity
         if high_similarity_count >= len(pattern_lines) * 0.5:
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
@@ -749,8 +792,10 @@ def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]
 # Helper Functions
 # =============================================================================
 
-def _calculate_line_positions(content_lines: List[str], start_line: int,
-                              end_line: int, content_length: int) -> Tuple[int, int]:
+
+def _calculate_line_positions(
+    content_lines: List[str], start_line: int, end_line: int, content_length: int
+) -> Tuple[int, int]:
     """Calculate start and end character positions from line indices.
 
     Args:
@@ -768,70 +813,75 @@ def _calculate_line_positions(content_lines: List[str], start_line: int,
     return start_pos, end_pos
 
 
-def _find_normalized_matches(content: str, content_lines: List[str],
-                              content_normalized_lines: List[str],
-                              pattern: str, pattern_normalized: str) -> List[Tuple[int, int]]:
+def _find_normalized_matches(
+    content: str,
+    content_lines: List[str],
+    content_normalized_lines: List[str],
+    pattern: str,
+    pattern_normalized: str,
+) -> List[Tuple[int, int]]:
     """
     Find matches in normalized content and map back to original positions.
-    
+
     Args:
         content: Original content string
         content_lines: Original content split by lines
         content_normalized_lines: Normalized content lines
         pattern: Original pattern
         pattern_normalized: Normalized pattern
-    
+
     Returns:
         List of (start, end) positions in the original content
     """
-    pattern_norm_lines = pattern_normalized.split('\n')
+    pattern_norm_lines = pattern_normalized.split("\n")
     num_pattern_lines = len(pattern_norm_lines)
-    
+
     matches = []
-    
+
     for i in range(len(content_normalized_lines) - num_pattern_lines + 1):
         # Check if this block matches
-        block = '\n'.join(content_normalized_lines[i:i + num_pattern_lines])
-        
+        block = "\n".join(content_normalized_lines[i : i + num_pattern_lines])
+
         if block == pattern_normalized:
             # Found a match - calculate original positions
             start_pos, end_pos = _calculate_line_positions(
                 content_lines, i, i + num_pattern_lines, len(content)
             )
             matches.append((start_pos, end_pos))
-    
+
     return matches
 
 
-def _map_normalized_positions(original: str, normalized: str,
-                               normalized_matches: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+def _map_normalized_positions(
+    original: str, normalized: str, normalized_matches: List[Tuple[int, int]]
+) -> List[Tuple[int, int]]:
     """
     Map positions from normalized string back to original.
-    
+
     This is a best-effort mapping that works for whitespace normalization.
     """
     if not normalized_matches:
         return []
-    
+
     # Build character mapping from normalized to original
     orig_to_norm = []  # orig_to_norm[i] = position in normalized
-    
+
     orig_idx = 0
     norm_idx = 0
-    
+
     while orig_idx < len(original) and norm_idx < len(normalized):
         if original[orig_idx] == normalized[norm_idx]:
             orig_to_norm.append(norm_idx)
             orig_idx += 1
             norm_idx += 1
-        elif original[orig_idx] in ' \t' and normalized[norm_idx] == ' ':
+        elif original[orig_idx] in " \t" and normalized[norm_idx] == " ":
             # Original has space/tab, normalized collapsed to space
             orig_to_norm.append(norm_idx)
             orig_idx += 1
             # Don't advance norm_idx yet - wait until all whitespace consumed
-            if orig_idx < len(original) and original[orig_idx] not in ' \t':
+            if orig_idx < len(original) and original[orig_idx] not in " \t":
                 norm_idx += 1
-        elif original[orig_idx] in ' \t':
+        elif original[orig_idx] in " \t":
             # Extra whitespace in original
             orig_to_norm.append(norm_idx)
             orig_idx += 1
@@ -839,21 +889,21 @@ def _map_normalized_positions(original: str, normalized: str,
             # Mismatch - shouldn't happen with our normalization
             orig_to_norm.append(norm_idx)
             orig_idx += 1
-    
+
     # Fill remaining
     while orig_idx < len(original):
         orig_to_norm.append(len(normalized))
         orig_idx += 1
-    
+
     # Reverse mapping: for each normalized position, find original range
     norm_to_orig_start = {}
     norm_to_orig_end = {}
-    
+
     for orig_pos, norm_pos in enumerate(orig_to_norm):
         if norm_pos not in norm_to_orig_start:
             norm_to_orig_start[norm_pos] = orig_pos
         norm_to_orig_end[norm_pos] = orig_pos
-    
+
     # Map matches
     original_matches = []
     for norm_start, norm_end in normalized_matches:
@@ -863,28 +913,30 @@ def _map_normalized_positions(original: str, normalized: str,
         else:
             # Find nearest
             orig_start = min(i for i, n in enumerate(orig_to_norm) if n >= norm_start)
-        
+
         # Find original end
         if norm_end - 1 in norm_to_orig_end:
             orig_end = norm_to_orig_end[norm_end - 1] + 1
         else:
             orig_end = orig_start + (norm_end - norm_start)
-        
+
         # Expand to include trailing whitespace that was normalized,
         # but only when the normalized match itself ended with whitespace.
         # When the match ends with a non-space character, the first
         # whitespace in the original is a word boundary and must not be
         # consumed.  See https://github.com/NousResearch/hermes-agent/issues/52491
-        if norm_end < len(normalized) and normalized[norm_end - 1] == ' ':
-            while orig_end < len(original) and original[orig_end] in ' \t':
+        if norm_end < len(normalized) and normalized[norm_end - 1] == " ":
+            while orig_end < len(original) and original[orig_end] in " \t":
                 orig_end += 1
-        
+
         original_matches.append((orig_start, min(orig_end, len(original))))
-    
+
     return original_matches
 
 
-def find_closest_lines(old_string: str, content: str, context_lines: int = 2, max_results: int = 3) -> str:
+def find_closest_lines(
+    old_string: str, content: str, context_lines: int = 2, max_results: int = 3
+) -> str:
     """Find lines in content most similar to old_string for "did you mean?" feedback.
 
     Returns a formatted string showing the closest matching lines with context,
@@ -946,8 +998,9 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
     return "\n---\n".join(parts)
 
 
-def format_no_match_hint(error: Optional[str], match_count: int,
-                         old_string: str, content: str) -> str:
+def format_no_match_hint(
+    error: Optional[str], match_count: int, old_string: str, content: str
+) -> str:
     """Return a '\\n\\nDid you mean...' snippet for plain no-match errors.
 
     Gated so the hint only fires for actual "old_string not found" failures.
@@ -1124,8 +1177,7 @@ def format_structured_error(
         snippet = _format_file_context_snippet(content, old_string, context_lines=5)
         if snippet:
             sections.append(
-                "Closest matching region in the file (>> marks best match):\n"
-                + snippet
+                "Closest matching region in the file (>> marks best match):\n" + snippet
             )
 
     # For ambiguous: the error message already lists the match locations,

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -965,3 +965,211 @@ def format_no_match_hint(error: Optional[str], match_count: int,
     if not hint:
         return ""
     return "\n\nDid you mean one of these sections?\n" + hint
+
+
+# ---------------------------------------------------------------------------
+# Structured error context for self-correction (issue #996)
+#
+# The functions below build a rich, structured error package that gives the
+# model everything it needs to produce a corrected patch on its next turn
+# WITHOUT re-reading the file: the error type, the closest matching lines
+# with line numbers, and the surrounding file content near the best match.
+#
+# This is the "Aider-style self-correction reflection loop" adapted to
+# Hermes's architecture: rather than re-invoking the LLM from inside the
+# tool handler (which would break the conversation loop, prompt caching,
+# and the narrow-waist principle), we enrich the tool-result error so the
+# model naturally self-corrects on its next turn.  The model already retries
+# failed patches — it just needs better information to guide the retry.
+# ---------------------------------------------------------------------------
+
+# Error-type classification labels.  These appear in the structured error
+# package so the model can reason about WHY the patch failed and choose the
+# right recovery strategy (re-read, add context, fix escapes, etc.).
+ERROR_TYPES = {
+    "no_match": "old_string not found in file",
+    "ambiguous": "multiple matches found — old_string is not unique",
+    "identical": "old_string and new_string are identical — no change needed",
+    "escape_drift": "escape-drift detected — likely tool-call serialization artifact",
+    "permission": "permission denied or protected path",
+    "read_failed": "could not read the file",
+    "write_failed": "could not write changes to the file",
+    "unknown": "unclassified failure",
+}
+
+
+def classify_error(error: Optional[str], strategy: Optional[str]) -> str:
+    """Classify a patch error string into a known error type.
+
+    Returns one of the keys from ``ERROR_TYPES``.
+    """
+    if not error:
+        return "unknown"
+    err = error.lower()
+    if strategy == "identical" or "identical" in err:
+        return "identical"
+    if "escape-drift" in err or "escape drift" in err:
+        return "escape_drift"
+    if "found" in err and "matches" in err:
+        return "ambiguous"
+    if "could not find" in err or "not find a match" in err:
+        return "no_match"
+    if "permission" in err or "denied" in err or "protected" in err:
+        return "permission"
+    if "failed to read" in err:
+        return "read_failed"
+    if "failed to write" in err:
+        return "write_failed"
+    return "unknown"
+
+
+def _format_file_context_snippet(
+    content: str,
+    old_string: str,
+    context_lines: int = 5,
+) -> str:
+    """Return a snippet of ``content`` around the best-matching region.
+
+    Uses the same line-similarity scoring as ``find_closest_lines`` to
+    locate the region of the file most similar to ``old_string``, then
+    returns ``±context_lines`` lines of file content with line numbers
+    so the model can see exactly what's there and craft a corrected
+    ``old_string`` without needing to re-read.
+
+    Returns an empty string when no useful snippet can be produced.
+    """
+    if not old_string or not content:
+        return ""
+
+    old_lines = old_string.splitlines()
+    content_lines = content.splitlines()
+
+    if not old_lines or not content_lines:
+        return ""
+
+    # Use first non-blank line of old_string as anchor
+    anchor = ""
+    for line in old_lines:
+        if line.strip():
+            anchor = line.strip()
+            break
+    if not anchor:
+        return ""
+
+    # Score each line by similarity to anchor
+    best_ratio = 0.0
+    best_idx = -1
+    for i, line in enumerate(content_lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        ratio = SequenceMatcher(None, anchor, stripped).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_idx = i
+
+    if best_idx < 0 or best_ratio < 0.3:
+        return ""
+
+    # Build the ±context_lines snippet around the best match
+    start = max(0, best_idx - context_lines)
+    end = min(len(content_lines), best_idx + len(old_lines) + context_lines)
+
+    snippet_lines = []
+    for j in range(start, end):
+        marker = ">>" if j == best_idx else "  "
+        snippet_lines.append(f"{j + 1:4d}{marker}| {content_lines[j]}")
+
+    return "\n".join(snippet_lines)
+
+
+def format_structured_error(
+    error: Optional[str],
+    match_count: int,
+    old_string: str,
+    new_string: str,
+    content: str,
+    file_path: str = "",
+    strategy: Optional[str] = None,
+) -> str:
+    """Build a structured error context for patch failures (issue #996).
+
+    Returns a multi-section diagnostic string containing:
+    - Error type classification
+    - The file path (when provided)
+    - The closest matching region with line numbers (±5 lines)
+    - A recovery suggestion matched to the error type
+
+    Returns an empty string when the error doesn't warrant structured
+    context (e.g. successful operations).
+    """
+    if not error:
+        return ""
+
+    error_type = classify_error(error, strategy)
+
+    # Don't add structured context for non-match failures that already
+    # have clear messages (permission, read/write failures).
+    if error_type in ("permission", "read_failed", "write_failed", "unknown"):
+        return ""
+
+    sections: List[str] = []
+    sections.append(f"Error type: {error_type} — {ERROR_TYPES.get(error_type, '')}")
+    if file_path:
+        sections.append(f"File: {file_path}")
+
+    # For no-match: show the closest matching region so the model can
+    # see what's actually there and craft a corrected old_string.
+    if error_type == "no_match":
+        snippet = _format_file_context_snippet(content, old_string, context_lines=5)
+        if snippet:
+            sections.append(
+                "Closest matching region in the file (>> marks best match):\n"
+                + snippet
+            )
+
+    # For ambiguous: the error message already lists the match locations,
+    # so we just add a recovery hint.
+    if error_type == "ambiguous":
+        sections.append(
+            "Recovery: provide a longer old_string with more surrounding "
+            "context lines to make the match unique, or use replace_all=True "
+            "if you intend to replace all occurrences."
+        )
+
+    # For escape-drift: the error already explains the issue; add a
+    # concise recovery hint.
+    if error_type == "escape_drift":
+        sections.append(
+            "Recovery: re-read the file with read_file, then pass "
+            "old_string/new_string without backslash-escaping apostrophe "
+            "or quote characters."
+        )
+
+    # For identical: just confirm no action needed.
+    if error_type == "identical":
+        sections.append(
+            "Recovery: no action needed — the file is already in the "
+            "desired state. Proceed with the next step."
+        )
+
+    # For no-match with a snippet, add a general recovery hint.
+    if error_type == "no_match":
+        snippet = _format_file_context_snippet(content, old_string, context_lines=5)
+        if snippet:
+            sections.append(
+                "Recovery: use the closest matching region above to craft "
+                "a corrected old_string that exactly matches the file's "
+                "current content (including indentation). Alternatively, "
+                "use read_file to see the full file, or use write_file to "
+                "replace the entire file if the targeted region is hard to "
+                "anchor."
+            )
+        else:
+            # No snippet found — fall back to the generic hint
+            sections.append(
+                "Recovery: use read_file to verify the current file "
+                "content, or search_files to locate the text."
+            )
+
+    return "\n\n".join(sections)

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Rework of closed PR #997 — enriches patch-failure error output with structured error context so the model can self-correct on its next turn without re-reading the file.

## Problem (Issue #996)

When a patch fails, the model receives a bare error string like `Could not find match for old_string` with no context about what's actually in the file. This causes retry loops where the model makes slight variations of the same incorrect old_string, wasting turns and tokens.

## Solution

Instead of re-invoking the LLM (which would violate the narrow-waist principle and break prompt caching), we **enrich the tool-result error** so the model naturally self-corrects on its next turn.

### Error package contents
1. **Error type classification** — `no_match`, `ambiguous`, `identical`, `escape_drift`, `permission`, etc.
2. **Closest matching region** — ±5 lines of file content with line numbers around the best match
3. **Recovery suggestion** — matched to the error type (re-read, add context, use replace_all, fix escapes, etc.)

### Config gate
```yaml
patch:
  self_correction_retries: 3  # 1-5, default 3
```

Controls how many consecutive patch failures on the same file before the error is classified as `PERMANENT FAILURE` and the model is instructed to stop retrying.

## Rework Note

PR #997 was closed because `uv.lock` was not regenerated after the version bump `0.18.2 → 0.18.3`, causing all CI test slices to fail at `uv sync --locked`. This PR regenerates `uv.lock` and also applies `ruff format` to the changed files.

## Files changed
- `tools/fuzzy_match.py` — `classify_error()`, `_format_file_context_snippet()`, `format_structured_error()`
- `tools/file_operations.py` — `PatchResult.structured_error` field; `patch_replace` builds structured context on failure
- `tools/file_tools.py` — `patch_tool` consumes `_diagnostic`; config-gated retry threshold; `PERMANENT FAILURE` classification
- `hermes_cli/config.py` — `patch.self_correction_retries` in `DEFAULT_CONFIG`
- `tests/tools/test_patch_self_correction.py` — 34 new tests
- `tests/tools/test_patch_failure_tracking.py` — updated escalation assertion
- `uv.lock` — regenerated for v0.18.3

## Test results
```
Pre-PR targeted test shard: PASSED (4/4)
Lint: PASSED
Format: PASSED (changed files)
Targeted tests: 237 passed, 0 failed
```

Closes #996