### PR TITLE
feat(agent): recheck suppression + calibration logging (#1041)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1370,11 +1370,19 @@ def init_agent(
         _policy_registry = build_registry_from_config(
             _agent_cfg.get("policy_interceptors", {})
         )
+        # #1041 — recheck-suppression controller (off by default). Passed to the
+        # guardrail so before_call can suppress a single redundant read-only
+        # recheck when ``recheck_suppression.enabled`` is set.
+        from agent.recheck_suppression import RecheckController
+        _recheck_controller = RecheckController.from_mapping(
+            _agent_cfg.get("recheck_suppression", {})
+        )
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
                 _agent_cfg.get("tool_loop_guardrails", {})
             ),
             policy_registry=_policy_registry,
+            recheck_controller=_recheck_controller,
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)

--- a/agent/recheck_suppression.py
+++ b/agent/recheck_suppression.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""Redundant self-verification recheck suppression (issue #1041, child of #1020).
+
+Second slice of recheck suppression. The first slice
+(``evolution/lib/recheck_classifier.py``) provided a standalone classifier; this
+is the **production, importable** controller that actually *suppresses*
+high-confidence redundant rechecks at the tool-call guardrail and logs every
+decision for calibration.
+
+A "recheck" here is a redundant self-verification: re-issuing an idempotent
+read-only call (``read_file``, ``search_files``, …) that just succeeded, with no
+intervening action that could have changed the answer. Suppressing it saves
+tokens without losing information. The controller is deliberately conservative —
+it only suppresses an **immediate identical repeat** of a successful idempotent
+call, so it can never drop a verification that a real intervening change made
+meaningful.
+
+Design goals (matching ``agent/tool_guardrails.py``):
+
+* Pure logic + frozen dataclasses; **no side effects on import**.
+* Standard library only; full type hints; ``from __future__ import annotations``.
+* Config built from a mapping (``from_mapping``) like ``ToolCallGuardrailConfig``.
+* Every decision is logged to a bounded in-memory :class:`CalibrationLog`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Deque, Mapping
+
+__all__ = [
+    "RecheckVerdict",
+    "RecheckResult",
+    "RecheckSuppressionConfig",
+    "CalibrationLog",
+    "RecheckClassifier",
+    "RecheckController",
+]
+
+
+class RecheckVerdict(str, Enum):
+    """Classification of a proposed verification call."""
+
+    rethink = "rethink"  # legitimate — keep it
+    recheck = "recheck"  # redundant — suppression candidate
+    uncertain = "uncertain"  # not enough information to decide
+
+
+@dataclass(frozen=True)
+class RecheckResult:
+    """Outcome of classifying one proposed call."""
+
+    verdict: RecheckVerdict
+    confidence: float
+    reason: str = ""
+    tool_name: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "tool_name": self.tool_name,
+        }
+
+
+@dataclass(frozen=True)
+class RecheckSuppressionConfig:
+    """Config for recheck suppression (``recheck_suppression`` config section)."""
+
+    enabled: bool = False
+    min_confidence: float = 0.85
+    log_capacity: int = 200
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "RecheckSuppressionConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        enabled = data.get("enabled", defaults.enabled)
+        try:
+            min_conf = float(data.get("min_confidence", defaults.min_confidence))
+        except (TypeError, ValueError):
+            min_conf = defaults.min_confidence
+        min_conf = min(1.0, max(0.0, min_conf))
+        try:
+            cap = int(data.get("log_capacity", defaults.log_capacity))
+        except (TypeError, ValueError):
+            cap = defaults.log_capacity
+        return cls(enabled=bool(enabled), min_confidence=min_conf, log_capacity=max(1, cap))
+
+
+@dataclass
+class CalibrationLog:
+    """Bounded in-memory record of suppression decisions for calibration."""
+
+    capacity: int = 200
+    _entries: Deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=200))
+
+    def __post_init__(self) -> None:
+        # Rebuild the deque with the requested capacity.
+        self._entries = deque(self._entries, maxlen=max(1, self.capacity))
+
+    def record(self, result: RecheckResult, *, suppressed: bool) -> None:
+        entry = result.to_dict()
+        entry["suppressed"] = suppressed
+        self._entries.append(entry)
+
+    def entries(self) -> list[dict[str, Any]]:
+        return list(self._entries)
+
+    @property
+    def suppressed_count(self) -> int:
+        return sum(1 for e in self._entries if e.get("suppressed"))
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+# Confidence assigned to an immediate identical repeat of a successful idempotent
+# call — the only pattern this conservative slice treats as a redundant recheck.
+_IMMEDIATE_REPEAT_CONFIDENCE = 0.9
+
+
+class RecheckClassifier:
+    """Heuristic recheck classifier.
+
+    Conservative by construction: only an *immediate identical repeat* of a
+    successful idempotent call is a ``recheck``; everything else is ``rethink``.
+    """
+
+    def classify(
+        self,
+        tool_name: str,
+        *,
+        is_idempotent: bool,
+        is_immediate_repeat: bool,
+        prior_succeeded: bool,
+    ) -> RecheckResult:
+        if not is_idempotent:
+            return RecheckResult(
+                RecheckVerdict.rethink,
+                0.0,
+                "mutating tool — never suppressed",
+                tool_name,
+            )
+        if is_immediate_repeat and prior_succeeded:
+            return RecheckResult(
+                RecheckVerdict.recheck,
+                _IMMEDIATE_REPEAT_CONFIDENCE,
+                "immediate identical repeat of a successful read-only call",
+                tool_name,
+            )
+        return RecheckResult(
+            RecheckVerdict.rethink,
+            0.0,
+            "not an immediate redundant repeat",
+            tool_name,
+        )
+
+
+class RecheckController:
+    """Owns the classifier, suppression policy, and calibration log."""
+
+    def __init__(
+        self,
+        config: RecheckSuppressionConfig | None = None,
+        classifier: RecheckClassifier | None = None,
+        calibration_log: CalibrationLog | None = None,
+    ) -> None:
+        self.config = config or RecheckSuppressionConfig()
+        self.classifier = classifier or RecheckClassifier()
+        self.calibration_log = calibration_log or CalibrationLog(self.config.log_capacity)
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled
+
+    def decide(
+        self,
+        tool_name: str,
+        *,
+        is_idempotent: bool,
+        is_immediate_repeat: bool,
+        prior_succeeded: bool,
+    ) -> tuple[bool, RecheckResult]:
+        """Classify a proposed call and decide whether to suppress it.
+
+        Always logs the decision to the calibration log. Returns
+        ``(suppress, result)``.
+        """
+        result = self.classifier.classify(
+            tool_name,
+            is_idempotent=is_idempotent,
+            is_immediate_repeat=is_immediate_repeat,
+            prior_succeeded=prior_succeeded,
+        )
+        suppress = (
+            result.verdict is RecheckVerdict.recheck
+            and result.confidence >= self.config.min_confidence
+        )
+        self.calibration_log.record(result, suppressed=suppress)
+        return suppress, result
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "RecheckController":
+        config = RecheckSuppressionConfig.from_mapping(data)
+        return cls(config=config)

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -18,6 +18,7 @@ from agent.tool_result_classification import file_mutation_result_landed
 
 if TYPE_CHECKING:  # avoid a circular import; policy_interceptors imports this module
     from agent.policy_interceptors import PolicyInterceptorRegistry
+    from agent.recheck_suppression import RecheckController
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -297,9 +298,14 @@ class ToolCallGuardrailController:
         self,
         config: ToolCallGuardrailConfig | None = None,
         policy_registry: "PolicyInterceptorRegistry | None" = None,
+        recheck_controller: "RecheckController | None" = None,
     ):
         self.config = config or ToolCallGuardrailConfig()
         self.policy_registry = policy_registry
+        # #1041 — optional recheck-suppression controller. When present and
+        # enabled it can suppress a single redundant read-only recheck in
+        # ``before_call``; None (the default) is a full no-op.
+        self.recheck_controller = recheck_controller
         # Cross-turn failure streaks — NOT reset by reset_for_turn so that
         # one-failing-call-per-turn spirals (the common pattern: the model
         # calls the same failing tool once per API turn) accumulate across
@@ -313,6 +319,9 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
+        # #1041 — last executed call, for immediate-recheck detection.
+        self._last_signature: ToolCallSignature | None = None
+        self._last_call_succeeded: bool = False
         if self.policy_registry is not None:
             self.policy_registry.reset_for_turn()
 
@@ -376,6 +385,43 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
+        # #1041 — recheck suppression. Config-gated via ``recheck_controller``
+        # (None/disabled by default -> skipped). Suppresses a single immediate
+        # identical repeat of a successful read-only call as a redundant
+        # self-verification, returning a non-halting ``suppress`` decision
+        # (allows_execution False, should_halt False) so the one call is skipped
+        # but the turn continues. Every idempotent-call decision is logged for
+        # calibration.
+        if (
+            self.recheck_controller is not None
+            and self.recheck_controller.enabled
+            and self._is_idempotent(tool_name)
+        ):
+            is_immediate_repeat = (
+                self._last_signature is not None
+                and signature == self._last_signature
+                and self._last_call_succeeded
+            )
+            suppress, _result = self.recheck_controller.decide(
+                tool_name,
+                is_idempotent=True,
+                is_immediate_repeat=is_immediate_repeat,
+                prior_succeeded=self._last_call_succeeded,
+            )
+            if suppress:
+                return ToolGuardrailDecision(
+                    action="suppress",
+                    code="recheck_suppressed",
+                    message=(
+                        f"Suppressed {tool_name}: this read-only call is an immediate "
+                        "repeat of one that just succeeded with identical arguments. "
+                        "Reuse the previous result instead of re-verifying it."
+                    ),
+                    tool_name=tool_name,
+                    count=0,
+                    signature=signature,
+                )
+
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -430,6 +476,11 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        # #1041 — record the last executed call so the next before_call can
+        # detect an immediate identical recheck of a successful read-only call.
+        self._last_signature = signature
+        self._last_call_succeeded = not failed
 
         # Feed the per-turn observation ledger so ordering-aware policy
         # interceptors (e.g. read-before-write) can see prior calls.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -425,6 +425,19 @@ failure_diagnosis:
   mode: off
 
 # =============================================================================
+# Recheck Suppression (#1041 — suppress redundant self-verification)
+# =============================================================================
+# When a read-only call (read_file, search_files, …) is issued again immediately
+# after it just succeeded with identical arguments — a redundant self-check with
+# nothing changed in between — suppress the repeat and reuse the prior result,
+# saving tokens. Conservative: only immediate identical repeats of successful
+# idempotent calls are suppressed; mutating tools are never touched. Every
+# decision is logged in-memory for calibration. OFF by default.
+recheck_suppression:
+  enabled: false
+  min_confidence: 0.85
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/tests/agent/test_recheck_suppression.py
+++ b/tests/agent/test_recheck_suppression.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for recheck suppression (#1041)."""
+
+from __future__ import annotations
+
+from agent.recheck_suppression import (
+    CalibrationLog,
+    RecheckClassifier,
+    RecheckController,
+    RecheckResult,
+    RecheckSuppressionConfig,
+    RecheckVerdict,
+)
+
+
+# --- config -------------------------------------------------------------------
+
+
+def test_config_defaults_off():
+    cfg = RecheckSuppressionConfig()
+    assert cfg.enabled is False
+    assert 0.0 <= cfg.min_confidence <= 1.0
+
+
+def test_config_from_mapping():
+    cfg = RecheckSuppressionConfig.from_mapping(
+        {"enabled": True, "min_confidence": 0.7, "log_capacity": 10}
+    )
+    assert cfg.enabled is True
+    assert cfg.min_confidence == 0.7
+    assert cfg.log_capacity == 10
+
+
+def test_config_from_mapping_clamps_and_defaults():
+    assert RecheckSuppressionConfig.from_mapping(None).enabled is False
+    cfg = RecheckSuppressionConfig.from_mapping({"min_confidence": 5, "log_capacity": -3})
+    assert cfg.min_confidence == 1.0
+    assert cfg.log_capacity == 1
+
+
+# --- classifier ---------------------------------------------------------------
+
+
+def test_mutating_tool_never_recheck():
+    r = RecheckClassifier().classify(
+        "write_file", is_idempotent=False, is_immediate_repeat=True, prior_succeeded=True
+    )
+    assert r.verdict is RecheckVerdict.rethink
+    assert r.confidence == 0.0
+
+
+def test_immediate_repeat_of_successful_idempotent_is_recheck():
+    r = RecheckClassifier().classify(
+        "read_file", is_idempotent=True, is_immediate_repeat=True, prior_succeeded=True
+    )
+    assert r.verdict is RecheckVerdict.recheck
+    assert r.confidence >= 0.85
+
+
+def test_non_immediate_repeat_is_rethink():
+    r = RecheckClassifier().classify(
+        "read_file", is_idempotent=True, is_immediate_repeat=False, prior_succeeded=True
+    )
+    assert r.verdict is RecheckVerdict.rethink
+
+
+def test_immediate_repeat_of_failed_call_is_not_suppressed():
+    r = RecheckClassifier().classify(
+        "read_file", is_idempotent=True, is_immediate_repeat=True, prior_succeeded=False
+    )
+    assert r.verdict is RecheckVerdict.rethink
+
+
+# --- controller + calibration log ---------------------------------------------
+
+
+def test_controller_disabled_by_default():
+    assert RecheckController().enabled is False
+
+
+def test_controller_suppresses_high_confidence_recheck_and_logs():
+    ctrl = RecheckController(RecheckSuppressionConfig(enabled=True, min_confidence=0.85))
+    suppress, result = ctrl.decide(
+        "read_file", is_idempotent=True, is_immediate_repeat=True, prior_succeeded=True
+    )
+    assert suppress is True
+    assert result.verdict is RecheckVerdict.recheck
+    assert len(ctrl.calibration_log) == 1
+    assert ctrl.calibration_log.suppressed_count == 1
+    assert ctrl.calibration_log.entries()[0]["suppressed"] is True
+
+
+def test_controller_does_not_suppress_below_min_confidence():
+    ctrl = RecheckController(RecheckSuppressionConfig(enabled=True, min_confidence=0.95))
+    # immediate repeat confidence is 0.9 < 0.95 -> not suppressed, but still logged
+    suppress, result = ctrl.decide(
+        "read_file", is_idempotent=True, is_immediate_repeat=True, prior_succeeded=True
+    )
+    assert suppress is False
+    assert len(ctrl.calibration_log) == 1
+    assert ctrl.calibration_log.suppressed_count == 0
+
+
+def test_controller_logs_rethink_decisions_too():
+    ctrl = RecheckController(RecheckSuppressionConfig(enabled=True))
+    ctrl.decide("read_file", is_idempotent=True, is_immediate_repeat=False, prior_succeeded=True)
+    assert len(ctrl.calibration_log) == 1
+    assert ctrl.calibration_log.suppressed_count == 0
+
+
+def test_calibration_log_is_bounded():
+    log = CalibrationLog(capacity=3)
+    for _ in range(10):
+        log.record(RecheckResult(RecheckVerdict.recheck, 0.9), suppressed=True)
+    assert len(log) == 3
+
+
+def test_from_mapping_builds_controller():
+    ctrl = RecheckController.from_mapping({"enabled": True, "min_confidence": 0.8})
+    assert ctrl.enabled is True
+    assert ctrl.config.min_confidence == 0.8

--- a/tests/run_agent/test_recheck_suppression_runtime.py
+++ b/tests/run_agent/test_recheck_suppression_runtime.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam runtime tests for #1041 recheck suppression.
+
+Drive the real ``AIAgent`` tool path so an immediate identical repeat of a
+successful read-only call is suppressed at the guardrail ``before_call`` seam —
+without executing the tool again and without halting the turn — and only when
+``recheck_suppression.enabled`` is set.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_agent(*tool_names: str, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _two_identical_reads(agent):
+    args = json.dumps({"path": "agent/plan_schema.py"})
+    calls = [
+        _mock_tool_call("read_file", args, "c-1"),
+        _mock_tool_call("read_file", args, "c-2"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages: list = []
+    executed = []
+
+    def fake_handle(name, a, task_id, **kwargs):
+        executed.append(kwargs.get("tool_call_id"))
+        return json.dumps({"content": "file body"})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    return messages, executed
+
+
+def test_recheck_suppression_defaults_off_executes_both():
+    agent = _make_agent("read_file")  # no recheck config
+    assert agent._tool_guardrails.recheck_controller is not None
+    assert agent._tool_guardrails.recheck_controller.enabled is False
+    messages, executed = _two_identical_reads(agent)
+    # both calls execute; no suppression
+    assert executed == ["c-1", "c-2"]
+    assert all("recheck_suppressed" not in m["content"] for m in messages)
+
+
+def test_recheck_suppression_enabled_suppresses_immediate_repeat():
+    agent = _make_agent("read_file", config={"recheck_suppression": {"enabled": True}})
+    assert agent._tool_guardrails.recheck_controller.enabled is True
+    messages, executed = _two_identical_reads(agent)
+    # only the first executes; the immediate repeat is suppressed
+    assert executed == ["c-1"]
+    contents = {m["tool_call_id"]: m["content"] for m in messages}
+    assert "recheck_suppressed" in contents["c-2"]
+    assert "recheck_suppressed" not in contents["c-1"]
+    # the turn is NOT halted by a suppression
+    assert agent._tool_guardrail_halt_decision is None
+    # calibration log recorded the suppression
+    log = agent._tool_guardrails.recheck_controller.calibration_log
+    assert log.suppressed_count == 1
+
+
+def test_recheck_suppression_does_not_touch_mutating_tools():
+    agent = _make_agent("write_file", config={"recheck_suppression": {"enabled": True}})
+    args = json.dumps({"path": "x.txt", "content": "a"})
+    calls = [
+        _mock_tool_call("write_file", args, "w-1"),
+        _mock_tool_call("write_file", args, "w-2"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages: list = []
+    executed = []
+
+    def fake_handle(name, a, task_id, **kwargs):
+        executed.append(kwargs.get("tool_call_id"))
+        return json.dumps({"success": True})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    # mutating tool: both execute, never suppressed
+    assert executed == ["w-1", "w-2"]


### PR DESCRIPTION
Closes #1041. Second slice of redundant self-verification recheck suppression (epic #1020).

## What
Suppresses a single high-confidence redundant recheck at the tool-call guardrail and logs every decision for calibration.

## How
- **`agent/recheck_suppression.py`** — `RecheckClassifier` (conservative: only an *immediate identical repeat* of a **successful** idempotent call is a recheck), a min-confidence suppression policy, and a bounded in-memory `CalibrationLog` recording every decision.
- **`agent/tool_guardrails.py`** — `before_call` returns a non-halting **`suppress`** decision (`allows_execution` False, `should_halt` False) for a high-confidence recheck, reusing the existing block/synthetic-result plumbing: the one call is skipped, the turn continues. Tracks the last executed call for immediate-repeat detection; mutating tools are never touched.
- **`agent_init`** — builds the controller from the `recheck_suppression` config (off by default) and passes it to the guardrail.

## Safety / no-regression
- **OFF by default** (`recheck_suppression.enabled: false`, documented in `cli-config.yaml.example`). When off the controller is present but `enabled` is False → `before_call` skips the check entirely. Conservative: never suppresses mutating tools or non-immediate repeats.
- Not dead code: **executable-seam runtime tests** drive the real `AIAgent` tool path (default-off executes both / enabled suppresses the repeat / mutating never suppressed).

## Tests
- `tests/agent/test_recheck_suppression.py` — classifier, policy, bounded calibration log, config.
- `tests/run_agent/test_recheck_suppression_runtime.py` — executable-seam tests.
- Guardrail unit + runtime regression suites still green.