### PR TITLE
fix(mcp): suppress ValidationError traceback storm from non-JSON stdout (Closes #1298)

### DIFF
--- a/tests/tools/test_mcp_stdout_noise_filter.py
+++ b/tests/tools/test_mcp_stdout_noise_filter.py
@@ -1,0 +1,106 @@
+"""Tests for the MCP stdout JSONRPC-parse noise suppression (#1298).
+
+The MCP SDK's ``stdout_reader`` logs ``logger.exception("Failed to parse
+JSONRPC message from server")`` for every stdout line that is not valid
+JSON-RPC, emitting a full pydantic ``ValidationError`` traceback at ERROR
+level — ~300 occurrences/scan in production. The filter installed at import
+time of ``tools.mcp_tool`` demotes that specific message to DEBUG and strips
+the traceback. Genuine ERROR logs from the same logger pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import tools.mcp_tool as mcp_tool  # noqa: F401  — import installs the filter
+
+_MCP_STDIO_LOGGER = "mcp.client.stdio"
+_MCP_JSONRPC_PARSE_MSG = "Failed to parse JSONRPC message from server"
+
+
+def _has_filter(logger: logging.Logger) -> bool:
+    return any(
+        isinstance(f, mcp_tool._SuppressNonJsonStdoutTraceback) for f in logger.filters
+    )
+
+
+class TestFilterInstalled:
+    def test_filter_attached_on_import(self):
+        """Importing tools.mcp_tool must attach the suppression filter."""
+        mcp_logger = logging.getLogger(_MCP_STDIO_LOGGER)
+        assert _has_filter(mcp_logger)
+
+    def test_install_is_idempotent(self):
+        """Calling install twice must not stack duplicate filters."""
+        before = len([
+            f
+            for f in logging.getLogger(_MCP_STDIO_LOGGER).filters
+            if isinstance(f, mcp_tool._SuppressNonJsonStdoutTraceback)
+        ])
+        mcp_tool._install_mcp_stdout_noise_filter()
+        mcp_tool._install_mcp_stdout_noise_filter()
+        after = len([
+            f
+            for f in logging.getLogger(_MCP_STDIO_LOGGER).filters
+            if isinstance(f, mcp_tool._SuppressNonJsonStdoutTraceback)
+        ])
+        assert before == 1
+        assert after == 1
+
+
+class TestSuppression:
+    @pytest.fixture
+    def capture(self, caplog):
+        """caplog at DEBUG on the mcp.client.stdio logger."""
+        caplog.set_level(logging.DEBUG, logger=_MCP_STDIO_LOGGER)
+        return caplog
+
+    def test_parse_error_demoted_to_debug_and_traceback_stripped(self, capture):
+        """The known-noisy parse message drops to DEBUG and loses exc_info."""
+        logger = logging.getLogger(_MCP_STDIO_LOGGER)
+        try:
+            raise ValueError("simulated pydantic validation noise")
+        except ValueError:
+            logger.exception(_MCP_JSONRPC_PARSE_MSG)
+
+        matched = [r for r in capture.records if r.name == _MCP_STDIO_LOGGER]
+        assert matched, "expected at least one log record"
+        rec = matched[-1]
+        assert rec.levelno == logging.DEBUG
+        assert rec.levelname == "DEBUG"
+        assert rec.exc_info is None
+        assert rec.exc_text is None
+
+    def test_unrelated_error_from_same_logger_passes_through(self, capture):
+        """A genuine, unrelated ERROR log must keep its level and traceback."""
+        logger = logging.getLogger(_MCP_STDIO_LOGGER)
+        try:
+            raise RuntimeError("a real transport failure")
+        except RuntimeError:
+            logger.exception("Transport closed unexpectedly")
+
+        matched = [
+            r
+            for r in capture.records
+            if r.name == _MCP_STDIO_LOGGER
+            and r.getMessage() == "Transport closed unexpectedly"
+        ]
+        assert matched, "expected the unrelated error record"
+        rec = matched[-1]
+        assert rec.levelno == logging.ERROR
+        assert rec.exc_info is not None
+
+    def test_non_exception_log_of_parse_msg_also_demoted(self, capture):
+        """Even a plain logger.error (no exc_info) of the message is demoted."""
+        logger = logging.getLogger(_MCP_STDIO_LOGGER)
+        logger.error(_MCP_JSONRPC_PARSE_MSG)
+
+        matched = [
+            r
+            for r in capture.records
+            if r.name == _MCP_STDIO_LOGGER and r.getMessage() == _MCP_JSONRPC_PARSE_MSG
+        ]
+        assert matched
+        assert matched[-1].levelno == logging.DEBUG

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -110,6 +110,55 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+# --------------------------------------------------------------------------- #
+# Suppress pydantic ValidationError traceback storm from non-JSON MCP stdout  #
+# (#1298: 300 occurrences/scan, ~3300 lines of noise in errors.log).          #
+# --------------------------------------------------------------------------- #
+# The MCP SDK's ``stdout_reader`` (mcp/client/stdio/__init__.py) calls
+# ``logger.exception("Failed to parse JSONRPC message from server")`` for every
+# stdout line that is not valid JSON-RPC. A misconfigured / failing MCP server
+# (e.g. a missing binary that prints CLI usage text to stdout) produces dozens
+# of these per connection attempt, each emitting a full ~11-line pydantic
+# ``ValidationError`` traceback at ERROR level — drowning real signal.
+#
+# This filter demotes that specific, known-noisy message to DEBUG and strips the
+# exc_info traceback so it no longer pollutes errors.log. The parse failure
+# itself is harmless (the SDK skips the line and keeps reading); we only lose
+# the traceback verbosity, not the information that a parse failure happened.
+_MCP_STDIO_LOGGER = "mcp.client.stdio"
+_MCP_JSONRPC_PARSE_MSG = "Failed to parse JSONRPC message from server"
+
+
+class _SuppressNonJsonStdoutTraceback(logging.Filter):
+    """Demote the SDK's JSONRPC-parse-error log to DEBUG + drop its traceback.
+
+    ``logging.Filter`` runs before the record reaches handlers, so we can edit
+    the record in place: lower its level and clear ``exc_info`` (which is what
+    ``logger.exception`` uses to emit the traceback). Genuine, unrelated ERROR
+    logs from the same logger pass through unchanged.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        if record.getMessage() == _MCP_JSONRPC_PARSE_MSG:
+            record.levelno = logging.DEBUG
+            record.levelname = "DEBUG"
+            record.exc_info = None
+            record.exc_text = None
+        return True
+
+
+def _install_mcp_stdout_noise_filter() -> None:
+    """Attach the suppression filter to the MCP stdio logger (idempotent)."""
+    mcp_logger = logging.getLogger(_MCP_STDIO_LOGGER)
+    # Avoid stacking duplicate filters across re-imports / test reloads.
+    for existing in mcp_logger.filters:
+        if isinstance(existing, _SuppressNonJsonStdoutTraceback):
+            return
+    mcp_logger.addFilter(_SuppressNonJsonStdoutTraceback())
+
+
+_install_mcp_stdout_noise_filter()
+
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
 # interrupt a stalled SSL handshake, which froze the asyncio event loop and


### PR DESCRIPTION
## Summary

Automated evolution PR for issue #1298.

Suppresses the pydantic **ValidationError traceback storm** (~300 occurrences/scan, ~3300 lines of noise in `errors.log`) that the MCP SDK emits when a stdio MCP server prints non-JSON output to stdout (e.g. a missing binary printing CLI usage text).

## Root cause
The MCP SDK's `stdout_reader` (`mcp/client/stdio/__init__.py`, line ~157) calls `logger.exception("Failed to parse JSONRPC message from server")` for every stdout line that fails `JSONRPCMessage.model_validate_json(line)`. Each call emits a full ~11-line pydantic `ValidationError` traceback at ERROR level via the `mcp.client.stdio` logger.

## Fix
Add a `logging.Filter` (`_SuppressNonJsonStdoutTraceback`) on the `mcp.client.stdio` logger that:
- Demotes the specific `"Failed to parse JSONRPC message from server"` message from ERROR → DEBUG.
- Strips `exc_info` / `exc_text` so the traceback no longer reaches handlers.

**Genuine unrelated ERROR logs from the same logger pass through unchanged.** The filter only matches the exact noisy message string. Fail-open by design: the parse failure itself is harmless (the SDK skips the line and keeps reading).

## Changes
- `tools/mcp_tool.py`: +49 lines — the filter class + idempotent installer (runs at import time).
- `tests/tools/test_mcp_stdout_noise_filter.py`: +106 lines — 5 tests covering filter installation (idempotent), ERROR→DEBUG demotion with traceback stripping, unrelated-error passthrough, and plain `logger.error` (no exc_info) demotion.

## Validation
- `ruff check` ✓
- `pytest tests/tools/test_mcp_stdout_noise_filter.py` → 5 passed
- Diff: 155 insertions, 0 deletions (within the 200-line autonomous merge cap)
- **No reformat noise** — the change is a surgical insertion after the module logger; the rest of `mcp_tool.py` is untouched.

Closes #1298