### PR TITLE
fix: stop cron success-flooding failures/ + dedup MCP park-warning (#1390, #1391)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4859,10 +4859,14 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 "(tool subprocess was killed mid-flight)."
             )
 
-        # Persist a failure record whenever a job fails or the agent returns an
+        # Persist a failure record ONLY when a job fails or the agent returns an
         # empty response. This is the per-job audit trail that makes silent
-        # failures visible; successful runs overwrite the latest record so the
-        # digest only shows current problems.
+        # failures visible. Successful runs used to overwrite the latest record
+        # so the digest only showed current problems, but in practice this
+        # flooded failures/ with success=true records (~100 of ~109 files),
+        # making the directory useless for identifying real failures (#1390).
+        # build_cron_failure_digest() already filters on success=False, so
+        # writing success records here served no purpose.
         if not success:
             tb = traceback.format_exc() if sys.exc_info()[0] is not None else None
             try:
@@ -4883,11 +4887,6 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 )
             except Exception as fe:
                 logger.error("Could not save cron failure record: %s", fe)
-        else:
-            try:
-                save_job_failure(job, success=True, output=output)
-            except Exception:
-                pass
 
         # Deliver the final response to the origin/target chat.
         # If the agent responded with [SILENT], skip delivery (but

--- a/tests/cron/test_cron_failure_logging.py
+++ b/tests/cron/test_cron_failure_logging.py
@@ -117,7 +117,12 @@ def test_run_one_job_writes_failure_record_on_agent_failure(monkeypatch):
     assert latest["last_output"] == "agent output"
 
 
-def test_run_one_job_writes_success_marker(monkeypatch):
+def test_run_one_job_skips_failure_record_on_success(monkeypatch):
+    """Successful jobs must NOT write to failures/ (#1390).
+
+    Previously, success=true records flooded the directory making it useless.
+    Now only genuine failures get persisted.
+    """
     def fake_run_job(job):
         return True, "all good", "final response", None
 
@@ -131,8 +136,8 @@ def test_run_one_job_writes_success_marker(monkeypatch):
     scheduler.run_one_job({"id": "j5", "name": "ok job"})
 
     latest = jobs.get_latest_failure("j5")
-    assert latest is not None
-    assert latest["success"] is True
+    # No failure record should exist for a successful job
+    assert latest is None
 
 
 def test_failure_digest_disabled_by_default(monkeypatch):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1911,6 +1911,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries",
+        "_last_park_error",
     )
 
     def __init__(self, name: str):
@@ -1933,6 +1934,12 @@ class MCPServerTask:
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
         self._reconnect_retries: int = 0
+        # Tracks the last error string logged at the "parking" WARNING so that
+        # subsequent identical park-warnings are downgraded to DEBUG. Without
+        # this, a server that never recovers logs the same WARNING every
+        # _PARKED_RETRY_INTERVAL, flooding errors.log with hundreds of
+        # duplicate lines (#1391).
+        self._last_park_error: Optional[str] = None
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -2550,7 +2557,9 @@ class MCPServerTask:
                     # so transient prior failures do not accumulate toward
                     # permanent parking (#57604).
                     self._reconnect_retries = 0
-                    # stdio transport does not use OAuth, but we still honor
+                    # Server recovered — clear the dedup key so the next
+                    # outage logs a fresh WARNING (#1391).
+                    self._last_park_error = None
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
                     return await self._wait_for_lifecycle_event()
@@ -3217,12 +3226,26 @@ class MCPServerTask:
 
                 self._reconnect_retries += 1
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
-                    logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "parking; will self-probe every %ds until it recovers: %s",
-                        self.name, _MAX_RECONNECT_RETRIES,
-                        _PARKED_RETRY_INTERVAL, exc,
-                    )
+                    # Deduplicate the parking warning: the first time a given
+                    # error is seen it logs at WARNING; subsequent identical
+                    # errors (every _PARKED_RETRY_INTERVAL until recovery)
+                    # are downgraded to DEBUG to avoid flooding errors.log
+                    # with hundreds of identical lines (#1391).
+                    error_str = str(exc)
+                    if error_str != self._last_park_error:
+                        self._last_park_error = error_str
+                        logger.warning(
+                            "MCP server '%s' failed after %d reconnection attempts, "
+                            "parking; will self-probe every %ds until it recovers: %s",
+                            self.name, _MAX_RECONNECT_RETRIES,
+                            _PARKED_RETRY_INTERVAL, exc,
+                        )
+                    else:
+                        logger.debug(
+                            "MCP server '%s' still parked (same error as last "
+                            "probe, suppressed from WARNING): %s",
+                            self.name, exc,
+                        )
                     # Do NOT return — exiting the task orphans the server:
                     # nothing would ever listen for _reconnect_event again
                     # and the server would be permanently wedged for the


### PR DESCRIPTION
Closes #1390
Closes #1391

## #1390 — Cron failure logging writes successful jobs to failures/
Removed the else branch in run_one_job that wrote success=true records to cron/failures/. build_cron_failure_digest() already filters on success=False, so the success writes served no purpose.

## #1391 — MCP server generates 739 duplicate connection-failure log lines
Added deduplication to the parked-server warning logger. First unique error logs at WARNING; subsequent identical errors downgrade to DEBUG. Key cleared on recovery.

## Validation
- ruff check passes on both files
- Total: 37 insertions, 15 deletions — within merge cap