### PR TITLE
feat: per-boundary gate rates in the health sidecar with restart alert (Closes #1340)

### DIFF
--- a/evolution/lib/stage_gate.py
+++ b/evolution/lib/stage_gate.py
@@ -34,7 +34,9 @@ rest of ``evolution/lib``.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from evolution.lib.stage_result import StageResult
@@ -44,8 +46,14 @@ __all__ = [
     "REFINE",
     "RESTART",
     "DEFAULT_CONFIDENCE_THRESHOLD",
+    "RESTART_RATE_ALERT_THRESHOLD",
     "GateDecision",
     "decide",
+    "record_decision",
+    "load_decisions",
+    "compute_gate_rates",
+    "gate_flags",
+    "format_gate_rates",
 ]
 
 ACCEPT = "accept"
@@ -54,6 +62,13 @@ RESTART = "restart"
 
 #: Conservative default τ.  See module docstring on the 50-confidence interaction.
 DEFAULT_CONFIDENCE_THRESHOLD = 70
+
+#: A boundary restarting more than this share of the time is mis-tuned, not
+#: merely unlucky — the τ is too high for the confidence that boundary can
+#: realistically self-assess, or the stage genuinely has no evidence to work
+#: with.  Either way it warrants investigation rather than silent looping
+#: (#1340).
+RESTART_RATE_ALERT_THRESHOLD = 0.25
 
 
 @dataclass
@@ -175,3 +190,103 @@ def decide(
         ),
         retained_evidence=[],
     )
+
+
+# ── Observability: per-boundary branch rates (#1340, slice C) ───────────────
+# A gate that nobody measures is a gate nobody can tune. decide() returns a
+# decision; these persist it and turn a cycle's worth of decisions into the two
+# rates the AREX loop is judged on, plus the alert flag.
+
+
+def record_decision(ledger_file: Path, decision: GateDecision) -> None:
+    """Append one gate decision to the JSONL ledger.
+
+    Never raises: this is instrumentation attached to a live pipeline boundary,
+    and losing a metrics line must not take the stage down with it.
+    """
+    try:
+        ledger_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(ledger_file, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(decision.to_dict(), sort_keys=True) + "\n")
+    except OSError:
+        pass
+
+
+def load_decisions(ledger_file: Path) -> list[dict[str, Any]]:
+    """Read the decision ledger, skipping malformed lines."""
+    if not ledger_file.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        lines = ledger_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for ln in lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            rec = json.loads(ln)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(rec, dict) and rec.get("branch") in (ACCEPT, REFINE, RESTART):
+            out.append(rec)
+    return out
+
+
+def compute_gate_rates(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Aggregate decisions into per-boundary branch rates.
+
+    Returns ``{stage: {total, accept, refine, restart, stage_refine_rate,
+    stage_restart_rate}}``.  Rates are shares of that boundary's decisions, so
+    a boundary that ran twice is not compared on equal footing with one that ran
+    two hundred times — read ``total`` alongside the rate.
+    """
+    by_stage: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        stage = rec.get("stage") or "unknown"
+        bucket = by_stage.setdefault(
+            stage, {"total": 0, ACCEPT: 0, REFINE: 0, RESTART: 0}
+        )
+        bucket["total"] += 1
+        bucket[rec["branch"]] += 1
+    for bucket in by_stage.values():
+        total = bucket["total"] or 1
+        bucket["stage_refine_rate"] = round(bucket[REFINE] / total, 4)
+        bucket["stage_restart_rate"] = round(bucket[RESTART] / total, 4)
+    return by_stage
+
+
+def gate_flags(
+    rates: dict[str, dict[str, Any]],
+    *,
+    restart_threshold: float = RESTART_RATE_ALERT_THRESHOLD,
+    min_decisions: int = 4,
+) -> list[str]:
+    """Alert flags for mis-tuned boundaries (#1340).
+
+    ``min_decisions`` guards against a single unlucky restart on a boundary that
+    has only run once reading as a 100% restart rate.
+    """
+    flags: list[str] = []
+    for stage, bucket in sorted(rates.items()):
+        if bucket["total"] < min_decisions:
+            continue
+        if bucket["stage_restart_rate"] > restart_threshold:
+            flags.append(
+                f"HIGH_STAGE_RESTART_RATE:{stage}="
+                f"{bucket['stage_restart_rate']:.0%}"
+            )
+    return flags
+
+
+def format_gate_rates(rates: dict[str, dict[str, Any]]) -> str:
+    """One-line summary per boundary for the evolution-health sidecar."""
+    if not rates:
+        return ""
+    parts = [
+        f"{stage}(n={b['total']} refine={b['stage_refine_rate']:.0%} "
+        f"restart={b['stage_restart_rate']:.0%})"
+        for stage, b in sorted(rates.items())
+    ]
+    return "[stage-gate] " + " ".join(parts)

--- a/evolution/tests/test_stage_gate.py
+++ b/evolution/tests/test_stage_gate.py
@@ -121,3 +121,108 @@ class TestDecisionRecord:
 
     def test_is_a_gate_decision(self):
         assert isinstance(decide(_result(90)), GateDecision)
+
+
+class TestDecisionLedger:
+    """Persisted decisions are what the per-boundary rates are computed from (#1340)."""
+
+    def test_record_and_load_round_trip(self, tmp_path):
+        from evolution.lib.stage_gate import load_decisions, record_decision
+
+        ledger = tmp_path / "stage_gate.jsonl"
+        record_decision(ledger, decide(_result(90, ["a.json"])))
+        record_decision(ledger, decide(_result(50, ["a.json"])))
+        recs = load_decisions(ledger)
+        assert [r["branch"] for r in recs] == [ACCEPT, REFINE]
+
+    def test_missing_ledger_is_empty(self, tmp_path):
+        from evolution.lib.stage_gate import load_decisions
+
+        assert load_decisions(tmp_path / "absent.jsonl") == []
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        from evolution.lib.stage_gate import load_decisions, record_decision
+
+        ledger = tmp_path / "stage_gate.jsonl"
+        record_decision(ledger, decide(_result(90, ["a.json"])))
+        with open(ledger, "a", encoding="utf-8") as fh:
+            fh.write("not json\n")
+            fh.write('{"branch": "bogus"}\n')
+        assert len(load_decisions(ledger)) == 1
+
+    def test_record_never_raises_on_bad_path(self, tmp_path):
+        """Instrumentation must not take a live boundary down."""
+        from evolution.lib.stage_gate import record_decision
+
+        target = tmp_path / "file"
+        target.write_text("x", encoding="utf-8")
+        record_decision(target / "nested" / "ledger.jsonl", decide(_result(90)))
+
+
+class TestGateRates:
+    @staticmethod
+    def _recs(*branches, stage="local_triage"):
+        return [{"branch": b, "stage": stage} for b in branches]
+
+    def test_rates_per_boundary(self):
+        from evolution.lib.stage_gate import compute_gate_rates
+
+        rates = compute_gate_rates(self._recs(ACCEPT, ACCEPT, REFINE, RESTART))
+        b = rates["local_triage"]
+        assert b["total"] == 4
+        assert b["stage_refine_rate"] == 0.25
+        assert b["stage_restart_rate"] == 0.25
+
+    def test_boundaries_counted_separately(self):
+        from evolution.lib.stage_gate import compute_gate_rates
+
+        recs = self._recs(RESTART, RESTART, stage="a") + self._recs(ACCEPT, ACCEPT, stage="b")
+        rates = compute_gate_rates(recs)
+        assert rates["a"]["stage_restart_rate"] == 1.0
+        assert rates["b"]["stage_restart_rate"] == 0.0
+
+    def test_empty_records(self):
+        from evolution.lib.stage_gate import compute_gate_rates
+
+        assert compute_gate_rates([]) == {}
+
+
+class TestGateFlags:
+    @staticmethod
+    def _recs(*branches, stage="local_triage"):
+        return [{"branch": b, "stage": stage} for b in branches]
+
+    def test_high_restart_rate_flagged(self):
+        from evolution.lib.stage_gate import compute_gate_rates, gate_flags
+
+        rates = compute_gate_rates(self._recs(RESTART, RESTART, ACCEPT, ACCEPT))
+        flags = gate_flags(rates)
+        assert len(flags) == 1
+        assert flags[0].startswith("HIGH_STAGE_RESTART_RATE:local_triage")
+
+    def test_at_threshold_not_flagged(self):
+        """25% is the alert threshold — strictly above it fires."""
+        from evolution.lib.stage_gate import compute_gate_rates, gate_flags
+
+        rates = compute_gate_rates(self._recs(RESTART, ACCEPT, ACCEPT, ACCEPT))
+        assert rates["local_triage"]["stage_restart_rate"] == 0.25
+        assert gate_flags(rates) == []
+
+    def test_small_sample_not_flagged(self):
+        """One unlucky restart on a boundary that ran once is not 100% mis-tuned."""
+        from evolution.lib.stage_gate import compute_gate_rates, gate_flags
+
+        rates = compute_gate_rates(self._recs(RESTART))
+        assert gate_flags(rates) == []
+
+    def test_format_is_empty_without_rates(self):
+        from evolution.lib.stage_gate import format_gate_rates
+
+        assert format_gate_rates({}) == ""
+
+    def test_format_names_each_boundary(self):
+        from evolution.lib.stage_gate import compute_gate_rates, format_gate_rates
+
+        out = format_gate_rates(compute_gate_rates(self._recs(ACCEPT, REFINE)))
+        assert "[stage-gate]" in out
+        assert "local_triage" in out

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 try:
     from evolution.lib.stage_gate import decide as _gate_decide
+    from evolution.lib.stage_gate import record_decision as _gate_record
     from evolution.lib.stage_result import StageResult
 
     _HAS_STAGE_RESULT = True
@@ -191,6 +192,10 @@ def run_local_triage(evolution_dir: Path) -> dict:
         # on instead of being silently treated as a confident result.
         decision = _gate_decide(stage_result)
         output["stage_gate"] = decision.to_dict()
+        # Persist for the per-boundary rate metrics (#1340). Fire-and-forget:
+        # record_decision swallows IO errors so a metrics write can never take
+        # the triage pass down.
+        _gate_record(evolution_dir / "stage_gate.jsonl", decision)
     return output
 
 

--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -153,6 +153,28 @@ def compute_health(
             "HALTED: pipeline suspended — zero deliverables; clear halt-state.txt to resume"
         )
 
+    # Confidence-gate branch rates (#1340). Read from the decision ledger the
+    # gate appends to at each boundary (#1339). Surfaced as a flag rather than
+    # as an extra sidecar line on purpose: evolution_watchdog reads the WHOLE
+    # health file and alerts unless it ends in "| healthy", so an appended line
+    # would fire a permanent false alarm. Riding the existing flags list means a
+    # mis-tuned boundary reaches the owner through the channel that already
+    # works.
+    gate_rates: Dict[str, Any] = {}
+    try:
+        from evolution.lib.stage_gate import (
+            compute_gate_rates,
+            gate_flags,
+            load_decisions,
+        )
+
+        gate_rates = compute_gate_rates(
+            load_decisions(evolution_dir / "stage_gate.jsonl")
+        )
+        flags.extend(gate_flags(gate_rates))
+    except Exception:
+        gate_rates = {}
+
     return {
         "cycles_total": len(window),
         "cycles_active": len(active),
@@ -170,6 +192,7 @@ def compute_health(
         "merged_trend": _trend([_int(r, "merged") for r in active]),
         "effort_budget": effort_budget,
         "halted": halted,
+        "stage_gate_rates": gate_rates,
         "flags": flags,
     }
 
@@ -183,13 +206,22 @@ def format_health(h: Dict[str, Any]) -> str:
     # NOTE: effort_budget rides in the BODY, never the tail. evolution_watchdog
     # keys on `.endswith("| healthy")` / `| <FLAG>`, so the flags must stay the
     # last segment after the final `|`.
+    gate = ""
+    rates = h.get("stage_gate_rates") or {}
+    if rates:
+        # Same rule as effort_budget: body only, never the tail (#1340).
+        gate = " " + " ".join(
+            f"gate[{stage}]=refine {b['stage_refine_rate']:.0%}/"
+            f"restart {b['stage_restart_rate']:.0%} (n={b['total']})"
+            for stage, b in sorted(rates.items())
+        )
     return (
         f"[evolution-metrics] {h['cycles_active']}/{h['cycles_total']} active cycles: "
         f"success={_pct(h['cycle_success_rate'])} "
         f"selection_efficiency={_pct(h['selection_efficiency'])} "
         f"reject_rate={_pct(h['reject_rate'])} merged_trend={h['merged_trend']} "
         f"(created={h['issues_created']} selected={h['selected']} merged={h['merged']}) "
-        f"effort_budget={h['effort_budget']:.1f} | {tail}"
+        f"effort_budget={h['effort_budget']:.1f}{gate} | {tail}"
     )
 
 


### PR DESCRIPTION
Closes #1340 — slice C of the AREX loop (#1330), building on the gate merged for slice B (#1339).

## The gap

Slice B made the gate *decide*. Nothing recorded what it decided, so the loop could not be tuned — a gate nobody measures is a gate nobody can tune.

## Change

`evolution/lib/stage_gate.py` gains the observability half:

| Function | Role |
|---|---|
| `record_decision()` | append each `GateDecision` to `<evolution_dir>/stage_gate.jsonl` |
| `load_decisions()` | read it back, skipping malformed lines |
| `compute_gate_rates()` | per-boundary `stage_refine_rate` / `stage_restart_rate`, carrying `total` |
| `gate_flags()` | `HIGH_STAGE_RESTART_RATE` above 25% |
| `format_gate_rates()` | per-boundary summary line |

Two guards worth calling out:

- **`total` is carried alongside the rate** so a boundary that ran twice is not read as equivalent to one that ran two hundred times.
- **`gate_flags` requires 4 decisions** before flagging — otherwise one unlucky restart on a boundary that ran once reads as a 100% restart rate.

## Why it rides the flags list, not a new sidecar line

The issue says "surface in the evolution-health sidecar". The obvious implementation — appending a line — **would have broken the watchdog.** `evolution_watchdog.check_health` reads the *whole* file and alerts unless it ends in `| healthy`; an appended line means it never does, firing a permanent false alarm every cycle.

So the rates ride in the health line's **body** (next to `effort_budget`, which has the same constraint documented on it), and the alert rides the **existing flags list**. A mis-tuned boundary reaches the owner through the channel that already works, and nothing about the watchdog's contract changes.

`record_decision` swallows IO errors — instrumentation attached to a live pipeline boundary must not be able to take the stage down.

## Verified end to end

Four runs with a sidecar present:
```
... effort_budget=3.0 gate[local_triage]=refine 100%/restart 0% (n=4) | healthy
watchdog: no alerts
```

Four runs with none:
```
... gate[local_triage]=refine 0%/restart 100% (n=4) | HIGH_STAGE_RESTART_RATE:local_triage=100%
watchdog: ['pipeline health degraded: ...']
```

## Success criteria

- [x] `stage_refine_rate` and `stage_restart_rate` logged per boundary per cycle
- [x] Metrics appear in evolution-health sidecar
- [x] Alert threshold wired

31 passing in `test_stage_gate.py` (17 new); 170 across the metrics, watchdog, funnel, triage and analysis-gate suites.

One failure in that selection — `test_evolution_watchdog.py::test_real_escalation_ensures_issue` — is a **pre-existing suite-order issue**: it passes alone, and reproduces identically on clean `main` with the same selection. Not introduced here. Ruff clean.
