### PR TITLE
fix(evolution): wire signal-verification gate + tool_search fallback (#1140, #1144)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -106,6 +106,15 @@ _SHORT_CIRCUIT_REPEAT_THRESHOLD = 4
 # The nudge explicitly tells it to stop searching and write the answer.
 _WEB_SEARCH_DIVERSE_QUERY_CAP = 6
 
+# #1144 — tool_search fallback directive: the agent keeps reformulating search
+# queries against the 128-tool deferred catalog without finding the right tool,
+# burning up to 9 consecutive searches. Each call "succeeds" (returns results)
+# but the agent never switches to tool_describe (for a candidate it almost has)
+# or proceeds without the deferred tool. This cap fires at 3 consecutive
+# tool_search calls with no intervening tool_call, directing the agent to
+# broaden the query, check tool_describe, or proceed without the deferred tool.
+_TOOL_SEARCH_FALLBACK_CAP = 3
+
 # Code-exploration tools whose mono-tool spiral is a STRATEGY problem, not a
 # failure (#625): 16-17 consecutive read_file calls / 14 consecutive
 # search_files calls, one file/query at a time, each succeeding — the agent
@@ -713,6 +722,26 @@ def maybe_nudge(
                 f"promising URL for depth, or report what you found and what is "
                 f"still missing instead of running another search."
             )
+
+    # #1144 — tool_search fallback directive: the agent has searched the deferred
+    # tool catalog 3+ times without invoking `tool_call` (the run would have
+    # broken if it had). Each search "succeeds" but the right tool isn't surfacing.
+    # Direct it to (a) broaden the query, (b) check `tool_describe` on a candidate
+    # it almost found, or (c) proceed without the deferred tool rather than keep
+    # reformulating. Mirrors the web_search diverse-query cap pattern.
+    if tool == "tool_search" and count >= _TOOL_SEARCH_FALLBACK_CAP:
+        return (
+            f"[loop-guard] You have called `tool_search` {count} times without "
+            f"invoking `tool_call` — the right deferred tool is not surfacing. "
+            f"STOP reformulating the same kind of query. Try one of: "
+            f"(a) broaden the query to a category (e.g. \"github\", \"browser\", "
+            f"\"file\") and scan the results; "
+            f"(b) if a candidate name is close, call `tool_describe` on it to see "
+            f"its full parameter schema before deciding; "
+            f"(c) proceed without the deferred tool — the core tools (terminal, "
+            f"read_file, patch, search_files) may already cover the task. "
+            f"Do not run another `tool_search` with a near-identical keyword query."
+        )
 
     if count >= repeat_threshold:
         # Build diversity score for the nudge.

--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -124,6 +124,77 @@ def record_verdict(
     )
 
 
+# ── Post-merge signal-verification gate (#1140) ────────────────────────────
+#
+# Merged fixes don't reduce their target signals because issues are closed at
+# merge, not at confirmed signal reduction. This gate lets the close loop
+# check whether a merged issue's signal was verified as dropped (or at least
+# recorded a verdict) before marking it fully resolved. If the signal is
+# flat/rising post-merge (verdict == "regressed" or "no-signal"), the gate
+# returns False so the issue stays open for a focused regression.
+
+
+def signal_verified(records: List[Dict[str, Any]], issue: int) -> bool:
+    """Whether a merged issue has a CONFIRMED signal-drop verdict.
+
+    Returns True only if the issue has a merge record AND a verdict of
+    "confirmed" (the signal dropped post-merge). Returns False if:
+    - No merge record exists (never tracked).
+    - No verdict has been recorded yet (not yet verified).
+    - The verdict is "no-signal" or "regressed" (the fix didn't help).
+
+    The close loop should NOT mark an issue as fully resolved until this
+    returns True. If it returns False after ``maturity_days``, the issue
+    should be re-examined or a regression filed.
+    """
+    for rec in reversed(records):
+        if rec.get("issue") == issue:
+            return rec.get("verdict") in VERDICTS_GOOD
+    return False
+
+
+def should_close_issue(
+    records: List[Dict[str, Any]],
+    issue: int,
+    today: str,
+    maturity_days: int = 5,
+) -> tuple[bool, str]:
+    """Gate for closing an issue after a fix PR merges.
+
+    Returns (should_close, reason). The issue should close only when:
+    - ``signal_verified`` returns True (the signal dropped), OR
+    - The merge is older than ``maturity_days`` AND no verdict exists
+      (the verification step didn't run — close with a note that it was
+      never verified, rather than leaving it open indefinitely).
+
+    If the verdict is "no-signal" or "regressed", returns (False, reason)
+    so the issue stays open for a focused regression — this is the core
+    fix for the REALIZED_IMPACT_LOW failure loop.
+    """
+    rec = None
+    for r in reversed(records):
+        if r.get("issue") == issue:
+            rec = r
+            break
+
+    if rec is None:
+        return True, "not tracked in ledger — no signal to verify"
+
+    verdict = rec.get("verdict")
+    if verdict in VERDICTS_GOOD:
+        return True, "signal confirmed dropped post-merge"
+
+    if verdict in VERDICTS_BAD:
+        return False, f"signal NOT verified — verdict: {verdict}. Keep open for regression."
+
+    # No verdict yet — check maturity
+    days_since = _days_between(rec.get("merged_at"), today)
+    if days_since is not None and days_since >= maturity_days:
+        return True, f"matured {days_since}d without verification — closing unverified"
+
+    return False, f"awaiting signal verification ({days_since or 0}d since merge, maturity={maturity_days}d)"
+
+
 def _days_between(a: Optional[str], b: Optional[str]) -> Optional[int]:
     """Whole days from ISO date ``a`` to ISO date ``b`` (both YYYY-MM-DD)."""
     if not a or not b:
@@ -270,6 +341,28 @@ def main(argv: List[str]) -> int:
         record_verdict(ledger_file, issue, verdict, verified_at, note)
         print(f"[realized-impact] recorded verdict for issue #{issue}")
         return 0
+
+    # Subcommand: check whether an issue should be closed post-merge (#1140).
+    # Wire-in for the signal-verification gate: exit 0 = may stay closed,
+    # exit 1 = re-open (bad verdict or awaiting verification within maturity).
+    if args and args[0] == "check-close":
+        try:
+            issue = int(args[1])
+        except (IndexError, ValueError):
+            print("usage: evolution_realized_impact.py check-close <issue> [--today D] [--maturity-days N]", file=sys.stderr)
+            return 2
+        from datetime import datetime, timezone
+
+        def _flag(n):
+            return args[args.index(n) + 1] if n in args and args.index(n) + 1 < len(args) else None
+
+        _today = _flag("--today") or datetime.now(timezone.utc).date().isoformat()
+        _md = _flag("--maturity-days")
+        _maturity = int(_md) if _md and _md.isdigit() else 5
+        records = load_ledger(ledger_file)
+        should, reason = should_close_issue(records, issue, _today, maturity_days=_maturity)
+        print(f"[signal-gate] issue #{issue}: {reason}")
+        return 0 if should else 1
 
     last = 30
     if "--last" in args:

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -116,6 +116,20 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    - Be honest: a `no-signal`/`regressed` verdict on the agent's OWN past change is
      exactly the feedback that stops blind feature-piling (analysis reads it and
      shifts to consolidation). Confirming uselessly to look good defeats the loop.
+   - **Signal-verification gate (#1140)** — after recording a verdict, consult the
+     gate to decide whether the issue should stay closed or be re-opened. GitHub
+     auto-closes issues at merge via `Closes #N`, but a `no-signal`/`regressed`
+     verdict means the fix did NOT deliver — re-open it for a focused regression:
+     ```bash
+     # exit 0 = may stay closed; exit 1 = re-open (bad verdict or awaiting verification)
+     python3 scripts/evolution_realized_impact.py check-close <#> --today "$TODAY" --maturity-days 5
+     if [ $? -ne 0 ]; then
+       gh issue reopen <#> --repo Lexus2016/hermes-agent-evolution \
+         --comment "Post-merge signal verification FAILED — re-opening for regression."
+     fi
+     ```
+     This is the close-loop wire-in: the issue is only resolved once
+     `should_close_issue()` agrees, not merely because GitHub auto-closed it.
 
 ## Creating issues
 

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -630,6 +630,50 @@ class TestFailureClassAndDiversionHints:
         assert n is not None
         assert "placeholder" in n or "provider" in n
 
+    def test_tool_search_fallback_directive_at_cap(self):
+        # #1144: 3 consecutive tool_search calls with no tool_call → fallback
+        # directive directing the agent to broaden, tool_describe, or proceed.
+        msgs = [{"role": "user", "content": "go"}]
+        for i in range(3):
+            cid = f"c{i}"
+            msgs.append(
+                _asst("tool_search", args=json.dumps({"query": f"attempt {i}"}), call_id=cid)
+            )
+            msgs.append(_result("3 matching tools", call_id=cid))
+        n = maybe_nudge(msgs)
+        assert n is not None
+        assert "tool_search" in n
+        assert "tool_describe" in n
+        assert "tool_call" in n
+
+    def test_tool_search_below_cap_is_quiet(self):
+        # #1144: 2 consecutive tool_search calls (below cap of 3) → no nudge.
+        msgs = [{"role": "user", "content": "go"}]
+        for i in range(2):
+            cid = f"c{i}"
+            msgs.append(
+                _asst("tool_search", args=json.dumps({"query": f"attempt {i}"}), call_id=cid)
+            )
+            msgs.append(_result("3 matching tools", call_id=cid))
+        assert maybe_nudge(msgs) is None
+
+    def test_tool_search_run_breaks_on_tool_call(self):
+        # #1144: if the agent calls tool_call between tool_search calls, the run
+        # breaks and the fallback directive must NOT fire (the agent found and
+        # used a tool — that's success, not a spiral).
+        msgs = [{"role": "user", "content": "go"}]
+        # 2 tool_search calls, then a tool_call (run breaks), then 1 tool_search.
+        for i in range(2):
+            cid = f"s{i}"
+            msgs.append(_asst("tool_search", args=json.dumps({"query": f"q{i}"}), call_id=cid))
+            msgs.append(_result("3 matching tools", call_id=cid))
+        msgs.append(_asst("tool_call", args=json.dumps({"name": "some_tool"}), call_id="tc1"))
+        msgs.append(_result("tool ran ok", call_id="tc1"))
+        msgs.append(_asst("tool_search", args=json.dumps({"query": "q3"}), call_id="s3"))
+        msgs.append(_result("3 matching tools", call_id="s3"))
+        # Only 1 trailing tool_search — below the cap, no nudge.
+        assert maybe_nudge(msgs) is None
+
 
 def _distinct_run(tool, n, *, result="ok"):
     """n consecutive single-tool turns with DISTINCT arguments each (real

--- a/tests/scripts/test_signal_verification_gate.py
+++ b/tests/scripts/test_signal_verification_gate.py
@@ -1,0 +1,93 @@
+"""Tests for the post-merge signal-verification gate (#1140).
+
+Covers signal_verified, should_close_issue, and the check-close CLI subcommand
+that wires the gate into the close loop (introspection skill).
+"""
+from __future__ import annotations
+
+import pytest
+
+from scripts.evolution_realized_impact import signal_verified, should_close_issue, main
+
+
+# ── signal_verified ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verdict,expected", [
+    ("confirmed", True),
+    ("no-signal", False),
+    ("regressed", False),
+])
+def test_signal_verified_verdicts(verdict, expected):
+    recs = [{"issue": 100, "merged_at": "2026-07-10", "verdict": verdict, "verified_at": "2026-07-15"}]
+    assert signal_verified(recs, 100) is expected
+
+
+def test_signal_verified_no_verdict_yet():
+    assert signal_verified([{"issue": 100, "merged_at": "2026-07-10"}], 100) is False
+
+
+def test_signal_verified_not_tracked():
+    assert signal_verified([{"issue": 200, "verdict": "confirmed"}], 100) is False
+
+
+def test_signal_verified_latest_verdict_wins():
+    recs = [
+        {"issue": 100, "merged_at": "2026-07-10"},
+        {"issue": 100, "verdict": "confirmed", "verified_at": "2026-07-12"},
+        {"issue": 100, "verdict": "regressed", "verified_at": "2026-07-15"},
+    ]
+    assert signal_verified(recs, 100) is False
+
+
+# ── should_close_issue ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verdict,should,frag", [
+    ("confirmed", True, "confirmed"),
+    ("regressed", False, "regressed"),
+    ("no-signal", False, "no-signal"),
+])
+def test_should_close_verdict_gating(verdict, should, frag):
+    """confirmed → close; regressed/no-signal → keep open."""
+    s, reason = should_close_issue(
+        [{"issue": 100, "merged_at": "2026-07-10", "verdict": verdict}], 100, "2026-07-17")
+    assert s is should and frag in reason
+
+
+def test_should_close_not_tracked():
+    s, reason = should_close_issue([{"issue": 200}], 100, "2026-07-17")
+    assert s is True and "not tracked" in reason
+
+
+def test_should_close_awaiting_then_matured():
+    """Recent merge → awaiting; old merge → matured (close unverified)."""
+    s, reason = should_close_issue(
+        [{"issue": 100, "merged_at": "2026-07-15"}], 100, "2026-07-17", maturity_days=5)
+    assert s is False and "awaiting" in reason.lower()
+    s, reason = should_close_issue(
+        [{"issue": 100, "merged_at": "2026-07-01"}], 100, "2026-07-17", maturity_days=5)
+    assert s is True and "matured" in reason.lower()
+
+
+# ── check-close CLI subcommand (#1140 wire-in) ──────────────────────────
+
+
+def _write_ledger(tmp_path, line):
+    ledger = tmp_path / "realized" / "ledger.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.write_text(line + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("ledger_line,extra_args,rc_expected,frag", [
+    ('{"issue": 100, "merged_at": "2026-07-10", "verdict": "confirmed"}', [], 0, "confirmed"),
+    ('{"issue": 100, "merged_at": "2026-07-10", "verdict": "regressed"}', [], 1, "regressed"),
+    ('{"issue": 100, "merged_at": "2026-07-15", "predicted_impact": 0.8}', ["--maturity-days", "5"], 1, "awaiting"),
+])
+def test_check_close_cli(capsys, tmp_path, monkeypatch, ledger_line, extra_args, rc_expected, frag):
+    """check-close exits 0 (may stay closed) or 1 (re-open) per the verdict."""
+    _write_ledger(tmp_path, ledger_line)
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    rc = main(["prog", "check-close", "100", "--today", "2026-07-17"] + extra_args)
+    assert rc == rc_expected
+    assert frag in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary

Implements two issues from the 2026-07-18 evolution analysis cycle (consolidation mode).

### Issue #1140 — Wire signal-verification gate into close-loop path

**Problem:** Merged fixes don't reduce their target signals because issues are closed at merge (via GitHub `Closes #N`), not at confirmed signal reduction. The realized-impact loop records verdicts but never acts on them — a `regressed`/`no-signal` verdict leaves the issue closed as 'resolved'.

**Root cause:** PR #1148 added `signal_verified()` and `should_close_issue()` but was rejected because the functions had no call site outside their own module + tests (dead code).

**Fix:** 
1. Recovered `signal_verified()` and `should_close_issue()` from PR #1148 (contributor credit preserved via `git checkout b2b56fdea`).
2. Added a `check-close` CLI subcommand to `evolution_realized_impact.py` — the actual wire-in point. Exit 0 = may stay closed; exit 1 = re-open.
3. Wired it into the introspection skill: after recording a verdict, the skill calls `check-close` and re-opens the issue if the gate says the signal was NOT verified.

This closes the REALIZED_IMPACT_LOW loop: issues are only treated as resolved once `should_close_issue()` agrees, not merely because GitHub auto-closed them.

### Issue #1144 — tool_search fallback directive

**Problem:** The agent repeatedly calls `tool_search` with reformulated queries (up to 9 consecutive times across 16 sessions) without finding the right deferred tool, burning turns.

**Fix:** Added a `tool_search`-specific fallback directive in the loop guard (`_TOOL_SEARCH_FALLBACK_CAP = 3`). After 3 consecutive `tool_search` calls with no intervening `tool_call`, inject a directive guiding the agent to: (a) broaden the query to a category, (b) check `tool_describe` on a candidate, or (c) proceed without the deferred tool. Mirrors the existing `web_search` diverse-query cap pattern.

## Testing

- `tests/scripts/test_signal_verification_gate.py`: 14 tests (parametrized) — covers `signal_verified`, `should_close_issue`, and the `check-close` CLI subcommand.
- `tests/agent/test_loop_guard.py`: 3 new tests (89 total pass) — covers the fallback directive at cap, below cap, and run-breaks-on-tool_call.
- All tests pass via `scripts/run_tests.sh`.

## Line counts (200-line cap per issue)

- #1140: 200 insertions (script 93 + test 93 + skill 14)
- #1144: 73 insertions (loop_guard 29 + test 44)

## Contributor credit

`signal_verified()` and `should_close_issue()` recovered from leftover branch `b2b56fdea` (original PR #1148 author preserved via cherry-pick, not rewritten from scratch per AGENTS.md contributor-credit policy).