### PR TITLE
fix(hydra-gate): self-recording dispatch ledger stops same-day false-positive wake-ups (#1305)

### DIFF
--- a/scripts/evolution_hydra_gate.py
+++ b/scripts/evolution_hydra_gate.py
@@ -12,6 +12,13 @@ The gate checks upstream→downstream staleness for the 7 evolution stages and
 returns false (sleep) when every consumer is ahead of or equal to its producer.
 It also sleeps when ``halt-state.txt`` is present, preventing expensive LLM work
 on a broken pipeline (#770).
+
+A per-edge dispatch ledger (#1305) suppresses false-positive wake-ups: once the
+gate has dispatched for an edge on a given day, subsequent ticks on the same day
+do NOT re-fire unless the upstream stage produced NEW output (a strictly newer
+mtime) since the last dispatch. Without this ledger the raw-mtime check re-fires
+on every tick — observed at 20+ wasted orchestrator wake-ups/day on the
+integration→upstream-sync edge alone (#1305).
 """
 
 from __future__ import annotations
@@ -22,7 +29,12 @@ import subprocess
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+
+# Ledger entries older than this are pruned to keep the file bounded. Entries are
+# keyed by day, so a week of history is ample for debugging a "did the gate fire
+# today?" question without growing unbounded over months.
+_LEDGER_PRUNE_DAYS = 7
 
 
 def _hot_path() -> Path:
@@ -58,6 +70,97 @@ def _latest_output(evo_dir: Path, stage: str) -> float:
     """Return the latest mtime of any output file for this stage (today)."""
     json_path, md_path = _today_paths(evo_dir, stage)
     return max(_mtime(json_path), _mtime(md_path))
+
+
+# ---------------------------------------------------------------------------
+# Dispatch ledger (#1305) — stop false-positive re-wake-ups on the same day
+# ---------------------------------------------------------------------------
+
+
+def _ledger_path(evo_dir: Path) -> Path:
+    """Path to the per-edge dispatch ledger (a small JSON file)."""
+    return evo_dir / ".hydra-dispatch-ledger.json"
+
+
+def _read_ledger(evo_dir: Path) -> Dict[str, dict]:
+    """Load the dispatch ledger, or ``{}`` if absent / corrupt.
+
+    Schema: ``{"<edge>": {"date": "YYYY-MM-DD", "upstream_mtime": <float>,
+    "verdict": <str|None>}}``. Corrupt files are treated as empty rather than
+    raising — a corrupt ledger must never block a genuine wake-up (fail-open).
+    """
+    path = _ledger_path(evo_dir)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_ledger(evo_dir: Path, ledger: Dict[str, dict]) -> None:
+    """Persist the ledger atomically. Best-effort: a write failure is logged to
+    stderr but never raised — the ledger is an optimization, not a correctness
+    requirement, so a failed write degrades to "may re-wake once" rather than
+    crashing the gate."""
+    path = _ledger_path(evo_dir)
+    tmp = path.with_suffix(".tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(ledger), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        # Don't leave a .tmp littering the dir on a failed rename.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        print(f"[hydra-gate] ledger write failed ({exc}) — continuing", file=sys.stderr)
+
+
+def _already_dispatched_today(evo_dir: Path, edge: str, upstream_mtime: float) -> bool:
+    """Return True if this edge was already dispatched today AND the upstream
+    stage has NOT produced newer output since that dispatch.
+
+    A NEW upstream mtime (strictly greater than the one recorded at dispatch
+    time) means genuinely fresh material arrived → re-fire. The same or older
+    mtime means the edge is a repeat of an already-adjudicated state → suppress.
+    """
+    entry = _read_ledger(evo_dir).get(edge)
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("date") != _today():
+        # Stale entry from a prior day — that day's verdict doesn't carry over.
+        return False
+    recorded_mtime = entry.get("upstream_mtime")
+    if not isinstance(recorded_mtime, (int, float)):
+        return False
+    # Suppress only when upstream has not advanced since the last dispatch.
+    # A strict-newer mtime is genuine new material and must re-fire.
+    return upstream_mtime <= float(recorded_mtime)
+
+
+def _record_dispatch(evo_dir: Path, edge: str, upstream_mtime: float) -> None:
+    """Record that the gate dispatched for ``edge`` at ``upstream_mtime`` today.
+
+    Also opportunistically prunes entries older than ``_LEDGER_PRUNE_DAYS`` so
+    the file stays small over time.
+    """
+    ledger = _read_ledger(evo_dir)
+    ledger[edge] = {
+        "date": _today(),
+        "upstream_mtime": upstream_mtime,
+        "verdict": None,
+    }
+    # Prune stale entries (older than the prune window). Keep today's + the
+    # last week for debugging "did the gate already see this edge?".
+    cutoff = (datetime.now() - timedelta(days=_LEDGER_PRUNE_DAYS)).date().isoformat()
+    pruned = {
+        k: v
+        for k, v in ledger.items()
+        if isinstance(v, dict) and str(v.get("date", "")) >= cutoff
+    }
+    _write_ledger(evo_dir, pruned)
 
 
 def _has_upstream_freshness(
@@ -170,15 +273,48 @@ def _check_pool(evo_dir: Path) -> Dict[str, bool]:
 
 
 def _has_work(evo_dir: Path) -> Tuple[bool, str]:
-    """Core gate logic. Returns (has_work, reason)."""
+    """Core gate logic. Returns (has_work, reason).
+
+    Freshness edges that were already dispatched today (with no upstream
+    advancement since) are suppressed via the dispatch ledger (#1305).
+    """
     now_ts = datetime.now().timestamp()
 
     freshness = _check_pool(evo_dir)
-    fresh_pairs = [(pair, v) for pair, v in freshness.items() if v]
+    # Map edge label → upstream stage name, so we can read the upstream mtime
+    # the ledger compares against. Pairs are defined in _check_pool.
+    edge_upstream = {
+        "research→issues": "research",
+        "issues→analysis": "issues",
+        "introspection→analysis": "introspection",
+        "analysis→implementation": "analysis",
+        "implementation→integration": "implementation",
+        "integration→upstream-sync": "integration",
+    }
+    fresh_pairs = []
+    suppressed = []
+    for pair, is_fresh in freshness.items():
+        if not is_fresh:
+            continue
+        up_stage = edge_upstream.get(pair)
+        if up_stage is None:
+            # Unknown edge label — can't ledger it; fire to be safe.
+            fresh_pairs.append(pair)
+            continue
+        up_mtime = _latest_output(evo_dir, up_stage)
+        if _already_dispatched_today(evo_dir, pair, up_mtime):
+            # Already dispatched today for this exact upstream state — suppress.
+            suppressed.append(pair)
+        else:
+            fresh_pairs.append(pair)
 
     if fresh_pairs:
-        reasons = [f"{pair}" for pair, _ in fresh_pairs]
-        return True, f"fresh material: {', '.join(reasons)}"
+        # Record the dispatch for each firing edge so a same-day re-tick with
+        # no upstream advancement is suppressed next time.
+        for pair in fresh_pairs:
+            up_stage = edge_upstream[pair]
+            _record_dispatch(evo_dir, pair, _latest_output(evo_dir, up_stage))
+        return True, f"fresh material: {', '.join(fresh_pairs)}"
 
     # Time-based triggers: root stages that should run periodically even when
     # the pool is settled — they generate the material that downstream stages
@@ -218,6 +354,12 @@ def _has_work(evo_dir: Path) -> Tuple[bool, str]:
         if age_hours >= 12:
             return True, f"safety wake: {age_hours:.0f}h since last output"
 
+    if suppressed:
+        return False, (
+            "pool settled — no fresh material "
+            f"({len(suppressed)} edge(s) already dispatched today: "
+            f"{', '.join(suppressed)})"
+        )
     return False, "pool settled — no fresh material"
 
 

--- a/tests/scripts/test_evolution_hydra_gate.py
+++ b/tests/scripts/test_evolution_hydra_gate.py
@@ -1,11 +1,13 @@
 """Tests for scripts/evolution_hydra_gate.py — wake-gate that checks upstream
-freshness, GitHub write access, and the pipeline halt-state."""
+freshness, GitHub write access, the pipeline halt-state, and the per-edge
+dispatch ledger (#1305) that suppresses false-positive re-wake-ups."""
 
 from __future__ import annotations
 
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -63,3 +65,169 @@ class TestMainHalt:
         assert "HALTED" in out
         last_line = out.strip().splitlines()[-1]
         assert json.loads(last_line) == {"wakeAgent": False}
+
+
+class TestDispatchLedger:
+    """The per-edge dispatch ledger (#1305) — a stage already dispatched today
+    must NOT re-wake the orchestrator on a subsequent tick unless the upstream
+    stage produced strictly newer output."""
+
+    def _make_edge_fresh(self, tmp_path: Path, edge: str):
+        """Create upstream-but-not-downstream output for a given edge label so
+        ``_check_pool`` reports the edge as fresh. Uses the real pair mapping."""
+        up_for = {
+            "research→issues": ("research", "issues"),
+            "issues→analysis": ("issues", "analysis"),
+            "introspection→analysis": ("introspection", "analysis"),
+            "analysis→implementation": ("analysis", "implementation"),
+            "implementation→integration": ("implementation", "integration"),
+            "integration→upstream-sync": ("integration", "upstream-sync"),
+        }
+        up, down = up_for[edge]
+        up_dir = tmp_path / up
+        up_dir.mkdir(parents=True, exist_ok=True)
+        (up_dir / f"{hydra._today()}.json").write_text("{}", encoding="utf-8")
+        # downstream dir absent → edge is "fresh" (down_mtime == 0).
+
+    def test_ledger_round_trip(self, tmp_path):
+        """_read_ledger returns what _write_ledger persisted; corrupt/missing
+        files read back as {} (fail-open)."""
+        assert hydra._read_ledger(tmp_path) == {}  # missing file
+        hydra._write_ledger(tmp_path, {"x": {"date": "2026-01-01"}})
+        assert hydra._read_ledger(tmp_path) == {"x": {"date": "2026-01-01"}}
+        # corrupt JSON → fail-open to {}
+        hydra._ledger_path(tmp_path).write_text("{not json", encoding="utf-8")
+        assert hydra._read_ledger(tmp_path) == {}
+
+    def test_already_dispatched_false_when_no_entry(self, tmp_path):
+        assert hydra._already_dispatched_today(tmp_path, "edge", 100.0) is False
+
+    def test_already_dispatched_false_for_stale_date(self, tmp_path):
+        """A ledger entry from a prior day does not suppress today's tick."""
+        hydra._write_ledger(
+            tmp_path,
+            {"edge": {"date": "1999-01-01", "upstream_mtime": 100.0}},
+        )
+        assert hydra._already_dispatched_today(tmp_path, "edge", 100.0) is False
+
+    def test_already_dispatched_true_for_same_mtime_today(self, tmp_path):
+        """Same upstream mtime, same day → suppress (the core false-positive fix)."""
+        hydra._write_ledger(
+            tmp_path,
+            {"edge": {"date": hydra._today(), "upstream_mtime": 100.0}},
+        )
+        assert hydra._already_dispatched_today(tmp_path, "edge", 100.0) is True
+
+    def test_already_dispatched_false_for_newer_upstream(self, tmp_path):
+        """Strictly newer upstream mtime → genuine new material → re-fire."""
+        hydra._write_ledger(
+            tmp_path,
+            {"edge": {"date": hydra._today(), "upstream_mtime": 100.0}},
+        )
+        assert hydra._already_dispatched_today(tmp_path, "edge", 200.0) is False
+
+    def test_first_tick_wakes_and_records_dispatch(self, tmp_path, capsys, monkeypatch):
+        """First fresh tick wakes the orchestrator AND writes a ledger entry."""
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        self._make_edge_fresh(tmp_path, "integration→upstream-sync")
+        with patch.object(
+            hydra, "_check_github_write_access", return_value=(True, "ok")
+        ):
+            rc = hydra.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "fresh material" in out
+        assert json.loads(out.strip().splitlines()[-1]) == {"wakeAgent": True}
+        # Ledger now has an entry for the edge, dated today.
+        ledger = hydra._read_ledger(tmp_path)
+        assert "integration→upstream-sync" in ledger
+        assert ledger["integration→upstream-sync"]["date"] == hydra._today()
+
+    def test_second_tick_same_day_same_mtime_suppressed(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The bug from #1305: a second tick on the same day with NO upstream
+        advancement must NOT re-wake the orchestrator on the SAME edge. This is
+        the regression test for the 20+/day false-positive wake-ups.
+
+        (A wake for an UNRELATED reason — e.g. a time trigger on a different
+        stage — is fine and out of scope for this test; the fix targets
+        repeat-dispatch of an already-adjudicated edge.)"""
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        self._make_edge_fresh(tmp_path, "integration→upstream-sync")
+        edge = "integration→upstream-sync"
+        with patch.object(
+            hydra, "_check_github_write_access", return_value=(True, "ok")
+        ):
+            hydra.main()  # tick 1 — wakes on the edge + records dispatch
+            out1 = capsys.readouterr().out
+            assert edge in out1
+            assert json.loads(out1.strip().splitlines()[-1]) == {"wakeAgent": True}
+
+            hydra.main()  # tick 2 — same day, same mtime
+            out2 = capsys.readouterr().out
+        last2 = json.loads(out2.strip().splitlines()[-1])
+        if last2["wakeAgent"]:
+            # If it wakes, it must NOT be a repeat-dispatch of the same edge.
+            # The suppression is verified by the edge being absent from the
+            # "fresh material" reason (either it sleeps, or wakes for a
+            # different reason like a time trigger).
+            assert edge not in out2, (
+                f"edge {edge} re-fired on tick 2 with no upstream advancement "
+                f"(reason: {out2.strip()!r})"
+            )
+        else:
+            # It slept — and the reason should note the suppression.
+            assert "already dispatched today" in out2
+
+    def test_newer_upstream_after_dispatch_re_fires(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Genuine new material (newer upstream mtime) must re-wake even after a
+        same-day dispatch — the ledger must not suppress a real state change."""
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        self._make_edge_fresh(tmp_path, "integration→upstream-sync")
+        with patch.object(
+            hydra, "_check_github_write_access", return_value=(True, "ok")
+        ):
+            hydra.main()  # tick 1 — records dispatch at mtime T1
+            capsys.readouterr()
+
+            # Simulate the upstream stage producing NEW output (newer mtime).
+            up_file = tmp_path / "integration" / f"{hydra._today()}.json"
+            new_time = time.time()
+            os.utime(up_file, (new_time, new_time))
+
+            hydra.main()  # tick 2 — newer upstream → must wake
+            out2 = capsys.readouterr().out
+        assert "fresh material" in out2
+        assert json.loads(out2.strip().splitlines()[-1]) == {"wakeAgent": True}
+
+    def test_ledger_prunes_old_entries(self, tmp_path):
+        """_record_dispatch prunes entries older than the prune window so the
+        file does not grow unbounded over months."""
+        # Seed with one very old entry and one from today.
+        old = {
+            "ancient-edge": {"date": "2000-01-01", "upstream_mtime": 1.0},
+            "fresh-edge": {"date": hydra._today(), "upstream_mtime": 5.0},
+        }
+        hydra._write_ledger(tmp_path, old)
+        # Recording a new dispatch should drop the ancient entry.
+        hydra._record_dispatch(tmp_path, "new-edge", 10.0)
+        ledger = hydra._read_ledger(tmp_path)
+        assert "ancient-edge" not in ledger
+        assert "fresh-edge" in ledger
+        assert "new-edge" in ledger
+
+    def test_corrupt_ledger_does_not_block_wake(self, tmp_path, capsys, monkeypatch):
+        """A corrupt ledger must fail-open: the first fresh tick still wakes the
+        orchestrator (never suppress a genuine wake-up due to a corrupt file)."""
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        self._make_edge_fresh(tmp_path, "integration→upstream-sync")
+        hydra._ledger_path(tmp_path).write_text("{broken json", encoding="utf-8")
+        with patch.object(
+            hydra, "_check_github_write_access", return_value=(True, "ok")
+        ):
+            hydra.main()
+            out = capsys.readouterr().out
+        assert json.loads(out.strip().splitlines()[-1]) == {"wakeAgent": True}


### PR DESCRIPTION
Automated evolution PR for issue #1305.

## Problem
The Hydra gate gated wake-ups purely on raw upstream file mtime, with no record of whether it had already dispatched for an edge that day. A stage already adjudicated STEADY_STATE/CONSUMED was re-evaluated and re-fired on every tick — observed at 20+ wasted orchestrator wake-ups/day on the integration→upstream-sync edge alone, each spending agent API tokens and running a full read cycle for a no-op.

## Fix
Add a self-recording per-edge dispatch ledger (`~/.hermes/evolution/.hydra-dispatch-ledger.json`), keyed by edge + date, storing the upstream mtime at dispatch time. A subsequent same-day tick suppresses the edge unless the upstream produced STRICTLY newer output (genuine new material re-fires).

**Why self-recording, not orchestrator-fed:** a prior attempt (branch `evolution/issue-1305-hydra-dispatch-ledger`, abandoned) read an orchestrator-written `hydra-dispatch-<date>.jsonl`. But the gate runs BEFORE the orchestrator — that file is never written, so the suppression never fires. This version records its own dispatch decision at wake time, so it works without orchestrator cooperation.

Fail-open: a corrupt/missing ledger never blocks a real wake-up. Entries prune after 7 days.

## Tests
9 regression tests: ledger round-trip + fail-open, no-entry/stale-date/same-mtime/newer-mtime semantics, first-tick-records, second-tick-suppressed (the core #1305 regression), newer-upstream-re-fires, prune, corrupt-ledger.

## Size note
316 insertions / 6 deletions — exceeds the 200-line autonomous-merge cap because the gate-fix and its regression tests are one safety-critical unit (a buggy ledger could suppress a genuine wake-up, so the tests are load-bearing). Held for human merge.

Closes #1305