### PR TITLE
fix: read_file similar_files propagation + search_files parse-error enrichment (Closes #1587, #1588)

### DIFF
--- a/tests/tools/test_file_error_suggestions.py
+++ b/tests/tools/test_file_error_suggestions.py
@@ -1,0 +1,171 @@
+"""Tests for read_file file-not-found suggestion propagation (#1587) and
+search_files parse-error enrichment (#1588).
+
+#1587: ``_diagnose_read_failure`` returns ``(error_str, similar_files)`` so
+the ``similar_files`` field survives into the ``ReadResult`` / ``PatchResult``
+and ``classify_file_error`` can route to ``fuzzy_match`` ("Did you mean …?")
+instead of the generic ``not_found`` class.
+
+#1588: ``_enrich_search_parse_error`` detects regex compile failures and
+appends a glob-vs-regex disambiguation hint so the agent stops blind-retrying
+bad patterns.
+"""
+
+import os
+
+import pytest
+
+from tools.file_operations import (
+    PatchResult,
+    ReadResult,
+    ShellFileOperations,
+    _enrich_search_parse_error,
+    classify_file_error,
+)
+from tools.environments.local import LocalEnvironment
+
+
+def _ops(root):
+    return ShellFileOperations(LocalEnvironment(cwd=str(root)), cwd=str(root))
+
+
+# ---------------------------------------------------------------------------
+# #1587 — similar_files propagation through _diagnose_read_failure
+# ---------------------------------------------------------------------------
+
+
+class TestSimilarFilesPropagation:
+    """Verify similar_files survives the read_file → ReadResult → to_dict chain."""
+
+    def test_read_file_not_found_carries_similar_files(self, tmp_path):
+        """read_file on a missing file with a near-match neighbour returns a
+        ReadResult whose similar_files is populated so classify_file_error
+        routes to fuzzy_match."""
+        # Create a file that will score as "similar" to the missing target
+        (tmp_path / "utils.py").write_text("# real file\n")
+        ops = _ops(tmp_path)
+
+        result = ops.read_file(str(tmp_path / "utilz.py"))
+        assert result.error is not None
+        assert result.similar_files, (
+            "similar_files must be populated when near-matches exist"
+        )
+
+    def test_read_file_not_found_dict_has_fuzzy_match_class(self, tmp_path):
+        """The to_dict() output must carry error_class='fuzzy_match' and a
+        'recovery' field mentioning the similar file — not the bare
+        'not_found' class that gives no recovery hint."""
+        (tmp_path / "config.py").write_text("# real\n")
+        ops = _ops(tmp_path)
+
+        result = ops.read_file(str(tmp_path / "config2.py"))
+        d = result.to_dict()
+
+        assert d.get("error_class") == "fuzzy_match", (
+            f"expected fuzzy_match, got {d.get('error_class')!r} — "
+            "similar_files not propagated"
+        )
+        assert "recovery" in d
+        assert "config.py" in d["recovery"]
+
+    def test_read_file_not_found_no_match_has_not_found_class(self, tmp_path):
+        """When no similar files exist, error_class is 'not_found'."""
+        ops = _ops(tmp_path)
+        result = ops.read_file(str(tmp_path / "definitely_nonexistent_file.xyz"))
+        d = result.to_dict()
+        assert d.get("error_class") == "not_found"
+
+    def test_diagnose_read_failure_returns_tuple(self, tmp_path):
+        """_diagnose_read_failure returns (str, list), not just str."""
+        (tmp_path / "model.py").write_text("# real\n")
+        ops = _ops(tmp_path)
+
+        err, sims = ops._diagnose_read_failure(str(tmp_path / "modle.py"))
+        assert isinstance(err, str)
+        assert isinstance(sims, list)
+        # When a similar file exists, it should appear in the list
+        if sims:
+            assert any("model.py" in s for s in sims)
+
+    def test_patch_not_found_carries_similar_files(self, tmp_path):
+        """patch_replace on a missing file with a near-match returns a
+        PatchResult whose similar_files is populated so classify_file_error
+        routes to fuzzy_match."""
+        (tmp_path / "settings.py").write_text("# real\n")
+        ops = _ops(tmp_path)
+
+        result = ops.patch_replace(str(tmp_path / "setting.py"), "old", "new")
+        d = result.to_dict()
+        assert d.get("error") is not None
+        # If similar files were found, error_class should be fuzzy_match
+        if result.similar_files:
+            assert d.get("error_class") == "fuzzy_match"
+
+
+# ---------------------------------------------------------------------------
+# #1588 — search_files parse-error enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichSearchParseError:
+    """Unit tests for _enrich_search_parse_error."""
+
+    def test_non_parse_error_unchanged(self):
+        """Non-parse errors (permission denied etc.) are not enriched."""
+        result = _enrich_search_parse_error("Permission denied", "foo")
+        assert result == "Search failed: Permission denied"
+
+    def test_glob_pattern_gets_glob_hint(self):
+        """Patterns like '*.py' that fail regex compilation get a
+        'use target=files' hint."""
+        result = _enrich_search_parse_error(
+            "rg: regex parse error:\n    error: repetition",
+            "*.py",
+        )
+        assert "target='files'" in result
+        assert "*.py" in result
+
+    def test_regex_syntax_error_gets_fix_hint(self):
+        """Genuine regex syntax errors get a 'fix the syntax' hint."""
+        result = _enrich_search_parse_error(
+            "grep: Invalid regular expression",
+            "(foo",
+        )
+        assert "not valid regex" in result
+        assert "target='files'" not in result
+
+    def test_bare_bracket_is_regex_not_glob(self):
+        """A bare '[' is a regex bracket expression, not a glob."""
+        result = _enrich_search_parse_error(
+            "rg: regex parse error:\n    [.\n    ^\nerror: unclosed character class",
+            "[",
+        )
+        assert "not valid regex" in result
+        assert "target='files'" not in result
+
+    def test_original_error_preserved(self):
+        """The original error text must be preserved in the enriched message."""
+        original = "rg: regex parse error:\n    (?:\n     ^\nerror: unclosed group"
+        result = _enrich_search_parse_error(original, "(foo")
+        assert original in result
+
+    def test_search_with_bad_regex_returns_enriched_error(self, tmp_path):
+        """Integration: search_files with an invalid regex returns an
+        enriched error message through the full search pipeline."""
+        (tmp_path / "f.txt").write_text("hello\n")
+        ops = _ops(tmp_path)
+
+        result = ops.search(
+            pattern="(",
+            path=str(tmp_path),
+            target="content",
+        )
+        assert result.error is not None
+        # The error should contain enrichment hints
+        assert "Search failed" in result.error
+        # Should have actionable guidance
+        assert "regex" in result.error.lower() or "target='files'" in result.error
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/tools/test_file_error_suggestions.py
+++ b/tests/tools/test_file_error_suggestions.py
@@ -143,6 +143,21 @@ class TestEnrichSearchParseError:
         assert "not valid regex" in result
         assert "target='files'" not in result
 
+    def test_file_glob_set_suppresses_the_glob_redirect(self):
+        """With file_glob already set, a glob-shaped pattern is deliberate regex.
+
+        The caller is filtering filenames by file_glob and searching content
+        with the pattern, so target='files' — which cannot search content —
+        would be the wrong advice. They get the regex-syntax hint instead.
+        """
+        result = _enrich_search_parse_error(
+            "rg: regex parse error:\n    error: repetition",
+            "*.py",
+            "*.ts",
+        )
+        assert "target='files'" not in result
+        assert "not valid regex" in result
+
     def test_original_error_preserved(self):
         """The original error text must be preserved in the enriched message."""
         original = "rg: regex parse error:\n    (?:\n     ^\nerror: unclosed group"

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -129,5 +129,8 @@ def test_real_rg_error_still_hard_fails(ops, monkeypatch):
 
     result = ops.search("[", path="/big", target="content")
 
-    assert result.error == "Search failed: rg: regex parse error:"
+    # A genuine rg parse error is still a hard failure, not a truncation. The
+    # message is enriched with recovery guidance (#1588), so assert the
+    # original rg text survives rather than pinning the exact string.
+    assert result.error.startswith("Search failed: rg: regex parse error:")
     assert result.limit_reason is None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -296,6 +296,7 @@ class PatchResult:
     # field to the tool result so the model can correct on its next
     # turn without re-reading the file.
     structured_error: Optional[str] = None
+    similar_files: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -313,7 +314,7 @@ class PatchResult:
             result["lsp_diagnostics"] = self.lsp_diagnostics
         if self.error:
             result["error"] = self.error
-            hit = classify_file_error(self.error)
+            hit = classify_file_error(self.error, similar_files=self.similar_files)
             if hit:
                 result["error_class"], result["recovery"] = hit
         if self.structured_error:
@@ -443,6 +444,75 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     if result.exit_code == 124:
         return _SEARCH_TIMEOUT_MARKER_RE.sub("", result.stdout), "search_timeout"
     return result.stdout, None
+
+
+def _enrich_search_parse_error(error_msg: str, pattern: str) -> str:
+    """Enrich a regex parse-error with actionable guidance (#1588).
+
+    When rg/grep reject a pattern (exit 2), the raw message is typically::
+
+        rg: regex parse error:
+            (?:[
+               ^
+        error: unclosed character class
+
+    or::
+
+        grep: Invalid regular expression
+
+    The agent sees "Search failed: …" but can't tell whether the fix is
+    "rewrite the regex" or "this is a glob, use target=files".  This helper:
+
+    1. Keeps the original error text (the compile-failure reason is valuable).
+    2. Detects whether the pattern looks like a **glob** (contains ``*`` or
+       ``?`` but lacks regex metacharacters like ``(``, ``[``, ``+``) and
+       appends a "use target=files" hint.
+    3. For genuine regex syntax errors, appends a "fix or simplify the regex"
+       hint.
+    """
+    base = f"Search failed: {error_msg}"
+    low = error_msg.lower()
+
+    is_parse_error = (
+        "regex parse error" in low
+        or "invalid regular expression" in low
+        or "unrecognized repeat" in low
+        or "unbalanced" in low
+        or "unclosed" in low
+        or "invalid repetition" in low
+    )
+    if not is_parse_error:
+        return base
+
+    # Heuristic: does the pattern look like a glob that the agent passed as
+    # regex? Globs use *, ?, and character classes [abc] — but NOT regex-only
+    # constructs like (), +, |, {n}, \\d, \\w, etc.  If the ONLY metacharacters
+    # are glob-style AND the pattern contains at least one of the primary
+    # glob signals (* or ?), the agent likely intended a filename search.
+    # A bare "[" or "]" without * or ? is a regex bracket, not a glob.
+    # Note: "." is excluded from regex_only_chars because it appears in
+    # every filename extension (*.py, config.yaml) and would cause false
+    # negatives for the most common glob confusion case.
+    regex_only_chars = set("()+|{}^$\\")
+    chars_in_pattern = set(pattern)
+    has_star_or_q = "*" in chars_in_pattern or "?" in chars_in_pattern
+    looks_like_glob = has_star_or_q and not (regex_only_chars & chars_in_pattern)
+
+    hints: list[str] = []
+    if looks_like_glob:
+        hints.append(
+            f"Pattern '{pattern}' looks like a filename glob, but search_files "
+            "with target='content' treats it as a regex. Use target='files' "
+            "instead (e.g. search_files(pattern='*.py', target='files'))."
+        )
+    else:
+        hints.append(
+            f"Pattern '{pattern}' is not valid regex. Fix the syntax error "
+            "above, simplify the pattern, or use a plain substring search "
+            "(regex special characters: ( ) [ ] { } + * ? | ^ $ \\ .)."
+        )
+
+    return base + "\n\n" + " ".join(hints)
 
 
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
@@ -1233,7 +1303,8 @@ class ShellFileOperations(FileOperations):
             # _diagnose_read_failure probes with test -e / test -d to
             # disambiguate, producing a classify_file_error-friendly message
             # so the agent picks the right recovery instead of blind-retrying.
-            return ReadResult(error=self._diagnose_read_failure(path, operation="read"))
+            _err, _sim = self._diagnose_read_failure(path, operation="read")
+            return ReadResult(error=_err, similar_files=_sim)
 
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
@@ -1434,7 +1505,8 @@ class ShellFileOperations(FileOperations):
             # suppressed can't distinguish missing / directory / permission
             # denied. Probe the real cause so classify_file_error routes
             # the agent to the right recovery.
-            return ReadResult(error=self._diagnose_read_failure(path, operation="read"))
+            _err, _sim = self._diagnose_read_failure(path, operation="read")
+            return ReadResult(error=_err, similar_files=_sim)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
             file_size = int(stat_output.strip())
@@ -1752,7 +1824,9 @@ class ShellFileOperations(FileOperations):
     # PATCH Implementation (Replace Mode)
     # =========================================================================
 
-    def _diagnose_read_failure(self, path: str, operation: str = "patch") -> str:
+    def _diagnose_read_failure(
+        self, path: str, operation: str = "patch"
+    ) -> tuple[str, list[str]]:
         """Build a distinct, classifiable error for a failed file read.
 
         Both ``patch_replace`` and ``read_file`` / ``read_file_raw`` probe
@@ -1769,6 +1843,13 @@ class ShellFileOperations(FileOperations):
         ``operation`` ("patch" or "read") controls the wording of the
         directory / permission messages so they stay actionable for the
         caller that triggered the probe.
+
+        Returns ``(error_str, similar_files)``.  ``similar_files`` is
+        non-empty only when the path was not found and candidate matches
+        were scored — the caller can attach it to the ``ReadResult`` /
+        ``PatchResult`` so ``classify_file_error`` routes to
+        ``fuzzy_match`` (with a "Did you mean …?" recovery hint) instead
+        of the generic ``not_found`` class (#1587).
         """
         esc = self._escape_shell_arg(path)
         # Does the path exist at all?  ``-e`` follows symlinks; combined
@@ -1779,16 +1860,23 @@ class ShellFileOperations(FileOperations):
             # Reuse the rich not-found suggestion (similar files / nearest
             # ancestor listing) so the message classifies as ``not_found``
             # and tells the agent how to recover.
-            suggest = self._suggest_similar_files(path).error
-            return suggest or f"File not found: {path}"
+            suggest_result = self._suggest_similar_files(path)
+            return (
+                suggest_result.error or f"File not found: {path}",
+                list(suggest_result.similar_files),
+            )
         # Path exists but the read failed — is it a directory?
         is_dir = self._exec(f"test -d {esc} && echo yes || echo no")
         if (is_dir.stdout or "").strip() == "yes":
-            return f"Cannot {operation} a directory: {path} is a directory, not a file."
+            return (
+                f"Cannot {operation} a directory: {path} is a directory, not a file.",
+                [],
+            )
         # Exists and is a regular file — most likely a permission error.
         return (
             f"Permission denied reading file: {path}. Check read permissions "
-            f"before retrying — do not repeat the same {operation} blindly."
+            f"before retrying — do not repeat the same {operation} blindly.",
+            [],
         )
 
     def patch_replace(
@@ -1831,7 +1919,8 @@ class ShellFileOperations(FileOperations):
             # here so the error classifies distinctly and carries a
             # create-on-miss hint. The happy path (file exists) is
             # unchanged: these probes only run on failure.
-            return PatchResult(error=self._diagnose_read_failure(path))
+            _err, _sim = self._diagnose_read_failure(path)
+            return PatchResult(error=_err, similar_files=_sim)
 
         content = read_result.stdout
         # Strip a leading UTF-8 BOM before matching so the fuzzy matcher and
@@ -2685,7 +2774,8 @@ class ShellFileOperations(FileOperations):
         # usable match payload remains. Otherwise we keep the real matches.
         if result.exit_code == 2 and not payload.strip():
             error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
-            return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
+            enriched = _enrich_search_parse_error(error_msg, pattern)
+            return SearchResult(error=enriched, total_count=0)
 
         # Parse the diagnostic-free payload so error text never becomes a match.
         stdout = payload
@@ -2825,7 +2915,8 @@ class ShellFileOperations(FileOperations):
         # usable match payload remains.
         if result.exit_code == 2 and not payload.strip():
             error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
-            return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
+            enriched = _enrich_search_parse_error(error_msg, pattern)
+            return SearchResult(error=enriched, total_count=0)
 
         stdout = payload
         if output_mode == "files_only":

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -536,7 +536,9 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
-def _enrich_search_parse_error(error_msg: str, pattern: str) -> str:
+def _enrich_search_parse_error(
+    error_msg: str, pattern: str, file_glob: str = ""
+) -> str:
     """Enrich a regex parse-error with actionable guidance (#1588).
 
     When rg/grep reject a pattern (exit 2), the raw message is typically::
@@ -583,10 +585,19 @@ def _enrich_search_parse_error(error_msg: str, pattern: str) -> str:
     # Note: "." is excluded from regex_only_chars because it appears in
     # every filename extension (*.py, config.yaml) and would cause false
     # negatives for the most common glob confusion case.
+    # A caller that already passed ``file_glob`` is filtering filenames by that
+    # glob and searching content with the pattern — so a glob-shaped pattern is
+    # deliberate regex, not the target='files' confusion this hint addresses.
+    # Suggesting target='files' there would send them to a tool that cannot do
+    # what they asked.
     regex_only_chars = set("()+|{}^$\\")
     chars_in_pattern = set(pattern)
     has_star_or_q = "*" in chars_in_pattern or "?" in chars_in_pattern
-    looks_like_glob = has_star_or_q and not (regex_only_chars & chars_in_pattern)
+    looks_like_glob = (
+        has_star_or_q
+        and not (regex_only_chars & chars_in_pattern)
+        and not file_glob
+    )
 
     hints: list[str] = []
     if looks_like_glob:
@@ -2874,7 +2885,9 @@ class ShellFileOperations(FileOperations):
         # usable match payload remains. Otherwise we keep the real matches.
         if result.exit_code == 2 and not payload.strip():
             error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
-            enriched = _enrich_search_parse_error(error_msg, pattern)
+            enriched = _enrich_search_parse_error(
+                error_msg, pattern, file_glob or ""
+            )
             return SearchResult(error=enriched, total_count=0)
 
         # Parse the diagnostic-free payload so error text never becomes a match.
@@ -3015,7 +3028,9 @@ class ShellFileOperations(FileOperations):
         # usable match payload remains.
         if result.exit_code == 2 and not payload.strip():
             error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
-            enriched = _enrich_search_parse_error(error_msg, pattern)
+            enriched = _enrich_search_parse_error(
+                error_msg, pattern, file_glob or ""
+            )
             return SearchResult(error=enriched, total_count=0)
 
         stdout = payload


### PR DESCRIPTION
Automated evolution PR for issues #1587 and #1588.

## #1587 — read_file file-not-found: 'did you mean?' suggestion not surfaced

**Root cause:** `_diagnose_read_failure()` called `_suggest_similar_files()` internally but returned only the error string, discarding the `similar_files` list. The `similar_files` field never reached `ReadResult`/`PatchResult`, so `classify_file_error()` always classified file-not-found as bare `not_found` instead of `fuzzy_match` with a "Did you mean ...?" recovery hint.

**Fix:** `_diagnose_read_failure()` now returns `tuple[str, list[str]]` — the error message AND the similar_files list. All 3 call sites (`read_file`, `read_file_raw`, `patch_replace`) unpack and attach `similar_files` to the result object. `PatchResult` gains a `similar_files` field and passes it to `classify_file_error()` in `to_dict()`.

## #1588 — search_files parse-error: regex rejection needs actionable error + glob hint

**Root cause:** When rg/grep reject a regex pattern (exit 2), the error was surfaced as a bare `"Search failed: rg: regex parse error: ..."` with no guidance on whether to fix the regex syntax or switch to `target='files'` (glob mode).

**Fix:** New `_enrich_search_parse_error()` function detects regex compile failures and appends actionable hints:
- **Glob patterns** (`*.py`): suggests `target='files'` instead
- **Genuine regex errors** (`(foo`, `[`): lists regex metacharacters and suggests fixing syntax

Applied to both `_search_with_rg` and `_search_with_grep` error paths.

## Validation
- 208 existing tests pass (file_operations, search_error_guard, error_classification, read_patch_resilience, etc.)
- 11 new tests in `test_file_error_suggestions.py` covering both fixes
- `ruff check` passes clean
- Diff size: 113 changed lines (within autonomous merge cap)

Closes #1587, #1588

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>