### PR TITLE
fix: validate delegated sub-agent resolves to ≥1 tool before launch (#1387)

### DIFF
--- a/tests/tools/test_delegate_empty_toolset_validation.py
+++ b/tests/tools/test_delegate_empty_toolset_validation.py
@@ -1,0 +1,102 @@
+"""Tests for delegate_tool pre-dispatch tool validation (#1387).
+
+Verifies that when a sub-agent's resolved toolset is empty (all requested
+toolsets were unrecognized or stripped), the delegation fails fast with a
+clear error instead of launching a toolless agent that spirals.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import delegate_task
+
+
+def _make_parent():
+    """Create a minimal mock parent agent."""
+    return SimpleNamespace(
+        enabled_toolsets=["terminal", "file"],
+        valid_tool_names=["terminal", "read_file", "write_file", "patch"],
+        model="test-model",
+        provider=None,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        acp_command=None,
+        acp_args=[],
+        reasoning_config=None,
+        _fallback_chain=None,
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        request_overrides={},
+        session_id="test-session",
+        _session_db=None,
+        _delegate_depth=0,
+        _print_fn=None,
+        _active_children=[],
+        prefill_messages=None,
+    )
+
+
+class TestEmptyToolsetValidation:
+    """A sub-agent with 0 resolved tools must fail fast (#1387)."""
+
+    def test_aborts_when_no_tools_resolved(self):
+        """If toolset resolution yields 0 tools, delegation returns an error."""
+        parent = _make_parent()
+        # Toolsets is not specified (None) — children inherit parent's tools.
+        # We mock _build_child_agent to return a child with NO valid tools.
+        mock_child = MagicMock()
+        mock_child.valid_tool_names = []
+        mock_child._denied_toolsets_for_prompt = []
+
+        with patch("tools.delegate_tool._build_child_agent", return_value=mock_child):
+            with patch(
+                "tools.delegation_live_log.create_live_transcripts",
+                return_value=("id", [], []),
+            ):
+                with patch(
+                    "tools.delegate_tool._resolve_delegation_credentials"
+                ):
+                    result = delegate_task(
+                        goal="test goal",
+                        parent_agent=parent,
+                    )
+
+        # Should be an error, not a launched delegation
+        result_data = json.loads(result) if isinstance(result, str) else result
+        assert "error" in result_data or (
+            isinstance(result_data, dict) and "error" in str(result_data)
+        )
+
+    def test_does_not_abort_when_tools_present(self):
+        """If toolset resolution yields >=1 tool, delegation proceeds normally."""
+        parent = _make_parent()
+        mock_child = MagicMock()
+        mock_child.valid_tool_names = ["terminal", "read_file"]
+        mock_child._denied_toolsets_for_prompt = []
+
+        with patch("tools.delegate_tool._build_child_agent", return_value=mock_child):
+            with patch(
+                "tools.delegation_live_log.create_live_transcripts",
+                return_value=("id", [], []),
+            ):
+                with patch(
+                    "tools.delegate_tool._resolve_delegation_credentials"
+                ):
+                    with patch(
+                        "tools.delegate_tool._run_single_child",
+                        return_value={"task": 0, "summary": "ok"},
+                    ):
+                        result = delegate_task(
+                            goal="test goal",
+                            parent_agent=parent,
+                        )
+
+        # Should NOT contain an abort error
+        result_str = result if isinstance(result, str) else json.dumps(result)
+        assert "resolved to 0 tools" not in result_str

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1552,6 +1552,8 @@ def _build_child_agent(
                 _seen_denied.add(t)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+
+    # Stash denied toolsets on the child for post-build validation (#1387).
     child_prompt = _build_child_system_prompt(
         goal,
         context,
@@ -1767,6 +1769,8 @@ def _build_child_agent(
         **child_optional_kwargs,
     )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
+    # Stash denied toolsets so post-build validation can name them (#1387).
+    child._denied_toolsets_for_prompt = denied_toolsets
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""
@@ -3180,6 +3184,32 @@ def delegate_task(
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
+
+    # ── Pre-dispatch tool validation (#1387) ────────────────────────────
+    # After toolset resolution (parent intersection, MCP preservation,
+    # blocked-tool stripping), a child could end up with ZERO usable tools
+    # if every requested toolset was unrecognized or stripped. Launching a
+    # toolless sub-agent wastes iterations — it spirals repeating "I have no
+    # shell" until the turn limit. Fail fast with the resolved toolsets so
+    # the parent can correct the delegation request.
+    for _i, _t, _child in children:
+        _child_tools = getattr(_child, "valid_tool_names", None) or []
+        if not _child_tools:
+            _denied = getattr(_child, "_denied_toolsets_for_prompt", None) or []
+            _requested = _t.get("_requested_toolsets") or None
+            _hint = ""
+            if _denied:
+                _hint = (
+                    f" Requested but unresolved/removed: {_denied}. "
+                    f"These toolsets are not available in the parent's "
+                    f"configuration. Remove them from the delegation request "
+                    f"or enable the corresponding tools in config.yaml."
+                )
+            return tool_error(
+                "Delegation aborted: sub-agent resolved to 0 tools after "
+                "toolset filtering. A toolless sub-agent cannot accomplish "
+                f"any task.{_hint}"
+            )
 
     def _execute_and_aggregate() -> dict:
         """Run all built children (1 or N), join on them, aggregate results,


### PR DESCRIPTION
Closes #1387

## Problem
When a delegated sub-agent's toolsets all resolved to nothing (unrecognized names, stripped by parent intersection, blocked tools), the child launched with ZERO tools and spiraled repeating 'I have no shell' until the turn limit.

## Fix
Added pre-dispatch validation in `delegate_task` after child construction but before execution: checks `child.valid_tool_names` and fails fast with a structured error naming the unresolved toolsets if the set is empty.

## Changes
- `tools/delegate_tool.py`: +30 lines (validation gate + denied-toolset stash)
- `tests/tools/test_delegate_empty_toolset_validation.py`: +102 lines (2 tests)
- Total: 132 insertions — within 200-line merge cap

## Validation
- ruff check ✓
- pytest: 2/2 passed ✓