### PR TITLE
feat: recovery-before-refusal prompt nudge (Closes #1356)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -585,6 +585,28 @@ DELIBERATE_WORK_GUIDANCE = (
     "real results and real blockers, never a plausible-looking guess."
 )
 
+# Recovery-before-refusal guidance (#1356).  When the agent is about to say
+# "I can't do X because I don't have Y", it should first check whether an
+# existing tool can achieve the same goal via a different path and propose
+# that alternative to the user.  Only refuse if no alternative exists.
+# This reduces soft-capability refusals (plateauing at ~51/week per #1327)
+# by steering the model toward recovery paths it already has.
+# Always on — static text in the cached stable tier, scoped to tool-bearing
+# sessions.  Short on purpose: shipped in the cached system prompt to every
+# user, every session.
+RECOVERY_BEFORE_REFUSAL_GUIDANCE = (
+    "# Recovery before refusal\n"
+    "Before telling the user you cannot do something because a specific tool "
+    "or capability is missing, check whether an existing tool can achieve the "
+    "same goal via a different path. If so, propose that alternative instead of "
+    "refusing. Only refuse when no alternative path exists.\n"
+    "Examples:\n"
+    "- No `grep` tool → use `search_files` with a regex pattern.\n"
+    "- No direct database access → write a script via `terminal` that queries it.\n"
+    "- No image editor → use `terminal` to invoke ImageMagick or Python PIL.\n"
+    "The goal is to exhaust available capabilities before declining a request."
+)
+
 # Universal parallel-tool-call guidance — applied to ALL models.
 #
 # Why this matters for cost: every assistant turn resends the entire

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
+    RECOVERY_BEFORE_REFUSAL_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -220,6 +221,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # acting, audit and rate your own work after. Always on — static text, scoped
     # to non-trivial work, so it raises quality without slowing simple replies.
     stable_parts.append(DELIBERATE_WORK_GUIDANCE)
+
+    # Recovery-before-refusal guidance (#1356): steer the model toward
+    # proposing alternative tool paths before issuing a soft-capability
+    # refusal.  Always on — static text, scoped to tool-bearing sessions
+    # so non-tool platforms (e.g. bare API) don't pay the token cost.
+    if agent.valid_tool_names:
+        stable_parts.append(RECOVERY_BEFORE_REFUSAL_GUIDANCE)
+
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one
     # call per turn — the runtime already runs independent calls concurrently

--- a/tests/agent/test_recovery_before_refusal.py
+++ b/tests/agent/test_recovery_before_refusal.py
@@ -1,0 +1,75 @@
+"""Tests for recovery-before-refusal guidance (#1356).
+
+Verifies the guidance constant exists with the right content and that
+build_system_prompt_parts injects it only when tools are loaded.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.prompt_builder import RECOVERY_BEFORE_REFUSAL_GUIDANCE
+from agent.system_prompt import build_system_prompt_parts
+
+
+def _make_agent(**overrides):
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names=[],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _stable_prompt(agent):
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        return build_system_prompt_parts(agent)["stable"]
+
+
+class TestRecoveryBeforeRefusalConstant:
+    def test_constant_has_heading(self):
+        assert "# Recovery before refusal" in RECOVERY_BEFORE_REFUSAL_GUIDANCE
+
+    def test_constant_mentions_alternative_path(self):
+        assert "alternative" in RECOVERY_BEFORE_REFUSAL_GUIDANCE.lower()
+
+    def test_constant_mentions_existing_tool(self):
+        assert "existing tool" in RECOVERY_BEFORE_REFUSAL_GUIDANCE.lower()
+
+    def test_constant_has_examples(self):
+        assert "Examples:" in RECOVERY_BEFORE_REFUSAL_GUIDANCE
+        assert "search_files" in RECOVERY_BEFORE_REFUSAL_GUIDANCE
+        assert "terminal" in RECOVERY_BEFORE_REFUSAL_GUIDANCE
+
+    def test_constant_is_concise(self):
+        # Should be under 800 chars — this is cached system prompt text
+        assert len(RECOVERY_BEFORE_REFUSAL_GUIDANCE) < 800
+
+
+class TestRecoveryBeforeRefusalInjection:
+    def test_injected_when_tools_loaded(self):
+        agent = _make_agent(valid_tool_names=["read_file", "terminal"])
+        stable = _stable_prompt(agent)
+        assert "Recovery before refusal" in stable
+        assert "alternative" in stable.lower()
+
+    def test_absent_when_no_tools(self):
+        agent = _make_agent(valid_tool_names=[])
+        stable = _stable_prompt(agent)
+        assert "Recovery before refusal" not in stable


### PR DESCRIPTION
Automated evolution PR for issue #1356.

## Summary
Add a recovery-before-refusal guidance block to the stable system-prompt tier. When the agent is about to refuse because a specific tool/capability is missing, it first checks whether an existing tool can achieve the same goal via a different path and proposes that alternative. Only refuses when no alternative exists.

## Changes
- `agent/prompt_builder.py`: New `RECOVERY_BEFORE_REFUSAL_GUIDANCE` constant (~20 lines)
- `agent/system_prompt.py`: Import + inject into `stable_parts` after `DELIBERATE_WORK_GUIDANCE`, gated on `valid_tool_names`
- `tests/agent/test_recovery_before_refusal.py`: 7 tests covering constant content + conditional injection

## Scope
- 106 lines total (under 200-line merge cap)
- Static text in cached stable tier — no cache break
- Scoped to tool-bearing sessions (no token cost for bare-API platforms)
- No behavioral test changes required (prompt-level change)

Closes #1356