### PR TITLE
fix(compact_context): mirror dispatch into sequential path (#1568 rework)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -59,7 +59,7 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task", "compact_context"}
 )
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2652,6 +2652,20 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "compact_context":
+        # Agent-driven context compaction (#1568 SelfCompact). The model
+        # decides when to compact (not just the threshold trigger) and may
+        # pass a focus topic the summariser should prioritise.
+        def _execute(next_args: dict) -> Any:
+            from tools.compact_context_tool import compact_context_tool as _cc
+            return _finish_agent_tool(
+                _cc(
+                    focus_topic=next_args.get("focus_topic", ""),
+                    agent=agent,
+                    messages=messages,
+                ),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -665,6 +665,26 @@ MODEL_FIRST_REASONING_GUIDANCE = (
     "a one-line answer, a simple formatting request) where it adds no value."
 )
 
+# Agent-driven context compaction rubric (#1568 SelfCompact, arXiv:2606.23525).
+# Injected only when the compact_context tool is loaded. The paper shows the
+# tool alone is used erratically by open-weight models; only the tool + this
+# rubric together elicit adaptive compaction. Short static text → stable prompt
+# prefix, no cache break.
+SELFCOMPACT_RUBRIC_GUIDANCE = (
+    "# Adaptive context compaction\n"
+    "You have a `compact_context` tool that summarises accumulated conversation "
+    "and tool history into a concise prefix, freeing context for the work still "
+    "ahead. Use it adaptively — not on a fixed schedule.\n"
+    "FIRE `compact_context` when a sub-task has just resolved and its verbose "
+    "tool outputs are no longer needed verbatim, or when the trajectory is "
+    "converging (repeated similar tool calls, diminishing new signal).\n"
+    "SUPPRESS it mid-derivation (inside a multi-step calculation or reasoning "
+    "chain), when stuck or iterating without progress, or on short "
+    "conversations where there is nothing to gain. After compaction, continue "
+    "from the summary — resolved facts are preserved; re-read a file or re-run "
+    "a search only if you need exact prior output."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -40,6 +40,7 @@ from agent.prompt_builder import (
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
     RECOVERY_BEFORE_REFUSAL_GUIDANCE,
+    SELFCOMPACT_RUBRIC_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -246,6 +247,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # problem model before planning complex tasks.
     if getattr(agent, "_model_first_reasoning", False) and agent.valid_tool_names:
         stable_parts.append(MODEL_FIRST_REASONING_GUIDANCE)
+
+    # Agent-driven context compaction rubric (#1568 SelfCompact). Injected
+    # only when the compact_context tool is loaded. The rubric steers when
+    # the model fires the tool; without it the paper shows the tool is used
+    # erratically by open-weight models.
+    if "compact_context" in agent.valid_tool_names:
+        stable_parts.append(SELFCOMPACT_RUBRIC_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1426,6 +1426,30 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     spinner.stop(cute_msg)
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
+        elif function_name == "compact_context":
+            # Agent-driven context compaction (#1568 SelfCompact). Mirrors the
+            # concurrent-path branch in agent_runtime_helpers.invoke_tool so
+            # both executors handle the same agent-runtime tool set (the
+            # post_tool_call hook must fire consistently regardless of which
+            # executor ran the tool).
+            def _execute(next_args: dict) -> Any:
+                from tools.compact_context_tool import compact_context_tool as _cc
+                return _cc(
+                    focus_topic=next_args.get("focus_topic", ""),
+                    agent=agent,
+                    messages=messages,
+                )
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('compact_context', function_args, tool_duration, result=function_result)}")
         elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
             # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
             spinner = None

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -145,3 +145,24 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestSelfCompactRubricInjection:
+    """Verify SELFCOMPACT_RUBRIC_GUIDANCE is injected only when the
+    compact_context tool is loaded (#1568)."""
+
+    def test_injected_when_tool_loaded(self):
+        agent = _make_agent(valid_tool_names=["read_file", "compact_context"])
+        stable = _stable_prompt(agent)
+        assert "Adaptive context compaction" in stable
+        assert "compact_context" in stable
+
+    def test_absent_when_tool_not_loaded(self):
+        agent = _make_agent(valid_tool_names=["read_file", "memory"])
+        stable = _stable_prompt(agent)
+        assert "Adaptive context compaction" not in stable
+
+    def test_absent_when_no_tools(self):
+        agent = _make_agent(valid_tool_names=[])
+        stable = _stable_prompt(agent)
+        assert "Adaptive context compaction" not in stable

--- a/tests/tools/test_compact_context_tool.py
+++ b/tests/tools/test_compact_context_tool.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for the compact_context tool (#1568 SelfCompact)."""
+
+import json
+from unittest.mock import MagicMock
+
+from tools.compact_context_tool import (
+    COMPACT_CONTEXT_SCHEMA,
+    check_compact_context_requirements,
+    compact_context_tool,
+)
+
+
+# ─── Schema ──────────────────────────────────────────────────────────────────
+
+def test_schema_name_and_optional_focus():
+    assert COMPACT_CONTEXT_SCHEMA["name"] == "compact_context"
+    params = COMPACT_CONTEXT_SCHEMA["parameters"]
+    assert "focus_topic" in params["properties"]
+    assert params["required"] == []
+
+
+# ─── Availability check ──────────────────────────────────────────────────────
+
+def test_check_requirements_no_agent_returns_true():
+    # Schema-level availability — handler guards the real check.
+    assert check_compact_context_requirements() is True
+
+
+def test_check_requirements_agent_without_compressor():
+    agent = MagicMock()
+    agent.context_compressor = None
+    assert check_compact_context_requirements(agent=agent) is False
+
+
+def test_check_requirements_agent_with_compressor():
+    agent = MagicMock()
+    agent.context_compressor = MagicMock()
+    assert check_compact_context_requirements(agent=agent) is True
+
+
+# ─── Handler — no agent / no messages ────────────────────────────────────────
+
+def test_no_agent_returns_error():
+    result = compact_context_tool(agent=None, messages=[])
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert "not available" in parsed["error"].lower()
+
+
+def test_no_messages_falls_back_to_session_messages():
+    agent = MagicMock()
+    agent._session_messages = None
+    result = compact_context_tool(agent=agent, messages=None)
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+
+
+# ─── Handler — abort path (compressor returns unchanged messages) ────────────
+
+def test_abort_when_compression_does_not_shrink():
+    """When _compress_context returns the same list unchanged, the tool
+    reports an abort (not a crash) so the model can continue."""
+    agent = MagicMock()
+    agent._cached_system_prompt = "sys"
+    messages = [{"role": "user", "content": "hi"}]
+    # Same object returned → no shrink.
+    agent._compress_context.return_value = (messages, "sys")
+
+    result = compact_context_tool(agent=agent, messages=messages)
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert parsed.get("aborted") is True
+    assert parsed["message_count"] == 1
+
+
+# ─── Handler — success path ──────────────────────────────────────────────────
+
+def test_success_rewrites_messages_in_place():
+    """When _compress_context returns a new shorter list, the tool copies it
+    back into the caller's list so the loop continues on the compacted data."""
+    agent = MagicMock()
+    agent._cached_system_prompt = "sys"
+    original = [
+        {"role": "user", "content": "long verbose turn 1"},
+        {"role": "assistant", "content": "long verbose reply 1"},
+        {"role": "user", "content": "long verbose turn 2"},
+        {"role": "assistant", "content": "long verbose reply 2"},
+    ]
+    compacted = [{"role": "user", "content": "summary"}]
+    agent._compress_context.return_value = (compacted, "new_sys")
+
+    # Pass a real list (the loop passes the live messages list).
+    live_messages = list(original)
+    result = compact_context_tool(
+        agent=agent, messages=live_messages, focus_topic="the contract"
+    )
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+    assert parsed["message_count_before"] == 4
+    assert parsed["message_count_after"] == 1
+
+    # The live list was rewritten in place.
+    assert live_messages == compacted
+    # Agent state updated.
+    assert agent._cached_system_prompt == "new_sys"
+    assert agent._session_messages is live_messages
+
+    # focus_topic was forwarded.
+    _args, kwargs = agent._compress_context.call_args
+    assert kwargs.get("focus_topic") == "the contract"
+    assert kwargs.get("force") is True
+
+
+# ─── Handler — exception path ────────────────────────────────────────────────
+
+def test_exception_returns_error_json():
+    agent = MagicMock()
+    agent._cached_system_prompt = "sys"
+    agent._compress_context.side_effect = RuntimeError("summariser down")
+
+    result = compact_context_tool(agent=agent, messages=[{"role": "user", "content": "x"}])
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert "summariser down" in parsed["error"]

--- a/tools/compact_context_tool.py
+++ b/tools/compact_context_tool.py
@@ -53,7 +53,10 @@ def compact_context_tool(
     """
     if agent is None:
         return json.dumps(
-            {"success": False, "error": "compact_context is not available in this execution context."},
+            {
+                "success": False,
+                "error": "compact_context is not available in this execution context.",
+            },
             ensure_ascii=False,
         )
     if messages is None:
@@ -194,8 +197,6 @@ registry.register(
         agent=kw.get("agent"),
         messages=kw.get("messages"),
     ),
-    check_fn=lambda *a, **kw: check_compact_context_requirements(
-        agent=kw.get("agent")
-    ),
+    check_fn=lambda *a, **kw: check_compact_context_requirements(agent=kw.get("agent")),
     emoji="🗜️",
 )

--- a/tools/compact_context_tool.py
+++ b/tools/compact_context_tool.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Compact Context Tool — agent-driven intra-trajectory compression (#1568).
+
+Implements the SelfCompact pattern (Li et al., arXiv:2606.23525): a tool the
+model invokes itself to summarise accumulated conversation/tool history into
+a concise prefix, replacing verbose prior turns. This complements the existing
+automatic threshold-triggered ``_compress_context`` — here the *agent* decides
+*when* to compact, reacting to context rot the system-level trigger cannot see
+(e.g. right after a sub-task resolves).
+
+The fire/suppress rubric lives in the system prompt
+(agent.prompt_builder.SELFCOMPACT_RUBRIC_GUIDANCE) — the paper shows the tool
+alone is used erratically by open-weight models; only tool + rubric together
+elicit adaptive compaction.
+
+Design:
+- Thin wrapper over ``agent._compress_context(force=True, focus_topic=...)``
+  — reuses the proven summariser, splitter, session-rotation, and memory
+  handoff already shipped in agent.conversation_compression.
+- ``force=True`` bypasses the summary-failure cooldown so the model can compact
+  even right after an auto-compress abort (mirrors the manual ``/compress``
+  slash command).
+- The tool result is purely informational — the real state change happened
+  inside ``_compress_context`` (the messages list was rewritten in place and
+  the session rotated). The model continues the turn on the compacted list.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def compact_context_tool(
+    *,
+    focus_topic: str = "",
+    agent=None,
+    messages: list = None,
+) -> str:
+    """Invoke agent-driven context compaction.
+
+    Args:
+        focus_topic: Optional focus string. The summariser will prioritise
+            preserving information related to this topic (mirrors the
+            ``/compact <focus>`` slash command). Omit for a general summary.
+        agent: The owning AIAgent (passed by the dispatcher).
+        messages: The current message list (the same object the conversation
+            loop is iterating). ``_compress_context`` rewrites it in place.
+
+    Returns:
+        JSON string with the compaction outcome.
+    """
+    if agent is None:
+        return json.dumps(
+            {"success": False, "error": "compact_context is not available in this execution context."},
+            ensure_ascii=False,
+        )
+    if messages is None:
+        # Fall back to the agent's session messages if the dispatcher did not
+        # inject the live list (defensive — the invoke_tool path always does).
+        messages = getattr(agent, "_session_messages", None)
+        if messages is None:
+            return json.dumps(
+                {"success": False, "error": "No active conversation to compact."},
+                ensure_ascii=False,
+            )
+
+    pre_count = len(messages)
+    system_message = getattr(agent, "_cached_system_prompt", None) or ""
+
+    try:
+        new_messages, new_prompt = agent._compress_context(
+            messages,
+            system_message,
+            focus_topic=focus_topic or None,
+            force=True,
+        )
+    except Exception as exc:
+        logger.exception("compact_context tool failed")
+        return json.dumps(
+            {"success": False, "error": f"Compaction failed: {exc}"},
+            ensure_ascii=False,
+        )
+
+    post_count = len(new_messages)
+    # _compress_context returns the input unchanged when it aborts (e.g.
+    # conversation too short to summarise, or the summary LLM failed).
+    if post_count >= pre_count and new_messages is messages:
+        return json.dumps(
+            {
+                "success": False,
+                "aborted": True,
+                "reason": (
+                    "Compaction did not shrink the context — the conversation "
+                    "may be too short, the summariser may be temporarily "
+                    "unavailable, or no savings were achievable. Continue "
+                    "working; the system will retry automatically at the "
+                    "threshold."
+                ),
+                "message_count": pre_count,
+            },
+            ensure_ascii=False,
+        )
+
+    # Propagate the compacted list back so the conversation loop continues on it.
+    # _compress_context may return a fresh list on session rotation; ensure the
+    # caller's reference points at the compacted data.
+    if new_messages is not messages:
+        messages.clear()
+        messages.extend(new_messages)
+    if new_prompt:
+        agent._cached_system_prompt = new_prompt
+        agent._session_messages = messages
+
+    return json.dumps(
+        {
+            "success": True,
+            "message_count_before": pre_count,
+            "message_count_after": post_count,
+            "note": (
+                "Context compacted. Continue from the summary — earlier "
+                "verbatim turns have been replaced by a concise prefix. "
+                "Resolved facts are preserved; re-read files or re-run "
+                "searches only if you need exact prior output."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
+def check_compact_context_requirements(agent=None) -> bool:
+    """Available when the agent has a context_compressor and compression is on."""
+    if agent is None:
+        # Schema-level check (no agent instance) — assume available; the
+        # handler guards the real availability.
+        return True
+    return getattr(agent, "context_compressor", None) is not None
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+COMPACT_CONTEXT_SCHEMA = {
+    "name": "compact_context",
+    "description": (
+        "Summarise the accumulated conversation and tool history into a concise "
+        "prefix, replacing verbose prior turns. Use this when you notice the "
+        "context has grown large with stale or resolved content and you want to "
+        "keep working without losing track of resolved facts.\n\n"
+        "FIRE this tool when:\n"
+        "- A sub-task has just resolved and its verbose tool outputs are no "
+        "longer needed verbatim.\n"
+        "- The trajectory is converging (repeated similar tool calls, "
+        "diminishing new signal).\n"
+        "- You find yourself re-reading old turns to re-establish what was "
+        "already decided.\n\n"
+        "SUPPRESS (do NOT fire) when:\n"
+        "- You are mid-derivation inside a multi-step calculation or reasoning "
+        "chain (compaction there loses signal without helping).\n"
+        "- You are stuck or iterating without progress — compaction will not "
+        "unblock you; change strategy instead.\n"
+        "- The conversation is short (few turns) — there is nothing to gain.\n\n"
+        "Optional `focus_topic` tells the summariser what to prioritise "
+        "preserving (e.g. 'the failing test names' or 'the API contract')."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "focus_topic": {
+                "type": "string",
+                "description": (
+                    "Optional focus string. The summariser will prioritise "
+                    "preserving information related to this topic. Omit for a "
+                    "general summary."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="compact_context",
+    toolset="compact_context",
+    schema=COMPACT_CONTEXT_SCHEMA,
+    handler=lambda args, **kw: compact_context_tool(
+        focus_topic=args.get("focus_topic", ""),
+        agent=kw.get("agent"),
+        messages=kw.get("messages"),
+    ),
+    check_fn=lambda *a, **kw: check_compact_context_requirements(
+        agent=kw.get("agent")
+    ),
+    emoji="🗜️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -82,6 +82,11 @@ _HERMES_CORE_TOOLS = [
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Agent-driven context compaction (#1568 SelfCompact). The model invokes
+    # this to summarise accumulated history when it detects context rot, in
+    # addition to the system-level threshold trigger. The fire/suppress rubric
+    # in the system prompt steers when to call it.
+    "compact_context",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,


### PR DESCRIPTION
Rework of #1568 (SelfCompact context-compaction tool, arXiv:2606.23525).

## What failed in PR #1573

The prior PR added the `compact_context` tool's dispatch branch only to the **concurrent** executor path (`agent_runtime_helpers.invoke_tool`), not the **sequential** path (`tool_executor.execute_tool_calls_sequential`). This broke the post-tool-hook ownership invariant enforced by `TestAgentRuntimePostHookOwnershipSync`, which failed in CI slice 3/8 (run 30731997516):

```
invoke_tool:                   [..., 'compact_context', ...]
execute_tool_calls_sequential: [... (NO compact_context) ...]
assert invoke_tool_names == inline_names  # diverged
```

The two executors must cover the same set of agent-runtime tools so `post_tool_call` fires exactly once regardless of which executor ran the tool.

## The fix

Two coordinated changes so both guard tests pass:

1. **`agent/tool_executor.py`** — add the matching `elif function_name == "compact_context"` branch to `execute_tool_calls_sequential`, mirroring the `clarify`/`delegate_task` pattern (`_run_agent_tool_execution_middleware` emits the hook).

2. **`agent/agent_runtime_helpers.py`** — register `compact_context` in `AGENT_RUNTIME_POST_HOOK_TOOL_NAMES` so the ownership frozenset agrees with both dispatch chains.

Plus a one-line `ruff format` cleanup of the lambda in `compact_context_tool.py`.

## Validation

- `TestAgentRuntimePostHookOwnershipSync` (both guards): PASS
- `test_compact_context_tool.py`, `test_system_prompt.py`, `test_model_tools.py`, `test_tool_search.py`: all PASS (file-isolated, CI's model)
- `ruff check`: clean
- The original full-suite flake (`test_interactive_env_var_routes_to_callback`) reproduces on clean `main` — pre-existing, unrelated to this change.

## Scope note

Total diff is ~420 lines (the feature is inherently tool + rubric + tests + dual-path wiring). This exceeds the 200-line autonomous-merge cap, so it needs human review — but the work is complete and the CI blocker is resolved.

Closes #1568