### PR TITLE
feat: subagent task-spec re-grounding (Closes #1578)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1602,6 +1602,21 @@ def init_agent(
     except Exception:
         pass
 
+    # Subagent task-spec re-grounding (#1578): re-inject the original goal as
+    # a user message every N iterations to counter context drift in long
+    # unattended subagent loops.  Configurable via
+    # ``agent.subagent_reground_interval`` in config.yaml; 0 disables.
+    # Only fires for ``platform == "subagent"``.
+    agent._subagent_reground_interval = 10
+    try:
+        _agent_section_rg = _agent_cfg.get("agent", {})
+        if isinstance(_agent_section_rg, dict):
+            agent._subagent_reground_interval = int(
+                _agent_section_rg.get("subagent_reground_interval", 10)
+            )
+    except Exception:
+        pass
+
     # Tool-use enforcement config: "auto" (default — matches hardcoded
     # model list), true (always), false (never), or list of substrings.
     _agent_section = _agent_cfg.get("agent", {})

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -85,6 +85,15 @@ logger = logging.getLogger(__name__)
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
+# ── Subagent task-spec re-grounding (#1578) ────────────────────────────
+# How many API-call iterations a subagent runs before its original goal is
+# re-injected as a user message.  Long subagent loops drift as tool results
+# fill the window; periodic re-grounding keeps the model focused.  Only
+# fires for ``platform == "subagent"`` — interactive surfaces have a human
+# to steer.  Configurable via ``agent.subagent_reground_interval`` in
+# config.yaml (see ``agent_init.py``); this constant is the fallback.
+_SUBAGENT_REGROUND_INTERVAL = 10
+
 # Modules that indicate a deterministic local processing error when they
 # appear in an exception traceback WITHOUT any API-call module. Used by the
 # outer-loop error classifier to avoid retrying bugs that will fail
@@ -1215,7 +1224,49 @@ def _run_conversation_impl(
         if (agent._skill_nudge_interval > 0
                 and "skill_manage" in agent.valid_tool_names):
             agent._iters_since_skill += 1
-        
+
+        # ── Task-spec re-grounding for subagents (#1578) ────────────────
+        # Subagents run unattended in long tool-calling loops with no human
+        # to course-correct.  As the message window fills with tool results,
+        # the original goal can drift out of the model's attention.  Periodically
+        # re-inject a concise reminder so the model re-grounds every
+        # ``_subagent_reground_interval`` iterations.  Only fires for
+        # ``platform == "subagent"`` — interactive sessions have a human to
+        # steer.  The reminder is a *user* message (preserving role alternation
+        # and cache validity — same pattern as the loop-guard nudge above).
+        try:
+            _platform = getattr(agent, "platform", None)
+            _rg_interval = getattr(
+                agent, "_subagent_reground_interval", _SUBAGENT_REGROUND_INTERVAL
+            )
+            if (
+                _platform == "subagent"
+                and _rg_interval > 0
+                and api_call_count > 0
+                and api_call_count % _rg_interval == 0
+            ):
+                _rg_goal = original_user_message or user_message or ""
+                if _rg_goal and isinstance(_rg_goal, str):
+                    _rg_goal = _rg_goal.strip()
+                    if len(_rg_goal) > 500:
+                        _rg_goal = _rg_goal[:500] + "…"
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            f"[task-reminder] You are a subagent working on a "
+                            f"delegated task. Your original goal (re-grounded "
+                            f"at iteration {api_call_count}): {_rg_goal}\n\n"
+                            f"Re-check: are your current tool calls advancing "
+                            f"this goal? If not, change your approach."
+                        ),
+                    })
+                    logger.debug(
+                        "subagent re-grounding nudge at iteration %d",
+                        api_call_count,
+                    )
+        except Exception as _rg_err:
+            logger.debug("re-grounding error (iteration %s): %s", api_call_count, _rg_err)
+
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
         # was thinking), drain it now — before we build api_messages — so

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1149,6 +1149,12 @@ DEFAULT_CONFIG = {
         # (force on/off for all models), or a list of model-name substrings
         # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
+        # Subagent task-spec re-grounding (#1578): re-inject the original
+        # delegated goal as a user message every N API-call iterations to
+        # counter context drift in long unattended subagent loops.  Only
+        # fires for platform="subagent".  0 disables (interactive sessions
+        # are unaffected — they have a human to steer).
+        "subagent_reground_interval": 10,
         # Intent-ack continuation: when the model opens a turn by narrating an
         # action it will take ("I'll go check the logs...") but emits no tool
         # call, intercept the turn-end, inject a "continue now, execute the

--- a/tests/agent/test_subagent_reground.py
+++ b/tests/agent/test_subagent_reground.py
@@ -1,0 +1,221 @@
+"""Tests for subagent task-spec re-grounding (#1578).
+
+The re-grounding nudge re-injects the original delegated goal as a user
+message every ``_subagent_reground_interval`` iterations, but only for
+``platform == "subagent"``.  Interactive platforms (cli, gateway, etc.)
+are unaffected — they have a human to steer.
+
+These tests exercise the guard logic directly (the conditional block in
+``conversation_loop._run_conversation_impl``) without spinning up a real
+AIAgent / provider, following the same pure-logic style as
+``test_loop_guard.py``.
+"""
+
+from __future__ import annotations
+
+from agent.conversation_loop import _SUBAGENT_REGROUND_INTERVAL
+
+
+def _build_reground_message(
+    api_call_count: int,
+    platform: str,
+    original_user_message: str,
+    user_message: str = "",
+    interval: int | None = None,
+) -> str | None:
+    """Replicate the re-grounding block from ``_run_conversation_impl``.
+
+    Returns the injected user-message content, or ``None`` if the guard
+    did not fire.  This mirrors the exact conditional logic in the
+    conversation loop so we can unit-test it without a full agent.
+    """
+    rg_interval = interval if interval is not None else _SUBAGENT_REGROUND_INTERVAL
+    if not (
+        platform == "subagent"
+        and rg_interval > 0
+        and api_call_count > 0
+        and api_call_count % rg_interval == 0
+    ):
+        return None
+
+    rg_goal = original_user_message or user_message or ""
+    if not rg_goal or not isinstance(rg_goal, str):
+        return None
+    rg_goal = rg_goal.strip()
+    if len(rg_goal) > 500:
+        rg_goal = rg_goal[:500] + "…"
+    return (
+        f"[task-reminder] You are a subagent working on a "
+        f"delegated task. Your original goal (re-grounded "
+        f"at iteration {api_call_count}): {rg_goal}\n\n"
+        f"Re-check: are your current tool calls advancing "
+        f"this goal? If not, change your approach."
+    )
+
+
+class TestRegroundFiring:
+    """Verify the nudge fires ONLY at the right iteration / platform."""
+
+    def test_fires_at_interval_for_subagent(self):
+        msg = _build_reground_message(
+            api_call_count=10,
+            platform="subagent",
+            original_user_message="Fix the bug in parser.py",
+        )
+        assert msg is not None
+        assert "[task-reminder]" in msg
+        assert "Fix the bug in parser.py" in msg
+        assert "iteration 10" in msg
+
+    def test_fires_at_multiple_of_interval(self):
+        msg = _build_reground_message(
+            api_call_count=20,
+            platform="subagent",
+            original_user_message="Run the test suite",
+        )
+        assert msg is not None
+        assert "iteration 20" in msg
+        assert "Run the test suite" in msg
+
+    def test_does_not_fire_below_interval(self):
+        for i in range(1, _SUBAGENT_REGROUND_INTERVAL):
+            assert (
+                _build_reground_message(
+                    api_call_count=i,
+                    platform="subagent",
+                    original_user_message="do stuff",
+                )
+                is None
+            )
+
+    def test_does_not_fire_for_cli(self):
+        assert (
+            _build_reground_message(
+                api_call_count=10,
+                platform="cli",
+                original_user_message="do stuff",
+            )
+            is None
+        )
+
+    def test_does_not_fire_for_gateway(self):
+        assert (
+            _build_reground_message(
+                api_call_count=10,
+                platform="telegram",
+                original_user_message="do stuff",
+            )
+            is None
+        )
+
+    def test_does_not_fire_at_zero(self):
+        assert (
+            _build_reground_message(
+                api_call_count=0,
+                platform="subagent",
+                original_user_message="do stuff",
+            )
+            is None
+        )
+
+    def test_disabled_when_interval_zero(self):
+        assert (
+            _build_reground_message(
+                api_call_count=10,
+                platform="subagent",
+                original_user_message="do stuff",
+                interval=0,
+            )
+            is None
+        )
+
+
+class TestRegroundContent:
+    """Verify the injected message is well-formed."""
+
+    def test_truncates_long_goals(self):
+        long_goal = "x" * 600
+        msg = _build_reground_message(
+            api_call_count=10,
+            platform="subagent",
+            original_user_message=long_goal,
+        )
+        assert msg is not None
+        # Truncated to 500 chars + ellipsis
+        assert "x" * 500 in msg
+        assert "…" in msg
+        assert ("x" * 600) not in msg
+
+    def test_falls_back_to_user_message(self):
+        msg = _build_reground_message(
+            api_call_count=10,
+            platform="subagent",
+            original_user_message="",
+            user_message="fallback goal",
+        )
+        assert msg is not None
+        assert "fallback goal" in msg
+
+    def test_empty_goal_does_not_fire(self):
+        assert (
+            _build_reground_message(
+                api_call_count=10,
+                platform="subagent",
+                original_user_message="",
+                user_message="",
+            )
+            is None
+        )
+
+    def test_strips_whitespace(self):
+        msg = _build_reground_message(
+            api_call_count=10,
+            platform="subagent",
+            original_user_message="  spaced goal  ",
+        )
+        assert msg is not None
+        assert "spaced goal" in msg
+        # No leading/trailing spaces from the original
+        assert "  spaced goal  " not in msg
+
+    def test_custom_interval(self):
+        """A non-default interval changes the firing cadence."""
+        # At interval=5, iteration 5 should fire
+        msg = _build_reground_message(
+            api_call_count=5,
+            platform="subagent",
+            original_user_message="do stuff",
+            interval=5,
+        )
+        assert msg is not None
+        assert "iteration 5" in msg
+
+        # At interval=5, iteration 10 should also fire
+        msg = _build_reground_message(
+            api_call_count=10,
+            platform="subagent",
+            original_user_message="do stuff",
+            interval=5,
+        )
+        assert msg is not None
+
+        # At interval=5, iteration 3 should NOT fire
+        assert (
+            _build_reground_message(
+                api_call_count=3,
+                platform="subagent",
+                original_user_message="do stuff",
+                interval=5,
+            )
+            is None
+        )
+
+
+class TestRegroundIntervalConfig:
+    """Verify the default interval constant is sensible."""
+
+    def test_default_interval_is_ten(self):
+        assert _SUBAGENT_REGROUND_INTERVAL == 10
+
+    def test_default_interval_positive(self):
+        assert _SUBAGENT_REGROUND_INTERVAL > 0


### PR DESCRIPTION
Automated evolution PR for issue #1578.

## What

Periodically re-inject the original delegated goal as a user message every N API-call iterations for subagents (platform="subagent"), countering context drift in long unattended tool-calling loops.

## Why

Subagents run unattended in long tool-calling loops with no human to course-correct. As the message window fills with tool results, the original goal can drift out of the model's attention, causing it to lose focus or repeat irrelevant work. Periodic re-grounding keeps the model focused on the original task.

## What changed

- `agent/conversation_loop.py`: New re-grounding block after the loop-guard nudge — fires at every `_subagent_reground_interval` iterations for `platform == "subagent"` only. Injects a concise `[task-reminder]` user message with the original goal (truncated to 500 chars). Guarded by try/except like the existing loop-guard.
- `agent/agent_init.py`: Initializes `agent._subagent_reground_interval` from config.
- `hermes_cli/config.py`: New config key `agent.subagent_reground_interval` (default 10, 0 disables).
- `tests/agent/test_subagent_reground.py`: 14 unit tests covering firing conditions, content, truncation, and config.

## Design notes

- Interactive platforms (cli, gateway, messaging) are unaffected — they have a human to steer.
- The reminder is a *user* message, preserving role alternation and cache validity (same pattern as the existing loop-guard nudge).
- The existing `loop_guard.py` tool-spiral detector already covers subagents (they go through `conversation_loop.py`), so the loop-detector half of #1578 was found to already exist. This PR implements the genuinely-new task-spec re-grounding half.

Closes #1578

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>