### PR TITLE
fix: _is_unattended_context requires positive cron/subagent signal (#1554)

### DIFF
--- a/tests/tools/test_approval_cron_block.py
+++ b/tests/tools/test_approval_cron_block.py
@@ -11,11 +11,21 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.approval import _cron_blocked_result, _is_unattended_context
+from tools.approval import (
+    _cron_blocked_result,
+    _is_unattended_context,
+    _is_subagent_context,
+    set_hermes_subagent_context,
+)
 
 
 class TestIsUnattendedContext:
-    """_is_unattended_context() detects cron/non-interactive/non-gateway."""
+    """_is_unattended_context() requires a positive cron/subagent signal.
+
+    Per #1554, the function must NOT default to "nobody's home" when none of
+    interactive-CLI / gateway / cron / subagent are detected — that catch-all
+    misfires in the non-interactive test environment, breaking the suite.
+    """
 
     def test_cron_session_is_unattended(self):
         """HERMES_CRON_SESSION=1 → always unattended."""
@@ -23,16 +33,20 @@ class TestIsUnattendedContext:
             "tools.approval.env_var_enabled",
             side_effect=lambda v: v == "HERMES_CRON_SESSION",
         ):
-            assert _is_unattended_context() is True
+            with patch("tools.approval._is_subagent_context", return_value=False):
+                assert _is_unattended_context() is True
 
     def test_interactive_cli_not_unattended(self):
-        """Interactive CLI with no cron → not unattended."""
+        """Interactive CLI with no cron/subagent → not unattended."""
         with patch("tools.approval.env_var_enabled", return_value=False):
             with patch("tools.approval._is_interactive_cli", return_value=True):
                 with patch(
                     "tools.approval._is_gateway_approval_context", return_value=False
                 ):
-                    assert _is_unattended_context() is False
+                    with patch(
+                        "tools.approval._is_subagent_context", return_value=False
+                    ):
+                        assert _is_unattended_context() is False
 
     def test_gateway_not_unattended(self):
         """Gateway session → not unattended."""
@@ -41,16 +55,65 @@ class TestIsUnattendedContext:
                 with patch(
                     "tools.approval._is_gateway_approval_context", return_value=True
                 ):
-                    assert _is_unattended_context() is False
+                    with patch(
+                        "tools.approval._is_subagent_context", return_value=False
+                    ):
+                        assert _is_unattended_context() is False
 
-    def test_no_context_is_unattended(self):
-        """No interactive CLI, no gateway, no cron → unattended (subagent)."""
+    def test_no_context_is_not_unattended(self):
+        """No interactive CLI, no gateway, no cron, no subagent → NOT unattended.
+
+        This is the #1554 fix: the prior catch-all "nobody's home → unattended"
+        default misfired in the non-interactive test environment (and any
+        bare-script context), turning pending_approval into blocked and
+        breaking tests. Absent a positive cron/subagent signal, we return
+        False so callers fall back to pending_approval.
+        """
         with patch("tools.approval.env_var_enabled", return_value=False):
             with patch("tools.approval._is_interactive_cli", return_value=False):
                 with patch(
                     "tools.approval._is_gateway_approval_context", return_value=False
                 ):
-                    assert _is_unattended_context() is True
+                    with patch(
+                        "tools.approval._is_subagent_context", return_value=False
+                    ):
+                        assert _is_unattended_context() is False
+
+    def test_subagent_context_is_unattended(self):
+        """Subagent contextvar set → unattended (the real subagent path)."""
+        with patch("tools.approval.env_var_enabled", return_value=False):
+            with patch("tools.approval._is_subagent_context", return_value=True):
+                assert _is_unattended_context() is True
+
+
+class TestIsSubagentContext:
+    """_is_subagent_context() reads the contextvar, then the env var."""
+
+    def test_default_not_subagent(self):
+        """No contextvar / env var set → not a subagent."""
+        with patch("tools.approval._hermes_subagent_ctx") as ctx_mock:
+            ctx_mock.get.return_value = None
+            with patch("tools.approval.env_var_enabled", return_value=False):
+                assert _is_subagent_context() is False
+
+    def test_contextvar_set_is_subagent(self):
+        """Contextvar set to '1' by _run_single_child → subagent."""
+        token = set_hermes_subagent_context(True)
+        try:
+            assert _is_subagent_context() is True
+        finally:
+            from tools.approval import _hermes_subagent_ctx
+
+            _hermes_subagent_ctx.reset(token)
+
+    def test_contextvar_reset_clears_subagent(self):
+        """Resetting the token restores the prior (non-subagent) state."""
+        token = set_hermes_subagent_context(True)
+        from tools.approval import _hermes_subagent_ctx
+
+        _hermes_subagent_ctx.reset(token)
+        with patch("tools.approval.env_var_enabled", return_value=False):
+            assert _is_subagent_context() is False
 
 
 class TestCronBlockedResult:

--- a/tests/tools/test_approval_cron_block.py
+++ b/tests/tools/test_approval_cron_block.py
@@ -1,0 +1,73 @@
+"""Tests for approval cron-context blocking (#1542).
+
+Verifies that _is_unattended_context() and _cron_blocked_result() correctly
+convert pending_approval into non-retryable blocked results in cron/subagent
+contexts, preventing the retry spirals that cause 44% of terminal failures.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tools.approval import _cron_blocked_result, _is_unattended_context
+
+
+class TestIsUnattendedContext:
+    """_is_unattended_context() detects cron/non-interactive/non-gateway."""
+
+    def test_cron_session_is_unattended(self):
+        """HERMES_CRON_SESSION=1 → always unattended."""
+        with patch(
+            "tools.approval.env_var_enabled",
+            side_effect=lambda v: v == "HERMES_CRON_SESSION",
+        ):
+            assert _is_unattended_context() is True
+
+    def test_interactive_cli_not_unattended(self):
+        """Interactive CLI with no cron → not unattended."""
+        with patch("tools.approval.env_var_enabled", return_value=False):
+            with patch("tools.approval._is_interactive_cli", return_value=True):
+                with patch(
+                    "tools.approval._is_gateway_approval_context", return_value=False
+                ):
+                    assert _is_unattended_context() is False
+
+    def test_gateway_not_unattended(self):
+        """Gateway session → not unattended."""
+        with patch("tools.approval.env_var_enabled", return_value=False):
+            with patch("tools.approval._is_interactive_cli", return_value=False):
+                with patch(
+                    "tools.approval._is_gateway_approval_context", return_value=True
+                ):
+                    assert _is_unattended_context() is False
+
+    def test_no_context_is_unattended(self):
+        """No interactive CLI, no gateway, no cron → unattended (subagent)."""
+        with patch("tools.approval.env_var_enabled", return_value=False):
+            with patch("tools.approval._is_interactive_cli", return_value=False):
+                with patch(
+                    "tools.approval._is_gateway_approval_context", return_value=False
+                ):
+                    assert _is_unattended_context() is True
+
+
+class TestCronBlockedResult:
+    """_cron_blocked_result() builds a non-retryable blocked response."""
+
+    def test_returns_blocked_status(self):
+        result = _cron_blocked_result("test desc", "rm -rf /")
+        assert result["status"] == "blocked"
+        assert result["approved"] is False
+        assert result["approval_pending"] is False
+
+    def test_message_says_do_not_retry(self):
+        result = _cron_blocked_result("desc", "cmd")
+        assert "Do NOT retry" in result["message"]
+
+    def test_preserves_command_and_desc(self):
+        result = _cron_blocked_result("my desc", "my cmd", pattern_key="pk")
+        assert result["command"] == "my cmd"
+        assert result["description"] == "my desc"
+        assert result["pattern_key"] == "pk"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -244,6 +244,37 @@ def _is_gateway_approval_context() -> bool:
         return True
     return bool(_get_session_platform())
 
+
+def _is_unattended_context() -> bool:
+    """True when no human or gateway is available to approve commands (#1542).
+
+    In cron/subagent contexts, returning ``pending_approval`` causes the agent
+    to retry the blocked command 3-4x (44% of terminal failures). Callers
+    should return a non-retryable ``blocked`` status instead.
+    """
+    if env_var_enabled("HERMES_CRON_SESSION"):
+        return True
+    return not _is_interactive_cli() and not _is_gateway_approval_context()
+
+
+def _cron_blocked_result(desc, command, pattern_key=""):
+    """Build a non-retryable ``blocked`` result for cron/subagent (#1542)."""
+    return {
+        "approved": False,
+        "status": "blocked",
+        "approval_pending": False,
+        "command": command,
+        "description": desc,
+        "pattern_key": pattern_key,
+        "message": (
+            f"BLOCKED: {desc} — no user or gateway present to approve in this "
+            f"context. Do NOT retry; find an alternative approach using "
+            f"file/search tools instead of terminal, or set "
+            f"approvals.cron_mode: approve in config.yaml."
+        ),
+    }
+
+
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
 # active profile home path such as /home/hermes/.hermes/config.yaml. The
@@ -3536,6 +3567,10 @@ def check_all_command_guards(command: str, env_type: str,
         # Return approval_required for backward compat. Redact secrets in the
         # user-facing copy — the raw `command` is preserved for execution and
         # the allowlist keys off pattern_key, so redaction is display-only.
+        #
+        # #1542: In unattended contexts, return non-retryable blocked.
+        if _is_unattended_context():
+            return _cron_blocked_result(combined_desc, command, pattern_key=primary_key)
         from agent.redact import redact_sensitive_text
         _disp_command = redact_sensitive_text(command)
         _disp_combined_desc = redact_sensitive_text(combined_desc)
@@ -3762,6 +3797,10 @@ def check_execute_code_guard(code: str, env_type: str,
     if notify_cb is None:
         # No gateway callback registered (e.g. ask-mode without a notifier):
         # surface a pending approval for backward compatibility.
+        #
+        # #1542: In unattended contexts, return non-retryable blocked.
+        if _is_unattended_context():
+            return _cron_blocked_result(display_description, display_command, pattern_key=pattern_key)
         pending_data = {
             "command": display_command,
             "pattern_key": pattern_key,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -65,6 +65,18 @@ _hermes_interactive_ctx: contextvars.ContextVar[Optional[str]] = contextvars.Con
     default=None,
 )
 
+# Subagent flag. Subagents are spawned on a ThreadPoolExecutor (delegate_tool),
+# so a process-global flag would race just like HERMES_INTERACTIVE once did. A
+# contextvar is thread/task-local: the parent's context is copied into the child
+# worker thread when it is spawned, so setting it inside _run_single_child scopes
+# the "unattended" verdict to that child only. None = unset → not a subagent.
+# Used by _is_unattended_context() to suppress pending_approval retry spirals
+# in subagent contexts where no human can approve (#1542, #1554).
+_hermes_subagent_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "hermes_subagent",
+    default=None,
+)
+
 
 def set_hermes_interactive_context(interactive: bool) -> contextvars.Token:
     """Bind interactive mode for the current context (thread or asyncio task).
@@ -245,16 +257,47 @@ def _is_gateway_approval_context() -> bool:
     return bool(_get_session_platform())
 
 
+def set_hermes_subagent_context(is_subagent: bool) -> contextvars.Token:
+    """Bind the subagent flag for the current context (#1542, #1554).
+
+    Used by ``delegate_tool._run_single_child`` so the child worker thread is
+    recognized as an unattended context. Thread/task-local, so concurrent
+    siblings and the parent are unaffected. Returns the reset token so the
+    caller can restore the prior value.
+    """
+    return _hermes_subagent_ctx.set("1" if is_subagent else "")
+
+
+def _is_subagent_context() -> bool:
+    """True when this call is inside a delegate_task subagent (#1542, #1554).
+
+    Prefers the context-local flag (set by ``_run_single_child``) and falls
+    back to the ``HERMES_SUBAGENT`` env var for callers that export it.
+    """
+    ctx_val = _hermes_subagent_ctx.get()
+    if ctx_val is not None:
+        return is_truthy_value(ctx_val)
+    return env_var_enabled("HERMES_SUBAGENT")
+
+
 def _is_unattended_context() -> bool:
     """True when no human or gateway is available to approve commands (#1542).
 
-    In cron/subagent contexts, returning ``pending_approval`` causes the agent
-    to retry the blocked command 3-4x (44% of terminal failures). Callers
-    should return a non-retryable ``blocked`` status instead.
+    Requires a POSITIVE signal of an unattended context — cron session or
+    subagent — rather than defaulting to "nobody's home" when none of
+    interactive-CLI / gateway / cron are detected. A catch-all default would
+    misfire in the non-interactive test environment (where there is no
+    interactive CLI, no gateway, and no cron session), turning every test's
+    ``pending_approval`` into a non-retryable ``blocked`` and breaking the
+    suite (#1554).
+
+    Returning ``pending_approval`` (rather than ``blocked``) in an ambiguous
+    context is safe: the worst case is a single retry, which is far cheaper
+    than wrongly blocking a command a human could have approved.
     """
     if env_var_enabled("HERMES_CRON_SESSION"):
         return True
-    return not _is_interactive_cli() and not _is_gateway_approval_context()
+    return _is_subagent_context()
 
 
 def _cron_blocked_result(desc, command, pattern_key=""):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2341,6 +2341,14 @@ def _run_single_child(
 
         set_thread_identity(_team_identity[0], _team_identity[1])
 
+    # Mark this worker thread as a subagent so approval gating treats it as
+    # unattended (no human can approve inside a delegate_task child). Thread-
+    # local via contextvar, so the parent and concurrent siblings are
+    # unaffected. Reset in the finally block below (#1542, #1554).
+    from tools.approval import set_hermes_subagent_context
+
+    _subagent_ctx_token = set_hermes_subagent_context(True)
+
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
 
@@ -2976,6 +2984,16 @@ def _run_single_child(
                 clear_thread_identity()
             except Exception as exc:
                 logger.debug("Failed to clear team identity: %s", exc)
+
+        # Clear the subagent contextvar binding so a recycled pool thread
+        # does not inherit "unattended" on its next, non-subagent task
+        # (#1542, #1554).
+        try:
+            from tools.approval import _hermes_subagent_ctx
+
+            _hermes_subagent_ctx.reset(_subagent_ctx_token)
+        except Exception as exc:
+            logger.debug("Failed to reset subagent context: %s", exc)
 
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.


### PR DESCRIPTION
## Summary

Fixes the CI failures on PR #1550 (accepted issue #1542 — suppress pending_approval retries, 44% of terminal failures).

## Problem

PR #1550 introduced `_is_unattended_context()` to convert `pending_approval` into non-retryable `blocked` in cron/subagent contexts. But the implementation defaulted to `True` whenever no interactive CLI, gateway, or cron session was detected — a catch-all "nobody's home" default. In the non-interactive CI test environment, this evaluates to `True`, breaking every test that expects `pending_approval` behavior (slices 2/8 and 8/8).

## Fix (#1554)

`_is_unattended_context()` now requires a **positive signal** of an unattended context:
1. `HERMES_CRON_SESSION` env var (already set in `cron/scheduler.py`), OR
2. A subagent contextvar (`_hermes_subagent_ctx`), set in `delegate_tool._run_single_child`

### Why a contextvar instead of `HERMES_SUBAGENT`?

Issue #1554 proposed checking a `HERMES_SUBAGENT` env var, but that env var **does not exist** on `main` (0 grep matches). Subagents are identified by the `_delegate_depth` attribute on the agent instance, which module-level `tools/approval.py` cannot access. The correct mechanism is a `contextvars.ContextVar` — mirroring the existing `_hermes_interactive_ctx` pattern (introduced for the same thread-safety reason: concurrent ACP/gateway sessions on a shared ThreadPoolExecutor). The contextvar is set in `_run_single_child` (the single entry point for both single and batch delegation) and reset in its `finally` block.

## Validation

- All 11 `test_approval_cron_block.py` tests pass (6 existing + 5 new)
- 392 approval/delegation tests pass
- 338 subagent/delegation tests pass
- ruff check + format clean
- The 3 `test_approval.py` failures (tee/sensitive-redirect patterns) are **pre-existing** — confirmed by running them against the pre-fix commit `c25748edf`; they fail identically and are caused by running as root (`~/.bashrc` path resolution)

## Size note

236 insertions across 3 files — over the 200-line autonomous-merge cap. The three files are tightly coupled (contextvar declared in `approval.py`, set in `delegate_tool.py`, tested in the test file); no smaller coherent slice exists. Holding for human review.

Closes #1554

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>
