### PR TITLE
refactor(#1022): hash the terminal failure signature to bound retained state

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.18.4",
+      "package": "hermes-agent[acp]==0.18.5",
       "args": ["hermes-acp"]
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.4"
+version = "0.18.5"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/tools/test_terminal_retry_spiral.py
+++ b/tests/tools/test_terminal_retry_spiral.py
@@ -46,6 +46,14 @@ class TestFailureSignature:
         b = terminal_tool._terminal_failure_signature("  make", 1, "x")
         assert a == b
 
+    def test_signature_is_fixed_size_hash(self):
+        # Bounded regardless of output size, so per-task retained state stays
+        # small even for huge command output.
+        small = terminal_tool._terminal_failure_signature("make", 1, "x")
+        huge = terminal_tool._terminal_failure_signature("make", 1, "y" * 500_000)
+        assert len(small) == len(huge) == 40
+        assert small != huge
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: identical-failure repeat tracker

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -32,6 +32,7 @@ Usage:
 """
 
 import importlib.util
+import hashlib
 import json
 import logging
 import os
@@ -1033,15 +1034,24 @@ _DEFAULT_MAX_COMMAND_REPEATS = 3
 _MAX_COMMAND_REPEATS_CEILING = 20
 _max_command_repeats_cached: Optional[int] = None
 
-# Only the tail of the output feeds the signature — errors surface at the end,
-# and this bounds the retained per-task state to a small, fixed size.
-_FAILURE_SIGNATURE_OUTPUT_TAIL = 2048
-
 
 def _terminal_failure_signature(command: str, exit_code: int, output: str) -> str:
-    """Build the signature that identifies a repeated identical failure."""
-    tail = (output or "")[-_FAILURE_SIGNATURE_OUTPUT_TAIL:]
-    return f"{(command or '').strip()}\x00{exit_code}\x00{tail}"
+    """Return a compact hash identifying a specific terminal failure.
+
+    Hashing (rather than retaining the raw command+output) keeps the per-task
+    state stored in ``_terminal_failure_repeats`` to a fixed ~40 bytes — matching
+    the footprint of ``_terminal_streak_counts`` — so a long-lived process that
+    accumulates one entry per never-succeeding task does not retain kilobytes of
+    output per task.  The full output feeds the hash, so discrimination is exact
+    (no truncation window).
+    """
+    h = hashlib.sha1()
+    h.update((command or "").strip().encode("utf-8", "replace"))
+    h.update(b"\x00")
+    h.update(str(exit_code).encode("ascii", "replace"))
+    h.update(b"\x00")
+    h.update((output or "").encode("utf-8", "replace"))
+    return h.hexdigest()
 
 
 def _note_terminal_failure(

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.4"
+version = "0.18.5"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Follow-up polish to #1023 (merged). The identical-failure tracker introduced there
stored the raw `(command + exit_code + output_tail)` signature per task — up to
~2KB each. Since hermes runs as a long-lived daemon and the tracker keeps one
entry per never-succeeding `task_id` (only cleared on success), retaining the raw
output does not scale.

Store a **SHA-1 hash** of `(command, exit_code, full output)` instead:
- Fixed ~40 bytes per entry, matching the footprint of `_terminal_streak_counts`.
- Hashing the **full** output (not a 2048-char tail) removes the arbitrary
  truncation window, so discrimination is exact.
- Detection semantics are unchanged — identical failures still collide, changed
  failures still differ.

## Provenance

Surfaced by an adversarial self-review (Gemini via consilium) of the merged #1022
diff. It returned **NO BLOCKERS** and flagged the per-task retained-output size as
the single strictly-improvable point; this PR addresses exactly that.

## Changes

- **`tools/terminal_tool.py`**: `_terminal_failure_signature` returns a sha1
  hexdigest; drop the now-unused `_FAILURE_SIGNATURE_OUTPUT_TAIL`; `import hashlib`.
- **`tests/tools/test_terminal_retry_spiral.py`**: assert the signature is a
  fixed-size hash regardless of output size.
- **`pyproject.toml` / `acp_registry/agent.json`**: 0.18.4 → 0.18.5; **`uv.lock`** regenerated.

## Test results

- `test_terminal_retry_spiral.py` — 19/19 passed
- `test_terminal_failure_classifier.py` — 40/40 passed
- `test_registry_manifest.py` — passed; `uv lock --check` — clean

Refs #1022