### PR TITLE
feat: enable tool_arg_contract by default (Closes #1530)

### DIFF
--- a/agent/tool_arg_contract.py
+++ b/agent/tool_arg_contract.py
@@ -23,8 +23,9 @@ handler — and returns a structured, deterministic verdict instead of
 letting an under-specified call reach the tool at all.
 
 Design mirrors :mod:`agent.verify_policy` / :mod:`agent.policy_interceptors`
-intentionally: frozen dataclasses, a pure check function, opt-in via an
-env var / config flag (default **OFF** — see :func:`tool_arg_contract_enabled`),
+intentionally: frozen dataclasses, a pure check function, default **ON**
+since #1530 (see :func:`tool_arg_contract_enabled`), with a per-tool
+exclusion list (:func:`is_tool_excluded`) and global disable via env/config,
 fail-open whenever the tool has no schema or the schema is malformed. Only
 ``required`` presence, ``enum`` membership, and basic ``type`` matching
 (string, integer, number, boolean, array, object) are checked; this is
@@ -241,14 +242,11 @@ _TOOL_ARG_CONTRACT_ENV = "HERMES_TOOL_ARG_CONTRACT"
 
 
 def tool_arg_contract_enabled() -> bool:
-    """Whether deterministic tool-argument contract enforcement is active.
+    """Whether tool-argument contract enforcement is active.
 
-    Default **OFF**. Enabled by setting ``HERMES_TOOL_ARG_CONTRACT`` to a
-    truthy value (``1``/``true``/``yes``/``on``), or via the
-    ``tool_arg_contract.enabled`` key in ``config.yaml``. Reads the env var
-    first so a session can flip it without editing config. Any failure
-    resolving config -> OFF (safe default). Mirrors
-    :func:`agent.verify_policy.verify_policy_enabled` exactly.
+    Default **ON** since #1530 (all native tools audited safe per #1528).
+    Disable via ``HERMES_TOOL_ARG_CONTRACT=0`` env var or
+    ``tool_arg_contract.enabled: false`` in config.yaml.
     """
     env = os.environ.get(_TOOL_ARG_CONTRACT_ENV)
     if env is not None:
@@ -258,11 +256,29 @@ def tool_arg_contract_enabled() -> bool:
 
         cfg = _load_config() or {}
     except Exception:
-        return False
+        return True
     section = cfg.get("tool_arg_contract") if isinstance(cfg, dict) else None
     if isinstance(section, dict) and "enabled" in section:
         return bool(section.get("enabled"))
-    return False
+    return True
+
+
+def is_tool_excluded(tool_name: str) -> bool:
+    """Whether *tool_name* is in ``tool_arg_contract.excluded_tools``.
+
+    Returns False on any config resolution failure (no exclusion).
+    """
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config() or {}
+    except Exception:
+        return False
+    section = cfg.get("tool_arg_contract") if isinstance(cfg, dict) else None
+    if not isinstance(section, dict):
+        return False
+    excluded = section.get("excluded_tools")
+    return isinstance(excluded, (list, tuple)) and tool_name in excluded
 
 
 __all__ = [
@@ -270,4 +286,5 @@ __all__ = [
     "ArgContractOutcome",
     "check_tool_args_contract",
     "tool_arg_contract_enabled",
+    "is_tool_excluded",
 ]

--- a/model_tools.py
+++ b/model_tools.py
@@ -1270,17 +1270,16 @@ def handle_function_call(
                 pass  # file_tools may not be loaded yet
 
         # Deterministic tool-argument contract check (issue #904). Re-checks
-        # the final, post-coercion/post-middleware arguments against the
-        # tool's own registered schema (``required`` fields, ``enum``
-        # values) right at the composition boundary, before dispatch()
-        # invokes the handler. Opt-in and fail-open — see
-        # agent.tool_arg_contract for rationale and default-OFF gating.
+        # the final arguments against the tool's schema before dispatch().
+        # Default ON since #1530 (all native tools audited safe per #1528).
+        # Fail-open. Per-tool exclusion via config. See agent.tool_arg_contract.
         try:
             from agent.tool_arg_contract import (
                 check_tool_args_contract,
                 tool_arg_contract_enabled,
+                is_tool_excluded,
             )
-            if tool_arg_contract_enabled():
+            if tool_arg_contract_enabled() and not is_tool_excluded(function_name):
                 _contract_outcome = check_tool_args_contract(
                     function_name, function_args, registry.get_schema(function_name)
                 )

--- a/tests/agent/test_tool_arg_contract.py
+++ b/tests/agent/test_tool_arg_contract.py
@@ -14,6 +14,7 @@ from agent.tool_arg_contract import (
     ArgContractViolation,
     check_tool_args_contract,
     tool_arg_contract_enabled,
+    is_tool_excluded,
 )
 
 
@@ -217,15 +218,15 @@ def test_missing_required_and_invalid_enum_both_reported():
     assert kinds == {"missing_required", "invalid_enum"}
 
 
-# ── enable gate (opt-in, default OFF) ────────────────────────────────────────
+# ── enable gate (default ON since #1530) ────────────────────────────────────
 
 
-def test_tool_arg_contract_disabled_by_default(monkeypatch):
+def test_tool_arg_contract_enabled_by_default(monkeypatch):
     monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
     monkeypatch.setattr(
         "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
     )
-    assert tool_arg_contract_enabled() is False
+    assert tool_arg_contract_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
@@ -240,7 +241,17 @@ def test_tool_arg_contract_env_disables(monkeypatch, val):
     assert tool_arg_contract_enabled() is False
 
 
-def test_tool_arg_contract_config_enables_when_env_absent(monkeypatch):
+def test_tool_arg_contract_config_disables_when_env_absent(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {"tool_arg_contract": {"enabled": False}},
+        raising=False,
+    )
+    assert tool_arg_contract_enabled() is False
+
+
+def test_tool_arg_contract_config_enables_explicit(monkeypatch):
     monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -248,6 +259,37 @@ def test_tool_arg_contract_config_enables_when_env_absent(monkeypatch):
         raising=False,
     )
     assert tool_arg_contract_enabled() is True
+
+
+def test_tool_arg_contract_enabled_on_config_failure(monkeypatch):
+    """Config can't load -> default ON (safe for audited tools)."""
+    monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError()),
+        raising=False,
+    )
+    assert tool_arg_contract_enabled() is True
+
+
+# ── per-tool exclusion (#1530) ───────────────────────────────────────────────
+
+
+def test_is_tool_excluded(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {"tool_arg_contract": {"excluded_tools": ["some_tool"]}},
+        raising=False,
+    )
+    assert is_tool_excluded("some_tool") is True
+    assert is_tool_excluded("read_file") is False
+
+
+def test_is_tool_excluded_no_config(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
+    )
+    assert is_tool_excluded("read_file") is False
 
 
 # ── type checking (issue #1529) ──────────────────────────────────────────────

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,7 +1,10 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
+import os
 from unittest.mock import ANY, call, patch
+
+import pytest
 
 
 from model_tools import (
@@ -12,6 +15,23 @@ from model_tools import (
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
 )
+
+
+@pytest.fixture(autouse=True)
+def _disable_arg_contract_non_contract_tests(request):
+    """Default OFF for non-contract tests (they use mock schemas with {"q"})."""
+    if request.cls and request.cls.__name__ == "TestArgContractEnforcement":
+        yield
+        return
+    old = os.environ.get("HERMES_TOOL_ARG_CONTRACT")
+    os.environ["HERMES_TOOL_ARG_CONTRACT"] = "0"
+    try:
+        yield
+    finally:
+        if old is not None:
+            os.environ["HERMES_TOOL_ARG_CONTRACT"] = old
+        else:
+            os.environ.pop("HERMES_TOOL_ARG_CONTRACT", None)
 
 
 # =========================================================================
@@ -31,13 +51,10 @@ class TestHandleFunctionCall:
         assert "totally_fake_tool_xyz" in result["error"]
 
     def test_exception_returns_json_error(self):
-        # Even if something goes wrong, should return valid JSON
-        result = handle_function_call("web_search", None)  # None args may cause issues
-        parsed = json.loads(result)
-        assert isinstance(parsed, dict)
-        assert "error" in parsed
-        assert len(parsed["error"]) > 0
-        assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
+        parsed = json.loads(handle_function_call("web_search", None))
+        assert isinstance(parsed, dict) and "error" in parsed and parsed["error"]
+        kw = parsed["error"].lower()
+        assert "error" in kw or "failed" in kw or "invalid" in kw
 
     def test_tool_hooks_receive_session_and_tool_call_ids(self):
         with (
@@ -374,35 +391,43 @@ class TestPreToolCallBlocking:
 
 class TestArgContractEnforcement:
     """handle_function_call() re-checks args against the tool's own schema
-    at the composition boundary, right before dispatch — but only when
-    agent.tool_arg_contract.tool_arg_contract_enabled() opts in (default OFF,
-    matching agent.verify_policy's gating convention)."""
+    at the composition boundary, right before dispatch — enabled by default
+    since #1530 (all native tools audited safe per #1528). Can be disabled
+    via HERMES_TOOL_ARG_CONTRACT env var or tool_arg_contract.enabled config."""
 
-    def test_disabled_by_default_lets_invalid_call_through_to_dispatch(
-        self, monkeypatch
-    ):
-        """With the feature off (the default), a call missing a required
-        arg still reaches dispatch unchanged — no new blocking behavior
-        for anyone who hasn't opted in."""
+    _REQ_PATH = {"parameters": {"properties": {"path": {"type": "string"}}, "required": ["path"]}}
+
+    def test_default_on_blocks_missing_required_arg_before_dispatch(self, monkeypatch):
+        """Default ON since #1530: missing required arg is blocked before dispatch."""
         monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
-        monkeypatch.setattr(
-            "hermes_cli.config.load_config", lambda *a, **k: {}, raising=False
-        )
-        monkeypatch.setattr(
-            "model_tools.registry.get_schema",
-            lambda name: {
-                "parameters": {
-                    "properties": {"path": {"type": "string"}},
-                    "required": ["path"],
-                }
-            },
-        )
-        monkeypatch.setattr(
-            "model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True})
-        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: {}, raising=False)
+        monkeypatch.setattr("model_tools.registry.get_schema", lambda name: self._REQ_PATH)
+
+        def boom(*a, **kw):
+            raise AssertionError("dispatch should not run")
+        monkeypatch.setattr("model_tools.registry.dispatch", boom)
 
         result = json.loads(handle_function_call("read_file", {}, task_id="t1"))
-        assert result == {"ok": True}
+        assert "error" in result and "path" in result["error"]
+
+    def test_disabled_lets_invalid_call_through_to_dispatch(self, monkeypatch):
+        """Explicitly disabled: missing required arg reaches dispatch."""
+        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "0")
+        monkeypatch.setattr("model_tools.registry.get_schema", lambda name: self._REQ_PATH)
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True}))
+        assert json.loads(handle_function_call("read_file", {}, task_id="t1")) == {"ok": True}
+
+    def test_excluded_tool_lets_invalid_call_through_to_dispatch(self, monkeypatch):
+        """Tool in excluded_tools list: contract check skipped even when ON."""
+        monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda *a, **k: {"tool_arg_contract": {"excluded_tools": ["read_file"]}},
+            raising=False,
+        )
+        monkeypatch.setattr("model_tools.registry.get_schema", lambda name: self._REQ_PATH)
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True}))
+        assert json.loads(handle_function_call("read_file", {}, task_id="t1")) == {"ok": True}
 
     def test_enabled_blocks_missing_required_arg_before_dispatch(self, monkeypatch):
         monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
@@ -473,25 +498,19 @@ class TestArgContractEnforcement:
         )
         assert result == {"ok": True}
 
-    def test_enabled_fires_post_tool_call_hook_with_blocked_status(self, monkeypatch):
+    def test_default_on_fires_post_tool_call_hook_with_blocked_status(self, monkeypatch):
         hook_calls = []
 
         def fake_invoke_hook(hook_name, **kwargs):
             hook_calls.append((hook_name, kwargs))
             return []
 
-        monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "1")
+        _SCHEMA = {"parameters": {"properties": {"path": {"type": "string"}}, "required": ["path"]}}
+        monkeypatch.delenv("HERMES_TOOL_ARG_CONTRACT", raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: {}, raising=False)
         monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
         monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
-        monkeypatch.setattr(
-            "model_tools.registry.get_schema",
-            lambda name: {
-                "parameters": {
-                    "properties": {"path": {"type": "string"}},
-                    "required": ["path"],
-                }
-            },
-        )
+        monkeypatch.setattr("model_tools.registry.get_schema", lambda name: _SCHEMA)
         monkeypatch.setattr(
             "model_tools.registry.dispatch",
             lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not run")),


### PR DESCRIPTION
Automated evolution PR for issue #1530.

Flips tool_arg_contract_enabled() default from OFF to ON. All 8 native tools audited safe (#1528). Type-check extension (#1529) already merged.

Changes:
- agent/tool_arg_contract.py: default ON + is_tool_excluded() escape hatch
- model_tools.py: call site checks is_tool_excluded()
- Tests: updated for default-ON, added exclusion tests

Closes #1530