### PR TITLE
feat: wire flip-gate verdict into merge verification (Closes #1447)

### DIFF
--- a/scripts/evolution_merge_gate.py
+++ b/scripts/evolution_merge_gate.py
@@ -151,25 +151,96 @@ def check_merge_policy(
     return out
 
 
+def check_flip_gate(
+    before: Optional[Dict[str, Any]] = None,
+    after: Optional[Dict[str, Any]] = None,
+    *,
+    max_regressions: Optional[int] = None,
+    override_reason: Optional[str] = None,
+) -> List[str]:
+    """Run the example-level flip gate (#1447, Child C of #1308).
+
+    Calls :mod:`evolution_flip_gate` to classify per-probe P→F / F→P deltas
+    between a baseline (``before``) and the candidate (``after``). A 'block'
+    verdict stops the merge and names which probes regressed.
+
+    Opt-in per skill: when *both* ``before`` and ``after`` are ``None`` (the
+    skill has no probe set), the gate is skipped entirely — skills without
+    probe sets merge as before.
+
+    ``override_reason`` — when a non-empty string is supplied, a block verdict
+    is downgraded to a warning and the reason is recorded in the violation
+    list (prefixed ``FLIP_GATE_OVERRIDE:``) so the override is auditable. An
+    empty/None override does nothing — the block stands.
+    """
+    if before is None and after is None:
+        return []  # no probe set → opt-out, merge as before
+
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from evolution_flip_gate import (  # noqa: E402
+            compare_runs,
+            flip_verdict,
+            format_table,
+        )
+    except ImportError:
+        return [
+            "FLIP_GATE_UNAVAILABLE: evolution_flip_gate could not be imported "
+            "— cannot verify per-example regressions; refusing unattended "
+            "self-merge (fix the deploy or merge with human review)"
+        ]
+
+    before = before or {}
+    after = after or {}
+    table = compare_runs(before, after)
+    kwargs: Dict[str, Any] = {}
+    if max_regressions is not None:
+        kwargs["max_regressions"] = max_regressions
+    verdict = flip_verdict(table, **kwargs)
+
+    if not verdict.blocked:
+        return []
+
+    summary = format_table(table, verdict)
+    if override_reason:
+        return [
+            f"FLIP_GATE_OVERRIDE: flip-gate blocked but override applied — "
+            f"reason: {override_reason}\n{summary}"
+        ]
+    return [f"FLIP_GATE_BLOCK: {verdict.reason}\n{summary}"]
+
+
 def check_merge_policy_with_quality(
     files: Sequence[Dict[str, Any]],
     max_lines: int = DEFAULT_MAX_LINES,
     high_risk_globs: Sequence[str] = HIGH_RISK_GLOBS,
     mock_ratio_threshold: float = 0.30,
     test_contents: Optional[Dict[str, str]] = None,
+    flip_gate_results: Optional[Dict[str, Any]] = None,
+    flip_gate_override: Optional[str] = None,
 ) -> List[str]:
-    """Extended merge policy: diff-size + high-risk + test-quality gates (#1209, #1210).
+    """Extended merge policy: diff-size + high-risk + test-quality + flip gates.
 
     Runs the original :func:`check_merge_policy` (diff-size cap + high-risk
-    path blocklist) and then appends test-quality violations from
+    path blocklist), appends test-quality violations from
     :func:`evolution_test_quality_gate.check_test_quality` (mock-ratio gate
-    + fabricated-reproduction detection).
+    + fabricated-reproduction detection), and then appends flip-gate
+    violations from :func:`check_flip_gate` (#1447).
 
     ``test_contents`` — map of test file path → full content for
     fabricated-reproduction detection.  When empty/None the fabrication check
     has nothing to scan (the mock-ratio gate, which only needs file metadata,
     still runs); ``main()`` populates it from the reviewed head SHA so the
     fabrication check is LIVE on the real merge path (#1246).
+
+    ``flip_gate_results`` — optional ``{"before": {...}, "after": {...}}`
+    dict of per-probe results for the skill being promoted. When ``None``
+    (no probe set) the flip gate is skipped — skills without probe sets
+    merge as before (opt-in per skill).
+
+    ``flip_gate_override`` — optional override reason string. When supplied
+    and non-empty, a flip-gate block is downgraded to a recorded warning
+    instead of stopping the merge.
     """
     violations = check_merge_policy(
         files, max_lines=max_lines, high_risk_globs=high_risk_globs
@@ -197,6 +268,28 @@ def check_merge_policy_with_quality(
             mock_ratio_threshold=mock_ratio_threshold,
         )
     )
+    # Flip gate (#1447): per-example P→F regression check. Opt-in per skill —
+    # when flip_gate_results is None the gate is skipped entirely.
+    if flip_gate_results is not None:
+        fg_before = flip_gate_results.get("before")
+        fg_after = flip_gate_results.get("after")
+        if fg_before is None and fg_after is None:
+            # Caller opted in (provided flip_gate_results) but both sides are
+            # missing — either a load failure or an empty probe set. Fail
+            # CLOSED: cannot verify regressions → block the unattended merge.
+            violations.append(
+                "FLIP_GATE_NO_DATA: flip-gate was requested but no before/after "
+                "probe results were provided — cannot verify per-example "
+                "regressions; refusing unattended self-merge"
+            )
+        else:
+            violations.extend(
+                check_flip_gate(
+                    before=fg_before,
+                    after=fg_after,
+                    override_reason=flip_gate_override,
+                )
+            )
     return violations
 
 
@@ -279,9 +372,13 @@ def _fetch_test_contents(
         path = f.get("path") if isinstance(f, dict) else None
         if not path or not _looks_like_test(path):
             continue
-        code, out, _ = runner(
-            ["gh", "api", f"repos/{slug}/contents/{path}?ref={head}", "--jq", ".content"]
-        )
+        code, out, _ = runner([
+            "gh",
+            "api",
+            f"repos/{slug}/contents/{path}?ref={head}",
+            "--jq",
+            ".content",
+        ])
         if code != 0 or not out.strip():
             continue
         try:
@@ -291,11 +388,29 @@ def _fetch_test_contents(
     return contents
 
 
+def _load_json_file(path: str) -> Optional[Dict[str, Any]]:
+    """Load a JSON object from ``path``; return ``None`` on any error."""
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _arg_or_env(args: List[str], flag: str, env: str) -> Optional[str]:
+    """Read a CLI flag value, falling back to an env var."""
+    if flag in args:
+        return args[args.index(flag) + 1]
+    return os.environ.get(env)
+
+
 def main(argv: List[str]) -> int:
     args = argv[1:]
     if "--pr" not in args:
         print(
-            "usage: evolution_merge_gate.py --pr N [--merge] [--method squash] [--repo O/R]"
+            "usage: evolution_merge_gate.py --pr N [--merge] [--method squash] "
+            "[--repo O/R] [--flip-gate-before F] [--flip-gate-after F] "
+            "[--flip-gate-override REASON]"
         )
         return 2
     pr = int(args[args.index("--pr") + 1])
@@ -311,12 +426,27 @@ def main(argv: List[str]) -> int:
     except ValueError:
         max_lines = DEFAULT_MAX_LINES
 
+    # Flip-gate inputs (#1447): JSON files mapping probe id → result.
+    before_path = _arg_or_env(args, "--flip-gate-before", "EVOLUTION_FLIP_GATE_BEFORE")
+    after_path = _arg_or_env(args, "--flip-gate-after", "EVOLUTION_FLIP_GATE_AFTER")
+    flip_override = _arg_or_env(
+        args, "--flip-gate-override", "EVOLUTION_FLIP_GATE_OVERRIDE"
+    )
+    flip_gate_results: Optional[Dict[str, Any]] = None
+    if before_path or after_path:
+        flip_gate_results = {
+            "before": _load_json_file(before_path) if before_path else None,
+            "after": _load_json_file(after_path) if after_path else None,
+        }
+
     runner = _run
     # One snapshot: the files we review and the SHA we merge come from the SAME
     # gh read, so the policy is checked against exactly the commit that lands.
     files, head = _pr_snapshot(pr, repo, runner)
     if files is None:
-        print(f"[merge-gate] could not read PR #{pr} files (gh error / malformed response) — refusing to merge")
+        print(
+            f"[merge-gate] could not read PR #{pr} files (gh error / malformed response) — refusing to merge"
+        )
         return 1
 
     # Fetch changed test-file contents at the reviewed head SHA so the
@@ -325,7 +455,11 @@ def main(argv: List[str]) -> int:
     slug = repo or os.environ.get("EVOLUTION_REPO_SLUG", "")
     test_contents = _fetch_test_contents(files, head, slug, runner)
     violations = check_merge_policy_with_quality(
-        files, max_lines=max_lines, test_contents=test_contents
+        files,
+        max_lines=max_lines,
+        test_contents=test_contents,
+        flip_gate_results=flip_gate_results,
+        flip_gate_override=flip_override or None,
     )
     if violations:
         print(f"[merge-gate] PR #{pr} BLOCKED from autonomous self-merge:")

--- a/tests/scripts/test_evolution_merge_gate.py
+++ b/tests/scripts/test_evolution_merge_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_merge_gate import (  # noqa: E402
+    check_flip_gate,
     check_merge_policy,
     check_merge_policy_with_quality,
     _pr_snapshot,
@@ -86,7 +87,9 @@ class TestCheckMergePolicy:
 
     def test_integration_skill_is_high_risk_but_other_skills_are_not(self):
         # The integration skill IS the self-merge safety procedure → gated.
-        v = check_merge_policy([_f("skills/evolution/evolution-integration/SKILL.md", 5, 2)])
+        v = check_merge_policy([
+            _f("skills/evolution/evolution-integration/SKILL.md", 5, 2)
+        ])
         assert any("HIGH_RISK_PATH" in x for x in v)
         # Other evolution skills stay self-improvable (only CODEOWNERS-gated).
         for p in (
@@ -265,6 +268,7 @@ class TestMainWiring:
 
 # ── #1246: fail-closed on quality-gate import + live fabrication check ──────
 
+
 class TestQualityGateFailClosed:
     """#1246: the test-quality gate is a self-merge safety control. If its
     module can't be imported, the merge must be BLOCKED, not silently allowed."""
@@ -292,6 +296,7 @@ class TestFetchTestContents:
                 if key in url:
                     return code, content, ""
             return 1, "", "not found"
+
         return runner
 
     def test_fetches_and_decodes_test_files_only(self):
@@ -307,20 +312,131 @@ class TestFetchTestContents:
 
     def test_no_head_or_slug_returns_empty(self):
         import evolution_merge_gate as emg
+
         runner = self._runner({})
-        assert emg._fetch_test_contents([_f("tests/test_x.py")], None, "O/r", runner) == {}
-        assert emg._fetch_test_contents([_f("tests/test_x.py")], "sha", "", runner) == {}
+        assert (
+            emg._fetch_test_contents([_f("tests/test_x.py")], None, "O/r", runner) == {}
+        )
+        assert (
+            emg._fetch_test_contents([_f("tests/test_x.py")], "sha", "", runner) == {}
+        )
 
     def test_gh_error_is_best_effort_omit(self):
         import evolution_merge_gate as emg
+
         runner = self._runner({})  # every fetch returns code 1
         out = emg._fetch_test_contents([_f("tests/test_x.py")], "sha", "O/r", runner)
         assert out == {}
 
     def test_looks_like_test_predicate(self):
         import evolution_merge_gate as emg
+
         assert emg._looks_like_test("tests/test_a.py")
         assert emg._looks_like_test("pkg/tests/test_b.py")
         assert emg._looks_like_test("foo/test_c.py")
         assert emg._looks_like_test("foo/d_test.py")
         assert not emg._looks_like_test("scripts/foo.py")
+
+
+# ── #1447: flip-gate wiring into merge verification ──────────────────────────
+
+
+class TestCheckFlipGate:
+    """Tests for the flip-gate wiring (#1447, Child C of #1308).
+
+    Success criteria: P→F regression prevents merge, blocking comment names
+    specific probes, override leaves recorded reason, skills without probes
+    merge as before.
+    """
+
+    def test_no_probe_set_skips_gate(self):
+        """Skills without probe sets are unaffected — opt-in per skill."""
+        assert check_flip_gate() == []
+        assert check_flip_gate(None, None) == []
+
+    def test_regression_blocks_and_names_probes(self):
+        """P→F regression prevents merge; violation names the regressed probe."""
+        v = check_flip_gate(
+            before={"probe_a": True, "probe_b": True},
+            after={"probe_a": False, "probe_b": True},
+        )
+        assert len(v) == 1
+        assert "FLIP_GATE_BLOCK" in v[0]
+        assert "probe_a" in v[0]
+        assert "regressed: probe_a" in v[0]  # per-example table in the comment
+
+    def test_override_records_reason(self):
+        """Override path downgrades block to a recorded warning with reason."""
+        v = check_flip_gate(
+            before={"probe_a": True},
+            after={"probe_a": False},
+            override_reason="Known flaky probe, manual review approved",
+        )
+        assert "FLIP_GATE_OVERRIDE" in v[0]
+        assert "Known flaky probe, manual review approved" in v[0]
+        assert "FLIP_GATE_BLOCK" not in v[0]
+
+    def test_empty_override_does_not_downgrade(self):
+        """An empty override string does not downgrade the block."""
+        v = check_flip_gate(
+            before={"probe_a": True}, after={"probe_a": False}, override_reason=""
+        )
+        assert "FLIP_GATE_BLOCK" in v[0]
+
+
+class TestFlipGateWiringInQualityGate:
+    """Verify check_merge_policy_with_quality wires the flip gate correctly."""
+
+    def test_no_flip_gate_results_unaffected(self):
+        """Skills without probe sets merge as before (flip_gate_results=None)."""
+        files = [_f("scripts/foo.py", 30, 5), _f("tests/test_foo.py", 20, 0)]
+        assert check_merge_policy_with_quality(files, flip_gate_results=None) == []
+
+    def test_regression_prevents_merge(self):
+        """P→F regression prevents merge through the quality gate."""
+        files = [_f("scripts/foo.py", 30, 5)]
+        v = check_merge_policy_with_quality(
+            files,
+            flip_gate_results={
+                "before": {"probe_a": True},
+                "after": {"probe_a": False},
+            },
+        )
+        assert any("FLIP_GATE_BLOCK" in x for x in v)
+        assert any("probe_a" in x for x in v)
+
+    def test_override_leaves_recorded_reason(self):
+        """Override path records a reason instead of blocking."""
+        files = [_f("scripts/foo.py", 30, 5)]
+        v = check_merge_policy_with_quality(
+            files,
+            flip_gate_results={
+                "before": {"probe_a": True},
+                "after": {"probe_a": False},
+            },
+            flip_gate_override="Manual override: probe deprecated",
+        )
+        assert any("FLIP_GATE_OVERRIDE" in x for x in v)
+        assert not any("FLIP_GATE_BLOCK" in x for x in v)
+
+    def test_no_data_fails_closed(self):
+        """When flip_gate_results is provided but both sides are None, fail closed."""
+        files = [_f("scripts/foo.py", 30, 5)]
+        v = check_merge_policy_with_quality(
+            files, flip_gate_results={"before": None, "after": None}
+        )
+        assert any("FLIP_GATE_NO_DATA" in x for x in v)
+
+    def test_clean_flip_gate_with_clean_policy_passes(self):
+        """Both policy and flip gate clean → no violations."""
+        files = [_f("scripts/foo.py", 30, 5)]
+        assert (
+            check_merge_policy_with_quality(
+                files,
+                flip_gate_results={
+                    "before": {"a": True, "b": False},
+                    "after": {"a": True, "b": True},
+                },
+            )
+            == []
+        )


### PR DESCRIPTION
Automated evolution PR for issue #1447 (Child C of #1308).

## What

Wires the flip-gate verdict from #1446 (PR #1449) into the autonomous self-merge gate so a P→F regression actually blocks promotion.

### Changes
- **`scripts/evolution_merge_gate.py`**: `check_flip_gate()` calls `evolution_flip_gate.compare_runs` + `flip_verdict` and returns `FLIP_GATE_BLOCK` violations naming the regressed probes. Wired into `check_merge_policy_with_quality()` via `flip_gate_results` param. CLI flags `--flip-gate-before`, `--flip-gate-after`, `--flip-gate-override` + env var fallbacks.
- **`tests/scripts/test_evolution_merge_gate.py`**: 8 new tests covering all success criteria.

### Success criteria
- [x] P→F regression above threshold prevents the merge
- [x] Blocking comment names the specific probes that flipped
- [x] Overriding is possible and leaves a recorded reason
- [x] Skill without probe set merges as before (opt-in per skill)

### Implementation-blind critic
The parent issue's mechanism 2 (verification subagent sees only rubric + traces + scorer output, never the diff) is a constraint on how the verification step consumes the gate — it is enforced by the integration skill's verification prompt, not by code in this PR. The flip gate produces its verdict from probe results alone (no diff access), so the gate itself is already implementation-blind.

### Note on diff size
262 insertions + 12 deletions = 274 changed lines, exceeding the 200-line autonomous merge cap. The overage is partly ruff formatting fixes on pre-existing unformatted code (the files were already non-compliant on main). The feature itself is ~140 lines of new code + ~90 lines of tests. The merge gate will hold this for human review, which is appropriate for safety-machinery changes.

Closes #1447