### PR TITLE
fix: two review defects — dead-end detector silent on alternating calls, recovery metric counted deflection

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -512,28 +512,33 @@ def detect_dead_end_loop(
             signatures[key] += 1
             sig_to_tool[key] = name
 
-    # Find the most-repeated identical call.
     if not signatures:
         return None
-    top_key, top_count = signatures.most_common(1)[0]
+
+    # Gate on the signature the agent is issuing RIGHT NOW, and on ITS OWN count.
+    #
+    # Two separate requirements, and both matter:
+    #
+    # * Liveness — counting across the whole window would flag a run the agent
+    #   has already moved on from: 5x terminal followed by a read_file, or 8x
+    #   terminal followed by a text reply, are treated as progress everywhere
+    #   else in this module (see TestRunBoundaries). A turn calling several
+    #   DIFFERENT tools at once is varied work, so it does not count either.
+    #
+    # * Its own count, NOT the window's most-repeated one. Ranking by
+    #   ``most_common`` and then requiring that winner to be live silently
+    #   disabled the detector whenever the agent alternated between two stuck
+    #   calls: with `pytest` and `ruff` each re-issued four times, the counter
+    #   returns `pytest` (insertion order breaks the tie), the latest turn is
+    #   `ruff`, the two do not match, and a textbook dead end went unreported.
+    key = _last_call_signature(scan)
+    if key is None:
+        return None
+    top_count = signatures.get(key, 0)
     if top_count < _DEAD_END_REPEAT_THRESHOLD:
         return None
 
-    # The repeated signature must be what the agent is doing RIGHT NOW.
-    #
-    # Counting across the whole window would flag a run the agent has already
-    # moved on from: 5x terminal followed by a read_file, or 8x terminal
-    # followed by a text reply, are treated as progress everywhere else in this
-    # module (see TestRunBoundaries) — the agent broke the pattern by itself and
-    # needs no nudge. Only when the latest tool turn re-issues the repeated
-    # signature is the loop still live.
-    #
-    # A turn calling several DIFFERENT tools at once is varied work, not a
-    # spiral, so it does not count as a live re-issue either.
-    if _last_call_signature(scan) != top_key:
-        return None
-
-    tool = sig_to_tool[top_key]
+    tool = sig_to_tool[key]
     return (
         f"[loop-guard] DEAD-END DETECTED (#1312): You have re-issued `{tool}` "
         f"with the SAME arguments {top_count} times. This is a dead-end loop, "

--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -122,14 +122,44 @@ _REFUSAL_RE = re.compile(
 # #1356 look effective when it is not, which is worse than under-counting.
 _RECOVERY_RE = re.compile(
     r"\b("
-    r"instead|alternative(ly)?|workaround|another (way|approach|option)|"
-    r"different (way|approach|path)|"
-    r"(but|however|though)[^.!?]{0,40}\b(i|we|you) (can|could|"
-    r"'ll|will|am able to)|"
-    r"what i can do|here'?s what i can|i can (still|however)"
+    r"instead[,:]? (i|we|let)|alternatively[,:]? (i|we|let)|"
+    r"workaround|another (way|approach|option)|different (way|approach|path)|"
+    r"(but|however|though)[^.!?]{0,40}\b(i|we) (can|could|'ll|will|am able to)|"
+    r"what i can do|here'?s what i can|i can (still|however)|"
+    r"let me (try|use|write|search|run)|i'?ll (try|use|write|search|run)"
     r")\b",
     re.IGNORECASE,
 )
+
+# Two shapes match the pivot above but are NOT the agent taking another path,
+# and counting them would make #1356 look effective precisely when it failed:
+#
+#   * DEFLECTION — the work is handed back to the human ("however you can try
+#     it yourself", "instead, please contact support"). The pivot clause is
+#     therefore first-person only above; this vetoes the rest.
+#   * EXPLANATION — the agent offers to describe the problem rather than solve
+#     it ("but I can tell you why it failed"). An explanation is not an
+#     alternative path to the goal.
+#
+# Vetoing beats narrowing the recovery pattern: the shapes are open-ended, and
+# under-counting a real recovery is far cheaper than reporting a refusal rate
+# that improves whenever the agent gets more polite about giving up.
+_NON_RECOVERY_RE = re.compile(
+    r"\b("
+    r"contact (support|your|the)|ask (your|someone|a )|"
+    r"you (can|could|should|will|may|might|'ll) |your (own|side|end)|"
+    r"(do|try|run|check) (it|this|that) yourself|manually|"
+    r"(tell|explain to|show) you (why|what|how) (it|this|that)? ?(failed|went|is|does)|"
+    r"i can (only )?(tell|explain|describe|suggest that you)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _is_recovered_refusal(text: str) -> bool:
+    """True when a refusing turn also proposes a path the AGENT will take."""
+    return bool(_RECOVERY_RE.search(text)) and not _NON_RECOVERY_RE.search(text)
+
 _REPEAT_THRESHOLD = 5  # same tool >=N consecutive in a session is a "repeated run"
 
 # --- failure-reason taxonomy (issue #1325) ----------------------------------
@@ -373,7 +403,7 @@ def scan_messages(messages) -> Dict[str, Any]:
             if isinstance(content, str) and _REFUSAL_RE.search(content):
                 refusals += 1
                 # Did the same turn also offer a way forward? (#1366)
-                if _RECOVERY_RE.search(content):
+                if _is_recovered_refusal(content):
                     refusals_recovered += 1
         elif role == "tool":
             content = obj.get("content")

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -59,20 +59,23 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    text out of the model entirely (complements the PII gate #82).
 
    **Compare rates, never raw counts (#1324).** The digest also emits
-   `failure_rate` (failures ÷ sessions_scanned) and `spiral_depth_per_session`.
-   Session volume grows cycle over cycle, so a raw `tool_failures` count rises
-   even when the per-session rate holds steady or improves — comparing raw
-   counts across windows manufactures false "regressed" verdicts. Use
-   `failure_rate` for every cross-window comparison; `tool_failures` is retained
-   only for back-compat and for within-window ranking.
+   `failure_rate` and `spiral_depth_per_session`, both keyed by tool exactly
+   like `tool_failures` — `failure_rate[tool]` is that tool's failures ÷
+   `sessions_scanned`, not one number for the whole digest. Session volume grows
+   cycle over cycle, so a raw `tool_failures` count rises even when the
+   per-session rate holds steady or improves — comparing raw counts across
+   windows manufactures false "regressed" verdicts. Use `failure_rate` for every
+   cross-window comparison; `tool_failures` is retained only for back-compat and
+   for within-window ranking.
 
    **Attribute by (tool, reason), not by tool alone (#1325).** The digest emits
-   `tool_failures_by_reason` — `{tool: {reason: count}}` over the buckets
-   `file-not-found`, `permission-denied`, `timeout`, `quota`, `parse-error`,
-   `no-match`, `non-zero-exit`, `other`. A fix for `read_file:file-not-found`
-   must not be credited or blamed for `read_file:timeout`; conflating them is
-   what produced the fix→regress→refile treadmill. When filing or verifying an
-   issue about a failing tool, name the reason bucket, not just the tool.
+   `tool_failures_by_reason` — `{tool: {reason: count}}` over exactly these
+   buckets: `file-not-found`, `permission-denied`, `timeout`, `quota/billing`,
+   `parse-error`, `no-match`, `non-zero-exit`, `other`. A fix for
+   `read_file:file-not-found` must not be credited or blamed for
+   `read_file:timeout`; conflating them is what produced the fix→regress→refile
+   treadmill. When filing or verifying an issue about a failing tool, name the
+   reason bucket, not just the tool.
 
 2. **Detect problem signals** (non-exhaustive):
    - **Tool failures** — a tool returned an error / non-zero / exception,
@@ -126,10 +129,13 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
      ledger entry carries a `baseline_failure_rate` (recorded at merge time),
      compare it against the current digest's `failure_rate` for that tool rather
      than eyeballing raw `tool_failures`. `classify_verdict_by_rate()` in
-     `scripts/evolution_realized_impact.py` implements the thresholds — a rate
-     rise >20% is `regressed`, a drop >5% is `confirmed`, anything between is
-     stable. A raw count that grew purely because session volume grew is NOT a
-     regression, and calling it one re-opens issues that were actually fixed.
+     `scripts/evolution_realized_impact.py` is the reference: it returns
+     `regressed` only when the per-session rate rose more than 20% over the
+     baseline, `confirmed` otherwise (a fall, a hold, or a rise within 20%), and
+     `no-signal` when either rate is missing. There is no separate "stable"
+     verdict — the ledger has three values only. A raw count that grew purely
+     because session volume grew is NOT a regression, and calling it one
+     re-opens issues that were actually fixed.
    - Record ONE verdict per such issue via the deterministic helper:
      ```bash
      python3 scripts/evolution_realized_impact.py record-verdict \

--- a/tests/agent/test_dead_end_loop.py
+++ b/tests/agent/test_dead_end_loop.py
@@ -146,3 +146,44 @@ class TestDetectDeadEndLoop:
         # ARE within the last 60 messages and should trigger.
         result = detect_dead_end_loop(msgs)
         assert result is not None
+
+
+class TestAlternatingCallsAreStillDeadEnds:
+    """Two stuck calls alternating is a dead end, not variety.
+
+    Regression for a defect found in review: the check ranked the window by
+    `most_common` and then required THAT winner to be the live one. With two
+    signatures re-issued four times each, the counter returns the first-inserted
+    on a tie while the latest turn is the other — they never matched, and a
+    textbook dead end went unreported. The gate is now on the live signature's
+    OWN count.
+    """
+
+    @staticmethod
+    def _alternating(n: int) -> list[dict]:
+        msgs: list[dict] = []
+        for i in range(n):
+            msgs.append(_make_tool_call("terminal", '{"command": "pytest"}', f"a{i}"))
+            msgs.append(_make_tool_result(f"a{i}", "FAIL"))
+            msgs.append(_make_tool_call("terminal", '{"command": "ruff check"}', f"b{i}"))
+            msgs.append(_make_tool_result(f"b{i}", "FAIL"))
+        return msgs
+
+    def test_alternating_pair_at_threshold_fires(self):
+        result = detect_dead_end_loop(self._alternating(4))
+        assert result is not None
+        assert "4 times" in result
+
+    def test_alternating_pair_below_threshold_is_quiet(self):
+        assert detect_dead_end_loop(self._alternating(3)) is None
+
+    def test_fires_on_the_live_signature_not_the_most_common(self):
+        """The nudge must describe the call being re-issued now."""
+        msgs = self._alternating(3)
+        # one extra `ruff` so it is BOTH the live call and above threshold,
+        # while `pytest` sits one below.
+        msgs.append(_make_tool_call("terminal", '{"command": "ruff check"}', "z"))
+        msgs.append(_make_tool_result("z", "FAIL"))
+        result = detect_dead_end_loop(msgs)
+        assert result is not None
+        assert "4 times" in result

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -798,3 +798,53 @@ class TestRefusalRecovery:
         """Back-compat: the recovered subset must not alter the aggregate."""
         _session(tmp_path, "a", [self._reply("I can't do X, but I can do Y instead.")])
         assert build_digest(tmp_path, window_days=7)["signals"]["refusals_or_access_denied"] == 1
+
+
+class TestRefusalRecoveryFalsePositives:
+    """Deflection and explanation are not recovery.
+
+    Regression for a defect found in review: the pivot clause allowed second
+    person, so "I can't access it, however you can try it yourself" counted as
+    a recovery. That inverts the metric — it would improve whenever the agent
+    got more polite about handing the work back, which is the exact behaviour
+    #1327 wants to eliminate.
+    """
+
+    @staticmethod
+    def _reply(text):
+        return {"role": "assistant", "content": text}
+
+    def _recovered(self, tmp_path, text, name="s"):
+        p = _session(tmp_path, name, [self._reply(text)])
+        s = scan_session(p)
+        assert s["refusals"] == 1, "fixture must actually refuse"
+        return s["refusals_with_recovery"]
+
+    def test_deflection_to_user_is_not_recovery(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "I can't access that URL, however you can try visiting it yourself."
+        ) == 0
+
+    def test_deflection_to_support_is_not_recovery(self, tmp_path):
+        assert self._recovered(tmp_path, "I cannot do that. Instead, please contact support.") == 0
+
+    def test_manual_handoff_is_not_recovery(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "I don't have permission. But you will need to run it manually."
+        ) == 0
+
+    def test_offering_an_explanation_is_not_recovery(self, tmp_path):
+        assert self._recovered(tmp_path, "I can't do that, but I can tell you why it failed.") == 0
+
+    def test_first_person_alternative_still_counts(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "I can't use grep directly, but I can search with a regex pattern."
+        ) == 1
+
+    def test_let_me_phrasing_counts(self, tmp_path):
+        assert self._recovered(tmp_path, "I cannot do X. Let me try Y instead.") == 1
+
+    def test_ill_write_a_script_counts(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "I can't call the API directly. I'll write a script via terminal."
+        ) == 1


### PR DESCRIPTION
Two defects found in post-merge review of work merged earlier today. Both are in code I wrote or repaired, both are confirmed by reproduction, and both would have degraded the signal the evolution loop runs on.

Independently flagged by a cross-provider review (Gemini via consilium) and then reproduced locally before fixing.

---

## 1. Dead-end detector went silent on alternating calls — `agent/loop_guard.py`

Repairing #1349 I added a liveness requirement: the repeated signature must be re-issued by the latest tool turn. That part is right — `5x terminal` then a `read_file`, or `8x terminal` then a text reply, count as progress everywhere else in that module (`TestRunBoundaries`).

**What was wrong is the order of operations.** The code ranked the window with `most_common(1)` and *then* required that winner to be live. When the agent alternates between two stuck calls, those two conditions select different signatures:

```
pytest, ruff, pytest, ruff, pytest, ruff, pytest, ruff   (each x4)
  most_common(1) -> "pytest"   (insertion order breaks the tie)
  live signature -> "ruff check"
  -> no match -> SILENT
```

Both calls are four-deep in identical re-issues. That is exactly the dead end #1312 exists to catch, and it went unreported.

**Fix:** look up the live signature first, gate on *its own* count. Liveness requirement unchanged.

New `TestAlternatingCallsAreStillDeadEnds` covers: fires at threshold, quiet below it, and names the live call rather than the most-common one.

---

## 2. Refusal-recovery counted deflection and explanation — `scripts/introspection_extract.py`

The pivot clause in `_RECOVERY_RE` allowed second person. So handing the work back to the human counted as a recovery:

| Text | Was counted | Actually |
|---|---|---|
| "I can't access that URL, however **you can** try visiting it yourself." | recovered | deflection |
| "I cannot do that. **Instead, please contact support**." | recovered | deflection |
| "I don't have permission. But **you will** need to run it **manually**." | recovered | deflection |
| "I can't do that, but **I can tell you why** it failed." | recovered | explanation, not an alternative path |

This inverts the metric: it improves whenever the agent gets *more polite about giving up* — the precise behaviour #1327 exists to eliminate.

**Fix:** pivot clause is first-person only, plus a `_NON_RECOVERY_RE` veto for deflection (`contact support`, `you can`, `yourself`, `manually`) and explanation-instead-of-action (`I can tell you why`). Vetoing beats narrowing the recovery pattern — these shapes are open-ended, and under-counting a real recovery is far cheaper than a rate that rises when the agent gives up nicely. Also adds first-person phrasings the original missed (`let me try`, `I'll write`).

### Measured impact on the real corpus

Same 4629 sessions, same 143 refusals:

```
before:  51 recovered   rate 0.3566
after:   31 recovered   rate 0.2168
```

**20 of the 51 were false positives — the headline number was inflated by ~64%.** The 21.7% figure is the one Child C (#1327 recovery dispatcher) should be measured against.

---

107 passing across the four loop-guard suites; 50 in `test_introspection_extract.py` (7 new). Ruff clean on all four files.

Refs #1312, #1366.
