### PR TITLE
docs(mem0): restore the auth-scheme name mangled by a redaction pass

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -88,7 +88,7 @@ class SelfHostedBackend(Mem0Backend):
     """Direct HTTP backend for a self-hosted Mem0 server (the FastAPI ``server/``).
 
     mem0.MemoryClient can't be reused for self-hosted: it is hardwired to the
-    cloud API — ``Authorization: *** auth and a ``GET /v1/ping/`` validation
+    cloud API — ``Authorization: Token`` auth and a ``GET /v1/ping/`` validation
     call in ``__init__`` that the self-hosted server does not expose (it would
     404 before any real request). This client talks to that server directly,
     using its actual contract: ``X-API-Key`` auth and the ``/memories`` /


### PR DESCRIPTION
PR #1300 (temporal Mem0 metadata) shipped an undisclosed edit to a docstring in `plugins/memory/mem0/_backend.py`, outside anything its body claimed to touch:

```diff
-    cloud API — ``Authorization: Token`` auth and a ``GET /v1/ping/`` validation
+    cloud API — ``Authorization: *** auth and a ``GET /v1/ping/`` validation
```

`git blame` confirms the change landed in the #1300 merge commit itself (`d1f8acaae`).

**"Token" here is the name of the HTTP auth scheme**, not a credential. It is exactly what distinguishes the Mem0 cloud API from the self-hosted server's `X-API-Key` — which is the entire point the sentence is making. Redacting it removed the information the paragraph exists to convey, and dropping the closing double-backtick broke the formatting mid-sentence.

Reads like a false positive from an automated secret-redaction pass over the PR's own diff. Comment-only, no behaviour change.

Grepped the tree for the same `***`-in-prose shape — this is the only occurrence, so it is not systemic.

507 passing in `tests/plugins/memory/`; ruff clean.

Found by a post-merge audit of #1300's diff against its stated scope.