### PR TITLE
docs(evolution): document rate-normalized verdicts in the stage instructions (Closes #1362)

### DIFF
--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -375,7 +375,8 @@ def main(argv: List[str]) -> int:
         except (IndexError, ValueError):
             print(
                 "usage: evolution_realized_impact.py record-merge "
-                "<issue> <YYYY-MM-DD> <predicted_impact> <target>",
+                "<issue> <YYYY-MM-DD> <predicted_impact> <target> "
+                "[baseline_failure_rate]",
                 file=sys.stderr,
             )
             return 2

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -315,12 +315,22 @@ PROFILE_SKILLS="${HERMES_HOME:-$HOME/.hermes}/skills/evolution"
 ```bash
 python3 scripts/evolution_realized_impact.py record-merge \
   <#> "<YYYY-MM-DD>" "<the issue's analysis impact 0..1>" \
-  "<one line: the concrete problem this was meant to fix>"
+  "<one line: the concrete problem this was meant to fix>" \
+  "<baseline_failure_rate>"
 ```
    `predicted_impact` is the impact the analysis stage assigned the issue; `target`
    is what "done" means for it. introspection later appends a `verdict` line for
    the same issue once it has matured. NEVER omit this — an unrecorded merge is
    an unmeasured one.
+
+   **The 5th argument, `baseline_failure_rate`, is optional but should always be
+   passed (#1324).** It is the current failures-per-session for the tool this
+   change targets — read `failure_rate` straight out of the latest introspection
+   digest (`python scripts/introspection_extract.py --days=7`). Recording it
+   snapshots the rate at merge time so the later verdict compares rate against
+   rate. Omit it and the verdict falls back to comparing raw counts, which rise
+   with session volume alone and manufacture false `regressed` verdicts — the
+   exact bug #1324 fixed in the scripts.
 
 ## What to NEVER merge
 

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -58,6 +58,22 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    text). This both bounds context (unbounded → ~2-5k tokens) and keeps private
    text out of the model entirely (complements the PII gate #82).
 
+   **Compare rates, never raw counts (#1324).** The digest also emits
+   `failure_rate` (failures ÷ sessions_scanned) and `spiral_depth_per_session`.
+   Session volume grows cycle over cycle, so a raw `tool_failures` count rises
+   even when the per-session rate holds steady or improves — comparing raw
+   counts across windows manufactures false "regressed" verdicts. Use
+   `failure_rate` for every cross-window comparison; `tool_failures` is retained
+   only for back-compat and for within-window ranking.
+
+   **Attribute by (tool, reason), not by tool alone (#1325).** The digest emits
+   `tool_failures_by_reason` — `{tool: {reason: count}}` over the buckets
+   `file-not-found`, `permission-denied`, `timeout`, `quota`, `parse-error`,
+   `no-match`, `non-zero-exit`, `other`. A fix for `read_file:file-not-found`
+   must not be credited or blamed for `read_file:timeout`; conflating them is
+   what produced the fix→regress→refile treadmill. When filing or verifying an
+   issue about a failing tool, name the reason bucket, not just the tool.
+
 2. **Detect problem signals** (non-exhaustive):
    - **Tool failures** — a tool returned an error / non-zero / exception,
      especially the SAME tool failing repeatedly across sessions.
@@ -106,6 +122,14 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    - For each, judge from the real sessions since its merge: did the `target`
      problem RECUR (the fix didn't hold)? is the merged capability actually used?
      did the friction it targeted disappear?
+   - **Judge a `regressed` verdict on the RATE, not the count (#1324).** When the
+     ledger entry carries a `baseline_failure_rate` (recorded at merge time),
+     compare it against the current digest's `failure_rate` for that tool rather
+     than eyeballing raw `tool_failures`. `classify_verdict_by_rate()` in
+     `scripts/evolution_realized_impact.py` implements the thresholds — a rate
+     rise >20% is `regressed`, a drop >5% is `confirmed`, anything between is
+     stable. A raw count that grew purely because session volume grew is NOT a
+     regression, and calling it one re-opens issues that were actually fixed.
    - Record ONE verdict per such issue via the deterministic helper:
      ```bash
      python3 scripts/evolution_realized_impact.py record-verdict \


### PR DESCRIPTION
Closes #1362.

#1334 fixed the false-regression bug in the **scripts**; the **stage instructions** were never updated to match. The agent running these stages was still told to work from raw `tool_failures`, so the fix was only half-deployed.

## Changes

**`evolution-introspection/SKILL.md`**
- compare `failure_rate` across windows, never raw `tool_failures` — a raw count rises with session volume alone, which is the false-regression bug itself
- attribute by `(tool, reason)` via `tool_failures_by_reason` (#1325), so a fix for `read_file:file-not-found` is not credited or blamed for `read_file:timeout`
- judge a `regressed` verdict against the recorded `baseline_failure_rate` using `classify_verdict_by_rate()` thresholds (>20% rise = regressed, >5% drop = confirmed)

**`evolution-integration/SKILL.md`**
- pass `baseline_failure_rate` to `record-merge`, sourced from the digest's `failure_rate`, so the later verdict compares rate against rate

**`scripts/evolution_realized_impact.py`**
- usage string now mentions the optional `[baseline_failure_rate]` argument

## Why it mattered

`record_merge()` has accepted `baseline_failure_rate` since #1334, and the CLI has read it as a 6th positional since then — but neither the usage string nor any skill mentioned it, so nothing ever passed it. Every merge recorded since #1334 has a null baseline, which means every later verdict silently falls back to raw-count comparison. Docs-only change plus a one-line usage fix; no behaviour change.

Salvaged from the closed #1332, which bundled this with a competing (and redundant) reimplementation of #1334.

60 passing in test_evolution_skill_integrity.py + test_evolution_realized_impact.py; ruff clean.