### PR TITLE
fix(tool-search): make an inactive streak counter visible instead of silent (Refs #1373)

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -949,3 +949,85 @@ class TestDescribeCache:
         r2 = dispatch_tool_describe({"name": "nonexistent"}, current_tool_defs=defs)
         assert "error" in r2
 
+
+
+class TestSearchStreakDisabledIsVisible:
+    """A silently-inactive streak counter is how #1153 shipped without moving
+    its own signal (#1373).
+
+    `note_tool_search` returns 0 for a falsy session id, so the threshold is
+    never reached and the fallback directive never fires. That is correct for
+    the pure unit tests that pass no session id — but the runtime reaches this
+    through `session_id=agent.session_id or ""`, so an unset session arrives as
+    `""` and is indistinguishable here. It must at least be visible in the log.
+    """
+
+    def _cfg(self, threshold: int = 3):
+        from tools.tool_search import ToolSearchConfig
+
+        return ToolSearchConfig(
+            enabled="on",
+            threshold_pct=10.0,
+            search_default_limit=5,
+            max_search_limit=20,
+            search_streak_threshold=threshold,
+        )
+
+    def _search(self, sid):
+        from tools.tool_search import dispatch_tool_search
+
+        return json.loads(
+            dispatch_tool_search(
+                {"query": "github"},
+                current_tool_defs=[_td("github_create_issue", "Create issue")],
+                config=self._cfg(),
+                session_id=sid,
+            )
+        )
+
+    def test_empty_session_id_warns_once(self, caplog):
+        import logging
+
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._STREAK_DISABLED_WARNED = False
+        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
+            for _ in range(5):
+                self._search("")
+        warnings = [r for r in caplog.records if "streak tracking is INACTIVE" in r.message]
+        assert len(warnings) == 1, "must warn exactly once per process, not per call"
+
+    def test_none_session_id_also_warns(self, caplog):
+        import logging
+
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._STREAK_DISABLED_WARNED = False
+        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
+            self._search(None)
+        assert any("streak tracking is INACTIVE" in r.message for r in caplog.records)
+
+    def test_no_directive_without_session_however_many_searches(self):
+        """The behaviour itself is unchanged — only its visibility."""
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._STREAK_DISABLED_WARNED = False
+        for _ in range(10):
+            out = self._search("")
+        assert "fallback_directive" not in out
+
+    def test_real_session_id_does_not_warn(self, caplog):
+        import logging
+
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._STREAK_DISABLED_WARNED = False
+        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
+            for _ in range(3):
+                out = self._search("sess-real")
+        assert not any("streak tracking is INACTIVE" in r.message for r in caplog.records)
+        assert "fallback_directive" in out

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -63,10 +63,37 @@ CHARS_PER_TOKEN = 4.0
 # tracked (keeps pure-function tests that pass no session_id unaffected).
 _SEARCH_STREAK: Dict[str, int] = {}
 
+#: Set once per process when a search arrives with no usable session key, so
+#: the "streak tracking is silently off" state is visible in the log exactly
+#: once instead of never (#1373).
+_STREAK_DISABLED_WARNED = False
+
 
 def note_tool_search(session_id: Optional[str]) -> int:
-    """Increment the consecutive-search streak for ``session_id``; return it."""
+    """Increment the consecutive-search streak for ``session_id``; return it.
+
+    Returns 0 — and therefore never reaches the threshold — when there is no
+    session key to count against. That is the correct behaviour for the pure
+    unit tests that pass none, but in production it silently disables the whole
+    feature, which is how #1153 could ship, pass CI, and leave the signal it
+    targeted completely unchanged (#1373). The runtime reaches this via
+    ``session_id=agent.session_id or ""`` in ``agent_runtime_helpers``, so an
+    unset session id arrives as ``""`` — falsy, and indistinguishable here from
+    a test calling with nothing.
+
+    The counter still declines to track it; what changes is that it says so.
+    """
     if not session_id:
+        global _STREAK_DISABLED_WARNED
+        if not _STREAK_DISABLED_WARNED:
+            _STREAK_DISABLED_WARNED = True
+            logger.warning(
+                "tool_search streak tracking is INACTIVE for this process: a "
+                "search arrived with no session id, so the consecutive-search "
+                "counter cannot key on anything and the fallback directive "
+                "(#1153) will never fire. Callers must pass a non-empty "
+                "session_id (see #1373)."
+            )
         return 0
     _SEARCH_STREAK[session_id] = _SEARCH_STREAK.get(session_id, 0) + 1
     return _SEARCH_STREAK[session_id]


### PR DESCRIPTION
#1373 reports that #1153's streak counter left its own signal unchanged — 17 sessions still at 9 consecutive searches, identical to the pre-merge baseline — but could not say **whether the counter never fires, or the nudge fires and is ignored**. Nothing in the code distinguishes those, which is why the issue has carried that ambiguity since 2026-07-23.

## Static trace of the production path

```
agent_runtime_helpers.py:2641   session_id=agent.session_id or ""
model_tools.py:1129             dispatch_tool_search(..., session_id=session_id)
tool_search.py                  note_tool_search(session_id)
                                  if not session_id: return 0
```

An unset session id arrives as `""` — **falsy** — so the counter returns 0 forever, the threshold is never reached, and the fallback directive never fires. The feature is off, with no trace anywhere that it is off.

Same silent-failure shape as #1304/#1314 and the analysis gate's `|| true`: correct primitives, no signal when they are inert.

## Change

`note_tool_search` logs a warning the first time it is asked to count without a key, naming the feature that is therefore inactive and pointing at this issue. **Once per process, not per call**, so a busy session cannot flood the log. Behaviour is otherwise identical — it still declines to track.

## What this does and does not claim

It does **not** prove the empty-session-id path is what #1373 observed. That signal comes from an environment this checkout has no data for — **0 `tool_search` mentions across 683 local session files**, so the pattern is not reproducible here at all.

What it does: makes the question answerable from **a single log line** on the machine that does see it, instead of by reading code. If the warning appears, the counter is the problem; if it does not and the sessions still show 9-deep streaks, the nudge is being ignored and the fix belongs in its wording or placement.

4 new tests — warns once for `""` and for `None`, still emits no directive without a session, stays quiet with a real session id while the directive fires normally. 72 passing in `test_tool_search.py`; ruff clean.