### PR TITLE
fix(#1325): reason-scoped realized-impact verdict path

### DIFF
--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -91,12 +91,18 @@ def record_merge(
     predicted_impact: float,
     target: str,
     baseline_failure_rate: Optional[float] = None,
+    baseline_failure_rate_by_reason: Optional[Dict[str, float]] = None,
 ) -> None:
     """Record a merge event in the realized-impact ledger.
 
     ``baseline_failure_rate`` (failures/session at merge time) is stored so later
     verdicts compare apples-to-apples rates, not raw counts that grow with
     session volume (#1324). Omitted/None keeps legacy records working.
+
+    ``baseline_failure_rate_by_reason`` (#1325) is a finer-grained snapshot:
+    ``{reason: failures/session}`` for the specific reason the merged change
+    targets. The aggregate tool rate is dominated by unaffected reasons, so a
+    reason-scoped baseline lets the verdict detect the targeted mode's drop.
     """
     rec: Dict[str, Any] = {
         "issue": issue,
@@ -106,6 +112,8 @@ def record_merge(
     }
     if baseline_failure_rate is not None:
         rec["baseline_failure_rate"] = baseline_failure_rate
+    if baseline_failure_rate_by_reason:
+        rec["baseline_failure_rate_by_reason"] = baseline_failure_rate_by_reason
     append_ledger_record(ledger_file, rec)
 
 
@@ -182,6 +190,7 @@ def should_close_issue(
     today: str,
     maturity_days: int = 5,
     current_failure_rate: Optional[float] = None,
+    current_failure_rate_by_reason: Optional[Dict[str, float]] = None,
     regression_threshold: float = 0.20,
 ) -> tuple:
     """Gate for closing an issue after a fix PR merges.
@@ -202,6 +211,14 @@ def should_close_issue(
     beyond ``regression_threshold``, the raw-count regression is treated as a
     false alarm and the issue may close. This stops growing session volume from
     forcing false HOLDs.
+
+    Reason-scoped rate (#1325): when the merge record stored a
+    ``baseline_failure_rate_by_reason`` and a ``current_failure_rate_by_reason``
+    is supplied, each targeted reason is compared against its own baseline.
+    An aggregate tool rate is dominated by unaffected reasons, so a fix that
+    dropped one reason shows flat and re-opened the issue; reason-scoped
+    comparison sees the real drop. Verdicts are ANDed — every targeted reason
+    must improve to clear the gate; any flat/regressed reason keeps it open.
     """
     rec = None
     for r in reversed(records):
@@ -215,6 +232,48 @@ def should_close_issue(
     verdict = rec.get("verdict")
     if verdict in VERDICTS_GOOD:
         return True, "signal confirmed dropped post-merge"
+
+    # Reason-scoped override (#1325): isolates the targeted failure mode by
+    # comparing each reason against its own baseline. Runs before the aggregate
+    # branch. A fix is credited only when EVERY targeted reason's rate DROPPED by
+    # at least ``regression_threshold``; flat = no-signal = block (not "held").
+    baseline_by_reason = rec.get("baseline_failure_rate_by_reason")
+    if (
+        verdict in VERDICTS_BAD
+        and baseline_by_reason
+        and current_failure_rate_by_reason
+    ):
+        all_improved = True
+        details = []
+        for reason, base in baseline_by_reason.items():
+            cur = current_failure_rate_by_reason.get(reason)
+            if cur is None:
+                all_improved = False
+                details.append(f"{reason}: current rate missing")
+                continue
+            if base > 0:
+                rel = (cur - base) / base
+                improved = rel <= -regression_threshold
+            else:
+                # Baseline was already zero — nothing to fix; a new nonzero
+                # rate is a regression for this reason.
+                rel = 0.0
+                improved = cur <= 0
+            details.append(f"{reason} {cur:.4f} vs {base:.4f} (Δ{rel:+.0%})")
+            if not improved:
+                all_improved = False
+        if all_improved:
+            return (
+                True,
+                "verdict re-checked by reason-scoped rate (#1325): "
+                + "; ".join(details)
+                + " — every targeted reason dropped",
+            )
+        return (
+            False,
+            "reason-scoped: fix did not reduce every targeted reason (#1325): "
+            + "; ".join(details),
+        )
 
     # Rate-normalization override: a "regressed" verdict from a raw-count
     # comparison is a false alarm if the per-session rate held or fell (#1324).

--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -653,6 +653,18 @@ def build_digest(
         tool: (count / scanned if scanned else 0.0)
         for tool, count in tool_failures.items()
     }
+    # Reason-scoped rate (issue #1325 — corrected fix). PR #1336 added reason
+    # *counts* (tool_failures_by_reason) but the realized-impact gate still
+    # compared the aggregate tool rate, so a fix that eliminated one reason
+    # (e.g. read_file:file-not-found) could not register against a tool rate
+    # dominated by an UNAFFECTED reason (read_file:timeout) → "no-signal".
+    # Exposing the per-(tool,reason) rate gives the verification loop a target
+    # that moves only when the targeted reason moves, breaking the treadmill.
+    failure_rate_by_reason: Dict[str, Dict[str, float]] = {}
+    for tool, reasons in failures_by_reason.items():
+        failure_rate_by_reason[tool] = {
+            reason: (n / scanned if scanned else 0.0) for reason, n in reasons.items()
+        }
     spiral_depth_per_session = {
         tool: round((meta["max_consecutive"] / scanned if scanned else 0.0), 4)
         for tool, meta in repeated.items()
@@ -671,6 +683,7 @@ def build_digest(
             "tool_failures": tool_failures,
             "tool_failures_by_reason": failures_by_reason,
             "failure_rate": failure_rate,
+            "failure_rate_by_reason": failure_rate_by_reason,
             "spiral_depth_per_session": spiral_depth_per_session,
             "timeouts": timeouts,
             "refusals_or_access_denied": refusals,

--- a/skills/evolution/evolution-introspection/SKILL.md
+++ b/skills/evolution/evolution-introspection/SKILL.md
@@ -69,13 +69,16 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
    for within-window ranking.
 
    **Attribute by (tool, reason), not by tool alone (#1325).** The digest emits
-   `tool_failures_by_reason` — `{tool: {reason: count}}` over exactly these
-   buckets: `file-not-found`, `permission-denied`, `timeout`, `quota/billing`,
+   `tool_failures_by_reason` — `{tool: {reason: count}}` — and the matching
+   `failure_rate_by_reason` — `{tool: {reason: failures/session}}` — over exactly
+   these buckets: `file-not-found`, `permission-denied`, `timeout`, `quota/billing`,
    `parse-error`, `no-match`, `non-zero-exit`, `other`. A fix for
    `read_file:file-not-found` must not be credited or blamed for
    `read_file:timeout`; conflating them is what produced the fix→regress→refile
    treadmill. When filing or verifying an issue about a failing tool, name the
-   reason bucket, not just the tool.
+   reason bucket, not just the tool. Use `failure_rate_by_reason` for every
+   cross-window comparison of a single reason — the aggregate tool rate is
+   dominated by the UNAFFECTED reasons and will not move.
 
 2. **Detect problem signals** (non-exhaustive):
    - **Tool failures** — a tool returned an error / non-zero / exception,
@@ -136,6 +139,17 @@ index and the `SessionDB` message store). These are real agent↔user dialogues.
      verdict — the ledger has three values only. A raw count that grew purely
      because session volume grew is NOT a regression, and calling it one
      re-opens issues that were actually fixed.
+   - **Prefer reason-scoped rates for reason-targeted fixes (#1325).** When the
+     ledger entry carries `baseline_failure_rate_by_reason` (a `{reason: rate}`
+     snapshot of the SPECIFIC reason the fix targets), compare it against the
+     current digest's `failure_rate_by_reason` for that reason, not the aggregate
+     tool rate. A fix for `read_file:file-not-found` cannot be judged against the
+     whole `read_file` rate, which is dominated by the UNAFFECTED
+     `read_file:timeout` — that was the PR #1336 gap that produced the
+     "no-signal" re-open. The reason-scoped path credits a fix only when EVERY
+     targeted reason's rate actually DROPPED (a flat reason = the fix did not
+     reduce that mode = no-signal). The aggregate tool rate is the fallback when
+     no reason baseline was recorded.
    - Record ONE verdict per such issue via the deterministic helper:
      ```bash
      python3 scripts/evolution_realized_impact.py record-verdict \

--- a/tests/scripts/test_evolution_realized_impact.py
+++ b/tests/scripts/test_evolution_realized_impact.py
@@ -345,3 +345,96 @@ class TestRecordMergeBaseline:
         record_merge(f, 5, "2026-06-01", 0.8, "fix")
         recs = load_ledger(f)
         assert "baseline_failure_rate" not in recs[0]
+
+    def test_baseline_failure_rate_by_reason_stored(self, tmp_path):
+        f = tmp_path / "ledger.jsonl"
+        record_merge(
+            f,
+            5,
+            "2026-06-01",
+            0.8,
+            "fix",
+            baseline_failure_rate_by_reason={"read_file:file-not-found": 0.42},
+        )
+        assert load_ledger(f)[0]["baseline_failure_rate_by_reason"] == {
+            "read_file:file-not-found": 0.42
+        }
+
+
+class TestReasonScopedCloseGate:
+    """#1325 — reason-scoped verdict path.
+
+    The aggregate tool rate is dominated by unaffected reasons, so a fix that
+    dropped ONE reason registered as flat → \"no-signal\" → re-open. These prove
+    the reason-scoped path sees the real drop (flat/any-regression = block)."""
+
+    @staticmethod
+    def _recs(reason_baseline):
+        return [
+            {
+                "issue": 1,
+                "merged_at": "2026-06-01",
+                "baseline_failure_rate_by_reason": reason_baseline,
+            }
+            | _verdict(1, "regressed")
+        ]
+
+    def test_reason_dropped_allows_close(self, tmp_path):
+        recs = self._recs({"read_file:file-not-found": 0.40})
+        should, reason = should_close_issue(
+            recs,
+            1,
+            "2026-06-17",
+            current_failure_rate_by_reason={"read_file:file-not-found": 0.10},
+        )
+        assert should is True and "#1325" in reason
+
+    def test_reason_flat_blocks_close(self, tmp_path):
+        # Flat = fix did not reduce that mode = no-signal → block (not "confirmed").
+        recs = self._recs({"read_file:file-not-found": 0.40})
+        should, reason = should_close_issue(
+            recs,
+            1,
+            "2026-06-17",
+            current_failure_rate_by_reason={"read_file:file-not-found": 0.40},
+        )
+        assert should is False and "#1325" in reason
+
+    def test_reason_regressed_blocks_close(self, tmp_path):
+        recs = self._recs({"read_file:file-not-found": 0.20})
+        should, _ = should_close_issue(
+            recs,
+            1,
+            "2026-06-17",
+            current_failure_rate_by_reason={"read_file:file-not-found": 0.60},
+        )
+        assert should is False
+
+    def test_one_regressed_reason_among_many_blocks_close(self, tmp_path):
+        # AND semantics: every targeted reason must drop; one regression blocks.
+        recs = self._recs({"read_file:file-not-found": 0.40, "read_file:timeout": 0.30})
+        should, _ = should_close_issue(
+            recs,
+            1,
+            "2026-06-17",
+            current_failure_rate_by_reason={
+                "read_file:file-not-found": 0.05,
+                "read_file:timeout": 0.50,  # regressed
+            },
+        )
+        assert should is False
+
+    def test_no_reason_baseline_falls_back_to_aggregate(self, tmp_path):
+        # Legacy record: aggregate tool-rate path still applies.
+        recs = [
+            {"issue": 1, "merged_at": "2026-06-01", "baseline_failure_rate": 5.0}
+            | _verdict(1, "regressed")
+        ]
+        should, _ = should_close_issue(
+            recs,
+            1,
+            "2026-06-17",
+            current_failure_rate=2.0,
+            current_failure_rate_by_reason={"read_file:file-not-found": 0.1},
+        )
+        assert should is True  # rate fell → close via aggregate path

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -363,6 +363,37 @@ class TestFailureReasonClassification:
         assert s["tool_failures_by_reason"] == {"terminal": {"non-zero-exit": 1}}
         assert secret not in json.dumps(s)
 
+    def test_digest_emits_reason_scoped_rate(self, tmp_path):
+        """The corrected #1325 fix: build_digest emits a per-(tool, reason)
+        RATE, not just counts. This is the signal the realized-impact gate
+        needs to detect a fix for ONE reason against a tool rate dominated by
+        an UNAFFECTED reason (the PR #1336 gap that produced "no-signal")."""
+        _session(
+            tmp_path,
+            "s_a",
+            [
+                _asst("read_file", "c1"),
+                _tool("c1", _fail("no such file or directory")),
+            ],
+        )
+        _session(
+            tmp_path,
+            "s_b",
+            [
+                _asst("read_file", "c1"),
+                _tool("c1", _fail("permission denied")),
+            ],
+        )
+        d = build_digest(tmp_path, window_days=7)
+        assert d["sessions_scanned"] == 2
+        # Two failures across two sessions → aggregate tool rate 1.0
+        assert d["signals"]["failure_rate"] == {"read_file": 1.0}
+        # Each reason carries its own rate (0.5), so a fix for one is visible
+        # even when the other is unchanged.
+        assert d["signals"]["failure_rate_by_reason"] == {
+            "read_file": {"file-not-found": 0.5, "permission-denied": 0.5}
+        }
+
 
 class TestBuildDigest:
     def test_window_excludes_old_sessions(self, tmp_path):


### PR DESCRIPTION
Automated evolution PR for issue #1325.

## Problem
Issue #1325 was a fix→regress→refile treadmill: it has been re-opened TWICE by the realized-impact gate with "no-signal", despite PR #1336 already adding reason-level failure *counts* (`tool_failures_by_reason`) to the introspection digest.

**Root cause:** the *verification loop* (`should_close_issue` / `classify_verdict_by_rate`) compared the aggregate **tool** failure rate (`failure_rate[read_file]`), which is dominated by the UNAFFECTED reasons. A fix that eliminated `read_file:file-not-found` showed ~flat against a tool rate dominated by unchanged `read_file:timeout` failures → `no-signal` → re-open. The capability was never delivered to the path that measures it.

## Fix
Wires reason-level signal into the verdict path (the granularity PR #1336 promised but never delivered to measurement):

- **`introspection_extract.build_digest`** now emits `failure_rate_by_reason` — `{tool: {reason: failures/session}}` — next to `failure_rate`.
- **`record_merge`** accepts `baseline_failure_rate_by_reason` (a snapshot of the specific reason(s) the fix targets).
- **`should_close_issue`** gains a reason-scoped override that runs BEFORE the aggregate branch: each targeted reason is compared against its own baseline; the fix is credited ONLY when EVERY targeted reason actually DROPPED by ≥ `regression_threshold`. Flat = no-signal = block (not "held"/"confirmed"). AND semantics: one regressed reason among many keeps the issue open.
- Legacy records (no reason baseline) fall back to the existing aggregate path — backward compatible.

## Tests
5 new tests in `TestReasonScopedCloseGate` covering: reason dropped → close; reason flat → block (the key #1325 invariant); reason regressed → block; one-regressed-among-many → block (AND semantics); no-reason-baseline → aggregate fallback. Plus `test_baseline_failure_rate_by_reason_stored`. All 103 targeted tests pass; ruff check clean.

## Scope / merge-gate note
~216 changed lines (213 insertions, 3 deletions), slightly above the 200-line self-merge cap. The overflow is the 5 essential regression tests that prove the AND-semantics verdict path works — they are the whole point of the corrected fix and cannot be cut without losing the guarantee that broke last time. Gate may hold this for human review.

Breaking the treadmill requires the verification loop to measure at the same granularity the fix acts at.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>