### PR TITLE
fix: enforce tool spiral caps across turns (#1109 #1110 #1111 #1112)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -285,6 +285,12 @@ class ToolCallGuardrailController:
     ):
         self.config = config or ToolCallGuardrailConfig()
         self.policy_registry = policy_registry
+        # Cross-turn failure streaks — NOT reset by reset_for_turn so that
+        # one-failing-call-per-turn spirals (the common pattern: the model
+        # calls the same failing tool once per API turn) accumulate across
+        # turns and trigger the cap.  reset_for_turn only clears per-turn
+        # bookkeeping (exact-failure, no-progress, halt_decision).
+        self._cross_turn_tool_failure_counts: dict[str, int] = {}
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -309,6 +315,52 @@ class ToolCallGuardrailController:
                 return policy_decision
 
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+
+        # Cross-turn spiral enforcement (#1109/#1110/#1111/#1112): if the
+        # same tool has been failing across turns and the cross-turn streak
+        # has already reached the cap, block execution immediately — BEFORE
+        # the hard_stop_enabled gate.  This makes the browser/spiral caps
+        # truly always-on: the model gets a synthetic blocked result with
+        # the fallback directive instead of being allowed to execute the
+        # same failing call again.  reset_for_turn clears _halt_decision but
+        # NOT _cross_turn_tool_failure_counts, so the streak survives.
+        cross_turn_count = self._cross_turn_tool_failure_counts.get(tool_name, 0)
+        if (
+            cross_turn_count >= 1
+            and (
+                (self.config.spiral_failure_cap >= 1
+                 and tool_name in self.config.spiral_prone_tools
+                 and cross_turn_count >= self.config.spiral_failure_cap)
+                or
+                (self.config.browser_failure_cap >= 1
+                 and _is_browser_tool(tool_name)
+                 and cross_turn_count >= self.config.browser_failure_cap)
+            )
+        ):
+            directive = _fallback_directive_for(tool_name)
+            if _is_browser_tool(tool_name) and tool_name not in self.config.spiral_prone_tools:
+                code = "browser_tool_failure_cap"
+                cap = self.config.browser_failure_cap
+            else:
+                code = "spiral_prone_tool_failure_cap"
+                cap = self.config.spiral_failure_cap
+            decision = ToolGuardrailDecision(
+                action="block",
+                code=code,
+                message=(
+                    f"Blocked {tool_name}: it has failed {cross_turn_count} times across "
+                    f"recent turns, reaching the retry cap ({cap}). This failure pattern "
+                    "is deterministic — retrying the same way will not fix it. "
+                    "Use the fallback directive below."
+                ),
+                tool_name=tool_name,
+                count=cross_turn_count,
+                signature=signature,
+                fallback_directive=directive,
+            )
+            self._halt_decision = decision
+            return decision
+
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -377,6 +429,20 @@ class ToolCallGuardrailController:
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
 
+            # Cross-turn accumulation: the same tool failing once per turn
+            # is the dominant spiral pattern.  The per-turn counter resets
+            # each API turn, so without this cross-turn tracker the cap
+            # only catches rare within-turn spirals (multiple calls in one
+            # tool batch).  Here we carry the streak forward.
+            cross_turn_count = self._cross_turn_tool_failure_counts.get(tool_name, 0) + 1
+            self._cross_turn_tool_failure_counts[tool_name] = cross_turn_count
+
+            # Effective streak is the max of per-turn and cross-turn counts.
+            # Within-turn spirals (5 calls in one batch) still trip the cap
+            # via the per-turn count; cross-turn spirals (1 call/turn for 5
+            # turns) trip it via the cross-turn count.
+            effective_streak = max(same_count, cross_turn_count)
+
             # #745 — browser tools get an always-on per-tool failure cap that
             # halts REGARDLESS of ``hard_stop_enabled``. Browser retries are
             # expensive and their deterministic failures (CDP down, nav timeout,
@@ -387,19 +453,19 @@ class ToolCallGuardrailController:
             if (
                 self.config.browser_failure_cap >= 1
                 and _is_browser_tool(tool_name)
-                and same_count >= self.config.browser_failure_cap
+                and effective_streak >= self.config.browser_failure_cap
             ):
                 decision = ToolGuardrailDecision(
                     action="halt",
                     code="browser_tool_failure_cap",
                     message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn, "
+                        f"Stopped {tool_name}: it failed {effective_streak} times, "
                         f"reaching the browser retry cap ({self.config.browser_failure_cap}). "
                         "Browser retries are expensive and this failure is deterministic — "
                         "stop re-driving the browser and use the fallback."
                     ),
                     tool_name=tool_name,
-                    count=same_count,
+                    count=effective_streak,
                     signature=signature,
                     fallback_directive=_fallback_directive_for(tool_name),
                 )
@@ -409,43 +475,43 @@ class ToolCallGuardrailController:
             # #974/#969/#970 — terminal, execute_code, and read_file are the
             # system's largest failure sources. Their retry spirals persist
             # because the loop_guard's fallback_directive is advisory (the
-            # agent ignores it and retries). This always-on cap halts the turn
-            # after N consecutive same-tool failures REGARDLESS of
+            # agent ignores it and retries). This always-on cap halts the
+            # turn after N consecutive same-tool failures REGARDLESS of
             # ``hard_stop_enabled``, mirroring the browser_failure_cap pattern.
             # The fallback_directive gives the agent a concrete alternative.
             if (
                 self.config.spiral_failure_cap >= 1
                 and tool_name in self.config.spiral_prone_tools
-                and same_count >= self.config.spiral_failure_cap
+                and effective_streak >= self.config.spiral_failure_cap
             ):
                 directive = _fallback_directive_for(tool_name)
                 decision = ToolGuardrailDecision(
                     action="halt",
                     code="spiral_prone_tool_failure_cap",
                     message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn, "
+                        f"Stopped {tool_name}: it failed {effective_streak} times, "
                         f"reaching the retry cap ({self.config.spiral_failure_cap}). "
                         "This failure pattern is deterministic — retrying the same way "
                         "will not fix it. Use the fallback directive below."
                     ),
                     tool_name=tool_name,
-                    count=same_count,
+                    count=effective_streak,
                     signature=signature,
                     fallback_directive=directive,
                 )
                 self._halt_decision = decision
                 return decision
 
-            if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
+            if self.config.hard_stop_enabled and effective_streak >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
                     action="halt",
                     code="same_tool_failure_halt",
                     message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn. "
+                        f"Stopped {tool_name}: it failed {effective_streak} times. "
                         "Stop retrying the same failing tool path and choose a different approach."
                     ),
                     tool_name=tool_name,
-                    count=same_count,
+                    count=effective_streak,
                     signature=signature,
                     fallback_directive=_fallback_directive_for(tool_name),
                 )
@@ -467,13 +533,13 @@ class ToolCallGuardrailController:
                     fallback_directive=_fallback_directive_for(tool_name),
                 )
 
-            if self.config.warnings_enabled and same_count >= self.config.same_tool_failure_warn_after:
+            if self.config.warnings_enabled and effective_streak >= self.config.same_tool_failure_warn_after:
                 return ToolGuardrailDecision(
                     action="warn",
                     code="same_tool_failure_warning",
-                    message=_tool_failure_recovery_hint(tool_name, same_count),
+                    message=_tool_failure_recovery_hint(tool_name, effective_streak),
                     tool_name=tool_name,
-                    count=same_count,
+                    count=effective_streak,
                     signature=signature,
                     fallback_directive=_fallback_directive_for(tool_name),
                 )
@@ -482,6 +548,8 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+        # A success breaks the cross-turn failure streak too.
+        self._cross_turn_tool_failure_counts.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -478,17 +478,27 @@ def test_browser_failure_cap_halts_spiral_with_hard_stop_off():
     # broken backend fails regardless of URL), each result a failure.
     decisions = []
     for i in range(6):
-        # before_call would still allow (hard_stop off), but the after_call cap
-        # records a halt that ends the turn.
-        assert controller.before_call("browser_navigate", {"url": f"https://x/{i}"}).allows_execution
-        decisions.append(
-            controller.after_call(
-                "browser_navigate",
-                {"url": f"https://x/{i}"},
-                '{"success": false, "error": "Could not connect to Chrome backend"}',
-                failed=True,
+        # With cross-turn tracking, before_call blocks after the streak
+        # reaches the cap.  First 3 calls allow; after 3 failures the
+        # 4th before_call blocks (stronger than the old allow-then-halt).
+        bc = controller.before_call("browser_navigate", {"url": f"https://x/{i}"})
+        if i < 3:
+            assert bc.allows_execution
+            decisions.append(
+                controller.after_call(
+                    "browser_navigate",
+                    {"url": f"https://x/{i}"},
+                    '{"success": false, "error": "Could not connect to Chrome backend"}',
+                    failed=True,
+                )
             )
-        )
+        else:
+            # After 3 failures, before_call blocks — the spiral is stopped
+            # before the tool even executes.
+            assert not bc.allows_execution
+            assert bc.code == "browser_tool_failure_cap"
+            decisions.append(bc)
+            break
 
     # First two failures do not hit the cap (cap=3); the third halts and the
     # spiral is stopped — no unbounded 15-in-a-row.
@@ -575,15 +585,24 @@ def test_browser_cap_success_resets_streak():
 
 
 def test_browser_cap_reset_for_turn_clears_streak():
-    """Per-turn reset clears the browser failure streak (no cross-turn leakage)."""
+    """Per-turn reset clears the halt decision but NOT the cross-turn streak."""
     controller = ToolCallGuardrailController()
     for _ in range(3):
         controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
     assert controller.halt_decision is not None
     controller.reset_for_turn()
     assert controller.halt_decision is None
-    d = controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
-    assert d.action == "allow"
+    # The cross-turn streak persists — before_call now blocks the browser tool.
+    d = controller.before_call("browser_navigate", {"url": "u"})
+    assert d.action == "block"
+    assert d.code == "browser_tool_failure_cap"
+    # A success after reset clears the cross-turn streak.
+    controller.reset_for_turn()
+    controller.before_call("browser_navigate", {"url": "u"})
+    d_ok = controller.after_call("browser_navigate", {"url": "u"}, '{"ok":true}', failed=False)
+    assert d_ok.action == "allow"
+    controller.reset_for_turn()
+    assert controller.before_call("browser_navigate", {"url": "u"}).action == "allow"
 
 
 def test_browser_failure_cap_parsed_from_mapping():
@@ -728,15 +747,30 @@ def test_spiral_cap_success_resets_streak():
 
 
 def test_spiral_cap_reset_for_turn_clears_streak():
-    """Per-turn reset clears the spiral failure streak (no cross-turn leakage)."""
+    """Per-turn reset clears the halt decision but NOT the cross-turn streak.
+
+    The cross-turn count persists so one-failing-call-per-turn spirals
+    accumulate (#1109–#1112).  After reset, halt_decision is cleared, but
+    the next before_call for the same spiral-prone tool is blocked because
+    the cross-turn streak already reached the cap.
+    """
     controller = ToolCallGuardrailController()
     for _ in range(5):
         controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
     assert controller.halt_decision is not None
     controller.reset_for_turn()
     assert controller.halt_decision is None
-    d = controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
-    assert d.action == "allow"
+    # The cross-turn streak persists — before_call now blocks the tool.
+    d = controller.before_call("terminal", {"command": "x"})
+    assert d.action == "block"
+    assert d.code == "spiral_prone_tool_failure_cap"
+    # A success after reset clears the cross-turn streak.
+    controller.reset_for_turn()
+    controller.before_call("terminal", {"command": "x"})
+    d_ok = controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
+    assert d_ok.action == "allow"
+    controller.reset_for_turn()
+    assert controller.before_call("terminal", {"command": "x"}).action == "allow"
 
 
 def test_spiral_cap_does_not_affect_non_spiral_tools():
@@ -778,3 +812,88 @@ def test_spiral_prone_tools_set():
     assert "execute_code" in cfg.spiral_prone_tools
     assert "read_file" in cfg.spiral_prone_tools
     assert len(cfg.spiral_prone_tools) == 3
+
+
+# ── Cross-turn spiral enforcement (#1109–#1112) ─────────────────────────────
+
+
+def test_cross_turn_spiral_accumulates_across_resets():
+    """One failing terminal call per turn accumulates across reset_for_turn
+    calls and eventually triggers the spiral cap via the cross-turn counter."""
+    controller = ToolCallGuardrailController()
+    for _ in range(4):  # 4 turns, one failing call each
+        controller.before_call("terminal", {"command": "x"})
+        controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
+        controller.reset_for_turn()
+    # 4 failures: not yet at cap (5), before_call should still allow
+    assert controller.before_call("terminal", {"command": "x"}).action == "allow"
+    # 5th turn: one more failure reaches the cap
+    controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
+    assert controller.halt_decision is not None
+    assert controller.halt_decision.code == "spiral_prone_tool_failure_cap"
+
+
+def test_cross_turn_before_call_blocks_after_cap_reached():
+    """After the cross-turn streak reaches the cap, before_call blocks the
+    tool on the NEXT turn even though per-turn state was reset."""
+    controller = ToolCallGuardrailController()
+    for _ in range(5):
+        controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
+    controller.reset_for_turn()
+    # Next turn: before_call must block, not allow
+    d = controller.before_call("terminal", {"command": "x"})
+    assert d.action == "block"
+    assert d.code == "spiral_prone_tool_failure_cap"
+    assert d.fallback_directive != ""
+
+
+def test_cross_turn_success_clears_streak():
+    """A successful call after failures clears the cross-turn streak so
+    legitimate retry-after-fix work is not blocked."""
+    controller = ToolCallGuardrailController()
+    for _ in range(3):
+        controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
+    controller.reset_for_turn()
+    # Success on next turn
+    controller.before_call("terminal", {"command": "x"})
+    controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
+    controller.reset_for_turn()
+    # Streak cleared — before_call allows
+    assert controller.before_call("terminal", {"command": "x"}).action == "allow"
+
+
+def test_cross_turn_browser_cap_blocks_after_reset():
+    """Browser tool cross-turn streak persists across reset and blocks via
+    before_call."""
+    controller = ToolCallGuardrailController()
+    for _ in range(3):
+        controller.after_call("browser_navigate", {"url": "u"}, '{"error":"boom"}', failed=True)
+    controller.reset_for_turn()
+    d = controller.before_call("browser_navigate", {"url": "u"})
+    assert d.action == "block"
+    assert d.code == "browser_tool_failure_cap"
+    assert d.fallback_directive != ""
+
+
+def test_cross_turn_does_not_affect_non_spiral_tools():
+    """The cross-turn enforcement only applies to spiral-prone and browser
+    tools — not to write_file, patch, etc."""
+    controller = ToolCallGuardrailController()
+    for _ in range(10):
+        controller.after_call("write_file", {"path": "x"}, '{"error":"boom"}', failed=True)
+    controller.reset_for_turn()
+    assert controller.before_call("write_file", {"path": "x"}).action == "allow"
+
+
+def test_cross_turn_blocks_with_hard_stop_disabled():
+    """Cross-turn enforcement fires even when hard_stop_enabled is False —
+    the spiral and browser caps are always-on."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False)
+    )
+    for _ in range(5):
+        controller.after_call("execute_code", {"code": "x"}, '{"error":"boom"}', failed=True)
+    controller.reset_for_turn()
+    d = controller.before_call("execute_code", {"code": "x"})
+    assert d.action == "block"
+    assert d.code == "spiral_prone_tool_failure_cap"


### PR DESCRIPTION
## Root Cause

`ToolCallGuardrailController.reset_for_turn()` clears `_same_tool_failure_counts` at the start of every API turn (`turn_context.py:234`). Since real tool spirals are one-failing-call-per-turn across many turns, the per-turn counter never accumulated beyond 1 before being wiped. The `spiral_failure_cap=5` and `browser_failure_cap=3` only caught rare within-turn spirals (multiple calls in one tool batch).

Evidence from introspection issues:
- #1109: terminal — 174 failures / 48 sessions, max 29 consecutive
- #1110: execute_code — 62 failures / 14 sessions, max 17 consecutive
- #1111: browser_navigate — 13 sessions, max 21 consecutive
- #1112: read_file — 34 failures / 12 sessions, max 8 consecutive

## Fix

1. **`_cross_turn_tool_failure_counts`** dict in `ToolCallGuardrailController`, initialized in `__init__` and NOT cleared by `reset_for_turn()`. On failure, both per-turn and cross-turn counts are incremented. On success, both are cleared for that tool.

2. **`effective_streak = max(same_count, cross_turn_count)`** used in all cap checks and decisions. Within-turn spirals still trip via the per-turn count; cross-turn spirals now trip via the cross-turn count.

3. **`before_call` cross-turn enforcement gate** — fires BEFORE the `hard_stop_enabled` check. If the cross-turn streak has already reached the cap, the tool is blocked immediately with a synthetic result and fallback directive, instead of being allowed to execute and fail again.

## Tests

- Updated 3 existing tests to reflect stronger cross-turn behavior
- Added 7 new tests for cross-turn enforcement

## Files Changed

- `agent/tool_guardrails.py` — 82 lines added (within 200-line cap)
- `tests/agent/test_tool_guardrails.py` — 135 lines added