### PR TITLE
fix(loop-guard): add process to spiral-prone tools cap (Closes #1141)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -68,7 +68,12 @@ MUTATING_TOOL_NAMES = frozenset(
 # read_file (26 failures / 10 sessions with ≥5 consecutive reads). These tools
 # get an always-on per-tool failure cap that halts regardless of
 # ``hard_stop_enabled``, mirroring the browser_failure_cap pattern.
-_SPIRAL_PRONE_TOOLS = frozenset({"terminal", "execute_code", "read_file"})
+# #1141 — process added: an 18-deep process polling spiral was observed in
+# production (11 failures, 1 session). process poll/wait loops that each
+# "succeed" but never converge on a terminal state run uncapped without this.
+_SPIRAL_PRONE_TOOLS = frozenset(
+    {"terminal", "execute_code", "read_file", "process"}
+)
 
 
 @dataclass(frozen=True)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -805,13 +805,15 @@ def test_spiral_cap_default_is_5():
 
 
 def test_spiral_prone_tools_set():
-    """The spiral-prone set contains exactly the three tools with the highest
-    trace-miner failure frequency."""
+    """The spiral-prone set contains the tools with the highest trace-miner
+    failure frequency. Membership is the invariant; the set grows as new
+    spiral-prone tools are identified (#1141 added process)."""
     cfg = ToolCallGuardrailConfig()
     assert "terminal" in cfg.spiral_prone_tools
     assert "execute_code" in cfg.spiral_prone_tools
     assert "read_file" in cfg.spiral_prone_tools
-    assert len(cfg.spiral_prone_tools) == 3
+    assert "process" in cfg.spiral_prone_tools
+    assert len(cfg.spiral_prone_tools) >= 4
 
 
 # ── Cross-turn spiral enforcement (#1109–#1112) ─────────────────────────────
@@ -883,6 +885,19 @@ def test_cross_turn_does_not_affect_non_spiral_tools():
         controller.after_call("write_file", {"path": "x"}, '{"error":"boom"}', failed=True)
     controller.reset_for_turn()
     assert controller.before_call("write_file", {"path": "x"}).action == "allow"
+
+
+def test_cross_turn_process_spiral_cap_fires():
+    """#1141 — process is now in _SPIRAL_PRONE_TOOLS so a cross-turn process
+    failure streak should trigger the spiral-prone cap, not run uncapped."""
+    controller = ToolCallGuardrailController()
+    for _ in range(5):
+        controller.after_call("process", {"action": "poll"}, '{"error":"timeout"}', failed=True)
+    controller.reset_for_turn()
+    d = controller.before_call("process", {"action": "poll"})
+    assert d.action == "block"
+    assert d.code == "spiral_prone_tool_failure_cap"
+    assert d.fallback_directive != ""
 
 
 def test_cross_turn_blocks_with_hard_stop_disabled():


### PR DESCRIPTION
Automated evolution PR for issue #1141.

## Problem
An 18-deep `process` polling spiral was observed in production (11 failures, 1 session). `process` poll/wait loops run uncapped because it is NOT in `_SPIRAL_PRONE_TOOLS` — only `terminal`, `execute_code`, and `read_file` are capped.

## Fix
Add `process` to `_SPIRAL_PRONE_TOOLS` in `agent/tool_guardrails.py` so the always-on spiral failure cap (default 5 consecutive failures) applies to process poll/wait loops. The existing `process` fallback directive ('use process action=list to find the correct session_id before retrying') already exists in `_TOOL_FALLBACK_DIRECTIVE`, so the cap surfaces actionable guidance.

## Tests
- Convert `test_spiral_prone_tools_set` from a change-detector (asserts exact count == 3) to an invariant test (asserts membership + `>= 4`).
- Add `test_cross_turn_process_spiral_cap_fires` verifying the cap fires for process cross-turn failure streaks.

## Checks
- lint ✓, targeted tests ✓ (139 passed), 28 changed lines (within 200-line self-merge cap).