### PR TITLE
fix(update): stop `hermes update` auto-merging bleeding-edge upstream/main

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7047,8 +7047,9 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
     - If upstream remote doesn't exist, ask user if they want to add it
     - Compare origin/main with upstream/main
     - If origin/main is strictly behind upstream/main, fast-forward pull
-    - If fork has diverged (ahead AND behind), attempt a merge
-    - Try to sync fork back to origin if possible
+    - If fork has diverged (ahead AND behind), SKIP the upstream/main merge
+      (this fork tracks upstream release tags via its release-sync process,
+      not bleeding-edge upstream/main)
     """
     has_upstream = _has_upstream_remote(git_cmd, cwd)
 
@@ -7120,48 +7121,23 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             print("  ✓ Fork is up to date with upstream (fork has extra commits)")
             return
 
-        # Fork has diverged: both ahead AND behind upstream.
-        # Attempt a merge to integrate upstream changes while preserving
-        # the fork's local commits.  This is safer than rebase for forks
-        # with many local commits because it preserves all commit SHAs
-        # and creates a single merge commit that can be easily reverted.
+        # Fork has diverged: both ahead AND behind upstream/main. Do NOT
+        # auto-merge upstream/main here. This fork tracks upstream RELEASE TAGS
+        # (the stabilized ``v2026.M.D`` releases) via its dedicated
+        # evolution-upstream-sync process, NOT bleeding-edge ``upstream/main``
+        # (~300 commits/day — an unwinnable chase that conflicts on essentially
+        # every update and would abort, or silently drop fork features on a
+        # blind resolve). Leave upstream integration to the release-sync process
+        # and preserve the fork's commits untouched here.
         print()
         print(
-            f"ℹ Your fork has {origin_ahead} commit(s) not on upstream "
-            f"and is {upstream_ahead} commit(s) behind."
+            f"ℹ Fork has {origin_ahead} commit(s) not on upstream and is "
+            f"{upstream_ahead} commit(s) behind upstream/main."
         )
-        print("→ Merging upstream changes into fork...")
-
-        merge_result = subprocess.run(
-            git_cmd + ["merge", "upstream/main", "--no-edit"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
+        print(
+            "  ↷ Skipping upstream/main auto-merge — this fork tracks upstream "
+            "release tags via its release-sync process, not bleeding-edge main."
         )
-        if merge_result.returncode != 0:
-            # Merge conflict — abort and let the user resolve manually
-            subprocess.run(
-                git_cmd + ["merge", "--abort"],
-                cwd=cwd,
-                capture_output=True,
-            )
-            print("  ✗ Merge conflict detected. Aborting merge.")
-            print("  To resolve manually, run:")
-            print("    git merge upstream/main")
-            print("  Resolve conflicts, then commit and push to your fork.")
-            return
-
-        print("  ✓ Successfully merged upstream changes into fork")
-
-        # Push the merge to origin so the fork stays in sync
-        print("→ Syncing fork...")
-        if _sync_fork_with_upstream(git_cmd, cwd):
-            print("  ✓ Fork synced with upstream")
-        else:
-            print(
-                "  ℹ Got updates from upstream but couldn't push to fork (no write access?)"
-            )
-            print("    Your local repo is updated, but your fork on GitHub may be behind.")
         return
 
     # If upstream is not ahead, fork is up to date

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -438,6 +438,40 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @patch("subprocess.run")
+    def test_diverged_fork_skips_upstream_main_automerge(self, mock_run, capsys):
+        """A fork diverged from upstream/main (ahead AND behind) must NOT
+        auto-merge bleeding-edge upstream/main — this fork tracks upstream
+        RELEASE tags via its dedicated release-sync process. The update must
+        skip the merge (never run ``git merge upstream/main``) and explain why.
+        Regression for the daily conflict-abort noise after release-tracking
+        landed (upstream/main is ~1000 commits ahead and always conflicts).
+        """
+        from pathlib import Path
+
+        from hermes_cli import main as hm
+
+        calls = []
+
+        def _run(cmd, **kwargs):
+            calls.append(" ".join(str(c) for c in cmd))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = _run
+
+        # origin_ahead=503 AND upstream_ahead=995 → diverged.
+        with patch.object(hm, "_has_upstream_remote", return_value=True), patch.object(
+            hm, "_count_commits_between", side_effect=[503, 995]
+        ):
+            hm._sync_with_upstream_if_needed(["git"], Path("/tmp/fork"))
+
+        assert not any(
+            "merge" in c and "upstream/main" in c for c in calls
+        ), f"must not auto-merge upstream/main: {calls}"
+        out = capsys.readouterr().out
+        assert "Skipping upstream/main auto-merge" in out
+        assert "503 commit(s) not on upstream" in out
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(


### PR DESCRIPTION
`hermes update` on the evolution fork printed a scary **"✗ Merge conflict detected. Aborting merge."** on every run — surfaced right after the v2026.7.20 release-sync landed.

## Root cause
`_sync_with_upstream_if_needed` (hermes_cli/main.py) still attempted `git merge upstream/main` on the **diverged-fork** path. Under release-tracking (evolution-upstream-sync SKILL v3.0.0) the fork syncs upstream **release tags** (`v2026.M.D`), not bleeding-edge `upstream/main` (~300 commits/day). The fork is now ~1000 commits behind main, so that merge **always conflicts and aborts** — noise on an otherwise-healthy update. It also contradicted what `AUTO_UPGRADE.md` / `EVOLUTION_README.md` already document ("the sync-from-upstream step skips to preserve our changes").

## Fix
Skip the `upstream/main` auto-merge on the diverged path and print why; leave upstream integration to the dedicated release-sync process. The fast-forward-behind path is unchanged. The abort left the checkout clean, so no state was ever at risk — this just removes the doomed attempt.

## Test
`+test_diverged_fork_skips_upstream_main_automerge` (asserts no `git merge upstream/main` runs + the skip message). Full `test_cmd_update.py` green (53 passed).