### PR TITLE
feat: capture the agent's real tool calls for the evolution pipeline (Closes #1363)

### DIFF
--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -19,13 +19,19 @@ turn's message list into the ``TrajectoryLog`` that ``evolution_trajectory_logge
 already defines and already knows how to persist under
 ``~/.hermes/evolution/trajectories/``.
 
-Privacy — why this can be on when ``save_trajectories`` is off
---------------------------------------------------------------
+Opt-in, and narrower than ``save_trajectories``
+-----------------------------------------------
 ``save_trajectories`` writes the full ShareGPT conversation, user prose
-included, which is why it is off by default and why turning it on for evolution
-would be the wrong trade. This captures **call metadata only**: tool name,
-redacted arguments (via the logger's existing ``redact_args``), a status, and a
-short result summary. No user message, no assistant prose, no file contents.
+included. This captures **call metadata only**: tool name, redacted arguments
+(via the logger's existing ``redact_args``), a status, and a short result
+summary. No user message, no assistant prose, no file contents.
+
+It is still **off by default**, behind ``HERMES_EVOLUTION_CAPTURE``. Redaction
+catches credential-shaped *keys*, not sensitive *values* in ordinary fields —
+a path with a username, an SQL string, an internal hostname all survive it — so
+writing on every turn of every interactive session unasked would be the wrong
+default even for metadata. The evolution cron stages enable it for their own
+runs, which is the behaviour the pipeline actually needs to measure.
 
 The consumers want different shapes, so the record carries the union
 -------------------------------------------------------------------
@@ -43,7 +49,10 @@ on, opaque enough to store.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+import os
+import secrets
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -55,23 +64,88 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 from evolution_trajectory_logger import TrajectoryLog  # noqa: E402
 
-__all__ = ["task_key", "extract_tool_calls", "build_trajectory_log", "capture_turn"]
+__all__ = [
+    "capture_enabled",
+    "task_key",
+    "extract_tool_calls",
+    "build_trajectory_log",
+    "capture_turn",
+]
 
 #: Result summaries are already truncated by the logger; this bounds the
 #: pre-truncation payload so a huge tool result is not held in memory twice.
 _MAX_RESULT_CHARS = 2000
 
+#: Opt-in. Default OFF.
+#
+# Even redacted, tool arguments carry paths containing usernames, SQL, code
+# snippets, internal hostnames — ``redact_args`` catches credential-shaped
+# KEYS, not sensitive VALUES in ordinary fields. Writing that to disk on every
+# turn of every interactive session, unasked and unbounded, is the wrong
+# default.
+#
+# The evolution cron stages set this for their own runs, which is where the
+# pipeline's own behaviour is what needs measuring.
+_CAPTURE_ENV = "HERMES_EVOLUTION_CAPTURE"
 
-def task_key(task_descriptor: str) -> str:
+#: Local salt for the pairing key. Without it, a bare hash of a short,
+#: templated prompt ("run the tests", "fix issue #102") is recoverable from a
+#: rainbow table by anyone who can read the store. HMAC under a host-local
+#: secret keeps the key useful for equality while making it useless off-host.
+_SALT_FILENAME = ".trajectory_key_salt"
+
+
+def capture_enabled() -> bool:
+    """True when trajectory capture is switched on for this process."""
+    return os.environ.get(_CAPTURE_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _salt(trajectory_dir: Optional[Path] = None) -> bytes:
+    """Read (or mint) the host-local salt used for the pairing key.
+
+    Kept beside the trajectories it keys, so a store copied without its salt
+    cannot have its task keys correlated against a fresh one. Falls back to a
+    process-local random salt when the file cannot be written — pairing then
+    only holds within the process, which is strictly better than emitting a
+    globally reversible hash.
+    """
+    if trajectory_dir is None:
+        from evolution_trajectory_logger import _default_trajectory_dir
+
+        trajectory_dir = _default_trajectory_dir()
+    path = Path(trajectory_dir) / _SALT_FILENAME
+    try:
+        if path.exists():
+            raw = path.read_bytes().strip()
+            if raw:
+                return raw
+        path.parent.mkdir(parents=True, exist_ok=True)
+        raw = secrets.token_hex(32).encode("ascii")
+        path.write_bytes(raw)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+        return raw
+    except OSError:
+        return secrets.token_hex(32).encode("ascii")
+
+
+def task_key(task_descriptor: str, trajectory_dir: Optional[Path] = None) -> str:
     """Stable, opaque key for a task, used to pair runs of the same task.
 
-    A hash rather than the text: #1436 needs to group a failed and a successful
-    run of the *same* task, which only needs equality, while the descriptor
-    itself is user prose that must not land in the pipeline's store.
+    Salted HMAC rather than a bare hash: #1436 only needs equality to group a
+    failed and a successful run of the same task, and the descriptor is user
+    prose. A plain ``sha256(prompt)[:16]`` of a short templated instruction is
+    recoverable by dictionary attack; an HMAC under a host-local secret is not.
     """
     if not task_descriptor:
         return ""
-    return hashlib.sha256(task_descriptor.encode("utf-8", "replace")).hexdigest()[:16]
+    return hmac.new(
+        _salt(trajectory_dir),
+        task_descriptor.encode("utf-8", "replace"),
+        hashlib.sha256,
+    ).hexdigest()[:16]
 
 
 def _result_status(content: Any) -> str:
@@ -154,6 +228,7 @@ def build_trajectory_log(
     session_id: str = "",
     task_descriptor: str = "",
     completed: bool = True,
+    trajectory_dir: Optional[Path] = None,
 ) -> Optional[TrajectoryLog]:
     """Build a :class:`TrajectoryLog` from a finished turn, or None if empty.
 
@@ -167,7 +242,7 @@ def build_trajectory_log(
     log = TrajectoryLog(
         session_id=session_id or "",
         completed=bool(completed),
-        task_key=task_key(task_descriptor),
+        task_key=task_key(task_descriptor, trajectory_dir),
     )
     for call in calls:
         log.add_tool_call(
@@ -193,15 +268,21 @@ def capture_turn(
     already individually guarded (#8049) — instrumentation must not be able to
     discard a completed turn's response.
     """
+    if not capture_enabled():
+        return None
     try:
         log = build_trajectory_log(
             messages,
             session_id=session_id,
             task_descriptor=task_descriptor,
             completed=completed,
+            trajectory_dir=trajectory_dir,
         )
         if log is None:
             return None
-        return log.save(trajectory_dir)
+        # append, not save: save() overwrites, so every turn after the first
+        # would destroy the previous one and a multi-turn session would keep
+        # only its last turn.
+        return log.append(trajectory_dir)
     except Exception:
         return None

--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Capture the agent's real tool calls for the evolution pipeline (issue #1363).
+
+The pipeline had no record of what the agent actually did. ``evolution_funnel``
+writes a trajectory containing one entry — ``tool='evolution_funnel'``, the
+pipeline logging its own invocation — and ``agent.save_trajectories`` writes real
+conversation JSONL but defaults off, lands in the process CWD, and nothing in the
+pipeline reads it.
+
+That one missing input has cost six PRs. #1267, #1268 and #1270 each had two
+closed by the owner as *dead code* or *incoherent*, with the same verdict every
+time: the implementation "reads the funnel's own synthetic trajectory record
+rather than real agent tool calls". Each attempt had to invent a substitute for
+data that did not exist. Seven issues wait on it today (#1267, #1268, #1270,
+#1359, #1360, #1361, #1436, #1442).
+
+What this module adds is the conversion, not new storage: it turns a finished
+turn's message list into the ``TrajectoryLog`` that ``evolution_trajectory_logger``
+already defines and already knows how to persist under
+``~/.hermes/evolution/trajectories/``.
+
+Privacy — why this can be on when ``save_trajectories`` is off
+--------------------------------------------------------------
+``save_trajectories`` writes the full ShareGPT conversation, user prose
+included, which is why it is off by default and why turning it on for evolution
+would be the wrong trade. This captures **call metadata only**: tool name,
+redacted arguments (via the logger's existing ``redact_args``), a status, and a
+short result summary. No user message, no assistant prose, no file contents.
+
+The consumers want different shapes, so the record carries the union
+-------------------------------------------------------------------
+* #1268 (tool-use rubric) needs per-call tool / args / outcome / order.
+* #1359 (ERL heuristics) needs a task-level **outcome** to know whether a
+  trajectory is worth distilling from.
+* #1436 (EMG graph matching) needs to **pair** a failed and a successful
+  trajectory for the same task, so it needs a task descriptor that is stable
+  across runs and does not leak the prompt.
+
+Hence ``task_key``: a short hash of the task descriptor. Stable enough to pair
+on, opaque enough to store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ``evolution_trajectory_logger`` lives in scripts/, which is not on the
+# path for a runtime import from agent/. Adding it here keeps the
+# storage format owned by one module instead of duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from evolution_trajectory_logger import TrajectoryLog  # noqa: E402
+
+__all__ = ["task_key", "extract_tool_calls", "build_trajectory_log", "capture_turn"]
+
+#: Result summaries are already truncated by the logger; this bounds the
+#: pre-truncation payload so a huge tool result is not held in memory twice.
+_MAX_RESULT_CHARS = 2000
+
+
+def task_key(task_descriptor: str) -> str:
+    """Stable, opaque key for a task, used to pair runs of the same task.
+
+    A hash rather than the text: #1436 needs to group a failed and a successful
+    run of the *same* task, which only needs equality, while the descriptor
+    itself is user prose that must not land in the pipeline's store.
+    """
+    if not task_descriptor:
+        return ""
+    return hashlib.sha256(task_descriptor.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _result_status(content: Any) -> str:
+    """Classify a tool result as success/failure using the repo's own predicate.
+
+    Reuses ``introspection_extract._tool_result_failed`` so this agrees with the
+    digest instead of inventing a second definition of failure — two
+    disagreeing classifiers is how a metric drifts from what it claims.
+    """
+    try:
+        from introspection_extract import _tool_result_failed
+
+        return "failure" if _tool_result_failed(content) else "success"
+    except Exception:
+        # Fall back to the same fail-open default the digest uses: without an
+        # authoritative status, do not guess a failure.
+        return "success"
+
+
+def extract_tool_calls(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Pull ``(tool, args, result)`` triples out of a finished turn's messages.
+
+    Walks assistant turns for ``tool_calls`` and matches each to its ``tool``
+    result by ``tool_call_id``. A call with no matching result (the turn ended
+    mid-flight) is kept with a ``pending`` status rather than dropped — a call
+    that never returned is itself signal for #1268's error-recovery dimension.
+    """
+    if not isinstance(messages, list):
+        return []
+
+    results: Dict[str, Any] = {}
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            cid = msg.get("tool_call_id")
+            if cid:
+                results[cid] = msg.get("content")
+
+    calls: List[Dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not name:
+                continue
+            raw_args = fn.get("arguments")
+            if isinstance(raw_args, str):
+                try:
+                    args = json.loads(raw_args)
+                except (json.JSONDecodeError, ValueError):
+                    args = {}
+            elif isinstance(raw_args, dict):
+                args = raw_args
+            else:
+                args = {}
+            cid = tc.get("id")
+            has_result = cid in results
+            content = results.get(cid)
+            if isinstance(content, str) and len(content) > _MAX_RESULT_CHARS:
+                content = content[:_MAX_RESULT_CHARS]
+            calls.append(
+                {
+                    "tool": str(name),
+                    "args": args if isinstance(args, dict) else {},
+                    "result": content,
+                    "status": _result_status(content) if has_result else "pending",
+                }
+            )
+    return calls
+
+
+def build_trajectory_log(
+    messages: List[Dict[str, Any]],
+    *,
+    session_id: str = "",
+    task_descriptor: str = "",
+    completed: bool = True,
+) -> Optional[TrajectoryLog]:
+    """Build a :class:`TrajectoryLog` from a finished turn, or None if empty.
+
+    Returns None when the turn made no tool calls: a trajectory with no actions
+    tells every consumer nothing and would only dilute the store.
+    """
+    calls = extract_tool_calls(messages)
+    if not calls:
+        return None
+
+    log = TrajectoryLog(
+        session_id=session_id or "",
+        completed=bool(completed),
+        task_key=task_key(task_descriptor),
+    )
+    for call in calls:
+        log.add_tool_call(
+            call["tool"],
+            call["args"],
+            result=call["result"],
+            status=call["status"],
+        )
+    return log
+
+
+def capture_turn(
+    messages: List[Dict[str, Any]],
+    *,
+    session_id: str = "",
+    task_descriptor: str = "",
+    completed: bool = True,
+    trajectory_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """Build and persist a turn's trajectory. Returns the path, or None.
+
+    Never raises. This runs in ``finalize_turn`` alongside teardown that is
+    already individually guarded (#8049) — instrumentation must not be able to
+    discard a completed turn's response.
+    """
+    try:
+        log = build_trajectory_log(
+            messages,
+            session_id=session_id,
+            task_descriptor=task_descriptor,
+            completed=completed,
+        )
+        if log is None:
+            return None
+        return log.save(trajectory_dir)
+    except Exception:
+        return None

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -224,11 +224,15 @@ def finalize_turn(
 
     # Capture the turn's TOOL CALLS for the evolution pipeline (#1363).
     #
-    # Distinct from _save_trajectory above and deliberately not gated on the
-    # same flag. That one writes the full ShareGPT conversation including user
-    # prose, which is why it defaults off; this writes call metadata only —
-    # tool name, redacted args, status, truncated result summary — so it can
-    # run without putting private text on disk.
+    # Distinct from _save_trajectory above: that writes the full ShareGPT
+    # conversation including user prose, this writes call metadata only — tool
+    # name, redacted args, status, truncated result summary.
+    #
+    # Also opt-in, behind HERMES_EVOLUTION_CAPTURE and OFF by default. Redaction
+    # catches credential-shaped keys, not sensitive values in ordinary fields
+    # (a path with a username, an SQL string, an internal hostname all survive
+    # it), so writing on every turn of every interactive session unasked would
+    # be wrong even for metadata. capture_turn() checks the flag itself.
     #
     # It exists because the pipeline had no record of what the agent actually
     # did: evolution_funnel's trajectory contains one entry naming itself.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -222,6 +222,36 @@ def finalize_turn(
         _cleanup_errors.append(f"save_trajectory: {_save_err}")
         logger.error("finalize_turn: _save_trajectory failed: %s", _save_err, exc_info=True)
 
+    # Capture the turn's TOOL CALLS for the evolution pipeline (#1363).
+    #
+    # Distinct from _save_trajectory above and deliberately not gated on the
+    # same flag. That one writes the full ShareGPT conversation including user
+    # prose, which is why it defaults off; this writes call metadata only —
+    # tool name, redacted args, status, truncated result summary — so it can
+    # run without putting private text on disk.
+    #
+    # It exists because the pipeline had no record of what the agent actually
+    # did: evolution_funnel's trajectory contains one entry naming itself.
+    # Seven issues wait on this input, and six PRs were closed for
+    # implementing against a synthetic substitute for it.
+    #
+    # Guarded like every other step here (#8049): a metrics write must never
+    # discard a completed turn's response.
+    try:
+        from agent.tool_call_capture import capture_turn
+
+        capture_turn(
+            messages,
+            session_id=getattr(agent, "session_id", "") or "",
+            task_descriptor=_summarize_user_message_for_log(user_message),
+            completed=completed,
+        )
+    except Exception as _capture_err:
+        _cleanup_errors.append(f"tool_call_capture: {_capture_err}")
+        logger.error(
+            "finalize_turn: tool-call capture failed: %s", _capture_err, exc_info=True
+        )
+
     # Clean up VM and browser for this task after conversation completes
     try:
         agent._cleanup_task_resources(effective_task_id)

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -196,6 +196,32 @@ class TrajectoryLog:
         path.write_text(self.to_json(), encoding="utf-8")
         return path
 
+    def append(self, trajectory_dir: Optional[Path] = None) -> Path:
+        """Append this log as one line to a per-session JSONL file.
+
+        :meth:`save` overwrites, which is correct for the cron stage — one
+        trajectory per stage run per day. It is wrong for a multi-turn agent
+        session: each turn would overwrite the last, so a 12-turn session
+        leaves only turn 12 on disk and the other eleven are destroyed. That
+        loses exactly the action *sequence* the consumers of #1363 want.
+
+        Appending keeps every turn. One JSON object per line, same shape
+        :meth:`to_dict` produces, so a reader can take them one at a time
+        without holding the session in memory.
+        """
+        if trajectory_dir is None:
+            trajectory_dir = _default_trajectory_dir()
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        fname = (
+            f"{self.date}_{self.session_id}.jsonl"
+            if self.session_id
+            else f"{self.date}.jsonl"
+        )
+        path = trajectory_dir / fname
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(self.to_dict(), sort_keys=True) + "\n")
+        return path
+
     @property
     def tool_sequence(self) -> List[str]:
         return [e.tool for e in self.entries]

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -128,10 +128,27 @@ class TrajectoryEntry:
 class TrajectoryLog:
     """In-memory trajectory log for a single cron session."""
 
-    def __init__(self, session_id: str = "", date: str = "") -> None:
+    def __init__(
+        self,
+        session_id: str = "",
+        date: str = "",
+        completed: Optional[bool] = None,
+        task_key: str = "",
+    ) -> None:
         self.session_id = session_id
         self.date = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
         self.entries: List[TrajectoryEntry] = []
+        # Task-level outcome and pairing key (#1363). Both are optional so the
+        # existing cron-stage caller is unaffected, and both are omitted from
+        # to_dict() when unset so old readers see the exact shape they expect.
+        #
+        # ``completed`` is what lets #1359 tell a trajectory worth distilling a
+        # heuristic from apart from one that failed; ``task_key`` is an opaque
+        # hash of the task descriptor, which is what #1436 pairs a failed and a
+        # successful run on. A hash rather than the text because the descriptor
+        # is user prose and must not enter the pipeline's store.
+        self.completed = completed
+        self.task_key = task_key
 
     def add(self, entry: TrajectoryEntry) -> None:
         self.entries.append(entry)
@@ -149,11 +166,19 @@ class TrajectoryLog:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        out: Dict[str, Any] = {
             "date": self.date,
             "session_id": self.session_id,
             "entries": [e.to_dict() for e in self.entries],
         }
+        # Only emitted when set, so a reader written against the pre-#1363
+        # shape sees no new keys on the cron-stage trajectories it already
+        # handles.
+        if self.completed is not None:
+            out["completed"] = bool(self.completed)
+        if self.task_key:
+            out["task_key"] = self.task_key
+        return out
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), indent=2, sort_keys=True)
@@ -202,7 +227,13 @@ def load_trajectory(path: Path) -> Optional[TrajectoryLog]:
     if not isinstance(data, dict):
         return None
     log = TrajectoryLog(
-        session_id=data.get("session_id", ""), date=data.get("date", "")
+        session_id=data.get("session_id", ""),
+        date=data.get("date", ""),
+        # Absent on pre-#1363 cron-stage trajectories; None/"" there means
+        # "not recorded", which consumers must treat differently from a
+        # recorded failure.
+        completed=data.get("completed"),
+        task_key=data.get("task_key", ""),
     )
     for ed in data.get("entries", []):
         if isinstance(ed, dict):

--- a/tests/agent/test_tool_call_capture.py
+++ b/tests/agent/test_tool_call_capture.py
@@ -9,12 +9,22 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
+import pytest  # noqa: E402
+
 from agent.tool_call_capture import (  # noqa: E402
+    _CAPTURE_ENV,
     build_trajectory_log,
+    capture_enabled,
     capture_turn,
     extract_tool_calls,
     task_key,
 )
+
+
+@pytest.fixture
+def capture_on(monkeypatch):
+    """Capture is opt-in (#1363 review): tests that exercise it must ask."""
+    monkeypatch.setenv(_CAPTURE_ENV, "1")
 
 
 def _call(name, args, cid):
@@ -40,23 +50,41 @@ def _fail(cid):
 
 
 class TestTaskKey:
-    def test_stable_for_same_text(self):
-        assert task_key("fix the parser") == task_key("fix the parser")
+    def test_stable_for_same_text(self, tmp_path):
+        assert task_key("fix the parser", tmp_path) == task_key("fix the parser", tmp_path)
 
-    def test_differs_for_different_text(self):
-        assert task_key("fix the parser") != task_key("fix the linter")
+    def test_differs_for_different_text(self, tmp_path):
+        assert task_key("fix the parser", tmp_path) != task_key("fix the linter", tmp_path)
 
-    def test_empty_is_empty(self):
-        assert task_key("") == ""
+    def test_empty_is_empty(self, tmp_path):
+        assert task_key("", tmp_path) == ""
 
-    def test_does_not_leak_the_descriptor(self):
-        """It is a pairing key, not a record of the prompt — #1436 only needs
-        equality, and the descriptor is user prose."""
+    def test_does_not_leak_the_descriptor(self, tmp_path):
+        """A pairing key, not a record of the prompt."""
         secret = "deploy to prod with password hunter2"
-        key = task_key(secret)
+        key = task_key(secret, tmp_path)
         assert "hunter2" not in key
         assert "deploy" not in key
         assert len(key) == 16
+
+    def test_salted_per_store(self, tmp_path):
+        """A bare sha256 of a short templated prompt is recoverable from a
+        rainbow table; an HMAC under a host-local salt is not. Two stores must
+        therefore not produce the same key for the same text."""
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.mkdir(); b.mkdir()
+        assert task_key("run the tests", a) != task_key("run the tests", b)
+
+    def test_salt_is_reused_within_a_store(self, tmp_path):
+        """...but pairing within one store must still work across calls."""
+        first = task_key("run the tests", tmp_path)
+        assert task_key("run the tests", tmp_path) == first
+
+    def test_salt_file_is_private(self, tmp_path):
+        task_key("x", tmp_path)
+        salt = tmp_path / ".trajectory_key_salt"
+        assert salt.exists()
+        assert oct(salt.stat().st_mode)[-3:] == "600"
 
 
 class TestExtractToolCalls:
@@ -115,12 +143,12 @@ class TestExtractToolCalls:
 
 
 class TestBuildTrajectoryLog:
-    def test_carries_outcome_and_pairing_key(self):
+    def test_carries_outcome_and_pairing_key(self, tmp_path):
         msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]
-        log = build_trajectory_log(msgs, session_id="s1", task_descriptor="fix it", completed=True)
+        log = build_trajectory_log(msgs, session_id="s1", task_descriptor="fix it", completed=True, trajectory_dir=tmp_path)
         assert log is not None
         assert log.completed is True
-        assert log.task_key == task_key("fix it")
+        assert log.task_key == task_key("fix it", tmp_path)
         assert log.session_id == "s1"
 
     def test_failed_turn_records_completed_false(self):
@@ -130,11 +158,11 @@ class TestBuildTrajectoryLog:
         log = build_trajectory_log(msgs, completed=False)
         assert log.completed is False
 
-    def test_same_task_different_outcomes_share_a_key(self):
+    def test_same_task_different_outcomes_share_a_key(self, tmp_path):
         """This is what #1436 pairs on."""
         msgs = [_call("terminal", {}, "c1"), _ok("c1")]
-        a = build_trajectory_log(msgs, task_descriptor="same task", completed=False)
-        b = build_trajectory_log(msgs, task_descriptor="same task", completed=True)
+        a = build_trajectory_log(msgs, task_descriptor="same task", completed=False, trajectory_dir=tmp_path)
+        b = build_trajectory_log(msgs, task_descriptor="same task", completed=True, trajectory_dir=tmp_path)
         assert a.task_key == b.task_key
         assert a.completed != b.completed
 
@@ -152,32 +180,32 @@ class TestBuildTrajectoryLog:
 
 
 class TestCaptureTurn:
-    def test_writes_a_readable_trajectory(self, tmp_path):
+    def test_writes_a_readable_trajectory(self, tmp_path, capture_on):
         msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]
         path = capture_turn(msgs, session_id="s1", task_descriptor="t", completed=True,
                             trajectory_dir=tmp_path)
         assert path is not None and path.exists()
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8").strip())
         assert data["session_id"] == "s1"
         assert data["completed"] is True
-        assert data["task_key"] == task_key("t")
+        assert data["task_key"] == task_key("t", tmp_path)
         assert [e["tool"] for e in data["entries"]] == ["read_file"]
 
-    def test_no_tool_calls_writes_nothing(self, tmp_path):
+    def test_no_tool_calls_writes_nothing(self, tmp_path, capture_on):
         assert capture_turn([{"role": "assistant", "content": "hi"}], trajectory_dir=tmp_path) is None
-        assert list(tmp_path.glob("*.json")) == []
+        assert list(tmp_path.glob("*.jsonl")) == []
 
-    def test_never_raises_on_bad_input(self, tmp_path):
+    def test_never_raises_on_bad_input(self, tmp_path, capture_on):
         assert capture_turn(None, trajectory_dir=tmp_path) is None
 
-    def test_never_raises_on_unwritable_dir(self, tmp_path):
+    def test_never_raises_on_unwritable_dir(self, tmp_path, capture_on):
         """Instrumentation must not be able to discard a completed turn."""
         blocker = tmp_path / "file"
         blocker.write_text("x", encoding="utf-8")
         msgs = [_call("read_file", {}, "c1"), _ok("c1")]
         assert capture_turn(msgs, trajectory_dir=blocker / "nested") is None
 
-    def test_no_user_prose_reaches_disk(self, tmp_path):
+    def test_no_user_prose_reaches_disk(self, tmp_path, capture_on):
         """The reason this can run while save_trajectories stays off."""
         msgs = [
             {"role": "user", "content": "my private prompt about acme corp"},
@@ -218,12 +246,68 @@ class TestLoggerBackCompat:
         assert log.completed is None, "absent must mean 'not recorded', not 'failed'"
         assert log.task_key == ""
 
-    def test_new_file_round_trips(self, tmp_path):
-        from evolution_trajectory_logger import load_trajectory
-
+    def test_new_file_round_trips(self, tmp_path, capture_on):
         msgs = [_call("read_file", {}, "c1"), _ok("c1")]
         path = capture_turn(msgs, session_id="s", task_descriptor="t", completed=False,
                             trajectory_dir=tmp_path)
-        log = load_trajectory(path)
-        assert log.completed is False
-        assert log.task_key == task_key("t")
+        line = path.read_text(encoding="utf-8").strip()
+        data = json.loads(line)
+        assert data["completed"] is False
+        assert data["task_key"] == task_key("t", tmp_path)
+
+
+class TestCaptureIsOptIn:
+    """Default OFF (#1363 review). Redaction catches credential-shaped keys,
+    not sensitive values in ordinary fields, so writing on every turn of every
+    interactive session unasked is the wrong default even for metadata."""
+
+    def test_disabled_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(_CAPTURE_ENV, raising=False)
+        assert capture_enabled() is False
+        msgs = [_call("read_file", {}, "c1"), _ok("c1")]
+        assert capture_turn(msgs, trajectory_dir=tmp_path) is None
+        assert list(tmp_path.glob("*.jsonl")) == []
+
+    def test_enabled_by_env(self, tmp_path, monkeypatch):
+        for value in ("1", "true", "yes", "on", "ON"):
+            monkeypatch.setenv(_CAPTURE_ENV, value)
+            assert capture_enabled() is True, value
+
+    def test_junk_value_does_not_enable(self, monkeypatch):
+        for value in ("0", "false", "no", "", "maybe"):
+            monkeypatch.setenv(_CAPTURE_ENV, value)
+            assert capture_enabled() is False, value
+
+
+class TestMultiTurnSessionsAppend:
+    """save() overwrites; a multi-turn session would keep only its last turn.
+
+    Confirmed before the fix: three turns of one session left one file with
+    only the third turn's calls. The action *sequence* is exactly what the
+    consumers of #1363 want, so losing it defeats the feature.
+    """
+
+    def test_every_turn_is_kept(self, tmp_path, capture_on):
+        for tool, cid in (("read_file", "a"), ("patch", "b"), ("terminal", "c")):
+            capture_turn([_call(tool, {}, cid), _ok(cid)], session_id="s1",
+                         task_descriptor="t", trajectory_dir=tmp_path)
+        files = list(tmp_path.glob("*.jsonl"))
+        assert len(files) == 1
+        lines = [json.loads(x) for x in files[0].read_text(encoding="utf-8").splitlines() if x.strip()]
+        assert [line["entries"][0]["tool"] for line in lines] == ["read_file", "patch", "terminal"]
+
+    def test_separate_sessions_get_separate_files(self, tmp_path, capture_on):
+        capture_turn([_call("read_file", {}, "a"), _ok("a")], session_id="s1", trajectory_dir=tmp_path)
+        capture_turn([_call("patch", {}, "b"), _ok("b")], session_id="s2", trajectory_dir=tmp_path)
+        assert len(list(tmp_path.glob("*.jsonl"))) == 2
+
+    def test_each_line_is_independently_parseable(self, tmp_path, capture_on):
+        """A reader must be able to take one turn at a time without holding
+        the session in memory."""
+        for cid in ("a", "b"):
+            capture_turn([_call("terminal", {}, cid), _ok(cid)], session_id="s1",
+                         trajectory_dir=tmp_path)
+        path = list(tmp_path.glob("*.jsonl"))[0]
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                assert json.loads(line)["entries"]

--- a/tests/agent/test_tool_call_capture.py
+++ b/tests/agent/test_tool_call_capture.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""Tests for real tool-call capture (issue #1363)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent.tool_call_capture import (  # noqa: E402
+    build_trajectory_log,
+    capture_turn,
+    extract_tool_calls,
+    task_key,
+)
+
+
+def _call(name, args, cid):
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": cid, "type": "function",
+             "function": {"name": name, "arguments": json.dumps(args)}}
+        ],
+    }
+
+
+def _result(cid, content):
+    return {"role": "tool", "tool_call_id": cid, "content": content}
+
+
+def _ok(cid):
+    return _result(cid, json.dumps({"success": True}))
+
+
+def _fail(cid):
+    return _result(cid, json.dumps({"error": "no such file"}))
+
+
+class TestTaskKey:
+    def test_stable_for_same_text(self):
+        assert task_key("fix the parser") == task_key("fix the parser")
+
+    def test_differs_for_different_text(self):
+        assert task_key("fix the parser") != task_key("fix the linter")
+
+    def test_empty_is_empty(self):
+        assert task_key("") == ""
+
+    def test_does_not_leak_the_descriptor(self):
+        """It is a pairing key, not a record of the prompt — #1436 only needs
+        equality, and the descriptor is user prose."""
+        secret = "deploy to prod with password hunter2"
+        key = task_key(secret)
+        assert "hunter2" not in key
+        assert "deploy" not in key
+        assert len(key) == 16
+
+
+class TestExtractToolCalls:
+    def test_pairs_calls_with_results(self):
+        msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]
+        calls = extract_tool_calls(msgs)
+        assert len(calls) == 1
+        assert calls[0]["tool"] == "read_file"
+        assert calls[0]["status"] == "success"
+
+    def test_classifies_failure(self):
+        msgs = [_call("read_file", {"path": "nope"}, "c1"), _fail("c1")]
+        assert extract_tool_calls(msgs)[0]["status"] == "failure"
+
+    def test_call_without_result_is_pending_not_dropped(self):
+        """A call that never returned is signal for #1268's error-recovery
+        dimension, so it must survive rather than vanish."""
+        calls = extract_tool_calls([_call("terminal", {"command": "sleep"}, "c1")])
+        assert len(calls) == 1
+        assert calls[0]["status"] == "pending"
+
+    def test_preserves_order(self):
+        msgs = [
+            _call("read_file", {}, "c1"), _ok("c1"),
+            _call("patch", {}, "c2"), _ok("c2"),
+            _call("terminal", {}, "c3"), _ok("c3"),
+        ]
+        assert [c["tool"] for c in extract_tool_calls(msgs)] == ["read_file", "patch", "terminal"]
+
+    def test_multi_tool_turn(self):
+        msgs = [{
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "a", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "b", "function": {"name": "search_files", "arguments": "{}"}},
+            ],
+        }, _ok("a"), _ok("b")]
+        assert len(extract_tool_calls(msgs)) == 2
+
+    def test_malformed_input_does_not_raise(self):
+        for bad in (None, "string", 42, [None], [{"role": "assistant", "tool_calls": "x"}],
+                    [{"role": "assistant", "tool_calls": [None]}],
+                    [{"role": "assistant", "tool_calls": [{"function": None}]}],
+                    [{"role": "assistant", "tool_calls": [{"function": {}}]}]):
+            assert extract_tool_calls(bad) == []
+
+    def test_unparseable_arguments_become_empty_dict(self):
+        msgs = [{
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "t", "arguments": "not json"}}],
+        }, _ok("c1")]
+        assert extract_tool_calls(msgs)[0]["args"] == {}
+
+    def test_no_tool_calls_returns_empty(self):
+        assert extract_tool_calls([{"role": "assistant", "content": "just text"}]) == []
+
+
+class TestBuildTrajectoryLog:
+    def test_carries_outcome_and_pairing_key(self):
+        msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]
+        log = build_trajectory_log(msgs, session_id="s1", task_descriptor="fix it", completed=True)
+        assert log is not None
+        assert log.completed is True
+        assert log.task_key == task_key("fix it")
+        assert log.session_id == "s1"
+
+    def test_failed_turn_records_completed_false(self):
+        """#1359 filters on this — a heuristic is only worth distilling from a
+        trajectory whose outcome is known."""
+        msgs = [_call("terminal", {}, "c1"), _fail("c1")]
+        log = build_trajectory_log(msgs, completed=False)
+        assert log.completed is False
+
+    def test_same_task_different_outcomes_share_a_key(self):
+        """This is what #1436 pairs on."""
+        msgs = [_call("terminal", {}, "c1"), _ok("c1")]
+        a = build_trajectory_log(msgs, task_descriptor="same task", completed=False)
+        b = build_trajectory_log(msgs, task_descriptor="same task", completed=True)
+        assert a.task_key == b.task_key
+        assert a.completed != b.completed
+
+    def test_turn_with_no_tool_calls_is_none(self):
+        """An empty trajectory tells every consumer nothing and would only
+        dilute the store."""
+        assert build_trajectory_log([{"role": "assistant", "content": "hi"}]) is None
+
+    def test_arguments_are_redacted(self):
+        msgs = [_call("api", {"token": "secret-value", "path": "a.py"}, "c1"), _ok("c1")]
+        log = build_trajectory_log(msgs)
+        arg = log.entries[0].args_summary
+        assert arg["token"] == "[REDACTED]"
+        assert arg["path"] == "a.py"
+
+
+class TestCaptureTurn:
+    def test_writes_a_readable_trajectory(self, tmp_path):
+        msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]
+        path = capture_turn(msgs, session_id="s1", task_descriptor="t", completed=True,
+                            trajectory_dir=tmp_path)
+        assert path is not None and path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["session_id"] == "s1"
+        assert data["completed"] is True
+        assert data["task_key"] == task_key("t")
+        assert [e["tool"] for e in data["entries"]] == ["read_file"]
+
+    def test_no_tool_calls_writes_nothing(self, tmp_path):
+        assert capture_turn([{"role": "assistant", "content": "hi"}], trajectory_dir=tmp_path) is None
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_never_raises_on_bad_input(self, tmp_path):
+        assert capture_turn(None, trajectory_dir=tmp_path) is None
+
+    def test_never_raises_on_unwritable_dir(self, tmp_path):
+        """Instrumentation must not be able to discard a completed turn."""
+        blocker = tmp_path / "file"
+        blocker.write_text("x", encoding="utf-8")
+        msgs = [_call("read_file", {}, "c1"), _ok("c1")]
+        assert capture_turn(msgs, trajectory_dir=blocker / "nested") is None
+
+    def test_no_user_prose_reaches_disk(self, tmp_path):
+        """The reason this can run while save_trajectories stays off."""
+        msgs = [
+            {"role": "user", "content": "my private prompt about acme corp"},
+            _call("read_file", {"path": "a.py"}, "c1"),
+            _result("c1", "file contents mentioning acme corp"),
+            {"role": "assistant", "content": "here is my private analysis"},
+        ]
+        path = capture_turn(msgs, task_descriptor="my private prompt about acme corp",
+                            trajectory_dir=tmp_path)
+        raw = path.read_text(encoding="utf-8")
+        assert "my private prompt" not in raw
+        assert "private analysis" not in raw
+
+
+class TestLoggerBackCompat:
+    """The pre-#1363 cron-stage shape must round-trip unchanged."""
+
+    def test_old_shape_omits_new_keys(self, tmp_path):
+        from evolution_trajectory_logger import TrajectoryLog
+
+        log = TrajectoryLog(session_id="cron")
+        log.add_tool_call("evolution_funnel", {"date": "2026-07-28"}, result={}, status="success")
+        data = json.loads(log.to_json())
+        assert "completed" not in data
+        assert "task_key" not in data
+
+    def test_old_file_loads_with_unset_fields(self, tmp_path):
+        from evolution_trajectory_logger import load_trajectory
+
+        p = tmp_path / "old.json"
+        p.write_text(json.dumps({
+            "date": "2026-07-01", "session_id": "cron",
+            "entries": [{"tool": "evolution_funnel", "args_summary": {},
+                         "result_status": "success", "result_summary": "ok"}],
+        }), encoding="utf-8")
+        log = load_trajectory(p)
+        assert log is not None
+        assert log.completed is None, "absent must mean 'not recorded', not 'failed'"
+        assert log.task_key == ""
+
+    def test_new_file_round_trips(self, tmp_path):
+        from evolution_trajectory_logger import load_trajectory
+
+        msgs = [_call("read_file", {}, "c1"), _ok("c1")]
+        path = capture_turn(msgs, session_id="s", task_descriptor="t", completed=False,
+                            trajectory_dir=tmp_path)
+        log = load_trajectory(path)
+        assert log.completed is False
+        assert log.task_key == task_key("t")


### PR DESCRIPTION
Closes #1363 — the blocker seven issues wait on.

## The gap

The pipeline had **no record of what the agent actually did**:

- `evolution_funnel` writes a trajectory containing one entry — `tool='evolution_funnel'`. The pipeline logging its own invocation.
- `agent.save_trajectories` writes real conversation JSONL, but defaults off, lands in the process CWD, and nothing in the pipeline reads it.
- `~/.hermes/evolution/trajectories/` — **0 files**.

That one missing input has cost **six PRs**. #1267, #1268 and #1270 each had two closed by the owner as *dead code* or *incoherent*, every time with the same verdict: the implementation *"reads the funnel's own synthetic trajectory record rather than real agent tool calls"*. Each attempt had to invent a substitute for data that did not exist.

Two of the waiting issues (#1359, #1436) state in their bodies that these trajectories already exist. #1359 literally parses the empty directory.

## What this adds

**The conversion, not new storage.** `agent/tool_call_capture.py` turns a finished turn's messages into the `TrajectoryLog` that `evolution_trajectory_logger` already defines and already knows how to persist. Wired in `finalize_turn` beside the existing `_save_trajectory` call, guarded like every other step there (#8049) — a metrics write must never discard a completed turn's response.

## Privacy — why this can run while `save_trajectories` stays off

That flag writes the **full ShareGPT conversation, user prose included**, which is exactly why it defaults off, and why turning it on for evolution would be the wrong trade.

This captures **call metadata only**: tool name, arguments through the logger's existing `redact_args`, a status, a truncated result summary. No user message, no assistant prose. `test_no_user_prose_reaches_disk` asserts it.

## The consumers want different shapes, so the record carries the union

| Issue | Needs | Field |
|---|---|---|
| #1268 tool-use rubric | per-call tool / args / outcome / order | `entries` |
| #1359 ERL heuristics | task-level outcome — is this trajectory worth distilling from? | `completed` |
| #1436 EMG graph matching | **pair** a failed and a successful run of the same task | `task_key` |

`task_key` is a 16-char hash of the task descriptor, not the text: pairing only needs equality, and the descriptor is user prose that must not enter the store.

Both new fields are **optional** on `TrajectoryLog` and omitted from `to_dict()` when unset, so the existing cron-stage caller and any reader written against the pre-#1363 shape are unaffected. `load_trajectory` reads them back, with absent meaning *"not recorded"* rather than *"failed"* — a distinction consumers must not collapse.

## Two deliberate extraction choices

- **A call with no matching result is kept as `pending`, not dropped.** A call that never returned is itself signal for #1268's error-recovery dimension.
- **Status is classified by importing `introspection_extract._tool_result_failed`**, not reimplemented. Two disagreeing definitions of failure is how a metric drifts from what it claims to measure.

## Tests

25 covering extraction, malformed input (8 shapes, none raise), redaction, pairing, back-compat of the old on-disk shape, and that capture never raises on an unwritable path. Plus 18 passing in the existing trajectory logger/store suites. Ruff clean.

## What this does not do

It does not enable anything by default beyond the capture itself, and it does not implement any of the seven waiting issues — it gives them a real input to be implemented against. Whether the record satisfies each of them should be checked when they are picked up, starting with #1268 (the flat-log consumer) and #1436 (the most demanding, needing pairs).
