### PR TITLE
feat: canonical version line per promoted skill (Closes #1448)

### DIFF
--- a/scripts/evolution_skill_version.py
+++ b/scripts/evolution_skill_version.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Canonical version line per promoted skill (issue #1448, Child D of #1308).
+
+Closes out the AgentDevel promotion gate. Child A (#1355) defined the probe
+sets, Child B (#1446) the flip gate that scores a candidate against them, Child
+C (#1447) wired the verdict into merge verification so a regression blocks. What
+was still missing is the record of *what was promoted and what approved it* —
+without which a regression is reverted by reconstructing history rather than by
+version.
+
+AgentDevel's argument (arXiv:2601.04620) is that self-evolution is release
+engineering, and a release you cannot roll back is not a release. A version line
+makes "which version is live, and what approved it?" answerable in one lookup.
+
+Each promotion appends one line to ``<store>/<skill>.jsonl``:
+
+    {"skill": "evolution-analysis", "version": 3,
+     "promoted_at": "2026-07-28T12:00:00+00:00",
+     "flip_verdict": "promote", "regressions": [], "fixes": ["p3"],
+     "diff_ref": "abc1234", "critic_ref": "...", "note": "..."}
+
+Append-only on purpose: the history IS the artifact. Overwriting would leave the
+current version with no record of what it replaced, which is the position this
+issue exists to get out of.
+
+Deterministic — no LLM, no network. Pure functions plus a thin CLI, matching the
+``evolution_*.py`` idiom.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = "1"
+
+
+def _default_store() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / "skill_versions"
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / "skill_versions"
+        if hh
+        else Path.home() / ".hermes" / "evolution" / "skill_versions"
+    )
+
+
+@dataclass
+class SkillVersion:
+    """One promotion of one skill, with the evidence that approved it."""
+
+    skill: str
+    version: int
+    promoted_at: str = ""
+    flip_verdict: str = ""
+    regressions: List[str] = field(default_factory=list)
+    fixes: List[str] = field(default_factory=list)
+    diff_ref: str = ""
+    critic_ref: str = ""
+    note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "skill": self.skill,
+            "version": self.version,
+            "promoted_at": self.promoted_at,
+            "flip_verdict": self.flip_verdict,
+            "regressions": list(self.regressions),
+            "fixes": list(self.fixes),
+            "diff_ref": self.diff_ref,
+            "critic_ref": self.critic_ref,
+            "note": self.note,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SkillVersion":
+        return cls(
+            skill=str(data.get("skill", "")),
+            version=int(data.get("version", 0) or 0),
+            promoted_at=str(data.get("promoted_at", "")),
+            flip_verdict=str(data.get("flip_verdict", "")),
+            regressions=list(data.get("regressions", []) or []),
+            fixes=list(data.get("fixes", []) or []),
+            diff_ref=str(data.get("diff_ref", "")),
+            critic_ref=str(data.get("critic_ref", "")),
+            note=str(data.get("note", "")),
+        )
+
+
+def _path(skill: str, store_dir: Optional[Path] = None) -> Path:
+    base = store_dir or _default_store()
+    safe = skill.replace("/", "_").replace(" ", "_")
+    return base / f"{safe}.jsonl"
+
+
+def load_versions(skill: str, store_dir: Optional[Path] = None) -> List[SkillVersion]:
+    """Every recorded promotion of ``skill``, oldest first.
+
+    Malformed lines are skipped rather than raising: a corrupted entry must not
+    make the rest of a skill's history unreadable, since the history is what a
+    rollback depends on.
+    """
+    path = _path(skill, store_dir)
+    if not path.exists():
+        return []
+    out: List[SkillVersion] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("skill"):
+            out.append(SkillVersion.from_dict(data))
+    return out
+
+
+def current_version(skill: str, store_dir: Optional[Path] = None) -> Optional[SkillVersion]:
+    """The live version — the highest recorded, not merely the last written.
+
+    Ordering by ``version`` rather than by file position means an out-of-order
+    append (a retried promotion, a merged history) cannot make an older version
+    look current.
+    """
+    versions = load_versions(skill, store_dir)
+    if not versions:
+        return None
+    return max(versions, key=lambda v: v.version)
+
+
+def record_promotion(
+    skill: str,
+    *,
+    flip_verdict: str = "",
+    regressions: Optional[List[str]] = None,
+    fixes: Optional[List[str]] = None,
+    diff_ref: str = "",
+    critic_ref: str = "",
+    note: str = "",
+    promoted_at: Optional[str] = None,
+    store_dir: Optional[Path] = None,
+) -> SkillVersion:
+    """Append the next version for ``skill`` and return it.
+
+    The version number is derived from what is on disk, not passed in, so two
+    callers cannot disagree about which number is next.
+    """
+    previous = current_version(skill, store_dir)
+    version = (previous.version + 1) if previous else 1
+    entry = SkillVersion(
+        skill=skill,
+        version=version,
+        promoted_at=promoted_at or datetime.now(timezone.utc).isoformat(),
+        flip_verdict=flip_verdict,
+        regressions=list(regressions or []),
+        fixes=list(fixes or []),
+        diff_ref=diff_ref,
+        critic_ref=critic_ref,
+        note=note,
+    )
+    path = _path(skill, store_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
+    return entry
+
+
+def rollback_target(
+    skill: str, store_dir: Optional[Path] = None
+) -> Optional[SkillVersion]:
+    """The version to revert to — the highest below the current one.
+
+    Answers the question this issue exists for: a regression is reverted BY
+    VERSION, with the evidence that approved that version attached, instead of
+    being reconstructed from commit history.
+    """
+    versions = sorted(load_versions(skill, store_dir), key=lambda v: v.version)
+    return versions[-2] if len(versions) >= 2 else None
+
+
+def format_current(skill: str, store_dir: Optional[Path] = None) -> str:
+    """One line answering 'which version is live, and what approved it?'."""
+    cur = current_version(skill, store_dir)
+    if cur is None:
+        return f"[skill-version] {skill}: no recorded promotions"
+    approved = cur.flip_verdict or "unrecorded"
+    detail = ""
+    if cur.fixes or cur.regressions:
+        detail = f" (+{len(cur.fixes)} fixed, -{len(cur.regressions)} regressed)"
+    ref = f" diff={cur.diff_ref}" if cur.diff_ref else ""
+    return (
+        f"[skill-version] {skill}: v{cur.version} "
+        f"promoted {cur.promoted_at or 'at unknown time'} "
+        f"via flip-gate '{approved}'{detail}{ref}"
+    )
+
+
+def _usage() -> str:
+    return (
+        "usage: evolution_skill_version.py <command> [args]\n"
+        "  record <skill> [--verdict V] [--diff REF] [--critic REF] [--note N]\n"
+        "         [--fixes a,b] [--regressions c,d]\n"
+        "  current <skill>          which version is live, and what approved it\n"
+        "  rollback <skill>         the version to revert to\n"
+        "  history <skill>          every promotion, oldest first\n"
+        "  Exit 0 ok, 2 bad input, 1 nothing to report."
+    )
+
+
+def _opt(args: List[str], name: str, default: str = "") -> str:
+    if name in args:
+        i = args.index(name)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return default
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or "--help" in args or "-h" in args:
+        print(_usage())
+        return 0 if args else 2
+
+    cmd = args[0]
+    if len(args) < 2:
+        print(_usage(), file=sys.stderr)
+        return 2
+    skill = args[1]
+
+    if cmd == "record":
+        entry = record_promotion(
+            skill,
+            flip_verdict=_opt(args, "--verdict"),
+            diff_ref=_opt(args, "--diff"),
+            critic_ref=_opt(args, "--critic"),
+            note=_opt(args, "--note"),
+            fixes=[x for x in _opt(args, "--fixes").split(",") if x],
+            regressions=[x for x in _opt(args, "--regressions").split(",") if x],
+        )
+        print(json.dumps(entry.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if cmd == "current":
+        cur = current_version(skill)
+        if cur is None:
+            print(format_current(skill), file=sys.stderr)
+            return 1
+        print(json.dumps(cur.to_dict(), indent=2, sort_keys=True))
+        print(format_current(skill), file=sys.stderr)
+        return 0
+
+    if cmd == "rollback":
+        target = rollback_target(skill)
+        if target is None:
+            print(f"[skill-version] {skill}: no earlier version to roll back to",
+                  file=sys.stderr)
+            return 1
+        print(json.dumps(target.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if cmd == "history":
+        versions = load_versions(skill)
+        if not versions:
+            print(f"[skill-version] {skill}: no recorded promotions", file=sys.stderr)
+            return 1
+        print(json.dumps([v.to_dict() for v in versions], indent=2, sort_keys=True))
+        return 0
+
+    print(_usage(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_skill_version.py
+++ b/tests/scripts/test_evolution_skill_version.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""Tests for the canonical skill version line (issue #1448, Child D of #1308)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_skill_version import (  # noqa: E402
+    SkillVersion,
+    current_version,
+    format_current,
+    load_versions,
+    main,
+    record_promotion,
+    rollback_target,
+)
+
+
+class TestRecordPromotion:
+    def test_first_promotion_is_version_one(self, tmp_path):
+        v = record_promotion("my-skill", store_dir=tmp_path)
+        assert v.version == 1
+
+    def test_versions_increment(self, tmp_path):
+        for expected in (1, 2, 3):
+            assert record_promotion("s", store_dir=tmp_path).version == expected
+
+    def test_version_derived_from_disk_not_passed_in(self, tmp_path):
+        """Two callers cannot disagree about which number is next."""
+        record_promotion("s", store_dir=tmp_path)
+        record_promotion("s", store_dir=tmp_path)
+        assert current_version("s", store_dir=tmp_path).version == 2
+
+    def test_skills_are_independent(self, tmp_path):
+        record_promotion("a", store_dir=tmp_path)
+        record_promotion("a", store_dir=tmp_path)
+        assert record_promotion("b", store_dir=tmp_path).version == 1
+
+    def test_evidence_is_stored(self, tmp_path):
+        v = record_promotion(
+            "s", flip_verdict="promote", fixes=["p1", "p2"], regressions=[],
+            diff_ref="abc1234", critic_ref="critic-9", note="why",
+            store_dir=tmp_path,
+        )
+        assert v.flip_verdict == "promote"
+        assert v.fixes == ["p1", "p2"]
+        assert v.diff_ref == "abc1234"
+        assert v.critic_ref == "critic-9"
+
+    def test_history_is_append_only(self, tmp_path):
+        """The history IS the artifact — overwriting would leave the current
+        version with no record of what it replaced."""
+        record_promotion("s", note="first", store_dir=tmp_path)
+        record_promotion("s", note="second", store_dir=tmp_path)
+        assert [v.note for v in load_versions("s", store_dir=tmp_path)] == ["first", "second"]
+
+    def test_path_is_safe_for_awkward_names(self, tmp_path):
+        record_promotion("group/my skill", store_dir=tmp_path)
+        assert (tmp_path / "group_my_skill.jsonl").exists()
+
+
+class TestCurrentVersion:
+    def test_none_when_never_promoted(self, tmp_path):
+        assert current_version("nope", store_dir=tmp_path) is None
+
+    def test_highest_wins_not_last_written(self, tmp_path):
+        """An out-of-order append — a retried promotion, a merged history —
+        must not make an older version look current."""
+        p = tmp_path / "s.jsonl"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w", encoding="utf-8") as fh:
+            for n in (1, 3, 2):
+                fh.write(json.dumps({"skill": "s", "version": n}) + "\n")
+        assert current_version("s", store_dir=tmp_path).version == 3
+
+
+class TestRollbackTarget:
+    def test_none_with_a_single_version(self, tmp_path):
+        record_promotion("s", store_dir=tmp_path)
+        assert rollback_target("s", store_dir=tmp_path) is None
+
+    def test_none_when_never_promoted(self, tmp_path):
+        assert rollback_target("s", store_dir=tmp_path) is None
+
+    def test_returns_the_one_below_current(self, tmp_path):
+        record_promotion("s", note="v1", store_dir=tmp_path)
+        record_promotion("s", note="v2", store_dir=tmp_path)
+        record_promotion("s", note="v3", store_dir=tmp_path)
+        target = rollback_target("s", store_dir=tmp_path)
+        assert target.version == 2
+        assert target.note == "v2"
+
+    def test_carries_the_evidence_that_approved_it(self, tmp_path):
+        """Reverting BY VERSION means knowing what approved that version."""
+        record_promotion("s", flip_verdict="promote", diff_ref="old", store_dir=tmp_path)
+        record_promotion("s", flip_verdict="promote", diff_ref="new", store_dir=tmp_path)
+        assert rollback_target("s", store_dir=tmp_path).diff_ref == "old"
+
+
+class TestLoadRobustness:
+    def test_malformed_lines_skipped(self, tmp_path):
+        record_promotion("s", store_dir=tmp_path)
+        with open(tmp_path / "s.jsonl", "a", encoding="utf-8") as fh:
+            fh.write("not json\n")
+            fh.write(json.dumps({"no": "skill key"}) + "\n")
+        assert len(load_versions("s", store_dir=tmp_path)) == 1
+
+    def test_a_corrupt_entry_does_not_hide_the_rest(self, tmp_path):
+        """The history is what a rollback depends on."""
+        record_promotion("s", store_dir=tmp_path)
+        with open(tmp_path / "s.jsonl", "a", encoding="utf-8") as fh:
+            fh.write("{broken\n")
+        record_promotion("s", store_dir=tmp_path)
+        assert [v.version for v in load_versions("s", store_dir=tmp_path)] == [1, 2]
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert load_versions("absent", store_dir=tmp_path) == []
+
+    def test_round_trip(self, tmp_path):
+        record_promotion("s", flip_verdict="promote", fixes=["a"], store_dir=tmp_path)
+        loaded = load_versions("s", store_dir=tmp_path)[0]
+        assert isinstance(loaded, SkillVersion)
+        assert loaded.fixes == ["a"]
+
+
+class TestFormatCurrent:
+    def test_answers_the_question(self, tmp_path):
+        record_promotion("s", flip_verdict="promote", fixes=["p1"], diff_ref="abc",
+                         store_dir=tmp_path)
+        line = format_current("s", store_dir=tmp_path)
+        assert "v1" in line
+        assert "promote" in line
+        assert "abc" in line
+
+    def test_says_so_when_nothing_recorded(self, tmp_path):
+        assert "no recorded promotions" in format_current("s", store_dir=tmp_path)
+
+
+class TestCli:
+    def test_record_then_current(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["record", "s", "--verdict", "promote", "--diff", "abc"]) == 0
+        capsys.readouterr()
+        assert main(["current", "s"]) == 0
+        assert json.loads(capsys.readouterr().out)["version"] == 1
+
+    def test_current_exits_one_when_unknown(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["current", "never-promoted"]) == 1
+        capsys.readouterr()
+
+    def test_rollback_exits_one_with_a_single_version(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        main(["record", "s"])
+        capsys.readouterr()
+        assert main(["rollback", "s"]) == 1
+        capsys.readouterr()
+
+    def test_rollback_returns_the_previous(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        main(["record", "s", "--diff", "old"])
+        main(["record", "s", "--diff", "new"])
+        capsys.readouterr()
+        assert main(["rollback", "s"]) == 0
+        assert json.loads(capsys.readouterr().out)["diff_ref"] == "old"
+
+    def test_history_lists_everything(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        main(["record", "s"])
+        main(["record", "s"])
+        capsys.readouterr()
+        assert main(["history", "s"]) == 0
+        assert len(json.loads(capsys.readouterr().out)) == 2
+
+    def test_bad_command_exits_two(self, capsys):
+        assert main(["nonsense", "s"]) == 2
+        capsys.readouterr()
+
+    def test_missing_skill_exits_two(self, capsys):
+        assert main(["current"]) == 2
+        capsys.readouterr()
+
+    def test_help_exits_zero(self, capsys):
+        assert main(["--help"]) == 0
+        assert "usage" in capsys.readouterr().out


### PR DESCRIPTION
Closes #1448 — **Child D of #1308, the last one**. This closes out the AgentDevel promotion gate.

| Child | What it gave |
|---|---|
| A (#1355) | the frozen probe sets |
| B (#1446) | the flip gate scoring a candidate against them |
| C (#1447) | the verdict wired into merge verification, so a regression blocks |
| **D (this)** | the record of *what was promoted and what approved it* |

Without D, a regression is reverted by **reconstructing history**. AgentDevel's framing ([arXiv:2601.04620](https://arxiv.org/abs/2601.04620)) is that self-evolution is release engineering — and a release you cannot roll back is not a release.

## What it stores

One line per promotion in `<store>/<skill>.jsonl`: version, timestamp, flip-gate verdict, the probes that regressed and fixed, refs to the diff and critic output.

## Four decisions worth calling out

**Append-only.** The history *is* the artifact. Overwriting would leave the current version with no record of what it replaced — exactly the position this issue exists to get out of.

**Version derived from disk, not passed in.** Two callers cannot disagree about which number is next.

**Current = highest, not last written.** An out-of-order append (a retried promotion, a merged history) must not make an older version look current. Tested with a deliberately shuffled file.

**The rollback target carries its own evidence.** Reverting *by version* is only useful if you can see what approved the version you are reverting **to**.

A malformed line is skipped rather than raising — the history is what a rollback depends on, so one corrupt entry must not make the rest unreadable.

## Verified end to end

```
$ record my-skill --verdict promote --diff aaa111 --fixes p1,p2
$ record my-skill --verdict promote --diff bbb222 --fixes p3
$ record my-skill --verdict promote --diff ccc333

$ current my-skill
[skill-version] my-skill: v3 promoted 2026-07-28T13:22:15Z via flip-gate 'promote' diff=ccc333

$ rollback my-skill
  v2 diff=bbb222          <- with the evidence that approved v2

$ history my-skill
  v1 aaa111 / v2 bbb222 / v3 ccc333
```

CLI exits 0 ok, 1 nothing to report, 2 bad input. 27 tests; ruff clean.