### PR TITLE
fix(tools): pass resolved absolute path to FileOperations.read_file (Closes #1044)

### DIFF
--- a/tests/tools/test_read_file_resolved_path.py
+++ b/tests/tools/test_read_file_resolved_path.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Test that read_file_tool passes the RESOLVED absolute path to
+FileOperations.read_file, not the raw user-supplied path.
+
+This is the root-cause fix for issue #1044: when a relative path was
+passed to read_file_tool, _resolve_path_for_task correctly resolved it
+to an absolute path (used for binary checks, dedup, etc.), but the raw
+relative path was then forwarded to FileOperations.read_file which runs
+shell commands (wc, sed, head) from the shell's cwd — which may differ
+from the terminal env's tracked cwd.  The file would not be found, and
+the agent would spiral through path variations.
+
+Run with:  python -m pytest tests/tools/test_read_file_resolved_path.py -v
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tools.file_tools import read_file_tool
+
+
+class _CapturedPathResult:
+    """Minimal ReadResult stand-in that captures the path argument."""
+
+    def __init__(self):
+        self.content = "line1\nline2\n"
+        self.total_lines = 2
+        self.file_size = 100
+        self.captured_path = None
+        self.error = None
+        self.hint = None
+        self.is_binary = False
+        self.is_image = False
+        self.truncated = False
+        self.similar_files = []
+
+    def to_dict(self):
+        d = {
+            "content": self.content,
+            "total_lines": self.total_lines,
+            "file_size": self.file_size,
+        }
+        return d
+
+
+class TestReadFileResolvedPath(unittest.TestCase):
+    """read_file_tool must pass the resolved absolute path to FileOperations."""
+
+    def setUp(self):
+        # Create a temp directory to use as TERMINAL_CWD
+        self._tmpdir = tempfile.mkdtemp(
+            prefix="test_readfile_resolved_", dir=os.getcwd()
+        )
+        self._test_file = os.path.join(self._tmpdir, "target.py")
+        with open(self._test_file, "w") as f:
+            f.write("line1\nline2\nline3\n")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_relative_path_resolved_before_shell_call(self):
+        """A relative path must be resolved to absolute before reaching
+        FileOperations.read_file, so the shell commands run from the
+        correct directory."""
+        captured = _CapturedPathResult()
+
+        def _capture_read_file(path, offset=1, limit=500):
+            captured.captured_path = path
+            return captured
+
+        fake_ops = MagicMock()
+        fake_ops.read_file = _capture_read_file
+
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmpdir}),
+        ):
+            # Pass a bare relative filename — no directory component.
+            # If the raw path is forwarded, it would be "target.py" and
+            # the shell would look in its own cwd (likely the repo root).
+            # The fix ensures the resolved absolute path is used.
+            result = read_file_tool("target.py", task_id="test_resolved")
+
+        # The path captured by FileOperations.read_file must be the
+        # resolved absolute path, not the raw relative "target.py".
+        self.assertIsNotNone(captured.captured_path)
+        captured_str: str = captured.captured_path or ""
+        self.assertTrue(
+            os.path.isabs(captured_str),
+            f"FileOperations.read_file received a relative path "
+            f"'{captured_str}' — it should be absolute.",
+        )
+        self.assertTrue(
+            captured_str.endswith("target.py"),
+            f"Resolved path '{captured_str}' should end with 'target.py'",
+        )
+
+    def test_absolute_path_passed_through(self):
+        """An absolute path should be passed through (resolved) unchanged."""
+        captured = _CapturedPathResult()
+
+        def _capture_read_file(path, offset=1, limit=500):
+            captured.captured_path = path
+            return captured
+
+        fake_ops = MagicMock()
+        fake_ops.read_file = _capture_read_file
+
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmpdir}),
+        ):
+            read_file_tool(self._test_file, task_id="test_abs")
+
+        self.assertEqual(
+            os.path.realpath(captured.captured_path or ""),
+            os.path.realpath(self._test_file),
+        )
+
+    def test_relative_path_with_subdir_resolved(self):
+        """A relative path with a subdirectory component should also be
+        resolved to an absolute path before reaching FileOperations."""
+        subdir = os.path.join(self._tmpdir, "subdir")
+        os.makedirs(subdir)
+        nested_file = os.path.join(subdir, "nested.py")
+        with open(nested_file, "w") as f:
+            f.write("content\n")
+
+        captured = _CapturedPathResult()
+
+        def _capture_read_file(path, offset=1, limit=500):
+            captured.captured_path = path
+            return captured
+
+        fake_ops = MagicMock()
+        fake_ops.read_file = _capture_read_file
+
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmpdir}),
+        ):
+            read_file_tool("subdir/nested.py", task_id="test_subdir")
+
+        self.assertIsNotNone(captured.captured_path)
+        captured_sub: str = captured.captured_path or ""
+        self.assertTrue(
+            os.path.isabs(captured_sub),
+            f"FileOperations.read_file received relative path "
+            f"'{captured_sub}' for a subdir-relative input.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1470,8 +1470,14 @@ def read_file_tool(
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
+        # Pass the RESOLVED path (str(_resolved)) to FileOperations.read_file
+        # so the shell commands inside (wc -c, sed, head) use the fully-
+        # qualified absolute path.  Passing the raw *path* here means a
+        # relative path is resolved by the shell's cwd, which may differ
+        # from the terminal env's tracked cwd — the root cause of the
+        # read_file file-not-found spiral (#1044, #886, #970).
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(str(_resolved), offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────


### PR DESCRIPTION
Automated evolution PR for issue #1044.

## Root Cause

`read_file_tool` in `tools/file_tools.py` resolved the path via `_resolve_path_for_task` (used for binary checks, dedup, device-path guards) but then passed the **raw unresolved path** to `FileOperations.read_file`, which runs shell commands (`wc -c`, `sed`, `head`) from the shell's own cwd. When a relative path was passed and the terminal env's tracked cwd differed from the shell's process cwd, the file was not found — causing the agent to spiral through path variations (up to 12 consecutive `read_file` calls).

## Fix

Pass `str(_resolved)` to `file_ops.read_file()` instead of the raw `path`. This matches the pattern already used by:
- `patch_replace` (line 2006): passes `_path_to_resolved.get(path) or path`
- `write_file` (line 1849): passes `_resolved`

## Tests

3 new tests in `tests/tools/test_read_file_resolved_path.py` verifying:
- Relative path is resolved to absolute before reaching `FileOperations.read_file`
- Absolute path passes through correctly
- Relative path with subdirectory component is also resolved

All 49 existing `test_file_read_guards.py` tests still pass.

## Impact

Addresses 60 read_file failures across 18 sessions (7-day window) with up to 12 consecutive calls. This is the 5th fix attempt — prior fixes (#970, #782, #757, #886) addressed symptoms (similar-file suggestions, ancestor-walking, batch reads) but not the core path-resolution mismatch between the tool layer and the shell layer.