### PR TITLE
feat: tool-use competency rubric over real agent traces (Closes #1268)

### DIFF
--- a/scripts/evolution_tooluse_rubric.py
+++ b/scripts/evolution_tooluse_rubric.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Tool-use competency rubric over real agent traces (issue #1268).
+
+Five diagnostic dimensions from MCP-Atlas (arXiv:2602.00933), scored over the
+tool-call trajectories that ``agent/tool_call_capture.py`` records since #1363:
+
+  discovery        did the agent find the right tool, or reformulate searches?
+  parameterization were argument shapes right, or retried after malformed args?
+  syntax           were the calls well-formed at all?
+  error_recovery   after a failure, a different approach or an identical retry?
+  efficiency       how much of the work was distinct rather than redundant?
+
+Written against the owner's rework brief on the two previous attempts, both of
+which were closed as incoherent. Quoting the verdict on PR #1281, because every
+clause of it is a requirement here:
+
+    "The rubric reads the funnel's own synthetic trajectory record rather than
+    real agent tool calls, then flattens independent sessions and assigns every
+    call turn 0. That makes the diagnostic unable to measure the claimed
+    competency dimensions and creates false repeated-call clusters. [...] it
+    needs a future implementation that extracts privacy-safe real traces from
+    session storage, preserves session and turn boundaries, evaluates each
+    trace separately, and lets the funnel consume only the resulting summary."
+
+So, concretely:
+
+* **Real traces.** Reads ``<evolution_dir>/trajectories/*.jsonl`` — the #1363
+  capture of actual agent tool calls — and ignores the single-entry
+  ``<date>.json`` files the funnel writes about itself.
+* **Boundaries preserved.** One JSONL line is one turn; the filename carries
+  the session. Turns are never concatenated across sessions, which is what
+  manufactured the false repeated-call clusters last time.
+* **Scored per trace.** Each turn is scored on its own; the corpus figure is an
+  average of per-turn scores, not a score over a merged pile of calls.
+* **Summary only.** ``score_corpus`` returns per-dimension averages and counts.
+  The funnel consumes that, never the traces.
+
+Privacy is inherited rather than re-solved: the captured entries already hold
+redacted argument summaries and truncated result summaries, never user prose.
+
+Deterministic — no LLM, no network. Pure functions plus a thin CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = "1"
+
+DIMENSIONS = (
+    "discovery",
+    "parameterization",
+    "syntax",
+    "error_recovery",
+    "efficiency",
+)
+
+#: Tools whose repeated use *is* the discovery process. Reformulating a search
+#: several times before invoking anything is the #1144 signal.
+_DISCOVERY_TOOLS = frozenset({"tool_search", "tool_describe"})
+_DISCOVERY_TOLERANCE = 2
+
+#: A failed call followed by an identical one is the "infinite debugging loop"
+#: LHTB names — the cheapest and highest-value error-recovery signal, per the
+#: issue.
+_IDENTICAL_RETRY_PENALTY = 0.5
+
+#: Syntax failures are parse-level: the call could not even be formed.
+_PARSE_ERROR_MARKERS = ("parse error", "invalid json", "jsondecode", "unexpected token")
+
+
+@dataclass
+class TurnScore:
+    """Per-dimension scores for ONE turn, plus what drove them."""
+
+    session_id: str = ""
+    turn_index: int = 0
+    n_calls: int = 0
+    scores: Dict[str, float] = field(default_factory=dict)
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def overall(self) -> float:
+        if not self.scores:
+            return 0.0
+        return round(sum(self.scores.values()) / len(self.scores), 4)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "turn_index": self.turn_index,
+            "n_calls": self.n_calls,
+            "scores": dict(self.scores),
+            "overall": self.overall,
+            "notes": list(self.notes),
+        }
+
+
+def _call_signature(entry: Dict[str, Any]) -> str:
+    """Identity of a call for redundancy purposes: tool + its argument shape."""
+    args = entry.get("args_summary")
+    try:
+        args_repr = json.dumps(args, sort_keys=True) if isinstance(args, dict) else str(args)
+    except (TypeError, ValueError):
+        args_repr = str(args)
+    return f"{entry.get('tool', '')}::{args_repr}"
+
+
+def _failed(entry: Dict[str, Any]) -> bool:
+    return str(entry.get("result_status", "")).lower() in ("failure", "error")
+
+
+def _looks_like_parse_error(entry: Dict[str, Any]) -> bool:
+    blob = f"{entry.get('result_summary', '')}".lower()
+    return any(marker in blob for marker in _PARSE_ERROR_MARKERS)
+
+
+def score_turn(
+    entries: List[Dict[str, Any]],
+    *,
+    session_id: str = "",
+    turn_index: int = 0,
+) -> TurnScore:
+    """Score ONE turn's tool calls across the five dimensions.
+
+    Every dimension is 0.0–1.0 where 1.0 is competent. A turn with no calls
+    returns an empty score rather than a perfect one — nothing was attempted,
+    so there is nothing to be competent at, and averaging in a free 1.0 would
+    flatter the corpus figure.
+    """
+    score = TurnScore(session_id=session_id, turn_index=turn_index, n_calls=len(entries))
+    if not entries:
+        return score
+
+    total = len(entries)
+    signatures = [_call_signature(e) for e in entries]
+    failures = [e for e in entries if _failed(e)]
+
+    # -- discovery: searching is fine; searching instead of acting is not.
+    discovery_calls = sum(
+        1 for e in entries if str(e.get("tool", "")) in _DISCOVERY_TOOLS
+    )
+    if discovery_calls:
+        excess = max(0, discovery_calls - _DISCOVERY_TOLERANCE)
+        score.scores["discovery"] = round(max(0.0, 1.0 - excess / max(1, total)), 4)
+        if excess:
+            score.notes.append(
+                f"{discovery_calls} discovery calls ({excess} beyond tolerance)"
+            )
+    else:
+        score.scores["discovery"] = 1.0
+
+    # -- parameterization: a failure followed by the SAME tool with DIFFERENT
+    #    args is the model correcting an argument shape. Frequent correction
+    #    means the first shape was wrong.
+    corrections = 0
+    for i, entry in enumerate(entries[:-1]):
+        if not _failed(entry):
+            continue
+        nxt = entries[i + 1]
+        if entry.get("tool") == nxt.get("tool") and signatures[i] != signatures[i + 1]:
+            corrections += 1
+    score.scores["parameterization"] = round(max(0.0, 1.0 - corrections / total), 4)
+    if corrections:
+        score.notes.append(f"{corrections} argument correction(s) after failure")
+
+    # -- syntax: calls that could not be formed at all.
+    parse_errors = sum(1 for e in entries if _looks_like_parse_error(e))
+    score.scores["syntax"] = round(max(0.0, 1.0 - parse_errors / total), 4)
+    if parse_errors:
+        score.notes.append(f"{parse_errors} parse-level failure(s)")
+
+    # -- error_recovery: after a failure, did the agent change anything?
+    #    An identical re-issue is the infinite-debugging-loop shape.
+    if failures:
+        identical_retries = 0
+        for i, entry in enumerate(entries[:-1]):
+            if _failed(entry) and signatures[i] == signatures[i + 1]:
+                identical_retries += 1
+        penalty = min(1.0, identical_retries * _IDENTICAL_RETRY_PENALTY)
+        score.scores["error_recovery"] = round(max(0.0, 1.0 - penalty), 4)
+        if identical_retries:
+            score.notes.append(f"{identical_retries} identical retry after failure")
+    else:
+        score.scores["error_recovery"] = 1.0
+
+    # -- efficiency: share of calls that were distinct work.
+    score.scores["efficiency"] = round(len(set(signatures)) / total, 4)
+    if len(set(signatures)) < total:
+        score.notes.append(f"{total - len(set(signatures))} redundant call(s)")
+
+    return score
+
+
+def load_turns(trajectory_dir: Path) -> List[Dict[str, Any]]:
+    """Read captured turns, preserving session and turn boundaries.
+
+    Reads only the ``.jsonl`` files written by the #1363 capture. The funnel's
+    own ``<date>.json`` files describe the pipeline's invocation of itself and
+    are deliberately skipped — scoring them was the core defect in the previous
+    attempt.
+    """
+    turns: List[Dict[str, Any]] = []
+    if not trajectory_dir.is_dir():
+        return turns
+    for path in sorted(trajectory_dir.glob("*.jsonl")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for idx, line in enumerate(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(rec, dict) or not isinstance(rec.get("entries"), list):
+                continue
+            rec["_turn_index"] = idx
+            turns.append(rec)
+    return turns
+
+
+def score_corpus(turns: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Average per-turn scores into the summary the funnel consumes.
+
+    Turns are scored individually and then averaged — never merged into one
+    pile of calls, which is what produced false repeated-call clusters before.
+    """
+    per_turn = [
+        score_turn(
+            t.get("entries", []),
+            session_id=str(t.get("session_id", "")),
+            turn_index=int(t.get("_turn_index", 0)),
+        )
+        for t in turns
+    ]
+    scored = [s for s in per_turn if s.n_calls]
+
+    dims: Dict[str, Optional[float]] = {}
+    for dim in DIMENSIONS:
+        values = [s.scores[dim] for s in scored if dim in s.scores]
+        dims[dim] = round(sum(values) / len(values), 4) if values else None
+
+    graded = [d for d in dims.values() if d is not None]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "turns_scored": len(scored),
+        "turns_seen": len(per_turn),
+        "sessions": len({s.session_id for s in scored if s.session_id}),
+        "total_calls": sum(s.n_calls for s in scored),
+        "dimensions": dims,
+        "overall": round(sum(graded) / len(graded), 4) if graded else None,
+    }
+
+
+def format_summary(summary: Dict[str, Any]) -> str:
+    """One line for the evolution-health sidecar / a log."""
+    if not summary.get("turns_scored"):
+        return "[tooluse-rubric] no captured turns to score"
+    parts = [
+        f"{dim}={summary['dimensions'][dim]:.0%}"
+        for dim in DIMENSIONS
+        if summary["dimensions"].get(dim) is not None
+    ]
+    return (
+        f"[tooluse-rubric] {summary['turns_scored']} turns / "
+        f"{summary['sessions']} sessions / {summary['total_calls']} calls: "
+        + " ".join(parts)
+    )
+
+
+def _default_trajectory_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / "trajectories"
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / "trajectories"
+        if hh
+        else Path.home() / ".hermes" / "evolution" / "trajectories"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if "--help" in args or "-h" in args:
+        print(
+            "usage: evolution_tooluse_rubric.py [--trajectory-dir DIR]\n"
+            "  Scores captured agent tool calls (#1363) across the five\n"
+            "  MCP-Atlas competency dimensions. JSON summary to stdout.\n"
+            "  Exit 0 always; 2 on bad arguments."
+        )
+        return 0
+
+    trajectory_dir = _default_trajectory_dir()
+    if "--trajectory-dir" in args:
+        i = args.index("--trajectory-dir")
+        try:
+            trajectory_dir = Path(args[i + 1])
+        except IndexError:
+            print("error: --trajectory-dir needs a path", file=sys.stderr)
+            return 2
+
+    summary = score_corpus(load_turns(trajectory_dir))
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print(format_summary(summary), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_tooluse_rubric.py
+++ b/tests/scripts/test_evolution_tooluse_rubric.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""Tests for the tool-use competency rubric (issue #1268)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_tooluse_rubric import (  # noqa: E402
+    DIMENSIONS,
+    format_summary,
+    load_turns,
+    main,
+    score_corpus,
+    score_turn,
+)
+
+
+def _entry(tool, args=None, status="success", summary=""):
+    return {
+        "tool": tool,
+        "args_summary": args or {},
+        "result_status": status,
+        "result_summary": summary,
+    }
+
+
+def _write_turns(d, session, turns):
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"2026-07-28_{session}.jsonl"
+    with open(p, "a", encoding="utf-8") as fh:
+        for entries in turns:
+            fh.write(json.dumps({"date": "2026-07-28", "session_id": session,
+                                 "entries": entries}) + "\n")
+    return p
+
+
+class TestCleanTurn:
+    def test_varied_successful_calls_score_well(self):
+        s = score_turn([_entry("read_file", {"p": "a"}), _entry("patch", {"p": "a"}),
+                        _entry("terminal", {"c": "test"})])
+        assert s.overall == 1.0
+        assert all(s.scores[d] == 1.0 for d in DIMENSIONS)
+
+    def test_empty_turn_is_not_a_free_pass(self):
+        """Nothing was attempted, so there is nothing to be competent at —
+        averaging in a 1.0 would flatter the corpus figure."""
+        s = score_turn([])
+        assert s.n_calls == 0
+        assert s.scores == {}
+        assert s.overall == 0.0
+
+
+class TestErrorRecovery:
+    def test_identical_retry_after_failure_is_penalised(self):
+        """The infinite-debugging-loop shape LHTB names."""
+        s = score_turn([_entry("terminal", {"c": "x"}, "failure"),
+                        _entry("terminal", {"c": "x"}, "failure")])
+        assert s.scores["error_recovery"] < 1.0
+        assert any("identical retry" in n for n in s.notes)
+
+    def test_changing_approach_after_failure_is_not_penalised(self):
+        s = score_turn([_entry("terminal", {"c": "x"}, "failure"),
+                        _entry("read_file", {"p": "a"})])
+        assert s.scores["error_recovery"] == 1.0
+
+    def test_no_failures_scores_full(self):
+        s = score_turn([_entry("read_file", {"p": "a"}), _entry("patch", {"p": "b"})])
+        assert s.scores["error_recovery"] == 1.0
+
+    def test_two_identical_retries_score_zero(self):
+        s = score_turn([_entry("terminal", {"c": "x"}, "failure")] * 3)
+        assert s.scores["error_recovery"] == 0.0
+
+
+class TestParameterization:
+    def test_argument_correction_after_failure_is_counted(self):
+        s = score_turn([_entry("read_file", {"p": "wrong"}, "failure"),
+                        _entry("read_file", {"p": "right"})])
+        assert s.scores["parameterization"] < 1.0
+        assert any("argument correction" in n for n in s.notes)
+
+    def test_first_time_right_scores_full(self):
+        s = score_turn([_entry("read_file", {"p": "right"})])
+        assert s.scores["parameterization"] == 1.0
+
+    def test_a_different_tool_after_failure_is_not_a_correction(self):
+        s = score_turn([_entry("read_file", {"p": "x"}, "failure"), _entry("patch", {"p": "y"})])
+        assert s.scores["parameterization"] == 1.0
+
+
+class TestDiscovery:
+    def test_a_couple_of_searches_is_within_tolerance(self):
+        s = score_turn([_entry("tool_search", {"q": "a"}), _entry("tool_search", {"q": "b"}),
+                        _entry("read_file", {"p": "x"})])
+        assert s.scores["discovery"] == 1.0
+
+    def test_reformulating_repeatedly_is_penalised(self):
+        entries = [_entry("tool_search", {"q": f"query {i}"}) for i in range(6)]
+        entries.append(_entry("read_file", {"p": "x"}))
+        s = score_turn(entries)
+        assert s.scores["discovery"] < 1.0
+        assert any("discovery calls" in n for n in s.notes)
+
+    def test_no_search_at_all_scores_full(self):
+        assert score_turn([_entry("read_file", {"p": "x"})]).scores["discovery"] == 1.0
+
+
+class TestSyntaxAndEfficiency:
+    def test_parse_error_lowers_syntax(self):
+        s = score_turn([_entry("terminal", {"c": "x"}, "failure", "invalid json in response")])
+        assert s.scores["syntax"] < 1.0
+
+    def test_redundant_calls_lower_efficiency(self):
+        s = score_turn([_entry("read_file", {"p": "a"})] * 4)
+        assert s.scores["efficiency"] == 0.25
+        assert any("redundant" in n for n in s.notes)
+
+    def test_all_distinct_scores_full_efficiency(self):
+        s = score_turn([_entry("read_file", {"p": f"f{i}"}) for i in range(4)])
+        assert s.scores["efficiency"] == 1.0
+
+
+class TestLoadTurnsPreservesBoundaries:
+    """The previous attempt flattened independent sessions and assigned every
+    call turn 0, manufacturing false repeated-call clusters (PR #1281)."""
+
+    def test_turn_index_is_per_file(self, tmp_path):
+        _write_turns(tmp_path, "s1", [[_entry("a")], [_entry("b")], [_entry("c")]])
+        turns = load_turns(tmp_path)
+        assert [t["_turn_index"] for t in turns] == [0, 1, 2]
+
+    def test_sessions_stay_separate(self, tmp_path):
+        _write_turns(tmp_path, "s1", [[_entry("a")]])
+        _write_turns(tmp_path, "s2", [[_entry("b")]])
+        assert {t["session_id"] for t in load_turns(tmp_path)} == {"s1", "s2"}
+
+    def test_funnel_self_record_is_ignored(self, tmp_path):
+        """Scoring the pipeline's record of its own invocation is what got the
+        last attempt closed as incoherent."""
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "2026-07-28.json").write_text(json.dumps({
+            "date": "2026-07-28", "session_id": "",
+            "entries": [_entry("evolution_funnel")],
+        }), encoding="utf-8")
+        assert load_turns(tmp_path) == []
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        p = _write_turns(tmp_path, "s1", [[_entry("a")]])
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write("not json\n")
+            fh.write(json.dumps({"no": "entries"}) + "\n")
+        assert len(load_turns(tmp_path)) == 1
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        assert load_turns(tmp_path / "absent") == []
+
+
+class TestScoreCorpus:
+    def test_turns_scored_separately_not_concatenated(self, tmp_path):
+        """Two turns each calling read_file once are NOT a redundant pair —
+        concatenating them would say otherwise."""
+        _write_turns(tmp_path, "s1", [[_entry("read_file", {"p": "a"})],
+                                      [_entry("read_file", {"p": "a"})]])
+        summary = score_corpus(load_turns(tmp_path))
+        assert summary["dimensions"]["efficiency"] == 1.0
+        assert summary["turns_scored"] == 2
+
+    def test_empty_turns_excluded_from_averages(self, tmp_path):
+        _write_turns(tmp_path, "s1", [[], [_entry("read_file", {"p": "a"})]])
+        summary = score_corpus(load_turns(tmp_path))
+        assert summary["turns_seen"] == 2
+        assert summary["turns_scored"] == 1
+
+    def test_counts_sessions_and_calls(self, tmp_path):
+        _write_turns(tmp_path, "s1", [[_entry("a"), _entry("b")]])
+        _write_turns(tmp_path, "s2", [[_entry("c")]])
+        summary = score_corpus(load_turns(tmp_path))
+        assert summary["sessions"] == 2
+        assert summary["total_calls"] == 3
+
+    def test_empty_corpus_reports_none_not_zero(self):
+        """No data is not a score of zero — a consumer must be able to tell
+        'not measured' from 'measured badly'."""
+        summary = score_corpus([])
+        assert summary["overall"] is None
+        assert all(v is None for v in summary["dimensions"].values())
+
+
+class TestCli:
+    def test_summary_json_and_exit_zero(self, tmp_path, capsys):
+        _write_turns(tmp_path, "s1", [[_entry("read_file", {"p": "a"})]])
+        assert main(["--trajectory-dir", str(tmp_path)]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["turns_scored"] == 1
+
+    def test_missing_dir_argument_exits_two(self, capsys):
+        assert main(["--trajectory-dir"]) == 2
+        capsys.readouterr()
+
+    def test_help_exits_zero(self, capsys):
+        assert main(["--help"]) == 0
+        assert "usage" in capsys.readouterr().out
+
+    def test_format_summary_handles_empty(self):
+        assert "no captured turns" in format_summary(score_corpus([]))


### PR DESCRIPTION
Closes #1268. **Third attempt** — the first two were closed by the owner (PR #1276 as dead code, PR #1281 as incoherent). This one is written against the rework brief on #1281, whose every clause is a requirement:

> *"The rubric reads the funnel's own synthetic trajectory record rather than real agent tool calls, then flattens independent sessions and assigns every call turn 0. That makes the diagnostic unable to measure the claimed competency dimensions and creates false repeated-call clusters. [...] it needs a future implementation that extracts privacy-safe real traces from session storage, preserves session and turn boundaries, evaluates each trace separately, and lets the funnel consume only the resulting summary."*

**What made the first two impossible is now fixed.** #1363 (merged `2f631a761`) captures real agent tool calls. Before it, there was nothing to read but the funnel's record of its own invocation — which is exactly what both attempts read.

## Each requirement, concretely

| Brief | Implementation |
|---|---|
| real traces, not the funnel's self-record | reads `trajectories/*.jsonl` (the #1363 capture); the funnel's `<date>.json` is skipped, with a test |
| preserve session and turn boundaries | one JSONL line = one turn; filename carries the session; turn index is **per file**, so turns are never renumbered across sessions |
| evaluate each trace separately | each turn scored on its own; the corpus figure averages per-turn scores rather than scoring a merged pile |
| funnel consumes only the summary | `score_corpus` returns per-dimension averages and counts |

A test pins the distinction that broke the last attempt: **two turns each calling `read_file` once are NOT a redundant pair.** Concatenating them would say otherwise.

## The five dimensions

MCP-Atlas ([arXiv:2602.00933](https://arxiv.org/abs/2602.00933)), each scored 0–1:

- **discovery** — searching is fine; searching *instead of acting* is not
- **parameterization** — failure, then same tool with different args = a correction
- **syntax** — parse-level failures, where the call could not be formed at all
- **error_recovery** — failure, then an **identical** re-issue: the LHTB infinite-debugging-loop shape, which the issue names as the cheapest and highest-value signal
- **efficiency** — distinct calls ÷ total

## Two deliberate scoring choices

**A turn with no calls scores nothing, not 1.0.** Nothing was attempted, so there is nothing to be competent at; averaging in a free pass would flatter the corpus figure.

**An empty corpus reports `None` per dimension, not `0.0`.** A consumer must be able to tell *"not measured"* from *"measured badly"* — collapsing those is how a metric starts lying.

## Verified end to end against real capture

A competent session (varied calls, recovers by changing approach) and an incompetent one (three identical failing `terminal` calls):

```
[tooluse-rubric] 2 turns / 2 sessions / 5 calls:
  discovery=100% parameterization=100% syntax=100% error_recovery=50% efficiency=67%
```

**The rubric separates the two**, which is the entire point of it. The scores are not a vibe — the identical-retry session is what pulls `error_recovery` to 50% and `efficiency` to 67%.

## Branch note

Pushed as `evolution/issue-1268-rubric-v3` rather than reusing `evolution/issue-1268-tooluse-rubric`, which still carries the closed first attempt (#1276). Keeping them separate so the rejected version stays inspectable.

28 tests, including one per closed-PR defect; ruff clean.
