### PR TITLE
fix(guardrails): sustained-recovery decay for spiral-prone tools (Closes #1585)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -105,6 +105,15 @@ _SPIRAL_PRONE_TOOLS = frozenset(
     }
 )
 
+# #1585 — number of consecutive successes required before a spiral-prone
+# tool's cross-turn failure streak decays by 1. The production terminal
+# spiral is fail, diagnostic-success (pwd, ls), fail, repeating — and the
+# fallback directive actively recommends the diagnostic. With a 1-success
+# decay that pattern nets 0 per cycle and the cap is unreachable. Requiring
+# a sustained run means a single interspersed success does not drain the
+# streak, so fail/succeed/fail climbs +1 per cycle toward the cap.
+_SUCCESSES_TO_DECAY = 2
+
 
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
@@ -341,6 +350,12 @@ class ToolCallGuardrailController:
         # turns and trigger the cap.  reset_for_turn only clears per-turn
         # bookkeeping (exact-failure, no-progress, halt_decision).
         self._cross_turn_tool_failure_counts: dict[str, int] = {}
+        # #1585 — track consecutive successes per spiral-prone tool so we
+        # only drain the failure streak after a SUSTAINED recovery (multiple
+        # successes in a row), not on a single interspersed success. Without
+        # this, the fail→diagnostic-success→fail pattern (the production
+        # spiral) nets 0 per cycle and the cap is unreachable.
+        self._cross_turn_success_streaks: dict[str, int] = {}
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -531,6 +546,9 @@ class ToolCallGuardrailController:
             # tool batch).  Here we carry the streak forward.
             cross_turn_count = self._cross_turn_tool_failure_counts.get(tool_name, 0) + 1
             self._cross_turn_tool_failure_counts[tool_name] = cross_turn_count
+            # #1585 — a failure breaks the consecutive-success chain, so the
+            # sustained-recovery counter restarts from zero.
+            self._cross_turn_success_streaks.pop(tool_name, None)
 
             # Effective streak is the max of per-turn and cross-turn counts.
             # Within-turn spirals (5 calls in one batch) still trip the cap
@@ -651,9 +669,35 @@ class ToolCallGuardrailController:
         # so a genuinely recovered backend (several successes in a row)
         # drains the streak back to 0, but a failure/success/failure pattern
         # still accumulates toward the cap and eventually halts.
+        #
+        # #1585 — for spiral-prone tools, the simple 1-success decay was
+        # insufficient: the production terminal spiral is fail → diagnostic-
+        # success (pwd, ls — the fallback directive's own advice) → fail,
+        # which nets 0 per cycle and never reaches the cap. Now we require a
+        # SUSTAINED run of successes (_SUCCESSES_TO_DECAY, default 2) before
+        # draining the streak by 1. A single interspersed success increments
+        # the success-streak but doesn't drain the failure streak, so the
+        # fail/succeed/fail pattern nets +1 per cycle and climbs toward the
+        # cap. A genuine recovery (N consecutive successes) drains it fully.
         if tool_name in self._cross_turn_tool_failure_counts:
             current = self._cross_turn_tool_failure_counts[tool_name]
-            if current <= 1:
+            is_spiral_prone = tool_name in self.config.spiral_prone_tools
+            if is_spiral_prone:
+                succ = self._cross_turn_success_streaks.get(tool_name, 0) + 1
+                if succ >= _SUCCESSES_TO_DECAY:
+                    # Sustained recovery — drain the failure streak by 1.
+                    if current <= 1:
+                        self._cross_turn_tool_failure_counts.pop(tool_name, None)
+                    else:
+                        self._cross_turn_tool_failure_counts[tool_name] = current - 1
+                    # Reset the success streak so the next decay needs another
+                    # sustained run (not a single additional success).
+                    self._cross_turn_success_streaks.pop(tool_name, None)
+                else:
+                    # Not enough consecutive successes yet — remember the
+                    # streak but don't drain the failure count.
+                    self._cross_turn_success_streaks[tool_name] = succ
+            elif current <= 1:
                 self._cross_turn_tool_failure_counts.pop(tool_name, None)
             else:
                 self._cross_turn_tool_failure_counts[tool_name] = current - 1

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -790,16 +790,26 @@ def test_spiral_cap_can_be_disabled():
 
 def test_spiral_cap_success_decays_streak():
     """A successful terminal call decays (not resets) the cross-turn failure
-    streak by 1 (#1188).  With spiral_failure_cap=5, four failures + one
+    streak (#1188).  With spiral_failure_cap=5, four failures + one
     success leaves streak=4; the 5th failure (streak 4→5) hits the cap.
-    Multiple consecutive successes drain the streak fully."""
+    Multiple consecutive successes drain the streak fully.
+
+    #1585 — spiral-prone tools now require _SUCCESSES_TO_DECAY (2)
+    consecutive successes before draining the streak by 1, so a single
+    interspersed success (the pwd/ls diagnostic the directive recommends)
+    does not reset the accumulation."""
+    from agent.tool_guardrails import _SUCCESSES_TO_DECAY
+
     controller = ToolCallGuardrailController()
     cap = controller.config.spiral_failure_cap  # default 5
     for _ in range(4):
         controller.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
     # Cross-turn streak is now 4.
     assert controller._cross_turn_tool_failure_counts.get("terminal", 0) == 4
-    # A success decays the streak by 1 (4→3), not resets to 0.
+    # A SINGLE success does NOT decay (needs _SUCCESSES_TO_DECAY in a row).
+    controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
+    assert controller._cross_turn_tool_failure_counts.get("terminal", 0) == 4
+    # A second consecutive success drains by 1 (4→3).
     controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
     assert controller._cross_turn_tool_failure_counts.get("terminal", 0) == 3
     # Two more failures bring the streak to 5, hitting the cap.
@@ -809,11 +819,13 @@ def test_spiral_cap_success_decays_streak():
     assert d.action == "halt"
     assert d.code == "spiral_prone_tool_failure_cap"
     # Drain with enough consecutive successes to reach 0.
+    # Each drain-by-1 requires _SUCCESSES_TO_DECAY consecutive successes,
+    # and the success streak resets after each drain.
     controller2 = ToolCallGuardrailController()
     for _ in range(cap):
         controller2.after_call("terminal", {"command": "x"}, '{"exit_code":1}', failed=True)
     assert controller2._cross_turn_tool_failure_counts.get("terminal", 0) == cap
-    for _ in range(cap):
+    for _ in range(cap * _SUCCESSES_TO_DECAY):
         controller2.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
     assert controller2._cross_turn_tool_failure_counts.get("terminal", 0) == 0
 
@@ -837,11 +849,17 @@ def test_spiral_cap_reset_for_turn_clears_streak():
     assert d.action == "block"
     assert d.code == "spiral_prone_tool_failure_cap"
     # A success after reset clears the cross-turn streak.
+    # #1585 — spiral-prone tools require _SUCCESSES_TO_DECAY (2) consecutive
+    # successes to drain by 1. With streak=5 we need 5*2=10 successes to
+    # fully clear it.
+    from agent.tool_guardrails import _SUCCESSES_TO_DECAY
+
     controller.reset_for_turn()
-    controller.before_call("terminal", {"command": "x"})
-    d_ok = controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
-    assert d_ok.action == "allow"
-    controller.reset_for_turn()
+    for _ in range(5 * _SUCCESSES_TO_DECAY):
+        controller.before_call("terminal", {"command": "x"})
+        d_ok = controller.after_call("terminal", {"command": "x"}, '{"exit_code":0}', failed=False)
+        assert d_ok.action == "allow"
+        controller.reset_for_turn()
     assert controller.before_call("terminal", {"command": "x"}).action == "allow"
 
 
@@ -1148,3 +1166,65 @@ def test_after_call_survives_lone_surrogates_in_result_and_args():
     controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
     controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
     assert controller.before_call("web_search", {"query": dirty}).action == "block"
+
+
+# ── #1585: spiral-prone interleaving pattern ──────────────────────────────
+
+
+def test_spiral_cap_fail_success_interleaving_accumulates():
+    """#1585 — the production terminal spiral pattern is fail → diagnostic-
+    success (pwd, ls) → fail → success → ..., repeating for 25+ turns. The
+    fallback directive actively recommends the diagnostic, which succeeds
+    (exit 0) and must NOT reset the failure streak. With the old code, the
+    pop() at current<=1 dropped the streak 1→0 on every interspersed
+    success, so it never climbed past 1 and the cap (5) was unreachable.
+
+    After the fix, spiral-prone tools only decay by 1 per success (never
+    pop at <=1), so the fail/succeed/fail pattern nets +1 per cycle and
+    eventually halts.
+    """
+    controller = ToolCallGuardrailController()
+    # Simulate fail → success per turn for 10 turns (20 calls).
+    for turn in range(10):
+        controller.reset_for_turn()
+        # Failing terminal call (the real command).
+        controller.after_call(
+            "terminal", {"command": f"cmd{turn}"}, '{"exit_code":1}', failed=True
+        )
+        # Successful diagnostic (pwd, ls — the fallback directive's advice).
+        controller.after_call(
+            "terminal", {"command": "pwd"}, '{"exit_code":0}', failed=False
+        )
+    # After 10 fail/success cycles, the cross-turn streak should have
+    # accumulated well beyond 1 (each cycle nets +1: fail +1, success -1).
+    # With the old pop()-at-1 code, this was permanently stuck at 0.
+    streak = controller._cross_turn_tool_failure_counts.get("terminal", 0)
+    assert streak >= 5, (
+        f"Interleaving spiral should accumulate to >=5 after 10 cycles, "
+        f"got {streak} — the single-success reset bug (#1585) is still present"
+    )
+
+
+def test_spiral_cap_interleaving_eventually_halts():
+    """The fail/success interleaving pattern must eventually hit the cap and
+    halt — proving #1585 is fixed end-to-end."""
+    controller = ToolCallGuardrailController()
+    halted = False
+    for turn in range(20):
+        controller.reset_for_turn()
+        d_fail = controller.after_call(
+            "terminal", {"command": f"failing-cmd-{turn}"},
+            '{"exit_code":1}', failed=True,
+        )
+        if d_fail.should_halt:
+            halted = True
+            break
+        # Interspersed success between failures (the pattern that defeated
+        # the old cap).
+        controller.after_call(
+            "terminal", {"command": "pwd"}, '{"exit_code":0}', failed=False
+        )
+    assert halted, (
+        "Terminal fail/success interleaving should have halted within 20 "
+        "turns — the #1585 spiral cap must fire for this pattern"
+    )


### PR DESCRIPTION
Automated evolution PR for issue #1585.

## Problem
Terminal non-zero-exit spiral persists at 93 failures/79 sessions (max 25 consecutive) despite prior fixes #1452/#1453/#1439. Root cause: the cross-turn failure streak was wiped by a single interspersed success. The production pattern is fail → diagnostic-success (pwd, ls — the fallback directive's own advice) → fail, repeating. Each success popped the streak at count<=1, so it never climbed past 1 and the cap (5) was permanently unreachable.

## Fix
Spiral-prone tools now require `_SUCCESSES_TO_DECAY` (2) consecutive successes before draining the failure streak by 1. A single interspersed success increments the success-streak but doesn't drain, so fail/succeed/fail nets +1 per cycle and climbs toward the cap. Browser tools and non-spiral tools keep the original 1-success decay.

Investigation confirmed via reproduction: the exact fail→success→fail pattern over 25 turns never halted with the old code; the new code halts at turn 5.

## Verification
- Lint: `ruff check` ✓
- Tests: 68 passed (including 2 new regression tests for the interleaving pattern)
- Diff: 133 lines (under 200-line self-merge cap)