### PR TITLE
fix(terminal): apply #1542 blocked-status treatment to security-scan blocks (#1590)

### DIFF
--- a/tests/tools/test_terminal_security_block_cron.py
+++ b/tests/tools/test_terminal_security_block_cron.py
@@ -1,0 +1,154 @@
+"""Regression tests for terminal security-scan (tirith) blocks in cron/subagent
+contexts (issue #1590).
+
+When ``_check_all_guards`` returns a plain ``approved: False`` block (the shape
+produced by the tirith security-scan cron-deny path — no ``status`` field, no
+``pending_approval``), and no interactive user or gateway is present, the
+terminal tool must still emit the #1542 non-retryable ``blocked`` treatment:
+an explicit "Do NOT retry" directive and a steer toward approval-free
+alternatives (write to a temp file, then read_file it).
+
+Without this, the agent retries the same blocked command 2-3 times before
+stalling — the cron-context failure mode described in #1590.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+def _tirith_block_result():
+    """The shape ``check_all_command_guards`` returns for a tirith security-scan
+    block in cron-deny mode: ``approved: False`` with a message but NO
+    ``status``/``pending_approval`` keys (unlike the gateway ask-mode path)."""
+    return {
+        "approved": False,
+        "message": (
+            "BLOCKED: pipe-to-interpreter pattern detected "
+            "(command pipes output to python3) but cron jobs run without "
+            "a user present to approve it. Find an alternative approach "
+            "that avoids this command. To allow dangerous commands in "
+            "cron jobs, set approvals.cron_mode: approve in config.yaml."
+        ),
+    }
+
+
+@pytest.fixture
+def _cron_env(monkeypatch):
+    """Simulate a cron session — no interactive CLI, no gateway."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(
+        terminal_tool, "_check_disk_usage_warning", lambda *a, **kw: None
+    )
+    yield
+
+
+@pytest.fixture
+def _subagent_env(monkeypatch):
+    """Simulate a headless subagent — no cron, no CLI, no gateway."""
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(
+        terminal_tool, "_check_disk_usage_warning", lambda *a, **kw: None
+    )
+    yield
+
+
+class TestSecurityScanBlockCronConversion:
+    """Verify a tirith security-scan block gets the #1542/#1590 treatment in
+    cron/subagent contexts — even though it lacks the pending_approval status."""
+
+    def test_cron_security_block_has_do_not_retry(self, _cron_env):
+        """A tirith block in cron context must carry 'Do NOT retry' so the
+        agent stops retrying the same blocked command."""
+        with patch.object(
+            terminal_tool, "_check_all_guards", return_value=_tirith_block_result()
+        ):
+            result = terminal_tool.terminal_tool(
+                command="gh pr list | python3 -c 'import sys; print(sys.stdin.read())'",
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "blocked", (
+            f"Expected status='blocked', got {parsed.get('status')!r}"
+        )
+        assert parsed["exit_code"] == -1
+        error = parsed.get("error", "")
+        assert "Do NOT retry" in error, (
+            "Security-scan block in cron context must contain 'Do NOT retry' "
+            f"directive; got error={error!r}"
+        )
+        assert "cron" in error.lower()
+
+    def test_cron_security_block_steers_to_alternatives(self, _cron_env):
+        """The block must steer toward approval-free alternatives (temp file +
+        read_file, or file/search tools) — not just say 'find an alternative'."""
+        with patch.object(
+            terminal_tool, "_check_all_guards", return_value=_tirith_block_result()
+        ):
+            result = terminal_tool.terminal_tool(
+                command="gh pr list | python3 -c 'import sys'",
+            )
+
+        parsed = json.loads(result)
+        error = parsed.get("error", "").lower()
+        assert "read_file" in error or "temp file" in error, (
+            "Block should steer toward writing output to a temp file + read_file"
+        )
+
+    def test_subagent_security_block_also_treated(self, _subagent_env):
+        """A headless subagent (no cron, no CLI, no gateway) must ALSO get the
+        blocked treatment for a security-scan block."""
+        with patch.object(
+            terminal_tool, "_check_all_guards", return_value=_tirith_block_result()
+        ):
+            result = terminal_tool.terminal_tool(
+                command="cat data.json | python3 -m json.tool",
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "blocked"
+        assert "Do NOT retry" in parsed.get("error", "")
+        assert "subagent" in parsed.get("error", "").lower()
+
+    def test_interactive_block_unchanged(self, monkeypatch):
+        """In an interactive CLI session, the block message must NOT get the
+        cron/subagent 'Do NOT retry' addendum — the user can still approve."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setattr(
+            terminal_tool, "_check_disk_usage_warning", lambda *a, **kw: None
+        )
+        raw = _tirith_block_result()
+        with patch.object(terminal_tool, "_check_all_guards", return_value=raw):
+            result = terminal_tool.terminal_tool(
+                command="gh pr list | python3 -c 'import sys'",
+            )
+
+        parsed = json.loads(result)
+        # Original message preserved; no cron-style addendum appended.
+        assert parsed["status"] == "blocked"
+        assert parsed["error"] == raw["message"]
+        assert "Do NOT retry" not in parsed["error"]
+
+    def test_existing_do_not_retry_not_duplicated(self, _cron_env):
+        """If the block message already contains 'Do NOT retry' (e.g. a hardline
+        or deny-rule block), the addendum must not be appended a second time."""
+        raw = _tirith_block_result()
+        raw["message"] = "BLOCKED: hardline. Do NOT retry this command."
+        with patch.object(terminal_tool, "_check_all_guards", return_value=raw):
+            result = terminal_tool.terminal_tool(
+                command="rm -rf /",
+            )
+
+        parsed = json.loads(result)
+        assert parsed["error"].count("Do NOT retry") == 1, (
+            "'Do NOT retry' must not be duplicated when already present"
+        )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2636,16 +2636,41 @@ def terminal_tool(
                         "smart_denied": approval.get("smart_denied", False),
                         "allow_permanent": approval.get("allow_permanent", True),
                     }, ensure_ascii=False)
-                # Command was blocked
+                # Command was blocked.  In cron/subagent contexts there is no
+                # human to answer an approval prompt, so the block is final.
+                # Apply the #1542/#1590 treatment: append a "Do NOT retry"
+                # directive and steer toward approval-free alternatives
+                # (write output to a temp file then read_file it) so the agent
+                # stops retrying the same blocked command and switches strategy.
                 desc = approval.get("description", "command flagged")
                 fallback_msg = (
                     f"Command denied: {desc}. "
                     "Use the approval prompt to allow it, or rephrase the command."
                 )
+                block_error = approval.get("message", fallback_msg)
+                from tools.approval import (
+                    _is_interactive_cli,
+                    _is_gateway_approval_context,
+                )
+                _is_cron = env_var_enabled("HERMES_CRON_SESSION")
+                _is_cli_ctx = _is_interactive_cli()
+                _is_gw_ctx = _is_gateway_approval_context()
+                if _is_cron or (not _is_cli_ctx and not _is_gw_ctx):
+                    if "Do NOT retry" not in block_error:
+                        block_error = (
+                            f"{block_error} Do NOT retry this command — no "
+                            f"interactive user or gateway is present to approve "
+                            f"it in this "
+                            f"{'cron' if _is_cron else 'subagent'} context. "
+                            f"Instead, write the output to a temp file "
+                            f"(e.g. `command > /tmp/out.txt`) and read it with "
+                            f"read_file, or use file/search tools to achieve "
+                            f"the same goal without a shell pipe."
+                        )
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
-                    "error": approval.get("message", fallback_msg),
+                    "error": block_error,
                     "status": "blocked"
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user


### PR DESCRIPTION
## Problem

In cron/unattended contexts, the terminal security scanner (tirith) blocks commands that pipe to interpreters (e.g. `gh ... | python3`). The block returns `exit_code -1` with the generic `approved: False` shape (no `status`/`pending_approval` keys), so it fell through to the terminal_tool generic block handler — which lacked the "Do NOT retry" directive and approval-free alternative steer that #1542/#1570 added for the `pending_approval` path.

The agent then retried the same blocked command 2-3 times before stalling — the cron-context failure mode described in #1590.

## Fix

Apply the same #1542 treatment to the generic block handler in `terminal_tool.py`: when a guard block occurs in a cron or headless-subagent context (no interactive CLI, no gateway), append:
1. A **"Do NOT retry this command"** directive
2. A steer toward **approval-free alternatives** (write output to a temp file like `command > /tmp/out.txt` then `read_file` it, or use file/search tools)

The addendum is **idempotent** — not appended when the block message already contains "Do NOT retry" (hardline/deny-rule blocks).

## Scope

- One change in `tools/terminal_tool.py` (generic block handler, ~line 2639)
- New regression test: `tests/tools/test_terminal_security_block_cron.py` (5 cases: cron block, alternative steer, subagent, interactive-unchanged, no-duplicate)

Does **not** touch the security scanner logic itself, the allowlist, or the approval gate — purely the terminal_tool block-result presentation in cron/subagent context.

Closes #1590