### PR TITLE
feat: retrieval-utility logging + history-based deletion (Closes #1480)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -690,6 +690,48 @@ def main(argv: list[str]) -> int:
     except Exception:
         pass
 
+    # Retrieval-utility outcome backfill (#1480) — for trajectories completed
+    # since the last cycle, propagate the task outcome back to any utility-log
+    # entries sharing the same task_key. This closes the loop: retrieval logged
+    # at task start, outcome recorded at task end, utility scored here.
+    try:
+        from evolution_retrieval_utility import update_outcome
+        from evolution_trajectory_logger import _default_trajectory_dir, load_trajectory
+
+        _traj_dir = _default_trajectory_dir()
+        if _traj_dir.is_dir():
+            _backfilled = 0
+            for _tf in sorted(_traj_dir.glob("*.jsonl")):
+                try:
+                    _lines = _tf.read_text(encoding="utf-8").splitlines()
+                except OSError:
+                    continue
+                for _line in _lines:
+                    _line = _line.strip()
+                    if not _line:
+                        continue
+                    try:
+                        _rec = json.loads(_line)
+                    except (ValueError, TypeError):
+                        continue
+                    if (
+                        isinstance(_rec, dict)
+                        and _rec.get("task_key")
+                        and _rec.get("completed") is not None
+                    ):
+                        _backfilled += update_outcome(
+                            _rec["task_key"],
+                            bool(_rec["completed"]),
+                            evolution_dir=evolution_dir,
+                        )
+            if _backfilled:
+                (evolution_dir / f"retrieval-utility-backfill-{date}.txt").write_text(
+                    f"backfilled {_backfilled} utility entries from trajectories\n",
+                    encoding="utf-8",
+                )
+    except Exception:
+        pass
+
     # Deterministic no_agent job: empty stdout = silent/healthy. Print a compact
     # one-liner only so the run log shows what was recorded.
     print(

--- a/scripts/evolution_heuristic_retrieve.py
+++ b/scripts/evolution_heuristic_retrieve.py
@@ -138,6 +138,22 @@ def _dedupe(heuristics: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return out
 
 
+def _heuristic_id(h: Dict[str, Any]) -> str:
+    """Stable identifier for a heuristic so retrievals accumulate in the
+    utility log (#1480). Uses the dedup key (task_type, pattern) hashed to a
+    short hex — same identity as _dedupe, so repeated retrievals of the same
+    claim are counted together regardless of prose variation.
+    """
+    import hashlib
+
+    key = (
+        str(h.get("task_type", "")),
+        tuple(h.get("pattern", []) or []),
+    )
+    raw = json.dumps(key, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 def retrieve(
     task_context: str,
     heuristics: Sequence[Dict[str, Any]],
@@ -145,6 +161,8 @@ def retrieve(
     top_k: int = DEFAULT_TOP_K,
     task_type: str = "",
     judge: Optional[Judge] = None,
+    task_key: str = "",
+    evolution_dir: Optional[Path] = None,
 ) -> List[RankedHeuristic]:
     """Return the top-k heuristics for ``task_context``, best first.
 
@@ -152,6 +170,10 @@ def retrieve(
     raises — ranking falls back to the measured evidence. A judge that fails
     must degrade to ranked-by-evidence, never to empty: an injection path that
     silently returns nothing looks exactly like one with nothing to say.
+
+    When ``task_key`` is provided, each retrieved heuristic is logged to the
+    retrieval-utility store (#1480) so downstream outcome can later score it.
+    Utility logging is best-effort and never raises.
     """
     candidates = _dedupe([h for h in heuristics if isinstance(h, dict)])
     if not candidates or top_k <= 0:
@@ -171,7 +193,9 @@ def retrieve(
                 source = "evidence"
         if score is None:
             score = _evidence_score(h, task_type)
-        ranked.append(RankedHeuristic(heuristic=h, score=round(score, 4), ranked_by=source))
+        ranked.append(
+            RankedHeuristic(heuristic=h, score=round(score, 4), ranked_by=source)
+        )
 
     # Highest score first; ties broken by evidence so the order is total and
     # stable rather than dependent on dict iteration.
@@ -183,7 +207,27 @@ def retrieve(
             str(r.heuristic.get("text", "")),
         )
     )
-    return ranked[:top_k]
+    selected = ranked[:top_k]
+
+    # Log retrievals to the utility store (#1480). Best-effort, never breaks
+    # the retrieval path — instrumentation must not be able to discard a
+    # retrieval result.
+    if task_key:
+        try:
+            from evolution_retrieval_utility import log_retrieval
+
+            for r in selected:
+                log_retrieval(
+                    _heuristic_id(r.heuristic),
+                    record_type="heuristic",
+                    task_key=task_key,
+                    task_type=task_type,
+                    evolution_dir=evolution_dir,
+                )
+        except Exception:
+            pass
+
+    return selected
 
 
 def format_for_injection(ranked: Sequence[RankedHeuristic]) -> str:
@@ -243,21 +287,25 @@ def main(argv: Optional[List[str]] = None) -> int:
     context = " ".join(a for a in args if not a.startswith("--")).strip()
     stored = load_heuristics(evolution_dir)
     if not stored:
-        print("[heuristics] none stored — run evolution_heuristic_extract first",
-              file=sys.stderr)
+        print(
+            "[heuristics] none stored — run evolution_heuristic_extract first",
+            file=sys.stderr,
+        )
         return 1
 
     ranked = retrieve(context, stored, top_k=top_k, task_type=task_type)
-    print(json.dumps(
-        {
-            "schema_version": SCHEMA_VERSION,
-            "task_type": task_type,
-            "considered": len(stored),
-            "selected": [r.to_dict() for r in ranked],
-        },
-        indent=2,
-        sort_keys=True,
-    ))
+    print(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "task_type": task_type,
+                "considered": len(stored),
+                "selected": [r.to_dict() for r in ranked],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
     print(format_for_injection(ranked), file=sys.stderr)
     return 0
 

--- a/scripts/evolution_retrieval_utility.py
+++ b/scripts/evolution_retrieval_utility.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Retrieval-utility logging + history-based deletion (issue #1480, child of #1270).
+
+The ACL-2026 memory-management paper proves an **add-all** memory policy
+self-degrades: records retrieved often but with poor downstream outcomes get
+imitated, amplifying errors. The fix is to track **retrieval utility** — did
+the retrieval of a record correlate with a successful task outcome? — and
+delete records with persistently low utility.
+
+This module provides the two halves of that mechanism for the pipeline's own
+artifacts (heuristics, skills, memories):
+
+1. **Retrieval-utility log** — append-only JSONL at
+   ``<EVOLUTION_PROFILE_DIR>/retrieval-utility.jsonl``. Each line records a
+   retrieval event: *which* record was retrieved, *when*, for *which* task
+   (paired by ``task_key``), and the *downstream outcome* (from trajectory
+   ``completed``). Outcome is recorded at retrieval time when known, or later
+   via :func:`update_outcome` when the trajectory completes after retrieval.
+
+2. **History-based deletion** — analyze the accumulated log and identify
+   records retrieved ≥ ``min_retrievals`` times whose average downstream
+   utility falls below ``utility_threshold``. Returns a deletion plan the
+   caller (funnel / maintenance cron) can act on.
+
+Design follows the sibling ``evolution_*.py`` helpers: pure functions, thin
+CLI, import-safe, deterministic, no LLM, fail-open (never raises on I/O).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+__all__ = [
+    "UtilityRecord",
+    "log_retrieval",
+    "update_outcome",
+    "load_utility_log",
+    "DeletionCandidate",
+    "compute_deletion_candidates",
+    "apply_deletions",
+    "main",
+]
+
+#: Minimum retrievals before a record is eligible for deletion evaluation.
+#: Below this the sample is too small to judge.
+DEFAULT_MIN_RETRIEVALS = 3
+
+#: Records with average utility below this are deletion candidates.
+#: 0.5 means "succeeded less than half the time it was retrieved".
+DEFAULT_UTILITY_THRESHOLD = 0.5
+
+
+def _default_evolution_dir() -> Path:
+    """Resolve the evolution profile directory from env, matching siblings."""
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return Path(hh) / "evolution" if hh else Path.home() / ".hermes" / "evolution"
+
+
+def _utility_log_path(evolution_dir: Optional[Path] = None) -> Path:
+    """Path to the append-only retrieval-utility JSONL."""
+    return (evolution_dir or _default_evolution_dir()) / "retrieval-utility.jsonl"
+
+
+@dataclass
+class UtilityRecord:
+    """One retrieval event in the utility log.
+
+    ``outcome`` is tri-state: ``True`` = task succeeded, ``False`` = task
+    failed, ``None`` = outcome not yet known (trajectory pending or pre-#1363).
+    Records with ``None`` outcome are excluded from deletion scoring — we do
+    not guess success or failure.
+    """
+
+    record_id: str
+    record_type: str  # "heuristic" | "skill" | "memory" | ...
+    retrieved_at: str = ""
+    task_key: str = ""
+    outcome: Optional[bool] = None
+    task_type: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.retrieved_at:
+            self.retrieved_at = datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "record_id": self.record_id,
+            "record_type": self.record_type,
+            "retrieved_at": self.retrieved_at,
+        }
+        if self.task_key:
+            d["task_key"] = self.task_key
+        if self.outcome is not None:
+            d["outcome"] = self.outcome
+        if self.task_type:
+            d["task_type"] = self.task_type
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "UtilityRecord":
+        outcome = d.get("outcome")
+        # Normalise outcome: explicit bool or None. Never coerce.
+        if outcome is not None and not isinstance(outcome, bool):
+            outcome = None
+        return cls(
+            record_id=str(d.get("record_id", "")),
+            record_type=str(d.get("record_type", "")),
+            retrieved_at=str(d.get("retrieved_at", "")),
+            task_key=str(d.get("task_key", "")),
+            outcome=outcome,
+            task_type=str(d.get("task_type", "")),
+        )
+
+
+def log_retrieval(
+    record_id: str,
+    record_type: str = "heuristic",
+    *,
+    task_key: str = "",
+    outcome: Optional[bool] = None,
+    task_type: str = "",
+    evolution_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """Append a retrieval event to the utility log. Returns path or None.
+
+    Never raises — runs alongside retrieval paths that must not break.
+    ``record_id`` should be a stable identifier (heuristic text hash, skill
+    name, memory key) so multiple retrievals of the same record accumulate.
+    """
+    if not record_id:
+        return None
+    try:
+        path = _utility_log_path(evolution_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rec = UtilityRecord(
+            record_id=record_id,
+            record_type=record_type,
+            task_key=task_key,
+            outcome=outcome,
+            task_type=task_type,
+        )
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec.to_dict(), sort_keys=True) + "\n")
+        return path
+    except Exception:
+        return None
+
+
+def update_outcome(
+    task_key: str,
+    outcome: bool,
+    *,
+    evolution_dir: Optional[Path] = None,
+) -> int:
+    """Backfill ``outcome`` on all log entries matching ``task_key``.
+
+    Called when a trajectory completes *after* its retrievals were logged
+    (the common case: retrieval happens at task start, outcome at task end).
+    Returns the number of entries updated. Never raises.
+    """
+    if not task_key:
+        return 0
+    try:
+        path = _utility_log_path(evolution_dir)
+        if not path.exists():
+            return 0
+        lines = path.read_text(encoding="utf-8").splitlines()
+        updated = 0
+        out_lines: List[str] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except (ValueError, TypeError):
+                out_lines.append(line)
+                continue
+            if (
+                isinstance(d, dict)
+                and d.get("task_key") == task_key
+                and d.get("outcome") is None
+            ):
+                d["outcome"] = outcome
+                updated += 1
+            out_lines.append(json.dumps(d, sort_keys=True))
+        if updated:
+            path.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+        return updated
+    except Exception:
+        return 0
+
+
+def load_utility_log(
+    evolution_dir: Optional[Path] = None,
+) -> List[UtilityRecord]:
+    """Read the full utility log as a list of :class:`UtilityRecord`.
+
+    Malformed lines are skipped, never raised. Returns [] if absent.
+    """
+    path = _utility_log_path(evolution_dir)
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    records: List[UtilityRecord] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(d, dict) and d.get("record_id"):
+            records.append(UtilityRecord.from_dict(d))
+    return records
+
+
+@dataclass
+class DeletionCandidate:
+    """A record recommended for deletion based on low accumulated utility."""
+
+    record_id: str
+    record_type: str
+    retrieval_count: int
+    scored_count: int  # retrievals with a known outcome
+    avg_utility: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "record_type": self.record_type,
+            "retrieval_count": self.retrieval_count,
+            "scored_count": self.scored_count,
+            "avg_utility": round(self.avg_utility, 4),
+        }
+
+
+def compute_deletion_candidates(
+    records: Sequence[UtilityRecord],
+    *,
+    min_retrievals: int = DEFAULT_MIN_RETRIEVALS,
+    utility_threshold: float = DEFAULT_UTILITY_THRESHOLD,
+) -> List[DeletionCandidate]:
+    """Identify records with persistently low downstream utility.
+
+    A record becomes a deletion candidate when:
+    - It was retrieved at least ``min_retrievals`` times (small samples are
+      noisy).
+    - At least one retrieval has a known outcome (``None`` outcomes are
+      excluded — we do not guess).
+    - The average outcome (success=1, failure=0) falls below
+      ``utility_threshold``.
+
+    Sorted worst-first (lowest utility, then most retrievals) so the caller
+    can cap the number acted on.
+    """
+    # Group scored retrievals by (record_id, record_type).
+    stats: Dict[tuple[str, str], Dict[str, Any]] = {}
+    total_retrievals: Dict[tuple[str, str], int] = {}
+
+    for r in records:
+        key = (r.record_id, r.record_type)
+        total_retrievals[key] = total_retrievals.get(key, 0) + 1
+        if r.outcome is None:
+            continue
+        if key not in stats:
+            stats[key] = {"scored": 0, "success_sum": 0}
+        stats[key]["scored"] += 1
+        if r.outcome:
+            stats[key]["success_sum"] += 1
+
+    candidates: List[DeletionCandidate] = []
+    for key, s in stats.items():
+        total = total_retrievals.get(key, 0)
+        if total < min_retrievals:
+            continue
+        scored = s["scored"]
+        if scored == 0:
+            continue
+        avg = s["success_sum"] / scored
+        if avg < utility_threshold:
+            candidates.append(
+                DeletionCandidate(
+                    record_id=key[0],
+                    record_type=key[1],
+                    retrieval_count=total,
+                    scored_count=scored,
+                    avg_utility=avg,
+                )
+            )
+
+    candidates.sort(key=lambda c: (c.avg_utility, -c.retrieval_count))
+    return candidates
+
+
+def apply_deletions(
+    candidates: Sequence[DeletionCandidate],
+    record_type: str,
+    loader: Any,
+    deleter: Any,
+) -> List[str]:
+    """Execute deletions for one ``record_type`` via caller-provided callbacks.
+
+    ``loader(record_id) -> Any`` fetches the record (returns None if absent).
+    ``deleter(record_id) -> bool`` deletes it and returns success.
+
+    This indirection keeps the module free of hard dependencies on specific
+    stores (heuristics dir, skills registry, memory plugin). The caller wires
+    in the concrete delete for each record type. Returns the list of
+    record_ids actually deleted.
+    """
+    deleted: List[str] = []
+    for c in candidates:
+        if c.record_type != record_type:
+            continue
+        try:
+            if loader(c.record_id) is None:
+                continue
+            if deleter(c.record_id):
+                deleted.append(c.record_id)
+        except Exception:
+            continue
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _usage() -> str:
+    return (
+        "usage: evolution_retrieval_utility.py <command> [options]\n"
+        "  analyze [--min-retrievals N] [--threshold F]  Show deletion candidates\n"
+        "  log <record_id> [--type T] [--task-key K] [--outcome B]  Log a retrieval\n"
+        "  update <task_key> <outcome>  Backfill outcome on pending entries\n"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or args[0] in ("--help", "-h"):
+        print(_usage())
+        return 0
+
+    cmd = args[0]
+    rest = args[1:]
+
+    if cmd == "analyze":
+        min_r = DEFAULT_MIN_RETRIEVALS
+        threshold = DEFAULT_UTILITY_THRESHOLD
+        evolution_dir: Optional[Path] = None
+        i = 0
+        while i < len(rest):
+            a = rest[i]
+            if a == "--min-retrievals" and i + 1 < len(rest):
+                try:
+                    min_r = int(rest[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif a == "--threshold" and i + 1 < len(rest):
+                try:
+                    threshold = float(rest[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif a == "--evolution-dir" and i + 1 < len(rest):
+                evolution_dir = Path(rest[i + 1])
+                i += 2
+            else:
+                i += 1
+
+        records = load_utility_log(evolution_dir)
+        candidates = compute_deletion_candidates(
+            records, min_retrievals=min_r, utility_threshold=threshold
+        )
+        print(
+            json.dumps(
+                {
+                    "total_log_entries": len(records),
+                    "min_retrievals": min_r,
+                    "utility_threshold": threshold,
+                    "deletion_candidates": [c.to_dict() for c in candidates],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    if cmd == "log":
+        if not rest:
+            print("error: log requires <record_id>", file=sys.stderr)
+            return 2
+        record_id = rest[0]
+        record_type = "heuristic"
+        task_key = ""
+        outcome: Optional[bool] = None
+        i = 1
+        while i < len(rest):
+            a = rest[i]
+            if a == "--type" and i + 1 < len(rest):
+                record_type = rest[i + 1]
+                i += 2
+            elif a == "--task-key" and i + 1 < len(rest):
+                task_key = rest[i + 1]
+                i += 2
+            elif a == "--outcome" and i + 1 < len(rest):
+                val = rest[i + 1].lower()
+                outcome = (
+                    True
+                    if val in ("true", "1", "yes")
+                    else False
+                    if val in ("false", "0", "no")
+                    else None
+                )
+                i += 2
+            else:
+                i += 1
+        path = log_retrieval(record_id, record_type, task_key=task_key, outcome=outcome)
+        if path:
+            print(f"logged: {path}")
+            return 0
+        print("error: failed to log", file=sys.stderr)
+        return 1
+
+    if cmd == "update":
+        if len(rest) < 2:
+            print("error: update requires <task_key> <outcome>", file=sys.stderr)
+            return 2
+        tk = rest[0]
+        val = rest[1].lower()
+        outcome = val in ("true", "1", "yes", "success")
+        n = update_outcome(tk, outcome)
+        print(f"updated {n} entries")
+        return 0
+
+    print(f"error: unknown command '{cmd}'", file=sys.stderr)
+    print(_usage(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_evolution_retrieval_utility.py
+++ b/tests/scripts/test_evolution_retrieval_utility.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Tests for retrieval-utility logging + history-based deletion (#1480)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from evolution_retrieval_utility import (  # noqa: E402
+    DEFAULT_MIN_RETRIEVALS,
+    DEFAULT_UTILITY_THRESHOLD,
+    DeletionCandidate,
+    UtilityRecord,
+    compute_deletion_candidates,
+    load_utility_log,
+    log_retrieval,
+    update_outcome,
+)
+
+
+def test_log_retrieval_writes_jsonl(tmp_path: Path) -> None:
+    """log_retrieval appends one JSON line per call."""
+    log_retrieval("rec-1", "heuristic", task_key="tk1", evolution_dir=tmp_path)
+    log_retrieval("rec-2", "heuristic", task_key="tk2", evolution_dir=tmp_path)
+
+    path = tmp_path / "retrieval-utility.jsonl"
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+    d = json.loads(lines[0])
+    assert d["record_id"] == "rec-1"
+    assert d["record_type"] == "heuristic"
+    assert d["task_key"] == "tk1"
+
+
+def test_log_retrieval_empty_id_is_noop(tmp_path: Path) -> None:
+    """Empty record_id must not write."""
+    result = log_retrieval("", "heuristic", evolution_dir=tmp_path)
+    assert result is None
+    assert not (tmp_path / "retrieval-utility.jsonl").exists()
+
+
+def test_log_retrieval_outcome_none_omitted(tmp_path: Path) -> None:
+    """When outcome is None (unknown), the key is omitted from the JSON line."""
+    log_retrieval("rec-1", outcome=None, evolution_dir=tmp_path)
+    lines = (
+        (tmp_path / "retrieval-utility.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    )
+    d = json.loads(lines[0])
+    assert "outcome" not in d
+
+
+def test_log_retrieval_outcome_bool_written(tmp_path: Path) -> None:
+    """When outcome is True/False, it is written."""
+    log_retrieval("rec-1", outcome=True, evolution_dir=tmp_path)
+    log_retrieval("rec-2", outcome=False, evolution_dir=tmp_path)
+    lines = (
+        (tmp_path / "retrieval-utility.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    )
+    assert json.loads(lines[0])["outcome"] is True
+    assert json.loads(lines[1])["outcome"] is False
+
+
+def test_load_utility_log_missing_file(tmp_path: Path) -> None:
+    """Missing file returns [], not raises."""
+    assert load_utility_log(tmp_path) == []
+
+
+def test_load_utility_log_skips_malformed(tmp_path: Path) -> None:
+    """Malformed lines are skipped, valid ones kept."""
+    path = tmp_path / "retrieval-utility.jsonl"
+    lines = [
+        json.dumps({"record_id": "a", "record_type": "h"}),
+        "not json",
+        json.dumps({"record_id": "b", "record_type": "h", "outcome": True}),
+        "",
+        '{"no_record_id": true}',
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    records = load_utility_log(tmp_path)
+    assert len(records) == 2
+    assert records[0].record_id == "a"
+    assert records[1].record_id == "b"
+    assert records[1].outcome is True
+
+
+def test_update_outcome_backfills_pending(tmp_path: Path) -> None:
+    """update_outcome fills None outcomes for matching task_key."""
+    log_retrieval("rec-1", task_key="tk1", outcome=None, evolution_dir=tmp_path)
+    log_retrieval("rec-2", task_key="tk1", outcome=None, evolution_dir=tmp_path)
+    log_retrieval("rec-3", task_key="tk2", outcome=None, evolution_dir=tmp_path)
+
+    updated = update_outcome("tk1", True, evolution_dir=tmp_path)
+    assert updated == 2
+
+    records = load_utility_log(tmp_path)
+    outcomes = {r.record_id: r.outcome for r in records}
+    assert outcomes["rec-1"] is True
+    assert outcomes["rec-2"] is True
+    assert outcomes["rec-3"] is None  # different task_key
+
+
+def test_update_outcome_skips_already_set(tmp_path: Path) -> None:
+    """update_outcome does not overwrite an already-recorded outcome."""
+    log_retrieval("rec-1", task_key="tk1", outcome=False, evolution_dir=tmp_path)
+    updated = update_outcome("tk1", True, evolution_dir=tmp_path)
+    assert updated == 0
+    records = load_utility_log(tmp_path)
+    assert records[0].outcome is False
+
+
+def test_compute_deletion_candidates_basic() -> None:
+    """Records below threshold with enough retrievals are candidates."""
+    records = [
+        UtilityRecord(record_id="good", record_type="h", outcome=True),
+        UtilityRecord(record_id="good", record_type="h", outcome=True),
+        UtilityRecord(record_id="good", record_type="h", outcome=True),
+        UtilityRecord(record_id="bad", record_type="h", outcome=False),
+        UtilityRecord(record_id="bad", record_type="h", outcome=False),
+        UtilityRecord(record_id="bad", record_type="h", outcome=True),
+    ]
+    candidates = compute_deletion_candidates(
+        records, min_retrievals=3, utility_threshold=0.5
+    )
+    assert len(candidates) == 1
+    assert candidates[0].record_id == "bad"
+    assert candidates[0].avg_utility == pytest.approx(1 / 3)
+    assert candidates[0].retrieval_count == 3
+
+
+def test_compute_deletion_candidates_excludes_unknown_outcome() -> None:
+    """None outcomes don't count toward scored utility."""
+    records = [
+        UtilityRecord(record_id="r", record_type="h", outcome=None),
+        UtilityRecord(record_id="r", record_type="h", outcome=None),
+        UtilityRecord(record_id="r", record_type="h", outcome=False),
+    ]
+    # 3 total retrievals, but only 1 scored. avg = 0/1 = 0 < 0.5 → candidate
+    candidates = compute_deletion_candidates(
+        records, min_retrievals=3, utility_threshold=0.5
+    )
+    assert len(candidates) == 1
+    assert candidates[0].scored_count == 1
+
+
+def test_compute_deletion_candidates_below_min_retrievals() -> None:
+    """Records with too few retrievals are not candidates."""
+    records = [
+        UtilityRecord(record_id="r", record_type="h", outcome=False),
+        UtilityRecord(record_id="r", record_type="h", outcome=False),
+    ]
+    candidates = compute_deletion_candidates(records, min_retrievals=3)
+    assert candidates == []
+
+
+def test_compute_deletion_candidates_all_none_outcome() -> None:
+    """Records with zero scored retrievals produce no candidates."""
+    records = [
+        UtilityRecord(record_id="r", record_type="h", outcome=None),
+        UtilityRecord(record_id="r", record_type="h", outcome=None),
+        UtilityRecord(record_id="r", record_type="h", outcome=None),
+    ]
+    candidates = compute_deletion_candidates(records, min_retrievals=3)
+    assert candidates == []
+
+
+def test_compute_deletion_candidates_sorted_worst_first() -> None:
+    """Candidates are sorted by lowest utility first."""
+    records = []
+    # mid: 1/3 = 0.33
+    for _ in range(2):
+        records.append(UtilityRecord(record_id="mid", record_type="h", outcome=False))
+    records.append(UtilityRecord(record_id="mid", record_type="h", outcome=True))
+    # worst: 0/3 = 0.0
+    for _ in range(3):
+        records.append(UtilityRecord(record_id="worst", record_type="h", outcome=False))
+
+    candidates = compute_deletion_candidates(records, min_retrievals=3)
+    assert candidates[0].record_id == "worst"
+    assert candidates[1].record_id == "mid"
+
+
+def test_compute_deletion_candidates_separates_by_type() -> None:
+    """Same record_id, different record_type are tracked separately."""
+    records = [
+        UtilityRecord(record_id="r", record_type="heuristic", outcome=False),
+        UtilityRecord(record_id="r", record_type="heuristic", outcome=False),
+        UtilityRecord(record_id="r", record_type="heuristic", outcome=False),
+        UtilityRecord(record_id="r", record_type="skill", outcome=True),
+        UtilityRecord(record_id="r", record_type="skill", outcome=True),
+        UtilityRecord(record_id="r", record_type="skill", outcome=True),
+    ]
+    candidates = compute_deletion_candidates(records, min_retrievals=3)
+    assert len(candidates) == 1
+    assert candidates[0].record_type == "heuristic"
+
+
+def test_utility_record_from_dict_normalizes_bad_outcome() -> None:
+    """Non-bool outcome in JSON is coerced to None, not truthy."""
+    rec = UtilityRecord.from_dict({"record_id": "x", "outcome": "maybe"})
+    assert rec.outcome is None
+
+
+def test_apply_deletions_calls_callbacks() -> None:
+    """apply_deletions invokes loader+deleter for matching record_type."""
+    from evolution_retrieval_utility import apply_deletions
+
+    candidates = [
+        DeletionCandidate(
+            record_id="a",
+            record_type="heuristic",
+            retrieval_count=3,
+            scored_count=3,
+            avg_utility=0.0,
+        ),
+        DeletionCandidate(
+            record_id="b",
+            record_type="skill",
+            retrieval_count=3,
+            scored_count=3,
+            avg_utility=0.0,
+        ),
+    ]
+    deleted_ids: list[str] = []
+    apply_deletions(
+        candidates,
+        record_type="heuristic",
+        loader=lambda rid: {"id": rid},
+        deleter=lambda rid: deleted_ids.append(rid) or True,
+    )
+    assert deleted_ids == ["a"]
+
+
+def test_apply_deletions_skips_absent() -> None:
+    """apply_deletions does not call deleter when loader returns None."""
+    from evolution_retrieval_utility import apply_deletions
+
+    candidates = [
+        DeletionCandidate(
+            record_id="a",
+            record_type="heuristic",
+            retrieval_count=3,
+            scored_count=3,
+            avg_utility=0.0,
+        ),
+    ]
+    deleted = apply_deletions(
+        candidates,
+        record_type="heuristic",
+        loader=lambda rid: None,
+        deleter=lambda rid: True,
+    )
+    assert deleted == []
+
+
+def test_retrieve_logs_to_utility_store(tmp_path: Path) -> None:
+    """evolution_heuristic_retrieve.retrieve logs retrievals to utility log."""
+    from evolution_heuristic_retrieve import retrieve
+
+    heuristics = [
+        {
+            "text": "use type hints",
+            "task_type": "coding",
+            "pattern": ["a", "b"],
+            "outcome_score": 0.8,
+            "frequency": 5,
+        },
+        {
+            "text": "check logs",
+            "task_type": "ops",
+            "pattern": ["c"],
+            "outcome_score": 0.6,
+            "frequency": 3,
+        },
+    ]
+    ranked = retrieve(
+        "write a function",
+        heuristics,
+        top_k=2,
+        task_type="coding",
+        task_key="test-task-key",
+        evolution_dir=tmp_path,
+    )
+    assert len(ranked) == 2
+
+    # Utility log should have one entry per retrieved heuristic.
+    records = load_utility_log(tmp_path)
+    assert len(records) == 2
+    assert all(r.task_key == "test-task-key" for r in records)
+    assert all(r.record_type == "heuristic" for r in records)
+
+
+def test_retrieve_no_task_key_skips_logging(tmp_path: Path) -> None:
+    """Without task_key, retrieval does not log utility (backward compat)."""
+    from evolution_heuristic_retrieve import retrieve
+
+    heuristics = [{"text": "x", "task_type": "t", "pattern": [], "outcome_score": 0.5}]
+    retrieve("ctx", heuristics, top_k=1)
+    # No evolution_dir passed → writes to default location, not tmp_path.
+    # Verify nothing was written to tmp_path.
+    assert not (tmp_path / "retrieval-utility.jsonl").exists()


### PR DESCRIPTION
Automated evolution PR for issue #1480 (Child A of #1270).

## What this delivers

**Retrieval-utility logging** — append-only JSONL at `<EVOLUTION_PROFILE_DIR>/retrieval-utility.jsonl`. Each retrieval of a heuristic (the first record type wired) records: record_id, record_type, task_key, timestamp, and (when known) downstream outcome.

**Outcome backfill** — when a trajectory completes, the funnel propagates the task outcome back to all utility-log entries sharing that task_key. This closes the loop: retrieval logged at task start, outcome recorded at task end.

**History-based deletion analysis** — `compute_deletion_candidates()` identifies records retrieved ≥N times whose average downstream utility falls below threshold. `apply_deletions()` executes via caller-provided callbacks (keeps the module free of hard store dependencies).

**Wiring** — `evolution_heuristic_retrieve.retrieve()` now logs each retrieval to the utility store when `task_key` is provided (opt-in, backward-compatible, best-effort — never breaks retrieval).

## Why this is not post-hoc reporting

The two prior PRs on #1270 (#1275, #1280) were closed as *incoherent* — they ran after artifacts were written and only reported decisions. This implementation intercepts at the **actual retrieval boundary** (inside `retrieve()`), and backfill happens at the **trajectory completion boundary** (in the funnel). The data flows from real retrievals, not synthetic substitutes.

## Tests

19 new tests, all green. Existing 30 tests for heuristic_retrieve + trajectory_wiring remain green (backward compat verified).

## Diff size: 876 lines (exceeds 200-line autonomous merge cap)

This slice is a coherent, indivisible unit: the utility module + its wiring + its tests cannot be meaningfully split further without becoming dead code (the exact failure mode that closed prior PRs). The merge gate will hold this for human review. The work is complete and green — throwing it away to fit an arbitrary line count would repeat the pattern that cost six PRs on #1270.

Closes #1480