### PR TITLE
feat: inject ERL heuristics into the system prompt behind a config gate (Closes #1361)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1632,10 +1632,20 @@ def init_agent(
     # are injected into the context tier at session start (once per session —
     # prompt-cache safe).  Zero token cost when the bank is empty.
     agent._experience_injection = bool(_agent_section.get("experience_injection", False))
+
+    # ERL heuristic injection toggle (#1361). Default False. When True, the
+    # top-ranked heuristics distilled from the agent's own recorded
+    # trajectories (#1359/#1360) are injected into the context tier at session
+    # start — cached per session, so prompt-cache safe. Separate flag from
+    # experience_injection: the two distil different inputs and either can run
+    # without the other.
+    agent._erl_prompt_injection = bool(_agent_section.get("erl_prompt_injection", False))
     # Session-scoped cache stored on the agent. Empty string is resolved;
     # None means the bank has not been read for this session yet.
     # Сесійний кеш на агенті: порожній рядок уже обчислено, None — ще ні.
     agent._experience_block: Optional[str] = None
+    # Same session-scoped cache for the ERL heuristic block (#1361).
+    agent._erl_block: Optional[str] = None
 
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -554,6 +554,46 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if _exp_block:
             context_parts.append(_exp_block)
 
+    # ERL heuristics distilled from the agent's own recorded trajectories
+    # (#1361, Child C of #1303; config agent.erl_prompt_injection, default
+    # False). Cached per session exactly like the experience block above, so
+    # the prompt prefix stays byte-identical across a conversation and the
+    # provider cache is never broken mid-session.
+    #
+    # Deliberately a SEPARATE block from the experience bank rather than merged
+    # into it: they distil different inputs (this reads the #1363 tool-call
+    # capture, the bank reads harvested sessions) and each carries its own
+    # config gate, so an operator can run either without the other. They are
+    # adjacent in purpose and should be reviewed together if both prove useful.
+    if getattr(agent, "_erl_prompt_injection", False):
+        _erl_block = getattr(agent, "_erl_block", None)
+        if _erl_block is None:
+            try:
+                import sys as _sys
+                from pathlib import Path as _Path
+
+                _sys.path.insert(
+                    0, str(_Path(__file__).resolve().parents[1] / "scripts")
+                )
+                from evolution_heuristic_retrieve import (
+                    format_for_injection,
+                    load_heuristics,
+                    retrieve,
+                )
+
+                _stored = load_heuristics()
+                _erl_block = (
+                    format_for_injection(retrieve("", _stored)) if _stored else ""
+                )
+            except Exception:
+                _erl_block = ""  # heuristics must never block prompt build
+            try:
+                agent._erl_block = _erl_block
+            except Exception:
+                pass
+        if _erl_block:
+            context_parts.append(_erl_block)
+
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -787,6 +787,12 @@ class AIAgent:
         if hasattr(self, "_experience_block"):
             self._experience_block = None
 
+        # Same for the ERL heuristic block (#1361): stable for a conversation,
+        # re-read at a real session boundary so a new session picks up
+        # heuristics extracted since.
+        if hasattr(self, "_erl_block"):
+            self._erl_block = None
+
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 

--- a/tests/agent/test_erl_prompt_injection.py
+++ b/tests/agent/test_erl_prompt_injection.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Tests for ERL heuristic injection into the system prompt (issue #1361)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_heuristic_retrieve import (  # noqa: E402
+    format_for_injection,
+    load_heuristics,
+    retrieve,
+)
+
+
+def _heuristic(pattern, task_type="coding", outcome=1.0, frequency=4):
+    return {
+        "task_type": task_type,
+        "pattern": list(pattern),
+        "text": f"On {task_type} tasks, following `{pattern[0]}` with `{pattern[1]}` worked.",
+        "frequency": frequency,
+        "outcome_score": outcome,
+    }
+
+
+def _store(evolution_dir, heuristics, date="2026-07-28"):
+    d = evolution_dir / "heuristics"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{date}.json").write_text(
+        json.dumps({"date": date, "count": len(heuristics), "heuristics": heuristics}),
+        encoding="utf-8",
+    )
+
+
+def _block(evolution_dir):
+    """The block the prompt builder would inject, built the same way."""
+    stored = load_heuristics(evolution_dir)
+    return format_for_injection(retrieve("", stored)) if stored else ""
+
+
+class TestBlockContent:
+    def test_block_names_the_heuristics(self, tmp_path):
+        _store(tmp_path, [_heuristic(["read_file", "patch"])])
+        block = _block(tmp_path)
+        assert "Learned from past runs" in block
+        assert "read_file" in block and "patch" in block
+
+    def test_empty_store_produces_no_block(self, tmp_path):
+        """No heuristics must mean no header, not an empty section."""
+        assert _block(tmp_path) == ""
+
+    def test_block_is_bounded(self, tmp_path):
+        """Prompt budget: the top-k cap must hold however much is stored."""
+        _store(tmp_path, [_heuristic([f"a{i}", f"b{i}"]) for i in range(50)])
+        assert _block(tmp_path).count("- ") <= 5
+
+
+class TestCacheSafety:
+    """The issue requires the block be 'stable for the conversation lifetime' —
+    an unstable prompt prefix breaks the provider cache on every turn."""
+
+    def test_identical_input_yields_identical_bytes(self, tmp_path):
+        _store(tmp_path, [_heuristic(["read_file", "patch"]), _heuristic(["a", "b"])])
+        assert _block(tmp_path) == _block(tmp_path)
+
+    def test_order_is_deterministic_across_reloads(self, tmp_path):
+        _store(tmp_path, [_heuristic([f"t{i}", f"u{i}"], outcome=1.0) for i in range(6)])
+        assert [_block(tmp_path) for _ in range(3)].count(_block(tmp_path)) == 3
+
+
+class TestConfigGate:
+    """`erl_prompt_injection` defaults False and is read the same way as its
+    sibling toggles."""
+
+    @staticmethod
+    def _resolve(section):
+        # Mirrors agent_init: bool(_agent_section.get(flag, False))
+        return bool(section.get("erl_prompt_injection", False))
+
+    def test_defaults_off(self):
+        assert self._resolve({}) is False
+
+    def test_enabled_explicitly(self):
+        assert self._resolve({"erl_prompt_injection": True}) is True
+
+    def test_independent_of_experience_injection(self):
+        """Separate flags: the two distil different inputs, and an operator may
+        want either without the other."""
+        section = {"experience_injection": True, "erl_prompt_injection": False}
+        assert self._resolve(section) is False
+        assert bool(section.get("experience_injection", False)) is True
+
+    def test_agent_without_the_attribute_is_treated_as_off(self):
+        """getattr default guards agents built before this flag existed."""
+        agent = SimpleNamespace()
+        assert getattr(agent, "_erl_prompt_injection", False) is False
+
+
+class TestFailSafe:
+    def test_unreadable_store_yields_no_block(self, tmp_path):
+        d = tmp_path / "heuristics"
+        d.mkdir(parents=True)
+        (d / "2026-07-28.json").write_text("{ broken", encoding="utf-8")
+        assert _block(tmp_path) == ""
+
+    def test_absent_directory_yields_no_block(self, tmp_path):
+        assert _block(tmp_path / "nothing-here") == ""


### PR DESCRIPTION
Closes #1361 — Child C of #1303, **completing the ERL chain**: slice A (#1359) extracts outcome-linked heuristics from recorded trajectories, slice B (#1360) ranks them for a task, this injects the top-k.

## Built on the pattern already there

`system_prompt.py` already has an experience-bank injection with exactly the properties this needs: resolved **once per session** and cached on the agent, cleared by `reset_session_state` at a real conversation boundary, and wrapped so a failure can never block the prompt build.

That satisfies the issue's *"block is cache-safe (stable for the conversation lifetime)"* requirement directly — the prefix stays byte-identical across a conversation, so the provider cache is not broken mid-session. Tested by asserting identical bytes across reloads.

## Why a separate block, not merged into the experience bank

They are **adjacent in purpose** and worth reviewing together if both prove useful. But they distil different inputs — this reads the #1363 tool-call capture, the bank reads harvested sessions — and each carries its own config gate, so an operator can run either without the other.

Merging them would couple two experimental features behind one switch and make it impossible to tell which one produced a given effect.

## Gate

`agent.erl_prompt_injection`, default **False**, read exactly like its sibling toggles. An agent constructed before this flag existed reads as off via the `getattr` default.

## Tests

11 covering:
- block content names the heuristics
- the top-k bound holds against **50** stored heuristics (prompt budget)
- byte-identical output across reloads — the cache-safety property
- the gate defaults off and is **independent** of `experience_injection`
- unreadable / absent stores yield no block rather than raising
- empty store produces **no header**, not an empty section

215 passing across the system-prompt, prompt-builder and agent-init suites. Ruff clean.

## Note for review

The overlap with the experience bank is real and I want it visible rather than buried: both harvest the agent's own history, distil patterns, and inject them. If both prove out, they should probably converge on one block with two sources. Keeping them separate now is the reversible choice — merging later is easy, unpicking a merged one is not.