### PR TITLE
feat(memory): auto-evict oldest entry on add-overflow (Closes #1283)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1514,6 +1514,8 @@ def init_agent(
                     memory_char_limit=mem_config.get("memory_char_limit", 4000),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
                     guard=_mem_guard,
+                    auto_evict_on_full=mem_config.get("auto_evict_on_full", True),
+                    auto_evict_keep_min=mem_config.get("auto_evict_keep_min", 1),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2476,6 +2476,20 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,  # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,  # ~500 tokens at 2.75 chars/token
+        # Auto-eviction on add-overflow (issue #1283): when a bare `add`
+        # would exceed the char budget, evict the OLDEST entry (insertion
+        # order = index 0) and retry, instead of hard-rejecting and forcing
+        # the model into a multi-call read/evict/rewrite spiral. Every
+        # eviction is surfaced in the tool response (`evicted` list) + logged
+        # so nothing is dropped silently.
+        #   auto_evict_on_full   — enable the behaviour (default true).
+        #   auto_evict_keep_min  — never evict below this many entries; a
+        #                          safety floor so one giant entry can't wipe
+        #                          the store. If the add still doesn't fit at
+        #                          the floor, the existing consolidation-failure
+        #                          response is returned (graceful degradation).
+        "auto_evict_on_full": True,
+        "auto_evict_keep_min": 1,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -529,17 +529,24 @@ class TestMemoryConsolidationGracefulDegrade:
         assert "current_entries" not in r
         assert "continue with your reply" in r["error"]
 
-    def test_add_overflow_degrades_after_cap(self, store):
+    def test_add_overflow_degrades_after_cap(self, store, tmp_path, monkeypatch):
         # Fill near the 500-char user/memory limit so add() overflows.
-        store.add("memory", "x" * 200)
-        store.add("memory", "y" * 200)
-        cap = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        # Disable auto-eviction (issue #1283) so this exercises the original
+        # overflow -> degradation path rather than auto-evict-and-succeed.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(
+            memory_char_limit=500, user_char_limit=300, auto_evict_on_full=False
+        )
+        s.load_from_disk()
+        s.add("memory", "x" * 200)
+        s.add("memory", "y" * 200)
+        cap = s._MAX_CONSOLIDATION_FAILURES_PER_TURN
         big = "z" * 200
         for _ in range(cap):
-            r = store.add("memory", big)
+            r = s.add("memory", big)
             assert r["success"] is False
             assert "retry this add" in r["error"]  # still instructs in-turn retry
-        r = store.add("memory", big)
+        r = s.add("memory", big)
         assert r["success"] is False
         assert r["done"] is True
         assert "continue with your reply" in r["error"]
@@ -548,8 +555,10 @@ class TestMemoryConsolidationGracefulDegrade:
         store.add("memory", "fact A")
         cap = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
         # Interleave replace + remove failures — they share the per-turn counter.
-        actions = [lambda: store.replace("memory", "nope", "x"),
-                   lambda: store.remove("memory", "nope")]
+        actions = [
+            lambda: store.replace("memory", "nope", "x"),
+            lambda: store.remove("memory", "nope"),
+        ]
         for i in range(cap):
             assert actions[i % 2]()["success"] is False
         # cap+1th failure (any action) degrades.
@@ -754,9 +763,18 @@ class TestMemoryBatch:
         assert "stale two" not in store.memory_entries
         assert "usage" in result
 
-    def test_batch_frees_room_for_otherwise_overflowing_add(self, store):
+    def test_batch_frees_room_for_otherwise_overflowing_add(
+        self, tmp_path, monkeypatch
+    ):
         # store limit is 500 (fixture). Fill it, then a single add would
         # overflow — but a batch that removes first lands in ONE call.
+        # Disable auto-eviction (issue #1283) so the single-add overflow
+        # path that the batch is meant to solve is actually exercised.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(
+            memory_char_limit=500, user_char_limit=300, auto_evict_on_full=False
+        )
+        store.load_from_disk()
         store.add("memory", "x" * 240)
         store.add("memory", "y" * 240)  # ~485 chars, near the 500 limit
         big_add = {"action": "add", "content": "z" * 200}
@@ -1132,3 +1150,108 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Auto-eviction on add-overflow (issue #1283)
+# =========================================================================
+
+
+class TestAutoEvictOnFull:
+    """When a bare `add` would exceed the char budget, the store should evict
+    the OLDEST entry (insertion order) and accept the add, rather than
+    hard-rejecting and forcing a multi-call read/evict/rewrite spiral.
+
+    Safety contract:
+      * default ON (auto_evict_on_full=True)
+      * the evicted text is surfaced in the response (never silent)
+      * the keep-min floor prevents a giant entry from wiping the store
+      * a single entry larger than the whole budget still rejects (graceful)
+      * opt-out (auto_evict_on_full=False) restores the pre-#1283 behaviour
+      * only the 'memory' target auto-evicts; 'user' keeps manual consolidation
+    """
+
+    @pytest.fixture()
+    def full_store(self, tmp_path, monkeypatch):
+        """A memory store with three entries that nearly fill a 200-char budget."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=200, user_char_limit=200)
+        s.load_from_disk()
+        # Each entry ~60 chars so three of them (~184 chars with delimiters)
+        # genuinely approach the 200-char budget.
+        s.add("memory", "oldest fact " + "a" * 50)  # insertion order: index 0
+        s.add("memory", "middle fact " + "b" * 50)
+        s.add("memory", "recent fact " + "c" * 50)
+        return s
+
+    def test_add_evicts_oldest_and_succeeds(self, full_store):
+        result = full_store.add("memory", "brand new fact " + "d" * 50)
+        assert result["success"] is True
+        # Oldest entry was evicted to make room.
+        assert result["evicted"] == ["oldest fact " + "a" * 50]
+        # New entry landed; oldest is gone.
+        joined = "\n§\n".join(full_store.memory_entries)
+        assert ("brand new fact " + "d" * 50) in joined
+        assert ("oldest fact " + "a" * 50) not in joined
+        # Middle + recent survived.
+        assert ("middle fact " + "b" * 50) in joined
+        assert ("recent fact " + "c" * 50) in joined
+
+    def test_eviction_respects_keep_min_floor(self, tmp_path, monkeypatch):
+        # A 1-entry floor: evicting down to 1 entry then a giant add must NOT
+        # wipe the last surviving entry.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=120, auto_evict_keep_min=1)
+        s.load_from_disk()
+        s.add("memory", "keep me A")
+        s.add("memory", "keep me B")
+        # An add so big it can't fit even after evicting to the floor.
+        giant = "x" * 500
+        result = s.add("memory", giant)
+        # Graceful degradation: rejected, not silently dropped.
+        assert result["success"] is False
+        assert "evicted" not in result
+        # Store untouched — the pre-existing entries survived.
+        assert len(s.memory_entries) == 2
+
+    def test_single_entry_larger_than_budget_rejects(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=50)
+        s.load_from_disk()
+        result = s.add("memory", "y" * 500)
+        assert result["success"] is False
+        # Falls through to the consolidation-failure shape.
+        assert "current_entries" in result
+        assert "retry" in result["error"].lower()
+
+    def test_opt_out_restores_hard_reject(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=100, auto_evict_on_full=False)
+        s.load_from_disk()
+        s.add("memory", "first fact " + "a" * 80)  # ~91 chars, near the 100 limit
+        # A second add big enough to overflow the remaining ~9 chars.
+        result = s.add("memory", "second fact " + "b" * 80)
+        assert result["success"] is False
+        assert "evicted" not in result
+        # Pre-#1283 consolidation guidance is shown.
+        assert "current_entries" in result
+        assert "retry" in result["error"].lower()
+
+    def test_user_target_never_auto_evicts(self, tmp_path, monkeypatch):
+        # User profile facts are scarce/high-value: keep manual consolidation.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=50, user_char_limit=50)
+        s.load_from_disk()
+        s.add("user", "name: Alice")
+        result = s.add(
+            "user", "a long preference entry that would overflow this small budget"
+        )
+        assert result["success"] is False
+        assert "evicted" not in result
+
+    def test_default_on_for_new_store(self, tmp_path, monkeypatch):
+        # The default MemoryStore() should have auto-evict enabled.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=100)
+        assert s.auto_evict_on_full is True
+        assert s.auto_evict_keep_min >= 1

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -57,6 +57,7 @@ def get_memory_dir() -> Path:
     """Return the profile-scoped memories directory."""
     return get_hermes_home() / "memories"
 
+
 # Stable header prefixes for the system-prompt memory blocks rendered by
 # MemoryStore._render_block. Exported so compression's prompt-retention check
 # (agent/conversation_compression.py) can detect a leftover block for a
@@ -285,6 +286,8 @@ class MemoryStore:
         user_char_limit: int = 2500,
         guard: Optional[object] = None,
         allow_batch_override: bool = False,
+        auto_evict_on_full: bool = True,
+        auto_evict_keep_min: int = 1,
     ):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
@@ -293,6 +296,12 @@ class MemoryStore:
         # Explicit opt-in for per-call dynamic limit overrides. Default False so
         # dynamic changes cannot silently alter the configured budget (issue #517).
         self.allow_batch_override = allow_batch_override
+        # Auto-eviction on add-overflow (issue #1283): when a bare `add` would
+        # exceed the char budget, evict the OLDEST entry and retry instead of
+        # hard-rejecting. ``auto_evict_keep_min`` is a safety floor so one huge
+        # entry can't wipe the whole store. See ``_evict_to_fit``.
+        self.auto_evict_on_full = auto_evict_on_full
+        self.auto_evict_keep_min = max(0, int(auto_evict_keep_min))
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Optional memory-poisoning guard (issue #315). DEFAULT None: when unset,
@@ -544,6 +553,44 @@ class MemoryStore:
             return 0
         return len(ENTRY_DELIMITER.join(entries))
 
+    def _evict_to_fit(
+        self,
+        target: str,
+        new_entry: str,
+        limit: int,
+    ) -> Optional[List[str]]:
+        """Evict OLDEST entries until ``new_entry`` fits ``limit`` (issue #1283).
+
+        Returns the list of evicted DISPLAY texts (oldest-first), or ``None``
+        when the add still doesn't fit — e.g. the single new entry alone
+        exceeds the limit, or the safety floor (``auto_evict_keep_min``) was
+        reached before it fit. The caller must treat ``None`` as "give up and
+        return the consolidation-failure response" so behaviour degrades
+        gracefully to the pre-#1283 path.
+
+        Entries are stored in insertion order (a §-delimited file is
+        append-mostly), so index 0 is the oldest — that is what we evict.
+        We never evict below ``auto_evict_keep_min`` entries. Only the
+        ``memory`` target is eligible; ``user`` profile facts are scarce and
+        high-value, so they keep the manual-consolidation path.
+        """
+        if not self.auto_evict_on_full or target != "memory":
+            return None
+
+        entries = self._entries_for(target)
+        # Working copy we mutate locally; only commit back if it fits.
+        working = list(entries)
+        evicted: List[str] = []
+
+        while True:
+            candidate = working + [new_entry]
+            if len(ENTRY_DELIMITER.join(candidate)) <= limit:
+                return evicted
+            # Can't evict further without breaching the safety floor.
+            if len(working) <= self.auto_evict_keep_min:
+                return None
+            evicted.append(parse_provenance(working.pop(0))[0])
+
     def _char_limit(self, target: str, dynamic_limit: Optional[int] = None) -> int:
         """Return the effective char limit for ``target``.
 
@@ -653,6 +700,37 @@ class MemoryStore:
             new_total = len(ENTRY_DELIMITER.join(new_entries))
 
             if new_total > limit:
+                # Auto-eviction (issue #1283): try to make room by evicting
+                # the OLDEST entries instead of hard-rejecting and forcing a
+                # multi-call read/evict/rewrite spiral. ``_evict_to_fit``
+                # returns the evicted display texts (oldest-first) on success
+                # or None when the add still can't fit (giant entry, or the
+                # safety floor was reached) — in which case we fall through to
+                # the existing consolidation-failure response below.
+                evicted = self._evict_to_fit(target, stored, limit)
+                if evicted is not None:
+                    working = self._entries_for(target)
+                    # Drop as many oldest entries as were evicted, then append.
+                    del working[: len(evicted)]
+                    working.append(stored)
+                    self._set_entries(target, working)
+                    self.save_to_disk(target)
+                    logger.info(
+                        "memory auto-evicted %d oldest entr%s to fit a new add "
+                        "(target=%s)",
+                        len(evicted),
+                        "y" if len(evicted) == 1 else "ies",
+                        target,
+                    )
+                    resp = self._success_response(
+                        target,
+                        f"Entry added; auto-evicted {len(evicted)} oldest "
+                        f"entr{'y' if len(evicted) == 1 else 'ies'} to make room.",
+                    )
+                    # Surface exactly what was dropped — never silent.
+                    resp["evicted"] = evicted
+                    return resp
+
                 current = self._char_count(target)
                 return self._consolidation_failure({
                     "success": False,
@@ -740,9 +818,9 @@ class MemoryStore:
                 # If all matches are identical (exact duplicates), operate on the first one
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
-                    previews = self._previews(
-                        [parse_provenance(e)[0] for _, e in matches]
-                    )
+                    previews = self._previews([
+                        parse_provenance(e)[0] for _, e in matches
+                    ])
                     return {
                         "success": False,
                         "error": f"Multiple entries matched '{old_text}'. Be more specific.",
@@ -810,9 +888,9 @@ class MemoryStore:
                 # If all matches are identical (exact duplicates), remove the first one
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
-                    previews = self._previews(
-                        [parse_provenance(e)[0] for _, e in matches]
-                    )
+                    previews = self._previews([
+                        parse_provenance(e)[0] for _, e in matches
+                    ])
                     return {
                         "success": False,
                         "error": f"Multiple entries matched '{old_text}'. Be more specific.",
@@ -1072,7 +1150,9 @@ class MemoryStore:
 
                 if act == "add":
                     if not content:
-                        return self._batch_error(target, f"{pos}: content is required.", limit=limit)
+                        return self._batch_error(
+                            target, f"{pos}: content is required.", limit=limit
+                        )
                     if content in working:
                         continue  # idempotent -- skip duplicate, don't fail the batch
                     working.append(content)
@@ -1091,7 +1171,9 @@ class MemoryStore:
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(
-                            target, f"{pos}: no entry matched '{old_text}'.", limit=limit
+                            target,
+                            f"{pos}: no entry matched '{old_text}'.",
+                            limit=limit,
                         )
                     if len({working[j] for j in matches}) > 1:
                         return self._batch_error(
@@ -1109,7 +1191,9 @@ class MemoryStore:
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
                         return self._batch_error(
-                            target, f"{pos}: no entry matched '{old_text}'.", limit=limit
+                            target,
+                            f"{pos}: no entry matched '{old_text}'.",
+                            limit=limit,
                         )
                     if len({working[j] for j in matches}) > 1:
                         return self._batch_error(
@@ -1152,7 +1236,9 @@ class MemoryStore:
             target, f"Applied {len(operations)} operation(s).", limit=limit
         )
 
-    def _batch_error(self, target: str, message: str, limit: Optional[int] = None) -> Dict[str, Any]:
+    def _batch_error(
+        self, target: str, message: str, limit: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Build a batch-abort error that reports live (uncommitted) state."""
         current = self._char_count(target)
         effective_limit = limit if limit is not None else self._char_limit(target)
@@ -1185,7 +1271,9 @@ class MemoryStore:
         """Truncated one-line previews of entries for error feedback."""
         return [e[:width] + ("..." if len(e) > width else "") for e in entries]
 
-    def _success_response(self, target: str, message: str = None, limit: Optional[int] = None) -> Dict[str, Any]:
+    def _success_response(
+        self, target: str, message: str = None, limit: Optional[int] = None
+    ) -> Dict[str, Any]:
         # A successful write means the consolidation loop made progress, so the
         # per-turn failure budget resets (the cap counts consecutive failures,
         # not lifetime ones within a turn) (#42405).
@@ -1193,7 +1281,11 @@ class MemoryStore:
         entries = self._entries_for(target)
         current = self._char_count(target)
         effective_limit = limit if limit is not None else self._char_limit(target)
-        pct = min(100, int((current / effective_limit) * 100)) if effective_limit > 0 else 0
+        pct = (
+            min(100, int((current / effective_limit) * 100))
+            if effective_limit > 0
+            else 0
+        )
 
         # The success response is intentionally TERMINAL: it confirms the write
         # landed and tells the model to stop. We do NOT echo the full entries
@@ -1225,7 +1317,9 @@ class MemoryStore:
         pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
 
         if target == "user":
-            header = f"{MEMORY_BLOCK_HEADERS['user']} [{pct}% — {current:,}/{limit:,} chars]"
+            header = (
+                f"{MEMORY_BLOCK_HEADERS['user']} [{pct}% — {current:,}/{limit:,} chars]"
+            )
         else:
             header = f"{MEMORY_BLOCK_HEADERS['memory']} [{pct}% — {current:,}/{limit:,} chars]"
 
@@ -1617,7 +1711,9 @@ def memory_tool(
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
-        result = store.apply_batch(target, operations, memory_char_limit=memory_char_limit)
+        result = store.apply_batch(
+            target, operations, memory_char_limit=memory_char_limit
+        )
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
@@ -1726,9 +1822,9 @@ MEMORY_SCHEMA = {
         "detail, or you learn a stable fact about their environment, conventions, or workflow. "
         "Priority: user preferences & corrections > environment facts > procedures. The best "
         "memory stops the user repeating themselves.\n\n"
-        "IF FULL: an add is rejected with the current entries shown. Reissue as ONE batch that "
-        "removes or shortens enough stale entries and adds the new one together. Or call "
-        "action='compact' first to shorten entries so the batch fits.\n\n"
+        "IF FULL: an add is auto-accepted by evicting the OLDEST entry to make room "
+        "(the evicted text is listed under `evicted` in the response, so nothing is lost silently). "
+        "Only if the new entry alone exceeds the whole budget, or the safety floor is reached, is the add rejected with the current entries shown — then reissue as ONE batch that removes or shortens enough stale entries and adds the new one together. Or call action='compact' first to shorten entries so the batch fits.\n\n"
         "TARGETS: 'user' = who the user is (name, role, preferences, style). 'memory' = your "
         "notes (environment, conventions, tool quirks, lessons).\n\n"
         "PROVENANCE (optional, on add/replace): tag where a fact came from. source_class = "


### PR DESCRIPTION
## Summary

When a bare `memory(action=add)` would exceed the char budget, the tool currently **hard-rejects**, forcing the agent into a multi-call read/evict/rewrite spiral (issue #1283 documents 3–5 extra tool calls per capacity hit). This PR makes `add` **auto-evict the OLDEST entry** (insertion order) and accept the add, eliminating the spiral.

## Changes

- `tools/memory_tool.py` — `MemoryStore.__init__` gains `auto_evict_on_full` (default `True`) and `auto_evict_keep_min` (default `1`); new `_evict_to_fit()` helper evicts oldest-first until the add fits or the floor is reached; `add()` uses it on overflow before falling back to the existing consolidation-failure response. `MEMORY_SCHEMA` "IF FULL" guidance updated.
- `agent/agent_init.py` — wires the two new config keys into the `MemoryStore` constructor.
- `hermes_cli/config.py` — adds `memory.auto_evict_on_full` and `memory.auto_evict_keep_min` to `DEFAULT_CONFIG` with documentation.
- `tests/tools/test_memory_tool.py` — new `TestAutoEvictOnFull` class (6 tests: oldest-eviction, keep-min floor, oversized-entry rejection, opt-out, user-target exemption, default-on). Two pre-existing tests that targeted the old overflow path are updated to opt out of auto-eviction so they still exercise their intended code path.

## Safety

- **Default ON** (`auto_evict_on_full: true`) because the spiral is real user pain; **opt-out** restores the pre-#1283 hard-reject path for anyone who wants manual control.
- **`auto_evict_keep_min` floor** (default 1) prevents a single giant entry from wiping the whole store.
- **Only the `memory` target auto-evicts**; `user` profile facts are scarce/high-value and keep manual consolidation.
- **Nothing is dropped silently** — every eviction is surfaced in the response `evicted` list and logged at INFO.
- **Graceful degradation** — a single entry larger than the whole budget, or an add that still can't fit at the keep-min floor, falls through to the existing consolidation-failure response (so the model still gets batch/compact guidance).

## Verification

- `ruff check` + `ruff format` clean on all changed files (remaining format drift on `agent_init.py`/`config.py` is pre-existing on `main`, confirmed via `git checkout origin/main`).
- `pytest tests/tools/test_memory_tool.py` → 95 passed.
- Broader memory suite (`test_memory_tool`, `test_memory_guard`, `test_memory_provenance`, `test_memory_tool_schema`, `test_write_approval`) → 183 passed.

Closes #1283

🤖 Automated evolution PR.