### PR TITLE
fix: preserve delegation lineage/provenance across context compression (#1388)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -808,7 +808,27 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
         goal = _str_arg(args, "goal")
         if len(goal) > 60:
             goal = goal[:57] + "..."
-        return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
+        # Extract provenance: try to parse delegation result for sub-agent
+        # summaries so the compaction summary preserves evidence chains (#1388).
+        provenance_hint = ""
+        try:
+            import json as _json
+
+            parsed = _json.loads(tool_content) if tool_content else None
+            if isinstance(parsed, dict) and "results" in parsed:
+                results = parsed["results"]
+                if isinstance(results, list):
+                    summaries = []
+                    for r in results:
+                        if isinstance(r, dict):
+                            s = r.get("summary") or r.get("error") or ""
+                            if s:
+                                summaries.append(str(s)[:80])
+                    if summaries:
+                        provenance_hint = " → " + " | ".join(summaries[:3])
+        except Exception:
+            pass
+        return f"[delegate_task] '{goal}' ({content_len:,} chars result){provenance_hint}"
 
     if tool_name == "execute_code":
         code_str = _str_arg(args, "code")
@@ -2308,6 +2328,9 @@ Be specific with file paths, commands, line numbers, and results.]
 
 ## Relevant Files
 [Files read, modified, or created — with brief note on each]
+
+## Delegations Performed
+[List each sub-agent delegation that was dispatched during the compacted turns. For each entry include: the task/goal given to the sub-agent, a brief summary of what it returned or accomplished, and any key evidence pointers (file paths, PR numbers, URLs) from its output. This ensures the orchestrator knows what has already been done and does not re-delegate completed work. If none, write "None."]
 
 {HISTORICAL_REMAINING_WORK_HEADING}
 [What remains to be done — framed as STALE context for reference only. The agent must NOT resume this work unless the latest user message explicitly asks for it.]

--- a/tests/agent/test_delegation_provenance_compression.py
+++ b/tests/agent/test_delegation_provenance_compression.py
@@ -1,0 +1,87 @@
+"""Tests for delegation provenance preservation across context compression (#1388).
+
+Verifies that:
+1. The compaction summary template includes a "Delegations Performed" section
+2. The delegate_task tool result summarizer extracts sub-agent provenance
+"""
+
+import json
+
+from agent.context_compressor import _summarize_tool_result
+
+
+class TestDelegateProvenanceSummarizer:
+    """_summarize_tool_result should extract sub-agent summaries from delegate_task results."""
+
+    def test_extracts_provenance_from_delegation_result(self):
+        """When delegate_task result contains summaries, they appear in the compressed view."""
+        result_content = json.dumps({
+            "results": [
+                {"task": 0, "summary": "Found the bug in auth.py:42"},
+                {"task": 1, "summary": "Created PR #123 with the fix"},
+            ]
+        })
+        args = {"goal": "Fix the auth bug in the API"}
+        summary = _summarize_tool_result("delegate_task", json.dumps(args), result_content)
+
+        assert "Found the bug in auth.py:42" in summary
+        assert "Created PR #123" in summary
+
+    def test_handles_error_results(self):
+        """Error results from sub-agents are preserved in provenance."""
+        result_content = json.dumps({
+            "results": [
+                {"task": 0, "error": "Sub-agent failed: no shell access"},
+            ]
+        })
+        args = {"goal": "Some task"}
+        summary = _summarize_tool_result("delegate_task", json.dumps(args), result_content)
+
+        assert "no shell access" in summary
+
+    def test_handles_empty_results(self):
+        """Empty or malformed delegation results fall back gracefully."""
+        args = {"goal": "Do something"}
+        summary = _summarize_tool_result("delegate_task", json.dumps(args), "{}")
+
+        # Should still have the base summary format without provenance
+        assert "[delegate_task]" in summary
+        assert "→" not in summary
+
+    def test_handles_non_json_content(self):
+        """Non-JSON content doesn't crash the summarizer."""
+        args = {"goal": "Do something"}
+        summary = _summarize_tool_result("delegate_task", json.dumps(args), "not json at all")
+
+        assert "[delegate_task]" in summary
+        assert "→" not in summary
+
+    def test_truncates_long_summaries(self):
+        """Each provenance hint is capped to avoid blowing up the summary."""
+        long_summary = "x" * 500
+        result_content = json.dumps({
+            "results": [
+                {"task": 0, "summary": long_summary},
+            ]
+        })
+        args = {"goal": "Do something"}
+        summary = _summarize_tool_result("delegate_task", json.dumps(args), result_content)
+
+        # The provenance hint should be capped at ~80 chars per entry
+        assert "→" in summary
+        assert long_summary not in summary
+
+
+class TestSummaryTemplateHasDelegationSection:
+    """The compaction summary template must include a Delegations Performed section."""
+
+    def test_template_includes_delegation_section(self):
+        """The summary prompt should instruct the model to preserve delegation history."""
+        # Read the compress method's template by checking the module source
+        import inspect
+
+        from agent import context_compressor
+
+        source = inspect.getsource(context_compressor)
+        assert "Delegations Performed" in source
+        assert "sub-agent delegation" in source.lower() or "delegation" in source.lower()


### PR DESCRIPTION
Closes #1388

## Problem
When Hermes compacts or truncates context mid-session, delegation history was lost — the orchestrator could re-delegate completed tasks and sub-agent evidence chains disappeared.

## Fix (two parts)
1. **Summary template**: Added `## Delegations Performed` section to the compaction summary prompt so the LLM is explicitly instructed to preserve delegation history (task goals, results, evidence pointers).
2. **Tool-result summarizer**: Enhanced `_summarize_tool_result` for `delegate_task` to parse JSON results and extract per-task summaries/errors as provenance hints in the compressed view.

## Changes
- `agent/context_compressor.py`: +24 lines (template section + provenance extraction)
- `tests/agent/test_delegation_provenance_compression.py`: +87 lines (6 tests)
- Total: 111 insertions — within 200-line merge cap

## Validation
- ruff check ✓
- pytest: 6/6 passed ✓