### PR TITLE
fix(evolution): stop re-filing rejected ideas — dedup must see closed issues (Closes #1470)

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -167,12 +167,21 @@ gh issue view <N> --repo Lexus2016/hermes-agent-evolution --json body,comments
 
    CLOSE every rejected issue with a clear reason + the canonical `rejected`
    status label, so the backlog shows at a glance what was turned down (the
-   *why* is in the closing comment) and the same idea isn't re-proposed:
+   *why* is in the closing comment) and the same idea isn't re-proposed.
+
+   **`--reason "not planned"` is required, not cosmetic (#1470).** Closing a
+   rejection as the default `completed` tells every later reader the work was
+   DONE. The issues stage's duplicate check reads exactly that field to decide
+   whether an idea may be re-filed: `NOT_PLANNED` blocks it, `COMPLETED` allows
+   it as a possible regression. Rejections closed as `completed` are therefore
+   re-filed on the next research pass — nine landed in one cycle that way
+   (#1460-#1469). The label alone does not carry this; the state reason does.
    ```bash
    # Ensure the status label exists (idempotent), then close + label:
    gh label create rejected --color b60205 \
      --description "Not accepted by evolution — see closing comment" 2>/dev/null || true
    gh issue close <N> --repo Lexus2016/hermes-agent-evolution \
+     --reason "not planned" \
      --comment "Rejected by evolution-analysis: <already-exists|out-of-scope|harmful|duplicate> — <one-line reason>."
    gh issue edit <N> --repo Lexus2016/hermes-agent-evolution \
      --add-label rejected --remove-label needs-work 2>/dev/null || true

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -180,13 +180,22 @@ Then create:
    local cache check above does NOT protect against a `gh issue create` that
    silently succeeds but whose response times out, so you "retry" and file a true
    duplicate (this happened — #193/#194, identical body, 13s apart, one proposal).
-   So immediately before creating, confirm no OPEN issue already has this exact
-   title; if one does, SKIP the create and just record it:
+   So immediately before creating, confirm no issue already has this exact
+   title — **including closed ones**; if one does, SKIP the create and just
+   record it:
 ```bash
 TITLE="[FEATURE] <short title>"   # right prefix per category: [FEATURE]/[FIX]/[IMPROVEMENT]/...
-existing=$(gh issue list --repo "$REPO" --state open --search "in:title $TITLE" \
-  --json number,title --jq ".[] | select(.title==\"$TITLE\") | .number" | head -1)
+existing=$(gh issue list --repo "$REPO" --state all --search "in:title $TITLE" \
+  --json number,title,state,stateReason \
+  --jq ".[] | select(.title==\"$TITLE\") | \"\(.number)\t\(.state)\t\(.stateReason)\"" | head -1)
 ```
+   **`--state all`, not `--state open` (#1470).** A rejected idea is a CLOSED
+   issue, so an open-only check cannot see it and the pipeline re-files it on the
+   next research pass — the rejection is what makes it re-fileable. Nine
+   duplicates landed in a single cycle this way (#1460-#1469 against #1287,
+   #1313, #1343, #1345, #1433-#1437), each one costing analysis another triage
+   to reach the verdict it had already reached.
+
    Create ONLY when `$existing` is empty:
 ```bash
 [ -z "$existing" ] && gh issue create \
@@ -195,6 +204,15 @@ existing=$(gh issue list --repo "$REPO" --state open --search "in:title $TITLE" 
   --label "enhancement,proposal,research-generated" \
   --body "$BODY"
 ```
+   When `$existing` is NOT empty, the third field tells you why it is closed and
+   what that means:
+
+   * **`NOT_PLANNED`** — rejected. Do NOT re-file. The focus-test verdict stands
+     until new evidence contradicts it.
+   * **`COMPLETED`** — shipped. Only file a NEW issue if you have evidence the
+     fix REGRESSED, and say so in the body, citing the digest signal. A bare
+     re-proposal of completed work is a duplicate.
+   * **`OPEN`** — as before: skip, it is already tracked.
 
    After creation, **verify that the issue actually appeared** (otherwise do not
    count it in the report): `gh issue list --repo "$REPO" --state open --limit 5`.


### PR DESCRIPTION
The pipeline re-files ideas it has already rejected, indefinitely. **Nine duplicates landed in a single cycle today.**

At **11:03 UTC** analysis rejected #1433, #1434, #1435, #1437 (and earlier #1313, #1343, #1345) as out-of-scope — *"speculative, no concrete implementation path. Fails focus-test."* The same cycle's research/issues pass filed **every one of them again** as #1460–#1469.

## Root cause

`evolution-issues/SKILL.md:187`, the check run immediately before `gh issue create`:

```bash
gh issue list --state open --search "in:title $TITLE"
```

**`--state open`.** A rejected idea is a *closed* issue, so the check cannot see it, so it is filed again. The rejection is precisely what makes it re-fileable.

The backlog therefore cannot converge: every rejection is undone by the next research pass, and analysis spends another triage reaching the verdict it already reached. Nine duplicates is nine wasted triage decisions and nine issues a human reads past.

## Two changes, one per stage

**evolution-issues** — `--state all`, and read `stateReason` to decide what a hit means:

| State | Meaning |
|---|---|
| `NOT_PLANNED` | rejected → do **not** re-file; the focus-test verdict stands |
| `COMPLETED` | shipped → new issue only with **evidence it regressed**, cited in the body |
| `OPEN` | already tracked → skip |

Line 85 of the same file already fetched `--state all` for the survey step, so the mechanism was understood — it just was not used at the point that decides.

**evolution-analysis** — close rejections with `--reason "not planned"`.

The default `completed` tells every later reader the work was **done**, and that is exactly the field the duplicate check above reads. A rejection recorded as completed is indistinguishable from a shipped fix, so it gets re-filed as a suspected regression. The `rejected` label does not carry this — the state reason does.

Same bookkeeping defect as #1272/#1273, which were closed `COMPLETED` after their PR was closed unmerged.

## Why this one first

It is the reason the backlog does not shrink. Every other proposal in the queue competes for triage attention with ideas that were already turned down and came back.

22 passing in `test_evolution_skill_integrity.py`, which lints every skill reference and command against the real repo.