### PR TITLE
feat(agent): compositional skill routing — SAD + listwise reranking (#1137)

### DIFF
--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""Compositional skill routing: SAD re-decomposition + listwise reranking (#1137).
+
+Adopts the two empirically-validated mechanisms from Compositional Skill Routing
+(arXiv:2606.18051) without the unvalidated DAG compose stage:
+
+* **Skill-Aware Decomposition (SAD)** — :func:`sad_redecompose` feeds the
+  candidate skill/tool names + descriptions returned by the first retrieval pass
+  back into a re-decomposition step, anchoring sub-task generation on the real
+  vocabulary. LLM-driven (injectable ``llm_call``) so it is testable without a
+  live model.
+* **Listwise reranking** — :func:`listwise_rerank` reorders the top-k
+  ``tool_search`` candidates by a listwise relevance signal and returns them
+  best-first. The scorer is pluggable: the deterministic default rewards
+  name-token coverage + query/description overlap (a signal BM25's per-term
+  scoring does not directly capture); an LLM scorer can be injected in
+  production.
+
+Both mechanisms are **config-gated and off by default** (:func:`load_skill_routing_config`).
+The runtime seam :func:`maybe_rerank_hits` returns the hits unchanged unless
+listwise reranking is enabled, so ``tool_search`` behaves identically by default.
+
+Design goals: pure functions + frozen dataclasses; no import-time side effects;
+standard library only; duck-typed candidates (anything with ``.name`` and
+``.description``) so this module never imports ``tools.tool_search`` (avoids an
+import cycle).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+__all__ = [
+    "SkillRoutingConfig",
+    "load_skill_routing_config",
+    "listwise_rerank",
+    "sad_redecompose",
+    "maybe_rerank_hits",
+    "lexical_listwise_score",
+]
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class SkillRoutingConfig:
+    """Config for the ``skill_routing`` section (both levers off by default)."""
+
+    sad_enabled: bool = False
+    listwise_rerank_enabled: bool = False
+    rerank_top_k: int = 10
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "SkillRoutingConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        try:
+            top_k = int(data.get("rerank_top_k", defaults.rerank_top_k))
+        except (TypeError, ValueError):
+            top_k = defaults.rerank_top_k
+        return cls(
+            sad_enabled=bool(data.get("sad", data.get("sad_enabled", defaults.sad_enabled))),
+            listwise_rerank_enabled=bool(
+                data.get("listwise_rerank", data.get("listwise_rerank_enabled", defaults.listwise_rerank_enabled))
+            ),
+            rerank_top_k=max(1, top_k),
+        )
+
+
+def load_skill_routing_config() -> SkillRoutingConfig:
+    """Lazily load the ``skill_routing`` config section (safe default: all off)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        if isinstance(cfg, Mapping):
+            return SkillRoutingConfig.from_mapping(cfg.get("skill_routing", {}))
+    except Exception:
+        pass
+    return SkillRoutingConfig()
+
+
+def _tokens(text: str) -> list[str]:
+    return _WORD_RE.findall((text or "").lower())
+
+
+def _candidate_text(candidate: Any) -> tuple[str, str]:
+    """Return ``(name, description)`` for a duck-typed candidate."""
+    if isinstance(candidate, Mapping):
+        return str(candidate.get("name", "")), str(candidate.get("description", ""))
+    return str(getattr(candidate, "name", "")), str(getattr(candidate, "description", ""))
+
+
+def lexical_listwise_score(query: str, candidate: Any) -> float:
+    """Deterministic listwise relevance score for one candidate.
+
+    Combines two signals BM25 does not directly reward:
+    * **name coverage** — fraction of the candidate's name tokens present in the
+      query (rewards precise, on-topic tool names);
+    * **query overlap** — fraction of query tokens present in name+description.
+    An exact name-in-query hit gets a fixed boost. Range ~[0, 2].
+    """
+    q = set(_tokens(query))
+    if not q:
+        return 0.0
+    name, desc = _candidate_text(candidate)
+    name_tokens = set(_tokens(name))
+    doc_tokens = name_tokens | set(_tokens(desc))
+    name_coverage = (len(name_tokens & q) / len(name_tokens)) if name_tokens else 0.0
+    query_overlap = len(q & doc_tokens) / len(q)
+    boost = 0.5 if name and name.lower() in query.lower() else 0.0
+    return name_coverage + query_overlap + boost
+
+
+def listwise_rerank(
+    query: str,
+    candidates: Sequence[Any],
+    *,
+    scorer: Callable[[str, Any], float] | None = None,
+    top_k: int | None = None,
+) -> list[Any]:
+    """Return ``candidates`` reordered best-first by a listwise relevance score.
+
+    ``scorer`` defaults to :func:`lexical_listwise_score`; inject an LLM-backed
+    scorer in production. The sort is **stable**, so candidates with equal scores
+    keep their incoming (retrieval) order — a strict reordering, never a drop.
+    Only the first ``top_k`` candidates are considered when given; the remainder
+    are appended unchanged after the reranked head.
+    """
+    if not candidates:
+        return []
+    score = scorer or lexical_listwise_score
+    head = list(candidates) if top_k is None else list(candidates[:top_k])
+    tail = [] if top_k is None else list(candidates[top_k:])
+    indexed = list(enumerate(head))
+    indexed.sort(key=lambda pair: (-score(query, pair[1]), pair[0]))
+    return [c for _, c in indexed] + tail
+
+
+def sad_redecompose(
+    request: str,
+    candidate_hints: Sequence[Any],
+    llm_call: Callable[[str], str],
+    *,
+    max_subtasks: int = 8,
+) -> list[str]:
+    """Skill-Aware Decomposition: re-decompose ``request`` anchored on candidates.
+
+    Feeds the retrieved candidate names + descriptions to ``llm_call`` as
+    vocabulary hints and parses the returned newline/JSON list of atomic
+    sub-tasks. ``llm_call`` is injected (a stub in tests, the agent's model in
+    production). Never raises — a bad/empty model reply yields ``[]``.
+    """
+    hints_lines = []
+    for c in candidate_hints:
+        name, desc = _candidate_text(c)
+        if name:
+            hints_lines.append(f"- {name}: {desc}".rstrip())
+    hints = "\n".join(hints_lines) if hints_lines else "(no candidates)"
+    prompt = (
+        "Decompose the request into atomic sub-tasks, each mapped to ONE of the "
+        "candidate skills/tools below. Use the candidate names as anchors. Return "
+        "one sub-task per line as `sub-task -> candidate_name`.\n\n"
+        f"Request: {request}\n\nCandidates:\n{hints}\n"
+    )
+    try:
+        reply = llm_call(prompt) or ""
+    except Exception:
+        return []
+    subtasks: list[str] = []
+    for line in reply.splitlines():
+        line = line.strip().lstrip("-*0123456789. ").strip()
+        if line:
+            subtasks.append(line)
+        if len(subtasks) >= max_subtasks:
+            break
+    return subtasks
+
+
+def maybe_rerank_hits(
+    query: str,
+    hits: Sequence[Any],
+    config: SkillRoutingConfig | None = None,
+    *,
+    scorer: Callable[[str, Any], float] | None = None,
+) -> list[Any]:
+    """Runtime seam: listwise-rerank ``hits`` iff listwise reranking is enabled.
+
+    Returns ``list(hits)`` unchanged (same order) when disabled, so the default
+    ``tool_search`` behavior is preserved. Never raises — any error degrades to
+    the original order.
+    """
+    cfg = config or load_skill_routing_config()
+    hits_list = list(hits)
+    if not cfg.listwise_rerank_enabled or not hits_list:
+        return hits_list
+    try:
+        return listwise_rerank(query, hits_list, scorer=scorer, top_k=cfg.rerank_top_k)
+    except Exception:
+        return hits_list

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -438,6 +438,22 @@ recheck_suppression:
   min_confidence: 0.85
 
 # =============================================================================
+# Compositional Skill Routing (#1137 — SAD + listwise reranking)
+# =============================================================================
+# Two composable levers over the on-demand tool_search retrieval path:
+#   listwise_rerank — reorder the BM25 top-k candidates by a listwise relevance
+#                     signal (name-token coverage + query overlap) before
+#                     returning them; a strict reordering, never a drop.
+#   sad             — Skill-Aware Decomposition: re-decompose the request using
+#                     the returned candidate names/descriptions as anchors
+#                     (LLM-driven; see agent.skill_routing.sad_redecompose).
+# Both OFF by default -> tool_search behaves identically (BM25 order preserved).
+skill_routing:
+  listwise_rerank: false
+  sad: false
+  rerank_top_k: 10
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/tests/agent/test_skill_routing.py
+++ b/tests/agent/test_skill_routing.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for compositional skill routing (#1137)."""
+
+from __future__ import annotations
+
+from agent.skill_routing import (
+    SkillRoutingConfig,
+    lexical_listwise_score,
+    listwise_rerank,
+    maybe_rerank_hits,
+    sad_redecompose,
+)
+
+
+class _Cand:
+    def __init__(self, name, description=""):
+        self.name = name
+        self.description = description
+
+    def __repr__(self):
+        return f"_Cand({self.name})"
+
+
+# --- config -------------------------------------------------------------------
+
+
+def test_config_defaults_off():
+    cfg = SkillRoutingConfig()
+    assert cfg.sad_enabled is False
+    assert cfg.listwise_rerank_enabled is False
+
+
+def test_config_from_mapping_accepts_both_key_spellings():
+    cfg = SkillRoutingConfig.from_mapping({"sad": True, "listwise_rerank": True, "rerank_top_k": 3})
+    assert cfg.sad_enabled is True
+    assert cfg.listwise_rerank_enabled is True
+    assert cfg.rerank_top_k == 3
+    cfg2 = SkillRoutingConfig.from_mapping({"sad_enabled": True})
+    assert cfg2.sad_enabled is True
+
+
+def test_config_from_mapping_none():
+    assert SkillRoutingConfig.from_mapping(None).listwise_rerank_enabled is False
+
+
+# --- scorer -------------------------------------------------------------------
+
+
+def test_score_rewards_name_match():
+    q = "read a file from disk"
+    high = lexical_listwise_score(q, _Cand("read_file", "read a file"))
+    low = lexical_listwise_score(q, _Cand("send_email", "send an email message"))
+    assert high > low
+
+
+def test_score_zero_for_empty_query():
+    assert lexical_listwise_score("", _Cand("read_file")) == 0.0
+
+
+# --- listwise rerank ----------------------------------------------------------
+
+
+def test_rerank_promotes_best_match():
+    cands = [
+        _Cand("send_email", "send an email"),
+        _Cand("read_file", "read a file from disk"),
+        _Cand("list_dir", "list a directory"),
+    ]
+    ranked = listwise_rerank("read a file", cands)
+    assert ranked[0].name == "read_file"
+    # strict reordering: same set of candidates
+    assert {c.name for c in ranked} == {c.name for c in cands}
+
+
+def test_rerank_is_stable_for_equal_scores():
+    # two candidates with no query overlap -> equal (zero) score -> keep order
+    cands = [_Cand("alpha", "xxx"), _Cand("beta", "yyy")]
+    ranked = listwise_rerank("zzz", cands)
+    assert [c.name for c in ranked] == ["alpha", "beta"]
+
+
+def test_rerank_top_k_leaves_tail_untouched():
+    cands = [_Cand(f"t{i}", "") for i in range(5)]
+    # put a strong match at the tail; with top_k=2 it must NOT be promoted
+    cands.append(_Cand("read_file", "read a file"))
+    ranked = listwise_rerank("read a file", cands, top_k=2)
+    assert ranked[-1].name == "read_file"
+
+
+def test_rerank_empty():
+    assert listwise_rerank("q", []) == []
+
+
+def test_rerank_accepts_mapping_candidates():
+    cands = [{"name": "send_email", "description": "email"}, {"name": "read_file", "description": "read a file"}]
+    ranked = listwise_rerank("read a file", cands)
+    assert ranked[0]["name"] == "read_file"
+
+
+# --- maybe_rerank_hits seam ---------------------------------------------------
+
+
+def test_seam_disabled_preserves_order():
+    cands = [_Cand("send_email", "email"), _Cand("read_file", "read a file")]
+    cfg = SkillRoutingConfig(listwise_rerank_enabled=False)
+    out = maybe_rerank_hits("read a file", cands, cfg)
+    assert [c.name for c in out] == ["send_email", "read_file"]
+
+
+def test_seam_enabled_reranks():
+    cands = [_Cand("send_email", "email"), _Cand("read_file", "read a file")]
+    cfg = SkillRoutingConfig(listwise_rerank_enabled=True)
+    out = maybe_rerank_hits("read a file", cands, cfg)
+    assert out[0].name == "read_file"
+
+
+def test_seam_never_raises_on_bad_scorer():
+    cfg = SkillRoutingConfig(listwise_rerank_enabled=True)
+    def boom(q, c):
+        raise RuntimeError("nope")
+    out = maybe_rerank_hits("q", [_Cand("a"), _Cand("b")], cfg, scorer=boom)
+    assert [c.name for c in out] == ["a", "b"]  # degrades to original order
+
+
+# --- SAD ----------------------------------------------------------------------
+
+
+def test_sad_redecompose_uses_candidate_hints_and_parses_lines():
+    seen_prompts = []
+
+    def fake_llm(prompt):
+        seen_prompts.append(prompt)
+        return "read the config -> read_file\nsummarize it -> summarize\n"
+
+    subtasks = sad_redecompose("do the thing", [_Cand("read_file", "read a file")], fake_llm)
+    assert subtasks == ["read the config -> read_file", "summarize it -> summarize"]
+    # the candidate name was injected into the prompt as an anchor
+    assert "read_file" in seen_prompts[0]
+
+
+def test_sad_redecompose_respects_max_subtasks():
+    def fake_llm(prompt):
+        return "\n".join(f"task {i} -> t" for i in range(20))
+    subtasks = sad_redecompose("x", [], fake_llm, max_subtasks=3)
+    assert len(subtasks) == 3
+
+
+def test_sad_redecompose_handles_llm_error():
+    def boom(prompt):
+        raise RuntimeError("model down")
+    assert sad_redecompose("x", [], boom) == []

--- a/tests/tools/test_tool_search_skill_routing.py
+++ b/tests/tools/test_tool_search_skill_routing.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam integration tests for #1137 listwise reranking in tool_search.
+
+Drive the real ``dispatch_tool_search`` handler to prove the listwise reranker
+is wired into the retrieval path and inert unless ``skill_routing.listwise_rerank``
+is enabled.
+"""
+
+from unittest.mock import patch
+
+from tools.tool_search import CatalogEntry, ToolSearchConfig, dispatch_tool_search
+
+
+def _entry(name, description):
+    return CatalogEntry(
+        name=name,
+        description=description,
+        schema={"type": "function", "function": {"name": name, "description": description}},
+        source="mcp",
+        source_name="mcp-test",
+    )
+
+
+def _hits_bm25_suboptimal():
+    # BM25 returns the weak match first, the strong one second.
+    return [
+        _entry("send_email", "send an email message to a recipient"),
+        _entry("read_file", "read a file from disk"),
+    ]
+
+
+def test_tool_search_default_off_preserves_bm25_order():
+    cfg = ToolSearchConfig.from_raw(None)
+    with (
+        patch("tools.tool_search.search_catalog", return_value=_hits_bm25_suboptimal()),
+        patch("hermes_cli.config.load_config", return_value={}),
+    ):
+        out = dispatch_tool_search({"query": "read a file"}, current_tool_defs=[], config=cfg)
+    import json
+
+    matches = json.loads(out)["matches"]
+    assert [m["name"] for m in matches] == ["send_email", "read_file"]
+
+
+def test_tool_search_listwise_rerank_promotes_best_match():
+    cfg = ToolSearchConfig.from_raw(None)
+    with (
+        patch("tools.tool_search.search_catalog", return_value=_hits_bm25_suboptimal()),
+        patch("hermes_cli.config.load_config", return_value={"skill_routing": {"listwise_rerank": True}}),
+    ):
+        out = dispatch_tool_search({"query": "read a file"}, current_tool_defs=[], config=cfg)
+    import json
+
+    matches = json.loads(out)["matches"]
+    # reranked: the strong lexical match rises to the top
+    assert matches[0]["name"] == "read_file"
+    # strict reordering — same set of tools returned
+    assert {m["name"] for m in matches} == {"send_email", "read_file"}
+
+
+def test_tool_search_rerank_failure_degrades_gracefully():
+    cfg = ToolSearchConfig.from_raw(None)
+    with (
+        patch("tools.tool_search.search_catalog", return_value=_hits_bm25_suboptimal()),
+        patch("agent.skill_routing.maybe_rerank_hits", side_effect=RuntimeError("boom")),
+        patch("hermes_cli.config.load_config", return_value={"skill_routing": {"listwise_rerank": True}}),
+    ):
+        out = dispatch_tool_search({"query": "read a file"}, current_tool_defs=[], config=cfg)
+    import json
+
+    # the try/except in dispatch keeps the original hits on any rerank error
+    matches = json.loads(out)["matches"]
+    assert [m["name"] for m in matches] == ["send_email", "read_file"]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -785,6 +785,16 @@ def dispatch_tool_search(args: Dict[str, Any],
     _, deferrable = classify_tools(current_tool_defs, config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
+    # #1137 — compositional skill routing: optional listwise reranking over the
+    # BM25 top-k. Config-gated via ``skill_routing.listwise_rerank`` (off by
+    # default -> hits pass through in BM25 order). Imported lazily so tool_search
+    # has no hard dependency on the agent package at import time.
+    try:
+        from agent.skill_routing import maybe_rerank_hits
+
+        hits = maybe_rerank_hits(query, hits)
+    except Exception:
+        pass
     result: Dict[str, Any] = {
         "query": query,
         "total_available": len(catalog),


### PR DESCRIPTION
Closes #1137. Adopts the two empirically-validated mechanisms from Compositional Skill Routing (arXiv:2606.18051) — SAD + listwise reranking — without the unvalidated DAG compose stage.

## How
- **`agent/skill_routing.py`**
  - `listwise_rerank()` — reorders the top-k `tool_search` candidates by a listwise relevance signal (name-token coverage + query overlap that BM25's per-term scoring does not directly reward). Pluggable scorer (deterministic default; LLM scorer injectable in production). Stable, strict reorder — never drops a candidate.
  - `sad_redecompose()` — Skill-Aware Decomposition: re-decompose a request using the retrieved candidate names/descriptions as anchors (injectable `llm_call`, testable without a live model).
  - `SkillRoutingConfig` + lazy loader; both levers off by default.
- **`tools/tool_search.dispatch_tool_search`** — config-gated seam applies the listwise rerank to the BM25 top-k before returning; lazy import keeps `tool_search` free of an import-time agent dependency.

## Safety / no-regression
- **OFF by default** (`skill_routing.listwise_rerank` / `sad`, documented in `cli-config.yaml.example`). When off, `tool_search` returns the BM25 order unchanged. Errors degrade to the original order.
- Not dead code: **executable-seam integration tests** drive the real `dispatch_tool_search` (default-off preserves order / enabled promotes the best match / rerank error degrades gracefully).

## Tests
- `tests/agent/test_skill_routing.py` — scorer, stable rerank, top_k tail preservation, mapping candidates, SAD parsing + error handling, config.
- `tests/tools/test_tool_search_skill_routing.py` — executable-seam integration tests.
- `tests/tools/test_tool_search.py` regression suite still green.