### PR TITLE
feat: paired McNemar test for transfer significance — increment 1 of #1498

### DIFF
--- a/scripts/evolution_bilevel_eval.py
+++ b/scripts/evolution_bilevel_eval.py
@@ -101,6 +101,54 @@ def _mean(xs: Sequence[float]) -> float:
     return sum(xs) / len(xs) if xs else 0.0
 
 
+def mcnemar_test(
+    candidate_pass: Mapping[str, bool],
+    incumbent_pass: Mapping[str, bool],
+) -> dict[str, Any]:
+    """Paired McNemar test for transfer significance (#1498).
+
+    Compares binary pass/fail outcomes on the SAME set of cases between a
+    candidate and an incumbent. Returns the exact two-sided p-value via the
+    binomial distribution (no scipy dependency — uses the exact test for small
+    discordant counts, normal approximation for large n).
+
+    A single-benchmark win is not transfer evidence — use this across diverse
+    benchmarks to detect transfer honestly (RSEA arXiv:2606.28374).
+    """
+    # Discordant pairs: b = cand wins, c = inc wins
+    b = sum(
+        1
+        for k in candidate_pass
+        if k in incumbent_pass and candidate_pass[k] and not incumbent_pass[k]
+    )
+    c = sum(
+        1
+        for k in candidate_pass
+        if k in incumbent_pass and not candidate_pass[k] and incumbent_pass[k]
+    )
+    n = b + c
+    if n == 0:
+        return {"b": 0, "c": 0, "p_value": 1.0, "significant": False}
+    # Exact binomial two-sided p-value for small n, normal approx for large
+    if n < 25:
+        from math import comb
+
+        # Two-sided exact: P(X <= min(b,c)) + P(X >= max(b,c)) under H0: p=0.5
+        lo, hi = min(b, c), max(b, c)
+        p = sum(comb(n, k) for k in range(lo + 1)) / (2**n)
+        p += sum(comb(n, k) for k in range(hi, n + 1)) / (2**n)
+        p = min(p, 1.0)
+    else:
+        from math import sqrt
+
+        z = (abs(b - c) - 1) / sqrt(n) if n > 0 else 0.0
+        # Two-sided normal approx
+        from math import erfc, sqrt as _sqrt
+
+        p = erfc(abs(z) / _sqrt(2))
+    return {"b": b, "c": c, "p_value": round(p, 6), "significant": p < 0.05}
+
+
 def partition_scores(
     cases: Sequence[EvalCase],
     scores: Mapping[str, float],

--- a/tests/scripts/test_evolution_bilevel_eval.py
+++ b/tests/scripts/test_evolution_bilevel_eval.py
@@ -95,3 +95,40 @@ def test_evaluate_from_payload():
     out = bl.evaluate(payload)
     assert out["decision"]["go"] is True
     assert out["budget"]["over_budget"] is False
+
+
+# ── McNemar paired test (#1498) ────────────────────────────────────────────────
+
+
+def test_mcnemar_no_discordant_pairs():
+    """All cases agree → p=1.0, not significant."""
+    r = bl.mcnemar_test({"a": True, "b": False}, {"a": True, "b": False})
+    assert r["b"] == 0 and r["c"] == 0
+    assert r["p_value"] == 1.0 and r["significant"] is False
+
+
+def test_mcnemar_strong_disagreement_significant():
+    """Candidate wins 10, incumbent wins 0 → highly significant."""
+    cand = {f"c{i}": True for i in range(10)}
+    inc = {f"c{i}": False for i in range(10)}
+    r = bl.mcnemar_test(cand, inc)
+    assert r["b"] == 10 and r["c"] == 0
+    assert r["p_value"] < 0.05 and r["significant"] is True
+
+
+def test_mcnemar_balanced_disagreement_not_significant():
+    """5 wins each way → not significant (p ~0.77 at n=10)."""
+    cand = {**{f"w{i}": True for i in range(5)}, **{f"l{i}": False for i in range(5)}}
+    inc = {**{f"w{i}": False for i in range(5)}, **{f"l{i}": True for i in range(5)}}
+    r = bl.mcnemar_test(cand, inc)
+    assert r["b"] == 5 and r["c"] == 5
+    assert r["significant"] is False
+
+
+def test_mcnemar_only_checks_discordant():
+    """Concordant pairs (both pass or both fail) don't count."""
+    cand = {"a": True, "b": True, "c": False, "d": False}
+    inc = {"a": True, "b": False, "c": False, "d": True}
+    # Only b and d are discordant: b=cand wins, d=inc wins
+    r = bl.mcnemar_test(cand, inc)
+    assert r["b"] == 1 and r["c"] == 1


### PR DESCRIPTION
## Summary

Implements the paired McNemar statistical test — a key missing piece from the RSEA held-out selection discipline (arXiv:2606.28374). The existing bi-level eval (#1166) already implements public/private held-out split and per-class regression detection; this adds the statistical significance test that RSEA requires.

RSEA demonstrates that a single-benchmark win is not transfer evidence. Without paired statistical testing across diverse benchmarks, a pipeline change that looks strong in training can catastrophically fail on unseen tasks.

## Changes

- `scripts/evolution_bilevel_eval.py` (+48): New `mcnemar_test()` function — exact binomial two-sided p-value for paired pass/fail outcomes between candidate and incumbent. No scipy dependency (exact test for n<25, normal approximation for larger n via `math.erfc`).
- `tests/scripts/test_evolution_bilevel_eval.py` (+37): 4 new tests — no discordant pairs, strong disagreement, balanced disagreement, discordant-only checking.

## Scope

Partial slice of #1498. The existing `evolution_bilevel_eval.py` already implements the core RSEA discipline (public/private split, strict improvement on private, per-class regression). This adds the McNemar test for multi-benchmark transfer significance.

Deferred (next increment):
- Three-way evolve/val/eval split (currently two-way public/private)
- Explicit context-distraction failure mode check
- Integration of mcnemar_test() into the bilevel_decision() verdict

## Validation

- Lint: ruff check clean
- Tests: 11/11 pass (4 new + 7 existing)
- Diff: 85 lines (within 200-line autonomous merge cap)
