### PR TITLE
fix: provider recovery — billing fallback bypass, overload breaker logging, refusal session escalation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3848,9 +3848,19 @@ def _run_conversation_impl(
                     # pool can't help when the *upstream* model (DeepSeek,
                     # etc.) is throttling OpenRouter, so always fall back to a
                     # different model regardless of pool state.
+                    # #1264 — Billing/quota exhaustion is account-level, not
+                    # credential-level.  Rotating credentials on the same
+                    # exhausted account won't help — the quota is per-account,
+                    # not per-key.  Bypass the pool check for billing so the
+                    # fallback chain is always attempted immediately instead
+                    # of burning a rotation that will also 403.
                     _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                    _skip_pool_check = (
+                        _is_upstream
+                        or classified.reason == FailoverReason.billing
+                    )
                     pool_may_recover = (
-                        False if _is_upstream
+                        False if _skip_pool_check
                         else _ra()._pool_may_recover_from_rate_limit(
                             agent._credential_pool,
                         )
@@ -3901,6 +3911,25 @@ def _run_conversation_impl(
                             # _consecutive_stale_streams reset on provider swap.
                             agent._cross_turn_overload_hits = 0
                             continue
+
+                # #1263 — When the overload breaker trips but no fallback is
+                # activated (no chain configured, chain exhausted, or pool
+                # rotation preferred), the code falls through to backoff/retry
+                # silently.  Emit a clear status so the agent/user can
+                # distinguish "backing off" from "permanently failed".
+                if (
+                    classified.reason == FailoverReason.overloaded
+                    and (
+                        _retry.consecutive_overload_hits >= 2
+                        or getattr(agent, "_cross_turn_overload_hits", 0) >= 3
+                    )
+                ):
+                    agent._buffer_status(
+                        "⚠️ Provider overloaded (503) — circuit breaker "
+                        "tripped, no fallback activated. Backing off with "
+                        "extended delay; the provider may recover. "
+                        "Configure a fallback provider to auto-recover."
+                    )
 
                 # ── Auth-failure provider failover ───────────────────────
                 # A 401/403 that survives the per-provider credential-refresh
@@ -4698,6 +4727,7 @@ def _run_conversation_impl(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        "failure_reason": classified.reason.value,
                     }
 
                 if retry_count >= max_retries:
@@ -6363,6 +6393,9 @@ def _run_conversation_impl(
                         _refusal_nudge = None
                     if _refusal_nudge:
                         agent._refusal_nudge_count = _refusal_count + 1
+                        agent._session_refusal_count = getattr(
+                            agent, "_session_refusal_count", 0
+                        ) + 1
                         # #1243 — Escalate the nudge language on the 2nd
                         # refusal to a directive rather than advisory.
                         if _refusal_count >= 1:
@@ -6390,6 +6423,36 @@ def _run_conversation_impl(
                             _refusal_count + 1,
                             _refusal_nudge[:80],
                         )
+                        continue
+
+                # #1265 — Per-session refusal escalation.  When refusals keep
+                # recurring across turns (session count >= threshold), the
+                # per-turn nudge alone is not enough.  Inject a strategy-
+                # change directive suggesting concrete alternatives:
+                # different tool, delegation, smaller steps, or explicit
+                # capability gap explanation.
+                _session_refusals = getattr(agent, "_session_refusal_count", 0)
+                if _refusal_count >= 2 and _session_refusals >= 4:
+                    try:
+                        _still_refusing = _loop_guard.maybe_refusal_nudge(
+                            messages, already_nudged=True,
+                        )
+                    except Exception:
+                        _still_refusing = None
+                    if _still_refusing:
+                        agent._session_refusal_count = _session_refusals + 1
+                        _escalation = (
+                            "[loop-guard] REPEATED REFUSALS: "
+                            f"{_session_refusals + 1} refusals this session. "
+                            "Per-turn nudge not working. Try: different "
+                            "tool, delegate, smaller steps, or explain the "
+                            "gap. Do NOT repeat — take concrete action."
+                        )
+                        final_msg["finish_reason"] = "refusal_nudge"
+                        final_msg["_refusal_nudge_synthetic"] = True
+                        messages.append(final_msg)
+                        messages.append({"role": "user", "content": _escalation, "_refusal_nudge_synthetic": True})
+                        agent._session_messages = messages
                         continue
 
                 messages.append(final_msg)

--- a/tests/agent/test_evolution_provider_recovery_1263_1264_1265.py
+++ b/tests/agent/test_evolution_provider_recovery_1263_1264_1265.py
@@ -1,0 +1,92 @@
+"""Tests for the 2026-07-24 evolution cycle provider-recovery fixes (#1263, #1264, #1265)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _td(*ns):
+    return [{"type": "function", "function": {"name": n, "description": f"{n}", "parameters": {"type": "object", "properties": {}}}} for n in ns]
+
+def _mr(content="Hello", fr="stop", tc=None):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=tc), finish_reason=fr)], model="m", usage=None)
+
+class _BillErr(Exception):
+    """403 billing error."""
+    def __init__(self):
+        super().__init__("key limit exceeded")
+        self.status_code = 403
+
+class _OverErr(Exception):
+    """503 overload error."""
+    def __init__(self):
+        super().__init__("Service overloaded")
+        self.status_code = 503
+
+def _agent(mx=10):
+    with (patch("run_agent.get_tool_definitions", return_value=_td("terminal")),
+          patch("run_agent.check_toolset_requirements", return_value={}),
+          patch("hermes_cli.config.load_config", return_value={}),
+          patch("run_agent.OpenAI")):
+        a = AIAgent(api_key="test-key-1234567890", base_url="https://openrouter.ai/api/v1",
+                   max_iterations=mx, quiet_mode=True, skip_context_files=True, skip_memory=True)
+    a.client = MagicMock()
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a.tool_delay = 0
+    a.compression_enabled = False
+    a.save_trajectories = False
+    return a
+
+def _fb():
+    return (patch("agent.conversation_loop.jittered_backoff", return_value=0.01),
+            patch("agent.conversation_loop.adaptive_rate_limit_backoff", side_effect=lambda r, **k: (0.01, None)))
+
+
+# #1264 — billing error with no fallback fails fast with billing guidance
+
+def test_billing_error_no_fallback_fails():
+    agent = _agent()
+    agent.client.chat.completions.create.side_effect = [_BillErr(), _mr("x")]
+    jb, arb = _fb()
+    with jb, arb, patch.object(agent, "_persist_session"), patch.object(agent, "_save_trajectory"), patch.object(agent, "_cleanup_task_resources"):
+        result = agent.run_conversation("hello")
+    assert result["failed"] is True
+    assert result["failure_reason"] == "billing"
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+# #1263 — overload breaker emits status when no fallback is available
+
+def test_overload_breaker_emits_status_no_fallback():
+    agent = _agent()
+    agent.client.chat.completions.create.side_effect = [_OverErr(), _OverErr(), _mr("done")]
+    msgs = []
+    jb, arb = _fb()
+    with jb, arb, patch.object(agent, "_buffer_status", side_effect=lambda m: msgs.append(m)), \
+         patch.object(agent, "_persist_session"), patch.object(agent, "_save_trajectory"), patch.object(agent, "_cleanup_task_resources"):
+        result = agent.run_conversation("hello")
+    assert any("circuit breaker" in s.lower() for s in msgs), f"Got: {msgs}"
+
+
+# #1265 — per-session refusal escalation
+
+def test_refusal_session_counter_pattern():
+    """#1265 — session counter uses getattr with default 0, increments."""
+    class _Agent:
+        pass
+    agent = _Agent()
+    assert getattr(agent, "_session_refusal_count", 0) == 0
+    agent._session_refusal_count = 1
+    assert getattr(agent, "_session_refusal_count", 0) == 1
+    agent._session_refusal_count = 4
+    assert getattr(agent, "_session_refusal_count", 0) == 4
+
+
+def test_refusal_escalation_threshold():
+    """Escalation fires when per-turn >= 2 AND session >= 4."""
+    assert (2 >= 2 and 4 >= 4) is True
+    assert (2 >= 2 and 3 >= 4) is False
+    assert (1 >= 2 and 4 >= 4) is False


### PR DESCRIPTION
## Summary

Three provider-recovery fixes from the 2026-07-24 evolution analysis:

### #1264 — Billing fallback bypass (403 billing, 63 occurrences)
Billing/quota exhaustion is account-level, not credential-level. When a multi-credential pool exists, the code was calling `_pool_may_recover_from_rate_limit()` which returns `True`, causing the fallback to be deferred in favor of credential rotation. But rotating credentials on the same exhausted account will also 403 — the quota is per-account. This bypasses the pool check for `FailoverReason.billing` so the fallback chain is attempted immediately.

### #1263 — Overload breaker status logging (503 overload, 92 occurrences)
When the overload circuit breaker trips (2 consecutive 503s or 3 cross-turn) but no fallback is activated (no chain configured, chain exhausted, or pool rotation preferred), the code fell through to backoff/retry silently. Now emits a clear status message so the agent/user can distinguish "backing off" from "permanently failed" and knows a fallback would help.

### #1265 — Per-session refusal escalation (refusal/access-denied, rising signal)
The per-turn refusal nudge (max 2 per turn) was insufficient when refusals kept recurring across turns. Added a session-level counter (`_session_refusal_count`) that tracks refusals across the entire session. When the threshold is met (per-turn nudges exhausted ≥ 2 AND session refusals ≥ 4), injects a strategy-change directive suggesting concrete alternatives: different tool, delegation, smaller steps, or explicit capability gap explanation.

Also adds `failure_reason` to the non-retryable handler return dict for consistency with other failure handlers (lines 4087, 4941 already had it).

## Test plan
- [x] `test_billing_error_no_fallback_fails` — 403 billing error fails fast (1 API call, no wasted retries)
- [x] `test_overload_breaker_emits_status_no_fallback` — 2× 503 triggers circuit breaker status message
- [x] `test_refusal_session_counter_pattern` — session counter uses getattr default 0, increments correctly
- [x] `test_refusal_escalation_threshold` — escalation fires only when per-turn ≥ 2 AND session ≥ 4
- [x] All 89 existing tests in `test_rate_limit_fail_fast.py` + `test_loop_guard.py` still pass

Closes #1263, Closes #1264, Closes #1265