### PR TITLE
feat(ci): auto-label PRs by title/body

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,47 @@
+name: PR Auto-Label
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [];
+
+            const title = context.payload.pull_request.title.toLowerCase();
+            const body = (context.payload.pull_request.body || '').toLowerCase();
+
+            // Priority: fix > bug > improvement > feature > docs
+            if (/^fix/i.test(title)) labels.push('fix');
+            else if (/\b(bug|fix|regression|broken|error|crash|fail)\b/.test(title + ' ' + body)) labels.push('bug');
+            else if (/^feat/i.test(title) || /\b(feature|add|new|implement)\b/.test(title)) labels.push('feature');
+            else if (/^(docs?|chore|refactor|test|style|perf)/i.test(title)) {
+              const type = title.match(/^(docs?|chore|refactor|test|style|perf)/i)[1];
+              const map = { doc: 'documentation', docs: 'documentation', chore: 'enhancement',
+                            refactor: 'enhancement', test: 'enhancement', style: 'enhancement', perf: 'performance' };
+              labels.push(map[type] || 'enhancement');
+            }
+            else if (/\b(improve|update|upgrade|bump)\b/.test(title)) labels.push('improvement');
+            else labels.push('enhancement');
+
+            // Security/introspection signals
+            if (/\b(security|vuln|cve|injection|xss)\b/.test(title + ' ' + body)) labels.push('security');
+            if (/\b(introspection|session.?audit)\b/.test(title + ' ' + body)) labels.push('introspection');
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+              console.log(`Applied labels: ${labels.join(', ')}`);
+            }

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -11,7 +11,7 @@ jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7.0.1
         with:
           script: |
             const labels = [];

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "evolution@hermes-agent.nousresearch.com": "Da-Mikey",  # PR #1181 (ci: auto-label PRs by title/body)
     "lexus@cdzv.com": "Lexus2016",  # repo owner (evolution fork maintenance PRs)
     "Burgunthy@users.noreply.github.com": "Burgunthy",  # PR #20096 salvage (gateway: profile-based routing for inbound messages)
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)


### PR DESCRIPTION
Automatically labels PRs based on title prefix and content:\n- `fix:` → `fix` label\n- `feat:` → `feature` label  \n- `docs:` → `documentation`\n- Bug/keywords → `bug`\n- Introspection references → `introspection`\n- All others → `enhancement`\n\nCloses #7 workflow gap.