### PR TITLE
feat: raise memory char limit from 2200 to 8000 (Closes #1283)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2474,7 +2474,7 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
-        "memory_char_limit": 2200,  # ~800 tokens at 2.75 chars/token
+        "memory_char_limit": 8000,  # ~2,900 tokens at 2.75 chars/token
         "user_char_limit": 1375,  # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",

--- a/skills/productivity/memory-audit/scripts/memory_audit.py
+++ b/skills/productivity/memory-audit/scripts/memory_audit.py
@@ -36,7 +36,7 @@ from typing import List, Optional, Tuple
 # is a standalone script (it runs via cron, not inside the agent), so it
 # reads no config. The caller can override via CLI flags.  If you changed
 # your memory limits in config.yaml, pass them explicitly.
-DEFAULT_MEMORY_CHAR_LIMIT = 2200
+DEFAULT_MEMORY_CHAR_LIMIT = 8000
 DEFAULT_USER_CHAR_LIMIT = 1375
 
 # ── Secret detection ───────────────────────────────────────────────────

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -160,7 +160,7 @@ def test_load_on_disk_store_honors_configured_char_limits(hermes_home, monkeypat
 
     monkeypatch.setattr("hermes_cli.config.load_config", _boom)
     fallback = load_on_disk_store()
-    assert fallback.memory_char_limit == 2200
+    assert fallback.memory_char_limit == 8000
     assert fallback.user_char_limit == 1375
 
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1354,7 +1354,7 @@ def load_on_disk_store() -> "MemoryStore":
     Falls back to the built-in defaults if config can't be loaded, so this can
     never raise on a missing/unreadable config.
     """
-    memory_char_limit = 2200
+    memory_char_limit = 8000
     user_char_limit = 1375
     allow_batch_override = False
     try:


### PR DESCRIPTION
Raises the default memory_char_limit from 2,200 to 8,000 chars across config.py, memory_tool.py, and memory_audit.py. Updates test assertion. Closes #1283. Automated evolution PR.