### PR TITLE
feat: record per-call duration in captured trajectories (Refs #1442)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2490,6 +2490,25 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
     def _finish_agent_tool(result: Any, observed_args: Optional[dict] = None) -> Any:
         hook_args = observed_args if isinstance(observed_args, dict) else function_args
+        # Stash the per-call duration for the turn's trajectory capture (#1442).
+        # This is the only point where it exists: the capture runs in
+        # finalize_turn, by which time nothing carries per-call timing, so
+        # without this every entry's duration_ms stays None and the
+        # failure-trajectory timestamp framework has nothing to place its
+        # t_fail / t_detect / t_recover against.
+        #
+        # A plain dict on the agent, keyed by tool_call_id, drained by the
+        # capture. Guarded because a timing that fails to record must not take
+        # the tool result down with it.
+        try:
+            if tool_call_id:
+                timings = getattr(agent, "_turn_call_timings", None)
+                if timings is None:
+                    timings = {}
+                    agent._turn_call_timings = timings
+                timings[tool_call_id] = int((time.monotonic() - tool_start_time) * 1000)
+        except Exception:
+            pass
         try:
             from model_tools import _emit_post_tool_call_hook
             _emit_post_tool_call_hook(

--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -165,14 +165,22 @@ def _result_status(content: Any) -> str:
         return "success"
 
 
-def extract_tool_calls(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def extract_tool_calls(
+    messages: List[Dict[str, Any]],
+    timings: Optional[Dict[str, int]] = None,
+) -> List[Dict[str, Any]]:
     """Pull ``(tool, args, result)`` triples out of a finished turn's messages.
 
     Walks assistant turns for ``tool_calls`` and matches each to its ``tool``
     result by ``tool_call_id``. A call with no matching result (the turn ended
     mid-flight) is kept with a ``pending`` status rather than dropped — a call
     that never returned is itself signal for #1268's error-recovery dimension.
+
+    ``timings`` maps ``tool_call_id`` to milliseconds, collected during the turn
+    by ``agent_runtime_helpers`` — the only place per-call duration exists, since
+    by the time this runs the calls are long finished (#1442).
     """
+    timings = timings or {}
     if not isinstance(messages, list):
         return []
 
@@ -217,6 +225,7 @@ def extract_tool_calls(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     "args": args if isinstance(args, dict) else {},
                     "result": content,
                     "status": _result_status(content) if has_result else "pending",
+                    "duration_ms": timings.get(cid) if cid else None,
                 }
             )
     return calls
@@ -229,13 +238,14 @@ def build_trajectory_log(
     task_descriptor: str = "",
     completed: bool = True,
     trajectory_dir: Optional[Path] = None,
+    timings: Optional[Dict[str, int]] = None,
 ) -> Optional[TrajectoryLog]:
     """Build a :class:`TrajectoryLog` from a finished turn, or None if empty.
 
     Returns None when the turn made no tool calls: a trajectory with no actions
     tells every consumer nothing and would only dilute the store.
     """
-    calls = extract_tool_calls(messages)
+    calls = extract_tool_calls(messages, timings)
     if not calls:
         return None
 
@@ -250,6 +260,7 @@ def build_trajectory_log(
             call["args"],
             result=call["result"],
             status=call["status"],
+            duration_ms=call.get("duration_ms"),
         )
     return log
 
@@ -261,6 +272,7 @@ def capture_turn(
     task_descriptor: str = "",
     completed: bool = True,
     trajectory_dir: Optional[Path] = None,
+    timings: Optional[Dict[str, int]] = None,
 ) -> Optional[Path]:
     """Build and persist a turn's trajectory. Returns the path, or None.
 
@@ -277,6 +289,7 @@ def capture_turn(
             task_descriptor=task_descriptor,
             completed=completed,
             trajectory_dir=trajectory_dir,
+            timings=timings,
         )
         if log is None:
             return None

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -249,7 +249,12 @@ def finalize_turn(
             session_id=getattr(agent, "session_id", "") or "",
             task_descriptor=_summarize_user_message_for_log(user_message),
             completed=completed,
+            timings=getattr(agent, "_turn_call_timings", None),
         )
+        # Drained per turn so a long session cannot accumulate one entry per
+        # call for its whole lifetime.
+        if getattr(agent, "_turn_call_timings", None):
+            agent._turn_call_timings = {}
     except Exception as _capture_err:
         _cleanup_errors.append(f"tool_call_capture: {_capture_err}")
         logger.error(

--- a/tests/agent/test_tool_call_capture.py
+++ b/tests/agent/test_tool_call_capture.py
@@ -311,3 +311,41 @@ class TestMultiTurnSessionsAppend:
         for line in path.read_text(encoding="utf-8").splitlines():
             if line.strip():
                 assert json.loads(line)["entries"]
+
+
+class TestPerCallTimings:
+    """duration_ms exists only during the turn (#1442).
+
+    The capture runs in finalize_turn, by which point nothing carries per-call
+    timing — so it has to be collected as calls finish and handed over. Without
+    it every entry's duration_ms is None and the failure-trajectory timestamp
+    framework has nothing to place t_fail / t_detect / t_recover against.
+    """
+
+    def test_timing_is_attached_by_call_id(self, tmp_path, capture_on):
+        msgs = [_call("terminal", {}, "c1"), _ok("c1")]
+        path = capture_turn(msgs, session_id="s", trajectory_dir=tmp_path,
+                            timings={"c1": 1234})
+        data = json.loads(path.read_text(encoding="utf-8").strip())
+        assert data["entries"][0]["duration_ms"] == 1234
+
+    def test_missing_timing_leaves_it_unset(self, tmp_path, capture_on):
+        """Absent must stay absent — a call whose duration was not recorded is
+        not a call that took zero milliseconds."""
+        msgs = [_call("terminal", {}, "c1"), _ok("c1")]
+        path = capture_turn(msgs, session_id="s", trajectory_dir=tmp_path, timings={})
+        data = json.loads(path.read_text(encoding="utf-8").strip())
+        assert "duration_ms" not in data["entries"][0]
+
+    def test_timings_map_to_the_right_calls(self, tmp_path, capture_on):
+        msgs = [_call("read_file", {}, "a"), _ok("a"),
+                _call("terminal", {}, "b"), _ok("b")]
+        path = capture_turn(msgs, session_id="s", trajectory_dir=tmp_path,
+                            timings={"a": 10, "b": 900})
+        entries = json.loads(path.read_text(encoding="utf-8").strip())["entries"]
+        by_tool = {e["tool"]: e.get("duration_ms") for e in entries}
+        assert by_tool == {"read_file": 10, "terminal": 900}
+
+    def test_extract_without_timings_still_works(self):
+        calls = extract_tool_calls([_call("read_file", {}, "c1"), _ok("c1")])
+        assert calls[0]["duration_ms"] is None


### PR DESCRIPTION
Unblocks the timing half of #1442.

## The gap

#1363 gave the pipeline real tool calls, but **every entry's `duration_ms` stayed `None`**. The capture runs in `finalize_turn`, and by then per-call timing no longer exists anywhere in the turn. #1442's failure-trajectory framework needs exactly that to place `t_fail` / `t_detect` / `t_recover` against — so it was blocked on a field that was in the schema but never populated.

## The measurement was already being taken

`agent_runtime_helpers` computes `int((time.monotonic() - tool_start_time) * 1000)` for the post-tool-call hook — and then **discards it**.

This keeps it: a dict on the agent keyed by `tool_call_id`, written as each call finishes, handed to `capture_turn` at the end of the turn, and **drained there** so a long session cannot accumulate one entry per call for its whole lifetime.

## Absent stays absent

A call whose duration was not recorded emits **no `duration_ms` at all**, rather than `0`. A missing measurement is not a call that took zero milliseconds, and collapsing those would quietly corrupt any latency analysis built on it. `TrajectoryEntry.to_dict` already omits `None`, so this falls out of the existing contract.

Both writes are guarded — a timing that fails to record must not take the tool result or the turn down with it.

## Tests

4 new: timing attaches by call id, several calls map to the right entries, a missing timing leaves the field unset, extraction without any timings still works. 66 passing across the capture and rubric suites.

**Regression check** on `tests/agent/` with the same `-k` selection: 4 pre-existing failures in `test_title_generator.py` reproduce **identically on clean main** — they are a test-isolation artifact of the selection, and the whole file passes 42/42 on both branches. Passed went 306 → 310, exactly the 4 new tests. Ruff clean.

## What remains for #1442

This supplies per-call latency. The 3-timestamp framework itself — deriving `t_fail`, `t_detect`, `t_recover` from a trajectory and reporting the gaps — is still to be built, and now has the input it needs.