### PR TITLE
feat: MCP stateless B-1 — capability flag + synthesize_capabilities (Closes #1511)

### DIFF
--- a/tests/test_mcp_stateless_b1.py
+++ b/tests/test_mcp_stateless_b1.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Unit tests for MCP stateless capability-detection shim (Slice B-1 / #1511)."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_server():
+    """Build an MCPServerTask instance (bypass __init__ heavy deps)."""
+    from tools.mcp_tool import MCPServerTask
+
+    srv = MCPServerTask.__new__(MCPServerTask)
+    srv.name = "test-server"
+    srv.initialize_result = None
+    srv._stateless_enabled = False
+    return srv
+
+
+class TestStatelessFlag:
+    def test_flag_off_by_default(self):
+        """Without HERMES_MCP_STATELESS, _stateless_enabled must be False."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_MCP_STATELESS", None)
+            from tools.mcp_tool import MCPServerTask
+
+            srv = MCPServerTask.__new__(MCPServerTask)
+            MCPServerTask.__init__(srv, "test")
+            assert srv._stateless_enabled is False
+
+    def test_flag_on_with_1(self):
+        with patch.dict(os.environ, {"HERMES_MCP_STATELESS": "1"}):
+            from tools.mcp_tool import MCPServerTask
+
+            srv = MCPServerTask("test")
+            assert srv._stateless_enabled is True
+
+    def test_flag_on_with_true(self):
+        with patch.dict(os.environ, {"HERMES_MCP_STATELESS": "true"}):
+            from tools.mcp_tool import MCPServerTask
+
+            srv = MCPServerTask("test")
+            assert srv._stateless_enabled is True
+
+    def test_flag_off_with_empty(self):
+        with patch.dict(os.environ, {"HERMES_MCP_STATELESS": ""}):
+            from tools.mcp_tool import MCPServerTask
+
+            srv = MCPServerTask("test")
+            assert srv._stateless_enabled is False
+
+
+class TestDetectStatelessSupport:
+    def test_off_when_disabled(self):
+        srv = _make_server()
+        srv._stateless_enabled = False
+        assert srv._detect_stateless_support() is False
+
+    def test_on_when_enabled(self):
+        srv = _make_server()
+        srv._stateless_enabled = True
+        assert srv._detect_stateless_support() is True
+
+
+class TestSynthesizeCapabilities:
+    def test_default_tools_only(self):
+        srv = _make_server()
+        result = srv.synthesize_capabilities()
+        assert result.capabilities.tools is not None
+        assert result.capabilities.resources is None
+        assert result.capabilities.prompts is None
+
+    def test_all_capabilities(self):
+        srv = _make_server()
+        result = srv.synthesize_capabilities({
+            "tools": True,
+            "resources": True,
+            "prompts": True,
+        })
+        assert result.capabilities.tools is not None
+        assert result.capabilities.resources is not None
+        assert result.capabilities.prompts is not None
+
+    def test_tools_only_explicit(self):
+        srv = _make_server()
+        result = srv.synthesize_capabilities({"tools": True, "resources": False})
+        assert result.capabilities.tools is not None
+        assert result.capabilities.resources is None
+
+    def test_works_with_advertises_tools(self):
+        """Synthesized caps must flow through _advertises_tools() correctly."""
+        srv = _make_server()
+        srv.initialize_result = srv.synthesize_capabilities()
+        assert srv._advertises_tools() is True
+
+    def test_works_with_select_utility_schemas(self):
+        """Synthesized caps must flow through _select_utility_schemas()."""
+        srv = _make_server()
+        srv.initialize_result = srv.synthesize_capabilities({
+            "tools": True,
+            "resources": True,
+        })
+        caps = srv.initialize_result.capabilities
+        assert getattr(caps, "tools", None) is not None
+        assert getattr(caps, "resources", None) is not None
+
+
+class TestStatefulPathUnchanged:
+    """When flag is OFF, the behavior must be identical to before (#1511)."""
+
+    def test_initialize_result_stays_none_before_connect(self):
+        srv = _make_server()
+        srv._stateless_enabled = False
+        assert srv.initialize_result is None
+        assert srv._detect_stateless_support() is False
+
+    def test_advertises_tools_returns_true_when_none(self):
+        """Legacy fallback: _advertises_tools returns True when caps unknown."""
+        srv = _make_server()
+        srv.initialize_result = None
+        assert srv._advertises_tools() is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1912,6 +1912,7 @@ class MCPServerTask:
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries",
         "_last_park_error",
+        "_stateless_enabled",
     )
 
     def __init__(self, name: str):
@@ -1978,6 +1979,49 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        # --- MCP 2026-07-28 stateless support (Slice B-1 / #1511) ---
+        # When HERMES_MCP_STATELESS=1, the adapter can synthesize capabilities
+        # instead of performing the initialize handshake. Default OFF — zero
+        # behavioral change unless explicitly enabled.
+        self._stateless_enabled: bool = os.environ.get(
+            "HERMES_MCP_STATELESS", ""
+        ).strip().lower() in ("1", "true", "yes", "on")
+
+    def _detect_stateless_support(self) -> bool:
+        """Whether the stateless protocol path is enabled for this server.
+
+        Currently driven solely by the ``HERMES_MCP_STATELESS`` env flag
+        (read once in ``__init__``). A future increment may add per-server
+        capability probing via ``server/discover`` RPC (B-2 / #1512).
+        """
+        return self._stateless_enabled
+
+    def synthesize_capabilities(self, capabilities_doc: Optional[dict] = None) -> Any:
+        """Build a minimal ``InitializeResult``-shaped object from a capabilities doc.
+
+        When the stateless flag is ON, the adapter skips the ``initialize``
+        handshake and instead populates ``self.initialize_result`` with this
+        synthesized object. The downstream consumers (``_advertises_tools``,
+        ``_select_utility_schemas``) only read ``.capabilities.tools``,
+        ``.capabilities.resources``, ``.capabilities.prompts`` — so a
+        ``SimpleNamespace`` mirroring that shape is sufficient.
+
+        Parameters
+        ----------
+        capabilities_doc
+            Optional dict with ``tools``, ``resources``, ``prompts`` keys
+            (each a truthy object if the capability is advertised). When
+            ``None``, defaults to advertising tools only (the common case
+            for stateless tool servers).
+        """
+        if capabilities_doc is None:
+            capabilities_doc = {"tools": True}
+        caps = SimpleNamespace(
+            tools=SimpleNamespace() if capabilities_doc.get("tools") else None,
+            resources=SimpleNamespace() if capabilities_doc.get("resources") else None,
+            prompts=SimpleNamespace() if capabilities_doc.get("prompts") else None,
+        )
+        return SimpleNamespace(capabilities=caps)
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -2542,9 +2586,12 @@ class MCPServerTask:
                     connect_timeout = float(
                         config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
                     )
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=connect_timeout
-                    )
+                    if self._detect_stateless_support():
+                        self.initialize_result = self.synthesize_capabilities()
+                    else:
+                        self.initialize_result = await asyncio.wait_for(
+                            session.initialize(), timeout=connect_timeout
+                        )
                     self.session = session
                     self._mark_lifecycle_started()
                     await self._discover_tools()
@@ -2850,9 +2897,12 @@ class MCPServerTask:
                     # stdio path (#59349): an endpoint that accepts the
                     # connection but never answers ``initialize`` parks this
                     # coroutine forever on the background loop.
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=float(connect_timeout)
-                    )
+                    if self._detect_stateless_support():
+                        self.initialize_result = self.synthesize_capabilities()
+                    else:
+                        self.initialize_result = await asyncio.wait_for(
+                            session.initialize(), timeout=float(connect_timeout)
+                        )
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
@@ -2907,9 +2957,12 @@ class MCPServerTask:
                 ):
                     async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
                         # Bound the handshake (#59349) — see stdio path.
-                        self.initialize_result = await asyncio.wait_for(
-                            session.initialize(), timeout=float(connect_timeout)
-                        )
+                        if self._detect_stateless_support():
+                            self.initialize_result = self.synthesize_capabilities()
+                        else:
+                            self.initialize_result = await asyncio.wait_for(
+                                session.initialize(), timeout=float(connect_timeout)
+                            )
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
@@ -2939,9 +2992,12 @@ class MCPServerTask:
             ):
                 async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
                     # Bound the handshake (#59349) — see stdio path.
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=float(connect_timeout)
-                    )
+                    if self._detect_stateless_support():
+                        self.initialize_result = self.synthesize_capabilities()
+                    else:
+                        self.initialize_result = await asyncio.wait_for(
+                            session.initialize(), timeout=float(connect_timeout)
+                        )
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()


### PR DESCRIPTION
## Summary

Slice B-1 of the MCP 2026-07-28 stateless migration (decomposed from #1287). Adds a **capability-detection mechanism** behind a feature flag that defaults OFF — zero behavioral change unless explicitly enabled.

### Changes
1. **Feature flag**: `HERMES_MCP_STATELESS` env var, read in `MCPServerTask.__init__`. Defaults OFF.
2. **`_detect_stateless_support()`**: returns whether the stateless path is enabled for this server.
3. **`synthesize_capabilities()`**: builds a minimal `InitializeResult`-shaped object (`SimpleNamespace`) from a capabilities doc, so downstream consumers (`_advertises_tools`, `_select_utility_schemas`) work without a real handshake.
4. **4 transport sites gated** (stdio, SSE, streamable_http new, streamable_http deprecated): when flag is ON, populate `initialize_result` from `synthesize_capabilities()` instead of calling `session.initialize()`.

### Success criteria (all met)
- [x] `HERMES_MCP_STATELESS` flag is read and defaults to OFF
- [x] `synthesize_capabilities()` produces a valid `InitializeResult` from a capabilities doc
- [x] Flag-gated population of `initialize_result` at the 4 capture sites
- [x] Existing stateful path unchanged when flag is OFF (no regressions)
- [x] 13 unit tests covering flag parsing, detection, synthesis, and stateful path
- [x] Fits self-merge cap (193 insertions, 12 deletions = 205 changed lines)

### What this does NOT do
- Does NOT touch the `session.initialize()` routing logic itself (that's B-2 / #1512)
- Does NOT add `_meta`-inline routing (that's B-2)
- Does NOT add mock stateless server tests (that's B-3 / #1513)
- Does NOT flip the flag default (that's Slice C)

### Audit reference
Full call-site map: `docs/mcp/2026-07-28-stateless-migration-audit.md`

Automated evolution PR for issue #1511.