### PR TITLE
fix: validate delegated sub-agent tool lists resolve to >=1 tool (Closes #1387)

### DIFF
--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -6,6 +6,7 @@ parent's enabled_toolsets, it can escalate privileges by requesting
 arbitrary toolsets.
 """
 
+import pytest
 from types import SimpleNamespace
 
 from tools.delegate_tool import _strip_blocked_tools, _emit_parent_console
@@ -126,3 +127,91 @@ class TestEmitParentConsole:
         _emit_parent_console(parent, "  ✓ [3/3] non-callable guard")
         captured = capsys.readouterr()
         assert "non-callable guard" in captured.out
+
+
+class TestEmptyToolsetValidation:
+    """#1387: _build_child_agent must raise ValueError when the resolved
+    toolset is empty, instead of launching a toolless sub-agent."""
+
+    def test_empty_requested_toolsets_raises(self):
+        """Explicitly requested toolsets that don't intersect parent → ValueError."""
+        from tools.delegate_tool import _build_child_agent
+
+        parent = SimpleNamespace(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=[],
+            api_key=None,
+            valid_tool_names=["terminal", "file"],
+        )
+
+        with pytest.raises(ValueError, match="resolved to zero tools"):
+            _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=["nonexistent_toolset"],
+                model="test-model",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+            )
+
+    def test_empty_inherited_toolsets_raises(self):
+        """Inherited toolsets that are all blocked → ValueError."""
+        from tools.delegate_tool import _build_child_agent
+
+        # Parent with only blocked toolsets (all will be stripped)
+        parent = SimpleNamespace(
+            enabled_toolsets=["delegation", "clarify", "memory"],
+            disabled_toolsets=[],
+            api_key=None,
+            valid_tool_names=[],
+        )
+
+        with pytest.raises(ValueError, match="inherited toolsets"):
+            _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=None,
+                model="test-model",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+            )
+
+    def test_nonempty_toolsets_does_not_raise(self):
+        """Valid toolsets that resolve to ≥1 tool should not raise."""
+        from tools.delegate_tool import _build_child_agent
+
+        parent = SimpleNamespace(
+            enabled_toolsets=["terminal", "file", "web"],
+            disabled_toolsets=[],
+            api_key=None,
+            valid_tool_names=["terminal", "file", "web"],
+        )
+
+        # This should NOT raise — terminal is a valid toolset
+        # We can't fully run the agent, but we verify no ValueError at
+        # the toolset validation stage by catching only that exception.
+        try:
+            _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=["terminal"],
+                model="test-model",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+            )
+        except ValueError as ve:
+            if "toolset validation" in str(ve).lower():
+                pytest.fail(
+                    f"Should not raise for valid toolsets, got: {ve}"
+                )
+        except Exception:
+            # Other exceptions (import errors, etc.) are expected since
+            # we're not fully set up to run a real agent — the point is
+            # the toolset validation guard doesn't fire.
+            pass

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1498,6 +1498,36 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
+    # ── Empty-toolset guard (#1387) ───────────────────────────────────
+    # After resolution + stripping, if the child has zero toolsets the
+    # sub-agent will have no tools to work with and will spiral on every
+    # tool call.  Fail fast with a structured error instead of launching
+    # a toolless sub-agent.  This catches both the case where explicitly
+    # requested toolsets don't intersect with the parent's, and the rare
+    # case where inherited toolsets are all stripped by _strip_blocked_tools.
+    if not child_toolsets:
+        if toolsets:
+            requested_str = ", ".join(toolsets)
+            available_str = (
+                ", ".join(sorted(parent_toolsets)) if parent_toolsets else "none"
+            )
+            raise ValueError(
+                f"Delegation toolset validation failed: requested toolsets "
+                f"[{requested_str}] resolved to zero tools after intersecting "
+                f"with parent's available toolsets [{available_str}] and "
+                f"removing blocked tools. The sub-agent would have no tools "
+                f"to work with. Check that the requested toolset names are "
+                f"valid and that the parent agent has them enabled."
+            )
+        else:
+            raise ValueError(
+                "Delegation toolset validation failed: inherited toolsets "
+                "resolved to zero tools after removing blocked tools "
+                "(delegation, clarify, memory, etc.). The parent agent "
+                "appears to have no enabled toolsets that survive "
+                "filtering. Check the parent's tools configuration."
+            )
+
     # Blocked tools also live inside mixed platform bundles (hermes-cli,
     # hermes-telegram, etc.) that _strip_blocked_tools must keep because they
     # carry useful tools too. Pass exact one-tool deny toolsets through to the
@@ -3135,31 +3165,45 @@ def delegate_task(
             if team_identity is not None:
                 child_toolsets = _ensure_team_toolset(child_toolsets, parent_agent)
             with _team_identity_scope(team_identity):
-                child = _build_child_agent(
-                    task_index=i,
-                    goal=t["goal"],
-                    context=t.get("context"),
-                    toolsets=child_toolsets,
-                    model=creds["model"],
-                    max_iterations=effective_max_iter,
-                    task_count=n_tasks,
-                    parent_agent=parent_agent,
-                    override_provider=creds["provider"],
-                    override_base_url=creds["base_url"],
-                    override_api_key=creds["api_key"],
-                    override_api_mode=creds["api_mode"],
-                    override_request_overrides=creds.get("request_overrides"),
-                    override_max_tokens=creds.get("max_output_tokens"),
-                    override_acp_command=t.get("acp_command")
-                    or acp_command
-                    or creds.get("command"),
-                    override_acp_args=(
-                        task_acp_args
-                        if task_acp_args is not None
-                        else (acp_args if acp_args is not None else creds.get("args"))
-                    ),
-                    role=effective_role,
-                )
+                try:
+                    child = _build_child_agent(
+                        task_index=i,
+                        goal=t["goal"],
+                        context=t.get("context"),
+                        toolsets=child_toolsets,
+                        model=creds["model"],
+                        max_iterations=effective_max_iter,
+                        task_count=n_tasks,
+                        parent_agent=parent_agent,
+                        override_provider=creds["provider"],
+                        override_base_url=creds["base_url"],
+                        override_api_key=creds["api_key"],
+                        override_api_mode=creds["api_mode"],
+                        override_request_overrides=creds.get("request_overrides"),
+                        override_max_tokens=creds.get("max_output_tokens"),
+                        override_acp_command=t.get("acp_command")
+                        or acp_command
+                        or creds.get("command"),
+                        override_acp_args=(
+                            task_acp_args
+                            if task_acp_args is not None
+                            else (acp_args if acp_args is not None else creds.get("args"))
+                        ),
+                        role=effective_role,
+                    )
+                except ValueError as ve:
+                    # #1387: _build_child_agent raises ValueError when the
+                    # resolved toolset is empty — fail this task with a
+                    # structured error instead of launching a toolless
+                    # sub-agent.
+                    results.append({
+                        "task_index": i,
+                        "goal": t["goal"],
+                        "status": "error",
+                        "error": str(ve),
+                        "response": None,
+                    })
+                    continue
             # Stamp the identity onto the child so _run_single_child can rebind
             # the threading.local inside the worker thread that runs it.
             child._team_identity = team_identity


### PR DESCRIPTION
Automated evolution PR for issue #1387.

## Problem

When a delegated sub-agent's toolset resolution produced an empty list (requested toolsets don't intersect with parent's, or inherited toolsets are all stripped by _strip_blocked_tools), the sub-agent was launched with zero tools. This caused the sub-agent to spiral on every tool call — the root cause of the 'is not a deferrable tool' pattern observed in introspection (64 failed sessions, 4.14% rate).

## Fix

Added a validation guard in `_build_child_agent` after toolset resolution:
- If `child_toolsets` is empty AND toolsets were explicitly requested → `ValueError` naming the requested toolsets and parent's available toolsets
- If `child_toolsets` is empty from inherited toolsets → `ValueError` explaining the parent has no surviving enabled toolsets
- The caller in `delegate_task` catches the `ValueError` and returns a per-task error result with `status: "error"` instead of launching the toolless sub-agent

## Changes

- `tools/delegate_tool.py`: Empty-toolset guard in `_build_child_agent` (raises `ValueError`); try/except in `delegate_task` batch loop catches it and returns structured error result
- `tests/tools/test_delegate_toolset_scope.py`: Added `TestEmptyToolsetValidation` with 3 tests covering explicit-request-empty, inherited-empty, and valid-toolsets-no-raise

## Validation

- Lint: ✓ (ruff check)
- Tests: 14/14 passed (`tests/tools/test_delegate_toolset_scope.py`)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>