### PR TITLE
fix: deduplicate identical parked-server reconnect warnings (Closes #1391)

### DIFF
--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -106,3 +106,127 @@ def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
             run_task.cancel()
 
     asyncio.run(_scenario())
+
+
+@pytest.mark.no_isolate
+def test_parked_server_dedup_identical_warnings(monkeypatch, tmp_path):
+    """#1391: repeated identical parked-server warnings must be deduplicated.
+
+    When a server is parked and the self-probe keeps failing with the same
+    error, only the FIRST occurrence should be WARNING; subsequent identical
+    ones should drop to DEBUG.  A different error gets a fresh WARNING.
+    """
+    import logging
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.05)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {
+        "transport_calls": 0,
+        "deregistered": 0,
+        "parked_cycles": 0,
+    }
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["deregistered"] += 1
+                self._registered_tool_names = []
+
+            def _register_discovered_tools_if_needed(self):
+                pass
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if state["transport_calls"] == 1:
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("backend outage begins")
+                # Always fail with the SAME error to trigger dedup
+                raise RuntimeError("persistent connection failure")
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        # Collect log records
+        records: list[logging.LogRecord] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Handler()
+        handler.setLevel(logging.DEBUG)
+        mcp_logger = logging.getLogger("tools.mcp_tool")
+        mcp_logger.addHandler(handler)
+        mcp_logger.setLevel(logging.DEBUG)
+        try:
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+            # Let it exhaust budget (1 retry), park, and cycle a few times
+            for _ in range(300):
+                await _real_sleep(0)
+                if state["deregistered"] >= 1:
+                    break
+            assert state["deregistered"] >= 1, "server never parked"
+
+            # Let it cycle through several parked self-probes — need real
+            # wall-clock time because the parking wait uses asyncio.wait_for
+            # (event-loop monotonic clock), not asyncio.sleep, so the
+            # monkeypatched _fast_sleep does NOT accelerate it.
+            for _ in range(200):
+                await _real_sleep(0.01)
+                if state["transport_calls"] >= 6:
+                    break
+
+            task._shutdown_event.set()
+            task._reconnect_event.set()
+            try:
+                await asyncio.wait_for(run_task, timeout=15)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                run_task.cancel()
+        finally:
+            mcp_logger.removeHandler(handler)
+
+        # Filter to WARNING-level parked-server messages
+        warning_msgs = [
+            r.getMessage()
+            for r in records
+            if r.levelno == logging.WARNING
+            and "failed after" in r.getMessage()
+            and "parking" in r.getMessage()
+        ]
+        debug_msgs = [
+            r.getMessage()
+            for r in records
+            if r.levelno == logging.DEBUG and "still parked" in r.getMessage()
+        ]
+
+        # Only ONE WARNING for the same error — dedup works
+        assert len(warning_msgs) >= 1, "expected at least one WARNING"
+        assert len(warning_msgs) == 1, (
+            f"expected exactly 1 WARNING (dedup), got {len(warning_msgs)}: "
+            f"{warning_msgs}"
+        )
+        # Subsequent identical cycles should be DEBUG
+        assert len(debug_msgs) >= 1, (
+            f"expected DEBUG-level dedup messages, got {len(debug_msgs)}"
+        )
+
+    asyncio.run(_scenario())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1910,7 +1910,7 @@ class MCPServerTask:
         "_lifecycle_started_at", "_last_tool_call_at",
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
-        "_reconnect_retries",
+        "_reconnect_retries", "_last_parked_error",
     )
 
     def __init__(self, name: str):
@@ -1933,6 +1933,12 @@ class MCPServerTask:
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
         self._reconnect_retries: int = 0
+        # Dedup key for parked-server warnings (#1391): when a server is parked
+        # and repeatedly fails the self-probe, the same warning would fire every
+        # _PARKED_RETRY_INTERVAL cycle.  We store the last error string and
+        # suppress identical repeats — first occurrence at WARNING, subsequent
+        # identical ones at DEBUG.
+        self._last_parked_error: Optional[str] = None
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -3117,6 +3123,7 @@ class MCPServerTask:
                 # a long-lived session would eventually exhaust it and
                 # permanently kill an otherwise-healthy server.
                 self._reconnect_retries = 0
+                self._last_parked_error = None  # #1391: fresh error gets fresh WARNING
                 backoff = 1.0
                 # Reset the session reference and readiness; _run_http/_run_stdio
                 # will repopulate both on successful re-entry.  Leaving
@@ -3186,6 +3193,7 @@ class MCPServerTask:
                         )
                         initial_retries = 0
                         self._reconnect_retries = 0
+                        self._last_parked_error = None  # #1391
                         backoff = 1.0
                         self._error = None
                         self._ready.clear()
@@ -3217,12 +3225,28 @@ class MCPServerTask:
 
                 self._reconnect_retries += 1
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
-                    logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "parking; will self-probe every %ds until it recovers: %s",
-                        self.name, _MAX_RECONNECT_RETRIES,
-                        _PARKED_RETRY_INTERVAL, exc,
-                    )
+                    # Deduplicate identical parked-server warnings (#1391):
+                    # when a server is parked and the self-probe keeps failing
+                    # with the same error, only the FIRST occurrence is logged
+                    # at WARNING; subsequent identical ones drop to DEBUG so
+                    # they don't drown real errors in noise (739 duplicate
+                    # lines observed for tqmemory on startup).
+                    error_str = str(exc)
+                    if error_str == self._last_parked_error:
+                        logger.debug(
+                            "MCP server '%s' still parked (same error as "
+                            "previous cycle); will self-probe every %ds: %s",
+                            self.name, _PARKED_RETRY_INTERVAL, exc,
+                        )
+                    else:
+                        logger.warning(
+                            "MCP server '%s' failed after %d reconnection "
+                            "attempts, parking; will self-probe every %ds "
+                            "until it recovers: %s",
+                            self.name, _MAX_RECONNECT_RETRIES,
+                            _PARKED_RETRY_INTERVAL, exc,
+                        )
+                    self._last_parked_error = error_str
                     # Do NOT return — exiting the task orphans the server:
                     # nothing would ever listen for _reconnect_event again
                     # and the server would be permanently wedged for the
@@ -3247,6 +3271,11 @@ class MCPServerTask:
                         "rebuilding transport.",
                         self.name,
                     )
+                    # Note: _last_parked_error is NOT reset here — the revival
+                    # attempt will likely fail with the same error, and resetting
+                    # would cause a fresh WARNING for every cycle.  It's reset
+                    # only on successful reconnection (where _reconnect_retries
+                    # is cleared to 0).
                     # One probe attempt per wake: budget of 1 so a still-dead
                     # server parks again for another interval instead of
                     # burning 5 rapid retries each cycle.


### PR DESCRIPTION
Automated evolution PR for issue #1391.

## Problem

When an MCP server is parked (reconnect budget exhausted) and the self-probe repeatedly fails with the same error, the WARNING was emitted every `_PARKED_RETRY_INTERVAL` cycle — 739 duplicate log lines observed for tqmemory on startup, drowning real errors in noise.

## Fix

Added `_last_parked_error` tracking to `MCPServerTask`:
- First occurrence of an error: logged at **WARNING** (unchanged behavior)
- Subsequent identical errors: dropped to **DEBUG** with "still parked" message
- Different error: fresh **WARNING** (so new failure modes are never hidden)
- Dedup key reset only on successful reconnection (where `_reconnect_retries` is cleared to 0), NOT at the start of each revival attempt — so repeated identical failures during parking are properly suppressed

## Changes

- `tools/mcp_tool.py`: Added `_last_parked_error` to `__slots__` and `__init__`; dedup logic in the parked-server warning path; reset on successful reconnection (2 sites)
- `tests/tools/test_mcp_parked_self_probe.py`: Added `test_parked_server_dedup_identical_warnings` verifying first WARNING is emitted, subsequent identical cycles are DEBUG

## Validation

- Lint: ✓ (ruff check)
- Tests: 2/2 passed (`tests/tools/test_mcp_parked_self_probe.py`)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>