### PR TITLE
feat: extend tool_arg_contract with type checking (Closes #1529)

### DIFF
--- a/agent/tool_arg_contract.py
+++ b/agent/tool_arg_contract.py
@@ -26,11 +26,12 @@ Design mirrors :mod:`agent.verify_policy` / :mod:`agent.policy_interceptors`
 intentionally: frozen dataclasses, a pure check function, opt-in via an
 env var / config flag (default **OFF** — see :func:`tool_arg_contract_enabled`),
 fail-open whenever the tool has no schema or the schema is malformed. Only
-``required`` presence and ``enum`` membership are checked; this is
-deliberately narrower than full JSON Schema validation (no type/format/
-min-max/pattern checks) — type mismatches are already handled by coercion
-in ``model_tools.coerce_tool_args``, which runs earlier in the same
-composition boundary and is intentionally forgiving rather than rejecting.
+Only ``required`` presence, ``enum`` membership, and basic ``type``
+matching are checked; this is deliberately narrower than full JSON Schema
+validation (no format/min-max/pattern checks) — more exotic constraints
+are already handled by coercion in ``model_tools.coerce_tool_args``, which
+runs earlier in the same composition boundary and is intentionally
+forgiving rather than rejecting.
 """
 
 from __future__ import annotations
@@ -44,7 +45,7 @@ from typing import Any, Mapping, Optional, Tuple
 class ArgContractViolation:
     """One concrete way a tool call's arguments failed to satisfy the schema."""
 
-    kind: str  # "missing_required" | "invalid_enum"
+    kind: str  # "missing_required" | "invalid_enum" | "type_mismatch"
     param: str
     detail: str
 
@@ -65,6 +66,17 @@ class ArgContractViolation:
             kind="invalid_enum",
             param=param,
             detail=f"'{param}'={value!r} is not one of the allowed values: {allowed_repr}",
+        )
+
+    @classmethod
+    def type_mismatch(
+        cls, param: str, value: Any, expected: str
+    ) -> "ArgContractViolation":
+        got = type(value).__name__
+        return cls(
+            kind="type_mismatch",
+            param=param,
+            detail=(f"'{param}' has wrong type: expected {expected}, got {got}"),
         )
 
 
@@ -114,6 +126,40 @@ def _allows_null(schema: Any) -> bool:
     return False
 
 
+# JSON Schema ``type`` strings → acceptable Python types. Mirrors
+# ``tools.tool_search._SCHEMA_PY_TYPES`` (kept local so this module stays
+# dependency-free, same rationale as ``_allows_null`` above). ``number``
+# accepts int too because JSON integers deserialise to ``int`` in Python
+# but are valid numbers. ``integer`` explicitly excludes ``bool`` even
+# though ``bool`` subclasses ``int`` — passing ``true`` for an integer
+# field is a type mismatch, not a creative shortcut.
+_SCHEMA_PY_TYPES: dict[str, tuple[type, ...]] = {
+    "string": (str,),
+    "integer": (int,),  # _check_type strips bool before this lookup
+    "number": (int, float),
+    "boolean": (bool,),
+    "array": (list, tuple),
+    "object": (dict,),
+}
+
+
+def _check_type(value: Any, type_str: str) -> bool:
+    """Check whether *value* matches the JSON Schema *type_str*.
+
+    Returns ``True`` for unknown types (fail-open — don't block dispatch
+    on a type this checker doesn't recognise). For ``integer``, ``bool``
+    is explicitly rejected even though it subclasses ``int``.
+    """
+    if type_str == "null":
+        return value is None
+    if type_str == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    py_types = _SCHEMA_PY_TYPES.get(type_str)
+    if py_types is None:
+        return True  # unknown type — don't block dispatch
+    return isinstance(value, py_types)
+
+
 def check_tool_args_contract(
     tool_name: str,
     args: Mapping[str, Any],
@@ -157,13 +203,25 @@ def check_tool_args_contract(
         if not isinstance(prop_schema, Mapping):
             continue
         allowed = prop_schema.get("enum")
-        if not isinstance(allowed, (list, tuple)) or not allowed:
-            continue
-        value = args.get(param)
-        if value not in allowed:
-            violations.append(
-                ArgContractViolation.invalid_enum(param, value, tuple(allowed))
-            )
+        if isinstance(allowed, (list, tuple)) and allowed:
+            value = args.get(param)
+            if value not in allowed:
+                violations.append(
+                    ArgContractViolation.invalid_enum(param, value, tuple(allowed))
+                )
+        # Type checking (issue #1529): validate the value's Python type
+        # against the schema's ``type`` declaration. Fail-open when no
+        # ``type`` is declared. A ``type`` may be a string or a list of
+        # strings (union types) — accept if *any* member type matches.
+        schema_type = prop_schema.get("type")
+        if schema_type:
+            types = [schema_type] if isinstance(schema_type, str) else schema_type
+            value = args.get(param)
+            if not any(_check_type(value, t) for t in types):
+                want = " or ".join(types)
+                violations.append(
+                    ArgContractViolation.type_mismatch(param, value, want)
+                )
 
     return ArgContractOutcome(tool_name=tool_name, violations=tuple(violations))
 

--- a/tests/agent/test_tool_arg_contract.py
+++ b/tests/agent/test_tool_arg_contract.py
@@ -217,6 +217,136 @@ def test_missing_required_and_invalid_enum_both_reported():
     assert kinds == {"missing_required", "invalid_enum"}
 
 
+# ── type enforcement (issue #1529) ──────────────────────────────────────────
+
+
+TYPE_SCHEMA = {
+    "name": "demo",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "count": {"type": "integer"},
+            "rate": {"type": "number"},
+            "enabled": {"type": "boolean"},
+            "items": {"type": "array"},
+            "meta": {"type": "object"},
+            "mixed": {"type": ["string", "null"]},
+        },
+        "required": ["path"],
+    },
+}
+
+
+def test_type_correct_values_ok():
+    outcome = check_tool_args_contract(
+        "demo",
+        {
+            "path": "a.txt",
+            "count": 3,
+            "rate": 1.5,
+            "enabled": True,
+            "items": [1, 2],
+            "meta": {"k": "v"},
+        },
+        TYPE_SCHEMA,
+    )
+    assert outcome.ok is True
+
+
+def test_type_string_for_integer_is_mismatch():
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", "count": "five"}, TYPE_SCHEMA
+    )
+    assert outcome.ok is False
+    v = outcome.violations[0]
+    assert v.kind == "type_mismatch"
+    assert v.param == "count"
+
+
+def test_type_bool_for_integer_is_mismatch():
+    """bool subclasses int but must be rejected for integer fields."""
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", "count": True}, TYPE_SCHEMA
+    )
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "type_mismatch"
+
+
+@pytest.mark.parametrize("param,value", [
+    ("path", 42),         # int for string
+    ("meta", [1, 2]),     # array for object
+    ("items", "x"),       # string for array
+    ("enabled", "yes"),   # string for boolean
+])
+def test_type_mismatches(param, value):
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", param: value}, TYPE_SCHEMA
+    )
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "type_mismatch"
+
+
+def test_type_union_accepts_matching_member():
+    """type: ['string','null'] accepts a string."""
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", "mixed": "hello"}, TYPE_SCHEMA
+    )
+    assert outcome.ok is True
+
+
+def test_type_union_rejects_non_member():
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", "mixed": 42}, TYPE_SCHEMA
+    )
+    assert outcome.ok is False
+    assert outcome.violations[0].kind == "type_mismatch"
+    assert outcome.violations[0].param == "mixed"
+
+
+def test_type_none_optional_is_ok():
+    """An optional field set to None should skip type checking."""
+    outcome = check_tool_args_contract(
+        "demo", {"path": "a.txt", "count": None}, TYPE_SCHEMA
+    )
+    assert outcome.ok is True
+
+
+def test_type_no_type_declared_is_ok():
+    """A property with no 'type' key is fail-open (no type check)."""
+    schema = {
+        "parameters": {
+            "properties": {"blob": {"description": "no type"}},
+            "required": ["blob"],
+        }
+    }
+    outcome = check_tool_args_contract("demo", {"blob": 12345}, schema)
+    assert outcome.ok is True
+
+
+def test_type_mismatch_violation_shape():
+    v = ArgContractViolation.type_mismatch("count", "five", "integer")
+    assert v.kind == "type_mismatch"
+    assert v.param == "count"
+    assert "integer" in v.detail
+    assert "str" in v.detail
+
+
+def test_type_mismatch_and_enum_both_reported():
+    """A field with both enum + type violations reports both."""
+    schema = {
+        "parameters": {
+            "properties": {
+                "mode": {"type": "string", "enum": ["a", "b"]},
+            },
+            "required": [],
+        }
+    }
+    outcome = check_tool_args_contract("demo", {"mode": 42}, schema)
+    kinds = {v.kind for v in outcome.violations}
+    assert kinds == {"type_mismatch", "invalid_enum"}
+
+
 # ── enable gate (opt-in, default OFF) ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Extends `check_tool_args_contract()` to validate basic JSON Schema types (string, integer, number, boolean, array, object, null) in addition to the existing `required` + `enum` checks.

## Changes
- **`agent/tool_arg_contract.py`**: Added `_SCHEMA_PY_TYPES` mapping, `_check_type()` helper, and `ArgContractViolation.type_mismatch` classmethod. Type validation runs alongside enum checks in the existing property loop. Fail-open when no `type` declared. `null` type matches only `None`. `integer` explicitly excludes `bool`.
- **`tests/agent/test_tool_arg_contract.py`**: 13 new test cases covering type matches, mismatches, union types, fail-open cases, and combined type+enum violations.

## Context
- Parent issue: #1487 (systemic parse-error — 484 events/7d across 8 tools)
- Audit (#1528) confirmed all 8 tools already have `required` declarations; the missing layer was type validation
- Logic mirrors `tools/tool_search.py:validate_tool_args()` / `_check_type()` for discovered tools, now available at the native-tool composition boundary
- Default-OFF gating unchanged — still opt-in via `HERMES_TOOL_ARG_CONTRACT` env or `tool_arg_contract.enabled` config

## Checklist
- [x] Lint passes (`ruff check`)
- [x] Format passes (`ruff format --check`)
- [x] 45 tests pass (was 32, added 13)
- [x] Lines changed: 214 (additive, minimal surface)

Closes #1529