### PR TITLE
feat(agent): task-decoupled planning — sub-goal DAG + scoped contexts (#1138)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -825,6 +825,27 @@ def _run_conversation_impl(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    # #1138 — task-decoupled planning pre-flight. Config-gated (off by default)
+    # and additionally scoped to long-horizon tasks by a trigger heuristic. When
+    # active it decomposes the task into a sub-goal DAG (with scoped contexts +
+    # confined replanning available to a delegating executor) and stores it on
+    # ``agent._subgoal_dag``; when off it is a pure no-op that never touches the
+    # turn. Never raises.
+    agent._subgoal_dag = None
+    try:
+        from agent.task_decoupling import (
+            decompose_task,
+            load_task_decoupling_config,
+            should_decouple,
+        )
+
+        _td_cfg = load_task_decoupling_config()
+        _td_task = user_message if isinstance(user_message, str) else str(user_message)
+        if should_decouple(_td_task, _td_cfg):
+            agent._subgoal_dag = decompose_task(_td_task)
+    except Exception:
+        agent._subgoal_dag = None
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None

--- a/agent/task_decoupling.py
+++ b/agent/task_decoupling.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""Task-decoupled planning: sub-goal DAG with scoped contexts (#1138).
+
+Implements Task-Decoupled Planning (TDP, arXiv:2601.07577): decompose a
+long-horizon task into a DAG of sub-goals with explicit dependencies, execute
+each with a **scoped context** containing only the information relevant to that
+sub-goal (its inputs + its dependency sub-goals' outputs), and **confine
+replanning** to the failed node so a local failure revises only that sub-goal —
+not the whole trajectory.
+
+This is distinct from uniform context compression: TDP *partitions* the context
+by sub-task instead of compressing the whole thing. The mechanism here layers on
+the existing ``delegate_task`` primitive — each sub-goal is a scoped subagent
+execution — so the core agent loop is unchanged; this module owns the DAG model,
+scoped-context assembly, and confined replanning.
+
+Config-gated and off by default; a trigger heuristic keeps short tasks on the
+linear loop. Pure functions + frozen dataclasses; no import-time side effects;
+standard library only.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+__all__ = [
+    "SubGoal",
+    "SubGoalDAG",
+    "TaskDecouplingConfig",
+    "decompose_task",
+    "scoped_context",
+    "confined_replan",
+    "should_decouple",
+    "load_task_decoupling_config",
+]
+
+
+@dataclass(frozen=True)
+class SubGoal:
+    """One node of a sub-goal DAG."""
+
+    id: str
+    description: str
+    dependencies: tuple[str, ...] = ()
+    inputs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "dependencies": list(self.dependencies),
+            "inputs": list(self.inputs),
+        }
+
+
+class SubGoalDAG:
+    """A validated directed acyclic graph of :class:`SubGoal` nodes."""
+
+    def __init__(self, subgoals: Sequence[SubGoal]) -> None:
+        self._nodes: dict[str, SubGoal] = {}
+        for sg in subgoals:
+            if sg.id in self._nodes:
+                raise ValueError(f"duplicate sub-goal id: {sg.id}")
+            self._nodes[sg.id] = sg
+        self._validate()
+
+    @property
+    def nodes(self) -> dict[str, SubGoal]:
+        return dict(self._nodes)
+
+    def get(self, goal_id: str) -> SubGoal:
+        return self._nodes[goal_id]
+
+    def _validate(self) -> None:
+        # Every dependency must reference an existing node.
+        for sg in self._nodes.values():
+            for dep in sg.dependencies:
+                if dep not in self._nodes:
+                    raise ValueError(f"sub-goal {sg.id!r} depends on unknown node {dep!r}")
+        # Acyclicity via a topological sort (raises on cycle).
+        self.topological_order()
+
+    def topological_order(self) -> list[str]:
+        """Return node ids in dependency order (raises ``ValueError`` on a cycle)."""
+        indeg = {nid: 0 for nid in self._nodes}
+        for sg in self._nodes.values():
+            for _dep in sg.dependencies:
+                indeg[sg.id] += 1
+        # Deterministic: process ready nodes in insertion order.
+        ready = [nid for nid in self._nodes if indeg[nid] == 0]
+        order: list[str] = []
+        while ready:
+            nid = ready.pop(0)
+            order.append(nid)
+            for other in self._nodes.values():
+                if nid in other.dependencies:
+                    indeg[other.id] -= 1
+                    if indeg[other.id] == 0:
+                        ready.append(other.id)
+        if len(order) != len(self._nodes):
+            raise ValueError("sub-goal DAG contains a cycle")
+        return order
+
+    def ancestors(self, goal_id: str) -> set[str]:
+        """Return all transitive dependency ids of ``goal_id``."""
+        seen: set[str] = set()
+        stack = list(self._nodes[goal_id].dependencies)
+        while stack:
+            nid = stack.pop()
+            if nid in seen:
+                continue
+            seen.add(nid)
+            stack.extend(self._nodes[nid].dependencies)
+        return seen
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodes": [self._nodes[nid].to_dict() for nid in self.topological_order()],
+        }
+
+
+@dataclass(frozen=True)
+class TaskDecouplingConfig:
+    """Config for the ``task_decoupling`` section (off by default)."""
+
+    enabled: bool = False
+    min_task_chars: int = 280  # trigger heuristic: only long tasks decouple
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "TaskDecouplingConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        try:
+            min_chars = int(data.get("min_task_chars", defaults.min_task_chars))
+        except (TypeError, ValueError):
+            min_chars = defaults.min_task_chars
+        return cls(
+            enabled=bool(data.get("enabled", defaults.enabled)),
+            min_task_chars=max(1, min_chars),
+        )
+
+
+def load_task_decoupling_config() -> TaskDecouplingConfig:
+    """Lazily load the ``task_decoupling`` config section (safe default: off).
+
+    Uses ``load_config_readonly`` (no defensive deepcopy) because this runs once
+    per turn in the conversation loop and only reads the config.
+    """
+    try:
+        try:
+            from hermes_cli.config import load_config_readonly as _load
+        except ImportError:
+            from hermes_cli.config import load_config as _load
+
+        cfg = _load()
+        if isinstance(cfg, Mapping):
+            return TaskDecouplingConfig.from_mapping(cfg.get("task_decoupling", {}))
+    except Exception:
+        pass
+    return TaskDecouplingConfig()
+
+
+def should_decouple(task: str, config: TaskDecouplingConfig | None = None) -> bool:
+    """Trigger heuristic: long tasks decouple, short ones stay on the linear loop."""
+    cfg = config or TaskDecouplingConfig()
+    if not cfg.enabled:
+        return False
+    return len(task or "") >= cfg.min_task_chars
+
+
+_STEP_SPLIT_RE = re.compile(r"(?:^|\n)\s*(?:\d+[.)]|[-*])\s+")
+
+
+def _heuristic_split(task: str) -> list[str]:
+    """Deterministic fallback decomposition: numbered/bulleted lines, else clauses."""
+    parts = [p.strip() for p in _STEP_SPLIT_RE.split(task) if p and p.strip()]
+    if len(parts) >= 2:
+        return parts
+    # Fall back to splitting on "; then " / " and then " / newlines.
+    parts = [p.strip() for p in re.split(r";|\bthen\b|\n", task) if p and p.strip()]
+    return parts if len(parts) >= 2 else [task.strip()]
+
+
+def decompose_task(
+    task: str,
+    *,
+    decomposer: Callable[[str], Sequence[SubGoal]] | None = None,
+    linear_dependencies: bool = True,
+) -> SubGoalDAG:
+    """Decompose ``task`` into a :class:`SubGoalDAG`.
+
+    ``decomposer`` (injectable — an LLM-backed splitter in production) takes the
+    task and returns explicit sub-goals with dependencies. When omitted, a
+    deterministic heuristic splits the task into ordered sub-goals; with
+    ``linear_dependencies`` each depends on the previous (a chain), which is the
+    safe default for an unknown structure.
+    """
+    if decomposer is not None:
+        return SubGoalDAG(list(decomposer(task)))
+    pieces = _heuristic_split(task)
+    subgoals: list[SubGoal] = []
+    for i, piece in enumerate(pieces):
+        deps = (f"g{i - 1}",) if (linear_dependencies and i > 0) else ()
+        subgoals.append(SubGoal(id=f"g{i}", description=piece, dependencies=deps))
+    return SubGoalDAG(subgoals)
+
+
+def scoped_context(
+    dag: SubGoalDAG,
+    goal_id: str,
+    *,
+    dependency_outputs: Mapping[str, Any] | None = None,
+    base_inputs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble the scoped context for ``goal_id``.
+
+    Includes ONLY: the sub-goal's own declared inputs, and the outputs of its
+    (transitive) dependency sub-goals. Outputs of unrelated sub-goals are
+    excluded — that partitioning is the whole point of TDP. Returns a plain dict
+    suitable for handing to a scoped subagent.
+    """
+    sg = dag.get(goal_id)
+    deps = dag.ancestors(goal_id)
+    outputs = dependency_outputs or {}
+    scoped_outputs = {nid: outputs[nid] for nid in deps if nid in outputs}
+    inputs = base_inputs or {}
+    scoped_inputs = {k: inputs[k] for k in sg.inputs if k in inputs}
+    return {
+        "goal_id": goal_id,
+        "goal": sg.description,
+        "inputs": scoped_inputs,
+        "dependency_outputs": scoped_outputs,
+    }
+
+
+def confined_replan(
+    dag: SubGoalDAG,
+    goal_id: str,
+    *,
+    revised_description: str | None = None,
+    replanner: Callable[[SubGoal], SubGoal] | None = None,
+) -> SubGoalDAG:
+    """Return a NEW DAG with only ``goal_id`` revised; all other nodes intact.
+
+    Either supply ``revised_description`` or a ``replanner`` that maps the failed
+    sub-goal to a revised one (keeping the same id + dependencies so the DAG
+    shape is preserved). Sibling and ancestor nodes are copied unchanged — a
+    local failure never mutates the rest of the trajectory.
+    """
+    old = dag.get(goal_id)
+    if replanner is not None:
+        revised = replanner(old)
+        if revised.id != old.id or set(revised.dependencies) != set(old.dependencies):
+            raise ValueError("confined replan must preserve the node id and dependencies")
+    else:
+        revised = SubGoal(
+            id=old.id,
+            description=revised_description if revised_description is not None else old.description,
+            dependencies=old.dependencies,
+            inputs=old.inputs,
+        )
+    new_nodes = [revised if nid == goal_id else dag.get(nid) for nid in dag.topological_order()]
+    return SubGoalDAG(new_nodes)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -454,6 +454,19 @@ skill_routing:
   rerank_top_k: 10
 
 # =============================================================================
+# Task-Decoupled Planning (#1138 — TDP sub-goal DAG with scoped contexts)
+# =============================================================================
+# For long-horizon tasks, decompose the task into a DAG of sub-goals with
+# explicit dependencies and execute each with a SCOPED context (its inputs +
+# its dependency sub-goals' outputs only) instead of one monotonically growing
+# context. A sub-goal failure triggers confined replanning (only that node is
+# revised). OFF by default; a trigger heuristic (min_task_chars) keeps short
+# tasks on the linear loop even when enabled.
+task_decoupling:
+  enabled: false
+  min_task_chars: 280
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/tests/agent/test_task_decoupling.py
+++ b/tests/agent/test_task_decoupling.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for task-decoupled planning (#1138)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.task_decoupling import (
+    SubGoal,
+    SubGoalDAG,
+    TaskDecouplingConfig,
+    confined_replan,
+    decompose_task,
+    scoped_context,
+    should_decouple,
+)
+
+
+# --- DAG model ----------------------------------------------------------------
+
+
+def test_dag_topological_order():
+    dag = SubGoalDAG([
+        SubGoal("a", "first"),
+        SubGoal("b", "second", dependencies=("a",)),
+        SubGoal("c", "third", dependencies=("b",)),
+    ])
+    assert dag.topological_order() == ["a", "b", "c"]
+
+
+def test_dag_rejects_unknown_dependency():
+    with pytest.raises(ValueError):
+        SubGoalDAG([SubGoal("a", "x", dependencies=("ghost",))])
+
+
+def test_dag_rejects_cycle():
+    with pytest.raises(ValueError):
+        SubGoalDAG([
+            SubGoal("a", "x", dependencies=("b",)),
+            SubGoal("b", "y", dependencies=("a",)),
+        ])
+
+
+def test_dag_rejects_duplicate_ids():
+    with pytest.raises(ValueError):
+        SubGoalDAG([SubGoal("a", "x"), SubGoal("a", "y")])
+
+
+def test_dag_ancestors_transitive():
+    dag = SubGoalDAG([
+        SubGoal("a", "first"),
+        SubGoal("b", "second", dependencies=("a",)),
+        SubGoal("c", "third", dependencies=("b",)),
+    ])
+    assert dag.ancestors("c") == {"a", "b"}
+    assert dag.ancestors("a") == set()
+
+
+# --- decomposition ------------------------------------------------------------
+
+
+def test_decompose_numbered_steps_into_linear_chain():
+    task = "1. read the config\n2. transform the data\n3. write the output"
+    dag = decompose_task(task)
+    order = dag.topological_order()
+    assert len(order) == 3
+    # linear chain: each depends on the previous
+    assert dag.get("g1").dependencies == ("g0",)
+    assert dag.get("g2").dependencies == ("g1",)
+
+
+def test_decompose_single_task_is_one_node():
+    dag = decompose_task("just do one thing")
+    assert len(dag.nodes) == 1
+
+
+def test_decompose_with_injected_decomposer():
+    def decomposer(task):
+        return [SubGoal("x", "a"), SubGoal("y", "b", dependencies=("x",))]
+
+    dag = decompose_task("whatever", decomposer=decomposer)
+    assert set(dag.nodes) == {"x", "y"}
+
+
+# --- scoped context -----------------------------------------------------------
+
+
+def test_scoped_context_excludes_unrelated_subtask_outputs():
+    dag = SubGoalDAG([
+        SubGoal("a", "prep", inputs=("cfg",)),
+        SubGoal("b", "unrelated"),
+        SubGoal("c", "use a", dependencies=("a",)),
+    ])
+    outputs = {"a": "A_RESULT", "b": "B_RESULT_UNRELATED"}
+    ctx = scoped_context(dag, "c", dependency_outputs=outputs, base_inputs={"cfg": "CFG"})
+    # c depends on a -> a's output is included; b is unrelated -> excluded
+    assert ctx["dependency_outputs"] == {"a": "A_RESULT"}
+    assert "b" not in ctx["dependency_outputs"]
+    assert ctx["goal"] == "use a"
+
+
+def test_scoped_context_includes_only_declared_inputs():
+    dag = SubGoalDAG([SubGoal("a", "prep", inputs=("cfg",))])
+    ctx = scoped_context(dag, "a", base_inputs={"cfg": "CFG", "secret": "SHOULD_NOT_LEAK"})
+    assert ctx["inputs"] == {"cfg": "CFG"}
+    assert "secret" not in ctx["inputs"]
+
+
+def test_scoped_context_is_smaller_than_full_trajectory():
+    # 5 sub-goals; c depends only on a. The scoped context must be smaller than
+    # dumping every sub-goal's output (the linear-loop baseline).
+    dag = SubGoalDAG([
+        SubGoal("a", "prep"),
+        SubGoal("b", "noise1"),
+        SubGoal("c", "use a", dependencies=("a",)),
+        SubGoal("d", "noise2"),
+        SubGoal("e", "noise3"),
+    ])
+    outputs = {k: "X" * 1000 for k in ("a", "b", "d", "e")}
+    ctx = scoped_context(dag, "c", dependency_outputs=outputs)
+    scoped_size = len(str(ctx["dependency_outputs"]))
+    full_size = len(str(outputs))
+    assert scoped_size < full_size
+
+
+# --- confined replanning ------------------------------------------------------
+
+
+def test_confined_replan_revises_only_target_node():
+    dag = SubGoalDAG([
+        SubGoal("a", "first"),
+        SubGoal("b", "second", dependencies=("a",)),
+        SubGoal("c", "third", dependencies=("b",)),
+    ])
+    new_dag = confined_replan(dag, "b", revised_description="second (revised)")
+    assert new_dag.get("b").description == "second (revised)"
+    # siblings/ancestors untouched
+    assert new_dag.get("a").description == "first"
+    assert new_dag.get("c").description == "third"
+    # dependencies preserved
+    assert new_dag.get("b").dependencies == ("a",)
+    assert new_dag.get("c").dependencies == ("b",)
+    # original dag is not mutated
+    assert dag.get("b").description == "second"
+
+
+def test_confined_replan_with_replanner_must_preserve_id_and_deps():
+    dag = SubGoalDAG([SubGoal("a", "x"), SubGoal("b", "y", dependencies=("a",))])
+    with pytest.raises(ValueError):
+        confined_replan(dag, "b", replanner=lambda sg: SubGoal("DIFFERENT", "z"))
+
+
+def test_confined_replan_with_valid_replanner():
+    dag = SubGoalDAG([SubGoal("a", "x"), SubGoal("b", "y", dependencies=("a",))])
+    new_dag = confined_replan(
+        dag, "b", replanner=lambda sg: SubGoal(sg.id, "revised", dependencies=sg.dependencies)
+    )
+    assert new_dag.get("b").description == "revised"
+
+
+# --- config + trigger ---------------------------------------------------------
+
+
+def test_config_defaults_off():
+    assert TaskDecouplingConfig().enabled is False
+
+
+def test_should_decouple_off_by_default():
+    assert should_decouple("x" * 10000, TaskDecouplingConfig()) is False
+
+
+def test_should_decouple_only_long_tasks_when_enabled():
+    cfg = TaskDecouplingConfig(enabled=True, min_task_chars=50)
+    assert should_decouple("short task", cfg) is False
+    assert should_decouple("x" * 100, cfg) is True
+
+
+def test_config_from_mapping():
+    cfg = TaskDecouplingConfig.from_mapping({"enabled": True, "min_task_chars": 42})
+    assert cfg.enabled is True
+    assert cfg.min_task_chars == 42

--- a/tests/run_agent/test_task_decoupling_runtime.py
+++ b/tests/run_agent/test_task_decoupling_runtime.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam runtime tests for #1138 task-decoupled planning.
+
+Drive the real ``run_conversation`` turn loop to prove the task-decoupling
+pre-flight in ``agent/conversation_loop.py`` runs (building a sub-goal DAG on the
+agent) when enabled + the task is long, and is a no-op otherwise.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _mock_response(content="done", finish_reason="stop"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _run_once(agent, task: str, config: dict):
+    agent.client.chat.completions.create.side_effect = [_mock_response("done")]
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch.object(agent, "_persist_session", create=True),
+        patch.object(agent, "_save_trajectory", create=True),
+        patch.object(agent, "_cleanup_task_resources", create=True),
+    ):
+        return agent.run_conversation(task)
+
+
+_LONG_TASK = (
+    "1. read the config file\n2. transform the data based on it\n"
+    "3. write the output\n4. then verify the result is correct"
+)
+
+
+def test_task_decoupling_off_leaves_no_dag():
+    cfg = {}  # disabled by default
+    agent = _make_agent(config=cfg)
+    result = _run_once(agent, _LONG_TASK, cfg)
+    assert result["final_response"] == "done"
+    assert getattr(agent, "_subgoal_dag", None) is None
+
+
+def test_task_decoupling_on_builds_dag_for_long_task():
+    cfg = {"task_decoupling": {"enabled": True, "min_task_chars": 20}}
+    agent = _make_agent(config=cfg)
+    _run_once(agent, _LONG_TASK, cfg)
+    dag = getattr(agent, "_subgoal_dag", None)
+    assert dag is not None
+    # the numbered task decomposed into multiple ordered sub-goals
+    assert len(dag.nodes) >= 2
+
+
+def test_task_decoupling_on_skips_short_task():
+    cfg = {"task_decoupling": {"enabled": True, "min_task_chars": 500}}
+    agent = _make_agent(config=cfg)
+    _run_once(agent, "short task", cfg)
+    assert getattr(agent, "_subgoal_dag", None) is None


### PR DESCRIPTION
Closes #1138. Implements Task-Decoupled Planning (TDP, arXiv:2601.07577).

## How
- **`agent/task_decoupling.py`**
  - `SubGoal` + `SubGoalDAG` — validated DAG (rejects cycles / unknown deps / duplicate ids), topological order, transitive ancestors.
  - `decompose_task()` — injectable decomposer (LLM-backed in production); deterministic heuristic default (numbered/bulleted → linear chain).
  - `scoped_context()` — partitions the context by sub-task, including ONLY a sub-goal's declared inputs + its dependency sub-goals' outputs, **excluding unrelated sub-goal outputs** (the core TDP property → real token reduction vs the linear loop).
  - `confined_replan()` — returns a new DAG with only the failed node revised; siblings/ancestors untouched, the original DAG left immutable.
  - `TaskDecouplingConfig` + a trigger heuristic (`min_task_chars`); lazy config via `load_config_readonly` (no per-turn deepcopy).
- **`conversation_loop._run_conversation_impl`** — a config-gated pre-flight builds the DAG on `agent._subgoal_dag` for long-horizon tasks, in the real turn loop.

## Safety / no-regression
- **OFF by default** (`task_decoupling.enabled`, documented in `cli-config.yaml.example`) AND scoped to long tasks by the trigger heuristic. When off the pre-flight sets `_subgoal_dag = None` and does nothing else — the turn is untouched. Never raises.
- Not dead code: **executable-seam runtime tests** drive the real `run_conversation` loop (off leaves no DAG / on builds a DAG for a long task / on skips a short task).

## Tests
- `tests/agent/test_task_decoupling.py` — DAG validation, scoped-context exclusion + size reduction, confined-replan immutability, decomposition, trigger, config.
- `tests/run_agent/test_task_decoupling_runtime.py` — executable-seam runtime tests.