### PR TITLE
fix(terminal): name shell-level exit codes 126/127 (Closes #1452)

### DIFF
--- a/tests/tools/test_terminal_exit_semantics.py
+++ b/tests/tools/test_terminal_exit_semantics.py
@@ -150,3 +150,50 @@ class TestInterpretExitCode:
     def test_only_env_vars(self):
         """Command with only env var assignments, no actual command."""
         assert _interpret_exit_code("FOO=bar", 1) is None
+
+
+class TestShellLevelExitCodes:
+    """126/127 are about the INVOCATION, not the program (#1452).
+
+    They are command-agnostic — 127 means the shell found nothing to run,
+    whatever the command was — so they fell through the per-command table and
+    produced no note at all. Worth naming because re-running unchanged cannot
+    succeed, which is the retry-spiral shape behind terminal's 27.4% failure
+    rate (#1371).
+    """
+
+    def test_127_names_the_cause_and_the_fix(self):
+        note = _interpret_exit_code("nosuchtool --flag", 127)
+        assert note is not None
+        assert "not found" in note.lower()
+        assert "path" in note.lower()
+
+    def test_126_distinguishes_permission_from_missing(self):
+        note = _interpret_exit_code("./script.sh", 126)
+        assert note is not None
+        assert "not executable" in note.lower()
+        assert "not found" not in note.lower()
+
+    def test_both_say_a_bare_retry_will_not_help(self):
+        """The point is to stop the identical re-issue, so it has to be said."""
+        for code in (126, 127):
+            note = _interpret_exit_code("cmd", code)
+            assert "unchanged" in note.lower()
+
+    def test_shell_codes_apply_to_any_command(self):
+        for cmd in ("foo", "git status", "curl https://x", "grep pattern file"):
+            assert _interpret_exit_code(cmd, 127) is not None
+
+    def test_command_specific_semantics_still_win(self):
+        """A per-command meaning must not be shadowed by the new fallback."""
+        assert "No matches" in _interpret_exit_code("grep x f", 1)
+        assert "connect" in _interpret_exit_code("curl https://x", 7)
+
+    def test_signal_codes_still_win(self):
+        assert "SIGKILL" in _interpret_exit_code("sleep 1", 137)
+
+    def test_unknown_code_still_returns_none(self):
+        assert _interpret_exit_code("mycmd", 3) is None
+
+    def test_zero_still_returns_none(self):
+        assert _interpret_exit_code("nosuchtool", 0) is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2089,6 +2089,31 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     if exit_code >= 128 and exit_code in _SIGNAL_NAMES:
         return f"Process terminated by {_SIGNAL_NAMES[exit_code]}"
 
+    # Shell-level exit codes, which are about the INVOCATION rather than the
+    # program (#1452). These are command-agnostic — 127 means the shell never
+    # found anything to run, whatever the command was — so they fall through
+    # the per-command table above and previously produced no note at all.
+    #
+    # They are worth naming precisely because the failure is not in the
+    # command's logic: re-running it unchanged cannot succeed, which is the
+    # retry-spiral shape that makes terminal the dominant failure signal
+    # (#1371, 27.4% across 673 sessions). Each note therefore states the cause
+    # AND what to change, so the next attempt differs.
+    _SHELL_EXIT_HINTS = {
+        126: (
+            "Command found but not executable — check the file's permissions "
+            "(chmod +x) or whether it is a directory. Re-running unchanged "
+            "will fail identically."
+        ),
+        127: (
+            "Command not found — check the spelling, or whether the tool is "
+            "installed and on PATH. Re-running unchanged will fail "
+            "identically; try `which <cmd>` or an absolute path."
+        ),
+    }
+    if exit_code in _SHELL_EXIT_HINTS:
+        return _SHELL_EXIT_HINTS[exit_code]
+
     return None
 
 


### PR DESCRIPTION
Child 1 of #1371 (terminal 27.4% failure rate across 673 sessions — the dominant failure signal).

## The gap

`_interpret_exit_code` already explains **per-command** exit codes (`grep` 1 = no matches, `curl` 7 = connection failed) and **signal** codes (137 = SIGKILL). It said nothing about **126 and 127**, because those are not per-command — they are about the *invocation*. 127 means the shell never found anything to run, whatever the command was, so it falls straight through the per-command table and produced no note at all.

## Why these two specifically

The failure is not in the command's logic. **Re-running the same string cannot succeed** — which is exactly the retry-spiral shape behind the parent issue's numbers. So each note states the cause *and* what to change:

| Code | Note |
|---|---|
| **126** | found but not executable; check permissions (`chmod +x`) or whether it is a directory. Re-running unchanged will fail identically. |
| **127** | not found; check spelling, or whether the tool is installed and on PATH. Re-running unchanged will fail identically; try `which` or an absolute path. |

## Ordering is the risk, and it is tested

The new lookup is a **fallback**, matched after the per-command table and the signal codes. Tests pin this:

- `grep x f` exit 1 still reads *"No matches found (not an error)"*, not a generic shell hint
- `curl` exit 7 still reads *"Failed to connect to host"*
- `sleep` exit 137 still reads *"SIGKILL"*
- an unknown code still returns `None` rather than a fabricated explanation

8 new tests, 39 passing in `test_terminal_exit_semantics.py`, 345 across the terminal suites; ruff clean.

## Scope

Deliberately just this. Children 2 (#1453, strategy-switch after 3 consecutive failures) and 3 (#1454, security-scan block directive) are separate — and #1453 in particular needs checking against `loop_guard`, which already fires on the third consecutive terminal failure today.