### PR TITLE
feat: cron-cycle trajectory logger for safety monitoring (Closes #1215)

### DIFF
--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Cron-cycle trajectory logger — records tool-call action sequences (#1215).
+
+Records the sequence of tool calls (name, key args, result summary, timestamp,
+pass/fail) during a cron session to a JSON sidecar at
+``~/.hermes/evolution/trajectories/<date>.json``.
+
+WHY THIS EXISTS — trajectory-level safety monitoring (parent #1203).
+A cron agent runs unattended for long horizons; the sequence of actions it
+takes is the primary audit trail for detecting suspicious patterns (e.g.
+a compromised skill silently calling ``write_file`` on a system path after
+a benign ``read_file``).  Per-tool logging already exists in agent.log, but
+the *sequence* — which tool followed which, and with what args — is not
+preserved in a structured, queryable form.  This module provides that.
+
+DESIGN — minimal surface, zero core coupling.
+``TrajectoryLogger`` is a standalone context manager.  The cron scheduler
+constructs one per job run, passes it the session_id, and the agent loop
+calls ``log_tool_call()`` after each tool dispatch.  The logger appends to
+an in-memory list and flushes to a JSON sidecar on close.  No core files
+are modified — the scheduler integration is a single call site (added
+separately if desired); the logger works as a standalone library today.
+
+Usage::
+
+    with TrajectoryLogger(session_id="cron-abc123") as tlog:
+        tlog.log_tool_call("terminal", {"command": "ls"}, "ok", True)
+        tlog.log_tool_call("write_file", {"path": "/tmp/x"}, "ok", True)
+    # → ~/.hermes/evolution/trajectories/2026-07-23.json updated
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Secret-like argument keys whose values must be redacted before logging.
+_REDACT_KEYS = frozenset({
+    "api_key",
+    "token",
+    "password",
+    "secret",
+    "authorization",
+    "credential",
+    "key",
+    "passphrase",
+    "private_key",
+})
+
+_REDACT_PATTERNS = [
+    re.compile(r"(api[_-]?key|token|password|secret)\s*[:=]\s*\S+", re.I),
+]
+
+# Max length for arg values and result summaries — keeps the sidecar small.
+_MAX_VALUE_LEN = 500
+_MAX_RESULT_LEN = 1000
+
+
+def _redact_value(val: Any) -> Any:
+    """Recursively redact secret-like values in nested dicts/lists."""
+    if isinstance(val, dict):
+        return {
+            k: ("***REDACTED***" if k.lower() in _REDACT_KEYS else _redact_value(v))
+            for k, v in val.items()
+        }
+    if isinstance(val, list):
+        return [_redact_value(v) for v in val]
+    if isinstance(val, str):
+        s = val
+        for pat in _REDACT_PATTERNS:
+            s = pat.sub(r"\1=***REDACTED***", s)
+        return s[:_MAX_VALUE_LEN]
+    return val
+
+
+def _truncate(s: str, max_len: int = _MAX_RESULT_LEN) -> str:
+    """Truncate a string to ``max_len`` with an ellipsis indicator."""
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + "...[truncated]"
+
+
+def _trajectories_dir() -> Path:
+    """Return the trajectory sidecar directory under HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+
+    d = get_hermes_home() / "evolution" / "trajectories"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _sidecar_path(date_str: Optional[str] = None) -> Path:
+    """Return the JSON sidecar path for a given date (YYYY-MM-DD)."""
+    if date_str is None:
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return _trajectories_dir() / f"{date_str}.json"
+
+
+class TrajectoryLogger:
+    """Context-managed trajectory logger for a single cron session.
+
+    Accumulates tool-call records in memory and flushes them to a JSON
+    sidecar on close.  The sidecar is a list of session objects, each
+    containing a ``tool_calls`` array.  Multiple sessions on the same day
+    are appended to the same file.
+
+    Attributes:
+        session_id: Identifier for the cron session being logged.
+        entries: In-memory list of tool-call records.
+    """
+
+    def __init__(
+        self, session_id: str, job_name: str = "", date_str: Optional[str] = None
+    ) -> None:
+        self.session_id = session_id
+        self.job_name = job_name
+        self._date_str = date_str
+        self.entries: List[Dict[str, Any]] = []
+        self._start_ts = time.time()
+        self._closed = False
+
+    def log_tool_call(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        result_summary: str,
+        success: bool,
+        error: Optional[str] = None,
+    ) -> None:
+        """Record a single tool call in the trajectory.
+
+        Args:
+            tool_name: Name of the tool invoked (e.g. ``"terminal"``).
+            args: Tool arguments dict — secret-like keys are redacted.
+            result_summary: Short text summary of the tool's output.
+            success: Whether the tool call succeeded.
+            error: Error message if the call failed, else None.
+        """
+        if self._closed:
+            return
+        entry: Dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tool": tool_name,
+            "args": _redact_value(args),
+            "result": _truncate(str(result_summary)),
+            "success": success,
+        }
+        if error:
+            entry["error"] = _truncate(str(error), _MAX_VALUE_LEN)
+        self.entries.append(entry)
+
+    def close(self) -> Path:
+        """Flush the accumulated trajectory to the JSON sidecar.
+
+        Returns the path to the written sidecar.  Idempotent — calling
+        close() twice writes only once.
+        """
+        if self._closed:
+            return _sidecar_path(self._date_str)
+        self._closed = True
+
+        session_record: Dict[str, Any] = {
+            "session_id": self.session_id,
+            "job_name": self.job_name,
+            "start_ts": self._start_ts,
+            "end_ts": time.time(),
+            "tool_call_count": len(self.entries),
+            "tool_calls": self.entries,
+        }
+
+        path = _sidecar_path(self._date_str)
+        existing: List[Dict[str, Any]] = []
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(existing, list):
+                    existing = []
+            except (json.JSONDecodeError, OSError):
+                existing = []
+
+        existing.append(session_record)
+        try:
+            path.write_text(
+                json.dumps(existing, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning("Failed to write trajectory sidecar %s: %s", path, exc)
+        return path
+
+    def __enter__(self) -> "TrajectoryLogger":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/tests/scripts/test_evolution_trajectory_logger.py
+++ b/tests/scripts/test_evolution_trajectory_logger.py
@@ -1,0 +1,167 @@
+"""Tests for the cron-cycle trajectory logger (#1215)."""
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.evolution_trajectory_logger import (
+    TrajectoryLogger,
+    _redact_value,
+    _truncate,
+)
+
+
+@pytest.fixture
+def tmp_trajectory_dir(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME so trajectory sidecars land in a temp dir."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+class TestRedactValue:
+    """Secret-like keys must be redacted; non-secret values preserved."""
+
+    def test_redacts_api_key(self):
+        result = _redact_value({"api_key": "sk-12345", "model": "gpt-4"})
+        assert result["api_key"] == "***REDACTED***"
+        assert result["model"] == "gpt-4"
+
+    def test_redacts_nested_token(self):
+        result = _redact_value({"config": {"token": "abc", "name": "test"}})
+        assert result["config"]["token"] == "***REDACTED***"
+        assert result["config"]["name"] == "test"
+
+    def test_redacts_list_elements(self):
+        result = _redact_value([{"password": "secret"}, {"port": 8080}])
+        assert result[0]["password"] == "***REDACTED***"
+        assert result[1]["port"] == 8080
+
+    def test_preserves_non_secret_string(self):
+        assert _redact_value("hello world") == "hello world"
+
+    def test_redacts_inline_pattern(self):
+        result = _redact_value("api_key=sk-abc123")
+        assert "sk-abc123" not in result
+        assert "REDACTED" in result
+
+
+class TestTruncate:
+    """Truncation preserves content within the limit and adds an indicator."""
+
+    def test_short_string_unchanged(self):
+        assert _truncate("hello", 100) == "hello"
+
+    def test_long_string_truncated(self):
+        long_s = "x" * 200
+        result = _truncate(long_s, 50)
+        assert len(result) < 200
+        assert result.endswith("...[truncated]")
+        assert result[:50] == "x" * 50
+
+
+class TestTrajectoryLogger:
+    """Integration: logger writes a valid JSON sidecar with tool-call records."""
+
+    def test_basic_logging(self, tmp_trajectory_dir):
+        with TrajectoryLogger(session_id="test-001", job_name="unit-test") as tlog:
+            tlog.log_tool_call(
+                "terminal", {"command": "ls -la"}, "file1.txt\nfile2.py", True
+            )
+            tlog.log_tool_call(
+                "read_file", {"path": "/tmp/x.py"}, "file contents", True
+            )
+
+        sidecar = tmp_trajectory_dir / "evolution" / "trajectories"
+        files = list(sidecar.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert isinstance(data, list)
+        assert len(data) == 1
+        session = data[0]
+        assert session["session_id"] == "test-001"
+        assert session["job_name"] == "unit-test"
+        assert session["tool_call_count"] == 2
+        assert len(session["tool_calls"]) == 2
+        assert session["tool_calls"][0]["tool"] == "terminal"
+        assert session["tool_calls"][0]["success"] is True
+        assert session["tool_calls"][1]["tool"] == "read_file"
+
+    def test_secret_redaction_in_logged_args(self, tmp_trajectory_dir):
+        with TrajectoryLogger(session_id="test-002") as tlog:
+            tlog.log_tool_call(
+                "web_search",
+                {"api_key": "sk-secret-123", "query": "test"},
+                "results",
+                True,
+            )
+        sidecar = list(
+            (tmp_trajectory_dir / "evolution" / "trajectories").glob("*.json")
+        )[0]
+        data = json.loads(sidecar.read_text())
+        call = data[0]["tool_calls"][0]
+        assert call["args"]["api_key"] == "***REDACTED***"
+        assert call["args"]["query"] == "test"
+
+    def test_failed_tool_call_records_error(self, tmp_trajectory_dir):
+        with TrajectoryLogger(session_id="test-003") as tlog:
+            tlog.log_tool_call(
+                "terminal",
+                {"command": "rm /"},
+                "permission denied",
+                False,
+                error="PermissionError: cannot remove root",
+            )
+        sidecar = list(
+            (tmp_trajectory_dir / "evolution" / "trajectories").glob("*.json")
+        )[0]
+        data = json.loads(sidecar.read_text())
+        call = data[0]["tool_calls"][0]
+        assert call["success"] is False
+        assert "PermissionError" in call["error"]
+
+    def test_multiple_sessions_append_to_same_file(self, tmp_trajectory_dir):
+        from datetime import datetime, timezone
+
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        with TrajectoryLogger(session_id="s1", date_str=date_str) as tlog:
+            tlog.log_tool_call("terminal", {"command": "echo hi"}, "hi", True)
+
+        with TrajectoryLogger(session_id="s2", date_str=date_str) as tlog:
+            tlog.log_tool_call("read_file", {"path": "/tmp/a"}, "content", True)
+
+        sidecar = tmp_trajectory_dir / "evolution" / "trajectories" / f"{date_str}.json"
+        data = json.loads(sidecar.read_text())
+        assert len(data) == 2
+        assert data[0]["session_id"] == "s1"
+        assert data[1]["session_id"] == "s2"
+
+    def test_close_is_idempotent(self, tmp_trajectory_dir):
+        tlog = TrajectoryLogger(session_id="test-004")
+        tlog.log_tool_call("terminal", {"command": "ls"}, "ok", True)
+        tlog.close()
+        tlog.close()  # should not duplicate or crash
+
+        sidecar = list(
+            (tmp_trajectory_dir / "evolution" / "trajectories").glob("*.json")
+        )[0]
+        data = json.loads(sidecar.read_text())
+        assert len(data) == 1  # only one session record
+
+    def test_log_after_close_is_ignored(self, tmp_trajectory_dir):
+        tlog = TrajectoryLogger(session_id="test-005")
+        tlog.log_tool_call("terminal", {"command": "ls"}, "ok", True)
+        tlog.close()
+        tlog.log_tool_call("write_file", {"path": "/tmp/x"}, "ok", True)
+
+        sidecar = list(
+            (tmp_trajectory_dir / "evolution" / "trajectories").glob("*.json")
+        )[0]
+        data = json.loads(sidecar.read_text())
+        assert data[0]["tool_call_count"] == 1  # second call was ignored


### PR DESCRIPTION
Automated evolution PR for issue #1215.

## Summary
Add a standalone `TrajectoryLogger` that records each tool call (name, redacted args, result summary, pass/fail, timestamp) during a cron session to a JSON sidecar at `~/.hermes/evolution/trajectories/<date>.json`.

This is increment 1 of 3 for parent #1203 (trajectory-level safety monitoring). Increments 2 (pattern detection) and 3 (alerting) are separate child issues.

## Implementation
- `scripts/evolution_trajectory_logger.py` — `TrajectoryLogger` context manager with secret redaction, value truncation, and append-to-daily-file semantics
- `tests/scripts/test_evolution_trajectory_logger.py` — 13 tests covering redaction, truncation, basic logging, failed calls, multi-session append, idempotent close, post-close ignore

## Design
- Zero core coupling: standalone library, no modifications to `run_agent.py` or `model_tools.py`
- Profile-safe: uses `get_hermes_home()` for the sidecar directory
- Secret-like argument keys (api_key, token, password, etc.) are redacted before logging

## Checks
- lint ✓ (ruff check + ruff format)
- tests ✓ (13/13 passed)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>