### PR TITLE
[UPSTREAM] Desktop hotfixes: node-pty packaging (#65611) + model-picker stale closure (#65777)

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -19,7 +19,8 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  rmSync
+  rmSync,
+  writeFileSync
 } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { isMain } from './utils.mjs'
@@ -27,6 +28,30 @@ import { isMain } from './utils.mjs'
 const here = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(here, '..')
 const require = createRequire(import.meta.url)
+
+function makeExecutable(filePath) {
+  chmodSync(filePath, 0o755)
+}
+
+function patchUnixTerminalAsarPaths(destRoot) {
+  const filePath = join(destRoot, 'lib', 'unixTerminal.js')
+  if (!existsSync(filePath)) return
+
+  const source = readFileSync(filePath, 'utf8')
+  const patched = source
+    .replace(
+      "helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      "helperPath = helperPath.replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked');"
+    )
+    .replace(
+      "helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');",
+      "helperPath = helperPath.replace(/node_modules\\.asar(?!\\.unpacked)/, 'node_modules.asar.unpacked');"
+    )
+
+  if (patched !== source) {
+    writeFileSync(filePath, patched)
+  }
+}
 
 /**
  * Locate node-pty's package root via real module resolution, so this
@@ -75,7 +100,11 @@ function copyBuildRelease(srcDir, destDir) {
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      const destFile = join(destDir, entry.name)
+      cpSync(join(srcDir, entry.name), destFile)
+      if (entry.name === 'spawn-helper') {
+        makeExecutable(destFile)
+      }
     }
   }
 }
@@ -220,6 +249,7 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
 
   // lib/**/*.js — the JS surface node-pty's `main` points into.
   copyGlobByExt(join(srcRoot, 'lib'), join(destRoot, 'lib'), ['.js'])
+  patchUnixTerminalAsarPaths(destRoot)
 
   // prebuilds/<platform>-<arch>/* — the prebuild-install payload for the
   // *target* we're packaging, not necessarily the host running this script.
@@ -239,8 +269,9 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
-        chmodSync(join(destPrebuild, entry.name), 0o775)
+        const destFile = join(destPrebuild, entry.name)
+        cpSync(join(prebuildDir, entry.name), destFile)
+        makeExecutable(destFile)
       }
     }
   }

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import fs, { existsSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { test } from 'vitest'
 
 import {
@@ -41,6 +42,19 @@ function makeFakeNodePty(srcRoot, { prebuildPlatform, prebuildArch } = {}) {
     const prebuildDir = join(srcRoot, 'prebuilds', `${prebuildPlatform}-${prebuildArch}`)
     makeFakeNode(join(prebuildDir, 'pty.node'), prebuildPlatform)
   }
+}
+
+function makeFakeUnixTerminal(srcRoot) {
+  fs.writeFileSync(
+    join(srcRoot, 'lib', 'unixTerminal.js'),
+    [
+      "exports.resolveHelper = function (helperPath) {",
+      "  helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      "  helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');",
+      '  return helperPath;',
+      '};'
+    ].join('\n')
+  )
 }
 
 // ─── classifyNativeBinary tests ─────────────────────────────────────
@@ -261,6 +275,66 @@ test('host-target: host build/Release IS staged for a matching target', () => {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
 })
+
+test.skipIf(process.platform === 'win32')(
+  'host-target: staged node-pty resolves an already-unpacked helper and preserves executable helpers',
+  async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+    try {
+      const srcRoot = join(tmp, 'node-pty')
+      const destRoot = join(tmp, 'dest')
+      const prebuildDir = join(srcRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+      const buildReleaseDir = join(srcRoot, 'build', 'Release')
+
+      makeFakeNodePty(srcRoot, {
+        prebuildPlatform: process.platform,
+        prebuildArch: process.arch
+      })
+      makeFakeUnixTerminal(srcRoot)
+      makeFakeNode(join(buildReleaseDir, 'pty.node'), process.platform)
+      fs.writeFileSync(join(prebuildDir, 'spawn-helper'), 'prebuild helper')
+      fs.writeFileSync(join(buildReleaseDir, 'spawn-helper'), 'build helper')
+      fs.chmodSync(join(prebuildDir, 'spawn-helper'), 0o644)
+      fs.chmodSync(join(buildReleaseDir, 'spawn-helper'), 0o644)
+
+      stageNodePtyInto(srcRoot, destRoot, { platform: process.platform, arch: process.arch })
+
+      const stagedUnixTerminalUrl = pathToFileURL(join(destRoot, 'lib', 'unixTerminal.js'))
+      stagedUnixTerminalUrl.searchParams.set('t', String(Date.now()))
+      const stagedUnixTerminal = await import(stagedUnixTerminalUrl.href)
+      const unpackedHelper = join(
+        tmp,
+        'Hermes.app',
+        'Contents',
+        'Resources',
+        'app.asar.unpacked',
+        'dist',
+        'node_modules',
+        'node-pty',
+        'prebuilds',
+        `${process.platform}-${process.arch}`,
+        'spawn-helper'
+      )
+      const nodeModulesUnpackedHelper = unpackedHelper.replace(
+        `${path.sep}node_modules${path.sep}`,
+        `${path.sep}node_modules.asar.unpacked${path.sep}`
+      )
+
+      assert.equal(stagedUnixTerminal.resolveHelper(unpackedHelper), unpackedHelper)
+      assert.equal(
+        stagedUnixTerminal.resolveHelper(nodeModulesUnpackedHelper),
+        nodeModulesUnpackedHelper
+      )
+      assert.equal(
+        fs.statSync(join(destRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')).mode & 0o777,
+        0o755
+      )
+      assert.equal(fs.statSync(join(destRoot, 'build', 'Release', 'spawn-helper')).mode & 0o777, 0o755)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  }
+)
 
 test('validation rejects a staged binary with the wrong platform magic', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -227,7 +227,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   const { refreshCurrentModel, selectModel, updateModelOptionsCache } = useModelControls({
-    activeSessionId,
     queryClient,
     requestGateway
   })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -32,16 +32,13 @@ vi.mock('@/store/notifications', () => ({
 type Controls = ReturnType<typeof useModelControls>
 
 function Harness({
-  activeSessionId,
   onReady,
   requestGateway
 }: {
-  activeSessionId: string | null
   onReady: (controls: Controls) => void
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
   const controls = useModelControls({
-    activeSessionId,
     queryClient: new QueryClient(),
     requestGateway
   })
@@ -74,7 +71,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -97,7 +93,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: 'runtime-1',
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -110,12 +105,11 @@ describe('useModelControls', () => {
   })
 
   it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
+    $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -133,12 +127,11 @@ describe('useModelControls', () => {
   })
 
   it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
+    $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
     let controls!: Controls
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -158,7 +151,7 @@ describe('useModelControls', () => {
     const requestGateway = vi.fn()
     let controls!: Controls
 
-    render(<Harness activeSessionId={null} onReady={value => (controls = value)} requestGateway={requestGateway} />)
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -180,7 +173,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -13,26 +13,30 @@ interface ModelSelection {
 }
 
 interface ModelControlsOptions {
-  activeSessionId: string | null
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
+export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
 
+  // All callbacks here read reactive session state from the store (.get())
+  // rather than capturing it as a prop. The actions bag in wiring.tsx mutates
+  // in place to keep a stable identity, so memoized surfaces capture these
+  // callbacks once and never re-evaluate — a captured prop would be stale
+  // forever. The store read is always current.
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
       const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
 
-      queryClient.setQueryData<ModelOptionsResponse>(['model-options', activeSessionId || 'global'], patch)
+      queryClient.setQueryData<ModelOptionsResponse>(['model-options', $activeSessionId.get() || 'global'], patch)
 
       if (includeGlobal) {
         queryClient.setQueryData<ModelOptionsResponse>(['model-options', 'global'], patch)
       }
     },
-    [activeSessionId, queryClient]
+    [queryClient]
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
@@ -82,36 +86,38 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       const prevModel = $currentModel.get()
       const prevProvider = $currentProvider.get()
 
+      const liveSessionId = $activeSessionId.get()
+
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
-      updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
+      updateModelOptionsCache(selection.provider, selection.model, !liveSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads
       // $currentModel/$currentProvider and applies it as that session's override.
-      if (!activeSessionId) {
+      if (!liveSessionId) {
         return true
       }
 
       try {
         await requestGateway('config.set', {
-          session_id: activeSessionId,
+          session_id: liveSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} --session`
         })
 
-        void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
+        void queryClient.invalidateQueries({ queryKey: ['model-options', liveSessionId] })
 
         return true
       } catch (err) {
         setCurrentModel(prevModel)
         setCurrentProvider(prevProvider)
-        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+        updateModelOptionsCache(prevProvider, prevModel, !liveSessionId)
         notifyError(err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [activeSessionId, copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
   )
 
   return { refreshCurrentModel, selectModel, updateModelOptionsCache }


### PR DESCRIPTION
## Summary

Cherry-picks the two self-contained upstream **desktop** fixes that landed on
`upstream/main` after the latest release (`v2026.7.7.2`, which the fork already
fully contains). These are the *only* `apps/desktop` deltas between the fork and
bleeding-edge upstream — both are upstream-domain (the fork does not customize
`apps/desktop`), so they were taken as-is with **zero conflicts**.

| Upstream PR | Fix |
|---|---|
| #65611 | preserve node-pty helper in packaged app — guards staged node-pty ASAR path rewrites so already-unpacked paths aren't rewritten twice; normalizes spawn-helper to mode 0755 |
| #65777 | model picker reverts in existing threads — `selectModel` captured a stale `activeSessionId` via a `useMemo` closure created before any session was active |

## Scope

- Touches **`apps/desktop/` only** (5 files: `stage-native-deps.mjs` + test,
  `wiring.tsx`, `use-model-controls.ts` + test). No backend / Python changes.
- Per the fork's `evolution-upstream-sync` policy we track upstream **release
  tags**, not bleeding-edge `main`; this is a narrow, owner-requested desktop
  hotfix pull, not a full main sync.
- Both commit authors are already present in `scripts/release.py` `AUTHOR_MAP`.

## Verification

- Cherry-picks applied cleanly; all 5 files match `upstream/main` byte-for-byte.
- No conflict markers. JS/TS + desktop build validated by CI (desktop is outside
  the Python `tests/` suite).
