### PR TITLE
feat(agent): architecture router — task-decomposability-based selector (#1139)

### DIFF
--- a/agent/architecture_router.py
+++ b/agent/architecture_router.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+"""Architecture router: single-agent vs centralized multi-agent selector (#1139).
+
+Classifies each task on two axes — decomposability and tool density (plus
+sequentiality) — and recommends the execution architecture, following the
+scaling principles from Google Research's "science of scaling agent systems"
+(arXiv:2512.08296): parallelizable tasks benefit from centralized multi-agent
+coordination; sequential tasks are penalized by multi-agent overhead; and
+independent parallel agents amplify errors far more than a centralized
+orchestrator.
+
+This slice is a **pre-flight recommender + telemetry**: it computes and logs the
+recommended architecture (the calibration dataset the issue asks for) without
+changing how the turn actually executes. Acting on the recommendation
+(auto-spawning orchestrated workers) is a documented follow-up; keeping this
+observation-only makes it safe to ship on by-config without behavior risk.
+
+Config-gated and off by default. Pure functions + frozen dataclasses; no
+import-time side effects; standard library only.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Deque, Mapping
+
+__all__ = [
+    "Architecture",
+    "TaskClassification",
+    "RoutingDecision",
+    "ArchitectureRouterConfig",
+    "RouterTelemetry",
+    "classify_task",
+    "route",
+    "maybe_route",
+    "load_router_config",
+]
+
+
+class Architecture(str, Enum):
+    single_agent = "single_agent"
+    centralized_orchestrator = "centralized_orchestrator"
+    plan_and_execute = "plan_and_execute"
+
+
+@dataclass(frozen=True)
+class TaskClassification:
+    decomposability: float  # 0..1 — can it split into independent sub-questions?
+    tool_density: int  # estimated number of distinct tools needed
+    sequentiality: float  # 0..1 — do outputs of step N feed step N+1?
+    confidence: float  # 0..1 — classifier confidence
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decomposability": self.decomposability,
+            "tool_density": self.tool_density,
+            "sequentiality": self.sequentiality,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    architecture: Architecture
+    max_workers: int
+    rationale: str
+    classification: TaskClassification
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "architecture": self.architecture.value,
+            "max_workers": self.max_workers,
+            "rationale": self.rationale,
+            "classification": self.classification.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ArchitectureRouterConfig:
+    enabled: bool = False
+    confidence_threshold: float = 0.5  # below this -> safe default (single-agent)
+    max_workers_cap: int = 4  # contain error amplification (Google: 17.2x -> 4.4x)
+    decomposability_threshold: float = 0.6
+    sequentiality_threshold: float = 0.6
+    high_tool_density: int = 16  # Google: coordination tax rises past ~16 tools
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "ArchitectureRouterConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        d = cls()
+
+        def _f(key: str, default: float) -> float:
+            try:
+                return float(data.get(key, default))
+            except (TypeError, ValueError):
+                return default
+
+        def _i(key: str, default: int) -> int:
+            try:
+                return int(data.get(key, default))
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            enabled=bool(data.get("enabled", d.enabled)),
+            confidence_threshold=min(1.0, max(0.0, _f("confidence_threshold", d.confidence_threshold))),
+            max_workers_cap=max(1, _i("max_workers_cap", d.max_workers_cap)),
+            decomposability_threshold=min(1.0, max(0.0, _f("decomposability_threshold", d.decomposability_threshold))),
+            sequentiality_threshold=min(1.0, max(0.0, _f("sequentiality_threshold", d.sequentiality_threshold))),
+            high_tool_density=max(1, _i("high_tool_density", d.high_tool_density)),
+        )
+
+
+def load_router_config() -> ArchitectureRouterConfig:
+    """Lazily load the ``architecture_router`` config section (safe default: off).
+
+    Uses ``load_config_readonly`` (no defensive deepcopy) because this runs once
+    per turn in the conversation loop and only reads the config.
+    """
+    try:
+        try:
+            from hermes_cli.config import load_config_readonly as _load
+        except ImportError:
+            from hermes_cli.config import load_config as _load
+
+        cfg = _load()
+        if isinstance(cfg, Mapping):
+            return ArchitectureRouterConfig.from_mapping(cfg.get("architecture_router", {}))
+    except Exception:
+        pass
+    return ArchitectureRouterConfig()
+
+
+# Markers used by the heuristic classifier.
+_SEQ_MARKERS = (
+    "then", "after", "once", "next", "finally", "afterwards", "subsequently",
+    "step 1", "step 2", "first,", "second,", "based on the", "using the result",
+)
+_PARALLEL_MARKERS = (
+    "each", "all of", "for every", "respectively", "in parallel", "compare",
+    "across", "both", "and also", "as well as", "multiple",
+)
+_TOOL_MARKERS = (
+    "file", "read", "write", "search", "web", "browser", "code", "run",
+    "terminal", "download", "api", "database", "image", "video", "email",
+    "commit", "test", "screenshot", "fetch", "scrape",
+)
+_ENUM_RE = re.compile(r"(?:^|\n)\s*(?:\d+[.)]|[-*])\s+")
+
+
+def _count_markers(text: str, markers: tuple[str, ...]) -> int:
+    return sum(1 for m in markers if m in text)
+
+
+def classify_task(task: str, *, tool_hint_count: int | None = None) -> TaskClassification:
+    """Heuristically score a task on decomposability / tool density / sequentiality."""
+    text = (task or "").lower()
+    if not text.strip():
+        return TaskClassification(0.0, 0, 0.0, 0.0)
+
+    enum_items = len(_ENUM_RE.findall(task or ""))
+    parallel_hits = _count_markers(text, _PARALLEL_MARKERS)
+    seq_hits = _count_markers(text, _SEQ_MARKERS)
+
+    # Decomposability: enumerated items and parallel markers raise it.
+    decomposability = min(1.0, 0.2 * enum_items + 0.15 * parallel_hits)
+    # Sequentiality: sequential markers raise it; enumerated steps imply order.
+    sequentiality = min(1.0, 0.2 * seq_hits + 0.05 * enum_items)
+    # Tool density: caller hint wins; else estimate from distinct tool markers.
+    if tool_hint_count is not None:
+        tool_density = max(0, int(tool_hint_count))
+    else:
+        distinct = sum(1 for m in _TOOL_MARKERS if m in text)
+        tool_density = distinct
+
+    # Confidence grows with the number of signals present.
+    signals = enum_items + parallel_hits + seq_hits
+    confidence = min(1.0, 0.3 + 0.1 * signals)
+    return TaskClassification(
+        decomposability=round(decomposability, 3),
+        tool_density=tool_density,
+        sequentiality=round(sequentiality, 3),
+        confidence=round(confidence, 3),
+    )
+
+
+def route(
+    classification: TaskClassification,
+    config: ArchitectureRouterConfig | None = None,
+) -> RoutingDecision:
+    """Map a classification to an architecture via the decision table + guardrails."""
+    cfg = config or ArchitectureRouterConfig()
+
+    # Guardrail: low confidence -> safe default (single-agent).
+    if classification.confidence < cfg.confidence_threshold:
+        return RoutingDecision(
+            Architecture.single_agent,
+            1,
+            "low classifier confidence — defaulting to single-agent",
+            classification,
+        )
+
+    high_decomp = classification.decomposability >= cfg.decomposability_threshold
+    high_seq = classification.sequentiality >= cfg.sequentiality_threshold
+    high_tools = classification.tool_density >= cfg.high_tool_density
+
+    # Sequential tasks are penalized by multi-agent overhead -> single/plan.
+    if high_seq and not high_decomp:
+        return RoutingDecision(
+            Architecture.plan_and_execute,
+            1,
+            "sequential task — multi-agent overhead hurts; plan-and-execute",
+            classification,
+        )
+
+    # Parallelizable tasks -> centralized orchestrator (contains error
+    # amplification vs independent parallel agents). Cap workers on high tool
+    # density where the coordination tax rises.
+    if high_decomp and not high_seq:
+        max_workers = min(cfg.max_workers_cap, 3 if high_tools else cfg.max_workers_cap)
+        return RoutingDecision(
+            Architecture.centralized_orchestrator,
+            max_workers,
+            "decomposable, low-sequentiality task — centralized orchestrator with capped workers",
+            classification,
+        )
+
+    # Low decomposability or mixed -> single-agent (the naive-safe default).
+    return RoutingDecision(
+        Architecture.single_agent,
+        1,
+        "low decomposability or mixed signals — single-agent",
+        classification,
+    )
+
+
+@dataclass
+class RouterTelemetry:
+    """Bounded in-memory log of routing decisions + outcomes for calibration."""
+
+    capacity: int = 500
+    _entries: Deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=500))
+
+    def __post_init__(self) -> None:
+        self._entries = deque(self._entries, maxlen=max(1, self.capacity))
+
+    def record(self, decision: RoutingDecision, *, outcome: str | None = None) -> None:
+        entry = decision.to_dict()
+        entry["outcome"] = outcome
+        self._entries.append(entry)
+
+    def entries(self) -> list[dict[str, Any]]:
+        return list(self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def maybe_route(
+    task: str,
+    *,
+    config: ArchitectureRouterConfig | None = None,
+    telemetry: RouterTelemetry | None = None,
+    tool_hint_count: int | None = None,
+) -> RoutingDecision | None:
+    """Runtime seam: classify + route + log a task's recommended architecture.
+
+    Returns ``None`` (and does nothing) unless the router is enabled, so the
+    default path is a pure no-op that never changes execution. When enabled it
+    returns the recommendation and, if a telemetry sink is given, logs it. Never
+    raises.
+    """
+    cfg = config or load_router_config()
+    if not cfg.enabled:
+        return None
+    try:
+        classification = classify_task(task, tool_hint_count=tool_hint_count)
+        decision = route(classification, cfg)
+        if telemetry is not None:
+            telemetry.record(decision)
+        return decision
+    except Exception:
+        return None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -846,6 +846,33 @@ def _run_conversation_impl(
     except Exception:
         agent._subgoal_dag = None
 
+    # #1139 — architecture router pre-flight. Config-gated (off by default):
+    # classifies the task (decomposability / tool density / sequentiality) and
+    # records the recommended architecture (single-agent / centralized
+    # orchestrator / plan-and-execute) to a telemetry sink for calibration —
+    # WITHOUT changing how this turn executes. Stores the decision on
+    # ``agent._architecture_route`` for callers/telemetry. Never raises.
+    agent._architecture_route = None
+    try:
+        from agent.architecture_router import (
+            RouterTelemetry,
+            load_router_config,
+            maybe_route,
+        )
+
+        _ar_cfg = load_router_config()
+        if _ar_cfg.enabled:
+            if getattr(agent, "_architecture_router_telemetry", None) is None:
+                agent._architecture_router_telemetry = RouterTelemetry()
+            _ar_task = user_message if isinstance(user_message, str) else str(user_message)
+            agent._architecture_route = maybe_route(
+                _ar_task,
+                config=_ar_cfg,
+                telemetry=agent._architecture_router_telemetry,
+            )
+    except Exception:
+        agent._architecture_route = None
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -467,6 +467,22 @@ task_decoupling:
   min_task_chars: 280
 
 # =============================================================================
+# Architecture Router (#1139 — single-agent vs centralized multi-agent selector)
+# =============================================================================
+# Pre-flight that classifies each task (decomposability / tool density /
+# sequentiality) and RECORDS the recommended execution architecture
+# (single-agent / centralized orchestrator / plan-and-execute) to a telemetry
+# sink for calibration — following Google's agent-scaling study (arXiv:2512.08296).
+# Observation-only: it logs a recommendation, it does NOT change how the turn
+# executes. Guardrails: low classifier confidence -> single-agent; workers capped
+# to contain error amplification. OFF by default.
+architecture_router:
+  enabled: false
+  confidence_threshold: 0.5
+  max_workers_cap: 4
+  high_tool_density: 16
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/tests/agent/test_architecture_router.py
+++ b/tests/agent/test_architecture_router.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the architecture router (#1139)."""
+
+from __future__ import annotations
+
+from agent.architecture_router import (
+    Architecture,
+    ArchitectureRouterConfig,
+    RouterTelemetry,
+    TaskClassification,
+    classify_task,
+    maybe_route,
+    route,
+)
+
+
+# --- classifier ---------------------------------------------------------------
+
+
+def test_classify_empty_task():
+    c = classify_task("")
+    assert c.decomposability == 0.0
+    assert c.tool_density == 0
+    assert c.confidence == 0.0
+
+
+def test_classify_parallelizable_task_high_decomposability():
+    task = (
+        "For each of the following companies compare their revenue: "
+        "1. Apple\n2. Microsoft\n3. Google\n4. Amazon — analyze all of them respectively"
+    )
+    c = classify_task(task)
+    assert c.decomposability >= 0.6
+
+
+def test_classify_sequential_task_high_sequentiality():
+    task = "First read the config, then transform the data, after that write the output, and finally verify it"
+    c = classify_task(task)
+    assert c.sequentiality >= 0.6
+
+
+def test_classify_tool_hint_count_overrides_estimate():
+    c = classify_task("do something", tool_hint_count=20)
+    assert c.tool_density == 20
+
+
+# --- routing decision table ---------------------------------------------------
+
+
+def test_route_low_confidence_defaults_to_single_agent():
+    c = TaskClassification(decomposability=0.9, tool_density=2, sequentiality=0.1, confidence=0.2)
+    d = route(c, ArchitectureRouterConfig(confidence_threshold=0.5))
+    assert d.architecture is Architecture.single_agent
+    assert d.max_workers == 1
+
+
+def test_route_sequential_to_plan_and_execute():
+    c = TaskClassification(decomposability=0.2, tool_density=3, sequentiality=0.8, confidence=0.9)
+    d = route(c)
+    assert d.architecture is Architecture.plan_and_execute
+    assert d.max_workers == 1
+
+
+def test_route_parallelizable_to_centralized_orchestrator():
+    c = TaskClassification(decomposability=0.8, tool_density=3, sequentiality=0.1, confidence=0.9)
+    d = route(c, ArchitectureRouterConfig(max_workers_cap=4))
+    assert d.architecture is Architecture.centralized_orchestrator
+    assert 1 < d.max_workers <= 4
+
+
+def test_route_high_tool_density_caps_workers():
+    c = TaskClassification(decomposability=0.9, tool_density=20, sequentiality=0.1, confidence=0.9)
+    d = route(c, ArchitectureRouterConfig(max_workers_cap=8, high_tool_density=16))
+    # high tool density -> capped at 3 to contain the coordination tax
+    assert d.architecture is Architecture.centralized_orchestrator
+    assert d.max_workers == 3
+
+
+def test_route_low_decomposability_single_agent():
+    c = TaskClassification(decomposability=0.1, tool_density=2, sequentiality=0.1, confidence=0.9)
+    d = route(c)
+    assert d.architecture is Architecture.single_agent
+
+
+def test_route_three_task_types_distinct_architectures():
+    parallel = route(TaskClassification(0.8, 3, 0.1, 0.9))
+    sequential = route(TaskClassification(0.2, 3, 0.8, 0.9))
+    simple = route(TaskClassification(0.1, 1, 0.1, 0.9))
+    assert parallel.architecture is Architecture.centralized_orchestrator
+    assert sequential.architecture is Architecture.plan_and_execute
+    assert simple.architecture is Architecture.single_agent
+
+
+# --- telemetry ----------------------------------------------------------------
+
+
+def test_telemetry_records_decision():
+    tel = RouterTelemetry()
+    d = route(TaskClassification(0.8, 3, 0.1, 0.9))
+    tel.record(d, outcome="success")
+    assert len(tel) == 1
+    e = tel.entries()[0]
+    assert e["architecture"] == "centralized_orchestrator"
+    assert e["outcome"] == "success"
+    assert "classification" in e
+
+
+def test_telemetry_bounded():
+    tel = RouterTelemetry(capacity=3)
+    d = route(TaskClassification(0.1, 1, 0.1, 0.9))
+    for _ in range(10):
+        tel.record(d)
+    assert len(tel) == 3
+
+
+# --- config + seam ------------------------------------------------------------
+
+
+def test_config_defaults_off():
+    assert ArchitectureRouterConfig().enabled is False
+
+
+def test_maybe_route_disabled_returns_none():
+    assert maybe_route("anything", config=ArchitectureRouterConfig(enabled=False)) is None
+
+
+def test_maybe_route_enabled_returns_and_logs():
+    tel = RouterTelemetry()
+    task = "First do A, then do B, after that do C, and finally verify"
+    d = maybe_route(task, config=ArchitectureRouterConfig(enabled=True), telemetry=tel)
+    assert d is not None
+    assert len(tel) == 1
+
+
+def test_maybe_route_never_raises(monkeypatch):
+    # Force classify_task to blow up; maybe_route must swallow it.
+    import agent.architecture_router as ar
+
+    monkeypatch.setattr(ar, "classify_task", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    assert maybe_route("t", config=ArchitectureRouterConfig(enabled=True)) is None

--- a/tests/run_agent/test_architecture_router_runtime.py
+++ b/tests/run_agent/test_architecture_router_runtime.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Executable-seam runtime tests for #1139 architecture router.
+
+Drive the real ``run_conversation`` turn loop to prove the architecture-router
+pre-flight in ``agent/conversation_loop.py`` runs (recording a routing decision
+to telemetry) when enabled, and is a no-op otherwise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _mock_response(content="done", finish_reason="stop"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _run_once(agent, task: str, config: dict):
+    agent.client.chat.completions.create.side_effect = [_mock_response("done")]
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch.object(agent, "_persist_session", create=True),
+        patch.object(agent, "_save_trajectory", create=True),
+        patch.object(agent, "_cleanup_task_resources", create=True),
+    ):
+        return agent.run_conversation(task)
+
+
+_PARALLEL_TASK = (
+    "For each of these companies compare their revenue respectively: "
+    "1. Apple\n2. Microsoft\n3. Google — analyze all of them"
+)
+
+
+def test_router_off_records_nothing():
+    cfg = {}
+    agent = _make_agent(config=cfg)
+    result = _run_once(agent, _PARALLEL_TASK, cfg)
+    assert result["final_response"] == "done"
+    assert getattr(agent, "_architecture_route", None) is None
+
+
+def test_router_on_records_decision_and_telemetry():
+    cfg = {"architecture_router": {"enabled": True}}
+    agent = _make_agent(config=cfg)
+    _run_once(agent, _PARALLEL_TASK, cfg)
+    decision = getattr(agent, "_architecture_route", None)
+    assert decision is not None
+    # a parallelizable task should route to the centralized orchestrator
+    assert decision.architecture.value == "centralized_orchestrator"
+    tel = getattr(agent, "_architecture_router_telemetry", None)
+    assert tel is not None
+    assert len(tel) == 1
+
+
+def test_router_on_sequential_task_avoids_multi_agent():
+    cfg = {"architecture_router": {"enabled": True}}
+    agent = _make_agent(config=cfg)
+    task = "First read the file, then transform it, after that write output, and finally verify"
+    _run_once(agent, task, cfg)
+    decision = getattr(agent, "_architecture_route", None)
+    assert decision is not None
+    assert decision.architecture.value in {"plan_and_execute", "single_agent"}
+    assert decision.max_workers == 1


### PR DESCRIPTION
Closes #1139. Adds an orchestrator router following Google's agent-scaling study (arXiv:2512.08296).

## How
- **`agent/architecture_router.py`**
  - `classify_task()` — heuristic scoring of decomposability / tool density / sequentiality with a confidence signal.
  - `route()` — decision table (`single_agent` / `centralized_orchestrator` / `plan_and_execute`) + guardrails: low classifier confidence → single-agent; workers capped to contain the error amplification the study documents (17.2× independent-parallel → 4.4× centralized).
  - `RouterTelemetry` — bounded log of decisions + outcomes (the calibration dataset the issue asks for).
- **`conversation_loop._run_conversation_impl`** — a config-gated pre-flight records the recommended architecture on `agent._architecture_route` + telemetry in the real turn loop.

## Safety / no-regression
- **Observation-only + OFF by default** (`architecture_router.enabled`, documented in `cli-config.yaml.example`). It logs a recommendation for calibration; it does **not** change how the turn executes (acting on it is a documented follow-up). When off the pre-flight sets `_architecture_route = None` and does nothing else. Never raises.
- Not dead code: **executable-seam runtime tests** drive the real `run_conversation` loop (off records nothing / parallelizable task → centralized orchestrator + telemetry / sequential task → plan-and-execute, single worker).

## Tests
- `tests/agent/test_architecture_router.py` — classifier, decision table across 3 task types, confidence/worker-cap guardrails, telemetry.
- `tests/run_agent/test_architecture_router_runtime.py` — executable-seam runtime tests.

Note: the research cycle §1 states all 7 other recommendations were already covered by existing issues; this closes the routing-decision-layer gap.