### PR TITLE
feat(agent): multi-hypothesis failure diagnosis + hypothesis history (#1029, #1030)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1400,6 +1400,26 @@ def init_agent(
             agent._plan_feasibility_enabled = bool(_pf_cfg.get("enabled", False))
     except Exception as _pf_err:
         _ra().logger.warning("Plan feasibility config ignored: %s", _pf_err)
+    # #1029/#1030 — multi-hypothesis failure diagnosis. Config-gated via
+    # ``failure_diagnosis.mode`` (off | reflect | multi-hypothesis); default off
+    # so ``_append_guardrail_observation`` leaves failed results unchanged. When
+    # not off, a per-session HypothesisHistory is armed so repeated failures
+    # surface fresh hypotheses (#1030).
+    agent._failure_diagnosis_mode = "off"
+    agent._hypothesis_history = None
+    try:
+        _fd_cfg = _agent_cfg.get("failure_diagnosis", {})
+        if isinstance(_fd_cfg, dict):
+            _mode = str(_fd_cfg.get("mode", "off")).strip().lower()
+            if _mode not in {"off", "reflect", "multi-hypothesis", "multi_hypothesis"}:
+                _mode = "off"
+            agent._failure_diagnosis_mode = _mode
+            if _mode != "off":
+                from agent.failure_diagnosis import HypothesisHistory
+
+                agent._hypothesis_history = HypothesisHistory()
+    except Exception as _fd_err:
+        _ra().logger.warning("Failure diagnosis config ignored: %s", _fd_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/failure_diagnosis.py
+++ b/agent/failure_diagnosis.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+"""Multi-hypothesis failure diagnosis for the tool-failure handler.
+
+Second slice of SAGE-style Multi-Hypothesis Failure Attribution (issue #1029,
+child of #994). Where the recovery dispatcher (#1027) commits to a single
+category, this produces a *ranked list of hypotheses* about why a tool call
+failed so the agent can weigh alternatives before retrying — instead of anchoring
+on the first pattern that matched.
+
+The hypotheses are derived from the **real** cross-tool classifier rule table
+(``tools.tool_failure_classifier.matched_categories``): every category whose
+pattern matches the error contributes a hypothesis, ranked by match strength
+with the primary classification first. Confidence is rank-derived and
+deterministic.
+
+Design goals (matching ``agent/tool_guardrails.py`` and
+``tools/recovery_strategy_dispatcher.py``):
+
+* Pure functions + frozen dataclasses; **no side effects on import**.
+* Standard library only; full type hints; ``from __future__ import annotations``.
+* JSON serialisation on every dataclass.
+* The runtime seam (:func:`maybe_append_diagnosis`) is config-gated and returns
+  the result byte-for-byte unchanged unless the mode is active AND the call
+  failed, so the default path introduces no behavior change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from tools.tool_failure_classifier import (
+    ToolFailureCategory,
+    classify_tool_failure,
+    matched_categories,
+)
+
+__all__ = [
+    "DiagnosisMode",
+    "Hypothesis",
+    "Diagnosis",
+    "HypothesisHistory",
+    "diagnose_failure",
+    "maybe_append_diagnosis",
+    "DIAGNOSIS_GUIDANCE_PREFIX",
+]
+
+DIAGNOSIS_GUIDANCE_PREFIX = "Failure diagnosis"
+
+
+class DiagnosisMode(str, Enum):
+    """Config values for ``failure_diagnosis.mode``.
+
+    ``off``              — no diagnosis (default).
+    ``reflect``          — single best hypothesis only (a lightweight reflection).
+    ``multi_hypothesis`` — full ranked list of hypotheses.
+    """
+
+    off = "off"
+    reflect = "reflect"
+    multi_hypothesis = "multi-hypothesis"
+
+    @classmethod
+    def coerce(cls, value: Any) -> "DiagnosisMode":
+        if isinstance(value, cls):
+            return value
+        text = str(value or "").strip().lower().replace("_", "-")
+        for member in cls:
+            if member.value == text:
+                return member
+        return cls.off
+
+
+# Rank-derived confidence: the primary hypothesis is the most confident, each
+# subsequent one less so. Deterministic, no model call.
+_RANK_CONFIDENCE = (0.7, 0.5, 0.35, 0.25, 0.15)
+
+
+@dataclass(frozen=True)
+class Hypothesis:
+    """One ranked explanation of a tool failure."""
+
+    category: ToolFailureCategory
+    rank: int  # 1 = most likely
+    confidence: float
+    hint: str
+    should_retry: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "category": self.category.value,
+            "rank": self.rank,
+            "confidence": self.confidence,
+            "hint": self.hint,
+            "should_retry": self.should_retry,
+        }
+
+
+@dataclass(frozen=True)
+class Diagnosis:
+    """A ranked multi-hypothesis diagnosis for a failed tool call."""
+
+    tool_name: str
+    hypotheses: tuple[Hypothesis, ...] = ()
+
+    @property
+    def primary(self) -> Hypothesis | None:
+        return self.hypotheses[0] if self.hypotheses else None
+
+    def top(self, n: int) -> tuple[Hypothesis, ...]:
+        return self.hypotheses[: max(0, n)]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "hypotheses": [h.to_dict() for h in self.hypotheses],
+        }
+
+
+def _confidence_for_rank(rank: int) -> float:
+    idx = rank - 1
+    if 0 <= idx < len(_RANK_CONFIDENCE):
+        return _RANK_CONFIDENCE[idx]
+    return _RANK_CONFIDENCE[-1]
+
+
+class HypothesisHistory:
+    """Per-session record of diagnosis hypotheses already surfaced (issue #1030).
+
+    Tracks, per failure key, which categories have already been proposed so a
+    *repeated* failure demotes them and surfaces a NEW top hypothesis instead of
+    re-proposing one the agent already acted on. Owned by a single agent session
+    and reset per turn; not thread-safe by design.
+    """
+
+    def __init__(self) -> None:
+        self._tried: dict[str, list[str]] = {}
+
+    def tried(self, key: str) -> tuple[ToolFailureCategory, ...]:
+        return tuple(ToolFailureCategory(v) for v in self._tried.get(key, ()))
+
+    def record(self, key: str, category: ToolFailureCategory) -> None:
+        bucket = self._tried.setdefault(key, [])
+        if category.value not in bucket:
+            bucket.append(category.value)
+
+    def reset(self) -> None:
+        self._tried.clear()
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {k: list(v) for k, v in self._tried.items()}
+
+
+def diagnose_failure(
+    tool_name: str,
+    error: str = "",
+    *,
+    exit_code: int | None = None,
+    consecutive_count: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    max_hypotheses: int = 3,
+    history: "HypothesisHistory | None" = None,
+    history_key: str | None = None,
+) -> Diagnosis:
+    """Produce a ranked multi-hypothesis diagnosis for a failed tool call.
+
+    The primary classification (from the same classifier the recovery dispatcher
+    uses) is hypothesis #1. Additional categories whose patterns also matched the
+    error text are ranked after it, deduplicated, best-first.
+
+    When ``history`` and ``history_key`` are supplied (issue #1030), categories
+    already surfaced for that key are **demoted** below fresh ones, so a repeated
+    failure yields a new top hypothesis; the resulting primary is then recorded
+    so the next repeat demotes it in turn.
+    """
+    primary = classify_tool_failure(
+        tool_name,
+        error,
+        exit_code=exit_code,
+        consecutive_count=consecutive_count,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    ordered: list[ToolFailureCategory] = [primary.category]
+    text = "\n".join(part for part in (error, stdout, stderr) if part)
+    for category in matched_categories(text):
+        if category not in ordered:
+            ordered.append(category)
+
+    # #1030 — demote already-tried categories so repeats surface fresh hypotheses.
+    if history is not None and history_key is not None:
+        tried = set(history.tried(history_key))
+        if tried:
+            fresh = [c for c in ordered if c not in tried]
+            stale = [c for c in ordered if c in tried]
+            ordered = fresh + stale
+
+    from tools.tool_failure_classifier import (
+        _CATEGORY_HINTS,
+        _CATEGORY_RETRYABLE,
+    )
+
+    hypotheses: list[Hypothesis] = []
+    for rank, category in enumerate(ordered[: max(1, max_hypotheses)], start=1):
+        should_retry = (
+            primary.should_retry
+            if category is primary.category
+            else _CATEGORY_RETRYABLE[category]
+        )
+        hypotheses.append(
+            Hypothesis(
+                category=category,
+                rank=rank,
+                confidence=_confidence_for_rank(rank),
+                hint=_CATEGORY_HINTS[category],
+                should_retry=should_retry,
+            )
+        )
+
+    if history is not None and history_key is not None and hypotheses:
+        history.record(history_key, hypotheses[0].category)
+
+    return Diagnosis(tool_name=tool_name, hypotheses=tuple(hypotheses))
+
+
+def _format_diagnosis(diagnosis: Diagnosis, *, single: bool) -> str:
+    hyps = diagnosis.hypotheses[:1] if single else diagnosis.hypotheses
+    if not hyps:
+        return ""
+    ranked = "; ".join(
+        f"{h.rank}) {h.category.value} (p={h.confidence:g}, retry={'yes' if h.should_retry else 'no'})"
+        for h in hyps
+    )
+    return f"\n\n[{DIAGNOSIS_GUIDANCE_PREFIX}: {ranked}. Weigh these before retrying.]"
+
+
+def maybe_append_diagnosis(
+    result: str | None,
+    tool_name: str,
+    *,
+    failed: bool,
+    mode: Any,
+    consecutive_count: int = 0,
+    max_hypotheses: int = 3,
+    history: "HypothesisHistory | None" = None,
+    history_key: str | None = None,
+) -> str:
+    """Runtime seam: append a ranked failure diagnosis to a failed result.
+
+    Returns ``result`` **byte-for-byte unchanged** unless ``failed`` is true and
+    ``mode`` is not ``off``. ``reflect`` appends only the single best hypothesis;
+    ``multi-hypothesis`` appends the full ranked list. When ``history`` is passed
+    (#1030), already-tried hypotheses are demoted so repeats surface fresh ones.
+    Never raises.
+    """
+    text = result or ""
+    resolved = DiagnosisMode.coerce(mode)
+    if not failed or resolved is DiagnosisMode.off:
+        return text
+    try:
+        diagnosis = diagnose_failure(
+            tool_name,
+            error=text[:2000],
+            exit_code=None,
+            consecutive_count=consecutive_count,
+            max_hypotheses=max_hypotheses,
+            history=history,
+            history_key=history_key,
+        )
+    except Exception:
+        return text
+    return text + _format_diagnosis(diagnosis, single=resolved is DiagnosisMode.reflect)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -412,6 +412,19 @@ plan_feasibility:
   enabled: false
 
 # =============================================================================
+# Failure Diagnosis (#1029/#1030 — SAGE-style multi-hypothesis attribution)
+# =============================================================================
+# When a tool call fails, append a ranked list of hypotheses about WHY it failed
+# (derived from the same cross-tool classifier the recovery dispatcher uses) so
+# the agent weighs alternatives before retrying. Hypotheses already surfaced this
+# session are demoted so repeats propose fresh explanations (#1030).
+#   off              — no diagnosis (default; failed results unchanged)
+#   reflect          — append only the single best hypothesis
+#   multi-hypothesis — append the full ranked list
+failure_diagnosis:
+  mode: off
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/run_agent.py
+++ b/run_agent.py
@@ -6213,6 +6213,26 @@ class AIAgent:
                 enabled=True,
                 consecutive_count=decision.count,
             )
+        # #1029/#1030 — multi-hypothesis failure diagnosis. Config-gated via
+        # ``failure_diagnosis.mode`` (off | reflect | multi-hypothesis); OFF by
+        # default so the branch never runs and the result is unchanged. When
+        # active, a failed result gains a ranked list of hypotheses about WHY it
+        # failed (demoting hypotheses already tried this session, #1030) so the
+        # agent weighs alternatives before retrying.
+        if failed and getattr(self, "_failure_diagnosis_mode", "off") != "off":
+            from agent.failure_diagnosis import maybe_append_diagnosis
+
+            _sig = decision.signature
+            _key = _sig.args_hash if _sig is not None else tool_name
+            function_result = maybe_append_diagnosis(
+                function_result,
+                tool_name,
+                failed=True,
+                mode=self._failure_diagnosis_mode,
+                consecutive_count=decision.count,
+                history=getattr(self, "_hypothesis_history", None),
+                history_key=f"{tool_name}:{_key}",
+            )
         return function_result
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:

--- a/tests/agent/test_failure_diagnosis.py
+++ b/tests/agent/test_failure_diagnosis.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for multi-hypothesis failure diagnosis (#1029)."""
+
+from __future__ import annotations
+
+from tools.tool_failure_classifier import ToolFailureCategory, matched_categories
+from agent.failure_diagnosis import (
+    DIAGNOSIS_GUIDANCE_PREFIX,
+    Diagnosis,
+    DiagnosisMode,
+    Hypothesis,
+    HypothesisHistory,
+    diagnose_failure,
+    maybe_append_diagnosis,
+)
+
+
+def test_matched_categories_surfaces_multiple_plausible_categories():
+    # "not found" alone -> not_found; but "command not found" -> tool_unavailable
+    cats = matched_categories("bash: command not found; also file does not exist")
+    assert ToolFailureCategory.tool_unavailable in cats
+    assert ToolFailureCategory.not_found in cats
+    # ordered + deduped
+    assert len(cats) == len(set(cats))
+
+
+def test_matched_categories_empty_for_unmatched_text():
+    assert matched_categories("") == []
+
+
+def test_diagnose_primary_hypothesis_matches_classifier():
+    diag = diagnose_failure("web_search", "429 Too Many Requests")
+    assert diag.primary is not None
+    assert diag.primary.category is ToolFailureCategory.rate_limited
+    assert diag.primary.rank == 1
+    assert diag.primary.confidence == 0.7
+
+
+def test_diagnose_produces_ranked_multiple_hypotheses():
+    diag = diagnose_failure("terminal", "command not found: foo; no such file or directory")
+    assert len(diag.hypotheses) >= 2
+    ranks = [h.rank for h in diag.hypotheses]
+    assert ranks == sorted(ranks)  # strictly ranked 1..n
+    confs = [h.confidence for h in diag.hypotheses]
+    assert confs == sorted(confs, reverse=True)  # decreasing confidence
+
+
+def test_diagnose_respects_max_hypotheses():
+    diag = diagnose_failure(
+        "terminal",
+        "command not found; no such file; permission denied; rate limit; timed out",
+        max_hypotheses=2,
+    )
+    assert len(diag.hypotheses) <= 2
+
+
+def test_diagnose_dedups_categories():
+    diag = diagnose_failure("web_search", "not found and does not exist and no such thing")
+    cats = [h.category for h in diag.hypotheses]
+    assert len(cats) == len(set(cats))
+
+
+def test_diagnosis_mode_coerce():
+    assert DiagnosisMode.coerce("off") is DiagnosisMode.off
+    assert DiagnosisMode.coerce("reflect") is DiagnosisMode.reflect
+    assert DiagnosisMode.coerce("multi-hypothesis") is DiagnosisMode.multi_hypothesis
+    assert DiagnosisMode.coerce("multi_hypothesis") is DiagnosisMode.multi_hypothesis
+    assert DiagnosisMode.coerce("garbage") is DiagnosisMode.off
+    assert DiagnosisMode.coerce(None) is DiagnosisMode.off
+
+
+def test_diagnosis_to_dict_shape():
+    diag = diagnose_failure("web_search", "429 rate limit")
+    data = diag.to_dict()
+    assert data["tool_name"] == "web_search"
+    assert data["hypotheses"][0]["category"] == "rate_limited"
+    assert data["hypotheses"][0]["rank"] == 1
+
+
+# --- seam ---------------------------------------------------------------------
+
+
+def test_seam_off_returns_unchanged():
+    r = '{"error": "429 rate limit"}'
+    assert maybe_append_diagnosis(r, "web_search", failed=True, mode="off") == r
+
+
+def test_seam_not_failed_returns_unchanged():
+    r = '{"ok": true}'
+    assert maybe_append_diagnosis(r, "web_search", failed=False, mode="multi-hypothesis") == r
+
+
+def test_seam_reflect_appends_single_hypothesis():
+    r = '{"error": "command not found; no such file"}'
+    out = maybe_append_diagnosis(r, "terminal", failed=True, mode="reflect")
+    assert DIAGNOSIS_GUIDANCE_PREFIX in out
+    # reflect => exactly one ranked entry "1)" and no "2)"
+    assert "1)" in out
+    assert "2)" not in out
+
+
+def test_seam_multi_hypothesis_appends_ranked_list():
+    r = '{"error": "command not found; no such file or directory"}'
+    out = maybe_append_diagnosis(r, "terminal", failed=True, mode="multi-hypothesis")
+    assert DIAGNOSIS_GUIDANCE_PREFIX in out
+    assert "1)" in out
+    assert "2)" in out
+
+
+def test_seam_never_raises():
+    out = maybe_append_diagnosis("\x00", "terminal", failed=True, mode="multi-hypothesis")
+    assert out.startswith("\x00")
+
+
+def test_seam_none_result():
+    out = maybe_append_diagnosis(None, "web_search", failed=True, mode="reflect")
+    assert isinstance(out, str)
+
+
+# --- #1030: hypothesis history --------------------------------------------------
+
+
+def test_history_records_and_reports_tried():
+    h = HypothesisHistory()
+    assert h.tried("k") == ()
+    h.record("k", ToolFailureCategory.rate_limited)
+    h.record("k", ToolFailureCategory.rate_limited)  # dedup
+    assert h.tried("k") == (ToolFailureCategory.rate_limited,)
+    h.record("k", ToolFailureCategory.timeout)
+    assert set(h.tried("k")) == {ToolFailureCategory.rate_limited, ToolFailureCategory.timeout}
+
+
+def test_history_reset_and_to_dict():
+    h = HypothesisHistory()
+    h.record("k", ToolFailureCategory.not_found)
+    assert h.to_dict() == {"k": ["not_found"]}
+    h.reset()
+    assert h.to_dict() == {}
+
+
+def test_diagnose_records_primary_into_history():
+    h = HypothesisHistory()
+    diag = diagnose_failure("web_search", "429 rate limit", history=h, history_key="web_search:x")
+    assert diag.primary.category is ToolFailureCategory.rate_limited
+    assert ToolFailureCategory.rate_limited in h.tried("web_search:x")
+
+
+def test_repeated_diagnosis_demotes_tried_hypothesis():
+    h = HypothesisHistory()
+    # Two plausible categories in the text: tool_unavailable + not_found.
+    err = "command not found: foo; also no such file or directory"
+    first = diagnose_failure("terminal", err, history=h, history_key="terminal:x")
+    first_primary = first.primary.category
+    # On the repeat, the previously-surfaced primary is demoted so a fresh
+    # hypothesis rises to rank 1 (as long as another category matched).
+    second = diagnose_failure("terminal", err, history=h, history_key="terminal:x")
+    assert second.primary.category is not first_primary
+    assert second.primary.category in matched_categories(err)
+
+
+def test_history_key_is_isolated():
+    h = HypothesisHistory()
+    err = "429 rate limit"
+    diagnose_failure("web_search", err, history=h, history_key="web_search:a")
+    # A different key is unaffected — same primary as a fresh diagnosis.
+    other = diagnose_failure("web_search", err, history=h, history_key="web_search:b")
+    assert other.primary.category is ToolFailureCategory.rate_limited
+
+
+def test_seam_threads_history_through():
+    h = HypothesisHistory()
+    err = '{"error": "command not found; no such file or directory"}'
+    out1 = maybe_append_diagnosis(err, "terminal", failed=True, mode="reflect", history=h, history_key="terminal:x")
+    out2 = maybe_append_diagnosis(err, "terminal", failed=True, mode="reflect", history=h, history_key="terminal:x")
+    assert DIAGNOSIS_GUIDANCE_PREFIX in out1
+    # The two reflections should differ because the first hypothesis was demoted.
+    assert out1 != out2

--- a/tests/run_agent/test_failure_diagnosis_runtime.py
+++ b/tests/run_agent/test_failure_diagnosis_runtime.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam runtime tests for #1029/#1030 multi-hypothesis diagnosis.
+
+Drive the real ``AIAgent`` tool path (``_execute_tool_calls_sequential`` ->
+``_append_guardrail_observation``) to prove the diagnosis is wired in and inert
+unless ``failure_diagnosis.mode`` is set.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_agent(*tool_names: str, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _run_failing_call(agent, tool_name, result, call_id):
+    tc = _mock_tool_call(tool_name, "{}", call_id)
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    with patch("run_agent.handle_function_call", return_value=result):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    return messages
+
+
+def test_diagnosis_defaults_off():
+    agent = _make_agent("web_search")
+    assert getattr(agent, "_failure_diagnosis_mode", "off") == "off"
+    assert getattr(agent, "_hypothesis_history", None) is None
+    messages = _run_failing_call(agent, "web_search", json.dumps({"error": "429 rate limit"}), "c-off")
+    assert "Failure diagnosis" not in messages[0]["content"]
+
+
+def test_diagnosis_multi_hypothesis_appends_ranked_list_through_seam():
+    agent = _make_agent("terminal", config={"failure_diagnosis": {"mode": "multi-hypothesis"}})
+    assert agent._failure_diagnosis_mode == "multi-hypothesis"
+    assert agent._hypothesis_history is not None
+    messages = _run_failing_call(
+        agent, "terminal", json.dumps({"exit_code": 127, "stderr": "command not found; no such file or directory"}), "c-multi"
+    )
+    content = messages[0]["content"]
+    assert "Failure diagnosis" in content
+    assert "1)" in content
+
+
+def test_diagnosis_reflect_mode_single_hypothesis():
+    agent = _make_agent("web_search", config={"failure_diagnosis": {"mode": "reflect"}})
+    assert agent._failure_diagnosis_mode == "reflect"
+    messages = _run_failing_call(agent, "web_search", json.dumps({"error": "429 rate limit"}), "c-reflect")
+    content = messages[0]["content"]
+    assert "Failure diagnosis" in content
+    assert "2)" not in content
+
+
+def test_diagnosis_inert_on_success():
+    agent = _make_agent("web_search", config={"failure_diagnosis": {"mode": "multi-hypothesis"}})
+    tc = _mock_tool_call("web_search", "{}", "c-ok")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": ["ok"]})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    assert "Failure diagnosis" not in messages[0]["content"]
+
+
+def test_invalid_mode_falls_back_to_off():
+    agent = _make_agent("web_search", config={"failure_diagnosis": {"mode": "garbage"}})
+    assert agent._failure_diagnosis_mode == "off"

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -386,3 +386,20 @@ def classify_tool_failure(
 
     text = "\n".join(part for part in (error, stdout, stderr) if part)
     return _classify_text(text, tool_type)
+
+
+def matched_categories(text: str) -> list[ToolFailureCategory]:
+    """Return every category whose pattern matches ``text``, in rule order (deduped).
+
+    Unlike :func:`classify_tool_failure` (first match wins → one category), this
+    surfaces ALL plausible categories so a multi-hypothesis diagnosis (#1029) can
+    rank them. Custom rules are checked before the built-ins, matching the
+    resolution order of ``_classify_text``.
+    """
+    seen: list[ToolFailureCategory] = []
+    if not text:
+        return seen
+    for rule in (*_CUSTOM_RULES, *_BUILTIN_RULES):
+        if rule.category not in seen and rule.pattern.search(text):
+            seen.append(rule.category)
+    return seen


### PR DESCRIPTION
Closes #1029. Closes #1030. Second and third slices of SAGE-style Multi-Hypothesis Failure Attribution (epic #994).

## #1029 — integrate multi-hypothesis diagnosis into the tool-failure handler
- **`tools/tool_failure_classifier.matched_categories()`** — public helper that surfaces ALL plausible categories (vs. first-match-wins), reusing the real rule table.
- **`agent/failure_diagnosis.py`** — `diagnose_failure()` builds a ranked, deduplicated hypothesis list (primary classification first) with rank-derived confidence.
- **`run_agent._append_guardrail_observation`** — config-gated seam appends the ranked hypotheses to a *failed* result.

## #1030 — hypothesis history + config gate
- **`HypothesisHistory`** — per-session record of surfaced hypotheses; a repeated failure demotes already-tried categories so a fresh hypothesis rises to the top (avoids re-trying failed hypotheses).
- **`failure_diagnosis.mode`** gate formalized: `off | reflect | multi-hypothesis` (documented in `cli-config.yaml.example`); history armed only when mode != off.

## Safety / no-regression
- **OFF by default** (`failure_diagnosis.mode: off`). When off the seam leaves failed results byte-for-byte unchanged. Builds on the recovery dispatcher's classifier (#1027) — one vocabulary, no duplication.
- Not dead code: **executable-seam runtime tests** drive the real `AIAgent` tool path (off / reflect / multi-hypothesis).

## Tests
- `tests/agent/test_failure_diagnosis.py` — matched_categories, ranking, dedup, mode coercion, history demotion + key isolation, serialization.
- `tests/run_agent/test_failure_diagnosis_runtime.py` — executable-seam tests.
- Classifier / guardrail / recovery regression suites still green.