### PR TITLE
fix(tool-search): treat empty string arguments as {} in tool_call

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -532,6 +532,25 @@ class TestBridgeDispatch:
         assert err is not None
         assert "JSON" in err
 
+    def test_resolve_underlying_call_treats_empty_string_args_as_empty_dict(self):
+        """#1173 — some providers (e.g. GLM-5.2 via OpenRouter) emit
+        ``arguments: ""`` for no-parameter tools. An empty string is not
+        malformed JSON that should be rejected; it is the absence of
+        arguments and must resolve to ``{}`` so the underlying tool can
+        be dispatched. Previously this hit ``json.loads("")`` and surfaced
+        a confusing "not valid JSON" error to the model, which then
+        looped on the same call."""
+        from tools.tool_search import resolve_underlying_call
+        name, args, err = resolve_underlying_call({
+            "name": "fake_no_params_tool",
+            "arguments": "",
+        })
+        # The empty string is accepted as {} — the only error, if any,
+        # is the (expected) deferrability classification failure, never
+        # a JSON parse error.
+        assert "not valid JSON" not in (err or "")
+        assert args == {}
+
     def test_resolve_underlying_call_rejects_recursion(self):
         """tool_call cannot invoke tool_call itself."""
         from tools.tool_search import resolve_underlying_call, TOOL_CALL_NAME

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1066,10 +1066,18 @@ def resolve_underlying_call(
     if raw_args is None:
         raw_args = {}
     if isinstance(raw_args, str):
-        try:
-            raw_args = json.loads(raw_args)
-        except json.JSONDecodeError as e:
-            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
+        # #1173 — some providers (e.g. GLM-5.2 via OpenRouter) emit
+        # ``arguments: ""`` for no-parameter tools. An empty string is
+        # the absence of arguments, not malformed JSON; treat it as ``{}``
+        # so the underlying tool can be dispatched instead of surfacing a
+        # confusing "not valid JSON" error that the model loops on.
+        if raw_args == "":
+            raw_args = {}
+        else:
+            try:
+                raw_args = json.loads(raw_args)
+            except json.JSONDecodeError as e:
+                return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name, config):


### PR DESCRIPTION
## Problem

Some LLM providers (e.g. GLM-5.2 via OpenRouter) emit `arguments: ""` (empty string) for no-parameter MCP tools instead of `arguments: {}` or omitting the field. The `tool_call` bridge tool's `resolve_underlying_call` function hit `json.loads("")` which raises `JSONDecodeError`, surfacing a confusing error to the model:

```
tool_call 'arguments' is not valid JSON: Expecting value: line 1 column 1 (char 0)
```

The model then loops on the same call, unable to dispatch any parameterless tool (`mcp__tqmemory__health`, `mcp__tqmemory__list_scopes`, `mcp__tqmemory__server_info`, etc.). The loop-guard eventually kicks in but the tool never runs.

## Root Cause

In `tools/tool_search.py:resolve_underlying_call`, the `arguments` field handling was:

```python
raw_args = args.get("arguments")
if raw_args is None:
    raw_args = {}
if isinstance(raw_args, str):
    try:
        raw_args = json.loads(raw_args)
    except json.JSONDecodeError as e:
        return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
```

The `None` → `{}` branch was correct, but an empty string `""` fell through to `json.loads("")` which raises. An empty string is the absence of arguments, not malformed JSON — it should resolve to `{}`.

## Fix

Short-circuit `raw_args == ""` → `raw_args = {}` before `json.loads`:

```python
if isinstance(raw_args, str):
    if raw_args == "":
        raw_args = {}
    else:
        try:
            raw_args = json.loads(raw_args)
        except json.JSONDecodeError as e:
            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
```

The existing reject-bad-JSON path is preserved — only the empty-string edge case is handled.

## Reproducer

```python
from tools.tool_search import resolve_underlying_call
# Before fix: err = "tool_call 'arguments' is not valid JSON: ..."
# After fix:  err = None (or classification error), args = {}
name, args, err = resolve_underlying_call(
    {"name": "mcp__tqmemory__health", "arguments": ""}
)
```

## Test Plan

- [x] New test `test_resolve_underlying_call_treats_empty_string_args_as_empty_dict` added
- [x] All 63 tests in `tests/tools/test_tool_search.py` pass
- [x] `test_resolve_underlying_call_rejects_bad_json` still passes (bad JSON still rejected)
- [x] `test_resolve_underlying_call_parses_json_string_args` still passes (valid JSON string still parsed)
- [x] Manually verified `arguments=""`, `arguments="{bad}"`, `arguments='{"a":1}'`, `arguments={}`, `arguments=None` all behave correctly

## Context

Discovered while verifying TQMemory MCP server health after a Hermes restart: `mcp__tqmemory__health` (a 0-parameter MCP tool) was unreachable via `tool_call` because the GLM-5.2 model emitted an empty string for `arguments`. The TQMemory server itself was healthy (`turbo-memory-mcp doctor` passed, `hermes mcp test tqmemory` connected in 594ms with 19 tools) — only the bridge dispatch was broken.