### PR TITLE
feat: StageResult contract + emission at local_triage boundary (#1338)

### DIFF
--- a/evolution/lib/stage_result.py
+++ b/evolution/lib/stage_result.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Structured result-tuple contract for evolution pipeline stages (issue #1338).
+
+AREX-style ``StageResult`` — every pipeline stage emits this instead of a
+free-form verdict, so downstream stages (and a future Accept/Refine/Restart
+gate) receive a uniform, evidence-annotated payload.
+
+This is **slice A** of the AREX confidence-gated loop (#1330): the contract
+exists and is emitted at one boundary, but the consuming gate logic is deferred
+to slice B (#1339).  Existing stage behaviour is unchanged — the tuple is purely
+additive.
+
+Design goals (matching the rest of the ``evolution/lib`` corpus):
+
+* Pure Python, ``dataclasses`` — **no external dependencies**.
+* Import-safe (no side effects on import), full type hints,
+  ``from __future__ import annotations``.
+* JSON serialisation via ``to_dict``/``from_dict``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["StageResult"]
+
+
+@dataclass
+class StageResult:
+    """Uniform result contract emitted by every evolution pipeline stage.
+
+    Attributes
+    ----------
+    result
+        The stage's payload — typically the dict it would have written to disk
+        anyway (e.g. the analysis JSON, the issues JSON).  Left as ``Any`` so
+        each stage controls its own internal schema.
+    evidence_pointers
+        Paths / URLs the result rests on (sidecar files read, issues queried,
+        upstream artefacts consumed).  Provides a traceable chain without
+        requiring the consumer to re-derive the stage's inputs.
+    confidence
+        Self-assessed confidence on an integer 0–100 scale (0 = no data,
+        100 = fully certain).  For slice A this is informational only — the
+        gate that *acts* on confidence comes in slice B (#1339).
+    stage
+        Human-readable name of the emitting stage (e.g. ``"local_triage"``).
+    timestamp
+        ISO-8601 UTC string when the result was produced, or ``""`` if unset.
+    """
+
+    result: Any = None
+    evidence_pointers: list[str] = field(default_factory=list)
+    confidence: int = 0
+    stage: str = ""
+    timestamp: str = ""
+
+    # -- serialisation ----------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable dict representation."""
+        return {
+            "result": self.result,
+            "evidence_pointers": list(self.evidence_pointers),
+            "confidence": self.confidence,
+            "stage": self.stage,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StageResult:
+        """Reconstruct from a :meth:`to_dict` payload."""
+        return cls(
+            result=data.get("result"),
+            evidence_pointers=list(data.get("evidence_pointers", [])),
+            confidence=int(data.get("confidence", 0)),
+            stage=data.get("stage", ""),
+            timestamp=data.get("timestamp", ""),
+        )
+
+    # -- helpers ----------------------------------------------------------
+
+    @classmethod
+    def wrap(
+        cls,
+        result: Any,
+        evidence_pointers: list[str] | None = None,
+        *,
+        confidence: int = 0,
+        stage: str = "",
+        timestamp: str = "",
+    ) -> StageResult:
+        """Convenience factory used at stage boundaries.
+
+        ``confidence`` is clamped to 0–100.  When ``confidence`` is left at 0
+        but ``evidence_pointers`` is non-empty, a sensible default of 50 is
+        used (``"we have data but haven't assessed how much to trust it"``).
+        """
+        ev = list(evidence_pointers or [])
+        if confidence == 0 and ev:
+            confidence = 50
+        confidence = max(0, min(100, confidence))
+        return cls(
+            result=result,
+            evidence_pointers=ev,
+            confidence=confidence,
+            stage=stage,
+            timestamp=timestamp,
+        )

--- a/evolution/tests/test_stage_result.py
+++ b/evolution/tests/test_stage_result.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`evolution.lib.stage_result` (issue #1338)."""
+
+from __future__ import annotations
+
+from evolution.lib.stage_result import StageResult
+
+
+class TestStageResultSerialisation:
+    """to_dict / from_dict round-trip."""
+
+    def test_roundtrip_basic(self):
+        sr = StageResult(
+            result={"selected": [1, 2, 3]},
+            evidence_pointers=["/path/a.json", "/path/b.json"],
+            confidence=72,
+            stage="local_triage",
+            timestamp="2026-07-27T10:00:00Z",
+        )
+        d = sr.to_dict()
+        sr2 = StageResult.from_dict(d)
+        assert sr2.result == sr.result
+        assert sr2.evidence_pointers == sr.evidence_pointers
+        assert sr2.confidence == sr.confidence
+        assert sr2.stage == sr.stage
+        assert sr2.timestamp == sr.timestamp
+
+    def test_roundtrip_empty_defaults(self):
+        sr = StageResult()
+        d = sr.to_dict()
+        sr2 = StageResult.from_dict(d)
+        assert sr2.result is None
+        assert sr2.evidence_pointers == []
+        assert sr2.confidence == 0
+        assert sr2.stage == ""
+        assert sr2.timestamp == ""
+
+    def test_to_dict_returns_plain_types(self):
+        """to_dict output must be JSON-serialisable."""
+        import json
+
+        sr = StageResult(
+            result={"k": "v"},
+            evidence_pointers=["a", "b"],
+            confidence=50,
+            stage="test",
+            timestamp="now",
+        )
+        json.dumps(sr.to_dict())  # must not raise
+
+
+class TestStageResultWrap:
+    """The ``wrap`` convenience factory."""
+
+    def test_wrap_default_confidence_with_evidence(self):
+        """When evidence exists but confidence unset, default to 50."""
+        sr = StageResult.wrap(
+            {"data": True},
+            evidence_pointers=["x"],
+        )
+        assert sr.confidence == 50
+
+    def test_wrap_explicit_confidence_preserved(self):
+        sr = StageResult.wrap({}, evidence_pointers=["x"], confidence=80)
+        assert sr.confidence == 80
+
+    def test_wrap_no_evidence_confidence_stays_zero(self):
+        sr = StageResult.wrap({})
+        assert sr.confidence == 0
+        assert sr.evidence_pointers == []
+
+    def test_wrap_clamps_confidence(self):
+        assert StageResult.wrap({}, confidence=150).confidence == 100
+        assert StageResult.wrap({}, confidence=-10).confidence == 0
+
+    def test_wrap_accepts_none_pointers(self):
+        sr = StageResult.wrap({}, evidence_pointers=None)
+        assert sr.evidence_pointers == []
+
+    def test_wrap_sets_stage_and_timestamp(self):
+        sr = StageResult.wrap(
+            {},
+            stage="analysis",
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        assert sr.stage == "analysis"
+        assert sr.timestamp == "2026-01-01T00:00:00Z"
+
+
+class TestStageResultImmutabilityOfPointers:
+    """Evidence_pointers list must not be shared across instances."""
+
+    def test_default_factory_isolation(self):
+        sr1 = StageResult()
+        sr2 = StageResult()
+        sr1.evidence_pointers.append("shared?")
+        assert sr2.evidence_pointers == []
+
+    def test_to_dict_does_not_leak_internal_list(self):
+        sr = StageResult(evidence_pointers=["a"])
+        d = sr.to_dict()
+        d["evidence_pointers"].append("b")
+        assert sr.evidence_pointers == ["a"]

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -155,21 +155,30 @@ def run_local_triage(evolution_dir: Path) -> dict:
     }
 
     # Emit a StageResult at this boundary (AREX #1338 slice A).
-    # The tuple is additive — it wraps the same output dict and records the
-    # sidecar paths as evidence pointers.  A confidence of 50 signals "we have
-    # data but no LLM verification"; a higher value can be self-assessed later.
+    #
+    # The envelope is attached to the same dict it describes, so its ``result``
+    # field is dropped here: keeping it would make output["stage_result"]
+    # ["result"] point back at output, and json.dumps raises
+    # "Circular reference detected" on exactly that. Dropping it also avoids
+    # serializing the whole triage payload twice. The rest of the tuple —
+    # evidence pointers, confidence, stage, timestamp — is what a consumer of
+    # this boundary actually needs; the result itself is the document it is
+    # attached to.
+    #
     # Skipped when the evolution package is not importable (see the import
-    # guard above) — the triage output itself is the contract.
+    # guard above) — the triage output is the contract, this is telemetry.
     if _HAS_STAGE_RESULT:
         evidence = list(output["sidecars_read"].values())
         stage_result = StageResult.wrap(
-            result=output,
+            result=None,
             evidence_pointers=[p for p in evidence if p],
             confidence=50,
             stage="local_triage",
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
-        output["stage_result"] = stage_result.to_dict()
+        envelope = stage_result.to_dict()
+        envelope.pop("result", None)
+        output["stage_result"] = envelope
     return output
 
 

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -23,6 +23,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from evolution.lib.stage_result import StageResult
+
 # Sidecar subdirectories to scan
 _SIDECAR_DIRS = ("issues", "introspection", "research")
 
@@ -140,6 +142,20 @@ def run_local_triage(evolution_dir: Path) -> dict:
         "rejected": [],
         "selected_for_implementation": selected,
     }
+
+    # Emit a StageResult at this boundary (AREX #1338 slice A).
+    # The tuple is additive — it wraps the same output dict and records the
+    # sidecar paths as evidence pointers.  A confidence of 50 signals "we have
+    # data but no LLM verification"; a higher value can be self-assessed later.
+    evidence = list(output["sidecars_read"].values())
+    stage_result = StageResult.wrap(
+        result=output,
+        evidence_pointers=[p for p in evidence if p],
+        confidence=50,
+        stage="local_triage",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+    output["stage_result"] = stage_result.to_dict()
     return output
 
 

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -23,7 +23,18 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from evolution.lib.stage_result import StageResult
+try:
+    from evolution.lib.stage_result import StageResult
+
+    _HAS_STAGE_RESULT = True
+except ImportError:  # pragma: no cover - exercised by the standalone-copy tests
+    # This script runs standalone from the access gate and from cron, where the
+    # `evolution` package is frequently not importable (the gate copies just
+    # this file into a working directory; see #1304/#1314 for the same lesson in
+    # the harvest cron). Triage output is the contract here — the StageResult
+    # tuple is additive telemetry, so its absence must not stop the file from
+    # being written.
+    _HAS_STAGE_RESULT = False
 
 # Sidecar subdirectories to scan
 _SIDECAR_DIRS = ("issues", "introspection", "research")
@@ -147,15 +158,18 @@ def run_local_triage(evolution_dir: Path) -> dict:
     # The tuple is additive — it wraps the same output dict and records the
     # sidecar paths as evidence pointers.  A confidence of 50 signals "we have
     # data but no LLM verification"; a higher value can be self-assessed later.
-    evidence = list(output["sidecars_read"].values())
-    stage_result = StageResult.wrap(
-        result=output,
-        evidence_pointers=[p for p in evidence if p],
-        confidence=50,
-        stage="local_triage",
-        timestamp=datetime.now(timezone.utc).isoformat(),
-    )
-    output["stage_result"] = stage_result.to_dict()
+    # Skipped when the evolution package is not importable (see the import
+    # guard above) — the triage output itself is the contract.
+    if _HAS_STAGE_RESULT:
+        evidence = list(output["sidecars_read"].values())
+        stage_result = StageResult.wrap(
+            result=output,
+            evidence_pointers=[p for p in evidence if p],
+            confidence=50,
+            stage="local_triage",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+        output["stage_result"] = stage_result.to_dict()
     return output
 
 

--- a/tests/scripts/test_evolution_local_triage.py
+++ b/tests/scripts/test_evolution_local_triage.py
@@ -152,3 +152,24 @@ def test_read_sidecar_md(tmp_path):
     f.write_text("# Research report\n\nContent here.")
     result = _read_sidecar(f)
     assert result["char_count"] > 0
+
+def test_output_is_json_serializable_with_stage_result(tmp_path):
+    """The triage output must survive json.dumps with the StageResult envelope
+    attached (#1338 slice A).
+
+    The envelope describes the very dict it is attached to, so carrying its
+    ``result`` field would make output["stage_result"]["result"] point back at
+    output — and json.dumps raises "Circular reference detected" on that. The
+    gate swallows the failure (`|| true`), so the only visible symptom is a
+    missing analysis file; this asserts serializability directly.
+    """
+    evolution_dir = tmp_path / "evolution"
+    evolution_dir.mkdir()
+    output = run_local_triage(evolution_dir)
+
+    encoded = json.dumps(output, indent=2, ensure_ascii=False)
+    assert json.loads(encoded) == output
+
+    if "stage_result" in output:
+        assert "result" not in output["stage_result"]
+        assert output["stage_result"]["stage"] == "local_triage"


### PR DESCRIPTION
Slice A of AREX confidence-gated loop (#1330). Defines StageResult{result, evidence_pointers, confidence} dataclass and emits it at the local_triage boundary. Tests: 11 passed. Closes #1338