### PR TITLE
feat: wire CFG/DFG graph extraction into evolution funnel pipeline (Closes #1221)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -617,6 +617,45 @@ def main(argv: list[str]) -> int:
     except Exception:
         pass
 
+    # CFG/DFG graph extraction wiring (#1221) — extract control/data-flow
+    # graphs for changed Python files so the IFG monitor (#1180 increment 1)
+    # has a live consumer producing graph data each cycle.
+    try:
+        from evolution_graph_extract import extract_graph
+
+        _repo_dir = _resolve_repo_dir()
+        if _repo_dir is not None:
+            import subprocess as _sp
+
+            _diff = _sp.run(
+                [
+                    "git",
+                    "-C",
+                    str(_repo_dir),
+                    "diff",
+                    "--name-only",
+                    "HEAD~1",
+                    "HEAD",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            _py_files = [
+                str(_repo_dir / f)
+                for f in _diff.stdout.splitlines()
+                if f.endswith(".py") and (_repo_dir / f).is_file()
+            ]
+            if _py_files:
+                _graphs = extract_graph(_py_files[:10])
+                (evolution_dir / "graphs").mkdir(parents=True, exist_ok=True)
+                (evolution_dir / "graphs" / f"{date}.json").write_text(
+                    json.dumps(_graphs, indent=2, sort_keys=True), encoding="utf-8"
+                )
+    except Exception:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_graph_extract.py
+++ b/scripts/evolution_graph_extract.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Control-flow/data-flow graph extraction from Python code (issue #1221, child of #1180).
+
+ast.parse-based graph extraction: per-function control-flow (branches, calls,
+returns, raises, loops) and data-flow (assignments, params, returns). Output
+structured JSON. Read-only analysis, no behavioral change.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+__all__ = [
+    "ControlFlowEdge",
+    "DataFlowEdge",
+    "FunctionGraph",
+    "FileGraph",
+    "extract_file_graph",
+    "extract_graph",
+    "graph_to_json",
+    "main",
+]
+
+
+@dataclass
+class ControlFlowEdge:
+    type: str
+    line: int
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {"type": self.type, "line": self.line}
+        if self.detail:
+            d["detail"] = self.detail
+        return d
+
+
+@dataclass
+class DataFlowEdge:
+    type: str
+    line: int
+    target: str = ""
+    source: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {"type": self.type, "line": self.line}
+        if self.target:
+            d["target"] = self.target
+        if self.source:
+            d["source"] = self.source
+        return d
+
+
+@dataclass
+class FunctionGraph:
+    name: str
+    line: int
+    control_flow: List[ControlFlowEdge] = field(default_factory=list)
+    data_flow: List[DataFlowEdge] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "line": self.line,
+            "control_flow": [e.to_dict() for e in self.control_flow],
+            "data_flow": [e.to_dict() for e in self.data_flow],
+        }
+
+
+@dataclass
+class FileGraph:
+    path: str
+    functions: List[FunctionGraph] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"path": self.path, "functions": [f.to_dict() for f in self.functions]}
+
+
+class _Extractor(ast.NodeVisitor):
+    """AST visitor extracting control/data-flow edges per function."""
+
+    def __init__(self) -> None:
+        self.current_func: Optional[FunctionGraph] = None
+        self._functions: List[FunctionGraph] = []
+
+    def _txt(self, node: ast.expr) -> str:
+        try:
+            return ast.unparse(node)
+        except Exception:
+            return type(node).__name__
+
+    def _handle_func(self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> None:
+        parent = self.current_func
+        fg = FunctionGraph(name=node.name, line=node.lineno)
+        self.current_func = fg
+        for arg in node.args.args:
+            fg.data_flow.append(
+                DataFlowEdge(type="param", line=node.lineno, target=arg.arg)
+            )
+        for stmt in node.body:
+            self.visit(stmt)
+        self._functions.append(fg)
+        self.current_func = parent
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._handle_func(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._handle_func(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        if self.current_func:
+            self.current_func.control_flow.append(
+                ControlFlowEdge(
+                    type="branch", line=node.lineno, detail=self._txt(node.test)
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        if self.current_func:
+            self.current_func.control_flow.append(
+                ControlFlowEdge(
+                    type="loop", line=node.lineno, detail=self._txt(node.iter)
+                )
+            )
+            self.current_func.data_flow.append(
+                DataFlowEdge(
+                    type="assign",
+                    line=node.lineno,
+                    target=self._txt(node.target),
+                    source=self._txt(node.iter),
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        if self.current_func:
+            self.current_func.control_flow.append(
+                ControlFlowEdge(
+                    type="loop", line=node.lineno, detail=self._txt(node.test)
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self.current_func:
+            target = self._txt(node.func)
+            args = [self._txt(a) for a in node.args]
+            self.current_func.control_flow.append(
+                ControlFlowEdge(
+                    type="call", line=node.lineno, detail=f"{target}({', '.join(args)})"
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if self.current_func:
+            val = self._txt(node.value) if node.value else "None"
+            self.current_func.control_flow.append(
+                ControlFlowEdge(type="return", line=node.lineno, detail=val)
+            )
+            self.current_func.data_flow.append(
+                DataFlowEdge(type="return_value", line=node.lineno, source=val)
+            )
+        self.generic_visit(node)
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        if self.current_func:
+            self.current_func.control_flow.append(
+                ControlFlowEdge(
+                    type="raise",
+                    line=node.lineno,
+                    detail=self._txt(node.exc) if node.exc else "re-raise",
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if self.current_func:
+            targets = ", ".join(self._txt(t) for t in node.targets)
+            self.current_func.data_flow.append(
+                DataFlowEdge(
+                    type="assign",
+                    line=node.lineno,
+                    target=targets,
+                    source=self._txt(node.value),
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if self.current_func:
+            self.current_func.data_flow.append(
+                DataFlowEdge(
+                    type="aug_assign",
+                    line=node.lineno,
+                    target=self._txt(node.target),
+                    source=self._txt(node.value),
+                )
+            )
+        self.generic_visit(node)
+
+    def extract(self, tree: ast.AST) -> List[FunctionGraph]:
+        self._functions = []
+        self.current_func = None
+        self.visit(tree)
+        return self._functions
+
+
+def extract_file_graph(source: str, path: str = "<string>") -> Optional[FileGraph]:
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return None
+    return FileGraph(path=path, functions=_Extractor().extract(tree))
+
+
+def extract_graph(paths: Sequence[Union[str, Path]]) -> Dict[str, Any]:
+    files_data, errors = [], []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            errors.append(str(path))
+            continue
+        try:
+            src = path.read_text(encoding="utf-8")
+        except OSError:
+            errors.append(str(path))
+            continue
+        g = extract_file_graph(src, str(path))
+        if g is None:
+            errors.append(str(path))
+            continue
+        files_data.append(g.to_dict())
+    return {"files": files_data, "errors": errors}
+
+
+def graph_to_json(g: Dict[str, Any]) -> str:
+    return json.dumps(g, indent=2, sort_keys=True)
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    paths = [a for a in args if not a.startswith("--")]
+    if not paths:
+        print("usage: evolution_graph_extract.py <file.py> [...]", file=sys.stderr)
+        return 2
+    print(graph_to_json(extract_graph(paths)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_graph_extract_wiring.py
+++ b/tests/scripts/test_evolution_graph_extract_wiring.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Test that evolution_funnel wires in CFG/DFG graph extraction (#1221).
+
+Verifies that:
+1. When no git repo is resolvable (_resolve_repo_dir -> None), funnel main()
+   completes without crash (graph-extraction sidecar is a no-op).
+2. When a fake repo with .git and a sample .py file exists, main() writes
+   ``<EVOLUTION_PROFILE_DIR>/graphs/<date>.json`` containing extracted
+   function control/data-flow data.
+
+Also confirms resilience: the lazy-import try/except/pass wrapping means a
+missing or broken graph extractor never crashes the funnel job.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make scripts/ importable so `from evolution_graph_extract import ...`
+# (used inside evolution_funnel.main) and `import evolution_funnel` both work.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import evolution_funnel as ef  # noqa: E402
+
+
+def _write_stage_reports(evolution_dir: Path, date: str) -> None:
+    """Write minimal analysis + integration stage reports for ``date``.
+
+    compute_funnel reads issues/<date>.json, analysis/<date>.json,
+    integration/<date>.json, and introspection/<date>.json — all optional and
+    all default to empty/0. We provide analysis + integration so the funnel
+    record has non-trivial selected/merged/skipped fields.
+    """
+    (evolution_dir / "analysis").mkdir(parents=True, exist_ok=True)
+    (evolution_dir / "integration").mkdir(parents=True, exist_ok=True)
+    (evolution_dir / "analysis" / f"{date}.json").write_text(
+        json.dumps({
+            "selected_for_implementation": [
+                {"issue_number": 1221, "selected_reason": "test"}
+            ],
+            "rejected": [{"reason_code": "dup"}],
+        }),
+        encoding="utf-8",
+    )
+    (evolution_dir / "integration" / f"{date}.json").write_text(
+        json.dumps({"merged": [{"issue_number": 1221}], "skipped": []}),
+        encoding="utf-8",
+    )
+
+
+_SAMPLE_PY = """\
+def foo(x):
+    if x > 0:
+        return x
+    return -x
+"""
+
+
+def test_no_repo_no_crash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When _resolve_repo_dir returns None, funnel completes without crash."""
+    date = "2099-01-02"
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setenv("EVOLUTION_FUNNEL_DATE", date)
+    monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda *a, **k: None, raising=False)
+    # Force _resolve_repo_dir to return None — no repo to diff.
+    monkeypatch.setattr(ef, "_resolve_repo_dir", lambda: None, raising=False)
+
+    _write_stage_reports(tmp_path, date)
+
+    rc = ef.main(["funnel", date])
+    assert rc == 0, f"evolution_funnel.main returned {rc}"
+
+    # No graphs directory should be created when there's no repo.
+    assert not (tmp_path / "graphs").exists(), (
+        "graphs/ written despite _resolve_repo_dir returning None"
+    )
+
+
+def test_graph_extraction_writes_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When a fake repo with .git + a .py file exists, graphs/<date>.json is
+    written with extracted function data."""
+    date = "2099-01-03"
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setenv("EVOLUTION_FUNNEL_DATE", date)
+    monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda *a, **k: None, raising=False)
+
+    # Build a fake repo with .git and one .py file.
+    fake_repo = tmp_path / "fake-repo"
+    fake_repo.mkdir()
+    (fake_repo / ".git").mkdir()
+    py_file = fake_repo / "sample.py"
+    py_file.write_text(_SAMPLE_PY, encoding="utf-8")
+
+    monkeypatch.setattr(ef, "_resolve_repo_dir", lambda: fake_repo, raising=False)
+
+    # Mock subprocess.run so the git-diff returns our sample file name.
+    # The wiring code does `import subprocess as _sp` *inside* its try block,
+    # creating a local alias — so we must patch the global subprocess module,
+    # not ef.subprocess (which is only used by the funnel's own gh calls, and
+    # those are already neutralised by the _gh_pr_list_merged mock above).
+    import subprocess as _sp_mod
+
+    def _fake_run(cmd, *a, **k):
+        result = MagicMock()
+        # The wiring uses ["git", "-C", <repo>, "diff", "--name-only",
+        # "HEAD~1", "HEAD"]. Return our sample file name.
+        if "diff" in cmd and "--name-only" in cmd:
+            result.stdout = "sample.py\n"
+            result.returncode = 0
+        else:
+            result.stdout = ""
+            result.returncode = 0
+        return result
+
+    monkeypatch.setattr(_sp_mod, "run", _fake_run, raising=False)
+
+    _write_stage_reports(tmp_path, date)
+
+    rc = ef.main(["funnel", date])
+    assert rc == 0, f"evolution_funnel.main returned {rc}"
+
+    graph_file = tmp_path / "graphs" / f"{date}.json"
+    assert graph_file.exists(), f"graphs/{date}.json was not written"
+
+    data = json.loads(graph_file.read_text(encoding="utf-8"))
+    assert "files" in data, "graph JSON missing 'files' key"
+    assert len(data["files"]) == 1, f"expected 1 file, got {len(data['files'])}"
+    fg = data["files"][0]
+    assert fg["path"].endswith("sample.py"), (
+        f"expected path ending in sample.py, got {fg['path']}"
+    )
+    assert len(fg["functions"]) == 1, f"expected 1 function, got {len(fg['functions'])}"
+    func = fg["functions"][0]
+    assert func["name"] == "foo", f"expected function 'foo', got {func['name']}"
+    # The function has a branch (if x > 0) and two returns.
+    cf_types = [e["type"] for e in func["control_flow"]]
+    assert "branch" in cf_types, f"expected 'branch' in control_flow, got {cf_types}"
+    assert "return" in cf_types, f"expected 'return' in control_flow, got {cf_types}"
+    # Data flow should include param edges for x.
+    df_types = [e["type"] for e in func["data_flow"]]
+    assert "param" in df_types, f"expected 'param' in data_flow, got {df_types}"


### PR DESCRIPTION
Automated evolution PR for issue #1221.

Wires evolution_graph_extract.py into evolution_funnel.py's daily no_agent cron cycle, giving the module a live consumer in the evolution pipeline. The graph extractor produces CFG/DFG JSON for changed Python files in ~/.hermes/evolution/graphs/.

This resolves the dead-code bounce: the module is now exercised from within the pipeline (imported and called by evolution_funnel.main()), not just callable as a standalone CLI.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>