### PR TITLE
feat(tool_search): nudge after N consecutive searches with no tool_call (Closes #1144)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2982,6 +2982,11 @@ DEFAULT_CONFIG = {
             "search_default_limit": 5,
             # Hard upper bound the model can request via ``limit``. Range 1..50.
             "max_search_limit": 20,
+            # #1144 — after this many consecutive tool_search calls with no
+            # intervening tool_call, append a fallback directive nudging the
+            # model to broaden the query, check tool_describe, or proceed
+            # without the deferred tool. 0 disables. Range 0..20.
+            "search_streak_threshold": 3,
         },
     },
     # Logging — controls file logging to ~/.hermes/logs/.

--- a/model_tools.py
+++ b/model_tools.py
@@ -1125,7 +1125,8 @@ def handle_function_call(
             current_defs = []
         if function_name == _ts_mod.TOOL_SEARCH_NAME:
             return _ts_mod.dispatch_tool_search(function_args or {},
-                                                current_tool_defs=current_defs)
+                                                current_tool_defs=current_defs,
+                                                session_id=session_id)
         if function_name == _ts_mod.TOOL_DESCRIBE_NAME:
             return _ts_mod.dispatch_tool_describe(function_args or {},
                                                   current_tool_defs=current_defs)
@@ -1155,6 +1156,9 @@ def handle_function_call(
             _ok, _err = _ts_mod.validate_tool_args(underlying_name, underlying_args, _schema)
             if not _ok:
                 return json.dumps({"error": _err}, ensure_ascii=False)
+            # #1144 — the model invoked a discovered tool, so reset the
+            # consecutive-search streak (the search loop converged).
+            _ts_mod.reset_search_streak(session_id)
             # Recurse with the underlying tool. All hooks fire against the
             # real tool name. The bridge is invisible to hooks by design.
             return handle_function_call(

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -543,6 +543,73 @@ class TestBridgeDispatch:
         assert "bridge tool" in err.lower()
 
 
+class TestSearchStreakGuard:
+    """#1144 — fallback directive after N consecutive searches with no tool_call."""
+
+    def _cfg(self, threshold: int):
+        from tools.tool_search import ToolSearchConfig
+        return ToolSearchConfig(enabled="on", threshold_pct=10.0,
+                                search_default_limit=5, max_search_limit=20,
+                                search_streak_threshold=threshold)
+
+    def _search(self, sid, threshold=3):
+        from tools.tool_search import dispatch_tool_search
+        return json.loads(dispatch_tool_search(
+            {"query": "github"},
+            current_tool_defs=[_td("github_create_issue", "Create issue")],
+            config=self._cfg(threshold), session_id=sid))
+
+    def test_no_directive_below_threshold(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        out = self._search("sess-A", threshold=3)
+        assert "fallback_directive" not in out  # streak=1 < 3
+
+    def test_directive_at_threshold(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        self._search("sess-B", threshold=3)
+        self._search("sess-B", threshold=3)
+        out = self._search("sess-B", threshold=3)  # streak=3
+        assert "fallback_directive" in out
+        assert "3 times" in out["fallback_directive"]
+
+    def test_reset_on_tool_call_clears_streak(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        self._search("sess-C", threshold=3)
+        self._search("sess-C", threshold=3)
+        ts.reset_search_streak("sess-C")  # model invoked a discovered tool
+        out = self._search("sess-C", threshold=3)  # streak=1 again
+        assert "fallback_directive" not in out
+
+    def test_no_session_id_not_tracked(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        out = self._search(None, threshold=3)  # pure-function path
+        assert "fallback_directive" not in out
+        assert ts._SEARCH_STREAK == {}
+
+    def test_threshold_zero_disables_guard(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        out = None
+        for _ in range(5):
+            out = self._search("sess-D", threshold=0)
+        assert "fallback_directive" not in out
+
+    def test_sessions_tracked_independently(self):
+        import tools.tool_search as ts
+        ts._SEARCH_STREAK.clear()
+        self._search("sess-E", threshold=3)
+        self._search("sess-F", threshold=3)
+        self._search("sess-F", threshold=3)
+        out_e = self._search("sess-E", threshold=3)  # E streak=2
+        out_f = self._search("sess-F", threshold=3)  # F streak=3
+        assert "fallback_directive" not in out_e
+        assert "fallback_directive" in out_f
+
+
 # ---------------------------------------------------------------------------
 # End-to-end via the real handle_function_call (smoke test).
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -54,6 +54,39 @@ BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_N
 # underestimating, which is the safer default.
 CHARS_PER_TOKEN = 4.0
 
+# ── #1144 — consecutive-tool_search streak tracking ───────────────────────
+# Per-session count of ``tool_search`` calls with no intervening ``tool_call``.
+# When the model keeps reformulating queries but never invokes a discovered
+# tool, ``dispatch_tool_search`` appends a ``fallback_directive`` once the
+# streak crosses ``ToolSearchConfig.search_streak_threshold``. The counter
+# resets on any ``tool_call``. Keyed by session_id; a None session_id is not
+# tracked (keeps pure-function tests that pass no session_id unaffected).
+_SEARCH_STREAK: Dict[str, int] = {}
+
+
+def note_tool_search(session_id: Optional[str]) -> int:
+    """Increment the consecutive-search streak for ``session_id``; return it."""
+    if not session_id:
+        return 0
+    _SEARCH_STREAK[session_id] = _SEARCH_STREAK.get(session_id, 0) + 1
+    return _SEARCH_STREAK[session_id]
+
+
+def reset_search_streak(session_id: Optional[str]) -> None:
+    """Reset the streak — call when the model invokes a discovered tool."""
+    if session_id and session_id in _SEARCH_STREAK:
+        _SEARCH_STREAK[session_id] = 0
+
+
+def _fallback_directive(streak: int) -> str:
+    """The nudge appended to a ``tool_search`` result when the streak is high."""
+    return (
+        f"You have run tool_search {streak} times in a row without calling a "
+        "discovered tool. Try one of: (a) broaden the query (more general terms), "
+        "(b) call tool_describe on a likely candidate to confirm it does what you "
+        "need, or (c) proceed without the deferred tool if the core tools suffice."
+    )
+
 
 # ---------------------------------------------------------------------------
 # Configuration plumbing
@@ -73,6 +106,11 @@ class ToolSearchConfig:
     # toolset name appears here. See ``effective_core_tool_names`` for how
     # this subtracts opted-in core tools from the never-defer set.
     defer_core_toolsets: frozenset[str] = frozenset()
+    # #1144 — after this many consecutive ``tool_search`` calls with no
+    # intervening ``tool_call``, append a fallback directive to the result
+    # nudging the model to broaden the query, check tool_describe, or proceed
+    # without the deferred tool. 0 disables the guard.
+    search_streak_threshold: int = 3
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -110,6 +148,7 @@ class ToolSearchConfig:
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
+        streak_threshold = max(0, min(20, _safe_int(raw.get("search_streak_threshold"), 3)))
 
         return cls(
             enabled=enabled,
@@ -117,6 +156,7 @@ class ToolSearchConfig:
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
             defer_core_toolsets=_parse_toolset_list(raw.get("defer_core_toolsets")),
+            search_streak_threshold=streak_threshold,
         )
 
 
@@ -727,7 +767,8 @@ def _format_search_hit(entry: CatalogEntry) -> Dict[str, Any]:
 def dispatch_tool_search(args: Dict[str, Any],
                          *,
                          current_tool_defs: List[Dict[str, Any]],
-                         config: Optional[ToolSearchConfig] = None) -> str:
+                         config: Optional[ToolSearchConfig] = None,
+                         session_id: Optional[str] = None) -> str:
     """Execute the ``tool_search`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -744,11 +785,18 @@ def dispatch_tool_search(args: Dict[str, Any],
     _, deferrable = classify_tools(current_tool_defs, config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
-    return json.dumps({
+    result: Dict[str, Any] = {
         "query": query,
         "total_available": len(catalog),
         "matches": [_format_search_hit(h) for h in hits],
-    }, ensure_ascii=False)
+    }
+    # #1144 — nudge the model after N consecutive searches with no tool_call.
+    threshold = config.search_streak_threshold
+    if threshold and threshold > 0:
+        streak = note_tool_search(session_id)
+        if streak >= threshold:
+            result["fallback_directive"] = _fallback_directive(streak)
+    return json.dumps(result, ensure_ascii=False)
 
 
 def _fuzzy_tool_names(query: str, available: List[str], limit: int = 3) -> List[str]:


### PR DESCRIPTION
Automated evolution PR for issue #1144.

## Problem
The model repeatedly reformulates `tool_search` queries without ever invoking a discovered tool — observed in 16 sessions, max 9 consecutive searches. This burns turns/tokens without converging on an action.

## Fix
After `search_streak_threshold` (default 3, configurable via `tools.tool_search.search_streak_threshold` in config.yaml) consecutive `tool_search` calls with no intervening `tool_call`, append a `fallback_directive` to the search result nudging the model to:
(a) broaden the query (more general terms),
(b) call `tool_describe` on a likely candidate to confirm it does what's needed, or
(c) proceed without the deferred tool if the core tools suffice.

The per-session streak resets on any `tool_call` (the model invoked a discovered tool — the loop converged). Setting the threshold to 0 disables the guard.

## Files
- `tools/tool_search.py` — `_SEARCH_STREAK` state + `note_tool_search`/`reset_search_streak`/`_fallback_directive`; `search_streak_threshold` on `ToolSearchConfig`; `session_id` param on `dispatch_tool_search` that appends the directive.
- `model_tools.py` — pass `session_id` to `dispatch_tool_search`; call `reset_search_streak(session_id)` in the `tool_call` branch after validation passes.
- `hermes_cli/config.py` — `search_streak_threshold: 3` default under `tools.tool_search` (no version bump — new key in existing section).
- `tests/tools/test_tool_search.py` — 6 new tests (TestSearchStreakGuard): below-threshold, at-threshold, reset-on-tool_call, no-session_id-not-tracked, threshold-zero-disables, independent sessions.

## Checks
- lint ✓ (ruff check)
- pre-PR test gate ✓ (2 shards passed: test_tool_search.py + test_config.py)
- 132 changed lines (within the 200-line autonomous self-merge cap)
- format: the 4 touched files are pre-existing non-ruff-formatted on main (verified via stash check); this PR introduces zero NEW format violations.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>