### PR TITLE
fix: attribute introspection failures by (tool, reason) not just tool (Closes #1325)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -23,6 +23,12 @@ Signals extracted:
   * tool_failures  — tool results that look like failures, attributed to the
     tool (via tool_call_id -> name from the preceding assistant turn). Reuses
     agent.loop_guard's failure markers for consistency.
+  * tool_failures_by_reason — sub-classifies each failure by reason (#1325):
+    {tool: {reason: count}} using a small no-LLM taxonomy (file-not-found,
+    permission-denied, timeout, quota-billing, parse-error, no-match,
+    non-zero-exit, other). Stops the fix→regress→refile treadmill where a
+    fix for one sub-cause gets credited/blamed for unrelated sub-causes of
+    the same tool.
   * timeouts       — results mentioning timeout / timed out.
   * refusals       — assistant text expressing "I can't / no access / denied".
   * repeated_tool_runs — same tool called many times consecutively (the spiral
@@ -51,6 +57,26 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from hermes_constants import get_hermes_home
 
 
+def _parse_envelope(content: Any) -> Optional[dict]:
+    """Parse a tool-result JSON envelope, returning the dict or None (#347).
+
+    Non-JSON / plain-string bodies return None (no authoritative status). This
+    is the shared parse step used by both the failure classifier and the
+    failure-reason sub-classifier (#1325).
+    """
+    data = content
+    if isinstance(data, (str, bytes)):
+        text = data.decode("utf-8", "replace") if isinstance(data, bytes) else data
+        stripped = text.strip()
+        if not (stripped.startswith("{") and stripped.endswith("}")):
+            return None  # not a JSON envelope → no authoritative status → don't guess
+        try:
+            data = json.loads(stripped)
+        except ValueError:
+            return None
+    return data if isinstance(data, dict) else None
+
+
 def _tool_result_failed(content: Any) -> bool:
     """Structural failure classifier for a tool result (issue #347).
 
@@ -75,17 +101,8 @@ def _tool_result_failed(content: Any) -> bool:
     a few genuinely-plain-string failures (rare; tools emit JSON envelopes) for
     eliminating the false-positive flood, exactly as the issue prescribes.
     """
-    data = content
-    if isinstance(data, (str, bytes)):
-        text = data.decode("utf-8", "replace") if isinstance(data, bytes) else data
-        stripped = text.strip()
-        if not (stripped.startswith("{") and stripped.endswith("}")):
-            return False  # not a JSON envelope → no authoritative status → don't guess
-        try:
-            data = json.loads(stripped)
-        except ValueError:
-            return False
-    if not isinstance(data, dict):
+    data = _parse_envelope(content)
+    if data is None:
         return False
     if "exit_code" in data:
         try:
@@ -98,6 +115,48 @@ def _tool_result_failed(content: Any) -> bool:
         if ok_key in data:
             return not bool(data[ok_key])
     return False
+
+
+# --- failure-reason sub-classifier (#1325) ----------------------------------
+# The aggregate tool_failures counter lumps every failure mode for a tool into
+# one bucket.  When one sub-cause is fixed but another appears, the tool-level
+# count barely moves, hiding real progress (fix→regress→refile treadmill).
+# Keyword checks run ONLY on error/output/stderr STATUS fields of a KNOWN
+# failure — never on successful output — so #347's false-positive guard holds.
+# fmt: off
+_FAILURE_REASON_RULES: list[tuple[str, re.Pattern]] = [
+    ("file-not-found", re.compile(r"\b(no such file|file not found|does not exist|not found)\b", re.IGNORECASE)),
+    ("permission-denied", re.compile(r"\b(permission denied|access denied|forbidden|eperm|eacces)\b", re.IGNORECASE)),
+    ("timeout", re.compile(r"\b(timed out|timeout|deadline exceeded)\b", re.IGNORECASE)),
+    ("quota-billing", re.compile(r"\b(quota|billing|insufficient|payment|429|rate.?limit)\b", re.IGNORECASE)),
+    ("parse-error", re.compile(r"\b(json|parse|syntax|decode).*?(error|invalid|failed)|unexpected (token|eof)\b", re.IGNORECASE)),
+    ("no-match", re.compile(r"\b(no match|nothing to|not found.*patch|hunk.*failed|context.*mismatch)\b", re.IGNORECASE)),
+]
+# fmt: on
+
+
+def _classify_failure_reason(content: Any) -> str:
+    """Return a failure-reason label for a KNOWN failure envelope (#1325).
+
+    Inspects only the ``error``, ``output``, ``stderr`` status fields of the
+    parsed envelope (never arbitrary returned content, so #347 is preserved).
+    Returns the first matching taxonomy label, or ``"non-zero-exit"`` when the
+    failure was signalled solely by a non-zero ``exit_code``, or ``"other"``.
+    """
+    data = _parse_envelope(content)
+    if data is None:
+        return "other"
+    blob = " ".join(
+        str(data.get(k, ""))
+        for k in ("error", "output", "stderr", "message")
+        if isinstance(data.get(k), (str, int, float))
+    )
+    for reason, pat in _FAILURE_REASON_RULES:
+        if pat.search(blob):
+            return reason
+    if "exit_code" in data:
+        return "non-zero-exit"
+    return "other"
 
 
 _TIMEOUT_RE = re.compile(r"\b(timed out|timeout)\b", re.IGNORECASE)
@@ -211,6 +270,7 @@ def scan_messages(messages) -> Dict[str, Any]:
     all formats yield the identical digest.
     """
     tool_failures: Counter = Counter()
+    tool_failures_by_reason: Dict[str, Counter] = {}  # tool -> {reason: count} (#1325)
     timeouts = 0
     refusals = 0
     id_to_tool: Dict[str, str] = {}
@@ -251,12 +311,17 @@ def scan_messages(messages) -> Dict[str, Any]:
             failed = _tool_result_failed(content)
             if failed:
                 tool_failures[tool] += 1
+                reason = _classify_failure_reason(content)
+                tool_failures_by_reason.setdefault(tool, Counter())[reason] += 1
             if failed and isinstance(content, str) and _TIMEOUT_RE.search(content):
                 timeouts += 1
 
     repeated = {t: n for t, n in max_runs.items() if n >= _REPEAT_THRESHOLD}
     return {
         "tool_failures": dict(tool_failures),
+        "tool_failures_by_reason": {
+            t: dict(rc) for t, rc in tool_failures_by_reason.items()
+        },
         "timeouts": timeouts,
         "refusals": refusals,
         "repeated_tool_runs": repeated,
@@ -321,6 +386,7 @@ def build_digest(
     now = now if now is not None else time.time()
     cutoff = now - window_days * 86400
     failures: Counter = Counter()
+    failures_by_reason: Dict[str, Counter] = {}  # tool -> {reason: count} (#1325)
     timeouts = 0
     refusals = 0
     provider_errors: Counter = Counter()
@@ -331,6 +397,8 @@ def build_digest(
     def _aggregate(s: Dict[str, Any]) -> None:
         nonlocal timeouts, refusals
         failures.update(s.get("tool_failures", {}))
+        for tool, reasons in s.get("tool_failures_by_reason", {}).items():
+            failures_by_reason.setdefault(tool, Counter()).update(reasons)
         timeouts += s.get("timeouts", 0)
         refusals += s.get("refusals", 0)
         provider_errors.update(s.get("provider_errors", {}))
@@ -402,6 +470,9 @@ def build_digest(
         "sessions_scanned": scanned,
         "signals": {
             "tool_failures": dict(failures.most_common()),
+            "tool_failures_by_reason": {
+                t: dict(rc.most_common()) for t, rc in failures_by_reason.items()
+            },
             "timeouts": timeouts,
             "refusals_or_access_denied": refusals,
             "repeated_tool_runs": repeated,

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -16,7 +16,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from introspection_extract import build_digest, scan_session  # noqa: E402
+from introspection_extract import (  # noqa: E402
+    _classify_failure_reason,
+    build_digest,
+    scan_session,
+)
 
 
 def _session(tmp_path, name, lines, *, age_days=0):
@@ -189,6 +193,118 @@ class TestScanSession:
         # A genuine failure is counted, but the digest carries only counts/tool
         # names — never the raw content/error text.
         assert s["tool_failures"] == {"terminal": 1}
+        assert secret not in json.dumps(s)
+
+
+class TestFailureReasonAttribution:
+    """#1325 — failures must be sub-classified by reason, not just tool, so a
+    fix for one sub-cause isn't credited/blamed for unrelated sub-causes of the
+    same tool (the fix→regress→refile treadmill)."""
+
+    def test_classifier_taxonomy(self):
+        cases = {
+            "no such file or directory": "file-not-found",
+            "File not found in repo": "file-not-found",
+            "permission denied": "permission-denied",
+            "access denied by policy": "permission-denied",
+            "request timed out after 120s": "timeout",
+            "rate limit exceeded (429)": "quota-billing",
+            "quota exceeded": "quota-billing",
+            "json decode error: unexpected token": "parse-error",
+            "JSON parse failed": "parse-error",
+            "no match: nothing to replace": "no-match",
+            "hunk failed at line 5": "no-match",
+        }
+        for text, expected in cases.items():
+            assert _classify_failure_reason(_fail(text)) == expected, text
+        # pure non-zero exit, no recognisable text → non-zero-exit
+        assert _classify_failure_reason(_term("", exit_code=127)) == "non-zero-exit"
+        # error with unrecognised text → other
+        assert _classify_failure_reason(_fail("something weird")) == "other"
+
+    def test_scan_session_attributes_by_reason(self, tmp_path):
+        """terminal has TWO distinct failure modes in one session; the digest
+        must separate them so fixing one doesn't mask the other (#1325)."""
+        p = _session(
+            tmp_path,
+            "s1",
+            [
+                {"role": "session_meta"},
+                _asst("terminal", "c1"),
+                _tool("c1", _term("bash: foo: command not found", exit_code=127)),
+                _asst("terminal", "c2"),
+                _tool("c2", _term("", exit_code=1, error="permission denied")),
+                _asst("read_file", "c3"),
+                _tool("c3", _fail("no such file or directory")),
+            ],
+        )
+        s = scan_session(p)
+        # aggregate still works
+        assert s["tool_failures"] == {"terminal": 2, "read_file": 1}
+        # reason breakdown separates the two terminal modes — "command not found"
+        # matches the file-not-found taxonomy rule, "permission denied" matches
+        # the permission-denied rule.  Before #1325 both were lumped as
+        # "terminal: 2" — now they're distinguishable.
+        assert s["tool_failures_by_reason"]["terminal"] == {
+            "file-not-found": 1,
+            "permission-denied": 1,
+        }
+        assert s["tool_failures_by_reason"]["read_file"] == {"file-not-found": 1}
+
+    def test_successful_results_never_classified(self, tmp_path):
+        """#347 must still hold: successful output mentioning marker words
+        must NOT appear in tool_failures_by_reason."""
+        p = _session(
+            tmp_path,
+            "fp",
+            [
+                _asst("read_file", "c1"),
+                _tool("c1", _ok(content="page says HTTP 404; permission denied docs")),
+                _asst("terminal", "c2"),
+                _tool("c2", _term("grep: timed out handling", exit_code=0)),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {}
+        assert s.get("tool_failures_by_reason", {}) == {}
+
+    def test_digest_aggregates_by_reason_across_sessions(self, tmp_path):
+        _session(
+            tmp_path,
+            "s1",
+            [
+                _asst("read_file", "c1"),
+                _tool("c1", _fail("no such file or directory")),
+            ],
+        )
+        _session(
+            tmp_path,
+            "s2",
+            [
+                _asst("read_file", "c2"),
+                _tool("c2", _fail("request timed out after 30s")),
+            ],
+        )
+        d = build_digest(tmp_path, window_days=7)
+        assert d["signals"]["tool_failures"] == {"read_file": 2}
+        # Two distinct sub-causes — fixing one must not credit the other (#1325)
+        assert d["signals"]["tool_failures_by_reason"]["read_file"] == {
+            "file-not-found": 1,
+            "timeout": 1,
+        }
+
+    def test_no_raw_text_in_reason_breakdown(self, tmp_path):
+        secret = "SECRET <REDACTED:email:db677acc382bd26bb3a00162f3e668d3>"
+        p = _session(
+            tmp_path,
+            "s1",
+            [
+                _asst("read_file", "c1"),
+                _tool("c1", _fail(f"no such file: {secret}")),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures_by_reason"]["read_file"] == {"file-not-found": 1}
         assert secret not in json.dumps(s)
 
 


### PR DESCRIPTION
Automated evolution PR for issue #1325. Adds a no-LLM failure-reason sub-classifier to the introspection extractor, emitting tool_failures_by_reason alongside the existing aggregate so fixes for one sub-cause aren't credited/blamed for unrelated sub-causes of the same tool.