### PR TITLE
fix(#1200): drain async delegations before cron session teardown

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4096,23 +4096,33 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured
-        # duration is caught and killed.  Default 600s (10 min inactivity);
-        # override via HERMES_CRON_TIMEOUT env var.  0 = unlimited.
+        # duration is caught and killed.  Default 900s (15 min inactivity);
+        # override via HERMES_CRON_TIMEOUT env var or
+        # cron.inactivity_timeout_seconds in config.yaml.  0 = unlimited.
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
+        _cron_default_timeout = 900.0
+        try:
+            _cfg_for_timeout = load_config() or {}
+            _cron_cfg_for_timeout = _cfg_for_timeout.get("cron", {}) if isinstance(_cfg_for_timeout, dict) else {}
+            _configured_timeout = _cron_cfg_for_timeout.get("inactivity_timeout_seconds")
+            if _configured_timeout is not None:
+                _cron_default_timeout = float(_configured_timeout)
+        except Exception:
+            pass
         _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
         if _raw_cron_timeout:
             try:
                 _cron_timeout = float(_raw_cron_timeout)
             except (ValueError, TypeError):
                 logger.warning(
-                    "Invalid HERMES_CRON_TIMEOUT=%r; using default 600s",
-                    _raw_cron_timeout,
+                    "Invalid HERMES_CRON_TIMEOUT=%r; using default %.0fs",
+                    _raw_cron_timeout, _cron_default_timeout,
                 )
-                _cron_timeout = 600.0
+                _cron_timeout = _cron_default_timeout
         else:
-            _cron_timeout = 600.0
+            _cron_timeout = _cron_default_timeout
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
@@ -4216,6 +4226,43 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
+            # Drain barrier (issue #1200): wait for background delegations
+            # spawned by this cron session to complete before tearing down.
+            # Without this, subagents dispatched via delegate_task(background=true)
+            # are still running on the daemon executor when the cron session
+            # ends, orphaning their completion events and losing artifacts.
+            try:
+                _drain_seconds = 1200.0
+                try:
+                    _drain_cfg = load_config() or {}
+                    _drain_cron_cfg = _drain_cfg.get("cron", {}) if isinstance(_drain_cfg, dict) else {}
+                    _configured_drain = _drain_cron_cfg.get("delegation_drain_seconds")
+                    if _configured_drain is not None:
+                        _drain_seconds = float(_configured_drain)
+                except Exception:
+                    pass
+                _raw_drain = os.getenv("HERMES_CRON_DELEGATION_DRAIN_SECONDS", "").strip()
+                if _raw_drain:
+                    try:
+                        _drain_seconds = float(_raw_drain)
+                    except (ValueError, TypeError):
+                        pass
+                if _drain_seconds > 0:
+                    from tools.async_delegation import wait_for_session_delegations
+                    _drain_result = wait_for_session_delegations(
+                        parent_session_id=_cron_session_id,
+                        deadline_seconds=_drain_seconds,
+                        poll_interval=_POLL_INTERVAL,
+                    )
+                    if _drain_result.get("waited", 0) > 0:
+                        logger.info(
+                            "Cron session %s delegation drain: %s",
+                            _cron_session_id, _drain_result,
+                        )
+            except Exception:
+                logger.debug(
+                    "Delegation drain for cron session %s failed", _cron_session_id, exc_info=True,
+                )
             _cron_pool.shutdown(wait=False, cancel_futures=True)
 
         if _inactivity_timeout:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2879,6 +2879,27 @@ DEFAULT_CONFIG = {
         # wedges the job's dispatch guard forever. Also overridable via
         # HERMES_CRON_SESSION_DB_TIMEOUT env var. 0 = unlimited (skip the bound).
         "session_db_timeout_seconds": 10,
+        # Drain barrier for background delegations after the agent run (issue
+        # #1200). When a cron agent dispatches subagents via
+        # delegate_task(background=true), those subagents run on a daemon
+        # executor that outlives the agent's own run_conversation thread. Without
+        # a drain step, the cron session tears down (inactivity timeout or normal
+        # completion) while subagents are still running, orphaning their
+        # completion events and losing artifacts. This sets how long (seconds) the
+        # scheduler waits for pending delegations matching the cron session_id
+        # before force-interrupting them. 0 = no drain (legacy behavior). Default
+        # 1200s (20 min) matches the in-tool heartbeat stale ceiling so legit
+        # long-running subagents get time to finish. Also overridable via
+        # HERMES_CRON_DELEGATION_DRAIN_SECONDS env var.
+        "delegation_drain_seconds": 1200,
+        # Inactivity timeout (seconds) for cron agent sessions. The agent can run
+        # for hours if actively calling tools, but a hung API call or stuck tool
+        # with no activity for this duration triggers termination. Default 900s
+        # (15 min) — raised from the legacy 600s because implementation subagents
+        # that the agent dispatches and waits on legitimately need more wall time.
+        # Also overridable via HERMES_CRON_TIMEOUT env var (which takes
+        # precedence). 0 = unlimited (no inactivity watchdog).
+        "inactivity_timeout_seconds": 900,
     },
     # Kanban multi-agent coordination — controls the dispatcher loop that
     # spawns workers for ready tasks. The dispatcher ticks every N seconds

--- a/tests/tools/test_async_delegation_drain.py
+++ b/tests/tools/test_async_delegation_drain.py
@@ -1,0 +1,238 @@
+"""Cron delegation drain barrier tests (issue #1200).
+
+Covers ``wait_for_session_delegations`` — the drain step the cron scheduler
+runs after the agent's ``run_conversation`` returns (or the inactivity
+timeout fires) but before the cron thread pool is shut down.
+
+Without this barrier, background subagents dispatched via
+``delegate_task(background=true)`` are still running on the daemon executor
+when the cron session tears down, orphaning their completion events and
+losing artifacts.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tools.async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_delegation():
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+class TestWaitForSessionDelegations:
+    """Behavioral contracts for wait_for_session_delegations()."""
+
+    def _seed_record(
+        self,
+        delegation_id,
+        parent_session_id="cron_job1_20260721_120000",
+        status="running",
+    ):
+        """Seed a delegation record directly into the in-memory registry."""
+        with ad._records_lock:
+            ad._records[delegation_id] = {
+                "delegation_id": delegation_id,
+                "status": status,
+                "parent_session_id": parent_session_id,
+                "session_key": "",
+                "origin_ui_session_id": "",
+                "interrupt_fn": None,
+                "goal": "test goal",
+                "context": None,
+                "toolsets": None,
+                "role": "leaf",
+                "model": None,
+                "dispatched_at": time.time(),
+                "completed_at": None,
+            }
+
+    def _complete_after(self, delegation_id, delay, lock):
+        """Mark a record completed after *delay* seconds from a background thread."""
+        def _completer():
+            time.sleep(delay)
+            with lock:
+                if delegation_id in ad._records:
+                    ad._records[delegation_id]["status"] = "completed"
+                    ad._records[delegation_id]["completed_at"] = time.time()
+
+        t = threading.Thread(target=_completer, daemon=True)
+        t.start()
+        return t
+
+    def test_no_delegations_returns_immediately(self):
+        """When there are zero running delegations for the session, drain is instant."""
+        start = time.monotonic()
+        result = ad.wait_for_session_delegations(
+            parent_session_id="cron_nonexistent",
+            deadline_seconds=10.0,
+            poll_interval=0.1,
+        )
+        elapsed = time.monotonic() - start
+        assert result == {
+            "waited": 0,
+            "completed": 0,
+            "interrupted": 0,
+            "timed_out": False,
+        }
+        # Should return in well under 1 second, not 10s.
+        assert elapsed < 1.0
+
+    def test_delegation_completes_before_deadline(self):
+        """A delegation that finishes on its own is waited for, not interrupted."""
+        self._seed_record("d1")
+        lock = threading.Lock()
+        self._complete_after("d1", delay=0.3, lock=lock)
+
+        start = time.monotonic()
+        result = ad.wait_for_session_delegations(
+            parent_session_id="cron_job1_20260721_120000",
+            deadline_seconds=10.0,
+            poll_interval=0.1,
+        )
+        elapsed = time.monotonic() - start
+
+        assert result["waited"] == 1
+        assert result["completed"] == 1
+        assert result["interrupted"] == 0
+        assert result["timed_out"] is False
+        # Should take ~0.3s (the completion delay), not 10s.
+        assert elapsed < 5.0
+
+    def test_deadline_expires_interrupts_remaining(self):
+        """When the deadline expires, remaining delegations are force-interrupted."""
+        self._seed_record("d1")
+        self._seed_record("d2")
+
+        with patch("tools.async_delegation.interrupt_for_session") as mock_int:
+            mock_int.return_value = 2
+            start = time.monotonic()
+            result = ad.wait_for_session_delegations(
+                parent_session_id="cron_job1_20260721_120000",
+                deadline_seconds=0.5,
+                poll_interval=0.1,
+            )
+            elapsed = time.monotonic() - start
+
+        assert result["waited"] == 2
+        assert result["timed_out"] is True
+        assert result["interrupted"] == 2
+        # interrupt_for_session must be called with the right parent_session_id
+        kwargs = mock_int.call_args.kwargs
+        assert kwargs["parent_session_id"] == "cron_job1_20260721_120000"
+        # Should take ~0.5s (the deadline), not much longer.
+        assert elapsed < 3.0
+
+    def test_only_matches_own_session(self):
+        """Delegations from a different parent_session_id are not drained."""
+        self._seed_record("d1", parent_session_id="cron_job1_20260721_120000")
+        self._seed_record("d2", parent_session_id="cron_other_job_999")
+
+        result = ad.wait_for_session_delegations(
+            parent_session_id="cron_job1_20260721_120000",
+            deadline_seconds=0.3,
+            poll_interval=0.1,
+        )
+
+        # Only d1 is counted; d2 belongs to a different session.
+        assert result["waited"] == 1
+        # d1 never completes, so deadline fires and d1 is interrupted.
+        assert result["timed_out"] is True
+
+    def test_completed_records_not_counted(self):
+        """Already-completed delegations are not waited for."""
+        self._seed_record("d1", status="completed")
+        self._seed_record("d2", status="running")
+
+        with patch("tools.async_delegation.interrupt_for_session") as mock_int:
+            mock_int.return_value = 1
+            result = ad.wait_for_session_delegations(
+                parent_session_id="cron_job1_20260721_120000",
+                deadline_seconds=0.3,
+                poll_interval=0.1,
+            )
+
+        # Only d2 (running) is counted.
+        assert result["waited"] == 1
+        assert result["timed_out"] is True
+        mock_int.assert_called_once()
+
+    def test_on_interrupt_callback_invoked(self):
+        """The on_interrupt callback is called when delegations are force-interrupted."""
+        self._seed_record("d1")
+        callback = MagicMock()
+
+        with patch("tools.async_delegation.interrupt_for_session") as mock_int:
+            mock_int.return_value = 1
+            ad.wait_for_session_delegations(
+                parent_session_id="cron_job1_20260721_120000",
+                deadline_seconds=0.2,
+                poll_interval=0.05,
+                on_interrupt=callback,
+            )
+
+        callback.assert_called_once_with(1)
+
+    def test_on_interrupt_exception_swallowed(self):
+        """An exception in on_interrupt must not propagate."""
+        self._seed_record("d1")
+        callback = MagicMock(side_effect=RuntimeError("boom"))
+
+        with patch("tools.async_delegation.interrupt_for_session") as mock_int:
+            mock_int.return_value = 1
+            # Must not raise.
+            result = ad.wait_for_session_delegations(
+                parent_session_id="cron_job1_20260721_120000",
+                deadline_seconds=0.2,
+                poll_interval=0.05,
+                on_interrupt=callback,
+            )
+
+        assert result["interrupted"] == 1
+        callback.assert_called_once()
+
+    def test_mixed_completion_and_timeout(self):
+        """Some delegations finish, others time out — both paths are exercised."""
+        self._seed_record("d1")
+        self._seed_record("d2")
+        lock = threading.Lock()
+        # d1 completes quickly; d2 never does.
+        self._complete_after("d1", delay=0.2, lock=lock)
+
+        with patch("tools.async_delegation.interrupt_for_session") as mock_int:
+            mock_int.return_value = 1
+            result = ad.wait_for_session_delegations(
+                parent_session_id="cron_job1_20260721_120000",
+                deadline_seconds=0.5,
+                poll_interval=0.1,
+            )
+
+        # Both were running at call time.
+        assert result["waited"] == 2
+        assert result["timed_out"] is True
+        # Only d2 was interrupted (d1 finished on its own).
+        assert result["interrupted"] == 1
+
+
+class TestCronConfigKeys:
+    """Verify the config keys added for issue #1200 exist with correct defaults."""
+
+    def test_delegation_drain_seconds_exists(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        cron_cfg = DEFAULT_CONFIG.get("cron", {})
+        assert "delegation_drain_seconds" in cron_cfg
+        assert cron_cfg["delegation_drain_seconds"] == 1200
+
+    def test_inactivity_timeout_seconds_exists(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        cron_cfg = DEFAULT_CONFIG.get("cron", {})
+        assert "inactivity_timeout_seconds" in cron_cfg
+        assert cron_cfg["inactivity_timeout_seconds"] == 900

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -923,6 +923,100 @@ def interrupt_for_session(
     return count
 
 
+def wait_for_session_delegations(
+    parent_session_id: str,
+    deadline_seconds: float = 1200.0,
+    poll_interval: float = 5.0,
+    on_interrupt: Optional[Callable[[int], None]] = None,
+) -> Dict[str, Any]:
+    """Wait for async delegations owned by *parent_session_id* to finish.
+
+    Called by the cron scheduler after the agent's ``run_conversation`` returns
+    (or the inactivity timeout fires) but BEFORE the cron thread pool is shut
+    down. Without this barrier, background subagents dispatched via
+    ``delegate_task(background=true)`` are still running on the daemon executor
+    when the cron session tears down — their completion events are orphaned and
+    the artifacts they produced are lost (issue #1200).
+
+    Polls ``active_count``-style records every *poll_interval* seconds until
+    either all matching delegations leave the ``running`` state or *deadline_seconds*
+    elapses. If the deadline expires, remaining delegations are interrupted via
+    ``interrupt_for_session`` (they still emit a completion event with
+    ``status='interrupted'``) and a warning is logged.
+
+    Returns a dict with:
+        ``waited``   — how many running delegations were found at call time
+        ``completed``— how many finished on their own before the deadline
+        ``interrupted``— how many were force-interrupted at the deadline
+        ``timed_out``— True if the deadline expired
+    """
+    import time as _time
+
+    def _running_for_session() -> List[Dict[str, Any]]:
+        with _records_lock:
+            return [
+                r for r in _records.values()
+                if r.get("status") in {"running", "finalizing"}
+                and str(r.get("parent_session_id") or "") == parent_session_id
+            ]
+
+    initial = _running_for_session()
+    waited = len(initial)
+    if waited == 0:
+        return {
+            "waited": 0,
+            "completed": 0,
+            "interrupted": 0,
+            "timed_out": False,
+        }
+
+    logger.info(
+        "Draining %d async delegation(s) for cron session %s (deadline %.0fs)",
+        waited, parent_session_id, deadline_seconds,
+    )
+
+    deadline = _time.monotonic() + deadline_seconds
+    completed = 0
+    timed_out = False
+
+    while True:
+        remaining = _running_for_session()
+        if not remaining:
+            completed = waited
+            break
+        if _time.monotonic() >= deadline:
+            timed_out = True
+            break
+        _time.sleep(poll_interval)
+
+    interrupted = 0
+    if timed_out:
+        still_running = _running_for_session()
+        if still_running:
+            interrupted = interrupt_for_session(
+                parent_session_id=parent_session_id,
+                reason="cron_session_drain_deadline",
+            )
+            logger.warning(
+                "Cron drain deadline (%.0fs) expired for session %s: "
+                "%d delegation(s) still running, interrupted %d",
+                deadline_seconds, parent_session_id,
+                len(still_running), interrupted,
+            )
+            if on_interrupt:
+                try:
+                    on_interrupt(interrupted)
+                except Exception:
+                    logger.debug("on_interrupt callback raised", exc_info=True)
+
+    return {
+        "waited": waited,
+        "completed": completed,
+        "interrupted": interrupted,
+        "timed_out": timed_out,
+    }
+
+
 def _reset_for_tests() -> None:
     """Test-only: clear all state and tear down the executor."""
     global _executor, _executor_max_workers


### PR DESCRIPTION
## Problem

Closes #1200 — Async delegate_task race in evolution-hydra: parent cron dispatches subagents but does not await completion before read-back, causing missing artifacts.

## Root Cause

In `cron/scheduler.py` `_run_job_impl`, the inactivity timeout loop (lines 4195-4214) terminates as soon as the agent stops calling tools. The `finally:` block then calls `_cron_pool.shutdown(wait=False, cancel_futures=True)` — **without waiting for background subagents dispatched via `delegate_task(background=true)`** that are still running on the daemon executor.

This orphans completion events and loses artifacts — the subagents' work vanishes when the cron session tears down before they finish.

Additionally, the inactivity timeout was hardcoded to 600s, which is too short for subagent-heavy cron jobs (the issue requests 900-1200s).

## Fix

**Three parts:**

### 1. `tools/async_delegation.py` — drain helper

New `wait_for_session_delegations(parent_session_id, deadline_seconds, poll_interval, on_interrupt)` function:
- Polls `_running_for_session(parent_session_id)` every `poll_interval`
- Waits up to `deadline_seconds` for delegations matching the session to complete naturally
- Force-interrupts stragglers via `interrupt_for_session(parent_session_id=...)` when deadline expires
- Returns `{waited, completed, interrupted, timed_out}`

### 2. `hermes_cli/config.py` — config keys

Two new cron config keys with defaults:
- `delegation_drain_seconds: 1200` — drain deadline (matches heartbeat stale ceiling of 40×30s)
- `inactivity_timeout_seconds: 900` — up from hardcoded 600s

### 3. `cron/scheduler.py` — wire the drain

- Inactivity timeout now reads `cron.inactivity_timeout_seconds` (default 900s) instead of hardcoded 600.0. `HERMES_CRON_TIMEOUT` env var still overrides.
- `finally:` block calls `wait_for_session_delegations()` before `_cron_pool.shutdown()`. Configurable via `cron.delegation_drain_seconds` (default 1200s) or `HERMES_CRON_DELEGATION_DRAIN_SECONDS` env var.
- Drain exceptions are caught and logged at debug — never block teardown.

## Tests

`tests/tools/test_async_delegation_drain.py` (10 tests):
- Empty session → immediate return
- Natural completion before deadline → waited, not interrupted
- Deadline expiry → force-interrupt remaining
- Session scoping → only matches own delegations
- Completed records not counted
- `on_interrupt` callback invoked with count
- `on_interrupt` exception swallowed (never propagates)
- Mixed: some complete, some timeout

All 821 existing cron + delegation lifecycle tests still pass.

## Verification

```
python -m pytest tests/tools/test_async_delegation_drain.py -v
# 10 passed in 2.56s

python -m pytest tests/tui_gateway/test_delegation_session_lifecycle.py tests/cron/ -v
# 821 passed in 36.23s
```

## Footprint

No new core tools. The drain helper is a plain function in an existing module. The config keys are additive (deep-merge handles them). The scheduler change adds a drain step to an existing `finally:` block — no structural change to the loop.