### PR TITLE
fix(read_file): inline 'did you mean?' suggestion into error text (Closes #1587)

### DIFF
--- a/tests/tools/test_read_patch_resilience.py
+++ b/tests/tools/test_read_patch_resilience.py
@@ -54,6 +54,24 @@ class TestSuggestSimilarFilesAntiSpiral:
         r = self.ops._suggest_similar_files(str(self.tmp / "analysis" / "2026-07-11.json"))
         assert any("2026-07-10" in f for f in r.similar_files)
 
+    def test_similar_suggestion_inlined_in_error_1587(self):
+        """#1587 — the 'did you mean?' suggestion must be inlined in the
+        error text so the agent (which only reads ``.error``) actually sees
+        it, not just in the separate ``similar_files`` field."""
+        r = self.ops._suggest_similar_files(str(self.tmp / "analysis" / "2026-07-11.json"))
+        assert r.error is not None
+        # The suggestion should appear directly in the error string...
+        assert "Did you mean" in r.error
+        # ...and reference the closest existing file by name.
+        assert "2026-07-10.json" in r.error
+
+    def test_no_suggestion_when_truly_missing(self):
+        """When no similar files exist, the error must NOT contain a
+        misleading 'Did you mean' with an empty list."""
+        r = self.ops._suggest_similar_files(str(self.tmp / "analysis" / "nope.json"))
+        assert r.error is not None
+        assert "Did you mean" not in r.error
+
 class TestIdenticalStrings:
     def test_sentinel_strategy(self):
         _, c, st, err = fuzzy_find_and_replace("hello", "hello", "hello")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1415,6 +1415,16 @@ class ShellFileOperations(FileOperations):
                 )
 
         error_msg = f"File not found: {path}"
+        # #1587 — the "did you mean?" suggestion MUST be inlined into the
+        # error text. The caller (_diagnose_read_failure → line ~1782) only
+        # reads ``.error``, so a suggestion left in the separate
+        # ``similar_files`` field is invisible to the agent and the 71/wk
+        # file-not-found spiral persists unchanged.
+        if similar:
+            error_msg += (
+                "\n\nDid you mean: " + ", ".join(similar) + "? "
+                "Re-run read_file with one of these paths instead of guessing."
+            )
         if hint_parts:
             error_msg += "\n\n" + "\n".join(hint_parts)
 


### PR DESCRIPTION
Automated evolution PR for issue #1587.

## Problem
read_file fails on file-not-found 71 times/week (8.8%). The `_suggest_similar_files()` machinery already finds the closest match, but stores it in a separate `similar_files` field on `ReadResult`. The caller (`_diagnose_read_failure` at line ~1782) only reads `.error`, so the suggestion was invisible to the agent — it kept guessing paths blindly.

## Fix
Inline the `Did you mean: <path>?` suggestion directly into the error text so the agent sees it in every file-not-found response.

## Verification
- Lint: `ruff check` ✓
- Tests: 13 passed (including 2 new tests verifying the suggestion is inlined)
- Diff: 28 lines (well under 200-line self-merge cap)