### PR TITLE
fix(loop-guard): enforce interactive hard-stop for genuine failing spirals (#1109–#1112)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -992,6 +992,42 @@ def _run_conversation_impl(
                             {"role": "assistant", "content": final_response}
                         )
                         break
+                    elif (
+                        _loop_guard.should_interactive_hard_stop(
+                            getattr(agent, "platform", None),
+                            _lg_warnings,
+                            _lg_genuine_spiral,
+                        )
+                    ):
+                        # #1109–#1112 — interactive failing-spiral enforcement:
+                        # the tool is genuinely failing (not just repetitive-
+                        # successful) and has ignored
+                        # INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD warnings.
+                        # Stop burning context/budget instead of nudging again.
+                        logger.warning(
+                            "loop_guard: interactive hard stop — `%s` failing "
+                            "spiral nudged %d times with no course-correction "
+                            "(%d consecutive calls), ending turn as a failure "
+                            "(#1109)",
+                            _lg_tool,
+                            _lg_warnings,
+                            _lg_count,
+                        )
+                        final_response = (
+                            f"[loop-guard] `{_lg_tool}` has been failing "
+                            f"repeatedly — {_lg_warnings} advisory warnings were "
+                            f"ignored across {_lg_count} consecutive calls with no "
+                            f"course-correction. Stopping to preserve context and "
+                            f"budget. Review the errors above and change the "
+                            f"approach, or report the blocker if it can't be "
+                            f"resolved."
+                        )
+                        failed = True
+                        _turn_exit_reason = "loop_guard_interactive_hard_stop"
+                        messages.append(
+                            {"role": "assistant", "content": final_response}
+                        )
+                        break
                     if not agent.quiet_mode:
                         agent._safe_print("\n🌀 loop-guard: nudging a strategy change")
         except Exception as _lg_err:  # never let the guard break the loop

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -301,6 +301,21 @@ _POLLING_TOOLS = frozenset({"process"})
 # constant is only consulted when ``agent.platform == "cron"``.
 CRON_LOOP_GUARD_HARD_STOP_THRESHOLD = 2
 
+# Interactive escalation (#1109, #1110, #1111, #1112): advisory nudges are
+# also routinely ignored on INTERACTIVE surfaces when the spiral is a genuine
+# failing one (``run_warrants_cron_hard_stop`` is True — the tool is actually
+# failing or stuck in an identical-call loop, not just doing repetitive but
+# successful work). Observed: terminal retry spirals reaching 29 consecutive
+# calls (#1109), execute_code at 17 (#1110), browser_navigate at 21 (#1111),
+# read_file at 8 (#1112). A human is present but the spiral burns context and
+# budget with no benefit. After this many warnings for the SAME stuck run —
+# deliberately HIGHER than the cron threshold (2) to give a human more room to
+# intervene — also end the interactive turn as a failure for genuine spirals.
+# Legitimate mono-tool runs that merely LOOK repetitive (distinct successful
+# calls) never reach this gate because ``run_warrants_cron_hard_stop`` returns
+# False for them, so this only ever stops genuine non-progress.
+INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD = 4
+
 
 def should_cron_hard_stop(platform: Optional[str], warning_count: int) -> bool:
     """True when an unattended cron turn should end as a failure instead of
@@ -310,6 +325,35 @@ def should_cron_hard_stop(platform: Optional[str], warning_count: int) -> bool:
     (CLI/gateway/messaging) always return False — a human is present there to
     course-correct, so the guard stays purely advisory."""
     return platform == "cron" and warning_count >= CRON_LOOP_GUARD_HARD_STOP_THRESHOLD
+
+
+def should_interactive_hard_stop(
+    platform: Optional[str],
+    warning_count: int,
+    genuine_spiral: bool,
+) -> bool:
+    """True when an INTERACTIVE (non-cron) turn should end as a failure for a
+    genuine failing spiral that has ignored ``INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD``
+    advisory warnings (#1109–#1112).
+
+    Only fires when ALL of the following hold:
+      * ``platform`` is NOT ``"cron"`` (cron uses its own lower threshold).
+      * ``genuine_spiral`` is True — i.e. ``run_warrants_cron_hard_stop`` says
+        the trailing run is genuinely flailing (failing repeatedly or stuck in
+        an identical-call loop), NOT merely doing repetitive-but-successful
+        mono-tool work.
+      * ``warning_count >= INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD`` — the
+        model has been given several escalating chances to course-correct.
+
+    This ensures interactive spirals that burn context with no progress are
+    stopped, while preserving the purely-advisory behaviour for legitimate
+    repetitive work (the iteration/budget guard remains the backstop there).
+    """
+    if platform == "cron":
+        return False  # cron has its own path via should_cron_hard_stop
+    if not genuine_spiral:
+        return False  # repetitive-but-successful work: keep nudging
+    return warning_count >= INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD
 
 
 def _failure_category(content: Any) -> Optional[str]:

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -10,11 +10,13 @@ import json
 
 from agent.loop_guard import (
     CRON_LOOP_GUARD_HARD_STOP_THRESHOLD,
+    INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
     current_run_signature,
     maybe_nudge,
     maybe_refusal_nudge,
     run_warrants_cron_hard_stop,
     should_cron_hard_stop,
+    should_interactive_hard_stop,
 )
 
 
@@ -459,6 +461,76 @@ class TestShouldCronHardStop:
         huge_count = CRON_LOOP_GUARD_HARD_STOP_THRESHOLD + 100
         for platform in ("cli", "telegram", "discord", "gateway", None, ""):
             assert should_cron_hard_stop(platform, huge_count) is False, platform
+
+
+class TestShouldInteractiveHardStop:
+    """#1109–#1112: interactive failing-spiral enforcement. After enough
+    advisory warnings for a GENUINE failing spiral (run_warrants_cron_hard_stop
+    is True), interactive surfaces also stop — not just cron. Legitimate
+    repetitive-but-successful work is never affected."""
+
+    def test_below_threshold_never_stops(self):
+        assert (
+            should_interactive_hard_stop(
+                "cli",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD - 1,
+                genuine_spiral=True,
+            )
+            is False
+        )
+
+    def test_at_threshold_stops_for_genuine_spiral(self):
+        assert (
+            should_interactive_hard_stop(
+                "cli",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+                genuine_spiral=True,
+            )
+            is True
+        )
+
+    def test_above_threshold_stops(self):
+        assert (
+            should_interactive_hard_stop(
+                "telegram",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 5,
+                genuine_spiral=True,
+            )
+            is True
+        )
+
+    def test_never_stops_for_non_genuine_spiral(self):
+        """Repetitive-but-successful work: keep nudging, never hard-stop."""
+        huge = INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 100
+        for platform in ("cli", "gateway", "telegram", "discord", None, ""):
+            assert should_interactive_hard_stop(
+                platform, huge, genuine_spiral=False
+            ) is False, platform
+
+    def test_cron_platform_never_triggers_interactive_path(self):
+        """Cron uses its own lower-threshold path; should_interactive_hard_stop
+        must defer to that and always return False for cron."""
+        assert (
+            should_interactive_hard_stop(
+                "cron",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 10,
+                genuine_spiral=True,
+            )
+            is False
+        )
+
+    def test_all_interactive_platforms_covered(self):
+        """Every non-cron platform should be eligible once the threshold is
+        met for a genuine spiral."""
+        for platform in ("cli", "gateway", "telegram", "discord", "web", None, ""):
+            assert should_interactive_hard_stop(
+                platform,
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+                genuine_spiral=True,
+            ) is True, platform
+
+    def test_zero_warnings_never_stops(self):
+        assert should_interactive_hard_stop("cli", 0, genuine_spiral=True) is False
 
 
 class TestFailureClassAndDiversionHints:

--- a/tests/agent/test_loop_guard_interactive_enforcement.py
+++ b/tests/agent/test_loop_guard_interactive_enforcement.py
@@ -1,0 +1,203 @@
+"""Tests for #1109–#1112: interactive failing-spiral enforcement.
+
+On interactive surfaces (CLI/gateway/messaging), after
+``INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD`` advisory warnings for a GENUINE
+failing spiral (``run_warrants_cron_hard_stop`` is True — the tool is failing
+or stuck in an identical-call loop), the turn ends as a failure instead of
+continuing to nudge. This extends the cron-only enforcement (#624) to
+interactive surfaces for genuine spirals, preventing the observed retry spirals
+(29 consecutive terminal calls, 17 execute_code, 21 browser_navigate, 8
+read_file) from burning context with no progress.
+
+Part 1 — pure-function tests: no agent/import-chain dependencies, fast, fully
+isolated.
+
+Part 2 — integration tests are in test_loop_guard_cron_enforcement.py (requires
+Python 3.10+ for the ``run_agent`` import chain).
+"""
+
+from agent.loop_guard import (
+    INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+    run_warrants_cron_hard_stop,
+    should_interactive_hard_stop,
+)
+
+
+# ── Message helpers (mirror test_loop_guard.py) ──────────────────────────
+
+
+def _asst(tool, args="{}", call_id="c"):
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": call_id, "function": {"name": tool, "arguments": args}}
+        ],
+    }
+
+
+def _result(content, call_id="c"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _failing_run(tool, n, *, error="error: something failed"):
+    """n consecutive single-tool turns, each with a FAILING result."""
+    msgs = [{"role": "user", "content": "do the thing"}]
+    for i in range(n):
+        cid = f"c{i}"
+        msgs.append(_asst(tool, call_id=cid))
+        msgs.append(_result(error, call_id=cid))
+    return msgs
+
+
+def _identical_ok_run(tool, n):
+    """n consecutive single-tool turns with the SAME args and ok results
+    — a degenerate identical-call loop that run_warrants_cron_hard_stop
+    flags via clause (3)."""
+    msgs = [{"role": "user", "content": "do the thing"}]
+    for i in range(n):
+        cid = f"c{i}"
+        msgs.append(_asst(tool, args='{"x": 1}', call_id=cid))
+        msgs.append(_result("ok", call_id=cid))
+    return msgs
+
+
+def _distinct_ok_run(tool, n):
+    """n consecutive single-tool turns with DISTINCT args and ok results
+    — legitimate mono-tool progress (e.g. git add / commit / push burst)."""
+    msgs = [{"role": "user", "content": "do the thing"}]
+    for i in range(n):
+        cid = f"c{i}"
+        msgs.append(_asst(tool, args=f'{{"step": {i}}}', call_id=cid))
+        msgs.append(_result("ok", call_id=cid))
+    return msgs
+
+
+# ── Tests: should_interactive_hard_stop pure function ────────────────────
+
+
+class TestShouldInteractiveHardStopPure:
+    """Pure-function tests for the interactive hard-stop gate."""
+
+    def test_below_threshold_never_stops(self):
+        assert (
+            should_interactive_hard_stop(
+                "cli",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD - 1,
+                genuine_spiral=True,
+            )
+            is False
+        )
+
+    def test_at_threshold_stops_for_genuine_spiral(self):
+        assert (
+            should_interactive_hard_stop(
+                "cli",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+                genuine_spiral=True,
+            )
+            is True
+        )
+
+    def test_above_threshold_stops(self):
+        assert (
+            should_interactive_hard_stop(
+                "telegram",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 5,
+                genuine_spiral=True,
+            )
+            is True
+        )
+
+    def test_never_stops_for_non_genuine_spiral(self):
+        """Repetitive-but-successful work: keep nudging, never hard-stop."""
+        huge = INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 100
+        for platform in ("cli", "gateway", "telegram", "discord", None, ""):
+            assert should_interactive_hard_stop(
+                platform, huge, genuine_spiral=False
+            ) is False, platform
+
+    def test_cron_platform_never_triggers_interactive_path(self):
+        """Cron uses its own lower-threshold path; should_interactive_hard_stop
+        must defer to that and always return False for cron."""
+        assert (
+            should_interactive_hard_stop(
+                "cron",
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD + 10,
+                genuine_spiral=True,
+            )
+            is False
+        )
+
+    def test_all_interactive_platforms_covered(self):
+        """Every non-cron platform should be eligible once the threshold is
+        met for a genuine spiral."""
+        for platform in ("cli", "gateway", "telegram", "discord", "web", None, ""):
+            assert should_interactive_hard_stop(
+                platform,
+                INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+                genuine_spiral=True,
+            ) is True, platform
+
+    def test_zero_warnings_never_stops(self):
+        assert should_interactive_hard_stop("cli", 0, genuine_spiral=True) is False
+
+
+# ── Tests: run_warrants_cron_hard_stop classifies correctly ──────────────
+# These verify the second gate that the interactive hard-stop depends on —
+# confirming that genuine spirals are True and legitimate work is False.
+
+
+class TestGenuineSpiralClassification:
+    """Verify run_warrants_cron_hard_stop (the ``genuine_spiral`` input)
+    classifies the right patterns as real spirals vs. legitimate work."""
+
+    def test_failing_terminal_spiral_is_genuine(self):
+        """#1109 — terminal failing repeatedly is a genuine spiral."""
+        assert run_warrants_cron_hard_stop(
+            _failing_run("terminal", 4)
+        ) is True
+
+    def test_failing_execute_code_spiral_is_genuine(self):
+        """#1110 — execute_code failing repeatedly is a genuine spiral."""
+        assert run_warrants_cron_hard_stop(
+            _failing_run("execute_code", 4)
+        ) is True
+
+    def test_failing_browser_navigate_spiral_is_genuine(self):
+        """#1111 — browser_navigate failing repeatedly is a genuine spiral."""
+        assert run_warrants_cron_hard_stop(
+            _failing_run("browser_navigate", 4)
+        ) is True
+
+    def test_failing_read_file_spiral_is_genuine(self):
+        """#1112 — read_file failing repeatedly is a genuine spiral."""
+        assert run_warrants_cron_hard_stop(
+            _failing_run("read_file", 5)
+        ) is True
+
+    def test_identical_ok_terminal_loop_is_genuine(self):
+        """Degenerate identical-call loop (``echo hi`` x N) is genuine even
+        though each call 'succeeded' — run_warrants clause (3)."""
+        assert run_warrants_cron_hard_stop(
+            _identical_ok_run("terminal", 5)
+        ) is True
+
+    def test_distinct_successful_terminal_burst_is_not_genuine(self):
+        """Distinct successful calls (real progress: lint -> git add ->
+        commit -> push) must NOT be classified as a genuine spiral."""
+        assert (
+            run_warrants_cron_hard_stop(
+                _distinct_ok_run("terminal", 10)
+            )
+            is False
+        )
+
+    def test_distinct_successful_read_file_burst_is_not_genuine(self):
+        """Reading several DIFFERENT files in a row is legitimate exploration,
+        not a spiral — must NOT be classified as genuine."""
+        assert (
+            run_warrants_cron_hard_stop(
+                _distinct_ok_run("read_file", 10)
+            )
+            is False
+        )


### PR DESCRIPTION
## Problem

The loop guard correctly **detects** genuine failing spirals via `run_warrants_cron_hard_stop`, but only **cron sessions** ever get real enforcement — interactive surfaces stay purely advisory. This means detected spirals continue to burn context and budget with no progress.

**Observed in production traces:**
- **#1109**: terminal retry spirals up to 29 consecutive calls (174 failures / 48 sessions)
- **#1110**: execute_code failure spirals up to 17 consecutive calls (62 failures / 14 sessions)
- **#1111**: browser_navigate loops up to 21 consecutive navigations (13 sessions)
- **#1112**: read_file loops up to 8 consecutive calls (34 failures / 12 sessions)

## Solution

Add `should_interactive_hard_stop()`: after `INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD` (4) advisory warnings for a **genuine failing spiral** on a non-cron surface, end the turn as a failure.

Safety constraints:
1. **Higher threshold** (4 vs cron's 2) — ample room for human intervention
2. **Only fires for genuine spirals** — `run_warrants_cron_hard_stop` must be True
3. **Never fires for legitimate work** — distinct successful mono-tool work is unaffected
4. **Cron excluded** — uses its own path

## Changes

- `agent/loop_guard.py`: New constant + `should_interactive_hard_stop()` function
- `agent/conversation_loop.py`: Wire as elif after cron hard-stop check
- `tests/agent/test_loop_guard.py`: 7 new tests
- `tests/agent/test_loop_guard_interactive_enforcement.py`: New file, 14 tests

## Test Results

All 100 tests pass.

## Rollback

Fully reversible — single revert. No migrations, no config changes.