### PR TITLE
refactor(stage-gate): use format_gate_rates instead of duplicating it

### DIFF
--- a/evolution/lib/stage_gate.py
+++ b/evolution/lib/stage_gate.py
@@ -290,12 +290,21 @@ def gate_flags(
 
 
 def format_gate_rates(rates: dict[str, dict[str, Any]]) -> str:
-    """One-line summary per boundary for the evolution-health sidecar."""
+    """Per-boundary rates as they appear in the evolution-health line body.
+
+    Emitted WITHOUT a leading marker and with no trailing ``|``: the health
+    line's flags must stay the last segment after the final pipe, because
+    ``evolution_watchdog.check_health`` keys on the line ending in
+    ``| healthy``. This belongs beside ``effort_budget`` in the body, under the
+    same constraint.
+
+    Returns ``""`` for an empty mapping so the caller can concatenate it
+    unconditionally.
+    """
     if not rates:
         return ""
-    parts = [
-        f"{stage}(n={b['total']} refine={b['stage_refine_rate']:.0%} "
-        f"restart={b['stage_restart_rate']:.0%})"
+    return " ".join(
+        f"gate[{stage}]=refine {b['stage_refine_rate']:.0%}/"
+        f"restart {b['stage_restart_rate']:.0%} (n={b['total']})"
         for stage, b in sorted(rates.items())
-    ]
-    return "[stage-gate] " + " ".join(parts)
+    )

--- a/evolution/tests/test_stage_gate.py
+++ b/evolution/tests/test_stage_gate.py
@@ -224,5 +224,15 @@ class TestGateFlags:
         from evolution.lib.stage_gate import compute_gate_rates, format_gate_rates
 
         out = format_gate_rates(compute_gate_rates(self._recs(ACCEPT, REFINE)))
-        assert "[stage-gate]" in out
-        assert "local_triage" in out
+        assert "gate[local_triage]" in out
+        assert "refine 50%" in out
+        assert "restart 0%" in out
+        assert "(n=2)" in out
+
+    def test_format_carries_no_pipe(self):
+        """The health line's flags must remain the last `|`-separated segment —
+        `evolution_watchdog.check_health` keys on it ending in `| healthy`."""
+        from evolution.lib.stage_gate import compute_gate_rates, format_gate_rates
+
+        out = format_gate_rates(compute_gate_rates(self._recs(ACCEPT, RESTART)))
+        assert "|" not in out

--- a/scripts/evolution_metrics.py
+++ b/scripts/evolution_metrics.py
@@ -209,12 +209,17 @@ def format_health(h: Dict[str, Any]) -> str:
     gate = ""
     rates = h.get("stage_gate_rates") or {}
     if rates:
-        # Same rule as effort_budget: body only, never the tail (#1340).
-        gate = " " + " ".join(
-            f"gate[{stage}]=refine {b['stage_refine_rate']:.0%}/"
-            f"restart {b['stage_restart_rate']:.0%} (n={b['total']})"
-            for stage, b in sorted(rates.items())
-        )
+        # Rendered by stage_gate's own formatter so the shape lives next to the
+        # data that defines it. Same rule as effort_budget: body, never the
+        # tail (#1340). Lazily imported for the same reason compute_health
+        # imports it lazily — the evolution package is not always available.
+        try:
+            from evolution.lib.stage_gate import format_gate_rates
+
+            rendered = format_gate_rates(rates)
+            gate = f" {rendered}" if rendered else ""
+        except ImportError:
+            gate = ""
     return (
         f"[evolution-metrics] {h['cycles_active']}/{h['cycles_total']} active cycles: "
         f"success={_pct(h['cycle_success_rate'])} "


### PR DESCRIPTION
Third review round on #1340, from a dead-code finding.

`format_gate_rates` had **no production caller** — only its own unit tests — while `evolution_metrics.format_health` rendered the same data inline in a different shape. Two renderings of one thing, one of them dead, in a repo whose integration skill runs an explicit dead-code check on every PR:

> *If the new code is referenced ONLY by its own module + tests (zero real call sites) → it's DEAD CODE. Do NOT merge.*

## Change

`format_gate_rates` now emits exactly what the health line body needs, and `format_health` calls it. The shape lives next to the data that defines it. Lazily imported for the same reason `compute_health` imports the module lazily — the evolution package is not always importable, and the health line must still render without it.

## Output is byte-identical

Verified end to end, not by reading:

```
healthy    ...effort_budget=3.0 gate[local_triage]=refine 50%/restart 0% (n=4) | healthy
           check_health -> 0 alerts

mis-tuned  ...gate[local_triage]=refine 0%/restart 75% (n=4) | HIGH_STAGE_RESTART_RATE:local_triage=75%
           check_health -> 1 alert
```

Added `test_format_carries_no_pipe` — the health line's flags must remain the last `|`-separated segment for `evolution_watchdog.check_health`, and that constraint was previously only implied by a comment.

52 passing in `test_stage_gate.py` + `test_evolution_metrics.py`; ruff clean.