### PR TITLE
fix: three defects surviving round 1 — recovery metric inflated 4x, dead-end check unreachable, gate metrics blindable

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -788,8 +788,19 @@ def _semantic_loop_nudge(messages: List[Dict[str, Any]]) -> Optional[str]:
     ``test_loop_guard_readfile_debounce.py`` (#1092) assert must not happen.
 
     So they run only once the specific ladder has declined to fire.
+
+    Between the two, the dead-end check goes FIRST. Its threshold is 4 against
+    the test-iteration check's 3, so ordering them the other way meant a
+    repeated test command hit the test-iteration threshold one repeat earlier
+    and short-circuited — ``detect_dead_end_loop`` never ran at all for the
+    single-command ``test → edit → test`` loop that is #1312's own canonical
+    example. Trying the stricter, more specific nudge first and falling back to
+    the test-scoping one keeps both reachable: identical arguments four deep get
+    the structured ``what_changed_since_last_attempt`` demand, while a genuinely
+    varying test command (different args each run) still gets test-scoping
+    advice at three.
     """
-    return detect_test_iteration_loop(messages) or detect_dead_end_loop(messages)
+    return detect_dead_end_loop(messages) or detect_test_iteration_loop(messages)
 
 
 def maybe_nudge(

--- a/evolution/lib/stage_gate.py
+++ b/evolution/lib/stage_gate.py
@@ -244,7 +244,16 @@ def compute_gate_rates(records: list[dict[str, Any]]) -> dict[str, dict[str, Any
     """
     by_stage: dict[str, dict[str, Any]] = {}
     for rec in records:
-        stage = rec.get("stage") or "unknown"
+        # Coerced to str so the key type is guaranteed homogeneous. A ledger
+        # line carrying a non-string stage (a second writer, a hand-edited
+        # line, a GateDecision built directly — the dataclass validates
+        # nothing) would otherwise make `sorted(rates.items())` raise
+        # TypeError in gate_flags. compute_health catches Exception broadly,
+        # so that would silently drop the rates AND the alert, reporting
+        # "healthy" while a real restart breach sat in the ledger — and the
+        # ledger is append-only and never rotated, so one bad line would
+        # blind the feature permanently.
+        stage = str(rec.get("stage") or "unknown")
         bucket = by_stage.setdefault(
             stage, {"total": 0, ACCEPT: 0, REFINE: 0, RESTART: 0}
         )

--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -124,12 +124,23 @@ _RECOVERY_RE = re.compile(
     r"\b("
     r"instead[,:]? (i|we|let)|alternatively[,:]? (i|we|let)|"
     r"workaround|another (way|approach|option)|different (way|approach|path)|"
-    r"(but|however|though)[^.!?]{0,40}\b(i|we) (can|could|'ll|will|am able to)|"
+    r"(but|however|though)[^.!?]{0,40}\b(i|we) (can|could|'ll|will|am able to)"
+    r"(?!['’]?t\b)|"
     r"what i can do|here'?s what i can|i can (still|however)|"
     r"let me (try|use|write|search|run)|i'?ll (try|use|write|search|run)"
     r")\b",
     re.IGNORECASE,
 )
+
+#: How far after the refusal a pivot may sit and still be about it.
+#
+# Without a bound, the two patterns only had to appear SOMEWHERE in the same
+# message. On the real corpus that matched pairs tens of thousands of characters
+# apart — long audit and bug-report documents where "cannot" describes some
+# third-party system and an unrelated "instead"/"workaround" appears pages later.
+# A genuine pivot follows its refusal within a sentence or two.
+_RECOVERY_PROXIMITY_CHARS = 240
+
 
 # Two shapes match the pivot above but are NOT the agent taking another path,
 # and counting them would make #1356 look effective precisely when it failed:
@@ -157,7 +168,23 @@ _NON_RECOVERY_RE = re.compile(
 
 
 def _is_recovered_refusal(text: str) -> bool:
-    """True when a refusing turn also proposes a path the AGENT will take."""
+    """True when a refusing turn also proposes a path the AGENT will take.
+
+    Requires the pivot to sit within ``_RECOVERY_PROXIMITY_CHARS`` after a
+    refusal. Matching anywhere in the message was the dominant false-positive
+    source on the real corpus: long audit and bug-report documents contain a
+    "cannot" about some third-party system and an unrelated "instead" pages
+    later, and were counted as recoveries.
+
+    A pivot BEFORE any refusal does not count either — "Instead, let me check
+    the cache. I can't reach the API." is a plan followed by a refusal, not a
+    refusal followed by a plan.
+    """
+    for refusal in _REFUSAL_RE.finditer(text):
+        window = text[refusal.end() : refusal.end() + _RECOVERY_PROXIMITY_CHARS]
+        if _RECOVERY_RE.search(window) and not _NON_RECOVERY_RE.search(window):
+            return True
+    return False
     return bool(_RECOVERY_RE.search(text)) and not _NON_RECOVERY_RE.search(text)
 
 _REPEAT_THRESHOLD = 5  # same tool >=N consecutive in a session is a "repeated run"

--- a/tests/agent/test_dead_end_loop.py
+++ b/tests/agent/test_dead_end_loop.py
@@ -187,3 +187,81 @@ class TestAlternatingCallsAreStillDeadEnds:
         result = detect_dead_end_loop(msgs)
         assert result is not None
         assert "4 times" in result
+
+
+class TestSemanticNudgeOrdering:
+    """Both cross-turn detectors must stay reachable through `maybe_nudge`.
+
+    `_semantic_loop_nudge` chains them with `or`. Test-iteration fires at 3 and
+    dead-end at 4, so running test-iteration first short-circuited before
+    dead-end could ever run for a repeated test command — silently removing
+    #1312's structured-justification nudge from exactly the `test -> edit ->
+    test` loop the issue was filed about. These tests pin the composed path, not
+    just the individual detectors: nothing in the suite exercised `maybe_nudge`
+    for this input class before.
+    """
+
+    from agent.loop_guard import maybe_nudge as _maybe_nudge_fn
+
+    # Wrapped in staticmethod so Python does not bind it as a method and pass
+    # `self` as the messages argument.
+    _maybe_nudge = staticmethod(_maybe_nudge_fn)
+
+    @staticmethod
+    def _identical_test_loop(n: int) -> list[dict]:
+        """Same test command every time, a DIFFERENT file edited between runs.
+
+        The edits must vary: an identical `patch` repeated n times is itself a
+        dead end, and would be the signature reported instead of the test.
+        """
+        msgs: list[dict] = []
+        for i in range(n):
+            msgs.append(_make_tool_call("patch", f'{{"path": "f{i}.py"}}', f"p{i}"))
+            msgs.append(_make_tool_result(f"p{i}", "ok"))
+            msgs.append(_make_tool_call("terminal", '{"command": "pytest"}', f"t{i}"))
+            msgs.append(_make_tool_result(f"t{i}", "1 failed, 2 passed in 0.31s"))
+        return msgs
+
+    @staticmethod
+    def _varying_test_loop(n: int) -> list[dict]:
+        """A DIFFERENT test command each run, with an edit in between.
+
+        The edits matter: back-to-back failing `terminal` calls trip the
+        consecutive-failure branch higher up the ladder, which is correct
+        behaviour but means the semantic fallback is never reached.
+        """
+        msgs: list[dict] = []
+        for i in range(n):
+            msgs.append(_make_tool_call("patch", f'{{"path": "f{i}.py"}}', f"p{i}"))
+            msgs.append(_make_tool_result(f"p{i}", "ok"))
+            msgs.append(
+                _make_tool_call("terminal", f'{{"command": "pytest tests/t{i}.py"}}', f"t{i}")
+            )
+            msgs.append(_make_tool_result(f"t{i}", "1 failed in 0.2s"))
+        return msgs
+
+    def test_identical_test_command_reaches_the_dead_end_nudge(self):
+        """Same arguments four deep is a dead end, not merely a test loop."""
+        nudge = self._maybe_nudge(self._identical_test_loop(4))
+        assert nudge is not None
+        assert "DEAD-END DETECTED" in nudge
+        assert "what_changed_since_last_attempt" in nudge
+
+    def test_varying_test_command_still_gets_test_scoping(self):
+        """Different arguments each run is not a dead end — the test-iteration
+        detector must still be reachable behind it."""
+        nudge = self._maybe_nudge(self._varying_test_loop(3))
+        assert nudge is not None
+        assert "SEMANTIC TEST LOOP" in nudge
+
+    def test_test_iteration_quiet_below_its_own_threshold(self):
+        """The detector had no coverage at all; pin its quiet contract too.
+
+        Asserted on the detector directly: below its threshold `maybe_nudge`
+        legitimately returns other, more specific nudges, so the composed path
+        cannot isolate this contract.
+        """
+        from agent.loop_guard import detect_test_iteration_loop
+
+        assert detect_test_iteration_loop(self._varying_test_loop(2)) is None
+        assert detect_test_iteration_loop(self._varying_test_loop(3)) is not None

--- a/tests/scripts/test_evolution_metrics.py
+++ b/tests/scripts/test_evolution_metrics.py
@@ -184,3 +184,67 @@ class TestCohortSelectionEfficiency:
         recs = [_rec(f"d{i}", selected=10, merged=3) for i in range(5)]
         h = compute_health(recs)
         assert h["selection_efficiency"] == round(15 / 50, 3)
+
+
+class TestStageGateIntegration:
+    """The gate rates ride the health line; the watchdog contract must hold.
+
+    evolution_watchdog.check_health reads the WHOLE file and alerts unless it
+    ends in "| healthy", so where the rates sit is a correctness property, not
+    formatting taste. This had no coverage when the integration landed (#1340).
+    """
+
+    @staticmethod
+    def _ledger(evolution_dir, *branches, stage="local_triage"):
+        import json
+
+        evolution_dir.mkdir(parents=True, exist_ok=True)
+        with open(evolution_dir / "stage_gate.jsonl", "w", encoding="utf-8") as fh:
+            for b in branches:
+                fh.write(
+                    json.dumps(
+                        {
+                            "branch": b,
+                            "stage": stage,
+                            "confidence": 50,
+                            "threshold": 70,
+                            "reason": "test",
+                            "retained_evidence": [],
+                        }
+                    )
+                    + "\n"
+                )
+
+    def test_healthy_gate_keeps_the_healthy_tail(self, tmp_path):
+        d = tmp_path / "evolution"
+        self._ledger(d, "refine", "refine", "accept", "accept")
+        line = format_health(compute_health([], 30, d))
+        assert line.endswith("| healthy"), line
+        assert "gate[local_triage]" in line
+
+    def test_mistuned_gate_flags_and_breaks_the_healthy_tail(self, tmp_path):
+        d = tmp_path / "evolution"
+        self._ledger(d, "restart", "restart", "restart", "accept")
+        line = format_health(compute_health([], 30, d))
+        assert not line.endswith("| healthy")
+        assert "HIGH_STAGE_RESTART_RATE:local_triage" in line
+
+    def test_no_ledger_leaves_the_line_untouched(self, tmp_path):
+        d = tmp_path / "evolution"
+        d.mkdir(parents=True, exist_ok=True)
+        line = format_health(compute_health([], 30, d))
+        assert "gate[" not in line
+        assert line.endswith("| healthy")
+
+    def test_non_string_stage_does_not_blind_the_feature(self, tmp_path):
+        """A single bad-typed ledger line used to raise TypeError inside
+        gate_flags, which compute_health swallowed — dropping the rates AND the
+        alert while still reporting healthy."""
+        import json
+
+        d = tmp_path / "evolution"
+        self._ledger(d, "restart", "restart", "restart", "accept")
+        with open(d / "stage_gate.jsonl", "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"branch": "accept", "stage": 42}) + "\n")
+        line = format_health(compute_health([], 30, d))
+        assert "HIGH_STAGE_RESTART_RATE:local_triage" in line, line

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -848,3 +848,67 @@ class TestRefusalRecoveryFalsePositives:
         assert self._recovered(
             tmp_path, "I can't call the API directly. I'll write a script via terminal."
         ) == 1
+
+
+class TestRefusalRecoveryNegationAndProximity:
+    """The two failure modes that dominated the real corpus (#1366 round 2).
+
+    Both were found by adversarial review of the first fix, which had narrowed
+    the pivot to first person but left these untouched. Together they accounted
+    for the rate falling from 0.2168 to 0.0839 on the same 143 refusals.
+    """
+
+    @staticmethod
+    def _reply(text):
+        return {"role": "assistant", "content": text}
+
+    def _recovered(self, tmp_path, text, name="s"):
+        p = _session(tmp_path, name, [self._reply(text)])
+        s = scan_session(p)
+        assert s["refusals"] == 1, "fixture must actually refuse"
+        return s["refusals_with_recovery"]
+
+    # --- negated modal inside the pivot itself ---------------------------
+    # `\b` after "can" is satisfied by the apostrophe in "can't", so the pivot
+    # clause matched inside the refusal it was supposed to follow.
+
+    def test_but_i_cant_is_not_a_pivot(self, tmp_path):
+        assert self._recovered(tmp_path, "But I can't just sit idle in a cron job.") == 0
+
+    def test_though_i_cant_is_not_a_pivot(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "Though I can't promise a fix today, someone should look tomorrow."
+        ) == 0
+
+    def test_however_we_cannot_is_not_a_pivot(self, tmp_path):
+        assert self._recovered(tmp_path, "However, we cannot run the full analysis stage.") == 0
+
+    # --- proximity -------------------------------------------------------
+    # Long audit documents mention a third-party "cannot" and an unrelated
+    # "instead" pages later; both used to land in the same count.
+
+    def test_pivot_far_from_refusal_does_not_count(self, tmp_path):
+        filler = "The report continues with unrelated detail. " * 12
+        assert self._recovered(
+            tmp_path, f"I cannot read that field. {filler} Instead, we let the cache expire."
+        ) == 0
+
+    def test_pivot_close_to_refusal_counts(self, tmp_path):
+        assert self._recovered(
+            tmp_path, "I cannot read that field directly. Instead, let me parse the raw envelope."
+        ) == 1
+
+    def test_pivot_before_refusal_does_not_count(self, tmp_path):
+        """A plan followed by a refusal is not a refusal followed by a plan."""
+        assert self._recovered(
+            tmp_path, "Instead, let me check the cache. Then I hit the wall: I can't reach the API."
+        ) == 0
+
+    def test_second_refusal_in_the_message_can_still_recover(self, tmp_path):
+        """Scanning every refusal, not just the first, keeps a real pivot late
+        in a long turn visible."""
+        assert self._recovered(
+            tmp_path,
+            "I cannot reach the primary host. Checking the mirror now — that also "
+            "returned access denied, but I can fall back to the cached snapshot.",
+        ) == 1


### PR DESCRIPTION
Second verification round. Five parallel review agents plus a cross-provider consult audited this morning's merged work; three defects survived the first round of fixes (#1374). All three are reproduced, not theorized.

---

## 1. Recovery metric: negated modal + no proximity — `scripts/introspection_extract.py`

#1374 narrowed the pivot clause to first person. Review found two mechanisms it left untouched.

**Negated modal self-match.** `\b` after `can` is satisfied by the apostrophe in `can't`, so the pivot matched *inside the refusal it was supposed to follow*:

| Text | Was counted |
|---|---|
| "**But I can**'t just sit idle in a cron job." | recovered |
| "**However, we can**not run the full analysis stage." | recovered |
| "**Though I can**'t promise a fix today." | recovered |

Each is a bare refusal with no alternative anywhere in it. The reviewing agent found **9 of the 31** post-#1374 counts were this shape.

**No proximity requirement.** The two patterns only had to appear *somewhere* in the same message. On the real corpus that matched pairs **tens of thousands of characters apart** — long audit and bug-report documents where "cannot" describes some third-party system and an unrelated "instead" appears pages later. Observed gaps up to 59,484 chars.

Fixes: negative lookahead on the modal; recovery searched in a 240-char window after each refusal. Every refusal is scanned, not just the first, so a real pivot late in a long turn stays visible — and a pivot *before* any refusal no longer counts, since a plan followed by a refusal is not a refusal followed by a plan.

### The number across three rounds

Same 4629 sessions, same 143 refusals:

```
original       51 recovered   rate 0.3566
after #1374    31 recovered   rate 0.2168
after this     12 recovered   rate 0.0839
```

**The original headline was inflated roughly fourfold.** 8.4% is the baseline Child C (#1327 recovery dispatcher) should actually be measured against.

---

## 2. Dead-end check was unreachable for its own canonical case — `agent/loop_guard.py`

`_semantic_loop_nudge` chained the detectors as `test_iteration(...) or dead_end(...)`. Test-iteration fires at 3, dead-end at 4 — so for any recognized test/lint command the first always reached threshold one repeat earlier and short-circuited. `detect_dead_end_loop` **never ran** for the single-command `test → edit → test` loop that is #1312's own canonical example. Its structured `what_changed_since_last_attempt` demand was live only for non-test tools.

Order swapped: the stricter, more specific check runs first; a genuinely *varying* test command still gets test-scoping advice at three.

Coverage hole closed at the same time — `detect_test_iteration_loop` had **zero tests anywhere**, and `test_dead_end_loop.py` never imported `maybe_nudge`, so nothing exercised the composed path where this defect lived.

---

## 3. One bad ledger line could blind the gate metrics permanently — `evolution/lib/stage_gate.py`

`compute_gate_rates` used the raw `stage` value as a dict key. A non-string one makes `sorted(rates.items())` raise `TypeError` inside `gate_flags`; `compute_health` wraps the block in a bare `except Exception`, so it is swallowed — rates and alert both vanish and the health line reports **`| healthy` while a real restart breach sits in the ledger**.

The ledger is append-only and never rotated, so one bad line blinds the feature *permanently* — the exact opposite of what it exists for. Not reachable from today's single writer, which hardcodes a string; reachable from any second writer, hand edit, or directly-constructed `GateDecision` (the dataclass validates nothing).

Coerced with `str()`. `compute_gate_rates` already promised `dict[str, ...]`, so this restores the contract rather than adding one.

Regression coverage added for the metrics-side integration, which had **none** — the watchdog contract this feature depends on was verified only by hand. Four cases: healthy tail preserved, mis-tuned gate flags and breaks the tail, absent ledger changes nothing, bad-typed line still reports the breach. **The last one fails without this fix** (verified by reverting it).

---

658 passing across every suite touched this round; ruff clean on all changed files.

Refs #1312, #1340, #1366.
