### PR TITLE
fix(hydra-gate): suppress false-positive wake-ups via dispatch ledger (Closes #1305)

### DIFF
--- a/scripts/evolution_hydra_gate.py
+++ b/scripts/evolution_hydra_gate.py
@@ -149,9 +149,70 @@ def _check_halt(evo_dir: Path) -> Tuple[bool, Path]:
         return False, halt_file
 
 
+# Verdicts that mark a dispatched stage pair as fully adjudicated for the day —
+# re-evaluating such a pair every tick is a no-op that wastes orchestrator wake-ups
+# (#1305: integration→upstream-sync fired 20+ false-positive wake-ups/day).
+_TERMINAL_VERDICTS = frozenset({"STEADY_STATE", "CONSUMED"})
+
+
+def _dispatch_ledger_path(evo_dir: Path) -> Path:
+    """Path to today's hydra dispatch ledger (jsonl), one JSON object per line.
+
+    The orchestrator appends a record per dispatch tick; each record carries at
+    least ``stage`` (the dispatched stage), ``verdict`` (STEADY_STATE / CONSUMED /
+    ...) and a timestamp. The ledger is optional — when absent we fall back to
+    the raw-mtime freshness logic.
+    """
+    return evo_dir / f"hydra-dispatch-{_today()}.jsonl"
+
+
+def _load_terminal_verdicts(evo_dir: Path) -> Dict[str, str]:
+    """Return a mapping ``"up→down" -> verdict`` for every pipeline pair that the
+    orchestrator already adjudicated with a terminal verdict today.
+
+    Reads ``hydra-dispatch-<date>.jsonl``. Each line is a JSON object shaped like
+    ``{"stage": "integration→upstream-sync", "verdict": "STEADY_STATE", ...}`` or
+    ``{"edge": "integration→upstream-sync", ...}``. Lines that do not parse or
+    lack a verdict are skipped silently — the gate must fail OPEN (wake) rather
+    than crash, and a malformed ledger line is not grounds to skip a real wake.
+    """
+    ledger = _dispatch_ledger_path(evo_dir)
+    terminal: Dict[str, str] = {}
+    try:
+        with ledger.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                verdict = rec.get("verdict")
+                if verdict not in _TERMINAL_VERDICTS:
+                    continue
+                # Accept either ``stage`` or ``edge`` as the pair key.
+                pair = rec.get("stage") or rec.get("edge") or rec.get("pair")
+                if not pair:
+                    continue
+                terminal[pair] = verdict
+    except FileNotFoundError:
+        pass
+    except OSError:
+        # Unreadable ledger → treat as empty (fail open).
+        pass
+    return terminal
+
+
 def _check_pool(evo_dir: Path) -> Dict[str, bool]:
     """Check all upstream→downstream pairs for staleness. Returns per-pair
-    freshness map."""
+    freshness map.
+
+    A pair that the orchestrator already resolved to a terminal verdict
+    (``STEADY_STATE`` / ``CONSUMED``) today is suppressed — it is a no-op to
+    re-dispatch it, and re-evaluating it produced 20+ false-positive wake-ups per
+    day (#1305).
+    """
     # Upstream → downstream pairs in the evolution pipeline
     pairs = [
         ("research", "issues"),  # new findings → need issues
@@ -162,10 +223,17 @@ def _check_pool(evo_dir: Path) -> Dict[str, bool]:
         ("integration", "upstream-sync"),  # new merges → need sync
     ]
 
+    terminal_verdicts = _load_terminal_verdicts(evo_dir)
+
     results: Dict[str, bool] = {}
     for up, down in pairs:
+        pair_key = f"{up}→{down}"
+        if pair_key in terminal_verdicts:
+            # Already adjudicated today with a terminal verdict — do not wake.
+            results[pair_key] = False
+            continue
         fresh = _has_upstream_freshness(evo_dir, up, down)
-        results[f"{up}→{down}"] = fresh
+        results[pair_key] = fresh
     return results
 
 

--- a/tests/scripts/test_evolution_hydra_gate.py
+++ b/tests/scripts/test_evolution_hydra_gate.py
@@ -63,3 +63,108 @@ class TestMainHalt:
         assert "HALTED" in out
         last_line = out.strip().splitlines()[-1]
         assert json.loads(last_line) == {"wakeAgent": False}
+
+
+class TestDispatchLedger:
+    """#1305 — a pair adjudicated STEADY_STATE/CONSUMED today must not re-wake."""
+
+    def _write_ledger(self, evo_dir: Path, records):
+        ledger = evo_dir / f"hydra-dispatch-{hydra._today()}.jsonl"
+        with ledger.open("w", encoding="utf-8") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
+
+    def test_terminal_verdict_suppresses_pair(self, tmp_path):
+        """integration→upstream-sync resolved STEADY_STATE today → not fresh."""
+        self._write_ledger(
+            tmp_path,
+            [{"stage": "integration→upstream-sync", "verdict": "STEADY_STATE"}],
+        )
+        terminal = hydra._load_terminal_verdicts(tmp_path)
+        assert terminal.get("integration→upstream-sync") == "STEADY_STATE"
+        pool = hydra._check_pool(tmp_path)
+        assert pool["integration→upstream-sync"] is False
+
+    def test_consumed_verdict_also_suppresses(self, tmp_path):
+        self._write_ledger(
+            tmp_path,
+            [{"edge": "analysis→implementation", "verdict": "CONSUMED"}],
+        )
+        terminal = hydra._load_terminal_verdicts(tmp_path)
+        assert terminal.get("analysis→implementation") == "CONSUMED"
+
+    def test_non_terminal_verdict_does_not_suppress(self, tmp_path):
+        """A non-terminal verdict (e.g. WORK_NEEDED) must NOT suppress the pair."""
+        self._write_ledger(
+            tmp_path,
+            [{"stage": "integration→upstream-sync", "verdict": "WORK_NEEDED"}],
+        )
+        terminal = hydra._load_terminal_verdicts(tmp_path)
+        assert "integration→upstream-sync" not in terminal
+
+    def test_missing_ledger_is_empty(self, tmp_path):
+        """No ledger file → no terminal verdicts (fail open)."""
+        assert hydra._load_terminal_verdicts(tmp_path) == {}
+
+    def test_malformed_ledger_line_skipped(self, tmp_path):
+        """Malformed lines must not crash the gate."""
+        ledger = tmp_path / f"hydra-dispatch-{hydra._today()}.jsonl"
+        ledger.write_text(
+            "not json\n"
+            + json.dumps({"verdict": "STEADY_STATE"})  # no stage/edge → skip
+            + "\n"
+            + json.dumps({"stage": "integration→upstream-sync", "verdict": "CONSUMED"})
+            + "\n",
+            encoding="utf-8",
+        )
+        terminal = hydra._load_terminal_verdicts(tmp_path)
+        assert terminal == {"integration→upstream-sync": "CONSUMED"}
+
+    def test_main_suppresses_wake_when_only_terminal_pair_would_fire(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """End-to-end: only the integration→upstream-sync pair has fresh upstream
+        material, but it was adjudicated STEADY_STATE today → gate sleeps.
+
+        All time-triggers (research, introspection, upstream-sync) must have
+        recent output so they don't independently wake the gate.
+        """
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        today = hydra._today()
+        # Satisfy every stage so no time-trigger fires.
+        for stage in (
+            "research",
+            "issues",
+            "introspection",
+            "analysis",
+            "implementation",
+            "integration",
+            "upstream-sync",
+        ):
+            (tmp_path / stage).mkdir()
+            (tmp_path / stage / f"{today}.json").write_text("{}", encoding="utf-8")
+        # Make upstream (integration) fresher than downstream (upstream-sync) —
+        # this pair would normally wake.
+        down = tmp_path / "upstream-sync" / f"{today}.json"
+        import os, time
+
+        old_ts = time.time() - 3600
+        os.utime(down, (old_ts, old_ts))
+        # Ledger says this pair is already settled today.
+        ledger = tmp_path / f"hydra-dispatch-{today}.jsonl"
+        ledger.write_text(
+            json.dumps({
+                "stage": "integration→upstream-sync",
+                "verdict": "STEADY_STATE",
+            })
+            + "\n",
+            encoding="utf-8",
+        )
+        with patch.object(
+            hydra, "_check_github_write_access", return_value=(True, "ok")
+        ):
+            rc = hydra.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        last_line = out.strip().splitlines()[-1]
+        assert json.loads(last_line) == {"wakeAgent": False}


### PR DESCRIPTION
## Summary

Automated evolution PR for issue #1305.

Adds a **dispatch-ledger gate predicate** to `scripts/evolution_hydra_gate.py`. A pipeline pair already adjudicated with a terminal verdict (`STEADY_STATE` / `CONSUMED`) today is no longer re-evaluated every cron tick — eliminating the 20+/day `integration→upstream-sync` false-positive wake-ups reported in the issue.

## Changes
- `_dispatch_ledger_path()` — canonical path to `hydra-dispatch-<date>.jsonl`.
- `_load_terminal_verdicts()` — reads today's terminal-verdict records (fails open: absent/malformed ledger → no suppression → wake).
- `_check_pool()` — a pair with a terminal verdict today is forced to `fresh=False`.
- 6 new tests covering: terminal-verdict suppression (STEADY_STATE + CONSUMED), non-terminal verdict passthrough, missing/malformed ledger, and end-to-end `main()` wake suppression.

## Design notes
- **Fail-open**: an unreadable or missing ledger never silently suppresses a real wake — the gate only *adds* suppression, never *removes* it.
- Accepts both `stage` and `edge` keys for the pair identifier (orchestrator record shape).
- Verdicts are matched against a frozen set `{STEADY_STATE, CONSUMED}` so only genuinely terminal adjudications suppress.

## Validation
- `ruff check` ✓
- `ruff format --check` ✓
- `pytest tests/scripts/test_evolution_hydra_gate.py` → 10 passed
- Diff: 175 insertions, 2 deletions (within the 200-line autonomous merge cap)

Closes #1305