### PR TITLE
feat(agent): wire plan feasibility gate into plan-execution loop (#1032)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1389,6 +1389,17 @@ def init_agent(
             agent._failure_recovery_enabled = bool(_tfr_cfg.get("enabled", False))
     except Exception as _tfr_err:
         _ra().logger.warning("Tool failure recovery config ignored: %s", _tfr_err)
+    # #1032 — plan feasibility gate. OFF by default and additionally scoped to
+    # plan mode: ``_maybe_activate_plan_mode`` validates a freshly built plan
+    # only when this flag is set. Reads ``plan_feasibility.enabled`` from config.
+    agent._plan_feasibility_enabled = False
+    agent._plan_feasibility_report = None
+    try:
+        _pf_cfg = _agent_cfg.get("plan_feasibility", {})
+        if isinstance(_pf_cfg, dict):
+            agent._plan_feasibility_enabled = bool(_pf_cfg.get("enabled", False))
+    except Exception as _pf_err:
+        _ra().logger.warning("Plan feasibility config ignored: %s", _pf_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/plan_feasibility.py
+++ b/agent/plan_feasibility.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Plan feasibility validation for the plan-execution loop (#1032, child of #1021).
+
+Second slice of PIVOT-style plan-feasibility validation. The first slice
+(``evolution/lib/feasibility_checker.py``) provided standalone check primitives;
+this module is the **production, importable** gate that validates a
+:class:`agent.plan_schema.Plan` *before* its steps drive any tool calls and
+returns structured, per-step feedback for plan revision.
+
+Plan steps are declarative free text (``Step.tool_call_intent`` — e.g.
+``"read_file(agent/plan_schema.py)"`` or ``"search the web for X"``), so this
+gate is deliberately **conservative**: it only reports :class:`FeasibilityStatus`
+``INFEASIBLE`` when it can confidently parse a concrete precondition that is
+definitively violated (a referenced file that does not exist, a referenced tool
+that is not available). Everything it cannot parse is ``UNCERTAIN`` — never a
+blocker on its own — so a false positive can never wrongly halt a plan.
+
+Design goals (matching the surrounding ``agent/`` corpus):
+
+* Pure functions + frozen dataclasses; **no side effects on import**.
+* Injectable IO seams (``file_exists``, ``available_tools``) so tests never
+  touch disk. Standard library only; full type hints.
+* JSON serialisation on every dataclass for storage on ``Plan.metadata``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Iterable
+
+from agent.plan_schema import Plan, Step
+
+__all__ = [
+    "FeasibilityStatus",
+    "StepFeasibility",
+    "PlanFeasibilityReport",
+    "check_plan_feasibility",
+    "maybe_validate_plan",
+    "PLAN_FEASIBILITY_METADATA_KEY",
+]
+
+PLAN_FEASIBILITY_METADATA_KEY = "feasibility"
+
+
+class FeasibilityStatus(str, Enum):
+    """Verdict for a single plan step's preconditions."""
+
+    FEASIBLE = "feasible"
+    INFEASIBLE = "infeasible"  # a definitively violated precondition (a blocker)
+    UNCERTAIN = "uncertain"  # nothing checkable / could not decide (not a blocker)
+
+
+# Intents whose first argument is a path that must ALREADY EXIST to proceed.
+_READ_LIKE_TOOLS = frozenset(
+    {"read_file", "edit_file", "patch", "apply_patch", "cat", "open"}
+)
+# Intents whose first argument is a path being WRITTEN — its parent must exist.
+_WRITE_LIKE_TOOLS = frozenset({"write_file", "create_file"})
+
+# Leading ``tool_name(args)`` form. Free text without this shape is UNCERTAIN.
+_INTENT_CALL_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class StepFeasibility:
+    """Feasibility verdict for one plan step."""
+
+    index: int
+    intent: str
+    status: FeasibilityStatus
+    reason: str = ""
+    suggestion: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_blocker(self) -> bool:
+        return self.status is FeasibilityStatus.INFEASIBLE
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "intent": self.intent,
+            "status": self.status.value,
+            "reason": self.reason,
+            "suggestion": self.suggestion,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class PlanFeasibilityReport:
+    """Aggregate feasibility of a whole plan."""
+
+    steps: tuple[StepFeasibility, ...] = ()
+
+    @property
+    def feasible(self) -> bool:
+        """True unless at least one step is a definitive blocker."""
+        return not any(s.is_blocker for s in self.steps)
+
+    @property
+    def blockers(self) -> list[StepFeasibility]:
+        return [s for s in self.steps if s.is_blocker]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "feasible": self.feasible,
+            "blocker_count": len(self.blockers),
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+
+def _default_file_exists(path: str) -> bool:
+    return os.path.isfile(path)
+
+
+def _first_arg_path(raw_args: str) -> str | None:
+    """Extract the first positional argument as a path, stripped of quotes."""
+    if not raw_args.strip():
+        return None
+    first = raw_args.split(",", 1)[0].strip()
+    if not first:
+        return None
+    # Drop keyword-arg forms like ``path=...`` -> keep the value.
+    if "=" in first and not first.startswith(("'", '"', "/", ".")):
+        first = first.split("=", 1)[1].strip()
+    first = first.strip("'\"").strip()
+    return first or None
+
+
+def _looks_like_path(candidate: str) -> bool:
+    """Heuristic: only treat a token as a checkable path when it plausibly is one."""
+    if not candidate or " " in candidate:
+        return False
+    return "/" in candidate or "." in candidate
+
+
+def _check_step(
+    index: int,
+    step: Step,
+    *,
+    file_exists: Callable[[str], bool],
+    available_tools: frozenset[str] | None,
+) -> StepFeasibility:
+    intent = step.tool_call_intent or ""
+    match = _INTENT_CALL_RE.match(intent)
+    if not match:
+        return StepFeasibility(index, intent, FeasibilityStatus.UNCERTAIN)
+
+    tool = match.group(1).strip().lower()
+    raw_args = match.group(2)
+
+    # Tool availability — only when the caller supplied the known tool set.
+    if available_tools is not None and tool not in available_tools:
+        return StepFeasibility(
+            index,
+            intent,
+            FeasibilityStatus.INFEASIBLE,
+            reason=f"tool '{tool}' is not available",
+            suggestion="use an available tool or drop this step",
+            metadata={"tool": tool},
+        )
+
+    if tool in _READ_LIKE_TOOLS:
+        path = _first_arg_path(raw_args)
+        if path and _looks_like_path(path):
+            if not file_exists(path):
+                return StepFeasibility(
+                    index,
+                    intent,
+                    FeasibilityStatus.INFEASIBLE,
+                    reason=f"target file does not exist: {path}",
+                    suggestion="verify the path (search or list the directory) before this step",
+                    metadata={"path": path, "tool": tool},
+                )
+            return StepFeasibility(index, intent, FeasibilityStatus.FEASIBLE, metadata={"path": path})
+
+    if tool in _WRITE_LIKE_TOOLS:
+        path = _first_arg_path(raw_args)
+        if path and _looks_like_path(path):
+            parent = os.path.dirname(path) or "."
+            # Only a blocker when the parent directory is definitively missing.
+            if not os.path.isdir(parent) and not file_exists(path):
+                return StepFeasibility(
+                    index,
+                    intent,
+                    FeasibilityStatus.UNCERTAIN,
+                    reason=f"parent directory may not exist: {parent}",
+                    suggestion="create the parent directory before writing",
+                    metadata={"path": path, "parent": parent, "tool": tool},
+                )
+            return StepFeasibility(index, intent, FeasibilityStatus.FEASIBLE, metadata={"path": path})
+
+    return StepFeasibility(index, intent, FeasibilityStatus.UNCERTAIN, metadata={"tool": tool})
+
+
+def check_plan_feasibility(
+    plan: Plan,
+    *,
+    file_exists: Callable[[str], bool] | None = None,
+    available_tools: Iterable[str] | None = None,
+) -> PlanFeasibilityReport:
+    """Validate every step of ``plan`` and return a structured report.
+
+    ``file_exists`` and ``available_tools`` are injectable so tests never touch
+    the disk or the live tool registry. When ``available_tools`` is ``None`` the
+    tool-availability check is skipped entirely (conservative default).
+    """
+    fx = file_exists or _default_file_exists
+    tools = frozenset(t.strip().lower() for t in available_tools) if available_tools is not None else None
+    results = tuple(
+        _check_step(i, step, file_exists=fx, available_tools=tools)
+        for i, step in enumerate(plan.steps, start=1)
+    )
+    return PlanFeasibilityReport(steps=results)
+
+
+def maybe_validate_plan(
+    plan: Plan | None,
+    *,
+    enabled: bool,
+    file_exists: Callable[[str], bool] | None = None,
+    available_tools: Iterable[str] | None = None,
+) -> PlanFeasibilityReport | None:
+    """Runtime seam: validate ``plan`` and record the report on its metadata.
+
+    Returns ``None`` — and touches nothing — unless ``enabled`` is true and a
+    plan is supplied, so the default (disabled) path is a pure no-op. On success
+    the report is stored under ``plan.metadata['feasibility']`` (the ``metadata``
+    dict is mutable even though ``Plan`` is frozen) for a later revision pass to
+    consume. Never raises — a validation error degrades to ``None``.
+    """
+    if not enabled or plan is None:
+        return None
+    try:
+        report = check_plan_feasibility(
+            plan, file_exists=file_exists, available_tools=available_tools
+        )
+        if isinstance(plan.metadata, dict):
+            plan.metadata[PLAN_FEASIBILITY_METADATA_KEY] = report.to_dict()
+        return report
+    except Exception:
+        return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -400,6 +400,18 @@ tool_failure_recovery:
   enabled: false
 
 # =============================================================================
+# Plan Feasibility Gate (#1032 — PIVOT-style pre-execution validation)
+# =============================================================================
+# Only active when plan mode is on (plan_mode: true). Before a freshly built
+# plan's steps drive any tool call, each step's declared intent is validated for
+# feasibility (referenced files exist, referenced tools are available). Blockers
+# are recorded as structured per-step feedback on the plan for a revision pass.
+# Conservative: only definitively-violated preconditions are flagged; anything
+# unparseable is "uncertain", never a blocker. OFF by default.
+plan_feasibility:
+  enabled: false
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/run_agent.py
+++ b/run_agent.py
@@ -6331,6 +6331,20 @@ class AIAgent:
 
         if plan is None:
             return
+        # #1032 — plan feasibility gate. Runs only inside plan mode (already
+        # opt-in) AND when plan_feasibility.enabled is set: validates the freshly
+        # built plan before any of its steps drive a tool call and records
+        # structured per-step feedback on plan.metadata['feasibility'] for a
+        # revision pass. Off by default -> the plan is left exactly as built.
+        if getattr(self, "_plan_feasibility_enabled", False):
+            try:
+                from agent.plan_feasibility import maybe_validate_plan
+
+                self._plan_feasibility_report = maybe_validate_plan(
+                    plan, enabled=True
+                )
+            except Exception:
+                self._plan_feasibility_report = None
         self._active_plan = plan
         # Re-arm emission so the freshly built plan prints before this run's
         # first tool dispatch, and reset the progress cursor for the new plan.

--- a/tests/agent/test_plan_feasibility.py
+++ b/tests/agent/test_plan_feasibility.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the plan feasibility gate (#1032)."""
+
+from __future__ import annotations
+
+from agent.plan_schema import Plan, Step
+from agent.plan_feasibility import (
+    FeasibilityStatus,
+    PlanFeasibilityReport,
+    check_plan_feasibility,
+    maybe_validate_plan,
+)
+
+
+def _plan(*intents: str) -> Plan:
+    steps = [
+        Step(tool_call_intent=intent, rationale="r", expected_observation="e")
+        for intent in intents
+    ]
+    return Plan(steps=steps, goal="g")
+
+
+def test_read_file_missing_path_is_infeasible():
+    plan = _plan("read_file(agent/does_not_exist.py)")
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    assert report.feasible is False
+    assert len(report.blockers) == 1
+    blocker = report.blockers[0]
+    assert blocker.status is FeasibilityStatus.INFEASIBLE
+    assert "does_not_exist" in blocker.reason
+    assert blocker.metadata["path"] == "agent/does_not_exist.py"
+
+
+def test_read_file_existing_path_is_feasible():
+    plan = _plan("read_file(agent/plan_schema.py)")
+    report = check_plan_feasibility(plan, file_exists=lambda p: True)
+    assert report.feasible is True
+    assert report.steps[0].status is FeasibilityStatus.FEASIBLE
+
+
+def test_free_text_intent_is_uncertain_not_a_blocker():
+    plan = _plan("search the web for FLARE benchmark numbers")
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    assert report.feasible is True
+    assert report.steps[0].status is FeasibilityStatus.UNCERTAIN
+
+
+def test_unavailable_tool_is_infeasible_only_when_toolset_supplied():
+    plan = _plan("nonexistent_tool(x)")
+    # Without a toolset, tool availability is not checked -> not a blocker.
+    report_no_tools = check_plan_feasibility(plan, file_exists=lambda p: True)
+    assert report_no_tools.feasible is True
+    # With a toolset that lacks the tool -> INFEASIBLE.
+    report = check_plan_feasibility(
+        plan, file_exists=lambda p: True, available_tools={"read_file", "web_search"}
+    )
+    assert report.feasible is False
+    assert report.blockers[0].metadata["tool"] == "nonexistent_tool"
+
+
+def test_available_tool_with_existing_file_is_feasible():
+    plan = _plan("read_file(agent/plan_schema.py)")
+    report = check_plan_feasibility(
+        plan, file_exists=lambda p: True, available_tools={"read_file"}
+    )
+    assert report.steps[0].status is FeasibilityStatus.FEASIBLE
+
+
+def test_write_file_missing_parent_is_uncertain_not_blocker():
+    plan = _plan("write_file(/definitely/missing/dir/out.txt)")
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    # A missing write parent is a soft signal, never a hard blocker.
+    assert report.feasible is True
+    assert report.steps[0].status is FeasibilityStatus.UNCERTAIN
+
+
+def test_read_file_non_path_argument_is_not_treated_as_path():
+    # "foo" has no slash/dot -> not confidently a path -> UNCERTAIN, not blocker.
+    plan = _plan("read_file(foo)")
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    assert report.feasible is True
+    assert report.steps[0].status is FeasibilityStatus.UNCERTAIN
+
+
+def test_first_arg_path_strips_quotes_and_keyword_form():
+    plan = _plan('read_file(path="agent/missing.py", offset=1)')
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    assert report.blockers[0].metadata["path"] == "agent/missing.py"
+
+
+def test_mixed_plan_reports_only_real_blockers():
+    plan = _plan(
+        "read_file(agent/missing_a.py)",  # infeasible
+        "search the web for X",  # uncertain
+        "read_file(agent/plan_schema.py)",  # feasible (exists stub True below)
+    )
+
+    def exists(p: str) -> bool:
+        return "plan_schema" in p
+
+    report = check_plan_feasibility(plan, file_exists=exists)
+    statuses = [s.status for s in report.steps]
+    assert statuses == [
+        FeasibilityStatus.INFEASIBLE,
+        FeasibilityStatus.UNCERTAIN,
+        FeasibilityStatus.FEASIBLE,
+    ]
+    assert len(report.blockers) == 1
+
+
+def test_report_to_dict_shape():
+    plan = _plan("read_file(agent/missing.py)")
+    report = check_plan_feasibility(plan, file_exists=lambda p: False)
+    data = report.to_dict()
+    assert data["feasible"] is False
+    assert data["blocker_count"] == 1
+    assert data["steps"][0]["status"] == "infeasible"
+
+
+def test_maybe_validate_disabled_is_noop():
+    plan = _plan("read_file(agent/missing.py)")
+    result = maybe_validate_plan(plan, enabled=False, file_exists=lambda p: False)
+    assert result is None
+    assert "feasibility" not in plan.metadata
+
+
+def test_maybe_validate_enabled_records_report_on_metadata():
+    plan = _plan("read_file(agent/missing.py)")
+    report = maybe_validate_plan(plan, enabled=True, file_exists=lambda p: False)
+    assert isinstance(report, PlanFeasibilityReport)
+    assert plan.metadata["feasibility"]["feasible"] is False
+    assert plan.metadata["feasibility"]["blocker_count"] == 1
+
+
+def test_maybe_validate_none_plan_is_noop():
+    assert maybe_validate_plan(None, enabled=True) is None
+
+
+def test_empty_plan_is_feasible():
+    plan = Plan(steps=[Step(tool_call_intent="noop step", rationale="r", expected_observation="e")], goal="g")
+    report = check_plan_feasibility(plan)
+    assert report.feasible is True

--- a/tests/run_agent/test_plan_feasibility_runtime.py
+++ b/tests/run_agent/test_plan_feasibility_runtime.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam integration tests for the #1032 plan feasibility gate.
+
+Drive the real ``AIAgent._maybe_activate_plan_mode`` seam to prove the gate is
+wired into the plan-execution loop — validating a freshly built plan before any
+of its steps drive a tool call — and that it is inert unless BOTH plan mode and
+``plan_feasibility.enabled`` are set.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.plan_schema import Plan, Step
+
+
+def _make_agent(config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=5,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = None  # force the deterministic stub planner path
+    agent._active_plan = None
+    return agent
+
+
+def _infeasible_plan() -> Plan:
+    return Plan(
+        steps=[
+            Step(
+                tool_call_intent="read_file(agent/definitely_missing_file_xyz.py)",
+                rationale="need the file",
+                expected_observation="file contents",
+            ),
+            Step(
+                tool_call_intent="search the web for background",
+                rationale="context",
+                expected_observation="results",
+            ),
+        ],
+        goal="do the thing",
+    )
+
+
+def test_plan_mode_off_seam_is_inert():
+    agent = _make_agent()  # plan mode off (default)
+    with patch("hermes_cli.config.load_config", return_value={}):
+        agent._maybe_activate_plan_mode("do the thing")
+    assert getattr(agent, "_active_plan", None) is None
+    assert getattr(agent, "_plan_feasibility_report", None) is None
+
+
+def test_plan_mode_on_feasibility_off_leaves_plan_unvalidated():
+    cfg = {"plan_mode": True}
+    agent = _make_agent(config=cfg)
+    assert agent._plan_feasibility_enabled is False
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.plan_mode.build_stub_plan", return_value=_infeasible_plan()),
+    ):
+        agent._maybe_activate_plan_mode("do the thing")
+    assert agent._active_plan is not None
+    assert "feasibility" not in agent._active_plan.metadata
+    assert agent._plan_feasibility_report is None
+
+
+def test_plan_mode_on_feasibility_on_validates_through_real_seam():
+    cfg = {"plan_mode": True, "plan_feasibility": {"enabled": True}}
+    agent = _make_agent(config=cfg)
+    assert agent._plan_feasibility_enabled is True
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.plan_mode.build_stub_plan", return_value=_infeasible_plan()),
+    ):
+        agent._maybe_activate_plan_mode("do the thing")
+    assert agent._active_plan is not None
+    report = agent._active_plan.metadata.get("feasibility")
+    assert report is not None
+    # The missing read_file target is caught before any tool call.
+    assert report["feasible"] is False
+    assert report["blocker_count"] == 1
+    assert agent._plan_feasibility_report is not None
+    assert agent._plan_feasibility_report.feasible is False


### PR DESCRIPTION
Closes #1032. Second slice of PIVOT-style plan-feasibility validation (epic #1021).

## What
Before a freshly built plan's steps drive any tool call, validate each step's declared intent for feasibility and record structured per-step feedback for a revision pass.

## How
- **`agent/plan_feasibility.py`** — conservative gate that parses `Step.tool_call_intent` (declarative free text) and flags `INFEASIBLE` only on definitively-violated preconditions (a referenced file that does not exist, a referenced tool that is not available). Anything it cannot confidently parse is `UNCERTAIN` — never a blocker — so a false positive can never wrongly halt a plan. Injectable IO seams (`file_exists`, `available_tools`) so tests never touch disk. Pure, stdlib-only, no import-time side effects.
- **`run_agent._maybe_activate_plan_mode`** — config-gated seam scoped to plan mode: validates the plan and stores the report under `plan.metadata['feasibility']` for the replan path to consume.

## Safety / no-regression
- **OFF by default** via `plan_feasibility.enabled` AND additionally scoped to plan mode (itself opt-in, off by default). Documented in `cli-config.yaml.example`. When disabled the plan is left exactly as built.
- Not dead code: **executable-seam integration tests** drive the real `_maybe_activate_plan_mode` path (plan-mode-off / feasibility-off / feasibility-on) proving the gate is wired in.

## Tests
- `tests/agent/test_plan_feasibility.py` — full unit coverage (missing/existing files, free-text, tool availability, write-parent, mixed plans, serialization, seam helper).
- `tests/run_agent/test_plan_feasibility_runtime.py` — executable-seam integration tests.
- Plan-subsystem regression tests still green.