### PR TITLE
fix(mcp): pre-flight guard stops turbo-memory-mcp retry storm (#1297)

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -219,3 +219,125 @@ def test_run_stdio_malware_check_times_out_fail_open():
         assert elapsed < 1.0, f"startup did not fail-open promptly ({elapsed:.1f}s)"
 
     asyncio.run(_test())
+
+
+# ---------------------------------------------------------------------------
+# #1297: pre-flight guard — a missing stdio command must fail ONCE with a
+# non-retryable error, not bubble FileNotFoundError through the reconnect
+# retry loop (3 retries × N revival cycles = the observed 189-failure/scan
+# storm). The guard is exercised directly here; the integration (it stops the
+# retry loop because MissingMcpCommandError subclasses NonMcpEndpointError,
+# which the reconnect loop catches-and-exits on) is covered by inspection of
+# the loop's `except NonMcpEndpointError` branch.
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+
+from tools.mcp_tool import (  # noqa: E402
+    MissingMcpCommandError,
+    _ensure_stdio_command_resolvable,
+)
+
+
+def test_preflight_raises_for_missing_bare_command():
+    """A bare command name not on PATH → MissingMcpCommandError (non-retryable),
+    naming the command and giving an install hint. This is the turbo-memory-mcp
+    case from #1297."""
+    with patch("tools.mcp_tool.shutil.which", return_value=None):
+        with pytest.raises(MissingMcpCommandError) as exc_info:
+            _ensure_stdio_command_resolvable(
+                "tqmemory", "turbo-memory-mcp", {"PATH": "/usr/bin"}
+            )
+    msg = str(exc_info.value)
+    assert "turbo-memory-mcp" in msg
+    assert "not found on PATH" in msg
+    # Actionable install hint must be present.
+    assert "install" in msg.lower()
+
+
+def test_preflight_raises_for_nonexistent_absolute_path():
+    """An absolute path that does not exist → MissingMcpCommandError with a
+    'path does not exist' message (distinct from the PATH case)."""
+    with patch("tools.mcp_tool.os.path.isfile", return_value=False):
+        with pytest.raises(MissingMcpCommandError) as exc_info:
+            _ensure_stdio_command_resolvable(
+                "srv", "/opt/does-not-exist/bin", {"PATH": "/usr/bin"}
+            )
+    assert "does not exist" in str(exc_info.value)
+
+
+def test_preflight_raises_for_non_executable_path(tmp_path):
+    """An existing-but-not-executable file → MissingMcpCommandError (chmod
+    hint). Prevents a confusing PermissionError retry storm."""
+    f = tmp_path / "server"
+    f.write_text("#!/bin/sh\n", encoding="utf-8")
+    f.chmod(0o644)  # not executable
+    with patch("tools.mcp_tool.os.access", return_value=False):
+        with pytest.raises(MissingMcpCommandError) as exc_info:
+            _ensure_stdio_command_resolvable("srv", str(f), {"PATH": "/usr/bin"})
+    assert "not executable" in str(exc_info.value)
+
+
+def test_preflight_raises_for_empty_command():
+    with pytest.raises(MissingMcpCommandError) as exc_info:
+        _ensure_stdio_command_resolvable("srv", "", {"PATH": "/usr/bin"})
+    assert "empty" in str(exc_info.value).lower()
+
+
+def test_preflight_passes_for_bare_command_on_path():
+    """A bare command found via shutil.which → no exception (server proceeds
+    to spawn). The common healthy case must not be blocked."""
+    with patch(
+        "tools.mcp_tool.shutil.which",
+        return_value="/usr/local/bin/turbo-memory-mcp",
+    ):
+        # Should not raise.
+        _ensure_stdio_command_resolvable(
+            "tqmemory", "turbo-memory-mcp", {"PATH": "/usr/local/bin"}
+        )
+
+
+def test_preflight_passes_for_existing_executable_absolute_path(tmp_path):
+    """An absolute path pointing at a real executable file → no exception."""
+    f = tmp_path / "server"
+    f.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    f.chmod(0o755)
+    _ensure_stdio_command_resolvable("srv", str(f), {"PATH": "/usr/bin"})
+
+
+def test_preflight_missing_command_is_non_retryable_subclass():
+    """MissingMcpCommandError MUST subclass NonMcpEndpointError so the
+    reconnect loop's `except NonMcpEndpointError` branch exits cleanly instead
+    of retrying. This is the invariant that converts the retry storm into one
+    clean failure — if it ever breaks, #1297 regresses."""
+    from tools.mcp_tool import NonMcpEndpointError
+
+    assert issubclass(MissingMcpCommandError, NonMcpEndpointError)
+    # And NonMcpEndpointError is itself a ConnectionError (the reconnect loop's
+    # broad-catch semantics) — verify the chain end-to-end.
+    assert issubclass(MissingMcpCommandError, ConnectionError)
+
+
+def test_preflight_uses_subprocess_env_path_not_process_path():
+    """The pre-flight must resolve against the SUBPROCESS env's PATH (what the
+    child will actually see), not the Hermes process's PATH. A binary present
+    in the subprocess PATH but not the process PATH must pass; a binary absent
+    from the subprocess PATH must fail even if the process PATH has it."""
+    # Subprocess PATH includes /opt/special where the binary lives; the fake
+    # which() returns a hit only for that path → should pass.
+    def _which(cmd, path=None):
+        if path and "/opt/special" in path:
+            return "/opt/special/" + cmd
+        return None
+
+    with patch("tools.mcp_tool.shutil.which", side_effect=_which):
+        # Passes with the subprocess PATH that includes /opt/special.
+        _ensure_stdio_command_resolvable(
+            "srv", "special-bin", {"PATH": "/opt/special:/usr/bin"}
+        )
+        # Fails when the subprocess PATH omits /opt/special, even though the
+        # process PATH (not consulted) might have it.
+        with pytest.raises(MissingMcpCommandError):
+            _ensure_stdio_command_resolvable(
+                "srv", "special-bin", {"PATH": "/usr/bin"}
+            )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1016,6 +1016,80 @@ class NonMcpEndpointError(ConnectionError):
     """
 
 
+class MissingMcpCommandError(NonMcpEndpointError):
+    """Raised when a stdio MCP server's command is not on PATH and not a valid
+    absolute path — a permanent, non-retryable misconfiguration.
+
+    This is the pre-flight guard for #1297: a missing binary (e.g.
+    ``turbo-memory-mcp``) has zero chance of spawning, so retrying it
+    ``_MAX_INITIAL_CONNECT_RETRIES`` times × every revival cycle only produces a
+    storm of identical ``FileNotFoundError`` tracebacks (observed at 189
+    failures/scan) and drowns real errors in the log. Failing fast with ONE
+    actionable message is strictly better.
+
+    Subclasses :class:`NonMcpEndpointError` so the existing non-retryable catch
+    in the reconnect loop (``except NonMcpEndpointError``) reports the server
+    failed immediately instead of entering backoff.
+    """
+
+
+def _ensure_stdio_command_resolvable(
+    server_name: str, command: str, env: dict | None
+) -> None:
+    """Pre-flight check that a stdio MCP ``command`` can actually be spawned.
+
+    Raises :class:`MissingMcpCommandError` (non-retryable) if the command is a
+    bare name not found on the subprocess PATH, or an absolute/relative path
+    that does not exist. Raises nothing when the command looks resolvable.
+
+    Rationale (#1297): ``_resolve_stdio_command`` only does PATH/dir-candidate
+    fallback for ``npx``/``npm``/``node``. Any OTHER missing binary passes
+    through unresolved and fails at ``execvp`` time inside the MCP SDK's
+    ``stdio_client`` with ``FileNotFoundError`` — which the reconnect loop treats
+    as a retryable connection error and re-attempts, producing the retry storm.
+    """
+    resolved = os.path.expanduser(str(command).strip())
+    if not resolved:
+        raise MissingMcpCommandError(
+            f"MCP server '{server_name}' has an empty 'command'"
+        )
+
+    # Absolute or relative path with a separator: must exist + be executable.
+    # We don't require a separator-less name to exist here (shutil.which handles
+    # that below against the subprocess PATH), but a path WITH a separator that
+    # the user wrote literally must point at a real file.
+    if os.sep in resolved or (os.altsep and os.altsep in resolved):
+        if not os.path.isfile(resolved):
+            raise MissingMcpCommandError(
+                f"MCP server '{server_name}': command not found at "
+                f"'{resolved}'. The path does not exist. "
+                f"Fix: install the binary or correct the 'command' in your "
+                f"mcp_servers config."
+            )
+        if not os.access(resolved, os.X_OK):
+            raise MissingMcpCommandError(
+                f"MCP server '{server_name}': command '{resolved}' is not "
+                f"executable. Fix: chmod +x '{resolved}' or correct the path."
+            )
+        return
+
+    # Bare command name: must be discoverable on the subprocess PATH.
+    # ``env`` is the resolved env (_build_safe_env output) whose PATH reflects
+    # what the subprocess will actually see.
+    path_arg = (env or {}).get("PATH") if isinstance(env, dict) else None
+    if not shutil.which(resolved, path=path_arg):
+        raise MissingMcpCommandError(
+            f"MCP server '{server_name}': command '{resolved}' not found on "
+            f"PATH. The binary is not installed (or not on the subprocess "
+            f"PATH). This is non-retryable — every spawn attempt fails "
+            f"identically. Fix: install '{resolved}' (e.g. for "
+            f"turbo-memory-mcp: `uv tool install "
+            f"git+https://github.com/Lexus2016/turbo_quant_memory`) or remove "
+            f"the '{server_name}' entry from your mcp_servers config if you no "
+            f"longer use it."
+        )
+
+
 def _validate_remote_mcp_url(server_name: str, url: Any) -> str:
     """Return the URL as a string if it's a valid http(s) remote MCP URL.
 
@@ -2300,6 +2374,16 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+
+        # Pre-flight: if the command did not resolve to an executable on PATH
+        # (or an absolute path that exists), fail ONCE with a clean, actionable,
+        # NON-retryable error instead of letting FileNotFoundError bubble through
+        # the reconnect loop's 3 initial retries × N revival cycles (#1297).
+        # ``_resolve_stdio_command`` only does PATH/dir-candidate fallback for
+        # npx/npm/node; any OTHER missing binary (e.g. ``turbo-memory-mcp``)
+        # remains a bare name here. A bare name that ``shutil.which`` cannot find
+        # has no chance of spawning successfully, so there is nothing to retry.
+        _ensure_stdio_command_resolvable(self.name, command, safe_env)
 
         # Check package against OSV malware database before spawning.
         # Run off the event loop (the urllib HTTPS call is blocking) and bound


### PR DESCRIPTION
Automated evolution PR for issue #1297.

## Problem
A stdio MCP server whose command binary is absent (e.g. `turbo-memory-mcp` missing from PATH) failed at `execvp` time inside the MCP SDK's `stdio_client` with `FileNotFoundError`. The reconnect loop treats that as a retryable connection error and re-attempts it `_MAX_INITIAL_CONNECT_RETRIES` (3) times, then parks and revives — producing **189 identical failure/scan** in errors.log (the #1297 retry storm) and drowning real errors.

## Fix
Add `_ensure_stdio_command_resolvable()`: a pre-flight in `_run_stdio`, run right after `_resolve_stdio_command`, that raises a **non-retryable** `MissingMcpCommandError` when the command is a bare name not on the subprocess PATH or an absolute path that does not exist.

`MissingMcpCommandError` subclasses `NonMcpEndpointError`, which the reconnect loop already catches-and-exits on cleanly (`except NonMcpEndpointError` → `self._ready.set(); return`). So the server fails **ONCE** with an actionable install hint instead of storming.

`_resolve_stdio_command` only does PATH/dir-candidate fallback for `npx/npm/node`; every other missing binary now hits this guard before any spawn is attempted.

## Design notes
- Resolves against the **subprocess env's PATH** (what the child actually sees), not the Hermes process PATH — a binary on the process PATH but absent from the subprocess PATH still fails correctly.
- Fails fast with a message naming the command + an install hint (e.g. `uv tool install git+https://github.com/Lexus2016/turbo_quant_memory` for turbo-memory-mcp).
- Zero behavioral risk: the server is already failing; this only changes the failure mode from a noisy 3×N retry storm to a single clean error.

## Tests
8 tests in `test_mcp_tool_issue_948.py`: missing bare command, bad absolute path, non-executable, empty command, healthy pass-through (bare-on-path + absolute-executable), the non-retryable subclass invariant, and subprocess-vs-process PATH scoping.

Closes #1297