### PR TITLE
fix(loop-guard): read the tool's status field, not marker words in its prose (Closes #1453)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -631,9 +631,58 @@ def _failure_category(content: Any) -> Optional[str]:
     return hit[0] if hit else None
 
 
+def _structural_failure(content: str) -> Optional[bool]:
+    """Read the authoritative status out of a tool's JSON envelope (#1453).
+
+    Every Hermes tool serialises its result as a JSON envelope carrying the real
+    status: ``exit_code`` for terminal/code-exec, ``error`` / ``success`` /
+    ``status`` for the rest. Returns True/False from that field, or None when
+    the content is not a recognisable envelope — so the caller can fall back to
+    the marker scan for plain-string results.
+
+    This exists because the marker scan alone MISSES structural failures. Its
+    exit-code regex matches the prose form ``exit code: 1``; the envelope uses
+    the key ``"exit_code"``, with an underscore, which that pattern never
+    matches. So ``{"exit_code": 2}`` — an unambiguous failure — read as success
+    unless its error text happened to contain a known marker word.
+
+    That is why the guard stayed silent through runs of genuinely failing
+    terminal calls: three failures with different error wording produced one
+    recognised failure, never reaching the threshold. ``introspection_extract``
+    was fixed to read the envelope in #347; this brings the loop guard into
+    agreement, so the digest and the guard stop disagreeing about what a
+    failure is.
+    """
+    stripped = content.strip()
+    if not (stripped.startswith("{") and stripped.endswith("}")):
+        return None
+    try:
+        data = json.loads(stripped)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if "exit_code" in data:
+        try:
+            return int(data["exit_code"]) != 0
+        except (TypeError, ValueError):
+            return None
+    if data.get("error") or str(data.get("status", "")).lower() == "error":
+        return True
+    for ok_key in ("success", "ok"):
+        if ok_key in data:
+            return not bool(data[ok_key])
+    return None
+
+
 def _looks_like_failure(content: Any) -> bool:
     if not isinstance(content, str) or not content:
         return False
+    # Structured status first — it is authoritative where present, and the
+    # marker scan cannot see it (#1453).
+    structural = _structural_failure(content)
+    if structural is not None:
+        return structural
     low = content.lower()
     if any(m in low for m in _FAILURE_MARKERS):
         return True

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -11,6 +11,7 @@ import json
 from agent.loop_guard import (
     CRON_LOOP_GUARD_HARD_STOP_THRESHOLD,
     INTERACTIVE_LOOP_GUARD_HARD_STOP_THRESHOLD,
+    _looks_like_failure,
     current_run_signature,
     maybe_nudge,
     maybe_refusal_nudge,
@@ -806,3 +807,71 @@ class TestMaybeRefusalNudge:
         assert nudge is not None
         # Should classify the first refusal
         assert "[loop-guard]" in nudge
+
+
+class TestStructuralFailureDetection:
+    """The guard must read the tool's own status field, not guess from prose.
+
+    Its exit-code regex matches the prose form `exit code: 1`; every Hermes tool
+    serialises `"exit_code"` with an underscore, which that pattern never
+    matches. So `{"exit_code": 2}` — an unambiguous failure — read as SUCCESS
+    unless its error text happened to contain a known marker word.
+
+    Consequence: three genuinely failing terminal calls with differently-worded
+    errors produced one recognised failure and never reached the threshold, so
+    the guard stayed silent through exactly the runs it exists to catch (#1453,
+    parent #1371). introspection_extract was fixed to read the envelope in #347;
+    this keeps the two in agreement about what a failure is.
+    """
+
+    @staticmethod
+    def _terminal_run(*errors):
+        msgs = []
+        for i, err in enumerate(errors):
+            msgs.append({
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": f"c{i}", "type": "function",
+                    "function": {"name": "terminal",
+                                 "arguments": json.dumps({"command": f"cmd{i}"})},
+                }],
+            })
+            msgs.append({"role": "tool", "tool_call_id": f"c{i}",
+                         "content": json.dumps({"exit_code": 1, "error": err})})
+        return msgs
+
+    def test_envelope_exit_code_is_a_failure(self):
+        assert _looks_like_failure(json.dumps({"exit_code": 2})) is True
+
+    def test_envelope_exit_code_zero_is_not(self):
+        assert _looks_like_failure(json.dumps({"exit_code": 0})) is False
+
+    def test_error_wording_no_longer_decides(self):
+        """'cannot open' is not in the marker list, but exit_code=1 is decisive."""
+        assert _looks_like_failure(json.dumps({"exit_code": 1, "error": "cannot open"})) is True
+
+    def test_success_flag_respected(self):
+        assert _looks_like_failure(json.dumps({"success": True})) is False
+        assert _looks_like_failure(json.dumps({"success": False})) is True
+
+    def test_error_field_alone(self):
+        assert _looks_like_failure(json.dumps({"error": "boom"})) is True
+
+    def test_plain_string_still_uses_markers(self):
+        """Non-envelope results keep the old behaviour."""
+        assert _looks_like_failure("bash: error: something broke") is True
+        assert _looks_like_failure("all good here") is False
+
+    def test_malformed_json_falls_back_to_markers(self):
+        assert _looks_like_failure('{"exit_code": broken') is False
+        assert _looks_like_failure('{"oops": permission denied') is True
+
+    def test_three_differently_worded_failures_now_nudge(self):
+        """The case the guard used to miss entirely."""
+        nudge = maybe_nudge(self._terminal_run(
+            "no such file", "cannot open", "permission denied"))
+        assert nudge is not None
+        assert "terminal" in nudge
+
+    def test_a_single_failure_still_stays_quiet(self):
+        assert maybe_nudge(self._terminal_run("no such file")) is None


### PR DESCRIPTION
Closes #1453 — Child 2 of #1371. Investigating it found the reason that parent issue's **27.4% terminal failure rate was not producing nudges**, and it is not a missing directive.

## The bug

`_looks_like_failure` decided by scanning result text for marker words, with an exit-code regex as backstop. That regex matches the **prose** form `exit code: 1`. Every Hermes tool serialises the key `"exit_code"` — **with an underscore** — which the pattern never matches.

Measured before the fix, on real envelope shapes:

```
{"exit_code":1,"error":"permission denied"}  -> True    (marker word hit)
{"exit_code":1,"error":"cannot open"}        -> False   <-- a failure, missed
{"exit_code":1,"error":"connection refused"} -> False   <-- a failure, missed
{"exit_code":2}                              -> False   <-- a failure, missed
```

Whether a failure counted depended on **how its error happened to be worded**.

## What that caused

Three genuinely failing terminal calls with differently-worded errors yielded **one** recognised failure — never reaching `_MUTATING_FAIL_THRESHOLD`, so the guard stayed silent through exactly the runs it exists to catch:

```
3 different failing terminal calls -> SILENT
```

That is what #1453 describes as *"3 consecutive terminal failures, any error class"*. The gap is not a missing directive — **the detector could not see the failures**.

After:

```
3 different failing terminal calls -> [loop-guard] The `terminal` tool (mutating)
                                      has failed 3 times in a row...
```

## The fix

`_structural_failure` reads the authoritative field where the result is a JSON envelope — `exit_code`, or `error` / `status` / `success` — and returns `None` when it is not an envelope, so **plain-string results keep the marker scan unchanged**.

`introspection_extract` was fixed the same way in #347, and its comment documents the marker scan being wrong in the *other* direction too: it over-counted by firing on marker words inside successful output. The digest and the guard now agree on what a failure is, rather than disagreeing.

## Tests

9 new: envelope statuses, malformed JSON falling back to markers, plain strings unchanged, `exit_code: 0` still a success, and the three-differently-worded-failures case that used to stay silent.

- 119 passing across the four loop-guard suites
- wider agent selection: **398 → 407** passed, with one pre-existing failure in `test_file_safety.py` reproducing **identically on clean main**
- ruff clean

## Expected effect

The guard will now fire on failure runs it previously slept through. That is the intent, and it is why the parent issue's signal was flat: nudges were not being suppressed, they were never being generated.
