### PR TITLE
feat: enrich search_files no-match results with directory listing (Closes #1486)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -586,6 +586,214 @@ class TestSearchHints:
 
 
 # ---------------------------------------------------------------------------
+# #1486 — no-match enrichment for search_files
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatchHint:
+    """search_files should enrich a zero-result response with what exists.
+
+    When a valid pattern matches nothing, the bare {total_count: 0} response
+    gives the agent no actionable info, causing blind retries (#1486: 95
+    file-not-found events/7d, 27-deep spirals). The fix adds a _no_match_hint
+    field listing what *does* exist in the search directory.
+    """
+
+    def setup_method(self):
+        """Clear read/search tracker between tests."""
+        from tools.file_tools import _read_tracker
+        _read_tracker.clear()
+
+    def test_build_no_match_hint_lists_entries(self, tmp_path):
+        """_build_no_match_hint returns a string listing directory entries."""
+        from tools.file_tools import _build_no_match_hint
+
+        (tmp_path / "alpha.py").touch()
+        (tmp_path / "beta.py").touch()
+        (tmp_path / "subdir").mkdir()
+
+        hint = _build_no_match_hint(str(tmp_path), "nonexistent", "content", tmp_path)
+        assert hint is not None
+        assert "matched nothing" in hint
+        assert "subdir/" in hint
+        assert "alpha.py" in hint
+        assert "beta.py" in hint
+
+    def test_build_no_match_hint_file_path(self, tmp_path):
+        """When the path is a single file, hint says to read_file directly."""
+        from tools.file_tools import _build_no_match_hint
+
+        f = tmp_path / "target.py"
+        f.touch()
+
+        hint = _build_no_match_hint(str(f), "xyz", "content", f)
+        assert hint is not None
+        assert "single file" in hint
+        assert "read_file" in hint
+
+    def test_build_no_match_hint_nonexistent_path(self):
+        """Nonexistent path returns None (path-not-found already handled elsewhere)."""
+        from tools.file_tools import _build_no_match_hint
+
+        hint = _build_no_match_hint("/nonexistent/path", "xyz", "content", None)
+        assert hint is None
+
+    def test_build_no_match_hint_empty_dir(self, tmp_path):
+        """Empty directory returns a hint saying so."""
+        from tools.file_tools import _build_no_match_hint
+
+        empty_dir = tmp_path / "empty_test_dir"
+        empty_dir.mkdir()
+
+        hint = _build_no_match_hint(str(empty_dir), "xyz", "content", empty_dir)
+        assert hint is not None
+        assert "no visible entries" in hint
+
+    def test_build_no_match_hint_files_target(self, tmp_path):
+        """File search mode hint suggests broader glob or content search."""
+        from tools.file_tools import _build_no_match_hint
+
+        (tmp_path / "alpha.py").touch()
+
+        hint = _build_no_match_hint(str(tmp_path), "nonexistent", "files", tmp_path)
+        assert hint is not None
+        assert "file search" in hint
+        assert "broader glob" in hint
+
+    def test_build_no_match_hint_content_target(self, tmp_path):
+        """Content search mode hint suggests different regex or file listing."""
+        from tools.file_tools import _build_no_match_hint
+
+        (tmp_path / "alpha.py").touch()
+
+        hint = _build_no_match_hint(str(tmp_path), "nonexistent", "content", tmp_path)
+        assert hint is not None
+        assert "content search" in hint
+        assert "different regex" in hint
+
+    def test_build_no_match_hint_hides_dotfiles(self, tmp_path):
+        """Hidden entries (starting with .) are excluded from the listing."""
+        from tools.file_tools import _build_no_match_hint
+
+        (tmp_path / ".hidden").touch()
+        (tmp_path / "visible.py").touch()
+
+        hint = _build_no_match_hint(str(tmp_path), "xyz", "content", tmp_path)
+        assert hint is not None
+        assert "visible.py" in hint
+        assert ".hidden" not in hint
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_adds_no_match_hint_on_first_miss(
+        self, mock_get, tmp_path, monkeypatch
+    ):
+        """search_tool includes _no_match_hint on the first empty result."""
+        from tools.file_tools import search_tool, _read_tracker
+
+        _read_tracker.clear()
+
+        (tmp_path / "alpha.py").touch()
+        (tmp_path / "beta.py").touch()
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.side_effect = lambda **kw: {"total_count": 0}
+        result_obj.matches = []
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        monkeypatch.setattr(
+            "tools.file_tools._resolve_path_for_task",
+            lambda p, tid: tmp_path,
+        )
+
+        raw = search_tool(pattern="nonexistent", path=str(tmp_path))
+        result = json.loads(raw)
+        assert result["total_count"] == 0
+        assert "_no_match_hint" in result
+        assert "alpha.py" in result["_no_match_hint"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_no_hint_on_second_miss(
+        self, mock_get, tmp_path, monkeypatch
+    ):
+        """_no_match_hint only appears on the FIRST empty result, not second."""
+        from tools.file_tools import search_tool, _read_tracker
+
+        _read_tracker.clear()
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.side_effect = lambda **kw: {"total_count": 0}
+        result_obj.matches = []
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        monkeypatch.setattr(
+            "tools.file_tools._resolve_path_for_task",
+            lambda p, tid: tmp_path,
+        )
+
+        raw1 = search_tool(pattern="nonexistent", path=str(tmp_path))
+        result1 = json.loads(raw1)
+        assert "_no_match_hint" in result1
+
+        raw2 = search_tool(pattern="other", path=str(tmp_path))
+        result2 = json.loads(raw2)
+        assert "_no_match_hint" not in result2
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_spiral_directive_after_3_misses(
+        self, mock_get, tmp_path, monkeypatch
+    ):
+        """After 3 consecutive empty results, _search_directive appears."""
+        from tools.file_tools import search_tool, _read_tracker
+
+        _read_tracker.clear()
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.side_effect = lambda **kw: {"total_count": 0}
+        result_obj.matches = []
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        monkeypatch.setattr(
+            "tools.file_tools._resolve_path_for_task",
+            lambda p, tid: tmp_path,
+        )
+
+        for i in range(3):
+            search_tool(pattern=f"pattern_{i}", path=str(tmp_path))
+
+        raw = search_tool(pattern="pattern_3", path=str(tmp_path))
+        result = json.loads(raw)
+        assert "_search_directive" in result
+        assert "SWITCH STRATEGY" in result["_search_directive"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_no_hint_when_results_exist(self, mock_get):
+        """No _no_match_hint when search finds results."""
+        from tools.file_tools import search_tool, _read_tracker
+
+        _read_tracker.clear()
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.side_effect = lambda **kw: {
+            "total_count": 2,
+            "matches": [{"path": "a.py", "line": 1, "content": "x"}],
+        }
+        result_obj.matches = []
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        raw = search_tool(pattern="found_something")
+        result = json.loads(raw)
+        assert "_no_match_hint" not in result
+
+
+# ---------------------------------------------------------------------------
 # PATCH_SCHEMA shape tests (issue #15524)
 # ---------------------------------------------------------------------------
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2157,6 +2157,80 @@ def patch_tool(
         return tool_error(str(e))
 
 
+# ---------------------------------------------------------------------------
+# #1486 — no-match enrichment for search_files
+# ---------------------------------------------------------------------------
+
+
+def _build_no_match_hint(
+    path: str,
+    pattern: str,
+    target: str,
+    resolved_path: "Path | PurePosixPath | None",
+) -> "str | None":
+    """Build a hint for the agent when search_files finds zero matches.
+
+    Lists what *does* exist in the search directory so the agent can correct
+    its pattern or verify the path instead of blind-retrying.  Returns None
+    when no useful hint can be constructed (e.g. the directory doesn't exist
+    or is empty), so the caller can skip adding an empty field.
+    """
+    search_dir = resolved_path if resolved_path else Path(path)
+
+    try:
+        search_dir = Path(os.path.expanduser(str(search_dir)))
+        if not search_dir.is_dir():
+            if search_dir.exists() and search_dir.is_file():
+                return (
+                    f"Pattern {pattern!r} matched nothing in {path!r}. "
+                    "The path is a single file — verify the pattern or "
+                    "read_file the file directly."
+                )
+            return None
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+    try:
+        children = sorted(
+            search_dir.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())
+        )
+    except (OSError, PermissionError):
+        return None
+
+    _max = 10
+    dirs = [c.name + "/" for c in children if c.is_dir() and not c.name.startswith(".")]
+    files_list = [c.name for c in children if c.is_file() and not c.name.startswith(".")]
+    entries = dirs[:_max]
+    remaining = _max - len(entries)
+    if remaining > 0:
+        entries.extend(files_list[:remaining])
+
+    if not entries:
+        return (
+            f"Pattern {pattern!r} matched nothing in {path!r}. "
+            "The directory exists but contains no visible entries. "
+            "Verify the path is correct."
+        )
+
+    mode_desc = "file search" if target == "files" else "content search"
+    listing = ", ".join(entries)
+    hint = (
+        f"Pattern {pattern!r} matched nothing in {path!r} ({mode_desc}). "
+        f"Entries that DO exist in this directory: {listing}"
+    )
+    if target == "files":
+        hint += (
+            ". Try a broader glob (e.g. '*.py' instead of a specific name), "
+            "or use target='content' to search inside files."
+        )
+    else:
+        hint += (
+            ". Try a different regex pattern, or use target='files' with a "
+            "glob like '*.py' to list files first."
+        )
+    return hint
+
+
 def search_tool(
     pattern: str,
     target: str = "content",
@@ -2242,13 +2316,17 @@ def search_tool(
                     m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
 
-        # ── Empty-result spiral detection (#1372) ─────────────────────
+        # ── Empty-result enrichment + spiral detection (#1372, #1486) ──
         # search_files returns {"total_count": 0} with no error key on a
-        # successful-but-empty search. The tool_guardrails spiral_failure_cap
-        # only counts errors, so diverse-query spirals (where the agent
-        # reformulates the query each time and gets empty each time) slip
-        # through — the regression of #1149. Track cumulative empty results
-        # per session and inject a directive when they pile up.
+        # successful-but-empty search.  When the pattern matches nothing the
+        # agent has no hint about what *does* exist, so it blind-retries or
+        # falls back to terminal directory listing — burning extra turns
+        # (#1486: 95 file-not-found events/7d, 27-deep spirals observed).
+        #
+        # Enrich the FIRST empty result with what actually exists in the
+        # search path (#1486), and keep the spiral counter (#1372) so that
+        # after 3 consecutive misses a stronger SWITCH STRATEGY directive is
+        # injected.
         if result_dict.get("total_count", 0) == 0 and not result_dict.get("error"):
             with _read_tracker_lock:
                 td = _read_tracker.setdefault(
@@ -2257,6 +2335,16 @@ def search_tool(
                 )
                 td["empty_searches"] = td.get("empty_searches", 0) + 1
                 _es = td["empty_searches"]
+
+            # ── #1486: immediate no-match hint on the FIRST empty result ─
+            # List what *does* exist in the search directory so the agent can
+            # correct the pattern instead of blind-retrying.  Runs before the
+            # spiral directive so even the first miss gets actionable info.
+            if _es == 1:
+                _hint = _build_no_match_hint(path, pattern, target, resolved_path)
+                if _hint:
+                    result_dict["_no_match_hint"] = _hint
+
             if _es >= 3:
                 result_dict.setdefault(
                     "_search_directive",


### PR DESCRIPTION
Automated evolution PR for issue #1486.

## Summary

When `search_files` returns zero results (valid pattern, no matches), the agent previously got a bare `{total_count: 0}` with no actionable info, causing blind retries (#1486: 95 file-not-found events/7d, 27-deep spirals observed).

## Changes

- **`tools/file_tools.py`**: Added `_build_no_match_hint()` function that lists what *does* exist in the search directory (up to 10 entries, dirs first). Enriches the FIRST empty result with a `_no_match_hint` field containing the directory listing + a mode-specific recovery suggestion. The existing #1372 spiral detection (SWITCH STRATEGY after 3 consecutive misses) is preserved.
- **`tests/tools/test_file_tools.py`**: Added `TestNoMatchHint` class with 11 tests covering: directory listing, file-path handling, nonexistent paths, empty dirs, files vs content search mode, dotfile hiding, first-miss-only hint, spiral directive, and no-hint-when-results-exist.

## Verification

- Lint: `ruff check` passes
- Tests: 11 new + 7 existing search tests all pass (18 total)
- Pre-PR test runner: PASSED

Closes #1486