### PR TITLE
feat: disable tqmemory MCP server when binary is broken (Closes #1541)

### DIFF
--- a/scripts/evolution_disable_failed_mcp.py
+++ b/scripts/evolution_disable_failed_mcp.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Disable tqmemory MCP server when binary is missing or broken (#1541).
+
+When ``turbo-memory-mcp`` fails every connection (zero successes, 1190+ error
+lines per batch), the gateway retries 3× then parks and self-probes every 300s
+forever — massive log noise + startup latency. The existing opt-out
+(``HERMES_NO_TQMEMORY=1`` / ``memory.tqmemory_autoinstall: false``) requires
+manual action; this script automates the disable when the binary is broken.
+
+Usage::
+
+    python scripts/evolution_disable_failed_mcp.py            # check + disable
+    python scripts/evolution_disable_failed_mcp.py --dry-run  # report only
+
+Exit 0 = success, 1 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def _import_tqmemory():
+    """Import tqmemory_setup from hermes_cli/ or scripts/. Returns module or None."""
+    repo_root = Path(__file__).resolve().parent.parent
+    for mod_path in [
+        str(repo_root / "hermes_cli"),
+        str(Path(__file__).resolve().parent),
+    ]:
+        if mod_path not in sys.path:
+            sys.path.insert(0, mod_path)
+    for mod_name in ["hermes_cli.tqmemory_setup", "tqmemory_setup"]:
+        try:
+            return __import__(mod_name, fromlist=["resolve_binary", "verify_tqmemory"])
+        except ImportError:
+            continue
+    return None
+
+
+def check_tqmemory_health() -> Tuple[bool, str]:
+    """Check if tqmemory binary exists and launches. Returns (healthy, message)."""
+    mod = _import_tqmemory()
+    if mod is None:
+        return False, "tqmemory_setup module not found — cannot check"
+    binary = mod.resolve_binary()
+    if not binary:
+        return False, "turbo-memory-mcp binary not found on PATH"
+    if not mod.verify_tqmemory(binary):
+        return False, f"turbo-memory-mcp at {binary} failed --help probe"
+    return True, f"turbo-memory-mcp healthy at {binary}"
+
+
+def disable_in_profiles(dry_run: bool = False) -> List[str]:
+    """Set ``mcp_servers.tqmemory.enabled: false`` in all profile configs."""
+    import yaml
+
+    mod = _import_tqmemory()
+    if mod is None:
+        return []
+    changed: List[str] = []
+    for cfg_path in mod._all_profile_config_paths():
+        if not cfg_path.exists():
+            continue
+        try:
+            data = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        servers = data.get("mcp_servers")
+        if not isinstance(servers, dict) or mod.SERVER_NAME not in servers:
+            continue
+        entry = servers[mod.SERVER_NAME]
+        if isinstance(entry, dict) and entry.get("enabled") is False:
+            continue
+        if dry_run:
+            changed.append(str(cfg_path))
+            continue
+        if isinstance(entry, dict):
+            entry["enabled"] = False
+        try:
+            from utils import atomic_yaml_write
+
+            atomic_yaml_write(cfg_path, data)
+            changed.append(str(cfg_path))
+        except Exception:
+            pass
+    return changed
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Disable tqmemory MCP when binary broken (#1541)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report without modifying"
+    )
+    args = parser.parse_args(argv)
+
+    healthy, msg = check_tqmemory_health()
+    print(f"[disable-mcp] tqmemory health: {msg}")
+    if healthy:
+        print("[disable-mcp] binary is healthy — no action needed")
+        return 0
+
+    print("[disable-mcp] binary is broken/missing — disabling in all profiles")
+    changed = disable_in_profiles(dry_run=args.dry_run)
+    action = "would be disabled in" if args.dry_run else "disabled in"
+    for path in changed:
+        print(f"  {action}: {path}")
+    if not changed:
+        print("[disable-mcp] no profiles needed changes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_disable_failed_mcp.py
+++ b/tests/scripts/test_evolution_disable_failed_mcp.py
@@ -1,0 +1,79 @@
+"""Tests for evolution_disable_failed_mcp.py (#1541)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_disable_failed_mcp import (  # noqa: E402
+    check_tqmemory_health,
+    disable_in_profiles,
+    main,
+)
+
+
+def _mock_mod(**kwargs):
+    m = MagicMock()
+    m.resolve_binary = MagicMock(return_value=kwargs.get("binary"))
+    m.verify_tqmemory = MagicMock(return_value=kwargs.get("verify", False))
+    m._all_profile_config_paths = kwargs.get("paths", MagicMock(return_value=[]))
+    m.SERVER_NAME = "tqmemory"
+    return m
+
+
+class TestCheckHealth:
+    def test_binary_not_found(self):
+        with patch(
+            "evolution_disable_failed_mcp._import_tqmemory",
+            return_value=_mock_mod(binary=None),
+        ):
+            assert check_tqmemory_health()[0] is False
+
+    def test_binary_healthy(self):
+        mod = _mock_mod(binary="/usr/bin/tqm", verify=True)
+        with patch("evolution_disable_failed_mcp._import_tqmemory", return_value=mod):
+            assert check_tqmemory_health()[0] is True
+
+    def test_binary_verify_fails(self):
+        mod = _mock_mod(binary="/usr/bin/tqm", verify=False)
+        with patch("evolution_disable_failed_mcp._import_tqmemory", return_value=mod):
+            healthy, msg = check_tqmemory_health()
+        assert healthy is False and "failed" in msg.lower()
+
+
+class TestDisableInProfiles:
+    def test_already_disabled(self, tmp_path):
+        import yaml
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(yaml.dump({"mcp_servers": {"tqmemory": {"enabled": False}}}))
+        mod = _mock_mod(paths=MagicMock(return_value=[cfg]))
+        with patch("evolution_disable_failed_mcp._import_tqmemory", return_value=mod):
+            assert disable_in_profiles(dry_run=False) == []
+
+
+class TestMain:
+    def test_healthy_no_action(self, capsys):
+        with patch(
+            "evolution_disable_failed_mcp.check_tqmemory_health",
+            return_value=(True, "ok"),
+        ):
+            assert main([]) == 0
+        assert "no action needed" in capsys.readouterr().out
+
+    def test_broken_disables(self, capsys):
+        with patch(
+            "evolution_disable_failed_mcp.check_tqmemory_health",
+            return_value=(False, "missing"),
+        ):
+            with patch(
+                "evolution_disable_failed_mcp.disable_in_profiles",
+                return_value=["/tmp/cfg.yaml"],
+            ):
+                assert main([]) == 0
+        assert "disabled in" in capsys.readouterr().out


### PR DESCRIPTION
Automated evolution PR for issue #1541.

## Problem

tqmemory MCP server fails every connection attempt (zero successes). Gateway retries 3x then parks and self-probes every 300s forever — 1190+ error lines per session batch, 218KB errors.log (95% tqmemory spam).

## Fix

Adds `scripts/evolution_disable_failed_mcp.py`: checks tqmemory binary health via `resolve_binary` + `verify_tqmemory`. If broken/missing, sets `mcp_servers.tqmemory.enabled: false` in all profile configs — stopping the connection retry storm immediately.

Features:
- `--dry-run` mode for checking without modifying
- Uses existing `tqmemory_setup` module functions (no duplication)
- Multi-profile support via `_all_profile_config_paths()`

## Files
- `scripts/evolution_disable_failed_mcp.py` (120 lines)
- `tests/scripts/test_evolution_disable_failed_mcp.py` (79 lines, 6 tests)

## Checks
- lint ✓, format ✓, tests ✓ (6 passed)