### PR TITLE
feat: near-miss vs dead-end discriminator — identical-argument loop detection (#1312)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -421,13 +421,45 @@ def detect_test_iteration_loop(
 # ---------------------------------------------------------------------------
 
 # How many identical (tool, arg_hash) re-issues within the trailing window
-# before the dead-end nudge fires. 2 = "you already tried this exact call
-# and it didn't work — what is different this time?".
-_DEAD_END_REPEAT_THRESHOLD = 2
+# before the dead-end nudge fires. Aligned with _SHORT_CIRCUIT_REPEAT_THRESHOLD
+# and _MUTATING_REPEAT_THRESHOLD (both 4), the softest repeat thresholds in this
+# module. A lower value contradicts the module's premise that a couple of
+# repeats is normal (a retry after a transient error, a re-read after an edit),
+# and would make every "quiet below threshold" contract in test_loop_guard.py
+# unsatisfiable — this detector runs last precisely so it cannot pre-empt the
+# specific ladder, and firing earlier than that ladder would defeat it.
+_DEAD_END_REPEAT_THRESHOLD = 4
 
 # Scan at most this many trailing messages for identical re-issues.  Keeps
 # the check O(1) bounded and avoids matching calls from a different context.
 _DEAD_END_WINDOW = 60
+
+
+def _last_call_signature(scan: List[Dict[str, Any]]) -> Optional[str]:
+    """Signature of the latest tool turn, or None when the pattern was broken.
+
+    Returns None when the most recent assistant turn produced text instead of a
+    tool call (the agent stopped to reason — that is the behaviour a nudge is
+    trying to provoke, so nudging now would be backwards), or when that turn
+    called more than one tool (varied work, not a single repeated call).
+    """
+    for msg in reversed(scan):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        tcs = [tc for tc in (msg.get("tool_calls") or []) if isinstance(tc, dict)]
+        if not tcs:
+            return None  # text reply broke the run
+        if len(tcs) != 1:
+            return None  # multi-tool turn = varied work
+        fn = tcs[0].get("function")
+        if not isinstance(fn, dict):
+            return None
+        name = fn.get("name", "")
+        arg_hash = _tool_call_arg_hash([tcs[0]])
+        if not name or arg_hash is None:
+            return None
+        return f"{name}::{arg_hash}"
+    return None
 
 
 def detect_dead_end_loop(
@@ -485,6 +517,20 @@ def detect_dead_end_loop(
         return None
     top_key, top_count = signatures.most_common(1)[0]
     if top_count < _DEAD_END_REPEAT_THRESHOLD:
+        return None
+
+    # The repeated signature must be what the agent is doing RIGHT NOW.
+    #
+    # Counting across the whole window would flag a run the agent has already
+    # moved on from: 5x terminal followed by a read_file, or 8x terminal
+    # followed by a text reply, are treated as progress everywhere else in this
+    # module (see TestRunBoundaries) — the agent broke the pattern by itself and
+    # needs no nudge. Only when the latest tool turn re-issues the repeated
+    # signature is the loop still live.
+    #
+    # A turn calling several DIFFERENT tools at once is varied work, not a
+    # spiral, so it does not count as a live re-issue either.
+    if _last_call_signature(scan) != top_key:
         return None
 
     tool = sig_to_tool[top_key]
@@ -723,6 +769,24 @@ def _tool_spiral_score(tool_name: str, count: int, base: int) -> Optional[str]:
     return None
 
 
+def _semantic_loop_nudge(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Cross-turn semantic loop checks, used as a LAST resort (#1312, #1328).
+
+    These two detectors look *through* intervening calls, so they see patterns
+    the consecutive-run detector cannot (``test → edit → test``). That same
+    breadth makes them far less specific than the targeted nudges above: the
+    same-argument short-circuit names ``offset/limit`` for a file read, the
+    failure-class branch names the dominant error class, ``_diversion_hint``
+    proposes a concrete alternative tool. Running these first would mask every
+    one of those with generic "you repeated a call" wording — which is exactly
+    what the pre-existing contracts in ``test_loop_guard.py`` and
+    ``test_loop_guard_readfile_debounce.py`` (#1092) assert must not happen.
+
+    So they run only once the specific ladder has declined to fire.
+    """
+    return detect_test_iteration_loop(messages) or detect_dead_end_loop(messages)
+
+
 def maybe_nudge(
     messages: List[Dict[str, Any]],
     *,
@@ -732,40 +796,22 @@ def maybe_nudge(
     """Return a nudge string if the trailing single-tool run is stuck, else None.
 
     Trigger levels (each is lower for mutating tools than idempotent):
-      0. Semantic test-iteration loop (#1328) — highest priority, fires when
-         a test/lint command has been run >= 3 times with failures, even with
-         intervening non-terminal calls (patch/write_file) between test runs.
       1. Non-retryable failure class repeated twice (highest priority, #231)
       2. Generic failures >= fail_threshold
       3. Same tool called >= repeat_threshold times in a row
       4. Escalated interrupt at higher counts (#432)
       5. Same *arguments* repeated for short-circuit idempotent tools
          (search_files / web_search / web_extract) >= 4 times (#467)
+      6. Last resort — cross-turn semantic loops that the consecutive-run
+         detector cannot see: test-iteration cycles (#1328) and identical-
+         argument dead ends (#1312). See :func:`_semantic_loop_nudge` for why
+         these run last rather than first.
 
     Returns None when the agent is making varied progress (not stuck).
     """
-    # #1328 — Semantic test-iteration loop detection: check this BEFORE the
-    # generic same-tool run detection. A test-iteration loop has intervening
-    # non-terminal calls (patch/write_file) between test runs, so the generic
-    # single-tool run detector would NOT see a consecutive run of terminal
-    # calls — the run would break at the patch call. This semantic check looks
-    # THROUGH intervening calls to find the test→edit→test→edit pattern.
-    _test_loop = detect_test_iteration_loop(messages)
-    if _test_loop:
-        return _test_loop
-
-    # #1312 — Dead-end loop detection: identical (tool, args) re-issued across
-    # turns, even with intervening calls between them. This is the
-    # near-miss-vs-dead-end discriminator — it fires when the agent repeats
-    # the exact same call, which is always a dead end (nothing changed → same
-    # result). Checked before the generic single-tool run detection.
-    _dead_end = detect_dead_end_loop(messages)
-    if _dead_end:
-        return _dead_end
-
     runs = _recent_tool_runs(messages)
     if not runs:
-        return None
+        return _semantic_loop_nudge(messages)
     tool = runs[0][0]
 
     # Pick thresholds based on tool category (#432).
@@ -978,7 +1024,8 @@ def maybe_nudge(
             f"{exploration_hint}"
         )
 
-    return None
+    # Nothing tool-specific fired — fall back to the cross-turn semantic checks.
+    return _semantic_loop_nudge(messages)
 
 
 def current_run_signature(messages: List[Dict[str, Any]]) -> Optional[Tuple[str, int]]:

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -293,6 +293,219 @@ _TOOL_FAIL_THRESHOLD_OVERRIDE: dict[str, int] = {
 # every run (see run_warrants_cron_hard_stop).
 _POLLING_TOOLS = frozenset({"process"})
 
+# ── Semantic test-iteration loop detection (#1328) ────────────────────
+# The generic same-tool guard catches terminal called N times in a row, but a
+# test-iteration loop is a SEMANTIC pattern: the agent cycles through
+# run-test → edit → run-test → edit → run-test, each terminal call technically
+# distinct (different commands), but the TEST command repeats with failures.
+# By the time the generic repeat_threshold (4 for mutating) trips, the agent has
+# wasted 4 full edit→test cycles. This semantic check inspects the terminal
+# command arguments to detect a repeated test command pattern and nudge EARLIER
+# with test-scoping advice (narrow to the specific failing test, check the error
+# message, etc.).
+_TEST_CMD_PATTERNS = (
+    re.compile(r"\bpytest\b", re.IGNORECASE),
+    re.compile(r"\bruff\b", re.IGNORECASE),
+    re.compile(r"\bmypy\b", re.IGNORECASE),
+    re.compile(r"\bflake8\b", re.IGNORECASE),
+    re.compile(r"\bpylint\b", re.IGNORECASE),
+    re.compile(r"\bcargo\s+test\b", re.IGNORECASE),
+    re.compile(r"\bnpm\s+test\b", re.IGNORECASE),
+    re.compile(r"\byarn\s+test\b", re.IGNORECASE),
+    re.compile(r"\bgo\s+test\b", re.IGNORECASE),
+    re.compile(r"\bnose2?\b", re.IGNORECASE),
+    re.compile(r"\bjest\b", re.IGNORECASE),
+    re.compile(r"\bvitest\b", re.IGNORECASE),
+)
+
+# How many times a test/lint command must appear in trailing terminal calls
+# (regardless of intervening non-test calls) before we fire the semantic nudge.
+# Deliberately LOWER than the generic repeat_threshold (4) so the agent gets
+# test-scoping advice before wasting more cycles.
+_TEST_LOOP_THRESHOLD = 3
+
+
+def _extract_terminal_command(args: Any) -> Optional[str]:
+    """Extract the command string from a terminal tool call's arguments."""
+    if isinstance(args, str):
+        try:
+            parsed = json.loads(args)
+        except (json.JSONDecodeError, ValueError):
+            return args
+        args = parsed
+    if isinstance(args, dict):
+        cmd = args.get("command") or args.get("cmd")
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
+    return None
+
+
+def _is_test_command(command: Optional[str]) -> bool:
+    """True when the terminal command matches a recognised test/lint pattern."""
+    if not command:
+        return False
+    return any(pat.search(command) for pat in _TEST_CMD_PATTERNS)
+
+
+def detect_test_iteration_loop(
+    messages: List[Dict[str, Any]],
+) -> Optional[str]:
+    """Detect a semantic test-iteration loop in terminal tool calls (#1328).
+
+    Scans the trailing terminal tool-call turns (allowing intervening
+    non-terminal calls like patch/write_file) for a repeated test/lint command
+    pattern. If a test-command family appears >= ``_TEST_LOOP_THRESHOLD`` times
+    with at least one failure among the results, returns a nudge string with
+    test-scoping advice. Returns None when no test-iteration loop is found.
+    """
+    test_runs: List[Tuple[str, bool]] = []
+    i = len(messages) - 1
+    while i >= 0:
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            i -= 1
+            continue
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            tcs = [tc for tc in msg["tool_calls"] if isinstance(tc, dict)]
+            for tc in tcs:
+                fn = tc.get("function")
+                if not isinstance(fn, dict):
+                    continue
+                name = fn.get("name")
+                if name not in ("terminal", "execute_code"):
+                    continue
+                cmd = _extract_terminal_command(fn.get("arguments"))
+                if not _is_test_command(cmd):
+                    continue
+                call_id = tc.get("id")
+                failed = False
+                for j in range(i + 1, len(messages)):
+                    tm = messages[j]
+                    if isinstance(tm, dict) and tm.get("role") == "tool":
+                        if tm.get("tool_call_id") == call_id:
+                            failed = _looks_like_failure(tm.get("content"))
+                            break
+                    elif isinstance(tm, dict) and tm.get("role") == "assistant":
+                        break
+                test_runs.append((cmd or "?", failed))
+        elif msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str) and "[loop-guard]" not in content:
+                break
+        i -= 1
+
+    if len(test_runs) < _TEST_LOOP_THRESHOLD:
+        return None
+    if not any(failed for _cmd, failed in test_runs):
+        return None
+
+    count = len(test_runs)
+    return (
+        f"[loop-guard] SEMANTIC TEST LOOP: You have run a test/lint command "
+        f"{count} times in this turn, with at least one failure. This is a "
+        f"test-iteration loop (#1328). STOP re-running the full test suite. "
+        f"Instead:\n"
+        f"  1. Read the ACTUAL error message from the last failing run.\n"
+        f"  2. Scope the next test run to ONLY the failing test "
+        f"(e.g. `pytest tests/test_foo.py::test_bar -x` or `ruff check "
+        f"path/to/specific_file.py`).\n"
+        f"  3. Fix the root cause before running tests again.\n"
+        f"  4. If the error is environmental, fix the environment, not the test.\n"
+        f"Do NOT run the test command again until you have addressed the "
+        f"specific failure from the last run."
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1312 — Near-miss vs dead-end discriminator
+# ---------------------------------------------------------------------------
+
+# How many identical (tool, arg_hash) re-issues within the trailing window
+# before the dead-end nudge fires. 2 = "you already tried this exact call
+# and it didn't work — what is different this time?".
+_DEAD_END_REPEAT_THRESHOLD = 2
+
+# Scan at most this many trailing messages for identical re-issues.  Keeps
+# the check O(1) bounded and avoids matching calls from a different context.
+_DEAD_END_WINDOW = 60
+
+
+def detect_dead_end_loop(
+    messages: List[Dict[str, Any]],
+) -> Optional[str]:
+    """Detect an identical-argument dead-end loop across turns (#1312).
+
+    Scans the trailing ``_DEAD_END_WINDOW`` messages (allowing intervening
+    non-matching calls — the classic ``edit → test → edit → test`` cycle where
+    the *same* test command is re-issued unchanged) for tool calls whose
+    ``(tool_name, normalized_arg_hash)`` identity has already appeared at
+    least ``_DEAD_END_REPEAT_THRESHOLD`` times.
+
+    Unlike :func:`_recent_tool_runs` (which only sees a consecutive
+    single-tool run), this function looks *through* intervening calls to find
+    the dead-end pattern: the agent re-issues the exact same arguments without
+    any structural change, which means nothing new can happen.
+
+    Returns a nudge string asking for a structured
+    ``{what_changed, why_expect_different_outcome}`` justification, or None.
+    """
+    from collections import Counter
+
+    signatures: Counter[str] = Counter()
+    sig_to_tool: dict[str, str] = {}
+    scan = messages[-_DEAD_END_WINDOW:] if len(messages) > _DEAD_END_WINDOW else messages
+
+    for msg in scan:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "assistant":
+            continue
+        tcs = msg.get("tool_calls")
+        if not tcs:
+            continue
+        for tc in tcs:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name", "")
+            if not name:
+                continue
+            # Reuse the existing canonical-arg hash from this module.
+            arg_hash = _tool_call_arg_hash([tc])
+            if arg_hash is None:
+                continue
+            key = f"{name}::{arg_hash}"
+            signatures[key] += 1
+            sig_to_tool[key] = name
+
+    # Find the most-repeated identical call.
+    if not signatures:
+        return None
+    top_key, top_count = signatures.most_common(1)[0]
+    if top_count < _DEAD_END_REPEAT_THRESHOLD:
+        return None
+
+    tool = sig_to_tool[top_key]
+    return (
+        f"[loop-guard] DEAD-END DETECTED (#1312): You have re-issued `{tool}` "
+        f"with the SAME arguments {top_count} times. This is a dead-end loop, "
+        f"not a near-miss. Repeating identical arguments will produce the "
+        f"identical result.\n\n"
+        f"Before calling `{tool}` again, you MUST answer:\n"
+        f"  1. **what_changed_since_last_attempt** — what is structurally "
+        f"different now (a file was edited, an env var was set, a dependency "
+        f"was installed)? If nothing changed, STOP.\n"
+        f"  2. **why_expect_different_outcome** — why would the same call "
+        f"produce a different result? If it can't, choose a different "
+        f"strategy: change the arguments, use a different tool, decompose "
+        f"the problem, or report the blocker.\n"
+        f"Do NOT re-issue `{tool}` with the same arguments. Change the "
+        f"approach or state the blocker concisely."
+    )
+
+
 # Unattended cron sessions get real enforcement, not just advisory text (#624):
 # advisory nudges are routinely ignored by the model with no human present to
 # course-correct (observed: 9 warnings ignored, 65 consecutive terminal calls).
@@ -519,6 +732,9 @@ def maybe_nudge(
     """Return a nudge string if the trailing single-tool run is stuck, else None.
 
     Trigger levels (each is lower for mutating tools than idempotent):
+      0. Semantic test-iteration loop (#1328) — highest priority, fires when
+         a test/lint command has been run >= 3 times with failures, even with
+         intervening non-terminal calls (patch/write_file) between test runs.
       1. Non-retryable failure class repeated twice (highest priority, #231)
       2. Generic failures >= fail_threshold
       3. Same tool called >= repeat_threshold times in a row
@@ -528,6 +744,25 @@ def maybe_nudge(
 
     Returns None when the agent is making varied progress (not stuck).
     """
+    # #1328 — Semantic test-iteration loop detection: check this BEFORE the
+    # generic same-tool run detection. A test-iteration loop has intervening
+    # non-terminal calls (patch/write_file) between test runs, so the generic
+    # single-tool run detector would NOT see a consecutive run of terminal
+    # calls — the run would break at the patch call. This semantic check looks
+    # THROUGH intervening calls to find the test→edit→test→edit pattern.
+    _test_loop = detect_test_iteration_loop(messages)
+    if _test_loop:
+        return _test_loop
+
+    # #1312 — Dead-end loop detection: identical (tool, args) re-issued across
+    # turns, even with intervening calls between them. This is the
+    # near-miss-vs-dead-end discriminator — it fires when the agent repeats
+    # the exact same call, which is always a dead end (nothing changed → same
+    # result). Checked before the generic single-tool run detection.
+    _dead_end = detect_dead_end_loop(messages)
+    if _dead_end:
+        return _dead_end
+
     runs = _recent_tool_runs(messages)
     if not runs:
         return None

--- a/tests/agent/test_dead_end_loop.py
+++ b/tests/agent/test_dead_end_loop.py
@@ -33,8 +33,13 @@ class TestDetectDeadEndLoop:
         msgs = [_make_tool_call("terminal", '{"command": "ls"}', "1")]
         assert detect_dead_end_loop(msgs) is None
 
-    def test_identical_call_twice_triggers(self):
-        """Two identical (tool, args) = dead-end."""
+    def test_identical_call_at_threshold_triggers(self):
+        """4 identical (tool, args) re-issues = dead-end.
+
+        The threshold matches _SHORT_CIRCUIT_REPEAT_THRESHOLD /
+        _MUTATING_REPEAT_THRESHOLD; below it, loop_guard deliberately stays
+        quiet (a retry after a transient failure is normal).
+        """
         msgs = [
             _make_tool_call("terminal", '{"command": "pytest"}', "1"),
             _make_tool_result("1", "FAIL"),
@@ -42,6 +47,14 @@ class TestDetectDeadEndLoop:
             _make_tool_result("2", "ok"),
             _make_tool_call("terminal", '{"command": "pytest"}', "3"),
             _make_tool_result("3", "FAIL"),
+            _make_tool_call("patch", '{"path": "y.py"}', "4"),
+            _make_tool_result("4", "ok"),
+            _make_tool_call("terminal", '{"command": "pytest"}', "5"),
+            _make_tool_result("5", "FAIL"),
+            _make_tool_call("patch", '{"path": "z.py"}', "6"),
+            _make_tool_result("6", "ok"),
+            _make_tool_call("terminal", '{"command": "pytest"}', "7"),
+            _make_tool_result("7", "FAIL"),
         ]
         result = detect_dead_end_loop(msgs)
         assert result is not None
@@ -49,6 +62,32 @@ class TestDetectDeadEndLoop:
         assert "terminal" in result
         assert "what_changed_since_last_attempt" in result
         assert "why_expect_different_outcome" in result
+
+    def test_below_threshold_is_quiet(self):
+        """Three identical re-issues are not yet a dead end."""
+        msgs = [
+            _make_tool_call("terminal", '{"command": "pytest"}', "1"),
+            _make_tool_result("1", "FAIL"),
+            _make_tool_call("patch", '{"path": "x.py"}', "2"),
+            _make_tool_result("2", "ok"),
+            _make_tool_call("terminal", '{"command": "pytest"}', "3"),
+            _make_tool_result("3", "FAIL"),
+            _make_tool_call("patch", '{"path": "y.py"}', "4"),
+            _make_tool_result("4", "ok"),
+            _make_tool_call("terminal", '{"command": "pytest"}', "5"),
+            _make_tool_result("5", "FAIL"),
+        ]
+        assert detect_dead_end_loop(msgs) is None
+
+    def test_moved_on_to_another_tool_is_quiet(self):
+        """A repeated call the agent has already abandoned is not a live loop."""
+        msgs = []
+        for i in range(1, 6):
+            msgs.append(_make_tool_call("terminal", '{"command": "pytest"}', str(i)))
+            msgs.append(_make_tool_result(str(i), "FAIL"))
+        msgs.append(_make_tool_call("read_file", '{"path": "x.py"}', "99"))
+        msgs.append(_make_tool_result("99", "ok"))
+        assert detect_dead_end_loop(msgs) is None
 
     def test_different_args_no_trigger(self):
         """Different arguments = not a dead-end (agent is trying variations)."""
@@ -60,8 +99,8 @@ class TestDetectDeadEndLoop:
         ]
         assert detect_dead_end_loop(msgs) is None
 
-    def test_three_identical_calls_triggers(self):
-        """Three identical calls with intervening edits = dead-end."""
+    def test_four_identical_calls_report_the_count(self):
+        """Four identical calls with intervening edits = dead-end."""
         msgs = [
             _make_tool_call("terminal", '{"command": "npm test"}', "1"),
             _make_tool_result("1", "FAIL"),
@@ -73,36 +112,37 @@ class TestDetectDeadEndLoop:
             _make_tool_result("4", "ok"),
             _make_tool_call("terminal", '{"command": "npm test"}', "5"),
             _make_tool_result("5", "FAIL"),
+            _make_tool_call("patch", '{"path": "c.js"}', "6"),
+            _make_tool_result("6", "ok"),
+            _make_tool_call("terminal", '{"command": "npm test"}', "7"),
+            _make_tool_result("7", "FAIL"),
         ]
         result = detect_dead_end_loop(msgs)
         assert result is not None
-        assert "3 times" in result
+        assert "4 times" in result
 
     def test_nudge_contains_structured_justification_prompt(self):
         """The nudge must ask for structured justification (#1312 success criteria)."""
-        msgs = [
-            _make_tool_call("execute_code", '{"code": "print(1)"}', "1"),
-            _make_tool_result("1", "1"),
-            _make_tool_call("execute_code", '{"code": "print(1)"}', "2"),
-            _make_tool_result("2", "1"),
-        ]
+        msgs = []
+        for i in range(1, 5):
+            msgs.append(_make_tool_call("execute_code", '{"code": "print(1)"}', str(i)))
+            msgs.append(_make_tool_result(str(i), "1"))
         result = detect_dead_end_loop(msgs)
         assert result is not None
         assert "strategy" in result.lower() or "different approach" in result.lower()
 
     def test_window_respected(self):
         """Calls outside the window should not be counted."""
-        # Fill with 60 non-matching messages, then the identical pair
+        # Fill with 60 non-matching messages, then the identical run
         msgs = []
         for i in range(30):
             cid = str(i)
             msgs.append(_make_tool_call("read_file", f'{{"path": "f{i}.py"}}', cid))
             msgs.append(_make_tool_result(cid))
-        msgs.append(_make_tool_call("terminal", '{"command": "ls"}', "100"))
-        msgs.append(_make_tool_result("100"))
-        msgs.append(_make_tool_call("terminal", '{"command": "ls"}', "101"))
-        msgs.append(_make_tool_result("101"))
-        # With default window=60, the two identical "ls" calls at the end
+        for i in range(100, 104):
+            msgs.append(_make_tool_call("terminal", '{"command": "ls"}', str(i)))
+            msgs.append(_make_tool_result(str(i)))
+        # With default window=60, the four identical "ls" calls at the end
         # ARE within the last 60 messages and should trigger.
         result = detect_dead_end_loop(msgs)
         assert result is not None

--- a/tests/agent/test_dead_end_loop.py
+++ b/tests/agent/test_dead_end_loop.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Tests for dead-end loop detection (issue #1312)."""
+
+from __future__ import annotations
+
+from agent.loop_guard import detect_dead_end_loop
+
+
+def _make_tool_call(name: str, args: str, call_id: str = "1") -> dict:
+    """Build a minimal assistant message with one tool call."""
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": args},
+            }
+        ],
+    }
+
+
+def _make_tool_result(call_id: str, content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+class TestDetectDeadEndLoop:
+    def test_no_messages_returns_none(self):
+        assert detect_dead_end_loop([]) is None
+
+    def test_single_call_returns_none(self):
+        """One call is not a loop."""
+        msgs = [_make_tool_call("terminal", '{"command": "ls"}', "1")]
+        assert detect_dead_end_loop(msgs) is None
+
+    def test_identical_call_twice_triggers(self):
+        """Two identical (tool, args) = dead-end."""
+        msgs = [
+            _make_tool_call("terminal", '{"command": "pytest"}', "1"),
+            _make_tool_result("1", "FAIL"),
+            _make_tool_call("patch", '{"path": "x.py"}', "2"),
+            _make_tool_result("2", "ok"),
+            _make_tool_call("terminal", '{"command": "pytest"}', "3"),
+            _make_tool_result("3", "FAIL"),
+        ]
+        result = detect_dead_end_loop(msgs)
+        assert result is not None
+        assert "DEAD-END DETECTED" in result
+        assert "terminal" in result
+        assert "what_changed_since_last_attempt" in result
+        assert "why_expect_different_outcome" in result
+
+    def test_different_args_no_trigger(self):
+        """Different arguments = not a dead-end (agent is trying variations)."""
+        msgs = [
+            _make_tool_call("terminal", '{"command": "pytest tests/a.py"}', "1"),
+            _make_tool_result("1", "FAIL"),
+            _make_tool_call("terminal", '{"command": "pytest tests/b.py"}', "2"),
+            _make_tool_result("2", "FAIL"),
+        ]
+        assert detect_dead_end_loop(msgs) is None
+
+    def test_three_identical_calls_triggers(self):
+        """Three identical calls with intervening edits = dead-end."""
+        msgs = [
+            _make_tool_call("terminal", '{"command": "npm test"}', "1"),
+            _make_tool_result("1", "FAIL"),
+            _make_tool_call("patch", '{"path": "a.js"}', "2"),
+            _make_tool_result("2", "ok"),
+            _make_tool_call("terminal", '{"command": "npm test"}', "3"),
+            _make_tool_result("3", "FAIL"),
+            _make_tool_call("patch", '{"path": "b.js"}', "4"),
+            _make_tool_result("4", "ok"),
+            _make_tool_call("terminal", '{"command": "npm test"}', "5"),
+            _make_tool_result("5", "FAIL"),
+        ]
+        result = detect_dead_end_loop(msgs)
+        assert result is not None
+        assert "3 times" in result
+
+    def test_nudge_contains_structured_justification_prompt(self):
+        """The nudge must ask for structured justification (#1312 success criteria)."""
+        msgs = [
+            _make_tool_call("execute_code", '{"code": "print(1)"}', "1"),
+            _make_tool_result("1", "1"),
+            _make_tool_call("execute_code", '{"code": "print(1)"}', "2"),
+            _make_tool_result("2", "1"),
+        ]
+        result = detect_dead_end_loop(msgs)
+        assert result is not None
+        assert "strategy" in result.lower() or "different approach" in result.lower()
+
+    def test_window_respected(self):
+        """Calls outside the window should not be counted."""
+        # Fill with 60 non-matching messages, then the identical pair
+        msgs = []
+        for i in range(30):
+            cid = str(i)
+            msgs.append(_make_tool_call("read_file", f'{{"path": "f{i}.py"}}', cid))
+            msgs.append(_make_tool_result(cid))
+        msgs.append(_make_tool_call("terminal", '{"command": "ls"}', "100"))
+        msgs.append(_make_tool_result("100"))
+        msgs.append(_make_tool_call("terminal", '{"command": "ls"}', "101"))
+        msgs.append(_make_tool_result("101"))
+        # With default window=60, the two identical "ls" calls at the end
+        # ARE within the last 60 messages and should trigger.
+        result = detect_dead_end_loop(msgs)
+        assert result is not None


### PR DESCRIPTION
Adds detect_dead_end_loop() to loop_guard.py that scans trailing messages for identical (tool, args) re-issues across turns (even with intervening calls). Requires structured {what_changed, why_expect_different} justification before retry. Tests: 7 passed. Closes #1312