### PR TITLE
fix(search_files): enrich invalid-regex errors with compile reason + hints (Closes #1588)

### DIFF
--- a/tests/tools/test_search_glob_redirect.py
+++ b/tests/tools/test_search_glob_redirect.py
@@ -198,3 +198,58 @@ class TestHandleSearchFilesGlobRedirect:
         data = json.loads(result)
         assert "error" in data
         assert "glob" in data["error"].lower()
+
+
+class TestInvalidRegexEnrichment:
+    """#1588 — invalid regex patterns (not globs) must return an enriched
+    error with the compile-failure reason, not a bare ripgrep parse error."""
+
+    def test_unclosed_bracket_returns_reason(self):
+        """An unclosed character class is an invalid regex, not a glob."""
+        result = _handle_search_files(
+            {"pattern": "[unclosed", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "Invalid regex" in data["error"]
+        # The specific re.error reason should be surfaced
+        assert "unterminated" in data["error"].lower()
+
+    def test_invalid_regex_mentions_escape_hint(self):
+        """The error should hint at escaping metacharacters."""
+        result = _handle_search_files(
+            {"pattern": "(", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "escape" in data["error"].lower()
+
+    def test_valid_regex_not_caught_by_enrichment(self):
+        """A valid regex must pass through to search_tool, not hit enrichment."""
+        result = _handle_search_files(
+            {"pattern": r"\bfoo\b", "target": "content"},
+            task_id="test",
+        )
+        # Should NOT contain the enrichment error
+        try:
+            data = json.loads(result)
+            if "error" in data:
+                assert "Invalid regex" not in data["error"]
+        except (json.JSONDecodeError, TypeError):
+            pass  # non-JSON -> went through to search_tool, correct
+
+    def test_invalid_regex_with_file_glob_passes_through(self):
+        """When file_glob is set, an invalid regex pattern should pass through
+        (the caller may intend a literal string combined with a filename filter)."""
+        result = _handle_search_files(
+            {"pattern": "(", "target": "content", "file_glob": "*.py"},
+            task_id="test",
+        )
+        try:
+            data = json.loads(result)
+            if "error" in data:
+                assert "Invalid regex" not in data["error"]
+        except (json.JSONDecodeError, TypeError):
+            pass

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2697,6 +2697,39 @@ def _handle_search_files(args, **kw):
             ),
         })
 
+    # #1588 — when a pattern that does NOT look like a glob still fails to
+    # compile as a regex, ripgrep returns a bare parse error with no guidance,
+    # causing 59/week parse-error spirals. Pre-validate and surface the exact
+    # compile-failure reason plus a glob-vs-regex hint so the agent can fix
+    # the pattern instead of blind-retrying with a near-identical one.
+    # Guard ``file_glob``: when it is set, the caller is intentionally
+    # combining a filename filter with their pattern, so the pattern should
+    # pass through even if it happens to be a bare glob.
+    if (
+        target == "content"
+        and not args.get("file_glob")
+        and not _is_valid_regex(pattern)
+    ):
+        try:
+            re.compile(pattern)
+            compile_reason = ""
+        except re.error as exc:
+            compile_reason = str(exc)
+        return json.dumps(
+            {
+                "error": (
+                    f"Invalid regex pattern {pattern!r}: {compile_reason}.\n\n"
+                    "To fix:\n"
+                    "  - If you meant a literal string, escape regex metacharacters "
+                    "(e.g. replace '[' with '\\[', '*' with '\\*').\n"
+                    "  - If you meant a filename pattern (like '*.py'), use target='files' "
+                    "or move it to the file_glob parameter instead of the regex pattern.\n"
+                    "  - Re-run search_files with a corrected regex pattern."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
     return search_tool(
         pattern=pattern,
         target=target,


### PR DESCRIPTION
Automated evolution PR for issue #1588.

## Problem
search_files failed 59/week on parse errors (7.3% failure rate). Patterns that are invalid regexes (but not globs) fell through to ripgrep, which returned a bare parse error with no actionable reason. The agent retried with near-identical patterns, spiraling up to 11 consecutive calls.

## Fix
Pre-validate the regex in `_handle_search_files` before invoking ripgrep. When `re.compile` fails, return the specific compile-failure reason (e.g. "unterminated character set") plus a structured recovery hint (escape metacharacters / use target='files' / move to file_glob).

## Verification
- Lint: `ruff check` ✓
- Tests: 32 passed (including 4 new tests for the enrichment path)
- Diff: 89 lines (under 200-line self-merge cap)