### PR TITLE
fix(loop-guard): add search_files to spiral-prone tools cap (#1143)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -71,8 +71,18 @@ MUTATING_TOOL_NAMES = frozenset(
 # #1141 — process added: an 18-deep process polling spiral was observed in
 # production (11 failures, 1 session). process poll/wait loops that each
 # "succeed" but never converge on a terminal state run uncapped without this.
+# #1143 — search_files added: 27 consecutive search_files calls across 224
+# sessions (190 failures) regressed from 15/8 — the agent reformulates
+# patterns (glob vs regex, retries after empty results) without switching
+# strategy. Cap consecutive search_files calls to force a strategy switch.
 _SPIRAL_PRONE_TOOLS = frozenset(
-    {"terminal", "execute_code", "read_file", "process"}
+    {
+        "terminal",
+        "execute_code",
+        "read_file",
+        "process",
+        "search_files",
+    }
 )
 
 
@@ -654,7 +664,7 @@ _TOOL_FALLBACK_DIRECTIVE: dict[str, str] = {
     "execute_code": "install missing packages via terminal, or verify the interpreter/venv first",
     "web_search": "try web_extract on a known URL, or refine the query terms",
     "web_extract": "try web_search to find alternative URLs, or use the browser tool",
-    "search_files": "try a broader glob pattern, or use read_file on a known path",
+    "search_files": "no results found repeatedly — switch strategy: (a) use target=files mode instead of content, (b) broaden the directory path, (c) try a different glob pattern instead of regex, or (d) ask the user for the correct path",
     "patch": "use read_file to verify the exact text before patching, or use write_file",
     "write_file": "verify the directory exists with terminal, or use patch for targeted edits",
     "process": "use process action=list to find the correct session_id before retrying",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -807,13 +807,15 @@ def test_spiral_cap_default_is_5():
 def test_spiral_prone_tools_set():
     """The spiral-prone set contains the tools with the highest trace-miner
     failure frequency. Membership is the invariant; the set grows as new
-    spiral-prone tools are identified (#1141 added process)."""
+    spiral-prone tools are identified (#1141 added process, #1143 added
+    search_files)."""
     cfg = ToolCallGuardrailConfig()
     assert "terminal" in cfg.spiral_prone_tools
     assert "execute_code" in cfg.spiral_prone_tools
     assert "read_file" in cfg.spiral_prone_tools
     assert "process" in cfg.spiral_prone_tools
-    assert len(cfg.spiral_prone_tools) >= 4
+    assert "search_files" in cfg.spiral_prone_tools
+    assert len(cfg.spiral_prone_tools) >= 5
 
 
 # ── Cross-turn spiral enforcement (#1109–#1112) ─────────────────────────────
@@ -898,6 +900,37 @@ def test_cross_turn_process_spiral_cap_fires():
     assert d.action == "block"
     assert d.code == "spiral_prone_tool_failure_cap"
     assert d.fallback_directive != ""
+
+
+def test_cross_turn_search_files_spiral_cap_fires():
+    """#1143 — search_files is now in _SPIRAL_PRONE_TOOLS so a cross-turn
+    search_files failure streak should trigger the spiral-prone cap,
+    not run uncapped as it did when 27 consecutive / 224 sessions regressed."""
+    controller = ToolCallGuardrailController()
+    for _ in range(5):
+        controller.after_call(
+            "search_files",
+            {"pattern": "*.py", "target": "content"},
+            '{"error":"no matches"}',
+            failed=True,
+        )
+    controller.reset_for_turn()
+    d = controller.before_call("search_files", {"pattern": "*.py", "target": "content"})
+    assert d.action == "block"
+    assert d.code == "spiral_prone_tool_failure_cap"
+    assert d.fallback_directive != ""
+    assert "target=files" in d.fallback_directive
+
+
+def test_search_files_fallback_directive_includes_strategy_switch():
+    """#1143 — the search_files fallback directive should guide the agent to
+    switch strategy (files mode, broader path, glob vs regex) rather than
+    just saying 'try a broader glob pattern'."""
+    from agent.tool_guardrails import _fallback_directive_for
+
+    directive = _fallback_directive_for("search_files")
+    assert "target=files" in directive
+    assert "broaden" in directive.lower()
 
 
 def test_cross_turn_blocks_with_hard_stop_disabled():


### PR DESCRIPTION
Rebased version of PR #1146. Adds `search_files` to `_SPIRAL_PRONE_TOOLS` frozenset and improves the search_files fallback directive to include strategy-switch guidance.

## Changes
- Add `search_files` to `_SPIRAL_PRONE_TOOLS` in `agent/tool_guardrails.py`
- Update `_tool_failure_recovery_hint` for search_files to include strategy-switch guidance (target=files, broaden path, glob vs regex)
- Update test invariants for `_SPIRAL_PRONE_TOOLS` membership and `>= 5` count
- Add `test_cross_turn_search_files_spiral_cap_fires` test
- Add `test_search_files_fallback_directive_includes_strategy_switch` test

Closes #1143