### PR TITLE
feat: disambiguate read_file/read_file_raw error classes (Closes #1488)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1001,3 +1001,137 @@ class TestPatchReplaceReadFailureClassification:
         assert "permission" in result.error.lower()
         # Distinct from the old generic "Failed to read file".
         assert "failed to read file" != result.error.strip().lower()
+
+
+# =========================================================================
+# #1488 — read_file / read_file_raw error disambiguation
+# =========================================================================
+# Before #1488, read_file and read_file_raw used ``wc -c < path 2>/dev/null``
+# with stderr suppressed, then routed ALL non-zero exits to
+# _suggest_similar_files — which returns a "File not found" error regardless
+# of the actual cause. This meant permission-denied and directory errors were
+# misclassified as not_found, causing the agent to blind-retry instead of
+# fixing permissions or choosing a different tool. 102 failures/7d (42
+# permission-denied + 60 "other") traced to this single root cause.
+# The fix routes the failure through _diagnose_read_failure (already used by
+# patch_replace since #1326), which probes with test -e / test -d to
+# disambiguate not-found / directory / permission-denied.
+
+
+class TestReadFileErrorDisambiguation:
+    """read_file and read_file_raw must distinguish not-found, directory,
+    and permission-denied failures instead of collapsing all to 'not found'."""
+
+    def test_read_file_permission_denied_classifies_as_permission(self, mock_env):
+        """A file that exists but is unreadable must surface 'permission'
+        so classify_file_error routes to the permission recovery, not
+        not_found."""
+        target = "/tmp/locked_1488.txt"
+
+        def side_effect(command, **kwargs):
+            # wc -c fails (permission denied), stderr suppressed.
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            # _diagnose_read_failure: test -e → yes (file exists).
+            if command.startswith("test -e "):
+                return {"output": "yes\n", "returncode": 0}
+            # test -d → no (not a directory).
+            if command.startswith("test -d "):
+                return {"output": "no\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file(target)
+        assert result.error is not None
+        assert "permission" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] == "permission"
+
+    def test_read_file_directory_classifies_distinctly(self, mock_env):
+        """Reading a directory must report 'directory', not 'not found'."""
+        target = "/tmp/some_dir_1488"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            if command.startswith("test -e "):
+                return {"output": "yes\n", "returncode": 0}
+            if command.startswith("test -d "):
+                return {"output": "yes\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file(target)
+        assert result.error is not None
+        assert "directory" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] != "not_found"
+
+    def test_read_file_not_found_still_suggests(self, mock_env):
+        """A genuinely missing file must still get the not_found class with
+        similar-file suggestions — the old behavior is preserved for the
+        actual not-found case."""
+        target = "/tmp/missing_1488.py"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            # _diagnose_read_failure: test -e → no (file absent).
+            if command.startswith("test -e "):
+                return {"output": "no\n", "returncode": 0}
+            # _suggest_similar_files: ls -1 of parent dir — empty.
+            if command.startswith("ls -1 "):
+                return {"output": "", "returncode": 1}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file(target)
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] == "not_found"
+
+    def test_read_file_raw_permission_denied_classifies_as_permission(self, mock_env):
+        """read_file_raw must also disambiguate permission-denied."""
+        target = "/tmp/locked_raw_1488.txt"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            if command.startswith("test -e "):
+                return {"output": "yes\n", "returncode": 0}
+            if command.startswith("test -d "):
+                return {"output": "no\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file_raw(target)
+        assert result.error is not None
+        assert "permission" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] == "permission"
+
+    def test_read_file_raw_directory_classifies_distinctly(self, mock_env):
+        """read_file_raw on a directory must report 'directory', not 'not found'."""
+        target = "/tmp/raw_dir_1488"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            if command.startswith("test -e "):
+                return {"output": "yes\n", "returncode": 0}
+            if command.startswith("test -d "):
+                return {"output": "yes\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file_raw(target)
+        assert result.error is not None
+        assert "directory" in result.error.lower()
+        d = result.to_dict()
+        assert d["error_class"] != "not_found"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1220,8 +1220,12 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(stat_cmd)
 
         if stat_result.exit_code != 0:
-            # File not found - try to suggest similar files
-            return self._suggest_similar_files(path)
+            # #1488 — wc -c with stderr suppressed can't tell us WHY the
+            # read failed (missing file, directory, permission denied).
+            # _diagnose_read_failure probes with test -e / test -d to
+            # disambiguate, producing a classify_file_error-friendly message
+            # so the agent picks the right recovery instead of blind-retrying.
+            return ReadResult(error=self._diagnose_read_failure(path, operation="read"))
 
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
@@ -1418,7 +1422,11 @@ class ShellFileOperations(FileOperations):
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:
-            return self._suggest_similar_files(path)
+            # #1488 — same disambiguation as read_file: wc -c with stderr
+            # suppressed can't distinguish missing / directory / permission
+            # denied. Probe the real cause so classify_file_error routes
+            # the agent to the right recovery.
+            return ReadResult(error=self._diagnose_read_failure(path, operation="read"))
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
             file_size = int(stat_output.strip())
@@ -1736,20 +1744,23 @@ class ShellFileOperations(FileOperations):
     # PATCH Implementation (Replace Mode)
     # =========================================================================
 
-    def _diagnose_read_failure(self, path: str) -> str:
-        """Build a distinct, classifiable error for a patch read failure.
+    def _diagnose_read_failure(self, path: str, operation: str = "patch") -> str:
+        """Build a distinct, classifiable error for a failed file read.
 
-        ``patch_replace`` reads the target via ``cat <path> 2>/dev/null``,
-        which discards *why* the read failed. Before #1326, every miss
-        (missing file, directory, permission error) collapsed to the same
-        generic ``"Failed to read file: {path}"`` string. That classifies
-        as ``read_error`` (never ``not_found``), so the agent never
-        learned that ``write_file`` — not ``patch`` — is the right tool
-        to create a missing file. File-not-found was the dominant
-        patch-failure class (68% of patch errors). This probe runs ONLY
-        after a failed read (happy path unchanged) and produces a
-        ``classify_file_error``-friendly message carrying a create-on-miss
-        hint when the file is absent.
+        Both ``patch_replace`` and ``read_file`` / ``read_file_raw`` probe
+        the target via shell redirects (``cat`` / ``wc -c``) with stderr
+        suppressed, which discards *why* the read failed. Before #1326 /
+        #1488, every miss (missing file, directory, permission error)
+        collapsed to the same generic string. That classifies as
+        ``read_error`` (never ``not_found`` or ``permission``), so the
+        agent never learned the right recovery — it kept blind-retrying.
+        This probe runs ONLY after a failed read (happy path unchanged)
+        and produces a ``classify_file_error``-friendly message carrying
+        a create-on-miss hint when the file is absent.
+
+        ``operation`` ("patch" or "read") controls the wording of the
+        directory / permission messages so they stay actionable for the
+        caller that triggered the probe.
         """
         esc = self._escape_shell_arg(path)
         # Does the path exist at all?  ``-e`` follows symlinks; combined
@@ -1762,14 +1773,14 @@ class ShellFileOperations(FileOperations):
             # and tells the agent how to recover.
             suggest = self._suggest_similar_files(path).error
             return suggest or f"File not found: {path}"
-        # Path exists but cat failed — is it a directory?
+        # Path exists but the read failed — is it a directory?
         is_dir = self._exec(f"test -d {esc} && echo yes || echo no")
         if (is_dir.stdout or "").strip() == "yes":
-            return f"Cannot patch a directory: {path} is a directory, not a file."
+            return f"Cannot {operation} a directory: {path} is a directory, not a file."
         # Exists and is a regular file — most likely a permission error.
         return (
             f"Permission denied reading file: {path}. Check read permissions "
-            f"before retrying — do not repeat the same patch blindly."
+            f"before retrying — do not repeat the same {operation} blindly."
         )
 
     def patch_replace(


### PR DESCRIPTION
## Summary

Both `read_file` and `read_file_raw` used `wc -c < path 2>/dev/null` with stderr suppressed, then routed ALL non-zero exits to `_suggest_similar_files` — which returns a "File not found" error regardless of the actual cause. This meant permission-denied and directory errors were misclassified as `not_found`, causing the agent to blind-retry instead of fixing permissions or choosing a different tool.

**102 failures/7d** (42 permission-denied + 60 "other") traced to this single root cause. 223 sessions affected, max 20 consecutive retries.

## Fix

Route the failure through `_diagnose_read_failure` (already used by `patch_replace` since #1326), which probes with `test -e` / `test -d` to disambiguate:
- **Not found** → `_suggest_similar_files` (preserves old behavior for genuine misses)
- **Directory** → "Cannot read a directory: ..." (classifies distinctly from `not_found`)
- **Permission denied** → "Permission denied reading file: ..." (classifies as `permission`)

The method is generalized with an `operation` parameter (default "patch") so directory/permission messages are actionable for both patch and read callers.

## Files changed
- `tools/file_operations.py` — `read_file` and `read_file_raw` failure path + `_diagnose_read_failure` generalization
- `tests/tools/test_file_operations.py` — 5 new tests in `TestReadFileErrorDisambiguation`

## Verification
- `ruff check` ✓
- `pytest tests/tools/test_file_operations.py` — 102 passed ✓
- `pytest tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_read_guards.py tests/tools/test_read_file_failure_rate.py` — 89 passed ✓
- Diff: 165 insertions + 20 deletions = 185 lines (within 200-line self-merge cap)

Closes #1488