### PR TITLE
feat: wire trajectory logger into evolution funnel pipeline (Closes #1215)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -584,6 +584,20 @@ def main(argv: list[str]) -> int:
     except Exception:
         pass
 
+    # Trajectory logger wiring (#1215) — record a trajectory entry for this
+    # funnel cycle so downstream analysis can detect suspicious action-sequence
+    # patterns (#1203 increment 1).
+    try:
+        from evolution_trajectory_logger import TrajectoryLog
+
+        traj = TrajectoryLog(session_id="funnel", date=date)
+        traj.add_tool_call(
+            "evolution_funnel", {"date": date}, result=record, status="success"
+        )
+        traj.save(evolution_dir / "trajectories")
+    except Exception:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Trajectory logging — record cron-cycle action sequences (issue #1215, child of #1203).
+
+Logging-only module: records tool calls during cron sessions as JSON sidecar
+in ~/.hermes/evolution/trajectories/<date>.json. No behavioral change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "TrajectoryEntry",
+    "TrajectoryLog",
+    "redact_args",
+    "summarize_result",
+    "load_trajectory",
+    "main",
+]
+
+_REDACT_ARG_KEYS = frozenset({
+    "token",
+    "api_key",
+    "apikey",
+    "password",
+    "passwd",
+    "secret",
+    "authorization",
+    "auth",
+    "credential",
+    "private_key",
+    "session_token",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+})
+_MAX_RESULT_SUMMARY_LEN = 500
+
+
+def redact_args(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact sensitive argument values. Recursively handles nested dicts/lists."""
+    if not isinstance(args, dict):
+        return args  # type: ignore[return-value]
+    out: Dict[str, Any] = {}
+    for k, v in args.items():
+        if isinstance(k, str) and k.lower() in _REDACT_ARG_KEYS:
+            out[k] = "[REDACTED]"
+        elif isinstance(v, dict):
+            out[k] = redact_args(v)
+        elif isinstance(v, list):
+            out[k] = [redact_args(x) if isinstance(x, dict) else x for x in v]
+        else:
+            out[k] = v
+    return out
+
+
+def summarize_result(result: Any) -> str:
+    """Short string summary of a tool result, truncated."""
+    if result is None:
+        return "null"
+    text = (
+        result
+        if isinstance(result, str)
+        else json.dumps(result, default=str)
+        if not isinstance(result, str)
+        else result
+    )
+    try:
+        text = result if isinstance(result, str) else json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        text = str(result)
+    return (
+        text[:_MAX_RESULT_SUMMARY_LEN] + "...[truncated]"
+        if len(text) > _MAX_RESULT_SUMMARY_LEN
+        else text
+    )
+
+
+@dataclass
+class TrajectoryEntry:
+    tool: str
+    args_summary: Dict[str, Any] = field(default_factory=dict)
+    result_status: str = "unknown"
+    result_summary: str = ""
+    timestamp: str = ""
+    duration_ms: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "timestamp": self.timestamp,
+            "tool": self.tool,
+            "args_summary": self.args_summary,
+            "result_status": self.result_status,
+            "result_summary": self.result_summary,
+        }
+        if self.duration_ms is not None:
+            d["duration_ms"] = self.duration_ms
+        return d
+
+    @classmethod
+    def from_tool_call(
+        cls,
+        tool: str,
+        args: Dict[str, Any],
+        result: Any = None,
+        status: str = "success",
+        duration_ms: Optional[int] = None,
+    ) -> "TrajectoryEntry":
+        return cls(
+            tool=tool,
+            args_summary=redact_args(args) if isinstance(args, dict) else {},
+            result_status=status,
+            result_summary=summarize_result(result),
+            duration_ms=duration_ms,
+        )
+
+
+class TrajectoryLog:
+    """In-memory trajectory log for a single cron session."""
+
+    def __init__(self, session_id: str = "", date: str = "") -> None:
+        self.session_id = session_id
+        self.date = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        self.entries: List[TrajectoryEntry] = []
+
+    def add(self, entry: TrajectoryEntry) -> None:
+        self.entries.append(entry)
+
+    def add_tool_call(
+        self,
+        tool: str,
+        args: Dict[str, Any],
+        result: Any = None,
+        status: str = "success",
+        duration_ms: Optional[int] = None,
+    ) -> None:
+        self.add(
+            TrajectoryEntry.from_tool_call(tool, args, result, status, duration_ms)
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "date": self.date,
+            "session_id": self.session_id,
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def save(self, trajectory_dir: Optional[Path] = None) -> Path:
+        if trajectory_dir is None:
+            trajectory_dir = _default_trajectory_dir()
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        fname = (
+            f"{self.date}_{self.session_id}.json"
+            if self.session_id
+            else f"{self.date}.json"
+        )
+        path = trajectory_dir / fname
+        path.write_text(self.to_json(), encoding="utf-8")
+        return path
+
+    @property
+    def tool_sequence(self) -> List[str]:
+        return [e.tool for e in self.entries]
+
+    def tools_used(self) -> set[str]:
+        return {e.tool for e in self.entries}
+
+    def failure_count(self) -> int:
+        return sum(1 for e in self.entries if e.result_status in ("failure", "error"))
+
+
+def _default_trajectory_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / "trajectories"
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / "trajectories"
+        if hh
+        else Path.home() / ".hermes" / "evolution" / "trajectories"
+    )
+
+
+def load_trajectory(path: Path) -> Optional[TrajectoryLog]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    log = TrajectoryLog(
+        session_id=data.get("session_id", ""), date=data.get("date", "")
+    )
+    for ed in data.get("entries", []):
+        if isinstance(ed, dict):
+            log.entries.append(
+                TrajectoryEntry(
+                    tool=ed.get("tool", "unknown"),
+                    args_summary=ed.get("args_summary", {}),
+                    result_status=ed.get("result_status", "unknown"),
+                    result_summary=ed.get("result_summary", ""),
+                    timestamp=ed.get("timestamp", ""),
+                    duration_ms=ed.get("duration_ms"),
+                )
+            )
+    return log
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    if not args:
+        print("usage: evolution_trajectory_logger.py <date> [--dir DIR] | --file PATH")
+        return 2
+    if args[0] == "--file" and len(args) > 1:
+        log = load_trajectory(Path(args[1]))
+        if log is None:
+            print(f"error: could not load {args[1]}", file=sys.stderr)
+            return 1
+        print(log.to_json())
+        return 0
+    date, traj_dir = args[0], _default_trajectory_dir()
+    if "--dir" in args and args.index("--dir") + 1 < len(args):
+        traj_dir = Path(args[args.index("--dir") + 1])
+    files = sorted(traj_dir.glob(f"{date}*.json"))
+    if not files:
+        print(f"no trajectory files for {date} in {traj_dir}")
+        return 0
+    print(f"Trajectory files for {date} ({len(files)}):")
+    for f in files:
+        log = load_trajectory(f)
+        if log:
+            tools = ", ".join(sorted(log.tools_used())) or "(none)"
+            print(
+                f"  {f.name}: {len(log.entries)} entries, tools=[{tools}], failures={log.failure_count()}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_trajectory_wiring.py
+++ b/tests/scripts/test_evolution_trajectory_wiring.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Test that evolution_funnel wires in the trajectory logger (#1215).
+
+Verifies that a trajectory JSON file is written to
+``<EVOLUTION_PROFILE_DIR>/trajectories/`` when ``evolution_funnel.main()``
+runs, and that the trajectory contains an entry with ``tool='evolution_funnel'``.
+Also tests resilience: missing stage modules must not crash the funnel.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable so `from evolution_trajectory_logger import ...`
+# (used inside evolution_funnel.main) and `import evolution_funnel` both work.
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import evolution_funnel as ef  # noqa: E402
+
+
+def _write_stage_reports(evolution_dir: Path, date: str) -> None:
+    """Write minimal analysis + integration stage reports for ``date``.
+
+    compute_funnel reads issues/<date>.json, analysis/<date>.json,
+    integration/<date>.json, and introspection/<date>.json — all optional and
+    all default to empty/0. We provide analysis + integration so the funnel
+    record has non-trivial selected/merged/skipped fields.
+    """
+    (evolution_dir / "analysis").mkdir(parents=True, exist_ok=True)
+    (evolution_dir / "integration").mkdir(parents=True, exist_ok=True)
+    (evolution_dir / "analysis" / f"{date}.json").write_text(
+        json.dumps({
+            "selected_for_implementation": [
+                {"issue_number": 1215, "selected_reason": "test"}
+            ],
+            "rejected": [{"reason_code": "dup"}],
+        }),
+        encoding="utf-8",
+    )
+    (evolution_dir / "integration" / f"{date}.json").write_text(
+        json.dumps({"merged": [{"issue_number": 1215}], "skipped": []}),
+        encoding="utf-8",
+    )
+
+
+def test_trajectory_wiring(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """main() writes a trajectory JSON containing an evolution_funnel entry."""
+    date = "2099-01-02"
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setenv("EVOLUTION_FUNNEL_DATE", date)
+    # Prevent any real GitHub network calls: _gh_pr_list_merged -> None makes
+    # merged_evolution_issue_ids return None (fail-open to self-report).
+    monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda *a, **k: None, raising=False)
+
+    _write_stage_reports(tmp_path, date)
+
+    rc = ef.main(["funnel", date])
+    assert rc == 0, f"evolution_funnel.main returned {rc}"
+
+    traj_dir = tmp_path / "trajectories"
+    traj_files = list(traj_dir.glob("*.json"))
+    assert traj_files, f"no trajectory JSON written under {traj_dir}"
+
+    # The funnel writes <date>_funnel.json (session_id='funnel').
+    found_entry = False
+    for f in traj_files:
+        data = json.loads(f.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+        for entry in data.get("entries", []):
+            if entry.get("tool") == "evolution_funnel":
+                found_entry = True
+                assert entry.get("result_status") == "success"
+                break
+        if found_entry:
+            break
+    assert found_entry, (
+        f"no trajectory entry with tool='evolution_funnel' in {traj_files}"
+    )
+
+
+def test_funnel_resilience_missing_modules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing optional modules must not crash the funnel — lazy imports are
+    wrapped in try/except/pass, so a broken/absent trajectory logger (or any
+    other sidecar) leaves main() returning 0 and the metrics line intact."""
+    date = "2099-01-03"
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    monkeypatch.setenv("EVOLUTION_FUNNEL_DATE", date)
+    monkeypatch.setattr(ef, "_gh_pr_list_merged", lambda *a, **k: None, raising=False)
+    # Sabotage the trajectory logger import path so the lazy import inside
+    # main() raises ImportError — the try/except/pass must swallow it.
+    monkeypatch.setitem(
+        sys.modules,
+        "evolution_trajectory_logger",
+        None,  # type: ignore[arg-type]
+    )
+
+    _write_stage_reports(tmp_path, date)
+
+    rc = ef.main(["funnel", date])
+    assert rc == 0, "funnel must not crash when a sidecar module is unavailable"
+
+    # The core metrics.jsonl must still be written even if sidecars fail.
+    metrics = tmp_path / "metrics.jsonl"
+    assert metrics.exists(), "metrics.jsonl missing despite sidecar failure"
+    rec = json.loads(metrics.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert rec["date"] == date


### PR DESCRIPTION
Automated evolution PR for issue #1215.

Wires evolution_trajectory_logger.py into evolution_funnel.py's daily no_agent cron cycle, giving the trajectory logger a live consumer in the evolution pipeline. The funnel records each cycle's tool calls as a JSON sidecar in ~/.hermes/evolution/trajectories/.

This resolves the dead-code bounce: the module is now exercised from within the pipeline (imported and called by evolution_funnel.main()), not just callable as a standalone CLI.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>