### PR TITLE
feat(eval): task-set schema and loader — Step 1 (#1514)

### DIFF
--- a/scripts/eval_tasks.py
+++ b/scripts/eval_tasks.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Evaluation task-set schema and loader for the Hermes eval harness (#1514).
+
+Defines ``EvalTask`` — a single evaluation scenario with a prompt, expected
+tool usage, optional result pattern, category, and difficulty — plus a
+versioned task-set registry and a ``load_task_set()`` loader.
+
+This is Step 1 of the eval harness (issue #1514, parent #1481). It provides
+only the data layer: the schema, a curated set of 8 tasks across 4 tool
+categories, and a loader. The runner (Step 2, #1515) and the null-agent
+baseline + scoring (Steps 3-4, #1516) are separate issues.
+
+Design decisions:
+- **Pure data, no network.** Tasks are static definitions; the runner
+  (Step 2) is responsible for executing them. This keeps the module
+  import-safe and unit-testable with no external dependencies.
+- **Versioned.** Each task set has a ``version`` string. The loader
+  ``load_task_set(version=...)`` returns tasks for the requested version,
+  defaulting to the latest. Breaking schema changes bump the major
+  version; additive changes bump the minor.
+- **≥3 tool categories.** The v1.0 set covers ``code``, ``search``,
+  ``file_ops``, and ``reasoning`` — 4 categories, satisfying the ≥3
+  requirement.
+- **Difficulty levels.** ``easy``, ``medium``, ``hard`` let the runner
+  compute per-difficulty pass rates.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Pattern
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EvalTask:
+    """A single evaluation task for the Hermes eval harness.
+
+    Attributes:
+        id: Unique task identifier (e.g. ``"code-001"``).
+        prompt: The user prompt presented to the agent.
+        expected_tools: List of tool names the agent is expected to call
+            (e.g. ``["terminal", "read_file"]``). Order is not significant.
+        expected_result_pattern: Optional regex pattern that the agent's
+            final response should match. ``None`` means no pattern check.
+        category: Tool category — one of ``"code"``, ``"search"``,
+            ``"file_ops"``, ``"reasoning"``.
+        difficulty: ``"easy"``, ``"medium"``, or ``"hard"``.
+        version: Task-set version this task belongs to (e.g. ``"1.0"``).
+        notes: Optional evaluator notes (not shown to the agent).
+    """
+
+    id: str
+    prompt: str
+    expected_tools: List[str] = field(default_factory=list)
+    expected_result_pattern: Optional[str] = None
+    category: str = "reasoning"
+    difficulty: str = "medium"
+    version: str = "1.0"
+    notes: str = ""
+
+    def compiled_pattern(self) -> Optional[Pattern[str]]:
+        """Return the compiled regex for ``expected_result_pattern``, or None."""
+        if self.expected_result_pattern is None:
+            return None
+        return re.compile(self.expected_result_pattern, re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Task-set registry
+# ---------------------------------------------------------------------------
+
+# v1.0 — initial task set: 8 tasks across 4 categories.
+_TASK_SET_V1: List[EvalTask] = [
+    # --- Code (2 tasks) ---
+    EvalTask(
+        id="code-001",
+        prompt="Write a Python function that reverses a string. "
+               "Put the code in a file called reverse_string.py.",
+        expected_tools=["terminal", "read_file"],
+        expected_result_pattern=r"def\s+reverse",
+        category="code",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests basic code generation + file creation.",
+    ),
+    EvalTask(
+        id="code-002",
+        prompt="Write a Python script that reads a CSV file and prints "
+               "the number of rows. The script should handle missing files "
+               "gracefully. Save it as count_rows.py.",
+        expected_tools=["terminal", "read_file"],
+        expected_result_pattern=r"csv|pandas|DictReader",
+        category="code",
+        difficulty="medium",
+        version="1.0",
+        notes="Tests error handling + file I/O.",
+    ),
+    # --- Search (2 tasks) ---
+    EvalTask(
+        id="search-001",
+        prompt="Search the web for the latest version of Python and tell "
+               "me the version number.",
+        expected_tools=["web_search"],
+        expected_result_pattern=r"3\.\d+\.\d+",
+        category="search",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests web search + information extraction.",
+    ),
+    EvalTask(
+        id="search-002",
+        prompt="Find all Python files in the current directory that "
+               "contain the word 'logger' and list their paths.",
+        expected_tools=["search_files"],
+        expected_result_pattern=r"\.py",
+        category="search",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests local file search.",
+    ),
+    # --- File ops (2 tasks) ---
+    EvalTask(
+        id="file-ops-001",
+        prompt="Create a directory called 'test_output' and write a file "
+               "named 'hello.txt' inside it with the content 'Hello, World!'.",
+        expected_tools=["terminal"],
+        expected_result_pattern=r"hello\.txt|Hello.*World",
+        category="file_ops",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests directory creation + file writing.",
+    ),
+    EvalTask(
+        id="file-ops-002",
+        prompt="Read the file /etc/hostname and tell me what it contains. "
+               "If the file doesn't exist, say so.",
+        expected_tools=["read_file"],
+        expected_result_pattern=r".+",
+        category="file_ops",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests file reading + error handling.",
+    ),
+    # --- Reasoning (2 tasks) ---
+    EvalTask(
+        id="reasoning-001",
+        prompt="If I have 3 apples and give away 1.5, how many do I have left? "
+               "Explain your reasoning.",
+        expected_tools=[],
+        expected_result_pattern=r"1\.5",
+        category="reasoning",
+        difficulty="easy",
+        version="1.0",
+        notes="Tests basic arithmetic reasoning. No tools expected.",
+    ),
+    EvalTask(
+        id="reasoning-002",
+        prompt="A train travels 60 mph for 2 hours, then 80 mph for 1.5 hours. "
+               "What is the total distance traveled? Show your work.",
+        expected_tools=[],
+        expected_result_pattern=r"240",
+        category="reasoning",
+        difficulty="medium",
+        version="1.0",
+        notes="Tests multi-step arithmetic. No tools expected.",
+    ),
+]
+
+# Registry of all task-set versions.
+_TASK_SETS: Dict[str, List[EvalTask]] = {
+    "1.0": _TASK_SET_V1,
+}
+
+# Latest version (used by load_task_set when version=None).
+_LATEST_VERSION = "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+def load_task_set(version: Optional[str] = None) -> List[EvalTask]:
+    """Load a task set by version.
+
+    Args:
+        version: Task-set version string (e.g. ``"1.0"``). If ``None``,
+            returns the latest version.
+
+    Returns:
+        List of ``EvalTask`` objects for the requested version.
+
+    Raises:
+        ValueError: If the requested version does not exist.
+    """
+    if version is None:
+        version = _LATEST_VERSION
+    if version not in _TASK_SETS:
+        available = ", ".join(sorted(_TASK_SETS.keys()))
+        raise ValueError(
+            f"Unknown task-set version: {version!r}. "
+            f"Available versions: {available}"
+        )
+    return list(_TASK_SETS[version])
+
+
+def list_versions() -> List[str]:
+    """Return all available task-set versions, sorted."""
+    return sorted(_TASK_SETS.keys())
+
+
+def latest_version() -> str:
+    """Return the latest task-set version string."""
+    return _LATEST_VERSION
+
+
+def task_count(version: Optional[str] = None) -> int:
+    """Return the number of tasks in a task set."""
+    return len(load_task_set(version))
+
+
+def categories(version: Optional[str] = None) -> List[str]:
+    """Return the distinct categories in a task set, sorted."""
+    return sorted({t.category for t in load_task_set(version)})
+
+
+def difficulties(version: Optional[str] = None) -> List[str]:
+    """Return the distinct difficulty levels in a task set, sorted."""
+    return sorted({t.difficulty for t in load_task_set(version)})

--- a/tests/scripts/test_eval_tasks.py
+++ b/tests/scripts/test_eval_tasks.py
@@ -1,0 +1,184 @@
+"""Tests for the eval harness task-set schema and loader (issue #1514).
+
+Verifies:
+- ``EvalTask`` dataclass fields, defaults, and ``compiled_pattern()``.
+- ``load_task_set()`` returns the correct tasks for a version.
+- v1.0 has 5-10 tasks, ≥3 categories, and ≥3 difficulty levels.
+- Versioning: ``list_versions()``, ``latest_version()``, unknown version raises.
+- Helper functions: ``task_count()``, ``categories()``, ``difficulties()``.
+"""
+
+import re
+import unittest
+
+from scripts.eval_tasks import (
+    EvalTask,
+    load_task_set,
+    list_versions,
+    latest_version,
+    task_count,
+    categories,
+    difficulties,
+)
+
+
+class TestEvalTaskSchema(unittest.TestCase):
+    """EvalTask dataclass — fields, defaults, compiled_pattern()."""
+
+    def test_minimal_task(self):
+        task = EvalTask(id="test-001", prompt="Hello")
+        self.assertEqual(task.id, "test-001")
+        self.assertEqual(task.prompt, "Hello")
+        self.assertEqual(task.expected_tools, [])
+        self.assertIsNone(task.expected_result_pattern)
+        self.assertEqual(task.category, "reasoning")
+        self.assertEqual(task.difficulty, "medium")
+        self.assertEqual(task.version, "1.0")
+        self.assertEqual(task.notes, "")
+
+    def test_full_task(self):
+        task = EvalTask(
+            id="test-002",
+            prompt="Write a function",
+            expected_tools=["terminal", "read_file"],
+            expected_result_pattern=r"def\s+\w+",
+            category="code",
+            difficulty="hard",
+            version="1.0",
+            notes="Tests code gen",
+        )
+        self.assertEqual(task.id, "test-002")
+        self.assertEqual(task.expected_tools, ["terminal", "read_file"])
+        self.assertEqual(task.category, "code")
+        self.assertEqual(task.difficulty, "hard")
+
+    def test_compiled_pattern_none(self):
+        task = EvalTask(id="t", prompt="p")
+        self.assertIsNone(task.compiled_pattern())
+
+    def test_compiled_pattern_returns_regex(self):
+        task = EvalTask(
+            id="t", prompt="p",
+            expected_result_pattern=r"\d+",
+        )
+        pattern = task.compiled_pattern()
+        self.assertIsNotNone(pattern)
+        self.assertTrue(pattern.search("abc123"))
+
+    def test_compiled_pattern_case_insensitive(self):
+        task = EvalTask(
+            id="t", prompt="p",
+            expected_result_pattern=r"hello",
+        )
+        pattern = task.compiled_pattern()
+        self.assertTrue(pattern.search("HELLO WORLD"))
+
+    def test_frozen(self):
+        """EvalTask is frozen — immutable."""
+        task = EvalTask(id="t", prompt="p")
+        with self.assertRaises(Exception):
+            task.id = "other"
+
+
+class TestLoadTaskSet(unittest.TestCase):
+    """load_task_set() — versioning and task counts."""
+
+    def test_load_default_returns_latest(self):
+        tasks = load_task_set()
+        self.assertEqual(len(tasks), 8)
+        for t in tasks:
+            self.assertIsInstance(t, EvalTask)
+
+    def test_load_v1_explicit(self):
+        tasks = load_task_set("1.0")
+        self.assertEqual(len(tasks), 8)
+
+    def test_load_unknown_version_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            load_task_set("99.0")
+        self.assertIn("99.0", str(ctx.exception))
+        self.assertIn("1.0", str(ctx.exception))
+
+    def test_load_returns_copy(self):
+        """load_task_set returns a new list — mutating it doesn't affect the registry."""
+        tasks1 = load_task_set()
+        tasks1.append(EvalTask(id="fake", prompt="x"))
+        tasks2 = load_task_set()
+        self.assertEqual(len(tasks2), 8)
+
+    def test_task_count_default(self):
+        self.assertEqual(task_count(), 8)
+
+    def test_task_count_v1(self):
+        self.assertEqual(task_count("1.0"), 8)
+
+
+class TestV1Requirements(unittest.TestCase):
+    """v1.0 task set meets the issue requirements: 5-10 tasks, ≥3 categories."""
+
+    def setUp(self):
+        self.tasks = load_task_set("1.0")
+
+    def test_task_count_in_range(self):
+        """Issue requires 5-10 tasks."""
+        self.assertGreaterEqual(len(self.tasks), 5)
+        self.assertLessEqual(len(self.tasks), 10)
+
+    def test_at_least_3_categories(self):
+        """Issue requires ≥3 tool categories."""
+        cats = categories("1.0")
+        self.assertGreaterEqual(len(cats), 3)
+
+    def test_categories_are_expected(self):
+        cats = set(categories("1.0"))
+        self.assertIn("code", cats)
+        self.assertIn("search", cats)
+        self.assertIn("file_ops", cats)
+        self.assertIn("reasoning", cats)
+
+    def test_difficulties_present(self):
+        diffs = set(difficulties("1.0"))
+        self.assertIn("easy", diffs)
+        self.assertIn("medium", diffs)
+
+    def test_all_tasks_have_unique_ids(self):
+        ids = [t.id for t in self.tasks]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_all_tasks_have_prompts(self):
+        for t in self.tasks:
+            self.assertTrue(t.prompt, f"Empty prompt for {t.id}")
+
+    def test_all_tasks_version_1_0(self):
+        for t in self.tasks:
+            self.assertEqual(t.version, "1.0")
+
+    def test_code_tasks_expect_tools(self):
+        for t in self.tasks:
+            if t.category == "code":
+                self.assertTrue(t.expected_tools, f"Code task {t.id} has no expected tools")
+
+    def test_reasoning_tasks_no_tools(self):
+        for t in self.tasks:
+            if t.category == "reasoning":
+                self.assertEqual(t.expected_tools, [],
+                                 f"Reasoning task {t.id} unexpectedly expects tools")
+
+
+class TestVersioningFunctions(unittest.TestCase):
+    """list_versions(), latest_version() — versioning helpers."""
+
+    def test_list_versions(self):
+        versions = list_versions()
+        self.assertIn("1.0", versions)
+        self.assertEqual(versions, sorted(versions))
+
+    def test_latest_version(self):
+        self.assertEqual(latest_version(), "1.0")
+
+    def test_latest_version_in_list(self):
+        self.assertIn(latest_version(), list_versions())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Step 1 of the eval harness (issue #1514, parent #1481).

### Changes
- **`EvalTask` dataclass** — frozen, with fields: `id`, `prompt`, `expected_tools`, `expected_result_pattern` (optional regex), `category`, `difficulty`, `version`, `notes`
- **v1.0 task set** — 8 tasks across 4 categories: `code` (2), `search` (2), `file_ops` (2), `reasoning` (2)
- **Versioning** — `_TASK_SETS` registry, `list_versions()`, `latest_version()`
- **`load_task_set(version)`** — loader returning tasks for a version (defaults to latest); raises `ValueError` for unknown versions
- **Helper functions** — `task_count()`, `categories()`, `difficulties()`

### Design
- Pure data layer — no network, no execution. The runner (Step 2, #1515) and null-agent baseline + scoring (Steps 3-4, #1516) are separate issues.
- `EvalTask` is frozen (immutable) for safe sharing across test runs.
- `compiled_pattern()` returns case-insensitive compiled regex or `None`.
- `load_task_set()` returns a copy of the list so callers can't mutate the registry.

### Test plan
- [x] 24 unit tests (`tests/scripts/test_eval_tasks.py`) — all pass
- [x] Tests cover: schema fields/defaults, `compiled_pattern()`, versioning, loader, v1.0 requirements (5-10 tasks, ≥3 categories, unique IDs, version consistency)
- [x] No external dependencies — import-safe and fast

### Requirements met (from issue #1514)
- ✅ EvalTask schema with id, prompt, expected_tools, expected_result_pattern, category, difficulty
- ✅ 5-10 tasks (8 tasks)
- ✅ ≥3 tool categories (4 categories: code, search, file_ops, reasoning)
- ✅ Versioning (v1.0, extensible registry)
- ✅ `load_task_set()` loader

Closes #1514