### PR TITLE
feat: terminal deterministic timeout category + lower threshold (Closes #1091)

### DIFF
--- a/tests/tools/test_terminal_failure_classifier.py
+++ b/tests/tools/test_terminal_failure_classifier.py
@@ -50,12 +50,42 @@ class TestClassifyTimeout:
         assert result.category == classifier.FailureCategory.timeout
         assert result.should_retry is True
 
-    def test_high_streak_becomes_persistent(self):
+    def test_first_timeout_is_retryable(self):
+        """A single timeout (consecutive_count=1) is retryable."""
+        result = classifier.classify_terminal_failure(
+            "sleep 10", 124, "", "", consecutive_count=1
+        )
+        assert result.category == classifier.FailureCategory.timeout
+        assert result.should_retry is True
+
+    def test_second_consecutive_timeout_is_deterministic(self):
+        """After 2 consecutive identical timeouts, the failure is
+        classified as ``timeout_deterministic`` (non-retryable) so
+        the agent gets a distinct signal to change parameters (issue #1091)."""
+        result = classifier.classify_terminal_failure(
+            "sleep 10", 124, "", "", consecutive_count=2
+        )
+        assert result.category == classifier.FailureCategory.timeout_deterministic
+        assert result.should_retry is False
+
+    def test_high_streak_is_deterministic(self):
+        """A high consecutive count also classifies as timeout_deterministic
+        (was persistent_error before issue #1091 lowered the threshold)."""
         result = classifier.classify_terminal_failure(
             "sleep 10", 124, "", "", consecutive_count=5
         )
-        assert result.category == classifier.FailureCategory.persistent_error
+        assert result.category == classifier.FailureCategory.timeout_deterministic
         assert result.should_retry is False
+
+    def test_deterministic_timeout_hint_mentions_parameter_change(self):
+        """The hint for timeout_deterministic should tell the agent to
+        change command/cwd/timeout/flags, not just 'try again'."""
+        result = classifier.classify_terminal_failure(
+            "slowcmd", 124, "", "", consecutive_count=3
+        )
+        assert result.category == classifier.FailureCategory.timeout_deterministic
+        assert "Change at least one of" in result.hint
+        assert "command" in result.hint.lower()
 
 
 class TestClassifyRetryableTransient:

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -242,6 +242,16 @@ class TestTerminalDelegation:
         # Repeated timeouts stop being retryable — force a strategy change.
         assert result.should_retry is False
 
+    def test_deterministic_timeout_maps_to_persistent(self):
+        """timeout_deterministic from terminal classifier maps to
+        ToolFailureCategory.persistent_error (issue #1091)."""
+        result = tfc.classify_tool_failure(
+            "terminal", "", exit_code=124, consecutive_count=2
+        )
+        assert result.category == tfc.ToolFailureCategory.persistent_error
+        assert result.should_retry is False
+        assert result.tool_type == tfc.ToolType.terminal
+
 
 # ---------------------------------------------------------------------------
 # Extensibility

--- a/tools/terminal_failure_classifier.py
+++ b/tools/terminal_failure_classifier.py
@@ -20,6 +20,10 @@ class FailureCategory(str, Enum):
     permission_denied = "permission_denied"
     persistent_error = "persistent_error"
     timeout = "timeout"
+    # Repeated identical timeout — deterministic, cannot be recovered by
+    # retrying with the same command.  The agent must change at least one
+    # of {command, cwd, timeout, flags} or switch tools (issue #1091).
+    timeout_deterministic = "timeout_deterministic"
     unknown = "unknown"
 
 
@@ -133,15 +137,23 @@ def classify_terminal_failure(
     base_cmd = _base_command(command)
 
     # Transient timeout / partial output is safe to retry with backoff.
+    # After 2 consecutive identical timeouts (was 3) the failure is
+    # deterministic — the same command with the same parameters cannot
+    # succeed.  Promote to ``timeout_deterministic`` so the agent gets a
+    # distinct signal to change parameters or switch tools (issue #1091).
     if exit_code == 124 or any(p.search(text) for p in _TIMEOUT_PATTERNS):
-        if consecutive_count >= 3:
+        if consecutive_count >= 2:
             return TerminalFailureClassification(
-                category=FailureCategory.persistent_error,
+                category=FailureCategory.timeout_deterministic,
                 hint=(
-                    "The command has timed out repeatedly ("
-                    f"{consecutive_count} consecutive terminal calls). "
-                    "Consider running it as a background process with "
-                    "notify_on_complete=true, or break the work into smaller steps."
+                    "The command has timed out deterministically ("
+                    f"{consecutive_count} consecutive identical failures). "
+                    "Retrying the same command with the same parameters will "
+                    "produce the same timeout. Change at least one of: the "
+                    "command, the working directory, the timeout value, or "
+                    "the flags. Alternatively, run it in the background with "
+                    "notify_on_complete=true, use execute_code, or split the "
+                    "work into smaller steps."
                 ),
                 should_retry=False,
             )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2898,7 +2898,12 @@ def terminal_tool(
                     )
 
                     # Timeout-like execution errors surface as exit code 124.
-                    if classification.category == FailureCategory.timeout:
+                    # Includes ``timeout_deterministic`` (repeated identical
+                    # timeouts) which is non-retryable (issue #1091).
+                    if classification.category in {
+                        FailureCategory.timeout,
+                        FailureCategory.timeout_deterministic,
+                    }:
                         result_dict = {
                             "output": "",
                             "exit_code": 124,

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -307,6 +307,9 @@ _TERMINAL_CATEGORY_MAP: dict[_TerminalCategory, ToolFailureCategory] = {
     _TerminalCategory.missing_command: ToolFailureCategory.tool_unavailable,
     _TerminalCategory.permission_denied: ToolFailureCategory.permission_denied,
     _TerminalCategory.persistent_error: ToolFailureCategory.persistent_error,
+    # Deterministic timeout (repeated identical failures) maps to persistent
+    # — the call cannot succeed unchanged (issue #1091).
+    _TerminalCategory.timeout_deterministic: ToolFailureCategory.persistent_error,
     _TerminalCategory.timeout: ToolFailureCategory.timeout,
     _TerminalCategory.unknown: ToolFailureCategory.unknown,
 }


### PR DESCRIPTION
Automated evolution PR for issue #1091.

## Summary

Terminal commands that time out repeatedly with identical parameters are deterministic — retrying the same command produces the same timeout. Previously, 3+ consecutive timeouts were promoted to the generic `persistent_error` class, which doesn't tell the agent *why* the failure is persistent or *what to do about it*.

## Changes

1. **New `FailureCategory.timeout_deterministic`** in `terminal_failure_classifier.py` — a distinct category for repeated identical timeouts, with a hint that explicitly tells the agent to change at least one of {command, cwd, timeout, flags} or switch tools (background, execute_code, split work).

2. **Lower threshold from 3 to 2** — two consecutive identical timeouts is a strong deterministic signal. Waiting for 3 wastes a turn.

3. **Cross-tool mapping** in `tool_failure_classifier.py` — `timeout_deterministic` maps to `ToolFailureCategory.persistent_error` (non-retryable).

4. **terminal_tool.py execute() path** — handles `timeout_deterministic` alongside `timeout` in the exception classification branch.

## Tests

- Updated existing `test_high_streak_becomes_persistent` → `test_high_streak_is_deterministic` (now asserts `timeout_deterministic` instead of `persistent_error`)
- Added `test_first_timeout_is_retryable` — single timeout is still retryable
- Added `test_second_consecutive_timeout_is_deterministic` — 2 consecutive → non-retryable
- Added `test_deterministic_timeout_hint_mentions_parameter_change` — hint tells agent to change parameters
- Added `test_deterministic_timeout_maps_to_persistent` in cross-tool classifier tests

All pre-PR test shards pass. Lint passes. 78 lines changed (within merge cap).