### PR TITLE
feat: enrich deferrable-tool error + validate sub-agent tool lists (#1392, #1387)

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -715,6 +715,31 @@ class TestRegression_OpenClawCron84141:
         assert err is not None
         assert "not a deferrable" in err
 
+    def test_not_deferrable_error_for_core_tool_has_direct_hint(self):
+        """#1392 -- the error for a known core tool should say 'call it directly'
+        AND include a non-terminal fallback so the agent changes strategy."""
+        from tools.tool_search import resolve_underlying_call
+        _, _, err = resolve_underlying_call({
+            "name": "terminal",
+            "arguments": {"command": "echo hi"},
+        })
+        assert err is not None
+        assert "not a deferrable" in err
+        assert "core tool" in err
+        assert "call it directly" in err
+        assert "read_file" in err  # fallback alternative
+
+    def test_not_deferrable_error_for_unknown_tool_no_alt(self):
+        """#1392 -- unknown tools get the generic message without an alt hint."""
+        from tools.tool_search import resolve_underlying_call
+        _, _, err = resolve_underlying_call({
+            "name": "totally_made_up_tool",
+            "arguments": {},
+        })
+        assert err is not None
+        assert "not a deferrable" in err
+        assert "core tool" not in err
+
 
 class TestRegression_ToolsetScoping:
     """A restricted-toolset session must not see or invoke out-of-scope tools.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1766,6 +1766,22 @@ def _build_child_agent(
         iteration_budget=None,  # fresh budget per subagent
         **child_optional_kwargs,
     )
+    # #1387 — Validate the child resolved to at least 1 tool.  If toolset
+    # resolution (intersection, blocked-tool stripping, role filtering)
+    # reduced the effective toolset to nothing, the child would launch with
+    # no tools and immediately spiral with "I have no [tool]" refusals until
+    # the turn limit.  Fail fast with a structured error naming what was
+    # requested vs. what survived so the parent can correct the delegation.
+    _child_tools = getattr(child, "valid_tool_names", None) or []
+    if not _child_tools:
+        requested_str = ", ".join(toolsets) if toolsets else "(inherited from parent)"
+        raise ValueError(
+            f"Sub-agent toolset resolved to 0 tools. "
+            f"Requested toolsets: {requested_str}. "
+            f"Effective child toolsets after filtering: {child_toolsets}. "
+            f"Check that the specified toolsets exist and are not all blocked."
+        )
+
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
@@ -3177,6 +3193,12 @@ def delegate_task(
                 )
                 child._live_transcript_path = str(_writer.path)
             children.append((i, t, child))
+    except ValueError as _build_err:
+        # #1387 — a child's toolset resolved to 0 tools; return a structured
+        # tool error so the parent agent sees the problem instead of
+        # propagating an unhandled exception.
+        _model_tools._last_resolved_tool_names = _parent_tool_names
+        return tool_error(str(_build_err))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1085,11 +1085,54 @@ def resolve_underlying_call(
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name, config):
-        return None, {}, (
-            f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
-            "list already, call it directly instead of via tool_call."
-        )
+        return None, {}, _not_deferrable_error(name, config)
     return name, raw_args, None
+
+
+# Core-tool → non-terminal alternative mapping (#1392). When an agent in a
+# restricted context (subagent, cron) tries to invoke a core tool via
+# tool_call, suggest the appropriate alternative that IS available.
+_NON_TERMINAL_ALTERNATIVES: Dict[str, str] = {
+    "terminal": (
+        "For filesystem operations, use read_file, write_file, or search_files. "
+        "For code execution, use execute_code."
+    ),
+    "delegate_task": "Sub-agents cannot spawn further sub-agents (nesting is off).",
+    "process": "Sub-agents cannot manage background processes.",
+    "send_message": "Sub-agents cannot send messages to the user.",
+}
+
+
+def _not_deferrable_error(
+    name: str,
+    config: Optional[ToolSearchConfig] = None,
+) -> str:
+    """Build an actionable error for tool_call on a non-deferrable tool (#1392).
+
+    The previous generic message left the agent looping because it gave no
+    fallback.  Now:
+    * If the name is a known core tool (terminal, read_file, ...), tell the agent
+      to call it directly -- it is in the model-facing tools list.
+    * If the tool is commonly absent in restricted contexts (subagent, cron),
+      suggest the non-terminal alternative so the agent changes strategy.
+    """
+    is_core = name in _hermes_core_tools()
+    alt = _NON_TERMINAL_ALTERNATIVES.get(name)
+
+    parts = [f"'{name}' is not a deferrable tool."]
+    if is_core:
+        parts.append(
+            "It is a core tool -- call it directly from the tools list "
+            "instead of via tool_call."
+        )
+    else:
+        parts.append(
+            "If it appears in the model-facing tools list already, "
+            "call it directly instead of via tool_call."
+        )
+    if alt:
+        parts.append(alt)
+    return " ".join(parts)
 
 
 def clear_describe_cache() -> None:


### PR DESCRIPTION
Automated evolution PR for issues #1392 and #1387.

## #1392: Enrich 'not a deferrable tool' error
Agents repeatedly try terminal via tool_call (57 errors/7d). Added core-tool hint + non-terminal fallback alternatives.

## #1387: Validate sub-agent tool lists
When toolset resolution reduces to 0 tools, child would spiral. Now fails fast with structured error.

## Files
- tools/tool_search.py: _not_deferrable_error() + _NON_TERMINAL_ALTERNATIVES
- tools/delegate_tool.py: post-build validation + ValueError catch
- tests/tools/test_tool_search.py: 2 new tests

## Checks
lint pass, tests 95 passed (70 tool_search + 25 delegate)

Closes #1392
Closes #1387