### PR TITLE
fix: stop writing successful cron jobs to failures/ directory (Closes #1390)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4883,11 +4883,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 )
             except Exception as fe:
                 logger.error("Could not save cron failure record: %s", fe)
-        else:
-            try:
-                save_job_failure(job, success=True, output=output)
-            except Exception:
-                pass
+        # Successful jobs are NOT written to failures/ — that directory is for
+        # failure records only.  Writing success=true records there drowned real
+        # failures in noise (~100 of ~109 files were success records) and made
+        # the digest/filtering useless.  The success "marker" pattern is
+        # redundant: run_job_output already persists output and the cron DB
+        # tracks last_run_status.  Fix for #1390.
 
         # Deliver the final response to the origin/target chat.
         # If the agent responded with [SILENT], skip delivery (but

--- a/tests/cron/test_cron_failure_logging.py
+++ b/tests/cron/test_cron_failure_logging.py
@@ -117,7 +117,8 @@ def test_run_one_job_writes_failure_record_on_agent_failure(monkeypatch):
     assert latest["last_output"] == "agent output"
 
 
-def test_run_one_job_writes_success_marker(monkeypatch):
+def test_run_one_job_does_not_write_success_record(monkeypatch):
+    """#1390: successful jobs must NOT be written to failures/ directory."""
     def fake_run_job(job):
         return True, "all good", "final response", None
 
@@ -130,9 +131,9 @@ def test_run_one_job_writes_success_marker(monkeypatch):
 
     scheduler.run_one_job({"id": "j5", "name": "ok job"})
 
+    # No failure record should exist for a successful job
     latest = jobs.get_latest_failure("j5")
-    assert latest is not None
-    assert latest["success"] is True
+    assert latest is None
 
 
 def test_failure_digest_disabled_by_default(monkeypatch):


### PR DESCRIPTION
Automated evolution PR for issue #1390.

## Problem

The `else` branch in `run_one_job` called `save_job_failure(job, success=True, output=output)` for every successful cron job, writing success records to the `failures/` directory. This drowned real failures in noise — ~100 of ~109 files in `failures/` were success records, making the directory and the failure digest essentially useless.

## Fix

Removed the `else` branch that wrote success=true records. The success "marker" was redundant:
- `run_job_output` already persists job output to `output/` 
- The cron DB tracks `last_run_status`

## Changes

- `cron/scheduler.py`: Deleted the `else` branch (5 lines) that called `save_job_failure(job, success=True, ...)`
- `tests/cron/test_cron_failure_logging.py`: Updated `test_run_one_job_writes_success_marker` → `test_run_one_job_does_not_write_success_record` verifying successful jobs do NOT create failure records

## Validation

- Lint: ✓ (ruff check + format)
- Tests: 9/9 passed (`tests/cron/test_cron_failure_logging.py`)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>