### PR TITLE
feat: add quota_exhausted failure category for sub-tool paid backends (Closes #1489)

### DIFF
--- a/tests/tools/test_recovery_strategy_dispatcher.py
+++ b/tests/tools/test_recovery_strategy_dispatcher.py
@@ -46,16 +46,27 @@ def _classification(
         (ToolFailureCategory.tool_unavailable, False, RecoveryStrategy.switch_tool),
         (ToolFailureCategory.invalid_arguments, False, RecoveryStrategy.fix_arguments),
         (ToolFailureCategory.not_found, False, RecoveryStrategy.verify_target),
-        (ToolFailureCategory.permission_denied, False, RecoveryStrategy.surface_blocker),
+        (
+            ToolFailureCategory.permission_denied,
+            False,
+            RecoveryStrategy.surface_blocker,
+        ),
         (ToolFailureCategory.rate_limited, True, RecoveryStrategy.retry_with_backoff),
-        (ToolFailureCategory.transient_network, True, RecoveryStrategy.retry_with_backoff),
+        (ToolFailureCategory.quota_exhausted, False, RecoveryStrategy.surface_blocker),
+        (
+            ToolFailureCategory.transient_network,
+            True,
+            RecoveryStrategy.retry_with_backoff,
+        ),
         (ToolFailureCategory.timeout, True, RecoveryStrategy.retry_with_backoff),
         (ToolFailureCategory.unexpected_output, True, RecoveryStrategy.retry),
         (ToolFailureCategory.persistent_error, False, RecoveryStrategy.switch_tool),
         (ToolFailureCategory.unknown, False, RecoveryStrategy.surface_blocker),
     ],
 )
-def test_dispatch_maps_every_category_to_expected_strategy(category, should_retry, expected):
+def test_dispatch_maps_every_category_to_expected_strategy(
+    category, should_retry, expected
+):
     action = dispatch_recovery(_classification(category, should_retry=should_retry))
     assert action.strategy is expected
     assert action.category is category
@@ -94,7 +105,9 @@ def test_retry_with_backoff_action_carries_backoff_seconds():
 
 
 def test_non_backoff_action_has_no_backoff():
-    action = dispatch_recovery(_classification(ToolFailureCategory.invalid_arguments, should_retry=False))
+    action = dispatch_recovery(
+        _classification(ToolFailureCategory.invalid_arguments, should_retry=False)
+    )
     assert action.backoff_seconds is None
 
 
@@ -149,18 +162,35 @@ def test_recover_from_failure_matches_direct_classification():
     assert action.category is classification.category
 
 
+def test_recover_from_failure_quota_exhausted_surfaces_blocker():
+    """Quota exhaustion classifies + dispatches to surface_blocker (issue #1489).
+
+    The agent must stop retrying and surface the quota state, not retry with
+    backoff as it would for a transient rate limit.
+    """
+    action = recover_from_failure("vision_analyze", "quota exceeded for this API key")
+    assert action.category is ToolFailureCategory.quota_exhausted
+    assert action.strategy is RecoveryStrategy.surface_blocker
+    assert action.should_retry is False
+    assert action.backoff_seconds is None
+
+
 # --- runtime seam (maybe_append_recovery_guidance) -----------------------------
 
 
 def test_seam_disabled_returns_result_unchanged():
     result = '{"error": "boom"}'
-    out = maybe_append_recovery_guidance(result, "web_search", failed=True, enabled=False)
+    out = maybe_append_recovery_guidance(
+        result, "web_search", failed=True, enabled=False
+    )
     assert out == result
 
 
 def test_seam_not_failed_returns_result_unchanged():
     result = '{"ok": true}'
-    out = maybe_append_recovery_guidance(result, "web_search", failed=False, enabled=True)
+    out = maybe_append_recovery_guidance(
+        result, "web_search", failed=False, enabled=True
+    )
     assert out == result
 
 
@@ -180,7 +210,9 @@ def test_seam_extracts_terminal_exit_code_from_json_result():
 
 
 def test_seam_never_raises_on_garbage_result():
-    out = maybe_append_recovery_guidance("\x00 not json", "terminal", failed=True, enabled=True)
+    out = maybe_append_recovery_guidance(
+        "\x00 not json", "terminal", failed=True, enabled=True
+    )
     # degrades gracefully: either unchanged or with guidance, but never raises
     assert out.startswith("\x00 not json")
 
@@ -194,10 +226,14 @@ def test_seam_none_result_is_handled():
 
 
 def test_register_strategy_overrides_category_mapping():
-    original = dispatch_recovery(_classification(ToolFailureCategory.unknown, should_retry=False)).strategy
+    original = dispatch_recovery(
+        _classification(ToolFailureCategory.unknown, should_retry=False)
+    ).strategy
     try:
         register_strategy(ToolFailureCategory.unknown, RecoveryStrategy.switch_tool)
-        action = dispatch_recovery(_classification(ToolFailureCategory.unknown, should_retry=False))
+        action = dispatch_recovery(
+            _classification(ToolFailureCategory.unknown, should_retry=False)
+        )
         assert action.strategy is RecoveryStrategy.switch_tool
     finally:
         register_strategy(ToolFailureCategory.unknown, original)

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -123,7 +123,6 @@ class TestRateLimited:
         [
             "rate limit exceeded, retry after 30s",
             "429 Too Many Requests",
-            "quota exceeded for this API key",
         ],
     )
     def test_rate_limit_errors(self, error):
@@ -131,6 +130,40 @@ class TestRateLimited:
         assert result.category == tfc.ToolFailureCategory.rate_limited
         # Rate limits clear over time — a backoff retry can succeed.
         assert result.should_retry is True
+
+
+class TestQuotaExhausted:
+    """Quota/billing exhaustion is non-retriable (issue #1489).
+
+    Unlike ``rate_limited`` (which clears over time), quota exhaustion means
+    the account is out of credits or has hit its billing plan cap. Retrying
+    cannot succeed until quota resets or billing is resolved.
+    """
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "quota exceeded for this API key",
+            "billing limit exceeded — upgrade your plan",
+            "insufficient credits for this request",
+            "out of quota for vision API",
+            "no credits remaining for this account",
+            "usage limit exceeded for current period",
+            "402 Payment Required",
+            "payment required to continue using this service",
+            "billing exhausted for this API key",
+        ],
+    )
+    def test_quota_exhausted_errors(self, error):
+        result = tfc.classify_tool_failure("vision_analyze", error)
+        assert result.category == tfc.ToolFailureCategory.quota_exhausted
+        assert result.should_retry is False
+
+    def test_quota_exceeded_takes_priority_over_rate_limited(self):
+        """'quota exceeded' must classify as quota_exhausted, not rate_limited."""
+        result = tfc.classify_tool_failure("search_files", "quota exceeded")
+        assert result.category == tfc.ToolFailureCategory.quota_exhausted
+        assert result.should_retry is False
 
 
 class TestTransientNetwork:

--- a/tools/recovery_strategy_dispatcher.py
+++ b/tools/recovery_strategy_dispatcher.py
@@ -83,6 +83,7 @@ _CATEGORY_STRATEGY: dict[ToolFailureCategory, RecoveryStrategy] = {
     ToolFailureCategory.not_found: RecoveryStrategy.verify_target,
     ToolFailureCategory.permission_denied: RecoveryStrategy.surface_blocker,
     ToolFailureCategory.rate_limited: RecoveryStrategy.retry_with_backoff,
+    ToolFailureCategory.quota_exhausted: RecoveryStrategy.surface_blocker,
     ToolFailureCategory.transient_network: RecoveryStrategy.retry_with_backoff,
     ToolFailureCategory.timeout: RecoveryStrategy.retry_with_backoff,
     ToolFailureCategory.unexpected_output: RecoveryStrategy.retry,
@@ -164,7 +165,7 @@ def backoff_seconds_for(consecutive_count: int) -> float:
     behavior is testable and reproducible.
     """
     exponent = max(0, int(consecutive_count))
-    delay = _BASE_BACKOFF_SECONDS * (2 ** exponent)
+    delay = _BASE_BACKOFF_SECONDS * (2**exponent)
     return float(min(delay, _MAX_BACKOFF_SECONDS))
 
 
@@ -197,7 +198,9 @@ def dispatch_recovery(
     if should_retry and strategy is RecoveryStrategy.retry_with_backoff:
         backoff = backoff_seconds_for(consecutive_count)
 
-    directive = _STRATEGY_DIRECTIVE.get(strategy, _STRATEGY_DIRECTIVE[RecoveryStrategy.surface_blocker])
+    directive = _STRATEGY_DIRECTIVE.get(
+        strategy, _STRATEGY_DIRECTIVE[RecoveryStrategy.surface_blocker]
+    )
     return RecoveryAction(
         category=category,
         strategy=strategy,

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -52,6 +52,12 @@ class ToolFailureCategory(str, Enum):
     not_found = "not_found"
     permission_denied = "permission_denied"
     rate_limited = "rate_limited"
+    # Quota/billing exhaustion on a sub-tool's paid backend (vision model,
+    # search API, etc.). Unlike ``rate_limited`` (which clears over time),
+    # quota exhaustion does NOT clear on retry — the account is out of credits
+    # or the billing plan's limit is reached. The agent must stop retrying and
+    # surface the quota state to the user (issue #1489).
+    quota_exhausted = "quota_exhausted"
     # Covers transient network failures AND local transient resource contention
     # (file/index locks, "device or resource busy"). The recovery dispatcher
     # (#1027) must not assume this always implies remote connectivity.
@@ -133,6 +139,7 @@ _CATEGORY_RETRYABLE: dict[ToolFailureCategory, bool] = {
     ToolFailureCategory.not_found: False,
     ToolFailureCategory.permission_denied: False,
     ToolFailureCategory.rate_limited: True,
+    ToolFailureCategory.quota_exhausted: False,
     ToolFailureCategory.transient_network: True,
     ToolFailureCategory.timeout: True,
     ToolFailureCategory.unexpected_output: True,
@@ -162,6 +169,12 @@ _CATEGORY_HINTS: dict[ToolFailureCategory, str] = {
     ToolFailureCategory.rate_limited: (
         "A rate limit or quota was hit. Back off and retry after a delay, or "
         "reduce request frequency."
+    ),
+    ToolFailureCategory.quota_exhausted: (
+        "The paid backend's quota or billing limit is exhausted — the account "
+        "is out of credits or has hit its plan cap. Retrying will not succeed "
+        "until quota resets or billing is resolved. Stop retrying and surface "
+        "the quota state to the user."
     ),
     ToolFailureCategory.transient_network: (
         "A transient network/resource issue occurred. A retry with backoff may "
@@ -212,15 +225,41 @@ def _rule(
 _BUILTIN_RULES: list[_Rule] = [
     # Argument-shaped "X not found" (missing required field / edit's old_string)
     # before the generic not_found rule.
-    _rule(r"(?:required|argument|parameter)\b.*\bnot found", ToolFailureCategory.invalid_arguments),
+    _rule(
+        r"(?:required|argument|parameter)\b.*\bnot found",
+        ToolFailureCategory.invalid_arguments,
+    ),
     _rule(r"old_(?:string|text)\b.*not found", ToolFailureCategory.invalid_arguments),
-    # Rate limits / quota.
+    # Quota / billing exhaustion — non-retriable (issue #1489).
+    # These MUST precede the generic rate_limited rules so a hard quota cap
+    # is not mistaken for a retriable throttle. The signal comes from sub-tool
+    # paid backends (vision models, search APIs, etc.) where the account is
+    # out of credits or has hit its billing plan limit.
+    _rule(r"quota exceeded", ToolFailureCategory.quota_exhausted),
+    _rule(
+        r"billing.*(?:exhausted|limit|exceeded|disabled|failed)",
+        ToolFailureCategory.quota_exhausted,
+    ),
+    _rule(
+        r"(?:insufficient|out of)\s+(?:credit|quota|balance)",
+        ToolFailureCategory.quota_exhausted,
+    ),
+    _rule(
+        r"no\s+credits?\s+(?:remaining|left|available)",
+        ToolFailureCategory.quota_exhausted,
+    ),
+    _rule(r"usage limit (?:exceeded|reached)", ToolFailureCategory.quota_exhausted),
+    _rule(r"\b402\b", ToolFailureCategory.quota_exhausted),
+    _rule(r"payment required", ToolFailureCategory.quota_exhausted),
+    # Rate limits / quota — retriable (clears over time).
     _rule(r"rate[ _-]?limit", ToolFailureCategory.rate_limited),
     _rule(r"\b429\b", ToolFailureCategory.rate_limited),
     _rule(r"too many requests", ToolFailureCategory.rate_limited),
-    _rule(r"quota exceeded", ToolFailureCategory.rate_limited),
     # Permission / authorization.
-    _rule(r"must be (?:logged in|authenticated|authori[sz]ed)", ToolFailureCategory.permission_denied),
+    _rule(
+        r"must be (?:logged in|authenticated|authori[sz]ed)",
+        ToolFailureCategory.permission_denied,
+    ),
     _rule(r"permission denied", ToolFailureCategory.permission_denied),
     _rule(r"operation not permitted", ToolFailureCategory.permission_denied),
     _rule(r"access denied", ToolFailureCategory.permission_denied),
@@ -247,7 +286,10 @@ _BUILTIN_RULES: list[_Rule] = [
     # before the generic not_found rule). "<component> not available" is scoped
     # to dependency-shaped nouns so missing *data* falls through to not_found.
     _rule(r"command not found", ToolFailureCategory.tool_unavailable),
-    _rule(r"not recognized as an internal or external command", ToolFailureCategory.tool_unavailable),
+    _rule(
+        r"not recognized as an internal or external command",
+        ToolFailureCategory.tool_unavailable,
+    ),
     _rule(r"unknown command", ToolFailureCategory.tool_unavailable),
     _rule(r"not connected", ToolFailureCategory.tool_unavailable),
     _rule(r"not installed", ToolFailureCategory.tool_unavailable),
@@ -284,7 +326,10 @@ _BUILTIN_RULES: list[_Rule] = [
     _rule(r"unknown mode", ToolFailureCategory.invalid_arguments),
     _rule(r"provide either", ToolFailureCategory.invalid_arguments),
     _rule(r"(?:is )?missing a\b", ToolFailureCategory.invalid_arguments),
-    _rule(r"invalid (?:argument|parameter|mode|value)", ToolFailureCategory.invalid_arguments),
+    _rule(
+        r"invalid (?:argument|parameter|mode|value)",
+        ToolFailureCategory.invalid_arguments,
+    ),
 ]
 
 # Runtime-registered rules take priority over the built-ins.


### PR DESCRIPTION
## Summary

Add a distinct non-retriable `quota_exhausted` category to the cross-tool failure classifier, separating hard quota/billing exhaustion from retriable rate limits.

## Problem (issue #1489)

Quota/billing exhaustion from sub-tool paid backends (vision_analyze, search_files, tool_call, terminal) surfaced as generic tool failures indistinguishable from a tool bug. The agent then retried the failing tool instead of recognizing "quota exhausted — switch approach." The existing `rate_limited` category was `should_retry=True`, so "quota exceeded" errors triggered retry spirals on tools that could never succeed until quota resets.

## Changes

**`tools/tool_failure_classifier.py`** (core):
- Add `ToolFailureCategory.quota_exhausted` — non-retriable, distinct from `rate_limited`
- Add 7 billing-specific regex patterns BEFORE the generic rate_limited rules (first match wins):
  - `quota exceeded`, `billing.*exhausted|limit|exceeded|disabled|failed`, `insufficient/out of credit|quota|balance`, `no credits remaining|left|available`, `usage limit exceeded|reached`, `402`, `payment required`
- Set `_CATEGORY_RETRYABLE[quota_exhausted] = False`
- Add actionable hint: "Stop retrying and surface the quota state to the user"

**`tools/recovery_strategy_dispatcher.py`** (recovery):
- Map `quota_exhausted` → `RecoveryStrategy.surface_blocker` (stop retrying, report the blocker)

**Tests** (both files):
- `TestQuotaExhausted` — 9 parametrized billing error patterns + priority test
- `test_recover_from_failure_quota_exhausted_surfaces_blocker` — end-to-end classify+dispatch
- Updated `TestRateLimited` — removed "quota exceeded" from rate_limited test cases (now classified as quota_exhausted)
- Updated dispatcher parametrized test — added `quota_exhausted` → `surface_blocker` row

## Verification
- `ruff check` ✓
- `ruff format --check` ✓
- `pytest tests/tools/test_tool_failure_classifier.py tests/tools/test_recovery_strategy_dispatcher.py` — 101 passed

## Diff size
4 files changed, 135 insertions(+), 18 deletions(-) — within the 200-line self-merge cap.

Closes #1489