### PR TITLE
feat: crash-isolation in optimizer loop — increment 1 of #1509

### DIFF
--- a/scripts/evolution_optimizer.py
+++ b/scripts/evolution_optimizer.py
@@ -66,9 +66,12 @@ on ``$?`` without parsing JSON.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 # Reuse the shipped evaluator gate — scoring + the bounded ACCEPT/OPTIMIZE/
 # STOP_BUDGET verdict are NOT reimplemented here.
@@ -90,7 +93,9 @@ EXIT_UNCONVERGED = 11
 EXIT_BAD_INPUT = 2
 
 # Seam type aliases (documentation only — kept loose so stubs/lambdas slot in).
-EvaluateFn = Callable[[List[Dict[str, Any]], int], Tuple[List[Dict[str, Any]], Dict[str, Any]]]
+EvaluateFn = Callable[
+    [List[Dict[str, Any]], int], Tuple[List[Dict[str, Any]], Dict[str, Any]]
+]
 RefineFn = Callable[[Optional[Dict[str, Any]], int], List[Dict[str, Any]]]
 
 
@@ -187,7 +192,25 @@ def run_optimizer_loop(
     last_decision: Dict[str, Any] = {}
 
     while current_pass <= max_passes:
-        scored, decision = evaluate(last_candidates, current_pass)
+        # Crash-isolation (#1509): a single malformed episode (LLM call failure,
+        # parse error, network timeout) must not crash the whole loop.  Wrap
+        # evaluate/refine so failures are scored as failed passes, not exceptions
+        # that propagate and kill the pipeline run.
+        try:
+            scored, decision = evaluate(last_candidates, current_pass)
+        except Exception as exc:
+            logger.warning(
+                "evaluate() crashed on pass %d — scoring as failed pass: %s",
+                current_pass,
+                exc,
+            )
+            decision = {
+                "verdict": STOP_BUDGET,
+                "reason": f"evaluate_crashed: {exc}",
+                "best_index": None,
+                "best_score": 0.0,
+            }
+            return _result(False, current_pass, max_passes, last_candidates, decision)
         last_candidates = scored
         last_decision = decision
         verdict = decision.get("verdict")
@@ -201,7 +224,22 @@ def run_optimizer_loop(
         if current_pass >= max_passes:
             break
         best = _best_candidate(scored, decision.get("best_index"))
-        last_candidates = list(refine(best, current_pass))
+        try:
+            last_candidates = list(refine(best, current_pass))
+        except Exception as exc:
+            logger.warning(
+                "refine() crashed on pass %d — terminating loop: %s",
+                current_pass,
+                exc,
+            )
+            last_decision = {
+                **last_decision,
+                "verdict": STOP_BUDGET,
+                "reason": f"refine_crashed: {exc}",
+            }
+            return _result(
+                False, current_pass, max_passes, last_candidates, last_decision
+            )
         current_pass += 1
 
     # Fell out of the loop without a terminal ACCEPT — treat as unconverged
@@ -234,7 +272,9 @@ def _result(
 
 
 # ── CLI (non-LLM seams: score from carried ``scores``, refine is a no-op) ────────
-def _noop_refine(best: Optional[Dict[str, Any]], current_pass: int) -> List[Dict[str, Any]]:
+def _noop_refine(
+    best: Optional[Dict[str, Any]], current_pass: int
+) -> List[Dict[str, Any]]:
     """CLI refinement seam: the terminal toolset has no model to call, so the
     'refinement' is the best candidate carried forward unchanged. The loop then
     re-evaluates it (same scores → same verdict) and the pass budget terminates

--- a/tests/scripts/test_evolution_optimizer.py
+++ b/tests/scripts/test_evolution_optimizer.py
@@ -269,3 +269,49 @@ class TestCli:
 
     def test_bad_numeric_flag_exit_2(self, capsys):
         assert main(["evolution_optimizer.py", "--max-passes", "lots"]) == EXIT_BAD_INPUT
+
+
+class TestCrashIsolation:
+    """Crash-isolation (#1509): a crashed evaluate/refine must not kill the
+    loop — it returns a STOP_BUDGET result, not an exception."""
+
+    def test_evaluate_crash_returns_unconverged(self):
+        def crashing_evaluate(candidates, current_pass):
+            raise RuntimeError("LLM API timeout")
+
+        out = run_optimizer_loop(
+            [{"candidate": "x", "scores": {}}],
+            evaluate=crashing_evaluate,
+            refine=_recording_refine(),
+            max_passes=3,
+        )
+        assert out["converged"] is False
+        assert out["verdict"] == STOP_BUDGET
+        assert "evaluate_crashed" in out["decision"].get("reason", "")
+
+    def test_refine_crash_returns_unconverged(self):
+        evaluate = _scripted_evaluate([_verdict(OPTIMIZE, best_index=0)])
+
+        def crashing_refine(best, current_pass):
+            raise ValueError("malformed LLM response")
+
+        out = run_optimizer_loop(
+            [{"candidate": "x", "scores": {}}],
+            evaluate=evaluate,
+            refine=crashing_refine,
+            max_passes=3,
+        )
+        assert out["converged"] is False
+        assert out["verdict"] == STOP_BUDGET
+        assert "refine_crashed" in out["decision"].get("reason", "")
+
+    def test_evaluate_crash_preserves_candidates(self):
+        cands = [{"candidate": "preserved", "scores": {}}]
+
+        def crashing_evaluate(candidates, current_pass):
+            raise RuntimeError("boom")
+
+        out = run_optimizer_loop(
+            cands, evaluate=crashing_evaluate, refine=_recording_refine(), max_passes=3
+        )
+        assert out["best_candidate"] is not None or out["decision"]["best_index"] is None


### PR DESCRIPTION
## Summary

Implements crash-isolation (pattern #2) from the Harness Control System study (arXiv:2607.25415) — the second-highest scoring issue selected this cycle (score 0.965).

The study found that a single malformed episode took down 39 other episodes in the same job because there was no per-episode error handling. The fix: wrap each pipeline stage so failures are scored as normal failed episodes, not exceptions that propagate.

## Changes

- `scripts/evolution_optimizer.py` (+44/-4): Wrap `evaluate()` and `refine()` calls in the optimizer loop with try/except. A crashed evaluate/refine returns STOP_BUDGET (unconverged) with a diagnostic reason, preserving candidates.
- `tests/scripts/test_evolution_optimizer.py` (+46): 3 new tests — evaluate crash, refine crash, candidate preservation on crash.

## Scope

This is a partial slice of #1509 — implements the crash-isolation pattern (the highest-value fix). The other two patterns from the paper are deferred:

Deferred (next increment):
- Cold-start trap: no RL bandit/controller exists in the evolution pipeline yet — advisory only until one does
- Cost measurement pitfall: DSPy LM disk-cache cost tracking — needs audit of cache-hit code paths across multiple modules

## Validation

- Lint: ruff check clean
- Tests: 21/21 pass (3 new + 18 existing)
- Diff: 94 lines total (within 200-line autonomous merge cap)
