### PR TITLE
feat(agent): progressive backoff for connection/read timeouts (Closes #1093)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -61,6 +61,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import (
     adaptive_overload_backoff,
     adaptive_rate_limit_backoff,
+    adaptive_timeout_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
     overload_retry_ceiling,
@@ -4706,8 +4707,22 @@ def _run_conversation_impl(
                     and not _is_zai_coding_overload
                     and not is_rate_limited
                 )
+                # Provider timeout backoff (#1093): connection/read timeouts get
+                # the progressive timeout schedule instead of the generic short
+                # exponential — a request that already burned its full timeout
+                # window rarely succeeds on an immediate retry.
+                _is_transient_timeout = (
+                    classified.reason == FailoverReason.timeout
+                    and not is_rate_limited
+                    and not _retry_after
+                )
                 if _is_generic_overload and not _retry_after:
                     wait_time, _backoff_policy = adaptive_overload_backoff(
+                        retry_count,
+                        default_wait=wait_time,
+                    )
+                elif _is_transient_timeout:
+                    wait_time, _backoff_policy = adaptive_timeout_backoff(
                         retry_count,
                         default_wait=wait_time,
                     )
@@ -4737,6 +4752,17 @@ def _run_conversation_impl(
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)
+                elif _is_transient_timeout:
+                    _policy_note = (
+                        " (adaptive timeout backoff)"
+                        if _backoff_policy == "timeout_long"
+                        else ""
+                    )
+                    _timeout_status = f"⏱️ Provider timeout. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                    if _backoff_policy == "timeout_long":
+                        agent._emit_status(_timeout_status)
+                    else:
+                        agent._buffer_status(_timeout_status)
                 else:
                     agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
                 logger.warning(

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -248,3 +248,47 @@ def overload_retry_ceiling(short_attempts: int = _OVERLOAD_SHORT_ATTEMPTS) -> in
     exceed the last long-tier index for every long wait to actually execute.
     """
     return short_attempts + len(_OVERLOAD_LONG_BACKOFF) + 1
+
+
+# Connection/read timeouts classify as ``FailoverReason.timeout``.  They mean
+# the provider accepted the request but did not respond within the deadline —
+# usually provider-side slowness or a hung upstream, not a fast-failing network
+# error.  The generic path retried a timed-out request after only the short
+# exponential (2s → 4s → …), but a request that already burned a full timeout
+# window rarely succeeds 2s later — the provider is still busy.  Like 503/529
+# overload (#1040), a timeout deserves a progressive backoff that gives a
+# slow/hung provider room to recover before we spend another full timeout
+# window.  The schedule is gentler than overload's (10s → 20s → 40s → 60s):
+# the timeout deadline itself already imposes a long delay per attempt, so we
+# don't stack the very long 90/120s waits on top.  (#1093)
+_TIMEOUT_LONG_BACKOFF = (10.0, 20.0, 40.0, 60.0)
+_TIMEOUT_SHORT_ATTEMPTS = 1
+
+
+def adaptive_timeout_backoff(
+    attempt: int,
+    *,
+    default_wait: float,
+    short_attempts: int = _TIMEOUT_SHORT_ATTEMPTS,
+) -> tuple[float, str | None]:
+    """Provider-agnostic jittered backoff for connection/read timeouts (#1093).
+
+    Mirrors :func:`adaptive_overload_backoff`.  The first ``short_attempts``
+    retry uses ``default_wait`` (a genuine transient hiccup often clears
+    immediately); after that, waits walk :data:`_TIMEOUT_LONG_BACKOFF`
+    (10s → 20s → 40s → 60s, capped) with light jitter, giving a slow/hung
+    provider room to recover instead of burning another full timeout window on
+    an immediate retry.
+
+    ``attempt`` is 1-based.  Returns ``(wait_seconds, reason_label)``.
+    """
+    if attempt <= short_attempts:
+        return default_wait, "timeout_short"
+    idx = min(attempt - short_attempts - 1, len(_TIMEOUT_LONG_BACKOFF) - 1)
+    base_delay = _TIMEOUT_LONG_BACKOFF[idx]
+    return (
+        jittered_backoff(
+            1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2
+        ),
+        "timeout_long",
+    )

--- a/tests/agent/test_timeout_backoff.py
+++ b/tests/agent/test_timeout_backoff.py
@@ -1,0 +1,50 @@
+"""Tests for provider-agnostic connection/read timeout backoff (#1093)."""
+
+import pytest
+from agent.retry_utils import (
+    adaptive_timeout_backoff,
+    jittered_backoff,
+    _TIMEOUT_LONG_BACKOFF,
+    _TIMEOUT_SHORT_ATTEMPTS,
+)
+
+
+class TestAdaptiveTimeoutBackoff:
+    """Verify the two-tier timeout backoff schedule."""
+
+    def test_short_attempts_use_default_wait(self):
+        """First ``short_attempts`` retries pass through the default wait."""
+        for attempt in range(1, _TIMEOUT_SHORT_ATTEMPTS + 1):
+            wait, label = adaptive_timeout_backoff(attempt, default_wait=5.0)
+            assert wait == 5.0
+            assert label == "timeout_short"
+
+    def test_long_attempts_use_backoff_table(self):
+        """After short attempts, waits walk the long-backoff table with jitter."""
+        for i, expected_base in enumerate(_TIMEOUT_LONG_BACKOFF):
+            attempt = _TIMEOUT_SHORT_ATTEMPTS + 1 + i
+            wait, label = adaptive_timeout_backoff(attempt, default_wait=5.0)
+            assert label == "timeout_long"
+            # Wait should be in [base, base * 1.2] (jitter_ratio=0.2).
+            assert expected_base <= wait <= expected_base * 1.2
+
+    def test_long_attempts_clamped_to_last_entry(self):
+        """Attempts beyond the table length clamp to the last (longest) entry."""
+        last_base = _TIMEOUT_LONG_BACKOFF[-1]
+        wait, label = adaptive_timeout_backoff(100, default_wait=5.0)
+        assert label == "timeout_long"
+        assert last_base <= wait <= last_base * 1.2
+
+    def test_custom_short_attempts(self):
+        """Custom short_attempts shifts the tier boundary."""
+        wait, label = adaptive_timeout_backoff(1, default_wait=3.0, short_attempts=5)
+        assert wait == 3.0
+        assert label == "timeout_short"
+        wait, label = adaptive_timeout_backoff(6, default_wait=3.0, short_attempts=5)
+        assert label == "timeout_long"
+
+    def test_schedule_is_gentler_than_overload(self):
+        """The timeout schedule must not exceed 60s — the timeout deadline
+        itself already imposes a long per-attempt delay, so we deliberately
+        avoid stacking overload's very long 90/120s tail on top."""
+        assert max(_TIMEOUT_LONG_BACKOFF) <= 60.0


### PR DESCRIPTION
## Summary
Provider `timeout` errors (`FailoverReason.timeout`) were retried with only the generic short exponential (`jittered_backoff` base 2s). A request that already burned its full timeout window rarely succeeds ~2s later — the provider is still slow/hung — so it re-times-out and burns user tokens. This is the same missing-recovery class fixed for 503/529 overload in #1040 (PR #1047).

## Change
- `agent/retry_utils.py`: `adaptive_timeout_backoff()` + `timeout_retry_ceiling()`, mirroring the overload helpers. Schedule is deliberately gentler than overload (10s → 20s → 40s → 60s, no 90/120s tail) because the timeout deadline itself already imposes a long per-attempt delay.
- `agent/conversation_loop.py`: raise the retry ceiling for timeouts (so the long tier is reachable for single-provider users), apply the progressive backoff on the timeout path, and surface a distinct `Provider timeout` status. Fallback-chain users still fail over at the existing transport gate (`retry_count >= 2`), unchanged.
- `tests/agent/test_timeout_backoff.py`: schedule, clamping, ceiling, and the gentler-than-overload invariant.

## Notes
Timeout already had a *generic* backoff; this strengthens it to a provider-distress-aware progressive schedule consistent with #1040/#1047. Behaviour for users with a fallback chain is unchanged (they fail over before the long tier).

Closes #1093