### PR TITLE
fix: classify patch 'could not find match' as patch-no-match (Closes #1537)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -187,6 +187,7 @@ def _is_recovered_refusal(text: str) -> bool:
     return False
     return bool(_RECOVERY_RE.search(text)) and not _NON_RECOVERY_RE.search(text)
 
+
 _REPEAT_THRESHOLD = 5  # same tool >=N consecutive in a session is a "repeated run"
 
 # --- failure-reason taxonomy (issue #1325) ----------------------------------
@@ -231,6 +232,17 @@ _PATCH_INDENTATION_MISMATCH_RE = re.compile(
 )
 _PATCH_AMBIGUOUS_RE = re.compile(
     r"\b(found \d+ matches|multiple matches found)\b", re.IGNORECASE
+)
+# #1537 — the dominant residual "other" contributor. fuzzy_find_and_replace
+# emits "Could not find a match for old_string in the file" (and file_operations
+# wraps it as "Could not find match for old_string in {path}") when NO strategy
+# succeeds. That phrasing contains none of the existing no-match keywords
+# ("no match", "nothing found", …), so 70/86 patch failures fell through to the
+# generic "other" bucket — 81% of all patch errors. Catch it explicitly here,
+# BEFORE the generic _NO_MATCH_RE, so the digest reports a named reason and the
+# model gets a concrete recovery directive instead of retrying 6×.
+_PATCH_NO_MATCH_RE = re.compile(
+    r"\bcould not find (a )?match for old_string\b", re.IGNORECASE
 )
 
 
@@ -301,6 +313,8 @@ def _classify_failure_reason(content: Any) -> Optional[str]:
         return "patch-indentation-mismatch"
     if _PATCH_AMBIGUOUS_RE.search(haystack):
         return "patch-ambiguous"
+    if _PATCH_NO_MATCH_RE.search(haystack):
+        return "patch-no-match"
     if _NO_MATCH_RE.search(haystack):
         return "no-match"
     if "exit_code" in data:

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -267,6 +267,41 @@ class TestFailureReasonClassification:
         s = scan_session(p)
         assert s["tool_failures_by_reason"] == {"patch": {"other": 1}}
 
+    def test_patch_no_match_reason(self, tmp_path):
+        """#1537 — the canonical fuzzy_find_and_replace no-match message must
+        classify as 'patch-no-match', NOT fall into 'other'."""
+        p = _session(
+            tmp_path,
+            "r_pnm",
+            [
+                _asst("patch", "c1"),
+                _tool(
+                    "c1",
+                    _fail("Could not find a match for old_string in the file"),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures_by_reason"] == {"patch": {"patch-no-match": 1}}
+
+    def test_patch_no_match_reason_wrapped_variant(self, tmp_path):
+        """#1537 — file_operations wraps the message with the path."""
+        p = _session(
+            tmp_path,
+            "r_pnm2",
+            [
+                _asst("patch", "c1"),
+                _tool(
+                    "c1",
+                    _fail(
+                        "Could not find match for old_string in /app/src/utils.py"
+                    ),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures_by_reason"] == {"patch": {"patch-no-match": 1}}
+
     def test_no_reason_for_successful_results(self, tmp_path):
         p = _session(
             tmp_path,

--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -31,8 +31,27 @@ class TestClassifyFileError:
         assert klass == "patch_parse"
 
     def test_block_no_match_is_fuzzy(self):
-        klass, rec = classify_file_error("search block did not match the file content")
+        klass, rec = classify_file_error(
+            "search block did not match the file content"
+        )
         assert klass == "fuzzy_match" and "EXACT" in rec
+
+    def test_could_not_find_match_is_patch_no_match(self):
+        """#1537 — the canonical fuzzy_find_and_replace no-match message must
+        get a named error_class with a write_file directive."""
+        klass, rec = classify_file_error(
+            "Could not find a match for old_string in the file"
+        )
+        assert klass == "patch_no_match"
+        assert "write_file" in rec
+
+    def test_could_not_find_match_wrapped_variant(self):
+        """#1537 — file_operations wraps the message with the path."""
+        klass, rec = classify_file_error(
+            "Could not find match for old_string in /app/src/utils.py"
+        )
+        assert klass == "patch_no_match"
+        assert "write_file" in rec
 
     def test_ambiguous_match_is_classified(self):
         """'Found N matches' errors get a specific error_class and recovery (#976)."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -200,6 +200,21 @@ def classify_file_error(
             "old_string to make it unique, or use replace_all=True if you want "
             "all occurrences replaced."
         )
+    # #1537 — the dominant "other"-bucket contributor. fuzzy_find_and_replace
+    # emits "Could not find (a )?match for old_string in {file}" when none of
+    # its match strategies succeed. This phrasing slipped past every prior
+    # branch (it's not "did not match", "no match", or "block"), landing in the
+    # generic fallback and accounting for 81% of patch failures. Route it to a
+    # named class with a strong recovery directive so the model doesn't retry
+    # the same block with whitespace variants up to 6× — re-read, fix the exact
+    # text, or switch to write_file after 2 consecutive misses.
+    if "could not find" in low and "match" in low and "old_string" in low:
+        return "patch_no_match", (
+            "old_string was not found in the file by any match strategy. "
+            "Re-read the file and copy the EXACT current text. If a second "
+            "patch attempt on the same file also fails, switch to write_file "
+            "with the full content — do NOT keep retrying patch variants."
+        )
     if (
         "did not match" in low
         or "no match" in low
@@ -810,7 +825,7 @@ LINTERS_INPROC = {
 # established, exercised pattern as an error and break it. Python source
 # keeps the existing (unchanged) post-write lint-delta *report* — still
 # visible to the caller, just not a write-blocking refusal.
-_FAIL_CLOSED_INPROC_EXTS = frozenset({'.json', '.yaml', '.yml', '.toml'})
+_FAIL_CLOSED_INPROC_EXTS = frozenset({".json", ".yaml", ".yml", ".toml"})
 
 # Max limits for read operations
 MAX_LINES = 2000
@@ -1606,7 +1621,9 @@ class ShellFileOperations(FileOperations):
         # re-adds the marker the read layer strips — see
         # ``_file_has_bom``/``_UTF8_BOM`` below.
         ext = os.path.splitext(path)[1].lower()
-        inproc_linter = LINTERS_INPROC.get(ext) if ext in _FAIL_CLOSED_INPROC_EXTS else None
+        inproc_linter = (
+            LINTERS_INPROC.get(ext) if ext in _FAIL_CLOSED_INPROC_EXTS else None
+        )
         if inproc_linter is not None:
             _ok, _lint_err = inproc_linter(content)
             if not _ok and _lint_err != "__SKIP__":


### PR DESCRIPTION
## Summary

The dominant residual `other`-bucket contributor (70/86 = **81%** of patch failures) was the canonical `fuzzy_find_and_replace` no-match message: `"Could not find a match for old_string in the file"`. That phrasing contains none of the existing no-match keywords (`"no match"`, `"nothing found"`), so it fell through every regex in `_classify_failure_reason` to the generic `other` bucket — leaving the model with no named reason and no recovery directive, causing retry spirals up to 6× deep.

## Root cause

`fuzzy_find_and_replace` emits `"Could not find a match for old_string in the file"` and `file_operations` wraps it as `"Could not find match for old_string in {path}"`. The introspection classifier's `_NO_MATCH_RE` pattern (`no match|no results?|nothing found|empty result|0 matches`) does NOT match the word "find", so these failures landed in `other`.

## Changes

| File | Change |
|------|--------|
| `scripts/introspection_extract.py` | Add `_PATCH_NO_MATCH_RE` regex (`could not find (a )?match for old_string`), checked BEFORE `_NO_MATCH_RE`, returns `patch-no-match` |
| `tools/file_operations.py` | `classify_file_error()` routes `"could not find...match...old_string"` to error_class `patch_no_match` with a recovery directive: re-read for exact text, switch to `write_file` after 2 consecutive misses |
| `tests/scripts/test_introspection_extract.py` | 2 new tests: both message variants classify as `patch-no-match` |
| `tests/tools/test_file_error_classification.py` | 2 new tests: `classify_file_error` returns `patch_no_match` with `write_file` directive |

## Validation

- `ruff check .` ✓
- `ruff format --check` — pre-existing format debt in touched files (advisory, not blocking)
- `pytest tests/tools/test_file_error_classification.py tests/scripts/test_introspection_extract.py` — **76 passed**
- Diff: 88 insertions, 3 deletions (≤ 200-line autonomous-merge cap)

Closes #1537