### PR TITLE
fix: actionable error for non-deferrable tool_call attempts (Closes #1392)

### DIFF
--- a/tests/tools/test_non_deferrable_error.py
+++ b/tests/tools/test_non_deferrable_error.py
@@ -1,0 +1,100 @@
+"""Tests for the enriched non-deferrable tool_call error path (#1392).
+
+When agents (especially subagents without terminal per #1307) try to invoke
+a core tool via tool_call, the error must guide recovery instead of a generic
+"not a deferrable tool" that triggers retry loops (57 errors/7d).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tools.tool_search import (
+    ToolSearchConfig,
+    _non_deferrable_error,
+    _CORE_TOOL_ALTERNATIVES,
+    resolve_underlying_call,
+)
+
+
+class TestNonDeferrableError:
+    """Verify the error message is actionable for the agent (#1392)."""
+
+    def _mock_core(self, tools: frozenset):
+        return patch("tools.tool_search.effective_core_tool_names",
+                      return_value=tools)
+
+    def test_terminal_unavailable_shows_alternatives(self):
+        with self._mock_core(frozenset({"read_file", "write_file", "patch"})):
+            msg = _non_deferrable_error("terminal")
+        assert "terminal" in msg
+        assert "not available in this environment" in msg
+        for alt in ("search_files", "read_file", "patch", "delegate_task"):
+            assert alt in msg, f"Missing alternative {alt}: {msg}"
+
+    def test_terminal_available_says_call_directly(self):
+        with self._mock_core(frozenset({"terminal", "read_file"})):
+            msg = _non_deferrable_error("terminal")
+        assert "core tool" in msg
+        assert "Call it directly" in msg
+        assert "tool_call" in msg
+
+    def test_execute_code_unavailable_shows_delegate(self):
+        with self._mock_core(frozenset({"read_file"})):
+            msg = _non_deferrable_error("execute_code")
+        assert "execute_code" in msg and "not available" in msg
+        assert "delegate_task" in msg
+
+    def test_browser_navigate_unavailable_shows_web_tools(self):
+        with self._mock_core(frozenset({"read_file"})):
+            msg = _non_deferrable_error("browser_navigate")
+        assert "browser_navigate" in msg and "not available" in msg
+        assert "web_search" in msg and "web_extract" in msg
+
+    def test_unknown_tool_generic_message(self):
+        msg = _non_deferrable_error("xx_definitely_not_a_tool_xx")
+        assert "not a deferrable tool" in msg
+        assert "tool_search" in msg or "call it directly" in msg
+
+    def test_case_insensitive_lookup_preserves_name(self):
+        with self._mock_core(frozenset({"Terminal"})):
+            msg = _non_deferrable_error("Terminal")
+        assert "core tool" in msg and "Call it directly" in msg
+
+    def test_all_alternatives_have_recovery_guidance(self):
+        """Every entry in _CORE_TOOL_ALTERNATIVES must mention at least one
+        alternative tool name so the agent can change strategy."""
+        for tool_name in _CORE_TOOL_ALTERNATIVES:
+            with self._mock_core(frozenset()):
+                msg = _non_deferrable_error(tool_name)
+            assert tool_name in msg and "not available" in msg
+            assert any(a in msg for a in (
+                "search_files", "read_file", "patch", "write_file",
+                "delegate_task", "web_search", "web_extract", "terminal",
+            )), f"No recovery tools in message for {tool_name}: {msg}"
+
+
+class TestResolveUnderlyingCallError:
+    """Integration: resolve_underlying_call returns the enriched error."""
+
+    def test_terminal_returns_enriched_error(self):
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        _name, _args, err = resolve_underlying_call(
+            {"name": "terminal", "arguments": {}}, cfg)
+        assert err is not None
+        # Must NOT be the old generic-only message.
+        assert "tool_search" in err or "not available" in err or \
+               "Call it directly" in err, f"Not enriched: {err}"
+
+    def test_unknown_tool_returns_error(self):
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        _name, _args, err = resolve_underlying_call(
+            {"name": "xx_not_a_tool", "arguments": {}}, cfg)
+        assert err is not None and "not a deferrable" in err
+
+    def test_available_core_tool_mentions_direct_call(self):
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        _name, _args, err = resolve_underlying_call(
+            {"name": "read_file", "arguments": {}}, cfg)
+        assert err is not None
+        assert "call it directly" in err.lower() or "Call it directly" in err or \
+               "tool_search" in err, f"Not actionable: {err}"

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1085,11 +1085,83 @@ def resolve_underlying_call(
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name, config):
-        return None, {}, (
-            f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
-            "list already, call it directly instead of via tool_call."
-        )
+        return None, {}, _non_deferrable_error(name, config)
     return name, raw_args, None
+
+
+# ── #1392 — actionable error for non-deferrable tool_call attempts ───────
+# When an agent (especially in a subagent/cron context where terminal is
+# unavailable per #1307) tries to invoke a core tool via tool_call, the
+# generic "is not a deferrable tool" message gave no recovery guidance and
+# the agent retried the same pattern in a loop (57 errors/7d).  The enriched
+# message below distinguishes two cases:
+#
+# 1. The tool IS in the effective core set and should be called directly
+#    (it is in the model-visible tools array — the agent just used the wrong
+#    bridge).  Tell it to call the tool directly.
+# 2. The tool is a known core tool but NOT in the current environment's
+#    effective core set (e.g. terminal in a subagent that has no terminal
+#    toolset).  Explain that the tool is unavailable in this environment and
+#    suggest concrete alternatives so the agent changes strategy instead of
+#    retrying.
+
+# Alternatives for common core tools that subagents frequently lack.
+# Keys are lowercased tool names; values are human-readable suggestions.
+_CORE_TOOL_ALTERNATIVES: Dict[str, str] = {
+    "terminal": (
+        "terminal is not available in this environment. "
+        "Use search_files for finding files, read_file for reading file contents, "
+        "patch for editing files, write_file for creating files, or delegate_task "
+        "to spawn a subagent that has terminal access."
+    ),
+    "execute_code": (
+        "execute_code is not available in this environment. "
+        "Use delegate_task to spawn a subagent that has code execution access, "
+        "or use terminal if available."
+    ),
+    "browser_navigate": (
+        "browser_navigate is not available in this environment. "
+        "Use web_search for search queries, web_extract for fetching page content, "
+        "or delegate_task to spawn a subagent that has browser access."
+    ),
+}
+
+
+def _non_deferrable_error(name: str, config: Optional[ToolSearchConfig] = None) -> str:
+    """Build an actionable error message for a non-deferrable tool_call attempt.
+
+    The message guides the agent to the correct recovery path instead of
+    leaving it to retry the same failed pattern (#1392).
+    """
+    lower = name.lower()
+
+    # Case 2: known core tool that may be unavailable in this environment.
+    if lower in _CORE_TOOL_ALTERNATIVES:
+        # Check whether the tool is in the effective core set (i.e. visible
+        # in the current tools array).  If it is, the agent should call it
+        # directly.  If not, it's genuinely unavailable — suggest alternatives.
+        effective = effective_core_tool_names(config)
+        if name in effective:
+            return (
+                f"'{name}' is a core tool, not a deferrable tool. "
+                "Call it directly — it is already in your tools list. "
+                "Do not use tool_call for core tools."
+            )
+        # Tool is a known core tool but not in this environment's toolset.
+        return (
+            f"'{name}' is not a deferrable tool and is not available in this "
+            f"environment. {_CORE_TOOL_ALTERNATIVES[lower]}"
+        )
+
+    # Case 1: any other non-deferrable tool (visible core tool, bridge tool,
+    # or unresolvable name).  Tell the agent to call it directly if visible
+    # or check spelling.
+    return (
+        f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
+        "list already, call it directly instead of via tool_call. "
+        "If it is not in your tools list, check the spelling or use tool_search "
+        "to find available deferred tools."
+    )
 
 
 def clear_describe_cache() -> None:
@@ -1121,5 +1193,7 @@ __all__ = [
     "resolve_underlying_call",
     "validate_tool_args",
     "scoped_deferrable_names",
+    "_non_deferrable_error",
+    "_CORE_TOOL_ALTERNATIVES",
     "clear_describe_cache",
 ]


### PR DESCRIPTION
## Summary

When agents (especially subagents without terminal per #1307) try to invoke a core tool via `tool_call`, the generic *"is not a deferrable tool"* message gave no recovery guidance. Agents retried the same pattern in a loop — **57 errors in 7 days**, making `tool_call` the #1 failure signal.

## Fix

Enriched the `resolve_underlying_call` error path in `tools/tool_search.py` to distinguish three cases:

1. **Core tool IS available** (in the effective core set) → *"call it directly — do not use tool_call for core tools"*
2. **Core tool NOT available** (e.g. `terminal` in a subagent without the terminal toolset) → names the tool, explains it is unavailable in this environment, and lists **concrete alternatives** (`search_files`, `read_file`, `patch`, `write_file`, `delegate_task`)
3. **Unknown tool** → generic message with a `tool_search` hint

The alternatives map (`_CORE_TOOL_ALTERNATIVES`) covers `terminal`, `execute_code`, and `browser_navigate` — the three core tools subagents most frequently lack.

## Files

- `tools/tool_search.py` — `_non_deferrable_error()` function + `_CORE_TOOL_ALTERNATIVES` dict (76 lines)
- `tests/tools/test_non_deferrable_error.py` — 10 tests covering all three cases (102 lines)

## Validation

- `ruff check` ✓
- `ruff format --check` ✓  
- `pytest tests/tools/test_non_deferrable_error.py` — 10 passed ✓
- `pytest tests/tools/test_tool_search.py` — 68 passed ✓ (no regressions)
- Total diff: 182 lines (under 200-line autonomous merge cap)

Closes #1392