### PR TITLE
fix: gate retrieval-utility logging behind enabled config flag (#1480)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -504,6 +504,24 @@ class MemoryManager:
 
     # -- Retrieval-utility logging (#1480) -----------------------------------
 
+    @staticmethod
+    def _retrieval_utility_enabled() -> bool:
+        """Check the ``memory.retrieval_utility.enabled`` config flag.
+
+        The flag defaults to ``False`` (opt-in).  Without this gate the
+        retrieval-utility logger writes a per-retrieval record to disk on
+        every memory hit in every session — an unasked-for on-disk trace.
+        """
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly() or {}
+            return bool(
+                (config.get("memory") or {}).get("retrieval_utility", {}).get("enabled")
+            )
+        except Exception:
+            return False
+
     def _record_retrieval_utility(
         self, provider_name: str, query: str, *, session_id: str = ""
     ) -> None:
@@ -514,7 +532,12 @@ class MemoryManager:
         provider name — granular enough to measure per-provider utility
         without needing to parse the returned context into individual
         records.
+
+        Gated behind ``memory.retrieval_utility.enabled`` (default OFF) so
+        ordinary sessions never write the sidecar.
         """
+        if not self._retrieval_utility_enabled():
+            return
         try:
             from agent.retrieval_utility import record_retrieval
 
@@ -531,8 +554,12 @@ class MemoryManager:
         signals for the turn. Uses ``event.friction_signals`` to derive a
         coarse outcome label (helpful/neutral/harmful) and records it
         against each pending retrieval.
+        Gated behind ``memory.retrieval_utility.enabled`` (default OFF).
         """
         if not self._pending_retrievals:
+            return
+        if not self._retrieval_utility_enabled():
+            self._pending_retrievals.clear()
             return
         try:
             from agent.retrieval_utility import record_outcome, derive_outcome

--- a/tests/agent/test_memory_retrieval_utility.py
+++ b/tests/agent/test_memory_retrieval_utility.py
@@ -57,6 +57,20 @@ def isolated_hermes_home(tmp_path, monkeypatch):
 class TestPrefetchRetrievalLogging:
     """Verify prefetch_all logs retrievals to the sidecar."""
 
+    @pytest.fixture(autouse=True)
+    def _enable_retrieval_utility(self):
+        """Existing tests assume retrieval-utility logging is ON.
+
+        The ``memory.retrieval_utility.enabled`` config flag defaults to
+        ``False`` (opt-in).  Mock it to ``True`` so the logging path is
+        exercised.  The dedicated ``TestRetrievalUtilityGate`` class below
+        tests the disabled path.
+        """
+        with patch.object(
+            MemoryManager, "_retrieval_utility_enabled", return_value=True
+        ):
+            yield
+
     def test_prefetch_logs_retrieval(self, isolated_hermes_home):
         from agent.retrieval_utility import load_log
 
@@ -105,6 +119,14 @@ class TestPrefetchRetrievalLogging:
 
 class TestSyncOutcomeRecording:
     """Verify sync_all records outcomes for pending retrievals."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_retrieval_utility(self):
+        """Existing tests assume retrieval-utility logging is ON."""
+        with patch.object(
+            MemoryManager, "_retrieval_utility_enabled", return_value=True
+        ):
+            yield
 
     def test_sync_records_helpful_outcome(self, isolated_hermes_home):
         from agent.retrieval_utility import load_log
@@ -159,3 +181,53 @@ class TestSyncOutcomeRecording:
         assert len(mgr._pending_retrievals) == 1
         mgr.sync_all("query", "answer", session_id="s1")
         assert len(mgr._pending_retrievals) == 0
+
+
+class TestRetrievalUtilityGate:
+    """Verify retrieval-utility logging respects the ``enabled`` config flag.
+
+    When ``memory.retrieval_utility.enabled`` is ``False`` (the default),
+    no sidecar file should be written and no pending retrievals should
+    accumulate.
+    """
+
+    def test_disabled_no_sidecar_written(self, isolated_hermes_home):
+        """prefetch_all must not write the sidecar when disabled."""
+        from agent.retrieval_utility import load_log
+
+        provider = _FakeProvider("builtin", context="recalled: foo")
+        mgr = MemoryManager()
+        mgr.add_provider(provider)
+
+        # _retrieval_utility_enabled() defaults to False (config not set).
+        result = mgr.prefetch_all("what is foo?", session_id="s1")
+        assert "recalled: foo" in result
+
+        log = load_log()
+        assert log["retrievals"] == []
+
+    def test_disabled_no_pending_retrievals_accumulated(self, isolated_hermes_home):
+        """_pending_retrievals must stay empty when disabled."""
+        provider = _FakeProvider("builtin", context="ctx")
+        mgr = MemoryManager()
+        mgr.add_provider(provider)
+
+        mgr.prefetch_all("query", session_id="s1")
+        assert len(mgr._pending_retrievals) == 0
+
+    def test_disabled_sync_does_not_record(self, isolated_hermes_home):
+        """sync_all must not record outcomes when disabled."""
+        from agent.retrieval_utility import load_log
+
+        provider = _FakeProvider("builtin", context="ctx")
+        mgr = MemoryManager()
+        mgr.add_provider(provider)
+
+        # Even if we manually inject a pending retrieval, sync should
+        # clear it without writing to the sidecar when disabled.
+        mgr._pending_retrievals.append(("memory:builtin", "s1"))
+        mgr.sync_all("query", "answer", session_id="s1")
+        assert len(mgr._pending_retrievals) == 0
+
+        log = load_log()
+        assert log["retrievals"] == []


### PR DESCRIPTION
## Summary

The `memory.retrieval_utility.enabled` config flag defaults to `False` (opt-in), but `_record_retrieval_utility` and `_record_retrieval_outcomes` in `MemoryManager` ran **unconditionally** — writing a per-retrieval record to disk on every memory hit in every session despite the user never opting in.

This was identified in the PR #1483 code review but never fixed. PR #1485 attempted to fix it but is stuck in a conflicting/dirty state (834 additions, mergeable_state=dirty). This PR is the minimal standalone fix.

## Changes

- **`agent/memory_manager.py`**: Added `_retrieval_utility_enabled()` static method that reads `memory.retrieval_utility.enabled` via `load_config_readonly()`. Both `_record_retrieval_utility` and `_record_retrieval_outcomes` now early-return when the flag is `False`. When disabled, `_pending_retrievals` is also cleared to prevent stale accumulation.
- **`tests/agent/test_memory_retrieval_utility.py`**: Existing test classes now mock `_retrieval_utility_enabled` to `True` (autouse fixture) so the logging path is still exercised. Added `TestRetrievalUtilityGate` with 3 new tests verifying the disabled path: no sidecar written, no pending retrievals accumulated, sync does not record outcomes.

## Verification

- `ruff check` ✓ (both files)
- `pytest tests/agent/test_memory_retrieval_utility.py` ✓ (10/10 passed)
- Diff: 99 insertions, 0 deletions (well under 200-line merge cap)

## Design

The fix reads config lazily at call time via `load_config_readonly()` rather than passing a config reference into the `MemoryManager` constructor — this avoids changing the constructor signature (which would ripple through all callers in `run_agent.py`, `cli.py`, gateway, etc.). The `try/except` wrapper ensures a missing or corrupt config never breaks memory operations.