### PR TITLE
feat(tools): recovery strategy dispatcher for tool failures (#1027)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1378,6 +1378,17 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    # #1027 — recovery strategy dispatcher gate. OFF by default: the
+    # ``_append_guardrail_observation`` seam only appends a structured recovery
+    # directive to a failed tool result when this flag is truthy, so the default
+    # behavior is unchanged. Reads ``tool_failure_recovery.enabled`` from config.
+    agent._failure_recovery_enabled = False
+    try:
+        _tfr_cfg = _agent_cfg.get("tool_failure_recovery", {})
+        if isinstance(_tfr_cfg, dict):
+            agent._failure_recovery_enabled = bool(_tfr_cfg.get("enabled", False))
+    except Exception as _tfr_err:
+        _ra().logger.warning("Tool failure recovery config ignored: %s", _tfr_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -386,6 +386,20 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 
 # =============================================================================
+# Tool Failure Recovery (#1027 — PALADIN-style structured recovery)
+# =============================================================================
+# When a tool call fails, append ONE structured recovery directive to the tool
+# result (retry / retry_with_backoff / fix_arguments / verify_target /
+# switch_tool / surface_blocker / escalate) so the agent takes a targeted next
+# step instead of blindly retrying the same call. Builds on the cross-tool
+# failure classifier; escalation is monotone (repeated failures give way to a
+# tool switch, then a surfaced blocker) so a directive never sustains a spiral.
+#
+# OFF by default: when disabled, failed tool results are byte-for-byte unchanged.
+tool_failure_recovery:
+  enabled: false
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/run_agent.py
+++ b/run_agent.py
@@ -6195,6 +6195,24 @@ class AIAgent:
             function_result = append_toolguard_guidance(function_result, decision)
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
+        # #1027 — recovery strategy dispatcher. Config-gated OFF by default: when
+        # ``tool_failure_recovery.enabled`` is unset the branch never runs, so the
+        # tool result is byte-for-byte unchanged (no behavior change, no prompt
+        # drift). When enabled, a failed result gains one structured recovery
+        # directive (retry/backoff/switch/fix/verify/surface) so the agent takes a
+        # targeted next step instead of blindly retrying.
+        if failed and getattr(self, "_failure_recovery_enabled", False):
+            from tools.recovery_strategy_dispatcher import (
+                maybe_append_recovery_guidance,
+            )
+
+            function_result = maybe_append_recovery_guidance(
+                function_result,
+                tool_name,
+                failed=True,
+                enabled=True,
+                consecutive_count=decision.count,
+            )
         return function_result
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:

--- a/tests/run_agent/test_recovery_dispatcher_runtime.py
+++ b/tests/run_agent/test_recovery_dispatcher_runtime.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam runtime tests for the #1027 recovery strategy dispatcher.
+
+These drive the real ``AIAgent`` tool-execution path (``_execute_tool_calls_
+sequential`` -> ``_append_guardrail_observation``) to prove the dispatcher is
+actually wired in — not merely importable — and that it is inert unless the
+``tool_failure_recovery.enabled`` config gate is set.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_agent(*tool_names: str, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _run_failing_call(agent: AIAgent, tool_name: str, result: str, call_id: str):
+    tc = _mock_tool_call(tool_name, "{}", call_id)
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    with patch("run_agent.handle_function_call", return_value=result):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    return messages
+
+
+def test_recovery_gate_defaults_off_so_seam_is_inert():
+    agent = _make_agent("read_file")  # no tool_failure_recovery config
+    assert getattr(agent, "_failure_recovery_enabled", False) is False
+    messages = _run_failing_call(
+        agent,
+        "read_file",
+        json.dumps({"error": "No such file or directory: /x/y"}),
+        "c-off",
+    )
+    assert len(messages) == 1
+    assert "Recovery strategy" not in messages[0]["content"]
+
+
+def test_recovery_gate_enabled_appends_directive_through_real_seam():
+    agent = _make_agent("read_file", config={"tool_failure_recovery": {"enabled": True}})
+    assert agent._failure_recovery_enabled is True
+    messages = _run_failing_call(
+        agent,
+        "read_file",
+        json.dumps({"error": "No such file or directory: /x/y"}),
+        "c-on",
+    )
+    assert len(messages) == 1
+    content = messages[0]["content"]
+    # A not_found failure dispatches to verify_target.
+    assert "Recovery strategy: verify_target" in content
+    # exactly one recovery line even though loop-guard guidance may also append
+    assert content.count("Recovery strategy") == 1
+
+
+def test_recovery_gate_enabled_is_inert_on_successful_call():
+    agent = _make_agent("read_file", config={"tool_failure_recovery": {"enabled": True}})
+    tc = _mock_tool_call("read_file", "{}", "c-ok")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"content": "hello"})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    assert "Recovery strategy" not in messages[0]["content"]

--- a/tests/tools/test_recovery_strategy_dispatcher.py
+++ b/tests/tools/test_recovery_strategy_dispatcher.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the tool-failure recovery strategy dispatcher (#1027)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.tool_failure_classifier import (
+    ToolFailureCategory,
+    ToolFailureClassification,
+    ToolType,
+    classify_tool_failure,
+)
+from tools.recovery_strategy_dispatcher import (
+    RECOVERY_GUIDANCE_PREFIX,
+    RecoveryAction,
+    RecoveryStrategy,
+    backoff_seconds_for,
+    dispatch_recovery,
+    maybe_append_recovery_guidance,
+    recover_from_failure,
+    register_strategy,
+)
+
+
+def _classification(
+    category: ToolFailureCategory,
+    *,
+    should_retry: bool,
+    tool_type: ToolType = ToolType.generic,
+) -> ToolFailureClassification:
+    return ToolFailureClassification(
+        category=category,
+        tool_type=tool_type,
+        hint="",
+        should_retry=should_retry,
+    )
+
+
+# --- category -> strategy table ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category,should_retry,expected",
+    [
+        (ToolFailureCategory.tool_unavailable, False, RecoveryStrategy.switch_tool),
+        (ToolFailureCategory.invalid_arguments, False, RecoveryStrategy.fix_arguments),
+        (ToolFailureCategory.not_found, False, RecoveryStrategy.verify_target),
+        (ToolFailureCategory.permission_denied, False, RecoveryStrategy.surface_blocker),
+        (ToolFailureCategory.rate_limited, True, RecoveryStrategy.retry_with_backoff),
+        (ToolFailureCategory.transient_network, True, RecoveryStrategy.retry_with_backoff),
+        (ToolFailureCategory.timeout, True, RecoveryStrategy.retry_with_backoff),
+        (ToolFailureCategory.unexpected_output, True, RecoveryStrategy.retry),
+        (ToolFailureCategory.persistent_error, False, RecoveryStrategy.switch_tool),
+        (ToolFailureCategory.unknown, False, RecoveryStrategy.surface_blocker),
+    ],
+)
+def test_dispatch_maps_every_category_to_expected_strategy(category, should_retry, expected):
+    action = dispatch_recovery(_classification(category, should_retry=should_retry))
+    assert action.strategy is expected
+    assert action.category is category
+    assert action.directive  # non-empty imperative directive
+    assert action.should_retry is should_retry
+
+
+def test_dispatch_covers_all_categories():
+    """Every ToolFailureCategory yields a concrete, non-surface_blocker-by-default action."""
+    for category in ToolFailureCategory:
+        action = dispatch_recovery(_classification(category, should_retry=False))
+        assert isinstance(action, RecoveryAction)
+        assert isinstance(action.strategy, RecoveryStrategy)
+
+
+# --- backoff -------------------------------------------------------------------
+
+
+def test_backoff_is_exponential_and_capped():
+    assert backoff_seconds_for(0) == 1.0
+    assert backoff_seconds_for(1) == 2.0
+    assert backoff_seconds_for(2) == 4.0
+    assert backoff_seconds_for(3) == 8.0
+    # capped at 30s
+    assert backoff_seconds_for(10) == 30.0
+    assert backoff_seconds_for(100) == 30.0
+
+
+def test_retry_with_backoff_action_carries_backoff_seconds():
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.rate_limited, should_retry=True),
+        consecutive_count=1,
+    )
+    assert action.strategy is RecoveryStrategy.retry_with_backoff
+    assert action.backoff_seconds == 2.0
+
+
+def test_non_backoff_action_has_no_backoff():
+    action = dispatch_recovery(_classification(ToolFailureCategory.invalid_arguments, should_retry=False))
+    assert action.backoff_seconds is None
+
+
+# --- monotone escalation -------------------------------------------------------
+
+
+def test_retryable_escalates_to_switch_tool_after_threshold():
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.transient_network, should_retry=True),
+        consecutive_count=3,
+    )
+    assert action.strategy is RecoveryStrategy.switch_tool
+    assert action.should_retry is False
+
+
+def test_retryable_escalates_to_escalate_after_higher_threshold():
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.transient_network, should_retry=True),
+        consecutive_count=5,
+    )
+    assert action.strategy is RecoveryStrategy.escalate
+    assert action.should_retry is False
+    assert action.backoff_seconds is None
+
+
+def test_non_retryable_category_is_not_escalated_by_count():
+    # invalid_arguments is deterministic (should_retry False); escalation only
+    # applies to retryable categories, so it stays fix_arguments regardless.
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.invalid_arguments, should_retry=False),
+        consecutive_count=9,
+    )
+    assert action.strategy is RecoveryStrategy.fix_arguments
+
+
+# --- recover_from_failure (classify + dispatch) --------------------------------
+
+
+def test_recover_from_failure_classifies_then_dispatches_missing_file():
+    # A read_file "No such file" is a not_found -> verify_target.
+    action = recover_from_failure("read_file", "No such file or directory: /x/y")
+    assert action.category is ToolFailureCategory.not_found
+    assert action.strategy is RecoveryStrategy.verify_target
+    assert action.tool_name == "read_file"
+
+
+def test_recover_from_failure_matches_direct_classification():
+    tool_name = "web_search"
+    error = "429 Too Many Requests: rate limit exceeded"
+    classification = classify_tool_failure(tool_name, error)
+    action = recover_from_failure(tool_name, error)
+    assert action.category is classification.category
+
+
+# --- runtime seam (maybe_append_recovery_guidance) -----------------------------
+
+
+def test_seam_disabled_returns_result_unchanged():
+    result = '{"error": "boom"}'
+    out = maybe_append_recovery_guidance(result, "web_search", failed=True, enabled=False)
+    assert out == result
+
+
+def test_seam_not_failed_returns_result_unchanged():
+    result = '{"ok": true}'
+    out = maybe_append_recovery_guidance(result, "web_search", failed=False, enabled=True)
+    assert out == result
+
+
+def test_seam_enabled_and_failed_appends_single_recovery_line():
+    result = '{"error": "No such file or directory: /x"}'
+    out = maybe_append_recovery_guidance(result, "read_file", failed=True, enabled=True)
+    assert out.startswith(result)
+    assert RECOVERY_GUIDANCE_PREFIX in out
+    assert out.count(RECOVERY_GUIDANCE_PREFIX) == 1
+    assert "verify_target" in out
+
+
+def test_seam_extracts_terminal_exit_code_from_json_result():
+    result = '{"exit_code": 127, "stderr": "command not found: foo"}'
+    out = maybe_append_recovery_guidance(result, "terminal", failed=True, enabled=True)
+    assert RECOVERY_GUIDANCE_PREFIX in out
+
+
+def test_seam_never_raises_on_garbage_result():
+    out = maybe_append_recovery_guidance("\x00 not json", "terminal", failed=True, enabled=True)
+    # degrades gracefully: either unchanged or with guidance, but never raises
+    assert out.startswith("\x00 not json")
+
+
+def test_seam_none_result_is_handled():
+    out = maybe_append_recovery_guidance(None, "web_search", failed=True, enabled=True)
+    assert isinstance(out, str)
+
+
+# --- runtime extensibility -----------------------------------------------------
+
+
+def test_register_strategy_overrides_category_mapping():
+    original = dispatch_recovery(_classification(ToolFailureCategory.unknown, should_retry=False)).strategy
+    try:
+        register_strategy(ToolFailureCategory.unknown, RecoveryStrategy.switch_tool)
+        action = dispatch_recovery(_classification(ToolFailureCategory.unknown, should_retry=False))
+        assert action.strategy is RecoveryStrategy.switch_tool
+    finally:
+        register_strategy(ToolFailureCategory.unknown, original)
+
+
+# --- serialization -------------------------------------------------------------
+
+
+def test_recovery_action_to_dict_roundtrip_shape():
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.rate_limited, should_retry=True),
+        tool_name="web_search",
+        consecutive_count=1,
+    )
+    data = action.to_dict()
+    assert data["category"] == "rate_limited"
+    assert data["strategy"] == "retry_with_backoff"
+    assert data["should_retry"] is True
+    assert data["tool_name"] == "web_search"
+    assert data["backoff_seconds"] == 2.0

--- a/tools/recovery_strategy_dispatcher.py
+++ b/tools/recovery_strategy_dispatcher.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+"""Recovery strategy dispatcher for tool failures (issue #1027, child of #1019).
+
+Third slice of PALADIN-style execution-level tool-failure recovery. The first
+slice (:mod:`tools.tool_failure_classifier`) turns a raw tool error into a
+structured :class:`~tools.tool_failure_classifier.ToolFailureClassification`.
+This module maps that classification onto a concrete **recovery action** — a
+retry-with-backoff, an argument fix, a tool switch, a target verification, or a
+surfaced blocker — so the agent takes a targeted next step instead of blindly
+re-running the same failing call.
+
+Pipeline::
+
+    classify (slice 1)  ->  dispatch recovery (this module)  ->  guidance seam
+
+The public entry point :func:`recover_from_failure` classifies *and* dispatches
+in one call, and :func:`maybe_append_recovery_guidance` is the runtime seam that
+``run_agent`` invokes after a failed tool call (config-gated, off by default).
+
+Design goals (matching ``tools/tool_failure_classifier.py`` and
+``agent/tool_guardrails.py``):
+
+* Pure functions + frozen dataclasses; **no side effects on import**.
+* Standard library only; full type hints; ``from __future__ import annotations``.
+* Deterministic, table-driven ``category -> strategy`` mapping, extensible at
+  runtime via :func:`register_strategy`.
+* Escalation is monotone: as the same call keeps failing, retryable strategies
+  give way to a tool switch and finally a surfaced blocker, so a recovery
+  directive can never itself drive an unbounded retry spiral.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from tools.tool_failure_classifier import (
+    ToolFailureCategory,
+    ToolFailureClassification,
+    classify_tool_failure,
+)
+
+__all__ = [
+    "RecoveryStrategy",
+    "RecoveryAction",
+    "dispatch_recovery",
+    "recover_from_failure",
+    "register_strategy",
+    "backoff_seconds_for",
+    "maybe_append_recovery_guidance",
+    "RECOVERY_GUIDANCE_PREFIX",
+]
+
+
+class RecoveryStrategy(str, Enum):
+    """Concrete recovery actions a failure can be dispatched to."""
+
+    retry = "retry"  # transient, plain retry may work
+    retry_with_backoff = "retry_with_backoff"  # transient, wait then retry
+    fix_arguments = "fix_arguments"  # deterministic arg error, correct then call
+    verify_target = "verify_target"  # target missing, look it up first
+    switch_tool = "switch_tool"  # this tool can't do it, use another
+    surface_blocker = "surface_blocker"  # external blocker, report it
+    escalate = "escalate"  # repeated failure, stop and change strategy
+
+
+# Number of consecutive same-call failures after which even a retryable category
+# stops retrying: first the tool is switched, then the blocker is surfaced. This
+# guarantees a recovery directive cannot sustain a retry spiral on its own.
+_SWITCH_AFTER = 3
+_SURFACE_AFTER = 5
+
+
+# Default category -> strategy table. ``should_retry`` on the classification is
+# authoritative for *whether* to retry; this table selects the *shape* of the
+# recovery when a retry is not the answer (or when a smarter retry — backoff —
+# is warranted). First lookup wins; extend at runtime with ``register_strategy``.
+_CATEGORY_STRATEGY: dict[ToolFailureCategory, RecoveryStrategy] = {
+    ToolFailureCategory.tool_unavailable: RecoveryStrategy.switch_tool,
+    ToolFailureCategory.invalid_arguments: RecoveryStrategy.fix_arguments,
+    ToolFailureCategory.not_found: RecoveryStrategy.verify_target,
+    ToolFailureCategory.permission_denied: RecoveryStrategy.surface_blocker,
+    ToolFailureCategory.rate_limited: RecoveryStrategy.retry_with_backoff,
+    ToolFailureCategory.transient_network: RecoveryStrategy.retry_with_backoff,
+    ToolFailureCategory.timeout: RecoveryStrategy.retry_with_backoff,
+    ToolFailureCategory.unexpected_output: RecoveryStrategy.retry,
+    ToolFailureCategory.persistent_error: RecoveryStrategy.switch_tool,
+    ToolFailureCategory.unknown: RecoveryStrategy.surface_blocker,
+}
+
+# Short imperative directives per strategy. Kept concise and structured so the
+# agent loop (or a policy interceptor) can surface a concrete alternative action.
+_STRATEGY_DIRECTIVE: dict[RecoveryStrategy, str] = {
+    RecoveryStrategy.retry: (
+        "retry the call once; if it fails again, change the request or switch tools"
+    ),
+    RecoveryStrategy.retry_with_backoff: (
+        "wait for the backoff window, then retry; reduce request frequency if it recurs"
+    ),
+    RecoveryStrategy.fix_arguments: (
+        "do not retry unchanged — correct the arguments (required fields, allowed "
+        "values, exact-match text) before calling again"
+    ),
+    RecoveryStrategy.verify_target: (
+        "verify the target exists first (list the directory or search) before "
+        "repeating the lookup"
+    ),
+    RecoveryStrategy.switch_tool: (
+        "this tool cannot complete the task — switch to an alternative tool or "
+        "resolve the missing dependency"
+    ),
+    RecoveryStrategy.surface_blocker: (
+        "this is an external blocker — report it after one diagnostic attempt "
+        "instead of retrying"
+    ),
+    RecoveryStrategy.escalate: (
+        "this call has failed repeatedly — stop retrying it and change strategy or "
+        "report the blocker"
+    ),
+}
+
+_BASE_BACKOFF_SECONDS = 1.0
+_MAX_BACKOFF_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class RecoveryAction:
+    """A concrete recovery decision for a classified tool failure."""
+
+    category: ToolFailureCategory
+    strategy: RecoveryStrategy
+    directive: str
+    should_retry: bool
+    backoff_seconds: float | None = None
+    tool_name: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "category": self.category.value,
+            "strategy": self.strategy.value,
+            "directive": self.directive,
+            "should_retry": self.should_retry,
+            "tool_name": self.tool_name,
+        }
+        if self.backoff_seconds is not None:
+            data["backoff_seconds"] = self.backoff_seconds
+        return data
+
+
+def register_strategy(
+    category: ToolFailureCategory, strategy: RecoveryStrategy
+) -> None:
+    """Override the recovery strategy for a failure category (runtime-extensible)."""
+    _CATEGORY_STRATEGY[category] = strategy
+
+
+def backoff_seconds_for(consecutive_count: int) -> float:
+    """Deterministic exponential backoff, capped, for retry-with-backoff actions.
+
+    ``consecutive_count`` is the number of prior consecutive failures of the same
+    call this turn (0 for the first failure). No jitter — deterministic so the
+    behavior is testable and reproducible.
+    """
+    exponent = max(0, int(consecutive_count))
+    delay = _BASE_BACKOFF_SECONDS * (2 ** exponent)
+    return float(min(delay, _MAX_BACKOFF_SECONDS))
+
+
+def dispatch_recovery(
+    classification: ToolFailureClassification,
+    *,
+    tool_name: str = "",
+    consecutive_count: int = 0,
+) -> RecoveryAction:
+    """Map a failure classification to a concrete :class:`RecoveryAction`.
+
+    Escalation: once the same call has failed ``_SWITCH_AFTER`` times a
+    retryable category is redirected to :attr:`RecoveryStrategy.switch_tool`, and
+    after ``_SURFACE_AFTER`` failures to :attr:`RecoveryStrategy.escalate`, so a
+    recovery directive never sustains an unbounded retry.
+    """
+    category = classification.category
+    strategy = _CATEGORY_STRATEGY.get(category, RecoveryStrategy.surface_blocker)
+    should_retry = bool(classification.should_retry)
+
+    # Monotone escalation for retryable categories that keep failing.
+    if should_retry and consecutive_count >= _SURFACE_AFTER:
+        strategy = RecoveryStrategy.escalate
+        should_retry = False
+    elif should_retry and consecutive_count >= _SWITCH_AFTER:
+        strategy = RecoveryStrategy.switch_tool
+        should_retry = False
+
+    backoff: float | None = None
+    if should_retry and strategy is RecoveryStrategy.retry_with_backoff:
+        backoff = backoff_seconds_for(consecutive_count)
+
+    directive = _STRATEGY_DIRECTIVE.get(strategy, _STRATEGY_DIRECTIVE[RecoveryStrategy.surface_blocker])
+    return RecoveryAction(
+        category=category,
+        strategy=strategy,
+        directive=directive,
+        should_retry=should_retry,
+        backoff_seconds=backoff,
+        tool_name=tool_name,
+    )
+
+
+def recover_from_failure(
+    tool_name: str,
+    error: str = "",
+    *,
+    exit_code: int | None = None,
+    consecutive_count: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> RecoveryAction:
+    """Classify a failed tool call and dispatch it to a recovery action.
+
+    This is the single structured entry point that wires a raw failure into a
+    recovery decision. Arguments mirror
+    :func:`tools.tool_failure_classifier.classify_tool_failure`.
+    """
+    classification = classify_tool_failure(
+        tool_name,
+        error,
+        exit_code=exit_code,
+        consecutive_count=consecutive_count,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    return dispatch_recovery(
+        classification,
+        tool_name=tool_name,
+        consecutive_count=consecutive_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime seam (config-gated, invoked from run_agent after a failed tool call)
+# ---------------------------------------------------------------------------
+
+RECOVERY_GUIDANCE_PREFIX = "Recovery strategy"
+
+
+def _format_recovery_guidance(action: RecoveryAction) -> str:
+    """Render a single structured guidance line for a recovery action."""
+    parts = [
+        f"{RECOVERY_GUIDANCE_PREFIX}: {action.strategy.value}",
+        f"category={action.category.value}",
+        f"retry={'yes' if action.should_retry else 'no'}",
+    ]
+    if action.backoff_seconds is not None:
+        parts.append(f"backoff={action.backoff_seconds:g}s")
+    line = "; ".join(parts)
+    return f"\n\n[{line}. {action.directive}]"
+
+
+def _terminal_exit_code(result: str) -> int | None:
+    """Best-effort extraction of a terminal tool's exit code from its JSON result."""
+    try:
+        parsed = json.loads(result)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(parsed, dict):
+        code = parsed.get("exit_code")
+        if isinstance(code, int):
+            return code
+    return None
+
+
+def maybe_append_recovery_guidance(
+    result: str | None,
+    tool_name: str,
+    *,
+    failed: bool,
+    enabled: bool,
+    consecutive_count: int = 0,
+    exit_code: int | None = None,
+) -> str:
+    """Runtime seam: append a structured recovery directive to a failed result.
+
+    Returns ``result`` **byte-for-byte unchanged** unless ``enabled`` and
+    ``failed`` are both true, so the default (disabled) path is a pure pass
+    through and introduces no behavior change. Never raises — a dispatch error
+    degrades to the original result.
+
+    For terminal failures the exit code is auto-extracted from the JSON result
+    when ``exit_code`` is not supplied, so the caller stays minimal.
+    """
+    text = result or ""
+    if not enabled or not failed:
+        return text
+    if exit_code is None and tool_name == "terminal":
+        exit_code = _terminal_exit_code(text)
+    try:
+        action = recover_from_failure(
+            tool_name,
+            error=text[:2000],
+            exit_code=exit_code,
+            consecutive_count=consecutive_count,
+        )
+    except Exception:
+        return text
+    return text + _format_recovery_guidance(action)


### PR DESCRIPTION
Closes #1027. Third slice of PALADIN-style execution-level tool-failure recovery (epic #1019).

## What
Maps the structured categories from the cross-tool failure classifier (slice 1, `tools/tool_failure_classifier.py`) onto concrete recovery actions and wires them into the real tool-execution seam so the agent takes a targeted next step instead of blindly retrying.

## How
- **`tools/recovery_strategy_dispatcher.py`** — table-driven `category -> RecoveryStrategy` (retry / retry_with_backoff / fix_arguments / verify_target / switch_tool / surface_blocker / escalate), deterministic capped exponential backoff, and **monotone escalation** (repeated failures give way to a tool switch, then a surfaced blocker) so a recovery directive can never itself sustain a retry spiral. Pure, stdlib-only, no import-time side effects.
- **`run_agent._append_guardrail_observation`** — config-gated seam that appends **one** structured recovery directive to a *failed* tool result, covering both sequential and concurrent execution paths.

## Safety / no-regression
- **OFF by default** via `tool_failure_recovery.enabled` (documented in `cli-config.yaml.example`). When disabled the gated branch never runs, so failed tool results are **byte-for-byte unchanged** — no prompt drift, no behavior change.
- Not dead code: **executable-seam runtime tests** drive the real `AIAgent` tool path with the gate enabled vs default-off, proving the dispatcher is actually wired in.

## Tests
- `tests/tools/test_recovery_strategy_dispatcher.py` — full unit coverage (every category, backoff, escalation, seam function, extensibility, serialization).
- `tests/run_agent/test_recovery_dispatcher_runtime.py` — executable-seam tests through `_execute_tool_calls_sequential`.
- Existing `tests/run_agent/test_tool_call_guardrail_runtime.py` still green (no regression).