### PR TITLE
fix: normalize realized-impact counts by session volume (Closes #1324)

### DIFF
--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -90,17 +90,23 @@ def record_merge(
     merged_at: str,
     predicted_impact: float,
     target: str,
+    baseline_failure_rate: Optional[float] = None,
 ) -> None:
-    """Record a merge event in the realized-impact ledger."""
-    append_ledger_record(
-        ledger_file,
-        {
-            "issue": issue,
-            "merged_at": merged_at,
-            "predicted_impact": predicted_impact,
-            "target": target,
-        },
-    )
+    """Record a merge event in the realized-impact ledger.
+
+    ``baseline_failure_rate`` (failures/session at merge time) is stored so later
+    verdicts compare apples-to-apples rates, not raw counts that grow with
+    session volume (#1324). Omitted/None keeps legacy records working.
+    """
+    rec: Dict[str, Any] = {
+        "issue": issue,
+        "merged_at": merged_at,
+        "predicted_impact": predicted_impact,
+        "target": target,
+    }
+    if baseline_failure_rate is not None:
+        rec["baseline_failure_rate"] = baseline_failure_rate
+    append_ledger_record(ledger_file, rec)
 
 
 def record_verdict(
@@ -122,6 +128,29 @@ def record_verdict(
             "note": note,
         },
     )
+
+
+def classify_verdict_by_rate(
+    baseline_rate: Optional[float],
+    current_rate: Optional[float],
+    regression_threshold: float = 0.20,
+) -> str:
+    """Rate-normalized verdict so growing session volume can't fake a regression.
+
+    Returns ``"regressed"`` only if the per-session failure rate rose by more
+    than ``regression_threshold`` (default 20%) over the baseline — NOT merely
+    because the raw count grew with the session denominator (#1324). Returns
+    ``"confirmed"`` when the rate fell or held, and ``"no-signal"`` when either
+    rate is missing (caller must still record a verdict; it just isn't forced to
+    ``regressed`` by volume alone).
+    """
+    if baseline_rate is None or current_rate is None:
+        return "no-signal"
+    # Relative change vs baseline; treat a zero baseline as "improved if not up".
+    if baseline_rate <= 0:
+        return "confirmed" if current_rate <= 0 else "regressed"
+    rel_delta = (current_rate - baseline_rate) / baseline_rate
+    return "regressed" if rel_delta > regression_threshold else "confirmed"
 
 
 # ── Post-merge signal-verification gate (#1140) ────────────────────────────
@@ -152,6 +181,8 @@ def should_close_issue(
     issue: int,
     today: str,
     maturity_days: int = 5,
+    current_failure_rate: Optional[float] = None,
+    regression_threshold: float = 0.20,
 ) -> tuple:
     """Gate for closing an issue after a fix PR merges.
 
@@ -164,6 +195,13 @@ def should_close_issue(
     If the verdict is "no-signal" or "regressed", returns ``(False, reason)``
     so the issue stays open for a focused regression — this is the core fix
     for the REALIZED_IMPACT_LOW failure loop.
+
+    Rate normalization (#1324): when a ``current_failure_rate`` is supplied and
+    the merge record stored a ``baseline_failure_rate``, a recorded ``regressed``
+    verdict is re-checked against the *rate* delta — if the rate did NOT rise
+    beyond ``regression_threshold``, the raw-count regression is treated as a
+    false alarm and the issue may close. This stops growing session volume from
+    forcing false HOLDs.
     """
     rec = None
     for r in reversed(records):
@@ -177,6 +215,27 @@ def should_close_issue(
     verdict = rec.get("verdict")
     if verdict in VERDICTS_GOOD:
         return True, "signal confirmed dropped post-merge"
+
+    # Rate-normalization override: a "regressed" verdict from a raw-count
+    # comparison is a false alarm if the per-session rate held or fell (#1324).
+    if (
+        verdict == "regressed"
+        and current_failure_rate is not None
+        and rec.get("baseline_failure_rate") is not None
+    ):
+        rate_verdict = classify_verdict_by_rate(
+            rec.get("baseline_failure_rate"),
+            current_failure_rate,
+            regression_threshold=regression_threshold,
+        )
+        if rate_verdict != "regressed":
+            return (
+                True,
+                "regressed verdict re-checked by rate: per-session failure rate "
+                f"{current_failure_rate:.4f} vs baseline "
+                f"{rec['baseline_failure_rate']:.4f} — volume-only increase, "
+                "not a real regression (#1324)",
+            )
 
     if verdict in VERDICTS_BAD:
         return (
@@ -320,7 +379,14 @@ def main(argv: List[str]) -> int:
                 file=sys.stderr,
             )
             return 2
-        record_merge(ledger_file, issue, merged_at, predicted, target)
+        baseline_rate = None
+        # Optional 6th positional arg: baseline failures/session at merge (#1324).
+        if len(args) > 5:
+            try:
+                baseline_rate = float(args[5])
+            except ValueError:
+                baseline_rate = None
+        record_merge(ledger_file, issue, merged_at, predicted, target, baseline_rate)
         print(f"[realized-impact] recorded merge for issue #{issue}")
         return 0
 
@@ -361,8 +427,21 @@ def main(argv: List[str]) -> int:
             from datetime import datetime, timezone
 
             today = datetime.now(timezone.utc).date().isoformat()
+        # Optional --current-rate <rate>: current per-session failure rate for the
+        # rate-normalization override (#1324). Enables re-checking a "regressed"
+        # verdict against the stored baseline rate instead of raw counts.
+        current_rate = None
+        if "--current-rate" in args:
+            i = args.index("--current-rate")
+            if i + 1 < len(args):
+                try:
+                    current_rate = float(args[i + 1])
+                except ValueError:
+                    current_rate = None
         records = load_ledger(ledger_file)
-        should, reason = should_close_issue(records, issue, today)
+        should, reason = should_close_issue(
+            records, issue, today, current_failure_rate=current_rate
+        )
         verdict = "CLOSE" if should else "HOLD"
         print(f"[realized-impact] #{issue} {verdict}: {reason}")
         return 0 if should else 1

--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -397,11 +397,26 @@ def build_digest(
                     scanned += 1
                     _aggregate(_state_db_session_signals(msgs))
 
+    # Normalize raw counts by session volume so growing volume does not inflate
+    # the absolute failure counts (issue #1324 — false "regressed" verdicts).
+    # Rate = failures[tool] / sessions_scanned (0 when nothing scanned).
+    tool_failures = dict(failures.most_common())
+    failure_rate = {
+        tool: (count / scanned if scanned else 0.0)
+        for tool, count in tool_failures.items()
+    }
+    spiral_depth_per_session = {
+        tool: round((meta["max_consecutive"] / scanned if scanned else 0.0), 4)
+        for tool, meta in repeated.items()
+    }
+
     return {
         "window_days": window_days,
         "sessions_scanned": scanned,
         "signals": {
-            "tool_failures": dict(failures.most_common()),
+            "tool_failures": tool_failures,
+            "failure_rate": failure_rate,
+            "spiral_depth_per_session": spiral_depth_per_session,
             "timeouts": timeouts,
             "refusals_or_access_denied": refusals,
             "repeated_tool_runs": repeated,

--- a/tests/scripts/test_evolution_realized_impact.py
+++ b/tests/scripts/test_evolution_realized_impact.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_realized_impact import (  # noqa: E402
     append_ledger_record,
+    classify_verdict_by_rate,
     compute_realized,
     format_realized,
     load_ledger,
@@ -279,3 +280,68 @@ class TestCheckCloseCli:
         rc = mod.main([_PROG, "check-close", "42", "2026-06-17"])
         out = capsys.readouterr().out
         assert rc == 0 and "CLOSE" in out and "confirmed" in out
+
+
+class TestClassifyVerdictByRate:
+    def test_rate_flat_or_down_is_confirmed(self):
+        # 298/42 (7.10) vs 168/21 (8.00) — the issue's concrete example: improved.
+        assert classify_verdict_by_rate(8.0, 7.1) == "confirmed"
+
+    def test_rate_up_beyond_threshold_is_regressed(self):
+        # >20% relative increase flips to regressed.
+        assert classify_verdict_by_rate(5.0, 7.0) == "regressed"  # +40%
+
+    def test_rate_up_within_threshold_is_confirmed(self):
+        assert classify_verdict_by_rate(5.0, 5.9) == "confirmed"  # +18%
+
+    def test_missing_rates_no_signal(self):
+        assert classify_verdict_by_rate(None, 5.0) == "no-signal"
+        assert classify_verdict_by_rate(5.0, None) == "no-signal"
+
+    def test_zero_baseline_up_is_regressed(self):
+        assert classify_verdict_by_rate(0.0, 1.0) == "regressed"
+
+
+class TestRateNormalizedCloseGate:
+    def _recs(self, baseline):
+        return [
+            {"issue": 1, "merged_at": "2026-06-01", "baseline_failure_rate": baseline}
+            | _verdict(1, "regressed")
+        ]
+
+    def test_volume_only_increase_allows_close(self):
+        # Raw count grew, but rate held/fell -> close (not a real regression).
+        recs = self._recs(baseline=8.0)
+        should, reason = should_close_issue(
+            recs, 1, "2026-06-17", current_failure_rate=7.1
+        )
+        assert should is True and "#1324" in reason
+
+    def test_real_rate_increase_blocks_close(self):
+        recs = self._recs(baseline=5.0)
+        should, reason = should_close_issue(
+            recs, 1, "2026-06-17", current_failure_rate=7.0
+        )
+        assert should is False and "regressed" in reason
+
+    def test_no_baseline_falls_back_to_verdict(self):
+        # Legacy record without baseline_failure_rate: regressed still blocks.
+        recs = [{"issue": 1, "merged_at": "2026-06-01"} | _verdict(1, "regressed")]
+        should, reason = should_close_issue(
+            recs, 1, "2026-06-17", current_failure_rate=7.0
+        )
+        assert should is False
+
+
+class TestRecordMergeBaseline:
+    def test_baseline_failure_rate_stored(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_merge(f, 5, "2026-06-01", 0.8, "fix", baseline_failure_rate=3.5)
+        recs = load_ledger(f)
+        assert recs[0]["baseline_failure_rate"] == 3.5
+
+    def test_baseline_omitted_keeps_legacy_shape(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_merge(f, 5, "2026-06-01", 0.8, "fix")
+        recs = load_ledger(f)
+        assert "baseline_failure_rate" not in recs[0]


### PR DESCRIPTION
## Summary

Realized-impact verdicts systematically produced false "regressed" results because they compared raw failure counts without normalizing for session volume — which is growing rapidly. As the session denominator rises, raw counts grow proportionally even when the per-session failure rate holds steady or improves.

This re-opens issues that are actually holding, burning cycles re-investigating working fixes, and erodes trust in the verification loop.

## Changes
- **introspection_extract.py**: emit `failure_rate` (failures/sessions_scanned) and `spiral_depth_per_session` alongside the raw counts in the digest.
- **evolution_realized_impact.py**: add `classify_verdict_by_rate()` which returns `regressed` **only** when the per-session rate rose >20% over baseline — not merely because the raw count grew with the session denominator. `record_merge()` now stores an optional `baseline_failure_rate`; `should_close_issue()` re-checks a `regressed` verdict against the rate delta so volume-only increases no longer force HOLD. The `record-merge` and `check-close` CLIs expose the new baseline/current-rate args.

## Backward compatibility
Legacy records without `baseline_failure_rate` fall back to the original verdict-based behavior, so existing ledgers keep working unchanged.

## Validation
- `ruff check` + `ruff format --check` clean on all 3 changed files
- 63 tests pass (38 in test_evolution_realized_impact.py incl. 10 new, 25 in test_introspection_extract.py)
- Diff: 173 insertions / 13 deletions across 3 files (under 200-line budget)

Automated evolution PR for issue #1324.