### PR TITLE
fix(search_files): escalate empty-spiral to real error at 6+ empties (Closes #1589)

### DIFF
--- a/tests/tools/test_search_empty_spiral.py
+++ b/tests/tools/test_search_empty_spiral.py
@@ -106,3 +106,31 @@ class TestSearchFilesEmptySpiral:
         assert "_search_directive" not in result, (
             "Counter should have reset after a successful search"
         )
+
+
+class TestSearchFilesEmptySpiralEscalation:
+    """#1589 — at 6+ cumulative empty searches, escalate from advisory
+    _search_directive to a real 'error' key so classify_tool_failure
+    counts it as a failure and the spiral_failure_cap can halt."""
+
+    def test_error_key_at_hard_cap(self):
+        """After 6 cumulative empty searches, the result must carry a real
+        'error' key (not just _search_directive) so it's classified as
+        a failure."""
+        for i in range(5):
+            _search_empty(pattern=_SEARCH_PATTERN + str(i), task_id="test-1589")
+        result = _search_empty(pattern=_SEARCH_PATTERN + "cap", task_id="test-1589")
+        assert "error" in result, (
+            "Expected 'error' key at 6+ empties so the spiral cap can fire"
+        )
+        assert "6 times" in result["error"]
+        assert "deterministic" in result["error"].lower()
+
+    def test_directive_still_present_below_cap(self):
+        """At 3-5 empties (below the hard cap), only the advisory directive
+        should be present — no error key yet."""
+        for i in range(2):
+            _search_empty(pattern=_SEARCH_PATTERN + str(i), task_id="test-1589b")
+        result = _search_empty(pattern=_SEARCH_PATTERN + "3rd", task_id="test-1589b")
+        assert "_search_directive" in result
+        assert "error" not in result

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2277,6 +2277,15 @@ def search_tool(
         # reformulates the query each time and gets empty each time) slip
         # through — the regression of #1149. Track cumulative empty results
         # per session and inject a directive when they pile up.
+        #
+        # #1589 — the directive at _es>=3 was advisory (appended text, no
+        # error key), so classify_tool_failure still saw success and the
+        # spiral_failure_cap never accumulated. 31 sessions hit 11-consecutive
+        # empty searches because the cap had no teeth. Escalate to a real
+        # error at _es>=6 so the failure is classified and the cross-turn
+        # spiral_failure_cap (search_files is in _SPIRAL_PRONE_TOOLS) can
+        # accumulate and halt.
+        _SEARCH_EMPTY_HARD_CAP = 6
         if result_dict.get("total_count", 0) == 0 and not result_dict.get("error"):
             with _read_tracker_lock:
                 td = _read_tracker.setdefault(
@@ -2285,7 +2294,16 @@ def search_tool(
                 )
                 td["empty_searches"] = td.get("empty_searches", 0) + 1
                 _es = td["empty_searches"]
-            if _es >= 3:
+            if _es >= _SEARCH_EMPTY_HARD_CAP:
+                result_dict["error"] = (
+                    f"search_files has returned 0 results {_es} times. Your "
+                    "queries are consistently not matching anything — this is a "
+                    "deterministic dead end. STOP searching and switch strategy: "
+                    "(a) use search_files target='files' with a glob like '*.py', "
+                    "(b) call repo_map for a structural overview, or "
+                    "(c) read_file on a known path instead of searching."
+                )
+            elif _es >= 3:
                 result_dict.setdefault(
                     "_search_directive",
                     (


### PR DESCRIPTION
Automated evolution PR for issue #1589.

## Problem
The search_files empty-spiral detector (#1372) injected an advisory `_search_directive` at 3+ cumulative empty searches, but the result still had no `error` key. `classify_tool_failure` therefore saw `success=True` and the `spiral_failure_cap` never accumulated. 31 sessions hit 11-consecutive empty searches with the cap never firing.

## Fix
Escalate from advisory `_search_directive` (at 3+ empties) to a real `error` key (at 6+ empties). This makes the failure classify correctly so the cross-turn `spiral_failure_cap` (search_files is in `_SPIRAL_PRONE_TOOLS`) accumulates and eventually halts the spiral.

## Verification
- Lint: `ruff check` ✓
- Tests: 7 passed (including 2 new tests for the escalation path)
- Diff: 47 lines (under 200-line self-merge cap)