### PR TITLE
fix: degrade gracefully when evolution package absent in harvest cron (Closes #1304)

### DIFF
--- a/scripts/evolution_experience_harvest.py
+++ b/scripts/evolution_experience_harvest.py
@@ -57,7 +57,14 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# Add the scripts/ dir (sibling-script imports like evolution_experience_distill)
+# AND the repo root (parent of scripts/) so the `evolution` namespace package
+# resolves when the script is run in-repo from any cwd.  When the script is
+# installed into HERMES_HOME/scripts (outside the repo), `evolution` is not
+# present — the graceful fallback below keeps the harvest running instead of
+# crashing every cron tick (mirrors evolution_watchdog.py's ImportError fallback).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agent.display import _detect_tool_failure  # noqa: E402
 from agent.experience_bank import (  # noqa: E402
@@ -69,7 +76,35 @@ from agent.experience_bank import (  # noqa: E402
     iter_entries,
     set_harvest_state,
 )
-from evolution.lib.root_cause_diagnosis import ErrorClassifier  # noqa: E402
+
+try:
+    from evolution.lib.root_cause_diagnosis import ErrorClassifier  # noqa: E402
+except ImportError:
+    import enum  # noqa: E402
+
+    class _FallbackFailureCategory(enum.Enum):
+        """Minimal stand-in for FailureCategory when `evolution` is absent."""
+
+        UNKNOWN = "unknown"
+
+    class ErrorClassifier:  # type: ignore[no-redef]
+        """Degraded fallback used when the `evolution` package is unavailable.
+
+        ``classify`` always returns ``UNKNOWN`` so the harvest still emits
+        valid entries (``failure_category="unknown"``) and distillation can
+        proceed, instead of the cron failing every tick with
+        ``ModuleNotFoundError``.  See GitHub issue #1304.
+        """
+
+        def classify(self, content: str):  # noqa: D401, ARG002
+            return _FallbackFailureCategory.UNKNOWN
+
+    print(
+        "[experience-harvest] evolution.lib.root_cause_diagnosis unavailable "
+        "— using UNKNOWN fallback (run from the repo root or install the "
+        "evolution package for full failure classification).",
+        file=sys.stderr,
+    )
 from hermes_constants import get_hermes_home  # noqa: E402
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_evolution_experience_harvest.py
+++ b/tests/scripts/test_evolution_experience_harvest.py
@@ -805,3 +805,89 @@ class TestLock:
         assert rc == 0
         assert "another bank operation is running" in capsys.readouterr().out
         assert _entries() == []
+
+
+class TestImportFallback:
+    """The cron installs this script into HERMES_HOME/scripts where the
+    ``evolution`` namespace package is absent.  The import must degrade
+    gracefully (issue #1304) rather than crashing every tick with
+    ``ModuleNotFoundError``.
+    """
+
+    def _reload_with_evolution_blocked(self, tmp_path, monkeypatch):
+        """Reload ``evolution_experience_harvest`` with the ``evolution``
+        import blocked, returning the reloaded module with the fallback
+        ``ErrorClassifier`` active.
+
+        Patches ``builtins.__import__`` to raise ``ImportError`` for the
+        ``evolution`` package — the exact failure the installed cron sees —
+        then reloads.  A finalizer restores the real ``ErrorClassifier`` by
+        reloading once more with the import unblocked, so sibling tests are
+        unaffected.
+        """
+        import builtins
+        import importlib
+        from unittest import mock
+
+        real_import = builtins.__import__
+
+        def blocking_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "evolution" or name.startswith("evolution."):
+                raise ImportError(f"No module named '{name.split('.')[0]}'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        removed = {
+            name: sys.modules.pop(name)
+            for name in list(sys.modules)
+            if name == "evolution" or name.startswith("evolution.")
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with mock.patch("builtins.__import__", side_effect=blocking_import):
+            reloaded = importlib.reload(eh)
+
+        def _restore():
+            sys.modules.update(removed)
+            try:
+                importlib.reload(eh)
+            except Exception:
+                pass
+
+        reloaded._restore_fn = _restore  # type: ignore[attr-defined]
+        return reloaded
+
+    def test_fallback_classifier_returns_unknown(self, tmp_path, monkeypatch):
+        reloaded = self._reload_with_evolution_blocked(tmp_path, monkeypatch)
+        try:
+            category = reloaded.ErrorClassifier().classify("Connection refused")
+            assert category.value == "unknown"
+        finally:
+            reloaded._restore_fn()
+
+    def test_harvest_runs_with_fallback_classifier(self, tmp_path, monkeypatch):
+        """A full harvest pass must not raise even when only the fallback
+        classifier is available — entries are still emitted with
+        ``failure_category='unknown'``."""
+        reloaded = self._reload_with_evolution_blocked(tmp_path, monkeypatch)
+        try:
+            db, db_path = _make_db(tmp_path)
+            _add_session(
+                db,
+                "s-err",
+                [
+                    _user(),
+                    {
+                        "role": "tool",
+                        "content": "Error: connection refused",
+                        "tool_name": "web_search",
+                    },
+                    _assistant("I apologize, but I encountered an error."),
+                ],
+            )
+            db.close()
+            summary = reloaded.run_harvest(db_path=db_path, now=NOW)
+            assert summary["entries_appended"] == 1
+            entries = _entries()
+            assert entries
+            assert entries[-1].failure_category == "unknown"
+        finally:
+            reloaded._restore_fn()


### PR DESCRIPTION
Automated evolution PR for issue #1304.

## Problem
The `evolution-experience-harvest` cron job fails on **every execution** with `ModuleNotFoundError: No module named 'evolution'`. The script (`scripts/evolution_experience_harvest.py`, line 72) imports `from evolution.lib.root_cause_diagnosis import ErrorClassifier`, but only `scripts/` is on `sys.path` — the repo root (parent of `scripts/`, where the `evolution/` namespace package lives) is not. When the script is installed into `HERMES_HOME/scripts` (outside the repo), the import cannot resolve. At least 3 consecutive failures on 2026-07-26 (01:53, 05:53, 09:53 UTC); the job never succeeds.

## Fix
Mirrors the established `evolution_watchdog.py` ImportError-fallback pattern (lines 1134-1139):
1. Add the repo root (parent of `scripts/`) to `sys.path` so the `evolution` namespace package resolves when the script is run in-repo from any cwd.
2. Wrap the `ErrorClassifier` import in `try/except ImportError` with a degraded fallback whose `classify()` always returns `UNKNOWN`. The harvest then emits valid entries (`failure_category="unknown"`) and distillation proceeds, instead of the cron failing every tick.
3. Emit a single-line stderr notice in degraded mode so operators know to install the `evolution` package for full failure classification.

Zero behavioral change when `evolution` is importable (the normal in-repo case) — the real `ErrorClassifier` is used.

## Acceptance criteria (#1304)
- [x] `evolution-experience-harvest` completes a run without `ModuleNotFoundError` (fallback path emits entries with `failure_category="unknown"`)
- [x] Entries are still appended so downstream distillation heals instead of stalling

## Validation
- `ruff check` ✓ (CI's blocking lint check — `lint.yml` enforces `ruff check .`, not `ruff format --check`)
- Targeted tests ✓ — 34/34 pass (`tests/scripts/test_evolution_experience_harvest.py`), including 2 new `TestImportFallback` cases:
  - `test_fallback_classifier_returns_unknown` — verifies the fallback `ErrorClassifier.classify()` returns `UNKNOWN` when the `evolution` import is blocked (simulating the installed cron).
  - `test_harvest_runs_with_fallback_classifier` — verifies a full `run_harvest` pass with only the fallback classifier appends an entry with `failure_category="unknown"`.

## Files
- `scripts/evolution_experience_harvest.py` (+34 lines: repo-root sys.path entry + try/except fallback)
- `tests/scripts/test_evolution_experience_harvest.py` (+87 lines: `TestImportFallback` class with 2 tests)

Diff: 122 insertions, 1 deletion — within the autonomous self-merge cap (≤200).