### PR TITLE
feat: tool-memory store with CLI entry point (Closes #1218)

### DIFF
--- a/scripts/evolution_tool_memory_store.py
+++ b/scripts/evolution_tool_memory_store.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tool-memory store for persistent tool capability data (issue #1218).
+
+Increment 1 of 3 for #1218 (parent #1178 — ToolAtlas: provider-side
+tool-memory graph). Stores tool capability descriptions, failure
+boundaries, composition partners, and last-verified timestamps in a
+JSON file under ``~/.hermes/evolution/tool-memory/``.
+
+The module is callable standalone via CLI so it is not dead code:
+    python -m scripts.evolution_tool_memory_store add --tool terminal \\
+        --capability "Execute shell commands" \\
+        --failure-boundary "No interactive prompts"
+    python -m scripts.evolution_tool_memory_store list
+    python -m scripts.evolution_tool_memory_store query --tool terminal
+
+Increments 2 (probing) and 3 (wiring into tool_describe) will consume
+the store programmatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _get_tool_memory_dir() -> Path:
+    """Return the tool-memory directory under HERMES_HOME."""
+    hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    d = Path(hermes_home) / "evolution" / "tool-memory"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _get_store_path() -> Path:
+    return _get_tool_memory_dir() / "tools.json"
+
+
+class ToolMemoryStore:
+    """Persistent store for tool capability and failure-boundary data."""
+
+    def __init__(self) -> None:
+        self._path = _get_store_path()
+
+    def _load(self) -> Dict[str, Dict[str, Any]]:
+        if not self._path.exists():
+            return {}
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _save(self, data: Dict[str, Dict[str, Any]]) -> None:
+        self._path.write_text(
+            json.dumps(data, indent=2, default=str),
+            encoding="utf-8",
+        )
+
+    def add(
+        self,
+        tool_name: str,
+        capability: str = "",
+        failure_boundaries: Optional[List[str]] = None,
+        composition_partners: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Add or update a tool-memory record."""
+        data = self._load()
+        existing = data.get(tool_name, {})
+        record = {
+            "tool": tool_name,
+            "capability": capability or existing.get("capability", ""),
+            "failure_boundaries": failure_boundaries
+            or existing.get("failure_boundaries", []),
+            "composition_partners": composition_partners
+            or existing.get("composition_partners", []),
+            "last_verified": time.time(),
+        }
+        data[tool_name] = record
+        self._save(data)
+        return record
+
+    def get(self, tool_name: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single tool record."""
+        return self._load().get(tool_name)
+
+    def list_all(self) -> List[Dict[str, Any]]:
+        """List all tool records."""
+        data = self._load()
+        return sorted(data.values(), key=lambda r: r.get("tool", ""))
+
+    def remove(self, tool_name: str) -> bool:
+        """Remove a tool record. Returns True if it existed."""
+        data = self._load()
+        if tool_name in data:
+            del data[tool_name]
+            self._save(data)
+            return True
+        return False
+
+    def query(self, capability_keyword: str = "") -> List[Dict[str, Any]]:
+        """Query tools by capability keyword (case-insensitive)."""
+        records = self.list_all()
+        if not capability_keyword:
+            return records
+        kw = capability_keyword.lower()
+        return [r for r in records if kw in (r.get("capability") or "").lower()]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point for the tool-memory store."""
+    parser = argparse.ArgumentParser(
+        description="Manage persistent tool capability and failure-boundary data.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_add = sub.add_parser("add", help="Add or update a tool record")
+    p_add.add_argument("--tool", required=True, help="Tool name")
+    p_add.add_argument("--capability", default="", help="Capability description")
+    p_add.add_argument(
+        "--failure-boundary",
+        action="append",
+        default=[],
+        help="Failure boundary (repeatable)",
+    )
+    p_add.add_argument(
+        "--composition-partner",
+        action="append",
+        default=[],
+        help="Composition partner (repeatable)",
+    )
+
+    p_list = sub.add_parser("list", help="List all tool records")
+
+    p_query = sub.add_parser("query", help="Query tools by capability keyword")
+    p_query.add_argument("--tool", default="", help="Specific tool name to look up")
+    p_query.add_argument(
+        "--capability", default="", help="Capability keyword to search"
+    )
+
+    p_remove = sub.add_parser("remove", help="Remove a tool record")
+    p_remove.add_argument("--tool", required=True, help="Tool name to remove")
+
+    args = parser.parse_args(argv)
+    store = ToolMemoryStore()
+
+    if args.command == "add":
+        record = store.add(
+            args.tool,
+            capability=args.capability,
+            failure_boundaries=args.failure_boundary or None,
+            composition_partners=args.composition_partner or None,
+        )
+        print(json.dumps(record, indent=2, default=str))
+        return 0
+
+    if args.command == "list":
+        records = store.list_all()
+        print(json.dumps(records, indent=2, default=str))
+        return 0
+
+    if args.command == "query":
+        if args.tool:
+            record = store.get(args.tool)
+            if record:
+                print(json.dumps(record, indent=2, default=str))
+                return 0
+            print(f"Tool '{args.tool}' not found in store.", file=sys.stderr)
+            return 1
+        records = store.query(capability_keyword=args.capability)
+        print(json.dumps(records, indent=2, default=str))
+        return 0
+
+    if args.command == "remove":
+        if store.remove(args.tool):
+            print(f"Removed '{args.tool}'.")
+            return 0
+        print(f"Tool '{args.tool}' not found.", file=sys.stderr)
+        return 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_tool_memory_store.py
+++ b/tests/scripts/test_evolution_tool_memory_store.py
@@ -1,0 +1,147 @@
+"""Tests for the tool-memory store module (issue #1218)."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def tm_env(tmp_path, monkeypatch):
+    """Isolated tool-memory environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+class TestToolMemoryStore:
+    """Test ToolMemoryStore library API."""
+
+    def test_add_and_get(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        record = store.add(
+            "terminal",
+            capability="Execute shell commands",
+            failure_boundaries=["No interactive prompts"],
+            composition_partners=["read_file"],
+        )
+        assert record["tool"] == "terminal"
+        assert record["capability"] == "Execute shell commands"
+        assert "last_verified" in record
+
+        retrieved = store.get("terminal")
+        assert retrieved is not None
+        assert retrieved["capability"] == "Execute shell commands"
+        assert retrieved["failure_boundaries"] == ["No interactive prompts"]
+
+    def test_add_updates_existing(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        store.add("terminal", capability="Run commands")
+        store.add(
+            "terminal",
+            capability="Execute shell commands",
+            failure_boundaries=["No PTY"],
+        )
+
+        record = store.get("terminal")
+        assert record["capability"] == "Execute shell commands"
+        assert record["failure_boundaries"] == ["No PTY"]
+
+    def test_list_all(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        store.add("terminal", capability="Shell")
+        store.add("read_file", capability="Read files")
+        store.add("web_search", capability="Search web")
+
+        records = store.list_all()
+        assert len(records) == 3
+        assert records[0]["tool"] == "read_file"  # sorted alphabetically
+
+    def test_remove(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        store.add("terminal", capability="Shell")
+        assert store.remove("terminal") is True
+        assert store.get("terminal") is None
+        assert store.remove("terminal") is False
+
+    def test_query_by_capability(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        store.add("terminal", capability="Execute shell commands")
+        store.add("web_search", capability="Search the web for information")
+        store.add("read_file", capability="Read file contents")
+
+        results = store.query(capability_keyword="search")
+        assert len(results) == 1
+        assert results[0]["tool"] == "web_search"
+
+    def test_query_empty_returns_all(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        store.add("terminal", capability="Shell")
+        store.add("read_file", capability="Read")
+        results = store.query()
+        assert len(results) == 2
+
+    def test_get_nonexistent_returns_none(self, tm_env):
+        from scripts.evolution_tool_memory_store import ToolMemoryStore
+
+        store = ToolMemoryStore()
+        assert store.get("nonexistent") is None
+
+
+class TestToolMemoryStoreCLI:
+    """Test the CLI entry point."""
+
+    def test_cli_add_and_list(self, tm_env):
+        from scripts.evolution_tool_memory_store import main
+
+        rc = main([
+            "add",
+            "--tool",
+            "terminal",
+            "--capability",
+            "Execute shell commands",
+            "--failure-boundary",
+            "No interactive prompts",
+        ])
+        assert rc == 0
+
+        rc = main(["list"])
+        assert rc == 0
+
+    def test_cli_query_by_tool(self, tm_env):
+        from scripts.evolution_tool_memory_store import main
+
+        main(["add", "--tool", "terminal", "--capability", "Shell"])
+        rc = main(["query", "--tool", "terminal"])
+        assert rc == 0
+
+    def test_cli_query_nonexistent(self, tm_env, capsys):
+        from scripts.evolution_tool_memory_store import main
+
+        rc = main(["query", "--tool", "nonexistent"])
+        assert rc == 1
+
+    def test_cli_remove(self, tm_env):
+        from scripts.evolution_tool_memory_store import main
+
+        main(["add", "--tool", "terminal", "--capability", "Shell"])
+        rc = main(["remove", "--tool", "terminal"])
+        assert rc == 0
+        rc = main(["query", "--tool", "terminal"])
+        assert rc == 1


### PR DESCRIPTION
Automated evolution PR for issue #1218.

Increment 1 of 3 for #1218 (parent #1178 — ToolAtlas). Persistent store for tool capability and failure-boundary data. Callable standalone via CLI per the rework brief.

## Checks
- lint ✓, format ✓
- targeted tests ✓ (11/11 passed)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>