### PR TITLE
fix: tool_search streak counter fires injection at 3 and tool_describe at 5 (Closes #1373)

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -20,7 +20,9 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 
-def _td(name: str, description: str = "", properties: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def _td(
+    name: str, description: str = "", properties: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
     return {
         "type": "function",
         "function": {
@@ -42,32 +44,38 @@ def _td(name: str, description: str = "", properties: Dict[str, Any] | None = No
 class TestConfigParsing:
     def test_default_when_missing(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw(None)
         assert cfg.enabled == "auto"
         assert cfg.threshold_pct == 10.0
 
     def test_bool_true_maps_to_auto(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw(True)
         assert cfg.enabled == "auto"
 
     def test_bool_false_maps_to_off(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw(False)
         assert cfg.enabled == "off"
 
     def test_explicit_on(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         assert cfg.enabled == "on"
 
     def test_invalid_enabled_falls_back_to_auto(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({"enabled": "maybe"})
         assert cfg.enabled == "auto"
 
     def test_threshold_clamped(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({"threshold_pct": 150})
         assert cfg.threshold_pct == 100.0
         cfg = ToolSearchConfig.from_raw({"threshold_pct": -5})
@@ -75,6 +83,7 @@ class TestConfigParsing:
 
     def test_search_limits_clamped(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({
             "search_default_limit": 999,
             "max_search_limit": 999,
@@ -84,22 +93,29 @@ class TestConfigParsing:
 
     def test_defer_core_toolsets_default_empty(self):
         from tools.tool_search import ToolSearchConfig
+
         assert ToolSearchConfig.from_raw(None).defer_core_toolsets == frozenset()
-        assert ToolSearchConfig.from_raw({"enabled": "on"}).defer_core_toolsets == frozenset()
+        assert (
+            ToolSearchConfig.from_raw({"enabled": "on"}).defer_core_toolsets
+            == frozenset()
+        )
 
     def test_defer_core_toolsets_list_form(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({"defer_core_toolsets": ["browser", "tts"]})
         assert cfg.defer_core_toolsets == frozenset({"browser", "tts"})
 
     def test_defer_core_toolsets_comma_string_form(self):
         from tools.tool_search import ToolSearchConfig
+
         cfg = ToolSearchConfig.from_raw({"defer_core_toolsets": "browser, tts ,"})
         assert cfg.defer_core_toolsets == frozenset({"browser", "tts"})
 
     def test_defer_core_toolsets_garbage_is_dropped(self):
         """A malformed entry must never crash assembly — non-strings are dropped."""
         from tools.tool_search import ToolSearchConfig, _parse_toolset_list
+
         assert _parse_toolset_list(123) == frozenset()
         assert _parse_toolset_list({"a": 1}) == frozenset()
         assert _parse_toolset_list([1, "tts", None, ""]) == frozenset({"tts"})
@@ -117,17 +133,31 @@ class TestClassification:
     def test_core_tools_never_defer(self):
         """The critical invariant from the OpenClaw report."""
         from tools.tool_search import is_deferrable_tool_name
+
         # Sample of core tools from _HERMES_CORE_TOOLS.
-        for core_name in ["terminal", "read_file", "write_file", "patch",
-                          "search_files", "todo", "memory", "browser_navigate",
-                          "web_search", "session_search", "clarify",
-                          "execute_code", "delegate_task", "send_message"]:
+        for core_name in [
+            "terminal",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "todo",
+            "memory",
+            "browser_navigate",
+            "web_search",
+            "session_search",
+            "clarify",
+            "execute_code",
+            "delegate_task",
+            "send_message",
+        ]:
             assert not is_deferrable_tool_name(core_name), (
                 f"Core tool '{core_name}' must NEVER be deferrable"
             )
 
     def test_bridge_tools_never_defer(self):
         from tools.tool_search import is_deferrable_tool_name, BRIDGE_TOOL_NAMES
+
         for name in BRIDGE_TOOL_NAMES:
             assert not is_deferrable_tool_name(name)
 
@@ -136,6 +166,7 @@ class TestClassification:
         not be claimed as deferrable. This protects against the OpenClaw
         cron regression where unresolved tools were silently dropped."""
         from tools.tool_search import is_deferrable_tool_name
+
         assert not is_deferrable_tool_name("xx_definitely_not_a_tool_xx")
 
     def test_classify_keeps_unknown_in_visible(self):
@@ -145,6 +176,7 @@ class TestClassification:
         because it wasn't in the catalog).
         """
         from tools.tool_search import classify_tools
+
         # Build a tool def for something we don't have a registry entry for.
         defs = [_td("xx_unknown_tool", "Unknown tool")]
         visible, deferrable = classify_tools(defs)
@@ -182,23 +214,31 @@ class TestCoreToolsetDeferral:
         are at runtime before any assembly. Importing model_tools and pulling
         the definitions once triggers registration."""
         import model_tools
-        model_tools.get_tool_definitions(quiet_mode=True, skip_tool_search_assembly=True)
+
+        model_tools.get_tool_definitions(
+            quiet_mode=True, skip_tool_search_assembly=True
+        )
 
     def _cfg(self, **over):
         from tools.tool_search import ToolSearchConfig
+
         raw = {"enabled": "on", "defer_core_toolsets": [self._DEMO_TOOLSET]}
         raw.update(over)
         return ToolSearchConfig.from_raw(raw)
 
     def test_effective_core_unchanged_by_default(self):
         from tools.tool_search import (
-            effective_core_tool_names, _hermes_core_tools, ToolSearchConfig,
+            effective_core_tool_names,
+            _hermes_core_tools,
+            ToolSearchConfig,
         )
+
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         assert effective_core_tool_names(cfg) == _hermes_core_tools()
 
     def test_effective_core_subtracts_opted_in_toolset(self):
         from tools.tool_search import effective_core_tool_names, _hermes_core_tools
+
         raw_core = _hermes_core_tools()
         # Pre-condition: the demo tool is genuinely a core tool.
         assert self._DEMO_TOOL in raw_core
@@ -211,23 +251,31 @@ class TestCoreToolsetDeferral:
 
     def test_opted_in_core_tool_is_deferrable(self):
         from tools.tool_search import is_deferrable_tool_name
+
         assert is_deferrable_tool_name(self._DEMO_TOOL, self._cfg())
         # Default config: still never deferrable.
         from tools.tool_search import ToolSearchConfig
+
         assert not is_deferrable_tool_name(
             self._DEMO_TOOL, ToolSearchConfig.from_raw({"enabled": "on"})
         )
 
     def test_protected_core_tool_never_deferrable_even_when_opting_browser(self):
         from tools.tool_search import is_deferrable_tool_name
+
         assert not is_deferrable_tool_name(self._PROTECTED_TOOL, self._cfg())
 
     def test_classify_defers_opted_in_native_toolset(self):
         import model_tools
         from tools.tool_search import classify_tools
-        defs = model_tools.get_tool_definitions(
-            quiet_mode=True, skip_tool_search_assembly=True,
-        ) or []
+
+        defs = (
+            model_tools.get_tool_definitions(
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            or []
+        )
         visible, deferrable = classify_tools(defs, self._cfg())
         deferred_names = {(td.get("function") or {}).get("name") for td in deferrable}
         visible_names = {(td.get("function") or {}).get("name") for td in visible}
@@ -246,11 +294,17 @@ class TestCoreToolsetDeferral:
         the token savings (deferred_tokens) so the win can be measured."""
         import model_tools
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
-        defs = model_tools.get_tool_definitions(
-            quiet_mode=True, skip_tool_search_assembly=True,
-        ) or []
+
+        defs = (
+            model_tools.get_tool_definitions(
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            or []
+        )
         baseline = assemble_tool_defs(
-            defs, context_length=200_000,
+            defs,
+            context_length=200_000,
             config=ToolSearchConfig.from_raw({"enabled": "on"}),
         )
         opted = assemble_tool_defs(defs, context_length=200_000, config=self._cfg())
@@ -258,7 +312,9 @@ class TestCoreToolsetDeferral:
         # the measured deferred-token total grows accordingly.
         assert opted.deferred_count > baseline.deferred_count
         assert opted.deferred_tokens > baseline.deferred_tokens
-        result_names = {(td.get("function") or {}).get("name") for td in opted.tool_defs}
+        result_names = {
+            (td.get("function") or {}).get("name") for td in opted.tool_defs
+        }
         # The deferred browser tools are no longer in the model-visible array.
         assert not any(n.startswith("browser_") for n in result_names)
         # Protected core tool is still visible.
@@ -270,21 +326,31 @@ class TestCoreToolsetDeferral:
         resolvable via tool_call, and describable via tool_describe."""
         import model_tools
         from tools.tool_search import (
-            scoped_deferrable_names, resolve_underlying_call, dispatch_tool_describe,
+            scoped_deferrable_names,
+            resolve_underlying_call,
+            dispatch_tool_describe,
         )
+
         cfg = self._cfg()
-        defs = model_tools.get_tool_definitions(
-            quiet_mode=True, skip_tool_search_assembly=True,
-        ) or []
+        defs = (
+            model_tools.get_tool_definitions(
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            or []
+        )
         scope = scoped_deferrable_names(defs, cfg)
         assert self._DEMO_TOOL in scope
         name, _args, err = resolve_underlying_call(
-            {"name": self._DEMO_TOOL, "arguments": {}}, cfg,
+            {"name": self._DEMO_TOOL, "arguments": {}},
+            cfg,
         )
         assert err is None and name == self._DEMO_TOOL
         described = json.loads(
             dispatch_tool_describe(
-                {"name": self._DEMO_TOOL}, current_tool_defs=defs, config=cfg,
+                {"name": self._DEMO_TOOL},
+                current_tool_defs=defs,
+                config=cfg,
             )
         )
         assert "parameters" in described
@@ -293,9 +359,11 @@ class TestCoreToolsetDeferral:
         """The inverse of the round-trip: with no opt-in, the core tool stays
         direct and the bridge refuses to resolve it (use it directly)."""
         from tools.tool_search import ToolSearchConfig, resolve_underlying_call
+
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         _name, _args, err = resolve_underlying_call(
-            {"name": self._DEMO_TOOL, "arguments": {}}, cfg,
+            {"name": self._DEMO_TOOL, "arguments": {}},
+            cfg,
         )
         assert err is not None
         assert "not a deferrable" in err
@@ -303,10 +371,16 @@ class TestCoreToolsetDeferral:
     def test_naming_non_core_toolset_is_a_noop(self):
         """Opting in a toolset with no core members changes nothing — those
         tools were already deferrable (or non-existent)."""
-        from tools.tool_search import effective_core_tool_names, _hermes_core_tools, ToolSearchConfig
-        cfg = ToolSearchConfig.from_raw(
-            {"enabled": "on", "defer_core_toolsets": ["xx_no_such_toolset"]}
+        from tools.tool_search import (
+            effective_core_tool_names,
+            _hermes_core_tools,
+            ToolSearchConfig,
         )
+
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_core_toolsets": ["xx_no_such_toolset"],
+        })
         assert effective_core_tool_names(cfg) == _hermes_core_tools()
 
     def test_opted_in_core_tool_deferrable_without_registry_entry(self, monkeypatch):
@@ -318,6 +392,7 @@ class TestCoreToolsetDeferral:
         authoritative — no registry round-trip required."""
         import tools.tool_search as ts
         from tools.registry import registry
+
         # Force the registry lookup to behave as if the tool isn't registered.
         monkeypatch.setattr(registry, "get_entry", lambda _name: None)
         assert ts.is_deferrable_tool_name(self._DEMO_TOOL, self._cfg())
@@ -333,27 +408,36 @@ class TestCoreToolsetDeferral:
 class TestThresholdGate:
     def test_off_never_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "off"})
-        assert not should_activate(cfg, deferrable_tokens=1_000_000, context_length=200_000)
+        assert not should_activate(
+            cfg, deferrable_tokens=1_000_000, context_length=200_000
+        )
 
     def test_zero_deferrable_never_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         assert not should_activate(cfg, deferrable_tokens=0, context_length=200_000)
 
     def test_on_activates_with_any_deferrable(self):
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         assert should_activate(cfg, deferrable_tokens=100, context_length=200_000)
 
     def test_auto_below_threshold_does_not_activate(self):
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
         # 5% of 200K = below 10% threshold
-        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+        assert not should_activate(
+            cfg, deferrable_tokens=10_000, context_length=200_000
+        )
 
     def test_auto_at_or_above_threshold_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
         assert should_activate(cfg, deferrable_tokens=20_000, context_length=200_000)
         assert should_activate(cfg, deferrable_tokens=50_000, context_length=200_000)
@@ -361,16 +445,23 @@ class TestThresholdGate:
     def test_auto_without_context_length_uses_20k_cutoff(self):
         """Fallback cutoff used when the active model is unknown."""
         from tools.tool_search import ToolSearchConfig, should_activate
+
         cfg = ToolSearchConfig.from_raw({"enabled": "auto"})
         assert not should_activate(cfg, deferrable_tokens=10_000, context_length=0)
         assert should_activate(cfg, deferrable_tokens=25_000, context_length=0)
 
     def test_token_estimate_proportional_to_schema_size(self):
         from tools.tool_search import estimate_tokens_from_schemas
+
         small = [_td("a", "x")]
-        big = [_td(f"name_{i}", f"description for tool {i} " * 20,
-                   {"q": {"type": "string", "description": "search query " * 10}})
-               for i in range(10)]
+        big = [
+            _td(
+                f"name_{i}",
+                f"description for tool {i} " * 20,
+                {"q": {"type": "string", "description": "search query " * 10}},
+            )
+            for i in range(10)
+        ]
         small_t = estimate_tokens_from_schemas(small)
         big_t = estimate_tokens_from_schemas(big)
         assert big_t > small_t * 10
@@ -385,22 +476,38 @@ class TestRetrieval:
     def _fake_catalog(self):
         """Build a catalog directly without touching the registry."""
         from tools.tool_search import CatalogEntry, _tokenize, _entry_search_text
+
         defs = [
-            _td("github_create_issue", "Open a new issue in a GitHub repository",
-                {"title": {"type": "string"}, "body": {"type": "string"}}),
-            _td("github_search_repos", "Search GitHub for matching repositories",
-                {"query": {"type": "string"}}),
-            _td("slack_send_message", "Post a message into a Slack channel",
-                {"channel": {"type": "string"}, "text": {"type": "string"}}),
-            _td("calendar_create_event", "Add an event to the user's calendar",
-                {"title": {"type": "string"}, "start": {"type": "string"}}),
+            _td(
+                "github_create_issue",
+                "Open a new issue in a GitHub repository",
+                {"title": {"type": "string"}, "body": {"type": "string"}},
+            ),
+            _td(
+                "github_search_repos",
+                "Search GitHub for matching repositories",
+                {"query": {"type": "string"}},
+            ),
+            _td(
+                "slack_send_message",
+                "Post a message into a Slack channel",
+                {"channel": {"type": "string"}, "text": {"type": "string"}},
+            ),
+            _td(
+                "calendar_create_event",
+                "Add an event to the user's calendar",
+                {"title": {"type": "string"}, "start": {"type": "string"}},
+            ),
         ]
         catalog = []
         for d in defs:
             fn = d["function"]
             e = CatalogEntry(
-                name=fn["name"], description=fn["description"],
-                schema=d, source="mcp", source_name="mcp-test",
+                name=fn["name"],
+                description=fn["description"],
+                schema=d,
+                source="mcp",
+                source_name="mcp-test",
             )
             e._tokens = _tokenize(_entry_search_text(d))
             catalog.append(e)
@@ -408,23 +515,27 @@ class TestRetrieval:
 
     def test_search_finds_relevant_tool(self):
         from tools.tool_search import search_catalog
+
         hits = search_catalog(self._fake_catalog(), "create a github issue", limit=3)
         names = [h.name for h in hits]
         assert names[0] == "github_create_issue"
 
     def test_search_returns_empty_for_irrelevant_query(self):
         from tools.tool_search import search_catalog
+
         hits = search_catalog(self._fake_catalog(), "asdf qwerty foobar", limit=3)
         assert hits == []
 
     def test_search_substring_fallback(self):
         """Even when no BM25 hit, a literal substring of the tool name returns."""
         from tools.tool_search import search_catalog
+
         hits = search_catalog(self._fake_catalog(), "calendar", limit=3)
         assert any("calendar" in h.name for h in hits)
 
     def test_search_respects_limit(self):
         from tools.tool_search import search_catalog
+
         hits = search_catalog(self._fake_catalog(), "github", limit=1)
         assert len(hits) <= 1
 
@@ -438,6 +549,7 @@ class TestAssembly:
     def test_no_deferrable_returns_unchanged(self):
         """Pure-core toolset: pass-through, no bridge tools added."""
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+
         defs = [_td("terminal", "Run shell"), _td("read_file", "Read a file")]
         result = assemble_tool_defs(
             defs,
@@ -445,11 +557,15 @@ class TestAssembly:
             config=ToolSearchConfig.from_raw({"enabled": "on"}),
         )
         assert not result.activated
-        assert {t["function"]["name"] for t in result.tool_defs} == {"terminal", "read_file"}
+        assert {t["function"]["name"] for t in result.tool_defs} == {
+            "terminal",
+            "read_file",
+        }
 
     def test_below_threshold_returns_unchanged(self):
         """Tiny deferrable surface: don't bother."""
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+
         # _td renders to ~80 chars / 20 tokens. 3 of them = ~60 tokens.
         # 10% of 200K = 20K. Way below.
         defs = [_td("unknown_tool_a"), _td("unknown_tool_b"), _td("unknown_tool_c")]
@@ -463,7 +579,12 @@ class TestAssembly:
         assert "tool_search" not in names
 
     def test_idempotent_when_bridge_already_present(self):
-        from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
+        from tools.tool_search import (
+            assemble_tool_defs,
+            ToolSearchConfig,
+            BRIDGE_TOOL_NAMES,
+        )
+
         defs = [_td("terminal", "Run shell"), _td("tool_search", "old")]
         result = assemble_tool_defs(
             defs,
@@ -484,11 +605,13 @@ class TestAssembly:
 class TestBridgeDispatch:
     def test_tool_search_requires_query(self):
         from tools.tool_search import dispatch_tool_search
+
         result = dispatch_tool_search({}, current_tool_defs=[])
         assert "error" in json.loads(result)
 
     def test_tool_describe_requires_name(self):
         from tools.tool_search import dispatch_tool_describe
+
         result = dispatch_tool_describe({}, current_tool_defs=[])
         assert "error" in json.loads(result)
 
@@ -496,13 +619,16 @@ class TestBridgeDispatch:
         """If the model asks to describe a core tool, refuse — it's already
         in the visible list."""
         from tools.tool_search import dispatch_tool_describe
+
         result = dispatch_tool_describe(
-            {"name": "terminal"}, current_tool_defs=[_td("terminal", "Run shell")],
+            {"name": "terminal"},
+            current_tool_defs=[_td("terminal", "Run shell")],
         )
         assert "error" in json.loads(result)
 
     def test_resolve_underlying_call_parses_object_args(self):
         from tools.tool_search import resolve_underlying_call
+
         name, args, err = resolve_underlying_call({
             "name": "unknown_xxx",
             "arguments": {"foo": "bar"},
@@ -513,6 +639,7 @@ class TestBridgeDispatch:
     def test_resolve_underlying_call_parses_json_string_args(self):
         """Some models emit ``arguments`` as a JSON string instead of object."""
         from tools.tool_search import resolve_underlying_call
+
         # Use a name that won't classify (so we don't depend on registry),
         # but exercise the JSON parse path.
         _, _, err = resolve_underlying_call({
@@ -525,6 +652,7 @@ class TestBridgeDispatch:
 
     def test_resolve_underlying_call_rejects_bad_json(self):
         from tools.tool_search import resolve_underlying_call
+
         _, _, err = resolve_underlying_call({
             "name": "fake",
             "arguments": "{this is not json",
@@ -541,6 +669,7 @@ class TestBridgeDispatch:
         a confusing "not valid JSON" error to the model, which then
         looped on the same call."""
         from tools.tool_search import resolve_underlying_call
+
         name, args, err = resolve_underlying_call({
             "name": "fake_no_params_tool",
             "arguments": "",
@@ -563,6 +692,7 @@ class TestBridgeDispatch:
         real value, so accepting whitespace-only cannot mask a valid
         payload."""
         from tools.tool_search import resolve_underlying_call
+
         name, args, err = resolve_underlying_call({
             "name": "fake_no_params_tool",
             "arguments": blank,
@@ -571,6 +701,7 @@ class TestBridgeDispatch:
         assert args == {}
         """tool_call cannot invoke tool_call itself."""
         from tools.tool_search import resolve_underlying_call, TOOL_CALL_NAME
+
         name, args, err = resolve_underlying_call({
             "name": TOOL_CALL_NAME,
             "arguments": {},
@@ -584,25 +715,37 @@ class TestSearchStreakGuard:
 
     def _cfg(self, threshold: int):
         from tools.tool_search import ToolSearchConfig
-        return ToolSearchConfig(enabled="on", threshold_pct=10.0,
-                                search_default_limit=5, max_search_limit=20,
-                                search_streak_threshold=threshold)
+
+        return ToolSearchConfig(
+            enabled="on",
+            threshold_pct=10.0,
+            search_default_limit=5,
+            max_search_limit=20,
+            search_streak_threshold=threshold,
+        )
 
     def _search(self, sid, threshold=3):
         from tools.tool_search import dispatch_tool_search
-        return json.loads(dispatch_tool_search(
-            {"query": "github"},
-            current_tool_defs=[_td("github_create_issue", "Create issue")],
-            config=self._cfg(threshold), session_id=sid))
+
+        return json.loads(
+            dispatch_tool_search(
+                {"query": "github"},
+                current_tool_defs=[_td("github_create_issue", "Create issue")],
+                config=self._cfg(threshold),
+                session_id=sid,
+            )
+        )
 
     def test_no_directive_below_threshold(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         out = self._search("sess-A", threshold=3)
         assert "fallback_directive" not in out  # streak=1 < 3
 
     def test_directive_at_threshold(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         self._search("sess-B", threshold=3)
         self._search("sess-B", threshold=3)
@@ -612,6 +755,7 @@ class TestSearchStreakGuard:
 
     def test_reset_on_tool_call_clears_streak(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         self._search("sess-C", threshold=3)
         self._search("sess-C", threshold=3)
@@ -621,6 +765,7 @@ class TestSearchStreakGuard:
 
     def test_no_session_id_not_tracked(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         out = self._search(None, threshold=3)  # pure-function path
         assert "fallback_directive" not in out
@@ -628,6 +773,7 @@ class TestSearchStreakGuard:
 
     def test_threshold_zero_disables_guard(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         out = None
         for _ in range(5):
@@ -636,6 +782,7 @@ class TestSearchStreakGuard:
 
     def test_sessions_tracked_independently(self):
         import tools.tool_search as ts
+
         ts._SEARCH_STREAK.clear()
         self._search("sess-E", threshold=3)
         self._search("sess-F", threshold=3)
@@ -655,6 +802,7 @@ class TestHandleFunctionCallIntegration:
     def test_tool_search_dispatch_through_handle_function_call(self):
         """The dispatcher recognizes the bridge tool by name."""
         import model_tools
+
         result = model_tools.handle_function_call(
             function_name="tool_search",
             function_args={"query": "nothing matches this"},
@@ -679,9 +827,12 @@ class TestRegression_OpenClawCron84141:
 
     def test_core_tool_survives_alongside_many_mcp_tools(self):
         from tools.tool_search import (
-            assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES,
+            assemble_tool_defs,
+            ToolSearchConfig,
+            BRIDGE_TOOL_NAMES,
             classify_tools,
         )
+
         # 1 core tool + 50 unknown/MCP-shaped tools (deferrable).
         defs = [_td("terminal", "Run shell commands")]
         # Pad with fake "deferrable" tools — without registry registration,
@@ -689,8 +840,7 @@ class TestRegression_OpenClawCron84141:
         # the core-tool side: terminal stays in visible regardless.
         visible, deferrable = classify_tools(defs)
         assert any(
-            (td.get("function") or {}).get("name") == "terminal"
-            for td in visible
+            (td.get("function") or {}).get("name") == "terminal" for td in visible
         ), "Core tool 'terminal' was wrongly classified as deferrable"
 
         # Now force activation and check the resulting tool-defs list.
@@ -708,6 +858,7 @@ class TestRegression_OpenClawCron84141:
         """Even if the model tries to invoke a core tool through tool_call,
         we reject the call and tell the model to use it directly."""
         from tools.tool_search import resolve_underlying_call
+
         _, _, err = resolve_underlying_call({
             "name": "terminal",
             "arguments": {"command": "echo hi"},
@@ -777,20 +928,27 @@ class TestRegression_ToolsetScoping:
 
         # Out-of-scope plugin tool: rejected even though it is registered
         # and deferrable in the global registry.
-        rejected = json.loads(model_tools.handle_function_call(
-            function_name="tool_call",
-            function_args={"name": "inscope_oos_plugin", "arguments": {}},
-            enabled_toolsets=["mcp-inscope-gh"],
-        ))
+        rejected = json.loads(
+            model_tools.handle_function_call(
+                function_name="tool_call",
+                function_args={"name": "inscope_oos_plugin", "arguments": {}},
+                enabled_toolsets=["mcp-inscope-gh"],
+            )
+        )
         assert "error" in rejected
         assert "not available in this session" in rejected["error"]
 
         # In-scope tool: dispatches normally.
-        ok = json.loads(model_tools.handle_function_call(
-            function_name="tool_call",
-            function_args={"name": "mcp_inscope_gh_op", "arguments": {"repo": "a/b"}},
-            enabled_toolsets=["mcp-inscope-gh"],
-        ))
+        ok = json.loads(
+            model_tools.handle_function_call(
+                function_name="tool_call",
+                function_args={
+                    "name": "mcp_inscope_gh_op",
+                    "arguments": {"repo": "a/b"},
+                },
+                enabled_toolsets=["mcp-inscope-gh"],
+            )
+        )
         assert ok.get("ok") is True
         assert ok.get("tool") == "mcp_inscope_gh_op"
 
@@ -802,7 +960,8 @@ class TestRegression_ToolsetScoping:
 
         # Establish the scoped session global.
         model_tools.get_tool_definitions(
-            enabled_toolsets=["mcp-pollute"], quiet_mode=True,
+            enabled_toolsets=["mcp-pollute"],
+            quiet_mode=True,
         )
         before = set(model_tools._last_resolved_tool_names)
         assert "terminal" not in before
@@ -817,8 +976,7 @@ class TestRegression_ToolsetScoping:
         )
         after = set(model_tools._last_resolved_tool_names)
         assert "terminal" not in after, (
-            "bridge dispatch polluted _last_resolved_tool_names with "
-            "out-of-scope tools"
+            "bridge dispatch polluted _last_resolved_tool_names with out-of-scope tools"
         )
 
     def test_scoped_deferrable_names_helper(self):
@@ -826,6 +984,7 @@ class TestRegression_ToolsetScoping:
 
         self._register("mcp_helper_op", "mcp-helper")
         import model_tools
+
         defs = model_tools.get_tool_definitions(
             enabled_toolsets=["mcp-helper"],
             quiet_mode=True,
@@ -852,10 +1011,12 @@ class TestDescribeCache:
             clear_describe_cache,
             is_deferrable_tool_name,
         )
+
         clear_describe_cache()
 
         # Register a deferrable tool so describe has something to find.
         from tools.registry import registry
+
         registry.register(
             name="cache_test_tool",
             toolset="mcp-cache-test",
@@ -868,16 +1029,22 @@ class TestDescribeCache:
         )
         try:
             # Use a toolset that will classify it as deferrable.
-            defs = [{
-                "type": "function",
-                "function": {
-                    "name": "cache_test_tool",
-                    "description": "Test tool for caching.",
-                    "parameters": {"type": "object", "properties": {}},
-                },
-            }]
-            r1 = dispatch_tool_describe({"name": "cache_test_tool"}, current_tool_defs=defs)
-            r2 = dispatch_tool_describe({"name": "cache_test_tool"}, current_tool_defs=defs)
+            defs = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "cache_test_tool",
+                        "description": "Test tool for caching.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            r1 = dispatch_tool_describe(
+                {"name": "cache_test_tool"}, current_tool_defs=defs
+            )
+            r2 = dispatch_tool_describe(
+                {"name": "cache_test_tool"}, current_tool_defs=defs
+            )
             # Cache hit: same JSON string (identity check — not just equal).
             assert r1 == r2
             assert "cache_test_tool" in r1
@@ -889,9 +1056,11 @@ class TestDescribeCache:
             dispatch_tool_describe,
             clear_describe_cache,
         )
+
         clear_describe_cache()
 
         from tools.registry import registry
+
         registry.register(
             name="cache_sig_tool",
             toolset="mcp-sig-test",
@@ -903,31 +1072,40 @@ class TestDescribeCache:
             handler=lambda args, **kw: '{"ok": true}',
         )
         try:
-            defs_v1 = [{
-                "type": "function",
-                "function": {
-                    "name": "cache_sig_tool",
-                    "description": "v1",
-                    "parameters": {"type": "object", "properties": {}},
+            defs_v1 = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "cache_sig_tool",
+                        "description": "v1",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            defs_v2 = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "cache_sig_tool",
+                        "description": "v2 CHANGED",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
                 },
-            }]
-            defs_v2 = [{
-                "type": "function",
-                "function": {
-                    "name": "cache_sig_tool",
-                    "description": "v2 CHANGED",
-                    "parameters": {"type": "object", "properties": {}},
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "other_tool",
+                        "description": "other",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
                 },
-            }, {
-                "type": "function",
-                "function": {
-                    "name": "other_tool",
-                    "description": "other",
-                    "parameters": {"type": "object", "properties": {}},
-                },
-            }]
-            r1 = dispatch_tool_describe({"name": "cache_sig_tool"}, current_tool_defs=defs_v1)
-            r2 = dispatch_tool_describe({"name": "cache_sig_tool"}, current_tool_defs=defs_v2)
+            ]
+            r1 = dispatch_tool_describe(
+                {"name": "cache_sig_tool"}, current_tool_defs=defs_v1
+            )
+            r2 = dispatch_tool_describe(
+                {"name": "cache_sig_tool"}, current_tool_defs=defs_v2
+            )
             # Different signatures → cache miss → different result.
             assert r1 != r2
             assert "v2 CHANGED" in r2
@@ -939,6 +1117,7 @@ class TestDescribeCache:
             dispatch_tool_describe,
             clear_describe_cache,
         )
+
         clear_describe_cache()
 
         defs: List[Dict[str, Any]] = []
@@ -950,19 +1129,21 @@ class TestDescribeCache:
         assert "error" in r2
 
 
-
-class TestSearchStreakDisabledIsVisible:
-    """A silently-inactive streak counter is how #1153 shipped without moving
-    its own signal (#1373).
-
-    `note_tool_search` returns 0 for a falsy session id, so the threshold is
-    never reached and the fallback directive never fires. That is correct for
-    the pure unit tests that pass no session id — but the runtime reaches this
-    through `session_id=agent.session_id or ""`, so an unset session arrives as
-    `""` and is indistinguishable here. It must at least be visible in the log.
+class TestSearchStreakEmptySessionNowFires:
+    """#1373 — an empty-string session id (the runtime's
+    ``agent.session_id or ""``) used to silently disable the streak counter,
+    which is how #1153 shipped without moving its own signal. The counter now
+    falls back to a stable default key so the feature actually fires in that
+    environment. Only an explicit ``None`` (the pure-function test path) opts
+    out of tracking.
     """
 
-    def _cfg(self, threshold: int = 3):
+    # A deferrable (MCP-prefixed) tool registered with the live registry so
+    # classify_tools / build_catalog treat it as deferrable and it appears in
+    # the catalog, hits, full_tool_list, and auto_describe.
+    _DEF_TOOL = "mcp_test__searchme"
+
+    def _cfg(self, threshold: int = 3, describe_threshold: int = 5):
         from tools.tool_search import ToolSearchConfig
 
         return ToolSearchConfig(
@@ -971,63 +1152,151 @@ class TestSearchStreakDisabledIsVisible:
             search_default_limit=5,
             max_search_limit=20,
             search_streak_threshold=threshold,
+            search_streak_describe_threshold=describe_threshold,
         )
 
-    def _search(self, sid):
+    def _ensure_registered(self):
+        """Register the deferrable test tool (idempotent)."""
+        from tools.registry import registry
+
+        try:
+            if registry.get_entry(self._DEF_TOOL) is None:
+                registry.register(
+                    name=self._DEF_TOOL,
+                    toolset="mcp-test",
+                    schema={"type": "function"},
+                    handler=lambda **kw: "{}",
+                    description="A test MCP tool",
+                )
+        except Exception:
+            pass
+
+    def _tool_defs(self):
+        self._ensure_registered()
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._DEF_TOOL,
+                    "description": "A test MCP tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+    def _search(self, sid, threshold=3, describe_threshold=5, query="searchme"):
         from tools.tool_search import dispatch_tool_search
 
         return json.loads(
             dispatch_tool_search(
-                {"query": "github"},
-                current_tool_defs=[_td("github_create_issue", "Create issue")],
-                config=self._cfg(),
+                {"query": query},
+                current_tool_defs=self._tool_defs(),
+                config=self._cfg(threshold, describe_threshold),
                 session_id=sid,
             )
         )
 
-    def test_empty_session_id_warns_once(self, caplog):
-        import logging
-
+    def test_empty_session_id_increments_streak(self):
+        """Empty-string session id must now be tracked, not silently dropped."""
         import tools.tool_search as ts
 
         ts._SEARCH_STREAK.clear()
-        ts._STREAK_DISABLED_WARNED = False
-        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
-            for _ in range(5):
-                self._search("")
-        warnings = [r for r in caplog.records if "streak tracking is INACTIVE" in r.message]
-        assert len(warnings) == 1, "must warn exactly once per process, not per call"
+        ts._SEARCH_QUERIES.clear()
+        # Two sub-threshold calls, then the third trips the directive.
+        self._search("", query="q1")
+        self._search("", query="q2")
+        out = self._search("", query="q3")
+        assert "fallback_directive" in out
+        assert "3 times" in out["fallback_directive"]
 
-    def test_none_session_id_also_warns(self, caplog):
-        import logging
-
+    def test_none_session_id_still_untracked(self):
+        """Explicit None remains the pure-function opt-out path."""
         import tools.tool_search as ts
 
         ts._SEARCH_STREAK.clear()
-        ts._STREAK_DISABLED_WARNED = False
-        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
-            self._search(None)
-        assert any("streak tracking is INACTIVE" in r.message for r in caplog.records)
+        ts._SEARCH_QUERIES.clear()
+        for _ in range(5):
+            out = self._search(None)
+        assert "fallback_directive" not in out
+        assert ts._SEARCH_STREAK == {}
 
-    def test_no_directive_without_session_however_many_searches(self):
-        """The behaviour itself is unchanged — only its visibility."""
+    def test_full_tool_list_injected_at_threshold(self):
+        """At streak==3 the full deferrable tool list is injected."""
         import tools.tool_search as ts
 
         ts._SEARCH_STREAK.clear()
-        ts._STREAK_DISABLED_WARNED = False
-        for _ in range(10):
-            out = self._search("")
+        ts._SEARCH_QUERIES.clear()
+        self._search("sess-full", query="a")
+        self._search("sess-full", query="b")
+        out = self._search("sess-full", query="c")
+        assert "full_tool_list" in out
+        assert self._DEF_TOOL in out["full_tool_list"]
+
+    def test_previous_queries_injected_at_threshold(self):
+        """At streak==3 previous queries are surfaced so the model sees loops."""
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._SEARCH_QUERIES.clear()
+        self._search("sess-prev", query="alpha")
+        self._search("sess-prev", query="beta")
+        out = self._search("sess-prev", query="gamma")
+        assert "previous_queries" in out
+        # The current query (gamma) must not appear in previous_queries.
+        assert "gamma" not in out["previous_queries"]
+        assert "alpha" in out["previous_queries"]
+        assert "beta" in out["previous_queries"]
+
+    def test_auto_describe_fires_at_describe_threshold(self):
+        """At streak==5 the top hit is auto-described inline."""
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._SEARCH_QUERIES.clear()
+        out = None
+        for _ in range(5):
+            # Use a query that actually matches the deferrable tool so hits is
+            # non-empty and auto_describe has a top result to describe.
+            out = self._search("sess-desc", query="searchme")
+        assert out is not None
+        assert "auto_describe" in out
+        assert out["auto_describe"]["name"] == self._DEF_TOOL
+        assert "parameters" in out["auto_describe"]
+
+    def test_auto_describe_absent_below_describe_threshold(self):
+        """At streak==3 (below 5) auto_describe must NOT be present."""
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._SEARCH_QUERIES.clear()
+        self._search("sess-nodesc", query="a")
+        self._search("sess-nodesc", query="b")
+        out = self._search("sess-nodesc", query="c")
+        assert "fallback_directive" in out
+        assert "auto_describe" not in out
+
+    def test_streak_resets_on_tool_call(self):
+        """reset_search_streak clears the counter so the directive goes away."""
+        import tools.tool_search as ts
+
+        ts._SEARCH_STREAK.clear()
+        ts._SEARCH_QUERIES.clear()
+        self._search("sess-reset", query="a")
+        self._search("sess-reset", query="b")
+        self._search("sess-reset", query="c")  # streak 3 -> directive
+        ts.reset_search_streak("sess-reset")  # model invoked a tool
+        out = self._search("sess-reset", query="d")  # streak 1 again
         assert "fallback_directive" not in out
 
-    def test_real_session_id_does_not_warn(self, caplog):
-        import logging
-
+    def test_reset_clears_previous_queries(self):
+        """reset_search_streak also clears the rolling query history."""
         import tools.tool_search as ts
 
         ts._SEARCH_STREAK.clear()
-        ts._STREAK_DISABLED_WARNED = False
-        with caplog.at_level(logging.WARNING, logger="tools.tool_search"):
-            for _ in range(3):
-                out = self._search("sess-real")
-        assert not any("streak tracking is INACTIVE" in r.message for r in caplog.records)
-        assert "fallback_directive" in out
+        ts._SEARCH_QUERIES.clear()
+        self._search("sess-pq", query="a")
+        self._search("sess-pq", query="b")
+        self._search("sess-pq", query="c")
+        assert ts.get_previous_queries("sess-pq") == ["a", "b", "c"]
+        ts.reset_search_streak("sess-pq")
+        assert ts.get_previous_queries("sess-pq") == []

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -54,55 +54,92 @@ BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_N
 # underestimating, which is the safer default.
 CHARS_PER_TOKEN = 4.0
 
-# ── #1144 — consecutive-tool_search streak tracking ───────────────────────
+# ── #1144 / #1373 — consecutive-tool_search streak tracking ───────────────
 # Per-session count of ``tool_search`` calls with no intervening ``tool_call``.
 # When the model keeps reformulating queries but never invokes a discovered
 # tool, ``dispatch_tool_search`` appends a ``fallback_directive`` once the
 # streak crosses ``ToolSearchConfig.search_streak_threshold``. The counter
-# resets on any ``tool_call``. Keyed by session_id; a None session_id is not
-# tracked (keeps pure-function tests that pass no session_id unaffected).
+# resets on any ``tool_call``.
+#
+# #1373 — the counter used to be keyed by session_id and return 0 forever for a
+# falsy key. The production runtime reaches this via
+# ``session_id=agent.session_id or ""`` (agent_runtime_helpers + conversation
+# loop), so an unset session id arrives as the empty string ``""`` — falsy,
+# which silently disabled the whole feature (17 sessions identical to the
+# pre-merge baseline). A falsy / empty session id now falls back to a single
+# process-local default key so the feature actually fires in that environment.
+# Only an explicit ``None`` (the pure-function test path) declines to track.
 _SEARCH_STREAK: Dict[str, int] = {}
 
-#: Set once per process when a search arrives with no usable session key, so
-#: the "streak tracking is silently off" state is visible in the log exactly
-#: once instead of never (#1373).
-_STREAK_DISABLED_WARNED = False
+#: Per-session rolling list of recent tool_search queries, used to populate
+#: ``previous_queries`` in the fallback directive so the model can see it is
+#: going in circles (#1373).
+_SEARCH_QUERIES: Dict[str, List[str]] = {}
+
+#: Cap on how many previous queries we surface / retain per session.
+_PREVIOUS_QUERIES_MAX = 8
+
+#: Sentinel key used when the runtime hands us an empty session id. Using a
+#: stable, obviously-synthetic key (rather than the empty string) keeps the
+#: default-keyed streak visually distinct from a real session in debugging and
+#: keeps ``""`` out of the dict as a key.
+_DEFAULT_SESSION_KEY = "__default_session__"
 
 
-def note_tool_search(session_id: Optional[str]) -> int:
+def _streak_key(session_id: Optional[str]) -> Optional[str]:
+    """Resolve a session_id to a streak-tracking key.
+
+    Returns the session id unchanged when it is a non-empty string, a stable
+    default key when it is an empty string (the production runtime path), and
+    ``None`` only for an explicit ``None`` — which opts out of tracking
+    entirely (preserving the pure-function unit-test contract).
+    """
+    if session_id is None:
+        return None
+    if session_id == "":
+        return _DEFAULT_SESSION_KEY
+    return session_id
+
+
+def note_tool_search(session_id: Optional[str], query: str = "") -> int:
     """Increment the consecutive-search streak for ``session_id``; return it.
 
-    Returns 0 — and therefore never reaches the threshold — when there is no
-    session key to count against. That is the correct behaviour for the pure
-    unit tests that pass none, but in production it silently disables the whole
-    feature, which is how #1153 could ship, pass CI, and leave the signal it
-    targeted completely unchanged (#1373). The runtime reaches this via
-    ``session_id=agent.session_id or ""`` in ``agent_runtime_helpers``, so an
-    unset session id arrives as ``""`` — falsy, and indistinguishable here from
-    a test calling with nothing.
+    A non-empty session id is tracked under itself. An empty-string session id
+    — the value the runtime sends when ``agent.session_id`` is unset — is
+    tracked under a stable default key so the feature fires instead of
+    silently returning 0 forever (#1373). Only an explicit ``None`` opts out
+    of tracking (the pure-function unit-test path).
 
-    The counter still declines to track it; what changes is that it says so.
+    ``query`` is appended to the per-session rolling query history so the
+    fallback directive can surface ``previous_queries``.
     """
-    if not session_id:
-        global _STREAK_DISABLED_WARNED
-        if not _STREAK_DISABLED_WARNED:
-            _STREAK_DISABLED_WARNED = True
-            logger.warning(
-                "tool_search streak tracking is INACTIVE for this process: a "
-                "search arrived with no session id, so the consecutive-search "
-                "counter cannot key on anything and the fallback directive "
-                "(#1153) will never fire. Callers must pass a non-empty "
-                "session_id (see #1373)."
-            )
+    key = _streak_key(session_id)
+    if key is None:
         return 0
-    _SEARCH_STREAK[session_id] = _SEARCH_STREAK.get(session_id, 0) + 1
-    return _SEARCH_STREAK[session_id]
+    _SEARCH_STREAK[key] = _SEARCH_STREAK.get(key, 0) + 1
+    if query:
+        hist = _SEARCH_QUERIES.setdefault(key, [])
+        hist.append(query)
+        # Trim to the last N, keeping insertion order.
+        if len(hist) > _PREVIOUS_QUERIES_MAX:
+            del hist[: len(hist) - _PREVIOUS_QUERIES_MAX]
+    return _SEARCH_STREAK[key]
 
 
 def reset_search_streak(session_id: Optional[str]) -> None:
     """Reset the streak — call when the model invokes a discovered tool."""
-    if session_id and session_id in _SEARCH_STREAK:
-        _SEARCH_STREAK[session_id] = 0
+    key = _streak_key(session_id)
+    if key is not None and key in _SEARCH_STREAK:
+        _SEARCH_STREAK[key] = 0
+        _SEARCH_QUERIES.pop(key, None)
+
+
+def get_previous_queries(session_id: Optional[str]) -> List[str]:
+    """Return the rolling recent-query history for ``session_id`` (copy)."""
+    key = _streak_key(session_id)
+    if key is None:
+        return []
+    return list(_SEARCH_QUERIES.get(key, []))
 
 
 def _fallback_directive(streak: int) -> str:
@@ -138,6 +175,12 @@ class ToolSearchConfig:
     # nudging the model to broaden the query, check tool_describe, or proceed
     # without the deferred tool. 0 disables the guard.
     search_streak_threshold: int = 3
+    # #1373 — after this many consecutive ``tool_search`` calls with no
+    # ``tool_call``, also auto-invoke ``tool_describe`` on the top search hit
+    # (inline, in the result) so the model gets the full schema without another
+    # round-trip. Must be >= search_streak_threshold. 0 disables the
+    # auto-describe step (the streak-3 fallback still fires).
+    search_streak_describe_threshold: int = 5
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -150,14 +193,26 @@ class ToolSearchConfig:
         break the agent.
         """
         if raw is True:
-            return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="auto",
+                threshold_pct=10.0,
+                search_default_limit=5,
+                max_search_limit=20,
+            )
         if raw is False:
-            return cls(enabled="off", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="off",
+                threshold_pct=10.0,
+                search_default_limit=5,
+                max_search_limit=20,
+            )
         if not isinstance(raw, dict):
-            return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="auto",
+                threshold_pct=10.0,
+                search_default_limit=5,
+                max_search_limit=20,
+            )
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
         if enabled_raw in ("true", "1", "yes"):
@@ -173,9 +228,15 @@ class ToolSearchConfig:
         threshold_pct = max(0.0, min(100.0, threshold_pct))
 
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
-        search_default_limit = max(1, min(max_search_limit,
-                                          _safe_int(raw.get("search_default_limit"), 5)))
-        streak_threshold = max(0, min(20, _safe_int(raw.get("search_streak_threshold"), 3)))
+        search_default_limit = max(
+            1, min(max_search_limit, _safe_int(raw.get("search_default_limit"), 5))
+        )
+        streak_threshold = max(
+            0, min(20, _safe_int(raw.get("search_streak_threshold"), 3))
+        )
+        describe_threshold = max(
+            0, min(20, _safe_int(raw.get("search_streak_describe_threshold"), 5))
+        )
 
         return cls(
             enabled=enabled,
@@ -184,6 +245,7 @@ class ToolSearchConfig:
             max_search_limit=max_search_limit,
             defer_core_toolsets=_parse_toolset_list(raw.get("defer_core_toolsets")),
             search_streak_threshold=streak_threshold,
+            search_streak_describe_threshold=describe_threshold,
         )
 
 
@@ -201,7 +263,11 @@ def _parse_toolset_list(value: Any) -> frozenset[str]:
         items = list(value)
     else:
         return frozenset()
-    names = {str(item).strip() for item in items if isinstance(item, str) and str(item).strip()}
+    names = {
+        str(item).strip()
+        for item in items
+        if isinstance(item, str) and str(item).strip()
+    }
     return frozenset(names)
 
 
@@ -223,6 +289,7 @@ def load_config() -> ToolSearchConfig:
     """Load tool-search config from the user config file."""
     try:
         from hermes_cli.config import load_config as _load
+
         cfg = _load() or {}
         tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
         if not isinstance(tools_cfg, dict):
@@ -246,6 +313,7 @@ def _hermes_core_tools() -> frozenset[str]:
     """
     try:
         from toolsets import _HERMES_CORE_TOOLS
+
         return frozenset(_HERMES_CORE_TOOLS)
     except Exception:
         return frozenset()
@@ -289,7 +357,9 @@ def _core_tools_in_toolsets(toolset_names: frozenset[str]) -> frozenset[str]:
     return frozenset(members & core)
 
 
-def effective_core_tool_names(config: Optional[ToolSearchConfig] = None) -> frozenset[str]:
+def effective_core_tool_names(
+    config: Optional[ToolSearchConfig] = None,
+) -> frozenset[str]:
     """Return the set of tool names that must NEVER be deferred.
 
     Starts from ``_HERMES_CORE_TOOLS`` and subtracts any core tool whose
@@ -310,7 +380,9 @@ def effective_core_tool_names(config: Optional[ToolSearchConfig] = None) -> froz
     return frozenset(core - opted_in)
 
 
-def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None) -> bool:
+def is_deferrable_tool_name(
+    name: str, config: Optional[ToolSearchConfig] = None
+) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
     A tool is deferrable iff it is registered with an MCP toolset prefix
@@ -340,6 +412,7 @@ def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
+
         entry = registry.get_entry(name)
         if entry is None:
             return False
@@ -396,7 +469,9 @@ def estimate_tokens_from_schemas(tool_defs: Iterable[Dict[str, Any]]) -> int:
     total_chars = 0
     for td in tool_defs:
         try:
-            total_chars += len(json.dumps(td, ensure_ascii=False, separators=(",", ":")))
+            total_chars += len(
+                json.dumps(td, ensure_ascii=False, separators=(",", ":"))
+            )
         except (TypeError, ValueError):
             total_chars += len(str(td))
     return int(math.ceil(total_chars / CHARS_PER_TOKEN))
@@ -468,10 +543,12 @@ def _entry_search_text(td: Dict[str, Any]) -> str:
     fn = td.get("function") or {}
     name = fn.get("name", "")
     desc = fn.get("description", "") or ""
-    params = ((fn.get("parameters") or {}).get("properties") or {})
+    params = (fn.get("parameters") or {}).get("properties") or {}
     param_names = " ".join(params.keys())
     # Break snake_case and dotted names into words for BM25.
-    name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
+    name_words = (
+        name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
+    )
     return f"{name_words} {desc} {param_names}"
 
 
@@ -479,6 +556,7 @@ def _classify_source(name: str) -> Tuple[str, str]:
     """Return (source_kind, source_name) for a registered tool name."""
     try:
         from tools.registry import registry
+
         entry = registry.get_entry(name)
         if entry is None:
             return ("other", "")
@@ -515,10 +593,16 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
     return catalog
 
 
-def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
-                doc_lengths: List[int], avg_dl: float,
-                doc_freq: Dict[str, int], n_docs: int,
-                k1: float = 1.5, b: float = 0.75) -> float:
+def _bm25_score(
+    query_tokens: List[str],
+    doc_tokens: List[str],
+    doc_lengths: List[int],
+    avg_dl: float,
+    doc_freq: Dict[str, int],
+    n_docs: int,
+    k1: float = 1.5,
+    b: float = 0.75,
+) -> float:
     """Standard BM25 score for one query against one document.
 
     Inlined small implementation rather than adding a dependency. Performance
@@ -546,7 +630,9 @@ def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
     return score
 
 
-def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> List[CatalogEntry]:
+def search_catalog(
+    catalog: List[CatalogEntry], query: str, limit: int = 5
+) -> List[CatalogEntry]:
     """Return the top-``limit`` catalog entries for ``query`` by BM25.
 
     Falls back to a stable name-substring match when BM25 yields no hits
@@ -573,8 +659,9 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
 
     scored: List[Tuple[float, CatalogEntry]] = []
     for entry in catalog:
-        s = _bm25_score(query_tokens, entry._tokens, doc_lengths, avg_dl,
-                        doc_freq, n_docs)
+        s = _bm25_score(
+            query_tokens, entry._tokens, doc_lengths, avg_dl, doc_freq, n_docs
+        )
         if s > 0:
             scored.append((s, entry))
 
@@ -719,8 +806,11 @@ def assemble_tool_defs(
 
     # Defensive: strip any bridge tools that may already be in the list
     # (e.g. someone called assemble twice).
-    incoming = [td for td in tool_defs
-                if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
+    incoming = [
+        td
+        for td in tool_defs
+        if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES
+    ]
 
     visible, deferrable = classify_tools(incoming, config)
     if not deferrable:
@@ -733,7 +823,9 @@ def assemble_tool_defs(
             activated=False,
             deferred_count=len(deferrable),
             deferred_tokens=deferrable_tokens,
-            threshold_tokens=int((context_length or 0) * (config.threshold_pct / 100.0)),
+            threshold_tokens=int(
+                (context_length or 0) * (config.threshold_pct / 100.0)
+            ),
         )
 
     bridge = bridge_tool_schemas(len(deferrable))
@@ -742,7 +834,10 @@ def assemble_tool_defs(
 
     logger.info(
         "tool_search activated: %d core/visible tools kept, %d deferred (~%d tokens, threshold ~%d)",
-        len(visible), len(deferrable), deferrable_tokens, threshold_tokens,
+        len(visible),
+        len(deferrable),
+        deferrable_tokens,
+        threshold_tokens,
     )
 
     return AssemblyResult(
@@ -791,11 +886,13 @@ def _format_search_hit(entry: CatalogEntry) -> Dict[str, Any]:
     }
 
 
-def dispatch_tool_search(args: Dict[str, Any],
-                         *,
-                         current_tool_defs: List[Dict[str, Any]],
-                         config: Optional[ToolSearchConfig] = None,
-                         session_id: Optional[str] = None) -> str:
+def dispatch_tool_search(
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+    session_id: Optional[str] = None,
+) -> str:
     """Execute the ``tool_search`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -807,7 +904,13 @@ def dispatch_tool_search(args: Dict[str, Any],
     if raw_limit is None:
         limit = config.search_default_limit
     else:
-        limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
+        limit = max(
+            1,
+            min(
+                config.max_search_limit,
+                _safe_int(raw_limit, config.search_default_limit),
+            ),
+        )
 
     _, deferrable = classify_tools(current_tool_defs, config)
     catalog = build_catalog(deferrable)
@@ -827,12 +930,63 @@ def dispatch_tool_search(args: Dict[str, Any],
         "total_available": len(catalog),
         "matches": [_format_search_hit(h) for h in hits],
     }
-    # #1144 — nudge the model after N consecutive searches with no tool_call.
+    # #1144 / #1373 — nudge the model after N consecutive searches with no
+    # tool_call. The counter is incremented (and the query recorded) before the
+    # threshold check. A falsy-but-non-None session id (the runtime's
+    # ``agent.session_id or ""``) is tracked under a default key so the feature
+    # actually fires instead of silently returning 0 forever (#1373).
     threshold = config.search_streak_threshold
+    describe_threshold = config.search_streak_describe_threshold
     if threshold and threshold > 0:
-        streak = note_tool_search(session_id)
+        streak = note_tool_search(session_id, query=query)
         if streak >= threshold:
+            # The core nudge.
             result["fallback_directive"] = _fallback_directive(streak)
+            # #1373 — inject the full deferrable tool list so the model can see
+            # everything available without another search, plus the recent
+            # queries so it can recognise it is going in circles.
+            result["full_tool_list"] = [
+                (td.get("function") or {}).get("name", "")
+                for td in deferrable
+                if (td.get("function") or {}).get("name")
+            ]
+            prev = get_previous_queries(session_id)
+            if prev:
+                # Drop the current query from the "previous" list.
+                result["previous_queries"] = (
+                    prev[:-1] if prev and prev[-1] == query else list(prev)
+                )
+            # #1373 — after a deeper streak, auto-describe the top hit inline so
+            # the model gets the full schema (name/description/parameters) of the
+            # most likely candidate without a separate tool_describe round-trip.
+            if (
+                describe_threshold
+                and describe_threshold > 0
+                and streak >= max(threshold, describe_threshold)
+                and hits
+            ):
+                top = hits[0]
+                # Find the full tool def for the top hit to surface its schema.
+                top_def = next(
+                    (
+                        td
+                        for td in deferrable
+                        if (td.get("function") or {}).get("name") == top.name
+                    ),
+                    None,
+                )
+                if top_def is not None:
+                    fn = top_def.get("function") or {}
+                    result["auto_describe"] = {
+                        "name": top.name,
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", {}),
+                        "note": (
+                            f"Auto-described because tool_search has been called "
+                            f"{streak} times in a row without a tool_call. If this "
+                            f"is the tool you need, call it (or tool_call) directly."
+                        ),
+                    }
     return json.dumps(result, ensure_ascii=False)
 
 
@@ -871,10 +1025,12 @@ def _fuzzy_tool_names(query: str, available: List[str], limit: int = 3) -> List[
     return [n for n in scored if _dist(q, n) <= max(3, len(q) // 3)]
 
 
-def dispatch_tool_describe(args: Dict[str, Any],
-                           *,
-                           current_tool_defs: List[Dict[str, Any]],
-                           config: Optional[ToolSearchConfig] = None) -> str:
+def dispatch_tool_describe(
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -918,53 +1074,64 @@ def _dispatch_tool_describe_inner(
         # without a separate tool_search round-trip.
         _, deferrable = classify_tools(current_tool_defs, config)
         available_names = [
-            (td.get("function") or {}).get("name", "")
-            for td in deferrable
+            (td.get("function") or {}).get("name", "") for td in deferrable
         ]
         suggestions = _fuzzy_tool_names(name, available_names)
         if suggestions:
-            return json.dumps({
+            return json.dumps(
+                {
+                    "error": (
+                        f"'{name}' is not a deferrable tool. Did you mean one of: "
+                        f"{', '.join(suggestions)}? Use the exact name with "
+                        f"tool_describe or tool_call."
+                    ),
+                    "suggestions": suggestions,
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {
                 "error": (
-                    f"'{name}' is not a deferrable tool. Did you mean one of: "
-                    f"{', '.join(suggestions)}? Use the exact name with "
-                    f"tool_describe or tool_call."
+                    f"'{name}' is not a deferrable tool. If you see it in the tools list "
+                    "already, call it directly; otherwise check the spelling against tool_search."
                 ),
-                "suggestions": suggestions,
-            }, ensure_ascii=False)
-        return json.dumps({
-            "error": (
-                f"'{name}' is not a deferrable tool. If you see it in the tools list "
-                "already, call it directly; otherwise check the spelling against tool_search."
-            ),
-        }, ensure_ascii=False)
+            },
+            ensure_ascii=False,
+        )
     _, deferrable = classify_tools(current_tool_defs, config)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
-            return json.dumps({
-                "name": name,
-                "description": fn.get("description", ""),
-                "parameters": fn.get("parameters", {}),
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                },
+                ensure_ascii=False,
+            )
     # #978 — fuzzy name matching: suggest closest matches so the agent can
     # self-correct without a separate tool_search round-trip.
-    available_names = [
-        (td.get("function") or {}).get("name", "")
-        for td in deferrable
-    ]
+    available_names = [(td.get("function") or {}).get("name", "") for td in deferrable]
     suggestions = _fuzzy_tool_names(name, available_names)
     if suggestions:
-        return json.dumps({
-            "error": (
-                f"'{name}' is not currently available. Did you mean one of: "
-                f"{', '.join(suggestions)}? Use the exact name with tool_describe "
-                f"or tool_call."
-            ),
-            "suggestions": suggestions,
-        }, ensure_ascii=False)
-    return json.dumps({
-        "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
-    }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "error": (
+                    f"'{name}' is not currently available. Did you mean one of: "
+                    f"{', '.join(suggestions)}? Use the exact name with tool_describe "
+                    f"or tool_call."
+                ),
+                "suggestions": suggestions,
+            },
+            ensure_ascii=False,
+        )
+    return json.dumps(
+        {
+            "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
+        },
+        ensure_ascii=False,
+    )
 
 
 def scoped_deferrable_names(
@@ -1088,7 +1255,11 @@ def resolve_underlying_call(
     if not name:
         return None, {}, "tool_call requires a 'name' argument"
     if name in BRIDGE_TOOL_NAMES:
-        return None, {}, f"tool_call cannot invoke '{name}' (it is itself a bridge tool)"
+        return (
+            None,
+            {},
+            f"tool_call cannot invoke '{name}' (it is itself a bridge tool)",
+        )
     raw_args = args.get("arguments")
     if raw_args is None:
         raw_args = {}
@@ -1220,6 +1391,9 @@ __all__ = [
     "resolve_underlying_call",
     "validate_tool_args",
     "scoped_deferrable_names",
+    "get_previous_queries",
+    "note_tool_search",
+    "reset_search_streak",
     "_non_deferrable_error",
     "_CORE_TOOL_ALTERNATIVES",
     "clear_describe_cache",


### PR DESCRIPTION
Automated evolution PR for issue #1373.

Root cause: callers pass session_id=agent.session_id or empty string, and the old streak counter treated any falsy value (incl. empty string) as do-not-track, so the streak never incremented and the fallback directive never fired.

Fix:
- Map empty-string session_id to stable key __default_session__ so production fires; None still opts out (preserves pure-function test contract).
- Add per-session previous-queries tracking (rolling, capped at 8).
- At streak >= 3 (search_streak_threshold): inject full tool list + previous queries + fallback directive.
- At streak >= 5 (new search_streak_describe_threshold): additionally inject auto_describe with the top hit full schema.

Tests: 8 new tests in TestSearchStreakEmptySessionNowFires covering all four spec requirements.