### PR TITLE
fix: recognize lookaround (?...) as regex, not glob, in search_files (Closes #1484)

### DIFF
--- a/tests/tools/test_search_glob_redirect.py
+++ b/tests/tools/test_search_glob_redirect.py
@@ -42,6 +42,30 @@ class TestLooksLikeGlob:
         # [a-z]+ is a regex, not a glob — no unescaped * or ?
         assert _looks_like_glob("[a-z]+") is False
 
+    # --- #1484: lookaround / (?...) groups must NOT be flagged as globs ---
+
+    def test_negative_lookahead_not_glob(self):
+        # (?!...) is a regex negative lookahead — ? follows (, not a glob
+        assert _looks_like_glob(r"(?!foo)bar") is False
+
+    def test_positive_lookahead_not_glob(self):
+        assert _looks_like_glob(r"(?=foo)bar") is False
+
+    def test_negative_lookbehind_not_glob(self):
+        # (?<=...) is the pattern that caused 59 retries/7d per #1484
+        assert _looks_like_glob(r"(?<=foo)bar") is False
+
+    def test_positive_lookbehind_not_glob(self):
+        assert _looks_like_glob(r"(?<!foo)bar") is False
+
+    def test_non_capturing_group_not_glob(self):
+        # (?:...) is a non-capturing group — ? follows (, not a glob
+        assert _looks_like_glob(r"(?:abc)+") is False
+
+    def test_lookaround_with_quantifier_not_glob(self):
+        # Combined lookaround + .* — still a regex, not a glob
+        assert _looks_like_glob(r"(?<=\d).*") is False
+
 
 class TestHandleSearchFilesGlobRedirect:
     """Integration tests for the _handle_search_files handler redirect."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2598,7 +2598,10 @@ def _looks_like_glob(pattern: str) -> bool:
                 continue
             # ``?`` in regex means "zero or one" — preceded by a
             # metacharacter it's a quantifier, not a glob wildcard.
-            if i > 0 and pattern[i - 1] in ".+*^$[":
+            # ``(`` is included so lookarounds ``(?!…)``, ``(?<=…)``,
+            # ``(?:…)`` and other ``(?…)`` groups are NOT misclassified
+            # as glob ``?`` wildcards (#1484 — caused 59 retries/7d).
+            if i > 0 and pattern[i - 1] in ".+*^$[(":
                 continue
             return True
     return False


### PR DESCRIPTION
## Summary

Fixes #1484 — `search_files` rejects valid regex with lookaround assertions (`(?<=…)`, `(?!…)`, `(?:…)`) because `_looks_like_glob` misclassifies the `?` following `(` as a shell glob wildcard, returning a misleading "looks like a shell glob" error instead of passing the regex to ripgrep.

This caused **59 wasted retry cycles per week** (8.7% failure rate across 681 sessions). The agent always recovers (100% recovery rate) by simplifying the regex, but each failure wastes 1-2 tool calls.

## Change

Added `(` to the exception set on the `?` handler in `_looks_like_glob` (`tools/file_tools.py:2604`):

```python
# Before:
if i > 0 and pattern[i - 1] in ".+*^$[":
    continue

# After:
if i > 0 and pattern[i - 1] in ".+*^$[(":
    continue
```

This ensures `(?` — which is regex syntax for lookarounds and non-capturing groups — is recognized as a regex construct, not a glob `?` wildcard.

## Why this is safe

- `(` only appears before `?` in regex group syntax: `(?=…)`, `(?!…)`, `(?<=…)`, `(?<!…)`, `(?:…)`
- A glob `?` wildcard is never preceded by `(` — globs use `?` standalone (e.g. `config?.yml`)
- Existing tests confirm glob detection still works (`test_question_mark_glob` passes)
- 6 new tests cover all lookaround variants

## Test coverage

- 6 new unit tests in `tests/tools/test_search_glob_redirect.py` covering negative/positive lookahead, negative/positive lookbehind, non-capturing groups, and combined lookaround+quantifier patterns
- All 19 tests pass (8 original + 6 new + 5 integration)
- Pre-PR test shard: PASSED
- `ruff check`: PASSED

## Diff size

29 lines (28 insertions, 1 deletion) — well within the 200-line autonomous merge cap.

Closes #1484