### PR TITLE
fix(tools): patch pre-flight distinguishes missing-file from generic read failure (Closes #1326)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -903,3 +903,101 @@ class _DeletedTestGitBaselineCheck:
     helper is restored or replaced.
     """
     pass
+
+
+# =========================================================================
+# #1326 — patch_replace file-not-found preflight
+# =========================================================================
+# Before #1326, ``cat <path> 2>/dev/null`` swallowed WHY the read failed, so
+# every miss (missing file / directory / permission error) collapsed to the
+# identical generic "Failed to read file: {path}". That string classifies as
+# ``read_error`` (never ``not_found``), so the agent never learned that
+# ``write_file`` — not ``patch`` — is the right tool to create the missing
+# file. File-not-found was the dominant patch-failure class (68% of errors).
+# These tests pin the new distinct-classification behavior.
+
+
+class TestPatchReplaceReadFailureClassification:
+    """patch_replace must distinguish missing-file / directory / permission
+    read failures and surface a create-on-miss hint, not a generic error."""
+
+    def test_missing_file_classifies_as_not_found(self, mock_env):
+        """A patch against a non-existent path must produce an error that
+        ``classify_file_error`` maps to ``not_found`` (with a write_file
+        recovery hint), NOT the old generic ``read_error``."""
+        target = "/tmp/does_not_exist_xyz_1326.py"
+
+        def side_effect(command, **kwargs):
+            # The initial ``cat <path> 2>/dev/null`` fails (file absent).
+            if command.startswith("cat ") and target in command:
+                return {"output": "", "returncode": 1}
+            # _diagnose_read_failure: ``test -e <path>`` → no (file absent).
+            if command.startswith("test -e ") and target in command:
+                return {"output": "no\n", "returncode": 0}
+            # _suggest_similar_files lists the parent dir — empty here.
+            if command.startswith("ls -1 "):
+                return {"output": "", "returncode": 1}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace(target, "old", "new")
+        assert result.error is not None
+        # The message must carry "not found" so classify_file_error returns
+        # error_class="not_found" (not "read_error").
+        assert "not found" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] == "not_found"
+        # Recovery must steer the agent toward write_file (create-on-miss).
+        assert "write_file" in d["recovery"]
+
+    def test_directory_target_returns_clear_error(self, mock_env):
+        """Patching a directory must report 'is a directory', not a generic
+        read failure or a misleading 'not found'."""
+        target = "/tmp/some_dir_1326"
+
+        def side_effect(command, **kwargs):
+            # cat on a directory fails (EISDIR).
+            if command.startswith("cat ") and target in command:
+                return {"output": "", "returncode": 1}
+            # _diagnose_read_failure: path exists.
+            if command.startswith("test -e ") and target in command:
+                return {"output": "yes\n", "returncode": 0}
+            # ... and is a directory.
+            if command.startswith("test -d ") and target in command:
+                return {"output": "yes\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace(target, "old", "new")
+        assert result.error is not None
+        assert "directory" in result.error.lower()
+        # Must NOT be classified as a plain read_error.
+        d = result.to_dict()
+        assert d["error_class"] != "read_error"
+
+    def test_permission_denied_classifies_distinctly(self, mock_env):
+        """A readable-path-but-unreadable-file failure should not collapse
+        to 'not found'; it should mention permissions."""
+        target = "/tmp/locked_1326.py"
+
+        def side_effect(command, **kwargs):
+            # cat fails (permission denied), but the file IS present.
+            if command.startswith("cat ") and target in command:
+                return {"output": "", "returncode": 1}
+            # _diagnose_read_failure: exists → yes.
+            if command.startswith("test -e ") and target in command:
+                return {"output": "yes\n", "returncode": 0}
+            # ... not a directory.
+            if command.startswith("test -d ") and target in command:
+                return {"output": "no\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace(target, "old", "new")
+        assert result.error is not None
+        assert "permission" in result.error.lower()
+        # Distinct from the old generic "Failed to read file".
+        assert "failed to read file" != result.error.strip().lower()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1736,6 +1736,42 @@ class ShellFileOperations(FileOperations):
     # PATCH Implementation (Replace Mode)
     # =========================================================================
 
+    def _diagnose_read_failure(self, path: str) -> str:
+        """Build a distinct, classifiable error for a patch read failure.
+
+        ``patch_replace`` reads the target via ``cat <path> 2>/dev/null``,
+        which discards *why* the read failed. Before #1326, every miss
+        (missing file, directory, permission error) collapsed to the same
+        generic ``"Failed to read file: {path}"`` string. That classifies
+        as ``read_error`` (never ``not_found``), so the agent never
+        learned that ``write_file`` — not ``patch`` — is the right tool
+        to create a missing file. File-not-found was the dominant
+        patch-failure class (68% of patch errors). This probe runs ONLY
+        after a failed read (happy path unchanged) and produces a
+        ``classify_file_error``-friendly message carrying a create-on-miss
+        hint when the file is absent.
+        """
+        esc = self._escape_shell_arg(path)
+        # Does the path exist at all?  ``-e`` follows symlinks; combined
+        # with ``-d`` below it cleanly separates missing / directory /
+        # unreadable-file.
+        exists = self._exec(f"test -e {esc} && echo yes || echo no")
+        if (exists.stdout or "").strip() == "no":
+            # Reuse the rich not-found suggestion (similar files / nearest
+            # ancestor listing) so the message classifies as ``not_found``
+            # and tells the agent how to recover.
+            suggest = self._suggest_similar_files(path).error
+            return suggest or f"File not found: {path}"
+        # Path exists but cat failed — is it a directory?
+        is_dir = self._exec(f"test -d {esc} && echo yes || echo no")
+        if (is_dir.stdout or "").strip() == "yes":
+            return f"Cannot patch a directory: {path} is a directory, not a file."
+        # Exists and is a regular file — most likely a permission error.
+        return (
+            f"Permission denied reading file: {path}. Check read permissions "
+            f"before retrying — do not repeat the same patch blindly."
+        )
+
     def patch_replace(
         self, path: str, old_string: str, new_string: str, replace_all: bool = False
     ) -> PatchResult:
@@ -1764,7 +1800,19 @@ class ShellFileOperations(FileOperations):
         read_result = self._exec(read_cmd)
 
         if read_result.exit_code != 0:
-            return PatchResult(error=f"Failed to read file: {path}")
+            # #1326 — The old ``cat ... 2>/dev/null`` swallowed the reason
+            # the read failed, so a missing file, a directory, and a
+            # permission error all produced the identical generic
+            # "Failed to read file: {path}". That string classifies as
+            # ``read_error`` (never ``not_found``), so the agent never
+            # learned that ``write_file`` is the right tool to create the
+            # file — it kept retrying patch against a non-existent path.
+            # File-not-found was the dominant patch-failure class (68%
+            # of patch errors across recent sessions). Probe the reason
+            # here so the error classifies distinctly and carries a
+            # create-on-miss hint. The happy path (file exists) is
+            # unchanged: these probes only run on failure.
+            return PatchResult(error=self._diagnose_read_failure(path))
 
         content = read_result.stdout
         # Strip a leading UTF-8 BOM before matching so the fuzzy matcher and


### PR DESCRIPTION
## Summary

Addresses **#1326** — the `patch` tool's 24% failure rate was dominated (68%) by "target file not found", but the agent couldn't tell, so it kept retrying `patch` against non-existent paths instead of switching to `write_file`.

## Root cause

`patch_replace` read the target via `cat <path> 2>/dev/null`. The `2>/dev/null` **discarded the reason** the read failed, so a missing file, a directory, and a permission error all collapsed to the identical generic `"Failed to read file: {path}"`. That string maps to `error_class="read_error"` via `classify_file_error` — **never** `not_found` — so the recovery hint never steered the agent toward `write_file` (the correct tool to create a missing file).

## Fix

On a failed read (happy path unchanged — the probes run **only** on failure), `patch_replace` now calls `_diagnose_read_failure()`, which distinguishes:

| Read-failure reason | Error produced | `classify_file_error` class | Recovery hint |
|---|---|---|---|
| File missing | reuses `_suggest_similar_files` (similar files + nearest ancestor) | `not_found` | "Create it with `write_file`…" |
| Path is a directory | `Cannot patch a directory: <path> is a directory` | (not `read_error`) | — |
| File unreadable (perms) | `Permission denied reading file: <path>…` | — | check permissions |

This makes the dominant failure class self-correcting: the agent now receives a `not_found` classification with a `write_file` recovery hint, exactly as the issue requested. The v4a patch path was already correct (it routes through `read_file_raw` → `_suggest_similar_files`), so only `patch_replace` needed the fix.

## Verification

- **3 new tests** (`TestPatchReplaceReadFailureClassification`) pin the classification: missing-file → `not_found` + `write_file` hint; directory → clear error; permission → distinct message.
- **187 regression tests** green (`test_file_operations.py`, `test_patch_self_correction.py`, `test_read_patch_resilience.py`, `test_file_write_safety.py`).
- **Pre-PR test shard**: PASSED.
- **Lint** (`ruff check`): clean.
- **Diff**: 148 lines (under the 200-line autonomous merge cap).

Closes #1326

🤖 Automated evolution PR.