### PR TITLE
fix(file_ops): sub-classify patch 'other' error bucket (#1586)

### DIFF
--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -68,6 +68,74 @@ class TestClassifyFileError:
         klass, rec = classify_file_error("something inexplicable happened")
         assert klass == "error" and "CHANGE the call" in rec
 
+    # ── #1586: sub-classify the fuzzy matcher's distinctive failure strings ──
+    # These previously collapsed into the generic "error" (other) bucket, which
+    # was 87% of patch failures (68/78). Each now gets a targeted error_class
+    # and recovery so the model can correct on its next turn.
+
+    def test_escape_drift_from_raw_string(self):
+        """The fuzzy matcher's 'Escape-drift detected: ...' string now classifies
+        as escape_drift instead of the generic 'error' bucket."""
+        klass, rec = classify_file_error(
+            "Escape-drift detected: old_string and new_string contain a "
+            "literal backslash-quote sequence but the matched region does not."
+        )
+        assert klass == "escape_drift"
+        assert "backslash" in rec
+
+    def test_escape_drift_no_hyphen_variant(self):
+        klass, _ = classify_file_error("Escape drift detected in old_string")
+        assert klass == "escape_drift"
+
+    def test_old_string_empty_from_raw_string(self):
+        klass, rec = classify_file_error("old_string cannot be empty")
+        assert klass == "old_string_empty"
+        assert "non-empty" in rec
+
+    def test_old_string_empty_variant(self):
+        klass, _ = classify_file_error("old_string is empty")
+        assert klass == "old_string_empty"
+
+    def test_indentation_mismatch_promoted_from_structured_error(self):
+        """When the raw error is the generic 'Could not find a match' but the
+        structured_error diagnostic pinpointed indentation_mismatch, the class is
+        promoted to indentation_mismatch (#1586). This is the core fix: the
+        finer classification is already computed by fuzzy_match — we just surface
+        it instead of collapsing to the coarse 'fuzzy_match' bucket."""
+        klass, rec = classify_file_error(
+            "Could not find a match for old_string in the file",
+            structured_error=(
+                "Error type: indentation_mismatch — indentation differs between "
+                "old_string and file content\n\nFile: /x.py"
+            ),
+        )
+        assert klass == "indentation_mismatch"
+        assert "whitespace" in rec or "indent" in rec
+
+    def test_structured_error_ignored_when_unrelated(self):
+        """A structured_error whose label we don't promote must NOT change the
+        coarse classification — the generic fuzzy_match arm still wins."""
+        klass, _ = classify_file_error(
+            "Could not find a match for old_string in the file",
+            structured_error="Error type: no_match — old_string not found in file",
+        )
+        assert klass == "fuzzy_match"
+
+    def test_structured_error_promotes_from_tail_error_bucket(self):
+        """An otherwise-unclassifiable raw string still benefits from the
+        structured diagnostic before falling back to the catch-all 'error'."""
+        klass, _ = classify_file_error(
+            "something weird happened",
+            structured_error="Error type: escape_drift — serialization artifact",
+        )
+        assert klass == "escape_drift"
+
+    def test_no_structured_error_keeps_legacy_behavior(self):
+        """Callers that don't pass structured_error get identical behavior to
+        before — backward compatible."""
+        klass, _ = classify_file_error("Could not find a match for old_string in the file")
+        assert klass == "fuzzy_match"
+
 
 class TestResultToDict:
     def test_read_result_success_has_no_error_class(self):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -155,13 +155,26 @@ def _is_write_denied(path: str) -> bool:
 
 
 def classify_file_error(
-    error: Optional[str], *, similar_files: Optional[List[str]] = None
+    error: Optional[str],
+    *,
+    similar_files: Optional[List[str]] = None,
+    structured_error: Optional[str] = None,
 ) -> Optional[Tuple[str, str]]:
     """Map a read/patch error string to ``(error_class, recovery)`` for #216, or
     None when there is no error. Lets the model route to the right recovery —
     create the file, fix the patch text, use a different tool — instead of
     re-issuing the same failing call. Derived from the already-set ``error``
-    string so no error-producing site has to be touched."""
+    string so no error-producing site has to be touched.
+
+    ``structured_error`` is the richer diagnostic produced by
+    :func:`tools.fuzzy_match.format_structured_error` (e.g.
+    "Error type: indentation_mismatch — ..."). When the raw ``error`` string is
+    generic (the fuzzy matcher's no-match message is identical regardless of
+    the *real* cause), the structured diagnostic already carries the precise
+    sub-classification. Consulting it here decomposes the dominant "other"
+    bucket (#1586: 68/78 patch failures) into actionable sub-classes
+    (indentation_mismatch, escape_drift, old_string_empty) without touching any
+    error-producing site."""
     if not error:
         return None
     low = error.lower()
@@ -200,6 +213,20 @@ def classify_file_error(
             "old_string to make it unique, or use replace_all=True if you want "
             "all occurrences replaced."
         )
+    # ── Sub-classify the fuzzy matcher's distinctive failure strings (#1586) ──
+    # These previously fell through to the generic "error" bucket (the 'other'
+    # class that dominated patch failures). Each now gets a targeted recovery.
+    if "escape-drift" in low or "escape drift" in low:
+        return "escape_drift", (
+            "Tool-call serialization added a spurious backslash before a quote/apostrophe "
+            "in old_string/new_string. Re-read the file and pass the strings without "
+            "backslash-escaping those characters."
+        )
+    if "old_string cannot be empty" in low or "old_string is empty" in low:
+        return "old_string_empty", (
+            "old_string was empty. Provide a non-empty search block that matches the "
+            "file; use read_file to see the current content if needed."
+        )
     if (
         "did not match" in low
         or "no match" in low
@@ -213,6 +240,15 @@ def classify_file_error(
         or "could not find" in low
         or "not find a match" in low
     ):
+        # Before settling for the coarse "fuzzy_match" class, check whether the
+        # structured diagnostic already pinpointed a narrower cause (e.g.
+        # indentation_mismatch). The structured_error field is populated by
+        # patch_replace via format_structured_error and carries the real reason
+        # the match failed — promoting it here keeps the agent's recovery hint
+        # precise instead of generic (#1586).
+        finer = _class_from_structured_error(structured_error)
+        if finer:
+            return finer
         return "fuzzy_match", (
             "The search block didn't match the file. Re-read the file and copy the EXACT "
             "current text into the patch — don't retry the same block."
@@ -225,9 +261,56 @@ def classify_file_error(
         return "read_error", (
             "The read failed. Check the path/permissions; don't repeat the same call blindly."
         )
+    # Last resort: the structured diagnostic may still classify an otherwise
+    # generic message before we fall back to the catch-all "error" bucket.
+    finer = _class_from_structured_error(structured_error)
+    if finer:
+        return finer
     return "error", (
         "The operation failed. Read the message, fix the root cause, and CHANGE the call."
     )
+
+
+# Sub-class recovery hints for causes the fuzzy matcher pinpoints in its
+# structured_error field but whose raw error string is generic (#1586).
+# Keys mirror the labels emitted by tools.fuzzy_match.classify_error /
+# format_structured_error ("Error type: <key> — ...").
+_STRUCTURED_SUBCLASS_RECOVERY: Dict[str, Tuple[str, str]] = {
+    "indentation_mismatch": (
+        "indentation_mismatch",
+        "The text matches but the leading whitespace differs (spaces vs tabs, "
+        "indent level). Re-read the file and copy the EXACT indentation into "
+        "old_string, or use write_file to replace the whole region.",
+    ),
+    "escape_drift": (
+        "escape_drift",
+        "Tool-call serialization added a spurious backslash before a quote/apostrophe. "
+        "Re-read the file and pass old_string/new_string without backslash-escaping "
+        "those characters.",
+    ),
+    "old_string_empty": (
+        "old_string_empty",
+        "old_string was empty. Provide a non-empty search block; use read_file to "
+        "see the current content if needed.",
+    ),
+}
+
+
+def _class_from_structured_error(
+    structured_error: Optional[str],
+) -> Optional[Tuple[str, str]]:
+    """Extract a ``(error_class, recovery)`` from a fuzzy_match structured_error
+    string, if it advertises a known sub-class. The structured diagnostic is
+    formatted as "Error type: <key> — <desc>" (see format_structured_error), so
+    we parse the leading label and look it up. Returns None when the field is
+    absent or the label isn't one we promote (#1586)."""
+    if not structured_error:
+        return None
+    m = re.search(r"Error type:\s*([a-z_]+)", structured_error, re.IGNORECASE)
+    if not m:
+        return None
+    label = m.group(1).lower()
+    return _STRUCTURED_SUBCLASS_RECOVERY.get(label)
 
 
 @dataclass
@@ -313,7 +396,7 @@ class PatchResult:
             result["lsp_diagnostics"] = self.lsp_diagnostics
         if self.error:
             result["error"] = self.error
-            hit = classify_file_error(self.error)
+            hit = classify_file_error(self.error, structured_error=self.structured_error)
             if hit:
                 result["error_class"], result["recovery"] = hit
         if self.structured_error:


### PR DESCRIPTION
Closes #1586.

## Problem
The patch tool's unclassified `other` error bucket was 87% of failures (68/78). Root cause: `classify_file_error` only inspected the **raw error string**, but the fuzzy matcher's dominant no-match message (`"Could not find a match for old_string in the file"`) is identical regardless of the *real* cause. So `escape_drift`, `old_string_empty`, and `indentation_mismatch` all collapsed into the generic `error` bucket, giving the model no signal to correct on its next turn.

The finer classification was **already being computed** by `fuzzy_match.classify_error` / `format_structured_error` and written into the `structured_error` field (`"Error type: indentation_mismatch — ..."`), but `classify_file_error` never consulted it.

## Fix
No error-producing site is touched. Two changes to `classify_file_error`:

1. **Two new arms for distinctive raw strings** that previously fell through to `error`:
   - `escape-drift` / `escape drift` → `escape_drift`
   - `old_string cannot be empty` / `old_string is empty` → `old_string_empty`
2. **Optional `structured_error` param**: when the raw error is the generic no-match message, parse the `"Error type: <label>"` from the structured diagnostic and promote to a known sub-class (`indentation_mismatch`, `escape_drift`, `old_string_empty`) with a targeted recovery hint. Threaded through from `PatchResult.to_dict`.

## Safety
- Consumers only check for the *presence* of `error_class` (verified via grep — no code branches on specific values: `file_tools.py:1429`, `test_read_file_failure_rate.py:44`). Adding new class values is backward compatible.
- Callers that don't pass `structured_error` get identical behavior to before.
- New sub-buckets surfaced by this change: `indentation_mismatch`, `escape_drift`, `old_string_empty`.

## Validation
- `ruff check` clean on both changed files.
- 8 new test cases in `tests/tools/test_file_error_classification.py`.
- 200 tests pass across `test_file_error_classification` + `test_patch_self_correction` + `test_fuzzy_match` + `test_file_operations`.
- Diff: **154 insertions, 3 deletions** (under the 200-line budget).