### PR TITLE
feat: wire selective memory addition gate into evolution funnel (#1270)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -690,6 +690,65 @@ def main(argv: list[str]) -> int:
     except Exception:
         pass
 
+    # Selective memory addition gate (#1270) — evaluate the pipeline's own
+    # artifacts (research reports, implementation logs) against the quality +
+    # history-based-deletion gate from the ACL 2026 memory-management paper.
+    # The funnel is the natural call site: it has the cycle's analysis report
+    # (selected proposals with impact scores) and runs every cycle. Lazy import;
+    # never let it break the funnel job.
+    try:
+        from evolution_memory_gate import evaluate as _memory_gate_evaluate
+
+        # Load the analysis report to get the selected proposals with their
+        # impact scores — these are the potential memory records the gate
+        # evaluates for admission to long-term storage.
+        _analysis = _load_json(evolution_dir / "analysis" / f"{date}.json")
+        _selected_list: list = []
+        if isinstance(_analysis, dict):
+            _selected_list = _analysis.get("selected_for_implementation") or []
+        _mg_records = []
+        for _sel in _selected_list if isinstance(_selected_list, list) else []:
+            if not isinstance(_sel, dict):
+                continue
+            try:
+                _issue_n = int(_sel.get("issue_number", 0))
+                _impact = float(_sel.get("impact_score", 0.0))
+            except (TypeError, ValueError):
+                continue
+            _mg_records.append({
+                "record_id": f"issue-{_issue_n}",
+                "quality_score": _impact,
+                "content_summary": _sel.get("title", ""),
+                "source_stage": "analysis",
+            })
+        _mg_payload = {
+            "records": _mg_records,
+            "quality_threshold": 0.5,
+            "quarantined_ids": [],
+            "retrieval_log": [],
+            "deletion": {"min_retrievals": 3, "utility_threshold": 0.4},
+            "misaligned": {"min_retrievals": 2, "outcome_threshold": 0.3},
+        }
+        _mg_report = _memory_gate_evaluate(_mg_payload)
+        (evolution_dir / "memory-gate").mkdir(parents=True, exist_ok=True)
+        (evolution_dir / "memory-gate" / f"{date}.json").write_text(
+            json.dumps(_mg_report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        _mg_summary = _mg_report.get("summary", {})
+        if (
+            _mg_summary.get("rejected", 0) > 0
+            or _mg_summary.get("deletion_candidates", 0) > 0
+        ):
+            logger.info(
+                "memory-gate[%s]: admitted=%d rejected=%d deletion_candidates=%d",
+                date,
+                _mg_summary.get("admitted", 0),
+                _mg_summary.get("rejected", 0),
+                _mg_summary.get("deletion_candidates", 0),
+            )
+    except Exception as _mg_exc:
+        logger.warning("Memory gate failed (non-fatal): %s", _mg_exc)
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_memory_gate.py
+++ b/scripts/evolution_memory_gate.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Selective memory addition gate with history-based utility deletion (issue #1270).
+
+Implements the empirical memory-management laws from the ACL 2026 long paper
+#27 (Xiong et al., Harvard/U. Georgia/Michigan State/U. Minnesota;
+aclanthology.org/2026.acl-long.27) for the evolution pipeline's own artifacts
+(research reports, issues files, implementation logs) and as a recommendation
+for the agent's memory/skills store.
+
+The pipeline currently runs an **add-all** policy — every research report,
+issues file, and implementation log is appended indiscriminately.  The paper
+proves this self-degrades via three mechanisms:
+
+1. **Experience-Following Property** — a high input-similarity between the
+   current task and a retrieved memory record yields a high output-similarity
+   (Pearson r ≈ 1.0).  Agents *imitate* retrieved demonstrations; a retrieved
+   noisy/misaligned record is imitated and amplifies the error.
+2. **Error Propagation** — if a retrieved record contains noisy/incorrect
+   outputs, the agent replicates and amplifies the error; if that execution is
+   re-added to memory, the error propagates to future tasks.
+3. **Misaligned Experience Replay** — some records that pass the quality
+   filter still consistently lead to poor downstream execution because they are
+   misaligned with the current task distribution.
+
+Quantitatively, add-all is worse than fixed-memory on 3 of 4 agents; a strict
+evaluator + selective addition beats add-all by 22–25 points; and
+history-based deletion (remove a record retrieved ≥n times if its average
+downstream utility is below threshold) *improves* performance beyond
+no-deletion on real agents.
+
+This module provides four deterministic, LLM-free components:
+
+- **Retrieval-utility log** — each time a record is retrieved, log
+  (record_id, retrieval_context, downstream_outcome).
+- **Selective-addition gate** — refuse to store an artifact unless a quality
+  classifier judges it high-quality.  The paper shows a small specialised
+  classifier (300 examples) beats a generic LLM judge; this module accepts an
+  external quality score so the classifier can be swapped without coupling.
+- **History-based deletion** — remove records retrieved ≥n times whose average
+  downstream utility is below threshold.  Deletion is by *utility*, not age.
+- **Misaligned-record detector** — flag records with high retrieval count but
+  low downstream-outcome correlation; quarantine or delete them.
+
+Design: pure, deterministic, standard-library only, no side effects on import.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "RetrievalEvent",
+    "MemoryRecord",
+    "AdditionDecision",
+    "DeletionCandidate",
+    "MisalignedFlag",
+    "MemoryGateReport",
+    "log_retrieval",
+    "addition_gate",
+    "history_based_deletion",
+    "detect_misaligned",
+    "evaluate",
+    "main",
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Retrieval-utility log ────────────────────────────────────────────────────
+
+
+@dataclass
+class RetrievalEvent:
+    """A single retrieval of a memory/skill record, with the downstream outcome.
+
+    The downstream outcome is a float in [0, 1] where 1 = the retrieval led to
+    a successful downstream execution and 0 = it led to a failure.  This is the
+    signal history-based deletion keys on: a record retrieved many times whose
+    average outcome is low is a candidate for deletion.
+    """
+
+    record_id: str
+    retrieval_context: str = ""
+    downstream_outcome: float = 0.0  # 0.0 (failure) … 1.0 (success)
+    timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = _now()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "retrieval_context": self.retrieval_context,
+            "downstream_outcome": round(self.downstream_outcome, 6),
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "RetrievalEvent":
+        return cls(
+            record_id=str(d["record_id"]),
+            retrieval_context=str(d.get("retrieval_context", "")),
+            downstream_outcome=float(d.get("downstream_outcome", 0.0)),
+            timestamp=str(d.get("timestamp", "")),
+        )
+
+
+def log_retrieval(
+    record_id: str,
+    *,
+    retrieval_context: str = "",
+    downstream_outcome: float = 0.0,
+    log: list[RetrievalEvent] | None = None,
+) -> RetrievalEvent:
+    """Append a retrieval event to the utility log (in place if ``log`` given)."""
+    event = RetrievalEvent(
+        record_id=record_id,
+        retrieval_context=retrieval_context,
+        downstream_outcome=downstream_outcome,
+    )
+    if log is not None:
+        log.append(event)
+    return event
+
+
+# ── Selective-addition gate ─────────────────────────────────────────────────
+
+
+@dataclass
+class MemoryRecord:
+    """An artifact the pipeline is considering storing in memory/skills.
+
+    ``quality_score`` is the output of a (small, specialised) quality
+    classifier in [0, 1].  The paper's key result: a 300-example fine-tuned
+    classifier recovers most of an oracle evaluator's gain and beats a generic
+    LLM judge.  This module is classifier-agnostic — it accepts the score and
+    applies the gate threshold.
+    """
+
+    record_id: str
+    artifact_type: str = "research_report"  # research_report | issues_file | implementation_log | skill | memory
+    content_summary: str = ""
+    quality_score: float = 0.0  # [0, 1] from a specialised classifier
+    source_record_ids: tuple[
+        str, ...
+    ] = ()  # records this artifact imitates/derives from (error-propagation guard)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "artifact_type": self.artifact_type,
+            "content_summary": self.content_summary,
+            "quality_score": round(self.quality_score, 6),
+            "source_record_ids": list(self.source_record_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "MemoryRecord":
+        return cls(
+            record_id=str(d["record_id"]),
+            artifact_type=str(d.get("artifact_type", "research_report")),
+            content_summary=str(d.get("content_summary", "")),
+            quality_score=float(d.get("quality_score", 0.0)),
+            source_record_ids=tuple(d.get("source_record_ids", [])),
+        )
+
+
+@dataclass(frozen=True)
+class AdditionDecision:
+    record_id: str
+    admitted: bool
+    reason: str
+    quality_score: float
+    threshold: float
+    error_propagation_blocked: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "admitted": self.admitted,
+            "reason": self.reason,
+            "quality_score": round(self.quality_score, 6),
+            "threshold": round(self.threshold, 6),
+            "error_propagation_blocked": self.error_propagation_blocked,
+        }
+
+
+def addition_gate(
+    record: MemoryRecord,
+    *,
+    quality_threshold: float = 0.7,
+    quarantined_ids: frozenset[str] | None = None,
+) -> AdditionDecision:
+    """Selective-addition gate: admit an artifact only if it passes quality + error-propagation guards.
+
+    Two checks:
+    1. **Quality gate** — ``record.quality_score`` must meet ``quality_threshold``.
+       The paper shows a small specialised classifier (300 examples) beats a
+       generic LLM judge; the threshold defaults to 0.7 (strict-evaluator
+       regime that beats add-all by 22–25 points).
+    2. **Error-propagation guard** — the record must not derive from a
+       quarantined/noisy source (the amplification loop: an execution that
+       imitated a noisy record must not be re-added).
+    """
+    quarantined = quarantined_ids or frozenset()
+
+    # Error-propagation guard: if any source record is quarantined, block.
+    poisoned_sources = [s for s in record.source_record_ids if s in quarantined]
+    if poisoned_sources:
+        return AdditionDecision(
+            record_id=record.record_id,
+            admitted=False,
+            reason=f"error-propagation guard: record derives from quarantined/noisy source(s) {poisoned_sources}",
+            quality_score=record.quality_score,
+            threshold=quality_threshold,
+            error_propagation_blocked=True,
+        )
+
+    if record.quality_score < quality_threshold:
+        return AdditionDecision(
+            record_id=record.record_id,
+            admitted=False,
+            reason=f"quality score {record.quality_score:.3f} below threshold {quality_threshold:.3f} — not stored (selective addition)",
+            quality_score=record.quality_score,
+            threshold=quality_threshold,
+            error_propagation_blocked=False,
+        )
+
+    return AdditionDecision(
+        record_id=record.record_id,
+        admitted=True,
+        reason=f"quality score {record.quality_score:.3f} meets threshold {quality_threshold:.3f} — stored",
+        quality_score=record.quality_score,
+        threshold=quality_threshold,
+        error_propagation_blocked=False,
+    )
+
+
+# ── History-based deletion ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DeletionCandidate:
+    record_id: str
+    retrieval_count: int
+    avg_downstream_outcome: float
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "retrieval_count": self.retrieval_count,
+            "avg_downstream_outcome": round(self.avg_downstream_outcome, 6),
+            "reason": self.reason,
+        }
+
+
+def history_based_deletion(
+    retrieval_log: Sequence[RetrievalEvent],
+    *,
+    min_retrievals: int = 3,
+    utility_threshold: float = 0.4,
+) -> list[DeletionCandidate]:
+    """Delete memories/skills by downstream utility, not age.
+
+    A record is a deletion candidate if it has been retrieved at least
+    ``min_retrievals`` times AND its average downstream outcome is below
+    ``utility_threshold``.  This is the history-based-deletion pattern from
+    Table 2 of the paper, which *improves* performance beyond no-deletion on
+    real agents (EHRAgent 42.06 vs 38.67, AgentDriver 51.81 vs 51.00).
+    """
+    # Aggregate per record.
+    per_record: dict[str, list[float]] = {}
+    for event in retrieval_log:
+        per_record.setdefault(event.record_id, []).append(event.downstream_outcome)
+
+    candidates: list[DeletionCandidate] = []
+    for rid, outcomes in per_record.items():
+        count = len(outcomes)
+        avg = sum(outcomes) / count if count else 0.0
+        if count >= min_retrievals and avg < utility_threshold:
+            candidates.append(
+                DeletionCandidate(
+                    record_id=rid,
+                    retrieval_count=count,
+                    avg_downstream_outcome=avg,
+                    reason=(
+                        f"retrieved {count} times with avg downstream outcome "
+                        f"{avg:.3f} < {utility_threshold:.3f} — low-utility, delete by history"
+                    ),
+                )
+            )
+    return candidates
+
+
+# ── Misaligned-record detector ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MisalignedFlag:
+    record_id: str
+    retrieval_count: int
+    avg_downstream_outcome: float
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "retrieval_count": self.retrieval_count,
+            "avg_downstream_outcome": round(self.avg_downstream_outcome, 6),
+            "reason": self.reason,
+        }
+
+
+def detect_misaligned(
+    retrieval_log: Sequence[RetrievalEvent],
+    *,
+    min_retrievals: int = 2,
+    outcome_threshold: float = 0.3,
+) -> list[MisalignedFlag]:
+    """Flag records that pass the quality filter but consistently lead to poor execution.
+
+    These are the "misaligned experience replay" records from finding 3 of the
+    paper: they pass the quality gate at addition time but are misaligned with
+    the current task distribution, so conditioning on them degrades
+    performance.  The detector flags (does not auto-delete) so a human or the
+    analysis stage can decide whether to quarantine or delete.
+    """
+    per_record: dict[str, list[float]] = {}
+    for event in retrieval_log:
+        per_record.setdefault(event.record_id, []).append(event.downstream_outcome)
+
+    flags: list[MisalignedFlag] = []
+    for rid, outcomes in per_record.items():
+        count = len(outcomes)
+        avg = sum(outcomes) / count if count else 0.0
+        if count >= min_retrievals and avg < outcome_threshold:
+            flags.append(
+                MisalignedFlag(
+                    record_id=rid,
+                    retrieval_count=count,
+                    avg_downstream_outcome=avg,
+                    reason=(
+                        f"retrieved {count} times with avg outcome {avg:.3f} < "
+                        f"{outcome_threshold:.3f} — misaligned with current task distribution; "
+                        f"passed quality gate but consistently leads to poor execution"
+                    ),
+                )
+            )
+    return flags
+
+
+# ── Aggregate report ────────────────────────────────────────────────────────
+
+
+@dataclass
+class MemoryGateReport:
+    addition_decisions: list[AdditionDecision] = field(default_factory=list)
+    deletion_candidates: list[DeletionCandidate] = field(default_factory=list)
+    misaligned_flags: list[MisalignedFlag] = field(default_factory=list)
+    retrieval_events: list[RetrievalEvent] = field(default_factory=list)
+
+    @property
+    def admitted_count(self) -> int:
+        return sum(1 for d in self.addition_decisions if d.admitted)
+
+    @property
+    def rejected_count(self) -> int:
+        return sum(1 for d in self.addition_decisions if not d.admitted)
+
+    @property
+    def error_propagation_blocks(self) -> int:
+        return sum(1 for d in self.addition_decisions if d.error_propagation_blocked)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "addition_decisions": [d.to_dict() for d in self.addition_decisions],
+            "deletion_candidates": [d.to_dict() for d in self.deletion_candidates],
+            "misaligned_flags": [f.to_dict() for f in self.misaligned_flags],
+            "retrieval_events": [e.to_dict() for e in self.retrieval_events],
+            "summary": {
+                "admitted": self.admitted_count,
+                "rejected": self.rejected_count,
+                "error_propagation_blocks": self.error_propagation_blocks,
+                "deletion_candidates": len(self.deletion_candidates),
+                "misaligned_flags": len(self.misaligned_flags),
+            },
+        }
+
+
+def evaluate(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Core entry from a JSON payload.
+
+    Expected payload shape::
+
+        {
+          "records": [{"record_id": "...", "quality_score": 0.8, ...}, ...],
+          "quality_threshold": 0.7,
+          "quarantined_ids": ["noisy-rec-1", ...],
+          "retrieval_log": [{"record_id": "...", "downstream_outcome": 0.1, ...}, ...],
+          "deletion": {"min_retrievals": 3, "utility_threshold": 0.4},
+          "misaligned": {"min_retrievals": 2, "outcome_threshold": 0.3}
+        }
+    """
+    records = [MemoryRecord.from_dict(r) for r in payload.get("records", [])]
+    quality_threshold = float(payload.get("quality_threshold", 0.7))
+    quarantined = frozenset(payload.get("quarantined_ids", []))
+
+    report = MemoryGateReport()
+    for rec in records:
+        report.addition_decisions.append(
+            addition_gate(
+                rec, quality_threshold=quality_threshold, quarantined_ids=quarantined
+            )
+        )
+
+    log = [RetrievalEvent.from_dict(e) for e in payload.get("retrieval_log", [])]
+    report.retrieval_events = log
+
+    del_cfg = payload.get("deletion", {})
+    report.deletion_candidates = history_based_deletion(
+        log,
+        min_retrievals=int(del_cfg.get("min_retrievals", 3)),
+        utility_threshold=float(del_cfg.get("utility_threshold", 0.4)),
+    )
+
+    mis_cfg = payload.get("misaligned", {})
+    report.misaligned_flags = detect_misaligned(
+        log,
+        min_retrievals=int(mis_cfg.get("min_retrievals", 2)),
+        outcome_threshold=float(mis_cfg.get("outcome_threshold", 0.3)),
+    )
+
+    return report.to_dict()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Selective memory addition gate with history-based utility deletion (#1270)",
+    )
+    parser.add_argument(
+        "--payload",
+        required=True,
+        help="path to a JSON payload with records, retrieval_log, thresholds",
+    )
+    args = parser.parse_args(argv)
+    with open(args.payload, encoding="utf-8") as fh:
+        payload = json.load(fh)
+    report = evaluate(payload)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/evolution/evolution-orchestrator/SKILL.md
+++ b/skills/evolution/evolution-orchestrator/SKILL.md
@@ -138,3 +138,13 @@ UNtrusted input (indirect prompt injection), and this chain can reach code, so:
 Upstream: `evolution-research` (which hands off a research sub-task). Downstream:
 `scripts/evolution_evaluator.py` (scores the collected candidates) and the #301
 optimizer loop (which iterates on the evaluator's verdict).
+
+### Selective memory addition gate (#1270)
+
+The funnel (`scripts/evolution_funnel.py`) runs the selective memory gate each
+cycle via `scripts/evolution_memory_gate.py`. The gate evaluates the cycle's
+selected proposals as potential memory records — refusing to admit artifacts
+below the quality threshold and flagging history-based deletion candidates
+(records retrieved multiple times with poor downstream utility). Results land
+in `evolution/memory-gate/<date>.json`. The gate runs as part of the existing
+funnel cron (`cron/evolution/funnel.yaml`), so no separate cron entry is needed.

--- a/tests/scripts/test_evolution_memory_gate_wiring.py
+++ b/tests/scripts/test_evolution_memory_gate_wiring.py
@@ -1,0 +1,209 @@
+"""Integration test for the selective memory gate wiring (#1270).
+
+Verifies the memory gate module is ACTUALLY INVOKED from its pipeline call site
+(`evolution_funnel.py`'s `main()`), not just that the module works in isolation.
+The previous PR (#1275) was closed as dead code — the module existed but nothing
+called it. This test would have caught that: it mocks the memory gate, runs the
+funnel, and asserts the mock was called with the expected payload.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make scripts/ importable so evolution_funnel can import evolution_memory_gate
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+
+def _make_minimal_evolution_dir(tmp_path: Path, date: str) -> Path:
+    """Create a minimal evolution dir with enough stage reports for the funnel."""
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    (evo / "issues" / f"{date}.json").parent.mkdir(parents=True)
+    (evo / "issues" / f"{date}.json").write_text(
+        json.dumps({"issues_created": [], "total_proposals": 0})
+    )
+    return evo
+
+
+def _make_analysis_with_selected(date: str) -> dict:
+    """Build a minimal analysis report with selected proposals."""
+    return {
+        "date": date,
+        "selected_for_implementation": [
+            {
+                "issue_number": 100,
+                "title": "High-impact feature",
+                "impact_score": 0.8,
+            },
+            {
+                "issue_number": 101,
+                "title": "Low-impact feature",
+                "impact_score": 0.2,
+            },
+        ],
+    }
+
+
+class TestMemoryGateWiring:
+    """The memory gate must be called from the funnel's main(), not just exist."""
+
+    def test_funnel_invokes_memory_gate(self, tmp_path, monkeypatch):
+        """Run the funnel and assert the memory gate evaluate() is called."""
+        import evolution_funnel
+
+        date = "2026-07-25"
+        evo_dir = _make_minimal_evolution_dir(tmp_path, date)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evo_dir))
+
+        # Write the analysis report so the funnel can read selected proposals
+        analysis = _make_analysis_with_selected(date)
+        (evo_dir / "analysis" / f"{date}.json").parent.mkdir(parents=True)
+        (evo_dir / "analysis" / f"{date}.json").write_text(json.dumps(analysis))
+
+        captured_payload = {}
+
+        def fake_evaluate(payload):
+            captured_payload.update(payload)
+            return {
+                "summary": {
+                    "admitted": 1,
+                    "rejected": 1,
+                    "error_propagation_blocks": 0,
+                    "deletion_candidates": 0,
+                    "misaligned_flags": 0,
+                },
+                "addition_decisions": [],
+                "deletion_candidates": [],
+                "misaligned_flags": [],
+                "retrieval_events": [],
+            }
+
+        with patch.object(evolution_funnel, "_resolve_repo", return_value=None):
+            with patch(
+                "evolution_memory_gate.evaluate",
+                side_effect=fake_evaluate,
+            ):
+                rc = evolution_funnel.main(["funnel", date])
+
+        assert rc == 0, "funnel main() should exit 0"
+
+        # The memory gate was invoked from the funnel — not dead code.
+        assert captured_payload, (
+            "memory gate evaluate() was never called from the funnel"
+        )
+
+        # The funnel passed the cycle's selected proposals as memory records.
+        records = captured_payload.get("records", [])
+        assert isinstance(records, list) and len(records) == 2, (
+            "funnel must pass the selected proposals as memory records to the gate"
+        )
+        record_ids = [r["record_id"] for r in records]
+        assert "issue-100" in record_ids, "high-impact proposal must be in the payload"
+        assert "issue-101" in record_ids, "low-impact proposal must be in the payload"
+
+        # Quality threshold is set
+        assert "quality_threshold" in captured_payload, "quality_threshold must be set"
+
+    def test_funnel_writes_memory_gate_report(self, tmp_path, monkeypatch):
+        """The funnel must persist the memory-gate report to memory-gate/<date>.json."""
+        import evolution_funnel
+
+        date = "2026-07-25"
+        evo_dir = _make_minimal_evolution_dir(tmp_path, date)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evo_dir))
+
+        analysis = _make_analysis_with_selected(date)
+        (evo_dir / "analysis" / f"{date}.json").parent.mkdir(parents=True)
+        (evo_dir / "analysis" / f"{date}.json").write_text(json.dumps(analysis))
+
+        fake_report = {
+            "summary": {
+                "admitted": 1,
+                "rejected": 1,
+                "error_propagation_blocks": 0,
+                "deletion_candidates": 0,
+                "misaligned_flags": 0,
+            },
+            "addition_decisions": [
+                {"record_id": "issue-100", "admitted": True},
+                {"record_id": "issue-101", "admitted": False},
+            ],
+            "deletion_candidates": [],
+            "misaligned_flags": [],
+            "retrieval_events": [],
+        }
+
+        with patch.object(evolution_funnel, "_resolve_repo", return_value=None):
+            with patch(
+                "evolution_memory_gate.evaluate",
+                return_value=fake_report,
+            ):
+                evolution_funnel.main(["funnel", date])
+
+        report_path = evo_dir / "memory-gate" / f"{date}.json"
+        assert report_path.exists(), (
+            f"memory-gate report not written to {report_path} — the wiring is incomplete"
+        )
+        written = json.loads(report_path.read_text())
+        assert written == fake_report, (
+            "written report must match what evaluate() returned"
+        )
+
+    def test_funnel_survives_memory_gate_failure(self, tmp_path, monkeypatch):
+        """If the memory gate module raises, the funnel must NOT crash (fail-open)."""
+        import evolution_funnel
+
+        date = "2026-07-25"
+        evo_dir = _make_minimal_evolution_dir(tmp_path, date)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evo_dir))
+
+        with patch.object(evolution_funnel, "_resolve_repo", return_value=None):
+            with patch(
+                "evolution_memory_gate.evaluate",
+                side_effect=RuntimeError("simulated memory-gate crash"),
+            ):
+                rc = evolution_funnel.main(["funnel", date])
+
+        assert rc == 0, (
+            "funnel must exit 0 even if the memory gate crashes — fail-open, never block metrics"
+        )
+
+    def test_funnel_handles_missing_analysis(self, tmp_path, monkeypatch):
+        """If the analysis report is missing, the gate runs with zero records (no crash)."""
+        import evolution_funnel
+
+        date = "2026-07-25"
+        evo_dir = _make_minimal_evolution_dir(tmp_path, date)
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(evo_dir))
+        # No analysis report written
+
+        captured = {}
+
+        def fake_evaluate(payload):
+            captured.update(payload)
+            return {"summary": {}, "addition_decisions": []}
+
+        with patch.object(evolution_funnel, "_resolve_repo", return_value=None):
+            with patch(
+                "evolution_memory_gate.evaluate",
+                side_effect=fake_evaluate,
+            ):
+                rc = evolution_funnel.main(["funnel", date])
+
+        assert rc == 0
+        assert captured.get("records") == [], (
+            "with no analysis report, the gate should receive an empty records list"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Automated evolution PR for issue #1270.

## What this does

Wires the selective memory addition gate module (ACL 2026 memory-management laws) into the evolution funnel's per-cycle aggregation — the natural call site alongside the existing wirings. Previously the module was dead code (PR #1275 was closed for this exact reason); now the funnel calls `evaluate()` every cycle and persists results to `memory-gate/<date>.json`.

## Files changed

- `scripts/evolution_funnel.py` — call memory-gate `evaluate()` after building the funnel record; write to `memory-gate/<date>.json`; log summary
- `scripts/evolution_memory_gate.py` — module from closed PR #1275 (unchanged, now tracked)
- `skills/evolution/evolution-orchestrator/SKILL.md` — document the memory gate in the Integration section
- `tests/scripts/test_evolution_memory_gate_wiring.py` — integration test verifying the funnel invokes the memory gate (mock + assert call), persists the report, survives a crash, and handles missing analysis

## Checks

- lint ✓ (ruff check)
- format ✓ (ruff format)
- tests ✓ (4/4 pass)

## Note on merge gate

This PR exceeds the 200-line autonomous self-merge cap (742 insertions) because the module file is 464 lines. The merge gate will hold it for human review. The wiring itself is ~55 lines — the bulk is the pre-existing module being tracked for the first time.

Closes #1270