### PR TITLE
fix(tool-search): accept whitespace-only tool_call arguments as {}

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -551,7 +551,24 @@ class TestBridgeDispatch:
         assert "not valid JSON" not in (err or "")
         assert args == {}
 
-    def test_resolve_underlying_call_rejects_recursion(self):
+    @pytest.mark.parametrize("blank", ["", " ", "   ", "\n", "\t", " \t\n "])
+    def test_resolve_underlying_call_treats_whitespace_only_args_as_empty_dict(
+        self, blank
+    ):
+        """Follow-up to #1173 — providers (and intermediary gateways) can
+        emit not just ``""`` but whitespace-only ``arguments`` (a stray
+        space or newline from tokenization). These are equally the absence
+        of arguments and must resolve to ``{}``, never a JSON parse error
+        that the model loops on. ``json.loads`` trims whitespace around a
+        real value, so accepting whitespace-only cannot mask a valid
+        payload."""
+        from tools.tool_search import resolve_underlying_call
+        name, args, err = resolve_underlying_call({
+            "name": "fake_no_params_tool",
+            "arguments": blank,
+        })
+        assert "not valid JSON" not in (err or "")
+        assert args == {}
         """tool_call cannot invoke tool_call itself."""
         from tools.tool_search import resolve_underlying_call, TOOL_CALL_NAME
         name, args, err = resolve_underlying_call({

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1067,11 +1067,15 @@ def resolve_underlying_call(
         raw_args = {}
     if isinstance(raw_args, str):
         # #1173 — some providers (e.g. GLM-5.2 via OpenRouter) emit
-        # ``arguments: ""`` for no-parameter tools. An empty string is
-        # the absence of arguments, not malformed JSON; treat it as ``{}``
-        # so the underlying tool can be dispatched instead of surfacing a
-        # confusing "not valid JSON" error that the model loops on.
-        if raw_args == "":
+        # ``arguments: ""`` for no-parameter tools. An empty (or
+        # whitespace-only, e.g. ``" "`` / ``"\n"`` from tokenization
+        # quirks) string is the absence of arguments, not malformed JSON;
+        # treat it as ``{}`` so the underlying tool can be dispatched
+        # instead of surfacing a confusing "not valid JSON" error that
+        # the model loops on. ``json.loads`` also trims surrounding
+        # whitespace around a real value, so this only widens the
+        # genuinely-empty case.
+        if raw_args.strip() == "":
             raw_args = {}
         else:
             try:


### PR DESCRIPTION
## What
Follow-up hardening to #1170. `resolve_underlying_call` normalized only an
exact empty string (`arguments == ""`) to `{}`; a whitespace-only value
(`" "`, `"\n"`, a stray tab/newline from provider tokenization) still fell
through to `json.loads` and produced a confusing `tool_call 'arguments' is
not valid JSON` error that the model loops on.

## Change
- `tools/tool_search.py`: widen the check from `raw_args == ""` to
  `raw_args.strip() == ""`. `json.loads` already trims whitespace around a
  real value, so this only widens the genuinely-empty case and cannot mask a
  valid payload.
- `tests/tools/test_tool_search.py`: add a parametrized test covering `""`,
  `" "`, `"   "`, `"\n"`, `"\t"`, and mixed whitespace.

## Why now
Independent review of #1170 (two AI advisors) flagged the exact-`""` check as
fragile against tokenization variants. This closes that gap.

## Testing
- `pytest tests/tools/test_tool_search.py` → all green (incl. 6 new params).
- `ruff check` clean on both files.