### PR TITLE
fix: wrap t.cancel() in try/except to prevent RuntimeError on closed event loop

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2183,8 +2183,8 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
                     except (asyncio.CancelledError, Exception):
                         pass
@@ -2227,8 +2227,8 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
                     except (asyncio.CancelledError, Exception):
                         pass


### PR DESCRIPTION
## Problem

When a stdio MCP server fails to connect during `hermes mcp add` or during process teardown, a `RuntimeError: Event loop is closed` traceback is printed to stderr.

Root cause: in `MCPServerTask._wait_for_reconnect_or_shutdown()` and `_run_with_keepalive()`, `t.cancel()` is called **outside** the `try/except` block. When the event loop is already closed (during GC of an abandoned coroutine or process exit), `t.cancel()` internally calls `loop.call_soon()` which raises `RuntimeError: Event loop is closed`. This exception was uncaught.

## Fix

Move `t.cancel()` **inside** the `try/except` block so `RuntimeError` is caught alongside `CancelledError` and other exceptions:

```python
# Before (buggy):
t.cancel()
try:
    await t
except (asyncio.CancelledError, Exception):
    pass

# After (fixed):
try:
    t.cancel()
    await t
except (asyncio.CancelledError, Exception):
    pass
```

Applied to both occurrences (lines 2183 and 2227) since they share the same pattern.

## Verification

- ✅ 212 MCP tool tests pass (`pytest tests/tools/test_mcp_tool.py`)
- ✅ Traceback no longer appears when adding stdio MCP servers that fail initial connection
- ✅ Minimal diff: 2 insertions, 2 deletions in 1 file