### PR TITLE
feat(agent): debounce identical read_file spirals at the loop-guard (Closes #1092)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -84,6 +84,17 @@ _NONRETRY_THRESHOLD = 2
 # return "success". Count these as non-progress after a shorter run so the model
 # is nudged toward a different query / tool / strategy.
 _SHORT_CIRCUIT_IDEMPOTENT = frozenset({"search_files", "web_search", "web_extract"})
+# File-read tools: re-reading the SAME path+offset+limit returns content the
+# model already has, so an identical-argument repeat is a spiral just like a
+# repeated search query.  read_file is the second-largest retry-spiral cluster
+# in the agent's own traces (up to 8 consecutive identical calls, #1092), so
+# trip the same-argument short-circuit at _SHORT_CIRCUIT_REPEAT_THRESHOLD (4)
+# instead of waiting for the generic idempotent repeat_threshold (8) — half the
+# wasted calls / prompt-cache budget.  Kept as a distinct set so the nudge can
+# speak in file terms (offset/limit) rather than the search "rephrase the query"
+# wording, which does not apply to a file read.
+_SHORT_CIRCUIT_FILE_READ = frozenset({"read_file", "mcp_filesystem_read_file"})
+_SHORT_CIRCUIT_IDEMPOTENT = _SHORT_CIRCUIT_IDEMPOTENT | _SHORT_CIRCUIT_FILE_READ
 _SHORT_CIRCUIT_REPEAT_THRESHOLD = 4
 
 # #1012 — web_search with *different* queries is a distinct spiral from the
@@ -597,21 +608,44 @@ def maybe_nudge(
     if tool in _SHORT_CIRCUIT_IDEMPOTENT and count >= short_circuit_threshold:
         arg_hashes = [r[3] for r in same if r[3] is not None]
         if arg_hashes and len(set(arg_hashes)) == 1:
-            score = _tool_spiral_score(tool, count, short_circuit_threshold)
-            score_line = f"\n{score}" if score else ""
-            return (
-                f"[loop-guard] You have called `{tool}` {count} times with the "
-                f"SAME arguments and the result is not making progress.{score_line} "
-                f"Do NOT repeat `{tool}` with those identical arguments. Rephrase "
-                f"the query, broaden or narrow it, switch to a different information "
-                f"source, or state the blocker if no relevant results are available."
-                # Deliberately NO appended hints here: this branch's advice is
-                # already specific to identical-argument repetition, and e.g.
-                # web_search's 'stop reformulating' diversion would directly
-                # contradict the 'rephrase the query' instruction above
-                # (consult review). The #625 exploration hints are excluded by
-                # the same long-standing design decision.
-            )
+            _is_file_read = tool in _SHORT_CIRCUIT_FILE_READ
+            # File-read tools defer an extreme identical-read spiral
+            # (>= escalate_threshold) to the stronger escalation interrupt
+            # below; the debounce owns the earlier
+            # [short_circuit_threshold, escalate_threshold) window. Search tools
+            # have no escalation tie-in, so they keep short-circuiting at any
+            # count above the threshold. (#1092)
+            if not (_is_file_read and count >= escalate_threshold):
+                score = _tool_spiral_score(tool, count, short_circuit_threshold)
+                score_line = f"\n{score}" if score else ""
+                if _is_file_read:
+                    return (
+                        f"[loop-guard] You have called `{tool}` {count} times with the "
+                        f"SAME path/offset/limit — you already have that file content "
+                        f"and re-reading returns the same bytes.{score_line} Do NOT "
+                        f"re-read the identical range. Use the content you already "
+                        f"have, read a DIFFERENT part of the file (change offset/limit) "
+                        f"or a different file, or state the blocker if the file does "
+                        f"not contain what you need."
+                        # Unlike the search branch below, the #625 exploration
+                        # hint (repo_map / bulk read / delegate_task) does NOT
+                        # contradict "don't re-read the identical range" — it is
+                        # the complementary better strategy, so keep it.
+                        f"{_diversion_hint(tool)}"
+                    )
+                return (
+                    f"[loop-guard] You have called `{tool}` {count} times with the "
+                    f"SAME arguments and the result is not making progress.{score_line} "
+                    f"Do NOT repeat `{tool}` with those identical arguments. Rephrase "
+                    f"the query, broaden or narrow it, switch to a different information "
+                    f"source, or state the blocker if no relevant results are available."
+                    # Deliberately NO appended hints here: this branch's advice is
+                    # already specific to identical-argument repetition, and e.g.
+                    # web_search's 'stop reformulating' diversion would directly
+                    # contradict the 'rephrase the query' instruction above
+                    # (consult review). The #625 exploration hints are excluded by
+                    # the same long-standing design decision.
+                )
 
     # #1012 — web_search diverse-query spiral: the model keeps reformulating
     # the query (different args each time, each call "succeeds") but never

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -49,8 +49,18 @@ class TestRepeatTrigger:
         assert n is not None and "terminal" in n and "loop-guard" in n
 
     def test_idempotent_below_threshold_is_quiet(self):
-        # read_file is idempotent (repeat_threshold=8) — 7 calls should be quiet.
-        assert maybe_nudge(_run("read_file", 7)) is None
+        # read_file is idempotent (repeat_threshold=8). 7 reads of DIFFERENT
+        # ranges are legitimate exploration and stay quiet. (Identical-argument
+        # repeats now trip the debounce at 4 — see
+        # test_loop_guard_readfile_debounce.py, #1092.)
+        msgs = [{"role": "user", "content": "explore"}]
+        for i in range(7):
+            cid = f"c{i}"
+            msgs.append(
+                _asst("read_file", args=json.dumps({"path": "a.py", "offset": i * 100}), call_id=cid)
+            )
+            msgs.append(_result("ok", call_id=cid))
+        assert maybe_nudge(msgs) is None
 
     def test_idempotent_at_threshold_nudges(self):
         n = maybe_nudge(_run("read_file", 8))

--- a/tests/agent/test_loop_guard_readfile_debounce.py
+++ b/tests/agent/test_loop_guard_readfile_debounce.py
@@ -1,0 +1,77 @@
+"""Tests for the read_file identical-argument short-circuit (#1092).
+
+``read_file`` is the second-largest retry-spiral cluster in the agent's own
+traces (up to 8 consecutive identical calls). Re-reading the SAME
+path/offset/limit returns bytes the model already has, so — like a repeated
+search query — it should trip the same-argument short-circuit at
+``_SHORT_CIRCUIT_REPEAT_THRESHOLD`` (4) rather than the generic idempotent
+repeat_threshold (8), with a file-appropriate nudge (offset/limit), not the
+search "rephrase the query" wording.
+"""
+
+import json
+
+from agent.loop_guard import maybe_nudge
+
+
+def _assistant_read_file(args: dict) -> dict:
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_read_file",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": json.dumps(args),
+                },
+            }
+        ],
+    }
+
+
+def _read_result(content: str = "line 1\nline 2\nline 3\n") -> dict:
+    # A SUCCESSFUL read — the point is that repeating an identical read that
+    # keeps succeeding is still a non-progressing loop.
+    return {"role": "tool", "tool_call_id": "call_read_file", "content": content}
+
+
+def _identical_read_run(n: int, args: dict | None = None) -> list[dict]:
+    args = args or {"path": "src/app.py", "offset": 0, "limit": 100}
+    msgs: list[dict] = []
+    for _ in range(n):
+        msgs.append(_assistant_read_file(args))
+        msgs.append(_read_result())
+    return msgs
+
+
+class TestReadFileIdenticalShortCircuit:
+    def test_trips_at_4_identical_reads(self):
+        """4 identical read_file calls trip the same-argument short-circuit."""
+        nudge = maybe_nudge(_identical_read_run(4))
+        assert nudge is not None
+        assert "read_file" in nudge
+
+    def test_no_trip_at_3_identical_reads(self):
+        """Below the short-circuit threshold (4) and the idempotent repeat (8),
+        no nudge fires — a couple of re-reads is not yet a spiral."""
+        assert maybe_nudge(_identical_read_run(3)) is None
+
+    def test_varying_offsets_do_not_short_circuit_at_4(self):
+        """Reading DIFFERENT ranges is legitimate progress — the identical-arg
+        short-circuit must NOT fire when offset/limit change each call."""
+        msgs: list[dict] = []
+        for i in range(4):
+            msgs.append(
+                _assistant_read_file({"path": "src/app.py", "offset": i * 100, "limit": 100})
+            )
+            msgs.append(_read_result())
+        assert maybe_nudge(msgs) is None
+
+    def test_nudge_speaks_in_file_terms_not_search(self):
+        """The read_file nudge must mention offset/limit and NOT tell the model
+        to 'rephrase the query' (which does not apply to a file read)."""
+        nudge = maybe_nudge(_identical_read_run(4))
+        assert nudge is not None
+        assert "offset/limit" in nudge
+        assert "rephrase the query" not in nudge.lower()


### PR DESCRIPTION
## Summary
`read_file` is the second-largest retry-spiral cluster in the agent's own traces (up to 8 consecutive identical calls). Re-reading the SAME `path/offset/limit` returns bytes the model already has, but `read_file` only tripped the generic idempotent `repeat_threshold` (8) — so the model could waste up to 8 identical reads (and prompt-cache budget) before any nudge.

## Change
- `agent/loop_guard.py`: add `read_file` / `mcp_filesystem_read_file` to the same-argument short-circuit (new `_SHORT_CIRCUIT_FILE_READ` set) so an identical-argument repeat is caught at **4** instead of 8 — half the wasted calls. Kept as a distinct set so the nudge:
  - speaks in **file terms** (offset/limit), not the search "rephrase the query" wording;
  - **appends the #625 exploration hint** (repo_map / bulk read / delegate_task), which complements — not contradicts — "don't re-read the identical range";
  - **defers an extreme identical spiral** (`>= escalate_threshold`) to the stronger ESCALATED INTERRUPT, so that path is preserved.
- `tests/agent/test_loop_guard_readfile_debounce.py`: identical trips at 4, varying-args does NOT, message speaks in file terms.
- `tests/agent/test_loop_guard.py`: the below-threshold-quiet test now uses **varying** args (identical repeats intentionally trip the new debounce).

## Notes
Varying-argument `read_file` (genuine exploration of different ranges/files) is unaffected — it still uses the `repeat_threshold` (8) / `escalate` (15) path with the repo_map exploration hint. Full loop_guard suite (92 tests) green.

Closes #1092