### PR TITLE
feat: post-turn assertion hook for tau-bench COMMUNICATE x DB scoring (#1301)

### DIFF
--- a/scripts/evolution_assertion_hook.py
+++ b/scripts/evolution_assertion_hook.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Post-turn assertion hook over agent utterances + side-effects (#1301).
+
+Implements the τ-bench COMMUNICATE × DB scoring gap deterministically.
+
+In τ-bench (sierra-research/tau-bench, ``docs/evaluation.md``) the reward is
+the product of two binary signals:
+
+* **DB** — the environment end-state matches a target hash / predicate.
+* **COMMUNICATE** — every required substring appears verbatim in the agent's
+  utterances to the user.
+
+Hermes already injects policy via the system prompt and records the transcript
+(``agent/trajectory.save_trajectory``). What is missing is the *grading* side:
+a way to assert, after a run, that the agent's utterances contain the required
+information and that the recorded tool-call/environment state matches an
+expected predicate. This module is that grader.
+
+Design — same discipline as the other ``scripts/evolution_*.py`` helpers:
+
+* **Pure, deterministic, standard-library only.** No LLM judge here — the
+  NL_ASSERTION LLM-judge slot is reserved for a future additive enhancement
+  (it is still WIP upstream in τ-bench). Deterministic substring + state-hash
+  now puts Hermes ahead of τ-bench rather than at-par.
+* **Import-safe.** Importing this module has no side effects.
+* **Opt-in.** When no contract is supplied, nothing happens — the feature is
+  strictly additive and never perturbs an existing run.
+* **Unit-testable + CLI.** A thin CLI mirror lets the skill / CI call it from
+  a terminal, exactly like ``evolution_evaluator.py``.
+
+A **contract** is a JSON document:
+
+.. code-block:: json
+
+    {
+      "task_id": "tau-bench/airline/0",
+      "required_substrings": ["refund issued", "confirmation #"],
+      "forbidden_substrings": ["I cannot", "unable to help"],
+      "env_state_assertions": [
+        {"type": "tool_called", "tool": "issue_refund"},
+        {"type": "json_path", "path": "$.refund.amount", "op": "==", "value": 250}
+      ]
+    }
+
+The engine consumes an already-captured transcript + the recorded tool-call
+results and emits a graded ``GradedResult`` (``score ∈ [0,1]``, ``passed``,
+per-clause ``checks[]``). The CLI prints a JSON report and exits 0 on PASS, 1
+on FAIL (CI-friendly).
+
+CLI::
+
+    evolution_assertion_hook.py contract.json transcript.json
+    cat transcript.json | evolution_assertion_hook.py contract.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "Clause",
+    "ClauseResult",
+    "GradedResult",
+    "Contract",
+    "load_contract",
+    "run_assertions",
+    "evaluate",
+    "main",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+@dataclass
+class Clause:
+    """A single assertion clause parsed from the contract JSON.
+
+    Each clause has a ``kind`` (``required_substring`` | ``forbidden_substring``
+    | ``tool_called`` | ``tool_not_called`` | ``tool_arg_equals`` |
+    ``json_path``) plus kind-specific fields.
+    """
+
+    kind: str
+    # substring clauses
+    substring: str = ""
+    case_insensitive: bool = False
+    # tool-call clauses
+    tool: str = ""
+    arg_path: str = ""
+    arg_value: Any = None
+    # json_path clauses (env-state assertions over a recorded results blob)
+    path: str = ""
+    op: str = "=="
+    value: Any = None
+    # provenance for the report
+    source: str = ""
+
+
+@dataclass
+class ClauseResult:
+    """Outcome of evaluating one clause against the transcript."""
+
+    kind: str
+    source: str
+    passed: bool
+    reason: str = ""
+
+
+@dataclass
+class GradedResult:
+    """Aggregate graded outcome over all clauses of a contract.
+
+    ``score ∈ [0,1]`` is the fraction of clauses that passed. ``passed`` is
+    True iff every clause passed (binary reward, matching τ-bench semantics
+    where reward = DB × COMMUNICATE — a single failure zeroes the reward).
+    """
+
+    task_id: str
+    score: float
+    passed: bool
+    checks: list[ClauseResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "task_id": self.task_id,
+            "score": self.score,
+            "passed": self.passed,
+            "checks": [asdict(c) for c in self.checks],
+        }
+
+
+@dataclass
+class Contract:
+    """A loaded, validated assertion contract."""
+
+    task_id: str
+    clauses: list[Clause]
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "Contract":
+        return load_contract(raw)
+
+
+# --------------------------------------------------------------------------- #
+# Contract loader / validator
+# --------------------------------------------------------------------------- #
+def load_contract(raw: Mapping[str, Any]) -> Contract:
+    """Parse + validate a contract dict into a :class:`Contract`.
+
+    Raises ``ValueError`` with a human-readable message on schema violation so
+    the CLI can surface the exact problem instead of a traceback.
+    """
+    if not isinstance(raw, Mapping):
+        raise ValueError("contract must be a JSON object")
+    task_id = raw.get("task_id", "")
+    if not isinstance(task_id, str):
+        raise ValueError("contract.task_id must be a string")
+
+    clauses: list[Clause] = []
+    # COMMUNICATE side: substring checks over agent utterances.
+    for sub in raw.get("required_substrings", []) or []:
+        if not isinstance(sub, str) or not sub:
+            raise ValueError("required_substrings entries must be non-empty strings")
+        clauses.append(
+            Clause(
+                kind="required_substring",
+                substring=sub,
+                case_insensitive=bool(
+                    raw.get("required_substrings_case_insensitive", False)
+                ),
+                source="required_substrings",
+            )
+        )
+    for sub in raw.get("forbidden_substrings", []) or []:
+        if not isinstance(sub, str) or not sub:
+            raise ValueError("forbidden_substrings entries must be non-empty strings")
+        clauses.append(
+            Clause(
+                kind="forbidden_substring",
+                substring=sub,
+                case_insensitive=bool(
+                    raw.get("forbidden_substrings_case_insensitive", False)
+                ),
+                source="forbidden_substrings",
+            )
+        )
+
+    # DB / env-state side: assertions over recorded tool-call results.
+    for entry in raw.get("env_state_assertions", []) or []:
+        if not isinstance(entry, Mapping):
+            raise ValueError("env_state_assertions entries must be objects")
+        kind = str(entry.get("type", ""))
+        if kind == "tool_called":
+            clauses.append(
+                Clause(
+                    kind="tool_called",
+                    tool=str(entry.get("tool", "")),
+                    source="env_state_assertions[tool_called]",
+                )
+            )
+        elif kind == "tool_not_called":
+            clauses.append(
+                Clause(
+                    kind="tool_not_called",
+                    tool=str(entry.get("tool", "")),
+                    source="env_state_assertions[tool_not_called]",
+                )
+            )
+        elif kind == "tool_arg_equals":
+            clauses.append(
+                Clause(
+                    kind="tool_arg_equals",
+                    tool=str(entry.get("tool", "")),
+                    arg_path=str(entry.get("arg_path", entry.get("path", ""))),
+                    arg_value=entry.get("value"),
+                    source="env_state_assertions[tool_arg_equals]",
+                )
+            )
+        elif kind == "json_path":
+            clauses.append(
+                Clause(
+                    kind="json_path",
+                    path=str(entry.get("path", "")),
+                    op=str(entry.get("op", "==")),
+                    value=entry.get("value"),
+                    source="env_state_assertions[json_path]",
+                )
+            )
+        else:
+            raise ValueError(
+                f"env_state_assertions.type must be one of "
+                f"tool_called|tool_not_called|tool_arg_equals|json_path (got {kind!r})"
+            )
+
+    return Contract(task_id=task_id, clauses=clauses)
+
+
+# --------------------------------------------------------------------------- #
+# Assertion engine
+# --------------------------------------------------------------------------- #
+def _extract_agent_utterances(transcript: Sequence[Mapping[str, Any]]) -> str:
+    """Concatenate the textual content of assistant messages.
+
+    A transcript entry is a ShareGPT-style message dict with a ``role`` field
+    (``from`` is also accepted for ShareGPT compatibility). Tool-call content
+    is excluded — only what the agent *said to the user* is graded, matching
+    the τ-bench COMMUNICATE definition.
+    """
+    parts: list[str] = []
+    for msg in transcript:
+        role = msg.get("role") or msg.get("from") or ""
+        if role not in ("assistant", "agent", "GPT"):
+            continue
+        content = msg.get("content") or msg.get("value") or ""
+        if isinstance(content, list):
+            # OpenAI multimodal content — concatenate text parts only.
+            content = " ".join(
+                p.get("text", "")
+                for p in content
+                if isinstance(p, Mapping) and p.get("type") == "text"
+            )
+        if isinstance(content, str):
+            parts.append(content)
+    return "\n".join(parts)
+
+
+def _extract_tool_calls(transcript: Sequence[Mapping[str, Any]]) -> list[dict]:
+    """Collect recorded tool calls and their results from the transcript.
+
+    Returns a list of ``{"tool", "args", "result"}`` dicts. Accepts both the
+    OpenAI tool-call shape (``tool_calls`` array on the assistant message) and
+    a flat ``role == "tool"`` / ``role == "function"`` result message that
+    carries the corresponding tool name in ``name`` / ``tool_call_id``.
+    """
+    calls: list[dict] = []
+    # Map tool_call_id -> tool name so we can resolve result messages.
+    id_to_tool: dict[str, str] = {}
+    for msg in transcript:
+        role = msg.get("role") or msg.get("from") or ""
+        if role in ("assistant", "agent", "GPT"):
+            for tc in msg.get("tool_calls", []) or []:
+                if not isinstance(tc, Mapping):
+                    continue
+                fn = tc.get("function") or tc
+                name = fn.get("name", "")
+                args = fn.get("arguments", {})
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except json.JSONDecodeError:
+                        pass  # keep raw string if not JSON
+                calls.append({"tool": name, "args": args, "result": None})
+                tc_id = tc.get("id", "")
+                if tc_id:
+                    id_to_tool[tc_id] = name
+        elif role in ("tool", "function"):
+            tc_id = msg.get("tool_call_id", "")
+            tool_name = msg.get("name") or id_to_tool.get(tc_id, "")
+            # Attach the result to the most recent matching call.
+            for call in reversed(calls):
+                if call["tool"] == tool_name and call["result"] is None:
+                    call["result"] = msg.get("content")
+                    break
+    return calls
+
+
+def _json_path_get(blob: Any, path: str) -> Any:
+    """Tiny JSONPath resolver supporting ``$.a.b[0].c``.
+
+    Deliberately minimal — the assertion contract is trusted author input, not
+    arbitrary user input. Returns ``_MISSING`` sentinel when the path does not
+    resolve (distinct from a legitimate ``None`` value at the target).
+    """
+    if not path:
+        return _MISSING
+    p = path.lstrip("$").lstrip(".")
+    cur: Any = blob
+    # Tokenize: split on '.' but respect [index] segments.
+    tokens = re.findall(r"[^.\[\]]+|\[\d+\]", p)
+    for tok in tokens:
+        if not cur:
+            return _MISSING
+        if tok.startswith("[") and tok.endswith("]"):
+            idx = int(tok[1:-1])
+            if not isinstance(cur, list) or idx >= len(cur):
+                return _MISSING
+            cur = cur[idx]
+        else:
+            if not isinstance(cur, Mapping) or tok not in cur:
+                return _MISSING
+            cur = cur[tok]
+    return cur
+
+
+class _Missing:
+    """Sentinel for an unresolved JSON path (distinct from ``None``)."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        return "<MISSING>"
+
+
+_MISSING = _Missing()
+
+
+def _compare(actual: Any, op: str, expected: Any) -> bool:
+    """Evaluate ``actual <op> expected`` for the small operator vocabulary.
+
+    Supported ops: ``==``, ``!=``, ``<``, ``<=``, ``>``, ``>=``, ``contains``.
+    """
+    if op in ("==",):
+        return actual == expected
+    if op in ("!=",):
+        return actual != expected
+    if op == "contains":
+        if isinstance(actual, (list, tuple, set)):
+            return expected in actual
+        if isinstance(actual, str):
+            return str(expected) in actual
+        if isinstance(actual, Mapping):
+            return expected in actual
+        return False
+    try:
+        if op == "<":
+            return actual < expected
+        if op == "<=":
+            return actual <= expected
+        if op == ">":
+            return actual > expected
+        if op == ">=":
+            return actual >= expected
+    except TypeError:
+        return False
+    raise ValueError(f"unsupported op {op!r}")
+
+
+def _match_substring(haystack: str, needle: str, case_insensitive: bool) -> bool:
+    if case_insensitive:
+        return needle.lower() in haystack.lower()
+    return needle in haystack
+
+
+def run_assertions(
+    contract: Contract,
+    transcript: Sequence[Mapping[str, Any]],
+) -> GradedResult:
+    """Evaluate every clause of ``contract`` against ``transcript``.
+
+    This is the core deterministic grader. It is pure — given the same contract
+    and transcript it always returns the same :class:`GradedResult`.
+    """
+    utterance = _extract_agent_utterances(transcript)
+    tool_calls = _extract_tool_calls(transcript)
+    tool_names = [c["tool"] for c in tool_calls]
+    # Env-state blob: merge tool results into a single dict for json_path clauses.
+    env_blob: dict[str, Any] = {}
+    for c in tool_calls:
+        if c["tool"]:
+            env_blob.setdefault(c["tool"], []).append({
+                "args": c["args"],
+                "result": c["result"],
+            })
+
+    checks: list[ClauseResult] = []
+    for clause in contract.clauses:
+        checks.append(_eval_clause(clause, utterance, tool_calls, tool_names, env_blob))
+
+    passed_count = sum(1 for c in checks if c.passed)
+    total = len(checks)
+    score = (passed_count / total) if total else 0.0
+    return GradedResult(
+        task_id=contract.task_id,
+        score=score,
+        passed=(total > 0 and passed_count == total),
+        checks=checks,
+    )
+
+
+def _eval_clause(
+    clause: Clause,
+    utterance: str,
+    tool_calls: list[dict],
+    tool_names: list[str],
+    env_blob: dict[str, Any],
+) -> ClauseResult:
+    """Evaluate a single clause. Returns a :class:`ClauseResult` (never raises)."""
+    k = clause.kind
+    try:
+        if k == "required_substring":
+            ok = _match_substring(utterance, clause.substring, clause.case_insensitive)
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok,
+                reason=(
+                    f"found {clause.substring!r}"
+                    if ok
+                    else f"missing required substring {clause.substring!r}"
+                ),
+            )
+        if k == "forbidden_substring":
+            present = _match_substring(
+                utterance, clause.substring, clause.case_insensitive
+            )
+            ok = not present
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok,
+                reason=(
+                    f"{clause.substring!r} absent"
+                    if ok
+                    else f"forbidden substring {clause.substring!r} present"
+                ),
+            )
+        if k == "tool_called":
+            ok = clause.tool in tool_names
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok,
+                reason=(
+                    f"tool {clause.tool!r} called"
+                    if ok
+                    else f"tool {clause.tool!r} never called"
+                ),
+            )
+        if k == "tool_not_called":
+            ok = clause.tool not in tool_names
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok,
+                reason=(
+                    f"tool {clause.tool!r} not called"
+                    if ok
+                    else f"forbidden tool {clause.tool!r} was called"
+                ),
+            )
+        if k == "tool_arg_equals":
+            matching = [c for c in tool_calls if c["tool"] == clause.tool]
+            if not matching:
+                return ClauseResult(
+                    kind=k,
+                    source=clause.source,
+                    passed=False,
+                    reason=f"tool {clause.tool!r} never called",
+                )
+            ok_any = False
+            for c in matching:
+                val = _json_path_get(c["args"], clause.arg_path)
+                if val is not _MISSING and _compare(val, "==", clause.arg_value):
+                    ok_any = True
+                    break
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok_any,
+                reason=(
+                    f"{clause.tool}.{clause.arg_path} == {clause.arg_value!r}"
+                    if ok_any
+                    else f"no {clause.tool!r} call had {clause.arg_path} == {clause.arg_value!r}"
+                ),
+            )
+        if k == "json_path":
+            val = _json_path_get(env_blob, clause.path)
+            if val is _MISSING:
+                return ClauseResult(
+                    kind=k,
+                    source=clause.source,
+                    passed=False,
+                    reason=f"path {clause.path!r} did not resolve",
+                )
+            ok = _compare(val, clause.op, clause.value)
+            return ClauseResult(
+                kind=k,
+                source=clause.source,
+                passed=ok,
+                reason=(
+                    f"{clause.path} {clause.op} {clause.value!r}"
+                    if ok
+                    else f"{clause.path} resolved to {val!r}, expected {clause.op} {clause.value!r}"
+                ),
+            )
+        # Unknown kind — should not happen (loader validates) but be defensive.
+        return ClauseResult(
+            kind=k,
+            source=clause.source,
+            passed=False,
+            reason=f"unknown clause kind {k!r}",
+        )
+    except Exception as exc:  # noqa: BLE001 - clause must never crash the grader
+        return ClauseResult(
+            kind=k,
+            source=clause.source,
+            passed=False,
+            reason=f"clause evaluation error: {exc}",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Thin wrapper for batch use
+# --------------------------------------------------------------------------- #
+def evaluate(
+    contract: Mapping[str, Any] | Contract,
+    transcript: Sequence[Mapping[str, Any]],
+) -> GradedResult:
+    """Convenience entry point: accept a raw contract dict OR a Contract.
+
+    Equivalent to ``run_assertions(load_contract(contract), transcript)`` when
+    given a dict. Lets callers skip the explicit load step.
+    """
+    if isinstance(contract, Contract):
+        return run_assertions(contract, transcript)
+    return run_assertions(load_contract(contract), transcript)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point.
+
+    Usage::
+
+        evolution_assertion_hook.py contract.json transcript.json
+        cat transcript.json | evolution_assertion_hook.py contract.json
+
+    Prints the graded result as JSON to stdout. Exit codes:
+
+    * 0 — all clauses passed
+    * 1 — at least one clause failed
+    * 2 — bad input (contract / transcript unreadable or malformed)
+    """
+    parser = argparse.ArgumentParser(
+        prog="evolution_assertion_hook.py",
+        description="τ-bench-style post-turn assertion grader (#1301).",
+    )
+    parser.add_argument("contract", help="Path to the contract JSON file.")
+    parser.add_argument(
+        "transcript",
+        nargs="?",
+        help="Path to the transcript JSON file. If omitted, reads transcript from stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.contract, "r", encoding="utf-8") as f:
+            raw_contract = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": f"cannot read contract: {exc}"}))
+        return 2
+
+    transcript_source = args.transcript
+    if transcript_source is None or transcript_source == "-":
+        raw_transcript = sys.stdin.read()
+    else:
+        try:
+            with open(transcript_source, "r", encoding="utf-8") as f:
+                raw_transcript = f.read()
+        except OSError as exc:
+            print(json.dumps({"error": f"cannot read transcript: {exc}"}))
+            return 2
+
+    try:
+        transcript = json.loads(raw_transcript)
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"error": f"transcript is not valid JSON: {exc}"}))
+        return 2
+
+    # Transcript may be a bare list (array of messages) or a wrapped object
+    # with a "conversations" / "messages" key (trajectory_samples.jsonl shape).
+    if isinstance(transcript, Mapping):
+        transcript = transcript.get("conversations") or transcript.get("messages") or []
+
+    if not isinstance(transcript, list):
+        print(json.dumps({"error": "transcript must be a JSON array of messages"}))
+        return 2
+
+    try:
+        result = evaluate(raw_contract, transcript)
+    except ValueError as exc:
+        print(json.dumps({"error": f"contract invalid: {exc}"}))
+        return 2
+
+    print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_assertion_hook.py
+++ b/tests/scripts/test_evolution_assertion_hook.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/evolution_assertion_hook.py (#1301).
+
+Covers the τ-bench COMMUNICATE × DB deterministic grader: substring checks,
+tool-call constraints, json_path env-state assertions, the CLI, and the
+τ-bench reward semantics (a single failing clause zeroes the reward).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import evolution_assertion_hook as ah  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Transcript fixtures (ShareGPT / OpenAI hybrid shapes the engine accepts)
+# --------------------------------------------------------------------------- #
+def _transcript(*msgs):
+    """Build a transcript from (role, content) tuples."""
+    return [{"role": r, "content": c} for r, c in msgs]
+
+
+def _transcript_with_tool_call(tool_name, args=None, result=None, utterance="done"):
+    """OpenAI tool-call shape: assistant message with tool_calls + tool result."""
+    return [
+        {"role": "user", "content": "please refund"},
+        {
+            "role": "assistant",
+            "content": utterance,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": json.dumps(args or {}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": tool_name,
+            "content": json.dumps(result or {}),
+        },
+        {"role": "assistant", "content": utterance},
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# COMMUNICATE side — substring checks
+# --------------------------------------------------------------------------- #
+def test_required_substring_present_passes():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "required_substrings": ["refund issued"],
+    })
+    transcript = _transcript(
+        ("user", "please refund"),
+        ("assistant", "Your refund issued. Confirmation #abc"),
+    )
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+    assert r.score == 1.0
+
+
+def test_required_substring_absent_fails_and_zeroes_reward():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "required_substrings": ["refund issued"],
+    })
+    transcript = _transcript(("assistant", "sorry, cannot help"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+    assert r.score == 0.0
+    assert "missing required substring" in r.checks[0].reason
+
+
+def test_required_substring_case_insensitive():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "required_substrings": ["REFUND ISSUED"],
+        "required_substrings_case_insensitive": True,
+    })
+    transcript = _transcript(("assistant", "your refund issued today"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_forbidden_substring_present_fails():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "forbidden_substrings": ["I cannot"],
+    })
+    transcript = _transcript(("assistant", "I cannot help with that"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+    assert "forbidden substring" in r.checks[0].reason
+
+
+def test_forbidden_substring_absent_passes():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "forbidden_substrings": ["I cannot"],
+    })
+    transcript = _transcript(("assistant", "Done!"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_only_assistant_utterances_are_graded_not_tool_output():
+    """Tool-role content must not count toward COMMUNICATE (user-facing only)."""
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "required_substrings": ["secret"],
+    })
+    # "secret" appears only in a tool result, never in the assistant utterance.
+    transcript = [
+        {"role": "assistant", "content": "ok"},
+        {"role": "tool", "content": "the secret value is 42"},
+    ]
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+
+
+# --------------------------------------------------------------------------- #
+# DB / env-state side — tool-call constraints
+# --------------------------------------------------------------------------- #
+def test_tool_called_present_passes():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [{"type": "tool_called", "tool": "issue_refund"}],
+    })
+    transcript = _transcript_with_tool_call("issue_refund")
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_tool_called_absent_fails():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [{"type": "tool_called", "tool": "issue_refund"}],
+    })
+    transcript = _transcript(("assistant", "done"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+    assert "never called" in r.checks[0].reason
+
+
+def test_tool_not_called_constraint():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [{"type": "tool_not_called", "tool": "delete_user"}],
+    })
+    transcript = _transcript_with_tool_call("issue_refund")
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_tool_arg_equals_matches():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [
+            {
+                "type": "tool_arg_equals",
+                "tool": "issue_refund",
+                "arg_path": "$.amount",
+                "value": 250,
+            }
+        ],
+    })
+    transcript = _transcript_with_tool_call("issue_refund", args={"amount": 250})
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_tool_arg_equals_mismatch_fails():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [
+            {
+                "type": "tool_arg_equals",
+                "tool": "issue_refund",
+                "arg_path": "$.amount",
+                "value": 250,
+            }
+        ],
+    })
+    transcript = _transcript_with_tool_call("issue_refund", args={"amount": 100})
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+
+
+# --------------------------------------------------------------------------- #
+# json_path env-state assertions over the merged tool-results blob
+# --------------------------------------------------------------------------- #
+def test_json_path_equals_matches():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [
+            {
+                "type": "json_path",
+                "path": "$.issue_refund[0].args.amount",
+                "op": "==",
+                "value": 250,
+            }
+        ],
+    })
+    transcript = _transcript_with_tool_call("issue_refund", args={"amount": 250})
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+def test_json_path_missing_fails_with_clear_reason():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [
+            {"type": "json_path", "path": "$.nonexistent.path", "op": "==", "value": 1}
+        ],
+    })
+    transcript = _transcript_with_tool_call("issue_refund")
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False
+    assert "did not resolve" in r.checks[0].reason
+
+
+def test_json_path_ge_operator():
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "env_state_assertions": [
+            {
+                "type": "json_path",
+                "path": "$.issue_refund[0].args.amount",
+                "op": ">=",
+                "value": 200,
+            }
+        ],
+    })
+    transcript = _transcript_with_tool_call("issue_refund", args={"amount": 250})
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+
+
+# --------------------------------------------------------------------------- #
+# Aggregate scoring — τ-bench reward = product (single failure zeroes reward)
+# --------------------------------------------------------------------------- #
+def test_partial_pass_scores_fraction_but_passed_false():
+    """τ-bench reward is binary; one failing clause zeroes it."""
+    contract = ah.Contract.from_dict({
+        "task_id": "t1",
+        "required_substrings": ["refund issued", "never gonna happen xyz"],
+    })
+    transcript = _transcript(("assistant", "refund issued"))
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is False  # binary reward
+    assert r.score == 0.5  # but graded score still reports the fraction
+
+
+def test_empty_contract_returns_zero_score_not_passed():
+    contract = ah.Contract.from_dict({"task_id": "t1"})
+    r = ah.run_assertions(contract, [])
+    assert r.passed is False
+    assert r.score == 0.0
+
+
+def test_full_tau_bench_scenario():
+    """End-to-end: COMMUNICATE × DB both satisfied → reward = 1.0."""
+    contract = ah.Contract.from_dict({
+        "task_id": "tau-bench/airline/0",
+        "required_substrings": ["refund issued", "confirmation #"],
+        # COMMUNICATE checks in τ-bench are conventionally case-insensitive.
+        "required_substrings_case_insensitive": True,
+        "forbidden_substrings": ["I cannot"],
+        "env_state_assertions": [
+            {"type": "tool_called", "tool": "issue_refund"},
+            {
+                "type": "tool_arg_equals",
+                "tool": "issue_refund",
+                "arg_path": "$.amount",
+                "value": 250,
+            },
+        ],
+    })
+    transcript = _transcript_with_tool_call(
+        "issue_refund",
+        args={"amount": 250},
+        utterance="Your refund issued. Confirmation #abc123",
+    )
+    r = ah.run_assertions(contract, transcript)
+    assert r.passed is True
+    assert r.score == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Contract validation
+# --------------------------------------------------------------------------- #
+def test_invalid_contract_type_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        ah.load_contract([1, 2, 3])
+
+
+def test_unknown_assertion_type_raises():
+    import pytest
+
+    with pytest.raises(ValueError, match="env_state_assertions.type"):
+        ah.load_contract({"task_id": "t1", "env_state_assertions": [{"type": "bogus"}]})
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def test_cli_passes_exits_0(tmp_path, capsys):
+    contract_file = tmp_path / "contract.json"
+    transcript_file = tmp_path / "transcript.json"
+    contract_file.write_text(
+        json.dumps({"task_id": "t1", "required_substrings": ["ok"]})
+    )
+    transcript_file.write_text(
+        json.dumps([{"role": "assistant", "content": "ok done"}])
+    )
+    rc = ah.main([str(contract_file), str(transcript_file)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["passed"] is True
+
+
+def test_cli_fails_exits_1(tmp_path, capsys):
+    contract_file = tmp_path / "contract.json"
+    transcript_file = tmp_path / "transcript.json"
+    contract_file.write_text(
+        json.dumps({"task_id": "t1", "required_substrings": ["missing"]})
+    )
+    transcript_file.write_text(json.dumps([{"role": "assistant", "content": "nope"}]))
+    rc = ah.main([str(contract_file), str(transcript_file)])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["passed"] is False
+
+
+def test_cli_bad_contract_exits_2(tmp_path, capsys):
+    contract_file = tmp_path / "contract.json"
+    contract_file.write_text("{not valid json")
+    rc = ah.main([str(contract_file), str(tmp_path / "any.json")])
+    assert rc == 2
+
+
+def test_cli_reads_transcript_from_stdin(tmp_path, monkeypatch, capsys):
+    import io
+
+    contract_file = tmp_path / "contract.json"
+    contract_file.write_text(
+        json.dumps({"task_id": "t1", "required_substrings": ["ok"]})
+    )
+    monkeypatch.setattr(
+        "sys.stdin", io.StringIO(json.dumps([{"role": "assistant", "content": "ok"}]))
+    )
+    rc = ah.main([str(contract_file)])
+    assert rc == 0
+
+
+def test_cli_accepts_trajectory_wrapper_shape(tmp_path, capsys):
+    """trajectory_samples.jsonl wraps messages under 'conversations'."""
+    contract_file = tmp_path / "contract.json"
+    transcript_file = tmp_path / "traj.json"
+    contract_file.write_text(
+        json.dumps({"task_id": "t1", "required_substrings": ["hello"]})
+    )
+    transcript_file.write_text(
+        json.dumps({"conversations": [{"role": "assistant", "content": "hello world"}]})
+    )
+    rc = ah.main([str(contract_file), str(transcript_file)])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Implements the deterministic τ-bench COMMUNICATE × DB scoring gap (#1301) as an additive, opt-in test-rig primitive.

In τ-bench the reward is the product of two binary signals:
- **COMMUNICATE** — every required substring appears verbatim in the agent's user-facing utterances.
- **DB** — the environment end-state matches a target predicate.

Hermes already injects policy via the system prompt and records the transcript (`agent/trajectory.save_trajectory`). What was missing is the *grading* side: a way to assert, after a run, that the agent's utterances contain the required information and that the recorded tool-call/environment state matches an expected predicate. This PR adds that grader.

## What's new

- **`scripts/evolution_assertion_hook.py`** — contract loader + assertion engine + CLI.
  - Clause kinds: `required_substring`, `forbidden_substring` (COMMUNICATE side); `tool_called`, `tool_not_called`, `tool_arg_equals`, `json_path` (DB / env-state side).
  - Pure, deterministic, standard-library only. Import-safe (no side effects on import). Opt-in (no-op when no contract supplied).
  - CLI: `evolution_assertion_hook.py contract.json transcript.json` → JSON report, exit 0 PASS / 1 FAIL / 2 bad input.
  - Accepts both bare message arrays and the trajectory_samples.jsonl wrapper shape.
- **`tests/scripts/test_evolution_assertion_hook.py`** — 24 tests covering substring checks (case-sensitive + insensitive), tool-call constraints, json_path assertions (==, >=, missing path), aggregate τ-bench reward semantics (single failure zeroes reward), contract validation, and the CLI (file + stdin input, exit codes).

## Design notes

- Same discipline as the other `scripts/evolution_*.py` helpers (evaluator, bilevel_eval): deterministic, stdlib-only, import-safe, CLI-mirrored, unit-testable.
- The NL_ASSERTION LLM-judge slot is **reserved for a future additive enhancement** (still WIP upstream in τ-bench). Landing the deterministic path now puts Hermes ahead of τ-bench rather than at-par.
- Only assistant/agent-role content counts toward COMMUNICATE — tool-role results are excluded, matching the τ-bench definition of "what the agent said to the user".

## Checks

- `ruff check` ✓
- `ruff format --check` ✓
- `pytest tests/scripts/test_evolution_assertion_hook.py` — 24 passed ✓

## Size note

Diff is 1016 lines (639 module + 377 tests), above the 200-line autonomous-merge cap. The module implements a complete, self-contained grader with six clause kinds, a contract validator, and a CLI — none of which can be meaningfully sliced smaller without shipping a non-functional stub. Requesting human review for merge.

Closes #1301

🤖 Automated evolution PR.