### PR TITLE
fix(mcp): pre-flight guard stops missing-binary retry storm (Closes #1297)

### DIFF
--- a/tests/tools/test_mcp_stdio_init_timeout.py
+++ b/tests/tools/test_mcp_stdio_init_timeout.py
@@ -73,6 +73,7 @@ class TestStdioInitializeTimeout:
             with patch.object(mcp_tool, "stdio_client", _fake_stdio_client), \
                  patch.object(mcp_tool, "ClientSession", _fake_client_session), \
                  patch.object(mcp_tool, "_resolve_stdio_command", lambda c, e: (c, e)), \
+                 patch.object(mcp_tool, "_ensure_stdio_command_resolvable", lambda c, e: None), \
                  patch.object(mcp_tool, "_write_stderr_log_header", lambda *_a, **_k: None), \
                  patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
                  patch("tools.osv_check.check_package_for_malware",

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -1,11 +1,18 @@
 import asyncio
 import os
+import stat
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
-from tools.mcp_tool import MCPServerTask, _format_connect_error, _resolve_stdio_command, _MCP_AVAILABLE
+from tools.mcp_tool import (
+    MCPServerTask,
+    _format_connect_error,
+    _resolve_stdio_command,
+    _MCP_AVAILABLE,
+)
 
 # Ensure the mcp module symbols exist for patching even when the SDK isn't installed
 if not _MCP_AVAILABLE:
@@ -219,3 +226,104 @@ def test_run_stdio_malware_check_times_out_fail_open():
         assert elapsed < 1.0, f"startup did not fail-open promptly ({elapsed:.1f}s)"
 
     asyncio.run(_test())
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight command resolver tests (#1297)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStdioCommandResolvable:
+    """Cover the pre-flight guard added for #1297.
+
+    ``_ensure_stdio_command_resolvable`` runs in ``_run_stdio`` right after
+    ``_resolve_stdio_command`` and raises a NON-retryable
+    :class:`MissingMcpCommandError` (subclass of
+    :class:`NonMcpEndpointError`) when the configured command binary is
+    absent, collapsing the 189-failure/scan retry storm for missing binaries
+    like ``turbo-memory-mcp``.
+    """
+
+    def test_missing_bare_command_raises(self):
+        """A bare name not on the SUBPROCESS PATH must raise."""
+        from tools.mcp_tool import (
+            MissingMcpCommandError,
+            _ensure_stdio_command_resolvable,
+        )
+
+        env = {"PATH": "/nonexistent-dir-948"}
+        with pytest.raises(MissingMcpCommandError, match="turbo-memory-mcp"):
+            _ensure_stdio_command_resolvable("turbo-memory-mcp", env)
+
+    def test_bad_absolute_path_raises(self, tmp_path):
+        """An absolute path that doesn't exist must raise."""
+        from tools.mcp_tool import (
+            MissingMcpCommandError,
+            _ensure_stdio_command_resolvable,
+        )
+
+        missing = tmp_path / "definitely-not-here-948"
+        env = {"PATH": os.environ.get("PATH", "")}
+        with pytest.raises(MissingMcpCommandError, match="does not exist"):
+            _ensure_stdio_command_resolvable(str(missing), env)
+
+    def test_non_executable_file_raises(self, tmp_path):
+        """A regular (non-executable) file at an absolute path must raise."""
+        from tools.mcp_tool import (
+            MissingMcpCommandError,
+            _ensure_stdio_command_resolvable,
+        )
+
+        non_exec = tmp_path / "not-executable-948"
+        non_exec.write_text("#!/bin/sh\n")
+        non_exec.chmod(0o644)
+        assert not os.access(str(non_exec), os.X_OK)
+        env = {"PATH": os.environ.get("PATH", "")}
+        with pytest.raises(MissingMcpCommandError, match="not executable"):
+            _ensure_stdio_command_resolvable(str(non_exec), env)
+
+    def test_empty_command_raises(self):
+        """An empty/whitespace command is a programming error -> ValueError."""
+        from tools.mcp_tool import _ensure_stdio_command_resolvable
+
+        with pytest.raises(ValueError):
+            _ensure_stdio_command_resolvable("", {"PATH": "/usr/bin"})
+        with pytest.raises(ValueError):
+            _ensure_stdio_command_resolvable("   ", {"PATH": "/usr/bin"})
+
+    def test_healthy_pass_through_no_exception(self):
+        """A resolvable bare command (on PATH) must pass through cleanly."""
+        from tools.mcp_tool import _ensure_stdio_command_resolvable
+
+        env = {"PATH": os.environ.get("PATH", "")}
+        # Should NOT raise.
+        _ensure_stdio_command_resolvable("python3", env)
+
+    def test_executable_absolute_path_passes(self, tmp_path):
+        """An executable file at an absolute path must pass through cleanly."""
+        from tools.mcp_tool import _ensure_stdio_command_resolvable
+
+        exec_file = tmp_path / "my-mcp-server-948"
+        exec_file.write_text("#!/bin/sh\n")
+        exec_file.chmod(
+            stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+        )
+        env = {"PATH": os.environ.get("PATH", "")}
+        # Should NOT raise.
+        _ensure_stdio_command_resolvable(str(exec_file), env)
+
+    def test_missing_command_error_subclasses_non_mcp_endpoint_error(self):
+        """MissingMcpCommandError must be caught as NonMcpEndpointError so the
+        reconnect loop treats it as a clean, non-retryable exit."""
+        from tools.mcp_tool import (
+            MissingMcpCommandError,
+            NonMcpEndpointError,
+            _ensure_stdio_command_resolvable,
+        )
+
+        assert issubclass(MissingMcpCommandError, NonMcpEndpointError)
+        env = {"PATH": "/nonexistent-dir-948"}
+        with pytest.raises(NonMcpEndpointError):
+            _ensure_stdio_command_resolvable("no-such-binary-948", env)
+        with pytest.raises(ConnectionError):
+            _ensure_stdio_command_resolvable("no-such-binary-948", env)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -787,6 +787,56 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+def _ensure_stdio_command_resolvable(command: str, env: dict) -> None:
+    """Pre-flight: raise if *command* cannot be resolved/executed at spawn.
+
+    Run in :meth:`MCPServerTask._run_stdio` right after
+    :func:`_resolve_stdio_command`, before any subprocess is forked, so that a
+    missing binary fails fast with an actionable, NON-retryable
+    :class:`MissingMcpCommandError` instead of entering the reconnect-backoff
+    loop (which used to retry 189 times/scan for ``turbo-memory-mcp``).
+
+    Resolution mirrors the rules the subprocess will actually use: the
+    *subprocess* env's ``PATH`` (``env["PATH"]``), not the Hermes process
+    PATH, so the check is honest about what ``execvp`` will see.
+
+    - Absolute / relative path containing ``os.sep``: must be an existing
+      executable file, else :class:`MissingMcpCommandError`.
+    - Bare name: resolved via :func:`shutil.which` against ``env["PATH"]``;
+      unresolved names raise :class:`MissingMcpCommandError`.
+    - Empty / whitespace-only command: :class:`ValueError` (a programming
+      error, not a missing-binary error).
+    """
+    cmd = str(command or "").strip()
+    if not cmd:
+        raise ValueError("stdio MCP command is empty")
+
+    path_env = (env or {}).get("PATH")
+
+    if os.sep in cmd:
+        # Absolute or explicit relative path — check the file directly.
+        if not os.path.isfile(cmd):
+            raise MissingMcpCommandError(
+                f"stdio MCP command not found: {cmd!r} does not exist. "
+                f"Check the path or install the server binary."
+            )
+        if not os.access(cmd, os.X_OK):
+            raise MissingMcpCommandError(
+                f"stdio MCP command not executable: {cmd!r}. "
+                f"Ensure the file has execute permission (chmod +x)."
+            )
+        return
+
+    # Bare name — resolve against the SUBPROCESS PATH (not ours).
+    resolved = shutil.which(cmd, path=path_env)
+    if resolved is None:
+        raise MissingMcpCommandError(
+            f"stdio MCP command not found on PATH: {cmd!r}. "
+            f"Install the server (e.g. `npm i -g {cmd}`) or add its directory "
+            f"to the server's env.PATH."
+        )
+
+
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     """Wrap a stdio MCP server command in the parent-death watchdog supervisor.
 
@@ -1062,6 +1112,18 @@ class NonMcpEndpointError(ConnectionError):
 
     Subclasses :class:`ConnectionError` so callers that only catch the broad
     class still treat it as a connection problem.
+    """
+
+
+class MissingMcpCommandError(NonMcpEndpointError):
+    """Raised when a stdio MCP command binary cannot be resolved at spawn time.
+
+    This is a non-retryable condition: if the binary isn't on the subprocess
+    ``PATH`` (or the absolute path doesn't exist), no amount of reconnect
+    backoff will make it appear.  Subclassing :class:`NonMcpEndpointError`
+    means the reconnect loop already treats it as a clean, non-retryable exit,
+    collapsing what used to be a 189-failure/scan retry storm (e.g.
+    ``turbo-memory-mcp`` missing from ``PATH``) into one actionable error.
     """
 
 
@@ -2349,6 +2411,7 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+        _ensure_stdio_command_resolvable(command, safe_env)
 
         # Check package against OSV malware database before spawning.
         # Run off the event loop (the urllib HTTPS call is blocking) and bound


### PR DESCRIPTION
Automated evolution PR for issue #1297.

## What
Adds _ensure_stdio_command_resolvable() pre-flight check in _run_stdio that raises a non-retryable MissingMcpCommandError when a stdio MCP command binary is missing from PATH. This collapses the 189-failure/scan retry storm (turbo-memory-mcp) into one clean actionable error.

## Fix for CI failure in prior PR #1319
The pre-flight broke test_hanging_initialize_is_bounded_not_leaked which uses a fake binary. Fixed by patching the pre-flight in that test so the timeout path is still exercised.