### PR TITLE
feat: rank stored heuristics for a task, judge optional (Closes #1360)

### DIFF
--- a/scripts/evolution_heuristic_retrieve.py
+++ b/scripts/evolution_heuristic_retrieve.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Retrieve the heuristics worth injecting for a task (issue #1360).
+
+Child B of #1303 (ERL). Slice A (#1359) extracts outcome-linked heuristics from
+recorded trajectories; this selects the top-k for a given task; slice C (#1361)
+injects them into the system prompt.
+
+The judge is a SEAM, not a hard dependency
+------------------------------------------
+ERL specifies an LLM judge that scores each stored heuristic against the new
+task. That call belongs to whoever has a model handy, so it enters here as an
+optional ``judge`` callable. Without one, ranking falls back to the evidence
+slice A already measured — ``outcome_score`` weighted by how much evidence backs
+it — which is deterministic, needs no network, and is what the tests exercise.
+
+That ordering is deliberate. A judge that is unavailable, slow, or wrong must
+degrade to *ranked by measured outcome*, never to *unranked* or *empty*: an
+injection path that silently returns nothing is indistinguishable from one that
+had nothing to say.
+
+Task-type match dominates the fallback because a heuristic about coding is
+near-useless on a research task no matter how strong its evidence — relevance
+gates usefulness, rather than averaging with it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+SCHEMA_VERSION = "1"
+
+DEFAULT_TOP_K = 5
+
+#: Weight of a task-type match relative to raw evidence. High on purpose: a
+#: coding heuristic is near-useless on a research task however strong it is.
+_TYPE_MATCH_BONUS = 1.0
+
+#: Evidence beyond this many trajectories stops adding confidence — the
+#: difference between 8 and 80 supporting runs is not worth ranking on.
+_FREQUENCY_CAP = 8
+
+#: A judge callable takes (task_context, heuristic_dict) and returns 0..1.
+Judge = Callable[[str, Dict[str, Any]], float]
+
+
+@dataclass
+class RankedHeuristic:
+    """A heuristic with the score that selected it, and where that came from."""
+
+    heuristic: Dict[str, Any]
+    score: float
+    ranked_by: str  # "judge" | "evidence"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "heuristic": dict(self.heuristic),
+            "score": self.score,
+            "ranked_by": self.ranked_by,
+        }
+
+    @property
+    def text(self) -> str:
+        return str(self.heuristic.get("text", ""))
+
+
+def _default_evolution_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return Path(hh) / "evolution" if hh else Path.home() / ".hermes" / "evolution"
+
+
+def load_heuristics(evolution_dir: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Load the most recent heuristics file written by slice A.
+
+    Most recent by FILENAME, which is the extraction date — the store is
+    append-per-day and the newest extraction reflects the newest trajectories.
+    Returns [] rather than raising when nothing has been extracted yet.
+    """
+    base = (evolution_dir or _default_evolution_dir()) / "heuristics"
+    if not base.is_dir():
+        return []
+    files = sorted(base.glob("*.json"))
+    if not files:
+        return []
+    try:
+        data = json.loads(files[-1].read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    heuristics = data.get("heuristics") if isinstance(data, dict) else None
+    if not isinstance(heuristics, list):
+        return []
+    return [h for h in heuristics if isinstance(h, dict) and h.get("text")]
+
+
+def _evidence_score(heuristic: Dict[str, Any], task_type: str) -> float:
+    """Rank by what slice A measured, gated on relevance to this task type."""
+    try:
+        outcome = float(heuristic.get("outcome_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        outcome = 0.0
+    try:
+        frequency = int(heuristic.get("frequency", 0) or 0)
+    except (TypeError, ValueError):
+        frequency = 0
+
+    confidence = min(frequency, _FREQUENCY_CAP) / _FREQUENCY_CAP
+    score = outcome * confidence
+    if task_type and str(heuristic.get("task_type", "")) == task_type:
+        score += _TYPE_MATCH_BONUS
+    return round(score, 4)
+
+
+def _dedupe(heuristics: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop repeats of the same claim, keeping the first seen.
+
+    Identity is (task_type, pattern) rather than text: the same transition
+    extracted on two days produces different counts and therefore different
+    prose, but injecting both would spend prompt budget saying one thing twice.
+    """
+    seen = set()
+    out: List[Dict[str, Any]] = []
+    for h in heuristics:
+        key = (
+            str(h.get("task_type", "")),
+            tuple(h.get("pattern", []) or []),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(h)
+    return out
+
+
+def retrieve(
+    task_context: str,
+    heuristics: Sequence[Dict[str, Any]],
+    *,
+    top_k: int = DEFAULT_TOP_K,
+    task_type: str = "",
+    judge: Optional[Judge] = None,
+) -> List[RankedHeuristic]:
+    """Return the top-k heuristics for ``task_context``, best first.
+
+    With a ``judge``, each heuristic is scored by it. Without one — or if it
+    raises — ranking falls back to the measured evidence. A judge that fails
+    must degrade to ranked-by-evidence, never to empty: an injection path that
+    silently returns nothing looks exactly like one with nothing to say.
+    """
+    candidates = _dedupe([h for h in heuristics if isinstance(h, dict)])
+    if not candidates or top_k <= 0:
+        return []
+
+    ranked: List[RankedHeuristic] = []
+    for h in candidates:
+        score: Optional[float] = None
+        source = "evidence"
+        if judge is not None:
+            try:
+                raw = judge(task_context, h)
+                score = max(0.0, min(1.0, float(raw)))
+                source = "judge"
+            except Exception:
+                score = None
+                source = "evidence"
+        if score is None:
+            score = _evidence_score(h, task_type)
+        ranked.append(RankedHeuristic(heuristic=h, score=round(score, 4), ranked_by=source))
+
+    # Highest score first; ties broken by evidence so the order is total and
+    # stable rather than dependent on dict iteration.
+    ranked.sort(
+        key=lambda r: (
+            -r.score,
+            -float(r.heuristic.get("outcome_score", 0.0) or 0.0),
+            -int(r.heuristic.get("frequency", 0) or 0),
+            str(r.heuristic.get("text", "")),
+        )
+    )
+    return ranked[:top_k]
+
+
+def format_for_injection(ranked: Sequence[RankedHeuristic]) -> str:
+    """Render the selected heuristics as the block slice C injects.
+
+    Empty string when there is nothing to say, so the caller can concatenate
+    unconditionally without emitting an empty header.
+    """
+    if not ranked:
+        return ""
+    lines = [
+        "# Learned from past runs",
+        "Patterns measured across this agent's own completed tasks:",
+    ]
+    lines.extend(f"- {r.text}" for r in ranked if r.text)
+    return "\n".join(lines)
+
+
+def _usage() -> str:
+    return (
+        "usage: evolution_heuristic_retrieve.py <task context> [--top-k N]\n"
+        "                                       [--task-type T] [--evolution-dir DIR]\n"
+        "  Ranks the stored heuristics (#1359) for a task. No LLM: ranks by\n"
+        "  measured evidence. Exit 0 ok, 1 nothing stored, 2 bad arguments."
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if "--help" in args or "-h" in args:
+        print(_usage())
+        return 0
+
+    top_k = DEFAULT_TOP_K
+    task_type = ""
+    evolution_dir: Optional[Path] = None
+
+    for flag in ("--top-k", "--task-type", "--evolution-dir"):
+        if flag in args:
+            i = args.index(flag)
+            if i + 1 >= len(args):
+                print(_usage(), file=sys.stderr)
+                return 2
+            value = args[i + 1]
+            if flag == "--top-k":
+                try:
+                    top_k = int(value)
+                except ValueError:
+                    print("error: --top-k expects a number", file=sys.stderr)
+                    return 2
+            elif flag == "--task-type":
+                task_type = value
+            else:
+                evolution_dir = Path(value)
+            del args[i : i + 2]
+
+    context = " ".join(a for a in args if not a.startswith("--")).strip()
+    stored = load_heuristics(evolution_dir)
+    if not stored:
+        print("[heuristics] none stored — run evolution_heuristic_extract first",
+              file=sys.stderr)
+        return 1
+
+    ranked = retrieve(context, stored, top_k=top_k, task_type=task_type)
+    print(json.dumps(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "task_type": task_type,
+            "considered": len(stored),
+            "selected": [r.to_dict() for r in ranked],
+        },
+        indent=2,
+        sort_keys=True,
+    ))
+    print(format_for_injection(ranked), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_heuristic_retrieve.py
+++ b/tests/scripts/test_evolution_heuristic_retrieve.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Tests for judge-reranked heuristic retrieval (issue #1360, Child B of #1303)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_heuristic_retrieve import (  # noqa: E402
+    format_for_injection,
+    load_heuristics,
+    main,
+    retrieve,
+)
+
+
+def _h(pattern, task_type="coding", outcome=1.0, frequency=4, text=None):
+    return {
+        "task_type": task_type,
+        "pattern": list(pattern),
+        "text": text or f"On {task_type} tasks, {pattern[0]} then {pattern[1]}.",
+        "frequency": frequency,
+        "outcome_score": outcome,
+    }
+
+
+def _store(evolution_dir, heuristics, date="2026-07-28"):
+    d = evolution_dir / "heuristics"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{date}.json").write_text(
+        json.dumps({"date": date, "count": len(heuristics), "heuristics": heuristics}),
+        encoding="utf-8",
+    )
+
+
+class TestLoadHeuristics:
+    def test_loads_the_newest_file(self, tmp_path):
+        _store(tmp_path, [_h(["a", "b"])], date="2026-07-01")
+        _store(tmp_path, [_h(["c", "d"]), _h(["e", "f"])], date="2026-07-28")
+        assert len(load_heuristics(tmp_path)) == 2
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        assert load_heuristics(tmp_path) == []
+
+    def test_malformed_file_is_empty(self, tmp_path):
+        d = tmp_path / "heuristics"
+        d.mkdir(parents=True)
+        (d / "2026-07-28.json").write_text("not json", encoding="utf-8")
+        assert load_heuristics(tmp_path) == []
+
+    def test_entries_without_text_dropped(self, tmp_path):
+        _store(tmp_path, [{"task_type": "coding", "pattern": ["a", "b"]}])
+        assert load_heuristics(tmp_path) == []
+
+
+class TestEvidenceRanking:
+    def test_stronger_outcome_ranks_higher(self):
+        weak = _h(["a", "b"], outcome=0.3)
+        strong = _h(["c", "d"], outcome=1.0)
+        ranked = retrieve("task", [weak, strong], task_type="coding")
+        assert ranked[0].heuristic["pattern"] == ["c", "d"]
+
+    def test_more_evidence_breaks_a_tie(self):
+        thin = _h(["a", "b"], outcome=1.0, frequency=2)
+        thick = _h(["c", "d"], outcome=1.0, frequency=8)
+        assert retrieve("t", [thin, thick])[0].heuristic["pattern"] == ["c", "d"]
+
+    def test_matching_task_type_outranks_stronger_evidence(self):
+        """Relevance gates usefulness — a coding heuristic is near-useless on a
+        research task however strong it is."""
+        offtype = _h(["a", "b"], task_type="coding", outcome=1.0, frequency=8)
+        ontype = _h(["c", "d"], task_type="research", outcome=0.4, frequency=2)
+        ranked = retrieve("t", [offtype, ontype], task_type="research")
+        assert ranked[0].heuristic["task_type"] == "research"
+
+    def test_evidence_is_the_default_source(self):
+        assert retrieve("t", [_h(["a", "b"])])[0].ranked_by == "evidence"
+
+    def test_top_k_respected(self):
+        hs = [_h([f"a{i}", f"b{i}"]) for i in range(10)]
+        assert len(retrieve("t", hs, top_k=3)) == 3
+
+    def test_zero_k_returns_nothing(self):
+        assert retrieve("t", [_h(["a", "b"])], top_k=0) == []
+
+    def test_empty_store(self):
+        assert retrieve("t", []) == []
+
+    def test_order_is_stable(self):
+        """Ties broken deterministically, not by dict iteration order."""
+        hs = [_h(["a", "b"]), _h(["c", "d"]), _h(["e", "f"])]
+        assert [r.text for r in retrieve("t", hs)] == [r.text for r in retrieve("t", hs)]
+
+
+class TestJudge:
+    def test_judge_scores_are_used(self):
+        hs = [_h(["a", "b"], outcome=1.0), _h(["c", "d"], outcome=0.1)]
+
+        def judge(_ctx, h):
+            return 1.0 if h["pattern"] == ["c", "d"] else 0.0
+
+        ranked = retrieve("t", hs, judge=judge)
+        assert ranked[0].heuristic["pattern"] == ["c", "d"]
+        assert ranked[0].ranked_by == "judge"
+
+    def test_judge_receives_context_and_heuristic(self):
+        seen = []
+
+        def judge(ctx, h):
+            seen.append((ctx, h["pattern"]))
+            return 0.5
+
+        retrieve("fix the parser", [_h(["a", "b"])], judge=judge)
+        assert seen == [("fix the parser", ["a", "b"])]
+
+    def test_judge_scores_are_clamped(self):
+        ranked = retrieve("t", [_h(["a", "b"])], judge=lambda c, h: 42.0)
+        assert ranked[0].score == 1.0
+
+    def test_failing_judge_degrades_to_evidence_not_empty(self):
+        """An injection path that silently returns nothing is indistinguishable
+        from one that had nothing to say."""
+        def judge(_c, _h):
+            raise RuntimeError("model unavailable")
+
+        ranked = retrieve("t", [_h(["a", "b"])], judge=judge)
+        assert len(ranked) == 1
+        assert ranked[0].ranked_by == "evidence"
+
+    def test_judge_returning_junk_degrades(self):
+        ranked = retrieve("t", [_h(["a", "b"])], judge=lambda c, h: "not a number")
+        assert ranked[0].ranked_by == "evidence"
+
+
+class TestDedup:
+    def test_same_claim_kept_once(self):
+        """The same transition extracted on two days differs in prose but says
+        one thing — injecting both spends prompt budget twice."""
+        a = _h(["read_file", "patch"], frequency=3, text="v1 wording")
+        b = _h(["read_file", "patch"], frequency=9, text="v2 wording")
+        assert len(retrieve("t", [a, b])) == 1
+
+    def test_first_seen_wins(self):
+        a = _h(["a", "b"], text="first")
+        b = _h(["a", "b"], text="second")
+        assert retrieve("t", [a, b])[0].text == "first"
+
+    def test_different_task_types_are_distinct(self):
+        a = _h(["a", "b"], task_type="coding")
+        b = _h(["a", "b"], task_type="research")
+        assert len(retrieve("t", [a, b])) == 2
+
+
+class TestFormatForInjection:
+    def test_empty_renders_nothing(self):
+        """So the caller can concatenate without emitting a bare header."""
+        assert format_for_injection([]) == ""
+
+    def test_renders_each_heuristic(self):
+        ranked = retrieve("t", [_h(["read_file", "patch"]), _h(["patch", "terminal"])])
+        out = format_for_injection(ranked)
+        assert "Learned from past runs" in out
+        assert out.count("- ") == 2
+
+
+class TestCli:
+    def test_exit_one_when_nothing_stored(self, tmp_path, capsys):
+        assert main(["some task", "--evolution-dir", str(tmp_path)]) == 1
+        capsys.readouterr()
+
+    def test_selects_and_prints(self, tmp_path, capsys):
+        _store(tmp_path, [_h(["read_file", "patch"]), _h(["a", "b"], task_type="research")])
+        assert main(["fix it", "--evolution-dir", str(tmp_path), "--task-type", "coding"]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["considered"] == 2
+        assert out["selected"][0]["heuristic"]["task_type"] == "coding"
+
+    def test_top_k_flag(self, tmp_path, capsys):
+        _store(tmp_path, [_h([f"a{i}", f"b{i}"]) for i in range(5)])
+        assert main(["t", "--evolution-dir", str(tmp_path), "--top-k", "2"]) == 0
+        assert len(json.loads(capsys.readouterr().out)["selected"]) == 2
+
+    def test_bad_top_k_exits_two(self, tmp_path, capsys):
+        assert main(["t", "--evolution-dir", str(tmp_path), "--top-k", "abc"]) == 2
+        capsys.readouterr()
+
+    def test_missing_flag_value_exits_two(self, capsys):
+        assert main(["t", "--task-type"]) == 2
+        capsys.readouterr()
+
+    def test_help_exits_zero(self, capsys):
+        assert main(["--help"]) == 0
+        assert "usage" in capsys.readouterr().out


### PR DESCRIPTION
Closes #1360 — Child B of #1303 (ERL). Slice A (#1359) extracts the heuristics, this selects the top-k, slice C (#1361) injects them.

## The judge is a seam, not a dependency

ERL specifies an LLM judge scoring each stored heuristic against the new task. That call belongs to whoever has a model handy, so it enters as an **optional `judge` callable**.

Without one, ranking falls back to the evidence slice A already measured — `outcome_score` weighted by how much evidence backs it. Deterministic, no network, and it is what the tests exercise. The issue's own acceptance criteria say *"tests mock the judge"*, so the seam is what it asked for.

**A judge that is unavailable, slow, or raising degrades to ranked-by-evidence — never to empty.** An injection path that silently returns nothing is indistinguishable from one that had nothing to say, and the second is a legitimate state while the first is a bug that hides itself.

## Two ranking decisions

**Task-type match dominates rather than averages.** A coding heuristic is near-useless on a research task however strong its evidence, so relevance *gates* usefulness instead of trading against it. Tested: an on-type heuristic with weak evidence outranks an off-type one with maximal evidence.

**Evidence saturates at 8 trajectories.** The difference between 8 and 80 supporting runs is not worth ranking on.

## Dedup is by claim, not by wording

Identity is `(task_type, pattern)`, not text. The same transition extracted on two different days carries different counts and therefore different prose — injecting both would spend prompt budget saying one thing twice.

## Verified end to end against slice A's real output

```
considered: 2 | selected: 2
  score=1.375 by=evidence :: patch->terminal
  score=1.375 by=evidence :: read_file->patch

# Learned from past runs
Patterns measured across this agent's own completed tasks:
- On coding tasks, following `patch` with `terminal` appeared in 3 successful and 0 failed run(s).
- On coding tasks, following `read_file` with `patch` appeared in 3 successful and 0 failed run(s).
```

1.375 = 1.0 type match + 0.375 evidence.

`format_for_injection` returns `""` for an empty selection, so slice C can concatenate unconditionally without emitting a bare header.

28 tests — evidence ranking, judge override, judge failure degrading, score clamping, dedup, and every CLI exit path. Ruff clean.