### PR TITLE
fix(#1022): output-aware retry-spiral detection for the terminal tool

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.18.3",
+      "package": "hermes-agent[acp]==0.18.4",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1219,6 +1219,16 @@ DEFAULT_CONFIG = {
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,
+        # Retry-spiral detection (issue #1022): the number of times a command
+        # may produce the *identical* failure (same exit code + output)
+        # back-to-back before the returned result is escalated to a precise
+        # ``retry_spiral`` diagnostic that tells the agent to stop and change
+        # approach.  Any observable change — a different command, exit code, or
+        # output — resets the counter, so edit-then-test and poll-until-ready
+        # loops that make progress are never flagged.  This is an advisory
+        # signal to the model (hard loop enforcement lives in the loop guard),
+        # so it does not by itself abort execution.  1–20; default 3.
+        "max_command_repeats": 3,
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).
         # A daemon that stalls in its SIGTERM handler is force-killed after this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.3"
+version = "0.18.4"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/tools/test_terminal_retry_spiral.py
+++ b/tests/tools/test_terminal_retry_spiral.py
@@ -1,0 +1,243 @@
+"""Tests for terminal retry-spiral detection (issue #1022).
+
+Covers the identical-failure repeat tracker, the failure signature, the
+spiral diagnostic, and the terminal_tool integration that escalates a command
+to a ``retry_spiral`` diagnostic only when it produces the SAME failure
+back-to-back — so that loops which make progress between runs (edit-then-test,
+poll-until-ready) are never flagged.
+"""
+
+import json
+
+import pytest
+
+import tools.terminal_failure_classifier as classifier
+import tools.terminal_tool as terminal_tool
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: failure signature
+# ---------------------------------------------------------------------------
+
+
+class TestFailureSignature:
+    def test_identical_inputs_match(self):
+        a = terminal_tool._terminal_failure_signature("make", 1, "boom")
+        b = terminal_tool._terminal_failure_signature("make", 1, "boom")
+        assert a == b
+
+    def test_differs_on_command(self):
+        a = terminal_tool._terminal_failure_signature("make", 1, "boom")
+        b = terminal_tool._terminal_failure_signature("pytest", 1, "boom")
+        assert a != b
+
+    def test_differs_on_exit_code(self):
+        a = terminal_tool._terminal_failure_signature("make", 1, "boom")
+        b = terminal_tool._terminal_failure_signature("make", 2, "boom")
+        assert a != b
+
+    def test_differs_on_output(self):
+        a = terminal_tool._terminal_failure_signature("make", 1, "boom")
+        b = terminal_tool._terminal_failure_signature("make", 1, "kaboom")
+        assert a != b
+
+    def test_command_whitespace_normalized(self):
+        a = terminal_tool._terminal_failure_signature("make ", 1, "x")
+        b = terminal_tool._terminal_failure_signature("  make", 1, "x")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: identical-failure repeat tracker
+# ---------------------------------------------------------------------------
+
+
+class TestFailureRepeatTracker:
+    def _reset(self, task_id):
+        terminal_tool._reset_terminal_failure_repeats(task_id)
+
+    def test_first_failure_returns_one(self):
+        self._reset("t")
+        assert terminal_tool._note_terminal_failure("t", "make", 1, "boom") == 1
+
+    def test_identical_failure_increments(self):
+        self._reset("t")
+        assert terminal_tool._note_terminal_failure("t", "make", 1, "boom") == 1
+        assert terminal_tool._note_terminal_failure("t", "make", 1, "boom") == 2
+        assert terminal_tool._note_terminal_failure("t", "make", 1, "boom") == 3
+
+    def test_different_command_resets(self):
+        self._reset("t")
+        terminal_tool._note_terminal_failure("t", "make", 1, "boom")
+        terminal_tool._note_terminal_failure("t", "make", 1, "boom")
+        assert terminal_tool._note_terminal_failure("t", "pytest", 1, "boom") == 1
+
+    def test_changed_output_resets(self):
+        # The core anti-false-positive property: a changed result (progress)
+        # resets the counter even for the same command.
+        self._reset("t")
+        assert terminal_tool._note_terminal_failure("t", "pytest", 1, "3 failed") == 1
+        assert terminal_tool._note_terminal_failure("t", "pytest", 1, "2 failed") == 1
+        assert terminal_tool._note_terminal_failure("t", "pytest", 1, "1 failed") == 1
+
+    def test_reset_clears_counter(self):
+        self._reset("t")
+        terminal_tool._note_terminal_failure("t", "make", 1, "boom")
+        terminal_tool._reset_terminal_failure_repeats("t")
+        assert terminal_tool.get_terminal_failure_repeat("t") == 0
+
+    def test_tasks_are_isolated(self):
+        self._reset("a")
+        self._reset("b")
+        terminal_tool._note_terminal_failure("a", "make", 1, "boom")
+        terminal_tool._note_terminal_failure("a", "make", 1, "boom")
+        assert terminal_tool._note_terminal_failure("b", "make", 1, "boom") == 1
+        assert terminal_tool.get_terminal_failure_repeat("a") == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: spiral-break diagnostic
+# ---------------------------------------------------------------------------
+
+
+class TestSpiralBreakDiagnostic:
+    def test_mentions_counts_and_alternatives(self):
+        msg = classifier.spiral_break_diagnostic("make build", repeat_count=4, budget=3)
+        assert "4" in msg
+        assert "3" in msg
+        assert "make build" in msg
+        assert any(t in msg for t in ("read_file", "execute_code", "web_search"))
+
+    def test_long_command_is_truncated(self):
+        long_cmd = "echo " + "x" * 500
+        msg = classifier.spiral_break_diagnostic(long_cmd, repeat_count=4, budget=3)
+        assert "..." in msg
+        assert "x" * 200 not in msg
+
+
+# ---------------------------------------------------------------------------
+# Integration: terminal_tool force-break on identical spiral
+# ---------------------------------------------------------------------------
+
+
+class FixedEnvironment:
+    """Environment double that returns the same response for every call."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+        self.env = {}
+        self.cwd = ""
+
+    def execute(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        return self._response
+
+
+class VaryingEnvironment:
+    """Environment double whose output changes every call (simulates progress)."""
+
+    def __init__(self, returncode=1):
+        self._returncode = returncode
+        self.calls = []
+        self.env = {}
+        self.cwd = ""
+
+    def execute(self, command, **kwargs):
+        n = len(self.calls)
+        self.calls.append((command, kwargs))
+        return {"output": f"attempt {n}", "returncode": self._returncode}
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    for key in ("spiral-test", "default"):
+        terminal_tool._reset_terminal_streak(key)
+        terminal_tool._reset_terminal_failure_repeats(key)
+    # Deterministic budget regardless of the machine's config.yaml.
+    monkeypatch.setattr(terminal_tool, "_get_max_command_repeats", lambda: 3)
+    yield
+    for key in ("spiral-test", "default"):
+        terminal_tool._reset_terminal_streak(key)
+        terminal_tool._reset_terminal_failure_repeats(key)
+
+
+class TestTerminalSpiralBreak:
+    def test_identical_failures_escalate_after_budget(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FixedEnvironment({"output": "boom", "returncode": 1})
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        # Budget 3: three identical failures return the normal classification,
+        # the fourth identical failure is escalated to retry_spiral.
+        for _ in range(3):
+            data = json.loads(
+                terminal_tool.terminal_tool("false", task_id="spiral-test")
+            )
+            assert data["failure_class"] == "persistent_error"
+
+        data = json.loads(terminal_tool.terminal_tool("false", task_id="spiral-test"))
+        assert data["failure_class"] == "retry_spiral"
+        assert data["should_retry"] is False
+        assert data["failure_repeat_count"] == 4
+        assert len(fake.calls) == 4
+
+    def test_escalation_preserves_streak_and_recommendation(self, monkeypatch):
+        # The escalated result must keep the real output/exit code and the
+        # existing streak/recommendation enrichment — it only sharpens the
+        # error text, it does not drop context.
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FixedEnvironment({"output": "boom", "returncode": 1})
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        data = {}
+        for _ in range(4):
+            data = json.loads(
+                terminal_tool.terminal_tool("false", task_id="spiral-test")
+            )
+        assert data["failure_class"] == "retry_spiral"
+        assert data["exit_code"] == 1
+        assert data["output"] == "boom"
+        assert "terminal_streak" in data
+        assert "recommendation" in data  # streak is high enough by the 4th call
+
+    def test_changing_output_never_breaks(self, monkeypatch):
+        # Gemini review case: an edit-then-test or poll-until-ready loop re-runs
+        # the identical command but the OUTPUT changes each time (progress).
+        # The guard must never fire here.
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = VaryingEnvironment(returncode=1)
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        for _ in range(8):
+            data = json.loads(
+                terminal_tool.terminal_tool("pytest -q", task_id="spiral-test")
+            )
+            assert data["failure_class"] != "retry_spiral"
+        assert len(fake.calls) == 8
+
+    def test_success_resets_the_spiral_counter(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fail_env = FixedEnvironment({"output": "boom", "returncode": 1})
+        monkeypatch.setattr(
+            terminal_tool, "_active_environments", {"default": fail_env}
+        )
+        for _ in range(2):
+            terminal_tool.terminal_tool("flaky", task_id="spiral-test")
+        assert terminal_tool.get_terminal_failure_repeat("spiral-test") == 2
+
+        ok_env = FixedEnvironment({"output": "ok", "returncode": 0})
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": ok_env})
+        data = json.loads(terminal_tool.terminal_tool("flaky", task_id="spiral-test"))
+        assert data["exit_code"] == 0
+        assert terminal_tool.get_terminal_failure_repeat("spiral-test") == 0
+
+    def test_different_command_does_not_trip_the_guard(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = FixedEnvironment({"output": "boom", "returncode": 1})
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        for cmd in ("cmd_a", "cmd_b", "cmd_a", "cmd_b", "cmd_a", "cmd_b"):
+            data = json.loads(terminal_tool.terminal_tool(cmd, task_id="spiral-test"))
+            assert data["failure_class"] == "persistent_error"
+        assert len(fake.calls) == 6

--- a/tools/terminal_failure_classifier.py
+++ b/tools/terminal_failure_classifier.py
@@ -256,3 +256,29 @@ def streak_recommendation(streak: int) -> str | None:
             "or ask the user before continuing."
         )
     return None
+
+
+def spiral_break_diagnostic(command: str, repeat_count: int, budget: int) -> str:
+    """Build the diagnostic returned when a retry spiral is detected.
+
+    Args:
+        command: The command that has been repeated back-to-back.
+        repeat_count: How many times this exact failure has occurred in a row.
+        budget: The configured threshold of identical consecutive failures.
+
+    Returns:
+        A directive message telling the agent to stop re-issuing the command
+        and change approach.  This is an advisory signal to the model — it does
+        not by itself prevent another call — so it is worded to make the futility
+        explicit rather than to imply the tool blocked anything.
+    """
+    preview = command if len(command) <= 120 else command[:117] + "..."
+    return (
+        f"Retry spiral detected: this exact command has failed identically "
+        f"{repeat_count} times in a row (threshold {budget}). It is failing "
+        "deterministically — running it again unchanged will produce the same "
+        "failure. Stop retrying it: read the last error and fix the root cause, "
+        "change the command or its arguments, switch to another tool (read_file, "
+        "execute_code, process, web_search), or report the blocker to the user. "
+        f"Command: {preview}"
+    )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -43,7 +43,7 @@ import atexit
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 from utils import env_var_enabled
 
@@ -51,6 +51,7 @@ from tools.terminal_failure_classifier import (
     FailureCategory,
     TerminalFailureClassification,
     classify_terminal_failure,
+    spiral_break_diagnostic,
     streak_recommendation,
 )
 
@@ -1011,6 +1012,88 @@ def _reset_terminal_streak(task_id: Optional[str]) -> None:
 def get_terminal_streak(task_id: Optional[str] = None) -> int:
     """Return the current terminal streak for the given task/session."""
     return _terminal_streak_counts.get(task_id or "default", 0)
+
+
+# Per-session tracker of consecutive IDENTICAL terminal failures (issue #1022).
+# The session-global streak above counts any terminal failure; this detects a
+# true retry spiral: the SAME command producing the SAME failure (exit code +
+# output) back-to-back (up to 55 consecutive observed in trace data).  Any
+# observable change — a different command, exit code, or output — resets the
+# count, so legitimate loops that make progress between runs (edit-then-test,
+# poll-until-ready) are never flagged.  Keyed by task/session ->
+# (failure signature, consecutive count).
+_terminal_failure_repeats: Dict[str, Tuple[str, int]] = {}
+
+# Retry-spiral detection threshold (issue #1022): how many identical
+# consecutive terminal failures are allowed before the returned result is
+# escalated to a ``retry_spiral`` diagnostic.  Read from
+# ``terminal.max_command_repeats`` in config.yaml on first use, cached for the
+# process lifetime.  Default 3, floored at 1 and ceilinged at 20.
+_DEFAULT_MAX_COMMAND_REPEATS = 3
+_MAX_COMMAND_REPEATS_CEILING = 20
+_max_command_repeats_cached: Optional[int] = None
+
+# Only the tail of the output feeds the signature — errors surface at the end,
+# and this bounds the retained per-task state to a small, fixed size.
+_FAILURE_SIGNATURE_OUTPUT_TAIL = 2048
+
+
+def _terminal_failure_signature(command: str, exit_code: int, output: str) -> str:
+    """Build the signature that identifies a repeated identical failure."""
+    tail = (output or "")[-_FAILURE_SIGNATURE_OUTPUT_TAIL:]
+    return f"{(command or '').strip()}\x00{exit_code}\x00{tail}"
+
+
+def _note_terminal_failure(
+    task_id: Optional[str], command: str, exit_code: int, output: str
+) -> int:
+    """Record a terminal FAILURE and return its consecutive-repeat count.
+
+    The count is how many times this exact (command, exit code, output tail)
+    failure has occurred back-to-back — including this one.  A different
+    command, exit code, or output resets it to 1, because a changed result
+    means the loop is making progress rather than spiralling.
+    """
+    key = task_id or "default"
+    signature = _terminal_failure_signature(command, exit_code, output)
+    last_sig, count = _terminal_failure_repeats.get(key, ("", 0))
+    count = count + 1 if signature == last_sig else 1
+    _terminal_failure_repeats[key] = (signature, count)
+    return count
+
+
+def _reset_terminal_failure_repeats(task_id: Optional[str]) -> None:
+    """Clear the identical-failure repeat counter for the given task/session."""
+    key = task_id or "default"
+    _terminal_failure_repeats.pop(key, None)
+
+
+def get_terminal_failure_repeat(task_id: Optional[str] = None) -> int:
+    """Return the current identical-failure repeat count for the task/session."""
+    return _terminal_failure_repeats.get(task_id or "default", ("", 0))[1]
+
+
+def _get_max_command_repeats() -> int:
+    """Return the configured retry-spiral budget (identical consecutive calls)."""
+    global _max_command_repeats_cached
+    if _max_command_repeats_cached is not None:
+        return _max_command_repeats_cached
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        term_cfg = cfg.get("terminal", {})
+        val = term_cfg.get("max_command_repeats")
+        if (
+            isinstance(val, (int, float))
+            and 1 <= int(val) <= _MAX_COMMAND_REPEATS_CEILING
+        ):
+            _max_command_repeats_cached = int(val)
+            return _max_command_repeats_cached
+    except Exception:
+        pass
+    _max_command_repeats_cached = _DEFAULT_MAX_COMMAND_REPEATS
+    return _max_command_repeats_cached
 
 
 _env_lock = threading.Lock()
@@ -2883,6 +2966,26 @@ def terminal_tool(
                             "should_retry": False,
                             "terminal_streak": streak,
                         }
+                        # Retry-spiral detection (issue #1022): if this exact
+                        # command has produced this exact failure back-to-back
+                        # beyond the budget, escalate the returned result to a
+                        # precise `retry_spiral` diagnostic so the agent gets a
+                        # sharper stop signal than the generic persistent-error
+                        # hint.  A changed command, exit code, or output resets
+                        # the counter, so edit-then-test and poll-until-ready
+                        # loops (which make progress) never trip it.  This is an
+                        # advisory signal — hard loop enforcement lives in
+                        # agent/loop_guard.py.
+                        repeat = _note_terminal_failure(
+                            task_id, command, returncode, output
+                        )
+                        budget = _get_max_command_repeats()
+                        if repeat > budget:
+                            diagnostic = spiral_break_diagnostic(command, repeat, budget)
+                            result_dict["error"] = diagnostic
+                            result_dict["suggestion"] = diagnostic
+                            result_dict["failure_class"] = "retry_spiral"
+                            result_dict["failure_repeat_count"] = repeat
                         if approval_note:
                             # An approved command interrupted mid-run exits 130
                             # with the executor's marker — never imply success in
@@ -2902,6 +3005,7 @@ def terminal_tool(
 
                 # Successful (or informational) result: reset streak and process output.
                 _reset_terminal_streak(task_id)
+                _reset_terminal_failure_repeats(task_id)
                 break
 
             # Extract output

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Detects the terminal retry spiral described in #1022 — the SAME command
producing the SAME failure back-to-back, observed up to **55 consecutive**
retries (1346 failures across 474 sessions in 7-day trace data). The existing
session-global streak counted any failure and the classifier only returned a
generic persistent-error hint; nothing distinguished a genuine spiral from
normal repeated work.

## What this does

Tracks consecutive identical failures per task by a signature of
`(command, exit_code, output_tail)`. When the same failure repeats past
`terminal.max_command_repeats` (default 3), the returned result is escalated to
a precise `failure_class: "retry_spiral"` diagnostic that names the repeat count
and tells the agent to stop and change approach — a sharper stop signal than the
generic hint.

Keying on the failure **result** (not just the command) is the core property:
any observable change — a different command, exit code, or output — resets the
counter, so loops that make **progress** between runs are never flagged:

- **edit-then-test** — `write_file → pytest(fail) → …`; pytest output changes as
  code is fixed, so the counter resets each run.
- **poll-until-ready** — `kubectl get pods` / `curl -f health`; status output
  changes as external state advances.

The in-call transient-retry loop (max 3 backoff retries within one call) is
untouched.

## Scope (important)

This is an **advisory tool-layer signal**: it sharpens what the agent is told, it
does **not** by itself abort execution. Hard loop enforcement is
`agent/loop_guard.py`'s responsibility — advisory nudges for interactive
sessions (by deliberate design) and a hard-stop for cron. A tool-layer guard
cannot see intervening tool calls (e.g. a `write_file` between two `pytest`
runs), so it cannot *safely* force-break; only the loop layer, which sees the
full message history, can. Wiring this output-aware signal into loop-level
enforcement is left to the broader recovery work (#1019 / #994).

This was the key correction from a self-review + independent second opinion
(Gemini via consilium): the original draft over-claimed a "force-stop", which a
tool-layer guard can't safely deliver. It is now scoped and framed honestly.

## Changes

- **`tools/terminal_failure_classifier.py`**: add `spiral_break_diagnostic()`.
- **`tools/terminal_tool.py`**: `_terminal_failure_signature`,
  `_note_terminal_failure`, `_reset_terminal_failure_repeats`,
  `get_terminal_failure_repeat`, `_get_max_command_repeats`; escalate to
  `retry_spiral` in the non-retryable failure path; reset on success.
- **`hermes_cli/config.py`**: `terminal.max_command_repeats` (1–20, default 3).
- **`pyproject.toml` / `acp_registry/agent.json`**: 0.18.3 → 0.18.4; **`uv.lock`** regenerated.
- **`tests/tools/test_terminal_retry_spiral.py`**: 18 tests — signature, tracker,
  diagnostic, and terminal_tool integration including the **changing-output
  must-not-flag** case and **enrichment-preserved** case.

## Test results

- `test_terminal_retry_spiral.py` — 18/18 passed
- `test_terminal_failure_classifier.py` — 40/40 passed (no regression)
- `TestBuildSchemaFromConfig` + `test_registry_manifest.py` — passed
- `uv lock --check` — clean

Closes #1022