### PR TITLE
fix: sub-classify the dominant patch 'other' error bucket (Closes #1537)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -232,6 +232,19 @@ _PATCH_INDENTATION_MISMATCH_RE = re.compile(
 _PATCH_AMBIGUOUS_RE = re.compile(
     r"\b(found \d+ matches|multiple matches found)\b", re.IGNORECASE
 )
+# Patch no-match: the dominant remaining 'other' cause (#1537). The fuzzy
+# matcher's failure message is "Could not find a match for old_string in the
+# file" (tools/fuzzy_match.py), which does NOT match the generic _NO_MATCH_RE
+# (it needs literal "no match"). Without this sub-category, 81% of patch
+# failures (70/86 per the 7d introspection window) fell into the opaque
+# 'other' bucket, hiding the dominant failure mode from the digest and
+# blocking targeted fixes. Placed BEFORE _NO_MATCH_RE so the specific tag
+# wins; the message never contained "no match" anyway, but the ordering keeps
+# the precedent set by the other patch-* sub-categories.
+_PATCH_NO_MATCH_RE = re.compile(
+    r"\b(could not find a match|could not find|cannot find a match)\b",
+    re.IGNORECASE,
+)
 
 
 def _classify_failure_reason(content: Any) -> Optional[str]:
@@ -301,6 +314,8 @@ def _classify_failure_reason(content: Any) -> Optional[str]:
         return "patch-indentation-mismatch"
     if _PATCH_AMBIGUOUS_RE.search(haystack):
         return "patch-ambiguous"
+    if _PATCH_NO_MATCH_RE.search(haystack):
+        return "patch-no-match"
     if _NO_MATCH_RE.search(haystack):
         return "no-match"
     if "exit_code" in data:

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -267,6 +267,27 @@ class TestFailureReasonClassification:
         s = scan_session(p)
         assert s["tool_failures_by_reason"] == {"patch": {"other": 1}}
 
+    def test_patch_no_match_classified_not_other(self, tmp_path):
+        """The dominant patch failure message — "Could not find a match for
+        old_string in the file" (tools/fuzzy_match.py) — is classified as
+        patch-no-match, NOT 'other' (#1537). Before the fix this message
+        matched no sub-category regex and 81% of patch failures (70/86 per
+        the 7d introspection window) fell into the opaque 'other' bucket,
+        hiding the dominant failure mode from the digest."""
+        p = _session(
+            tmp_path,
+            "r5b",
+            [
+                _asst("patch", "c1"),
+                _tool(
+                    "c1",
+                    _fail("Could not find a match for old_string in the file"),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures_by_reason"] == {"patch": {"patch-no-match": 1}}
+
     def test_no_reason_for_successful_results(self, tmp_path):
         p = _session(
             tmp_path,

--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -34,6 +34,19 @@ class TestClassifyFileError:
         klass, rec = classify_file_error("search block did not match the file content")
         assert klass == "fuzzy_match" and "EXACT" in rec
 
+    def test_could_not_find_match_is_fuzzy(self):
+        """The fuzzy matcher's dominant failure message — "Could not find a
+        match for old_string in the file" — routes to fuzzy_match recovery,
+        not the generic 'error' class (#1537). Before the fix this message
+        contained neither "did not match" nor "no match", so the model got
+        the unhelpful "The operation failed. ... CHANGE the call." recovery
+        with no signal to re-read the file, driving the observed retry
+        spirals (up to 6 deep)."""
+        klass, rec = classify_file_error(
+            "Could not find a match for old_string in the file"
+        )
+        assert klass == "fuzzy_match" and ("Re-read" in rec or "EXACT" in rec)
+
     def test_ambiguous_match_is_classified(self):
         """'Found N matches' errors get a specific error_class and recovery (#976)."""
         klass, rec = classify_file_error(

--- a/tests/tools/test_patch_failure_tracking.py
+++ b/tests/tools/test_patch_failure_tracking.py
@@ -58,7 +58,7 @@ def fresh_tracker():
 
 
 class TestPatchFailureEscalation:
-    def test_first_two_failures_use_normal_hint(
+    def test_first_two_failures_no_hard_escalation(
         self, hermes_home, tmp_path, fresh_tracker
     ):
         from tools.file_tools import _handle_patch
@@ -78,8 +78,12 @@ class TestPatchFailureEscalation:
             )
             d = json.loads(result)
             hint = d.get("_hint", "") or ""
-            assert "failure #" not in hint, (
-                f"Escalating hint fired too early on attempt {_i + 1}: {hint!r}"
+            # The hard "PERMANENT FAILURE" escalation must not fire before the
+            # 3rd consecutive failure (#507). Note: a softer write_file nudge
+            # MAY appear on the 2nd no-match failure (#1537) — that's tested
+            # separately in test_second_consecutive_no_match_nudges_write_file.
+            assert "PERMANENT FAILURE" not in hint, (
+                f"Hard escalation fired too early on attempt {_i + 1}: {hint!r}"
             )
 
     def test_third_consecutive_failure_escalates(
@@ -112,6 +116,56 @@ class TestPatchFailureEscalation:
         assert "write_file" in last_hint, (
             "Escalating hint should mention write_file fallback"
         )
+
+    def test_second_consecutive_no_match_nudges_write_file(
+        self, hermes_home, tmp_path, fresh_tracker
+    ):
+        """On the 2nd consecutive no-match failure on the same file, the patch
+        tool surfaces a write_file-forward nudge BEFORE the hard 3rd-failure
+        refuse-gate fires (#1537). The introspection evidence showed the
+        model keeps retrying near-identical old_string variants past the
+        point a full rewrite would have been faster; surfacing write_file
+        early biases it toward the reliably-terminating path. The hint puts
+        write_file FIRST and must appear on attempt 2 but not attempt 1."""
+        from tools.file_tools import _handle_patch
+
+        target = tmp_path / "g.py"
+        target.write_text("def foo():\n    return 1\n")
+
+        # Attempt 1: generic no-match hint, no write_file-forward nudge yet.
+        result = _handle_patch(
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "GHOST_ATTEMPT1_QQQ",
+                "new_string": "x",
+            },
+            task_id="esc_t1b",
+        )
+        d1 = json.loads(result)
+        hint1 = d1.get("_hint", "") or ""
+        assert "switch to write_file" not in hint1, (
+            f"write_file nudge fired too early on attempt 1: {hint1!r}"
+        )
+
+        # Attempt 2: the #1537 write_file-forward nudge now appears.
+        result = _handle_patch(
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "GHOST_ATTEMPT2_QQQ",
+                "new_string": "x",
+            },
+            task_id="esc_t1b",
+        )
+        d2 = json.loads(result)
+        hint2 = d2.get("_hint", "") or ""
+        assert "failure #2" in hint2, repr(hint2)
+        assert "write_file" in hint2, (
+            f"2nd-failure nudge should recommend write_file: {hint2!r}"
+        )
+        # Must NOT yet be the hard refuse-gate message.
+        assert "PERMANENT FAILURE" not in hint2
 
     def test_success_clears_failure_counter(self, hermes_home, tmp_path, fresh_tracker):
         from tools.file_tools import _handle_patch

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -204,6 +204,14 @@ def classify_file_error(
         "did not match" in low
         or "no match" in low
         or ("match" in low and "block" in low)
+        # The fuzzy matcher's dominant failure message is "Could not find a
+        # match for old_string in the file" (#1537) — it contains neither
+        # "did not match" nor "no match", so without this arm it fell through
+        # to the generic "error" class whose recovery ("The operation failed.
+        # ... CHANGE the call.") gives the model no signal to re-read the
+        # file, driving the observed retry spirals (up to 6 deep).
+        or "could not find" in low
+        or "not find a match" in low
     ):
         return "fuzzy_match", (
             "The search block didn't match the file. Re-read the file and copy the EXACT "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2102,6 +2102,33 @@ def patch_tool(
                     f"(3) use write_file to replace the entire file if the "
                     f"targeted region is hard to anchor."
                 )
+            elif failure_count >= 2 and is_no_match:
+                # Earlier write_file nudge (#1537). Before reaching the hard
+                # refuse threshold, surface write_file as the recommended
+                # escape on the 2nd consecutive no-match failure on the same
+                # file. The introspection evidence (70 patch-no-match
+                # failures/7d, spirals up to 6 deep) showed the model keeps
+                # retrying near-identical old_string variants past the point a
+                # full rewrite would have been faster. Putting write_file
+                # FIRST here — ahead of the "re-read / longer old_string"
+                # options — biases the model toward the reliably-terminating
+                # path before the refuse-gate has to fire.
+                #
+                # Note: deliberately NOT gated on ``not has_diagnostic`` (unlike
+                # the other branches below). The structured _diagnostic gives
+                # the model the corrected old_string to try, but it does NOT
+                # surface the consecutive-failure count or the write_file
+                # escape — both of which become the right call once the same
+                # file has missed twice in a row. The two signals are
+                # complementary, not mutually exclusive.
+                result_dict["_hint"] = (
+                    f"This is failure #{failure_count} patching {path!r} "
+                    f"with a not-found old_string. The targeted region is "
+                    f"hard to anchor with patch — switch to write_file with "
+                    f"the full intended file content now, or re-read the "
+                    f"file and copy the exact current text before retrying "
+                    f"patch. Do not retry the same old_string again."
+                )
             elif is_ambiguous and not has_diagnostic:
                 result_dict["_hint"] = (
                     "Multiple matches found. Use read_file to see the "


### PR DESCRIPTION
## Summary

Automated evolution PR for issue **#1537** — the patch tool's `other` error bucket was 81% of all patch failures (70/86 in a 7d introspection window): opaque to the digest and giving the agent no recovery signal, driving retry spirals up to 6 deep.

## Root cause (verified against the real code path)

The fuzzy matcher's dominant failure message — `"Could not find a match for old_string in the file"` (`tools/fuzzy_match.py:197`, fired on every fuzzy-match miss) — matched **neither** classifier:

- **Introspection** (`scripts/introspection_extract.py`): `_NO_MATCH_RE` requires the literal phrase `"no match"`, but the message says "Could not find **a** match" → fell to the opaque `other` bucket (the measured 81%).
- **Runtime** (`tools/file_operations.py::classify_file_error`): the `fuzzy_match` branch checked `"did not match"` / `"no match"` / `("match" + "block")` — none match "Could not find a match" → fell to the generic `error` class with the unhelpful recovery "The operation failed. ... CHANGE the call.", giving the model no signal to re-read the file.

The recovery directive mechanism (hard refuse + write_file at threshold 3) **already existed** (`#507`/`#1037`) — the gap was purely the misclassification, plus surfacing the write_file escape one step earlier.

## Changes (3 targeted fixes)

1. **Introspection** (`scripts/introspection_extract.py`): add a `patch-no-match` sub-category regex for `"could not find (a) match"`, placed before `_NO_MATCH_RE`. The 70 previously-`other` failures now become a trackable, actionable signal in the digest.

2. **Runtime classifier** (`tools/file_operations.py::classify_file_error`): extend the `fuzzy_match` branch to recognize `"could not find"` / `"not find a match"`, so the model gets the "Re-read the file and copy the EXACT current text" recovery directive instead of the generic one.

3. **Earlier write_file nudge** (`tools/file_tools.py`): on the **2nd** consecutive no-match failure on the same file, surface write_file as the recommended escape BEFORE the hard 3rd-failure refuse-gate fires. The existing gate already refuses at threshold 3; this biases the model toward the reliably-terminating rewrite path one step earlier. Deliberately NOT gated on `has_diagnostic` — the consecutive-failure count + write_file signal is complementary to (not mutually exclusive with) the structured diagnostic.

## Tests

- `test_patch_no_match_classified_not_other` — introspection classifies "Could not find a match" as `patch-no-match`, not `other`.
- `test_could_not_find_match_is_fuzzy` — runtime classifier routes it to `fuzzy_match` recovery.
- `test_second_consecutive_no_match_nudges_write_file` — the #1537 nudge fires on attempt 2 (not 1), recommends write_file, and is not the hard refuse-gate.
- `test_first_two_failures_no_hard_escalation` (existing, updated) — tightened to assert on `PERMANENT FAILURE` so the new soft nudge remains valid.

## Validation

- Pre-PR targeted test shard: ✅ PASS (3 shards)
- `ruff check`: ✅ All checks passed
- Full related suites (324 tests across patch/file/fuzzy/introspection/recovery): ✅ all pass
- Diff: 141 insertions, 3 deletions across 6 files — within the 200-line self-merge cap.

Closes #1537