### PR TITLE
feat: add refusal nudge telemetry sidecar (Closes #1265)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -78,6 +78,12 @@ from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
+# #1265 — Refusal nudge telemetry (best-effort, never breaks the loop).
+try:
+    from agent import refusal_telemetry as _refusal_telemetry
+except Exception:  # pragma: no cover - best-effort import
+    _refusal_telemetry = None
+
 logger = logging.getLogger(__name__)
 
 # Stable prefix of the local interrupt status string emitted when a turn is
@@ -5435,6 +5441,11 @@ def _run_conversation_impl(
             
             # Check for tool calls
             if assistant_message.tool_calls:
+                # #1265 — Record transition if a nudge was just issued.
+                if _refusal_telemetry:
+                    _refusal_telemetry.record_transition_if_pending(
+                        agent, category_after="", took_action=True
+                    )
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
                 
@@ -6421,6 +6432,18 @@ def _run_conversation_impl(
                 #   3rd refusal: accept with a structured explanation
                 #     appended so the user sees the refusal was flagged
                 _refusal_count = getattr(agent, "_refusal_nudge_count", 0)
+                # #1265 — Record transition for the PREVIOUS nudge (if any).
+                if _refusal_telemetry and _refusal_count > 0:
+                    _after_cat = ""
+                    try:
+                        _after_cat = _loop_guard.detect_refusal_category(
+                            final_response or ""
+                        )
+                    except Exception:
+                        pass
+                    _refusal_telemetry.record_transition_if_pending(
+                        agent, category_after=_after_cat, took_action=False
+                    )
                 if _refusal_count < 2:
                     try:
                         _refusal_nudge = _loop_guard.maybe_refusal_nudge(
@@ -6434,6 +6457,19 @@ def _run_conversation_impl(
                         agent._session_refusal_count = getattr(
                             agent, "_session_refusal_count", 0
                         ) + 1
+                        # #1265 — Record nudge telemetry.
+                        _nudge_tier = "directive" if _refusal_count >= 1 else "advisory"
+                        _nudge_cat = ""
+                        try:
+                            _nudge_cat = _loop_guard.detect_refusal_category(
+                                final_response or ""
+                            )
+                        except Exception:
+                            pass
+                        if _refusal_telemetry:
+                            _refusal_telemetry.record_nudge_and_set_pending(
+                                agent, _nudge_cat, _nudge_tier, _refusal_count + 1
+                            )
                         # #1243 — Escalate the nudge language on the 2nd
                         # refusal to a directive rather than advisory.
                         if _refusal_count >= 1:
@@ -6479,6 +6515,18 @@ def _run_conversation_impl(
                         _still_refusing = None
                     if _still_refusing:
                         agent._session_refusal_count = _session_refusals + 1
+                        # #1265 — Record session-level escalation telemetry.
+                        _esc_cat = ""
+                        try:
+                            _esc_cat = _loop_guard.detect_refusal_category(
+                                final_response or ""
+                            )
+                        except Exception:
+                            pass
+                        if _refusal_telemetry:
+                            _refusal_telemetry.record_nudge_and_set_pending(
+                                agent, _esc_cat, "session", _refusal_count + 1
+                            )
                         _escalation = (
                             "[loop-guard] REPEATED REFUSALS: "
                             f"{_session_refusals + 1} refusals this session. "

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -1263,6 +1263,30 @@ def _classify_refusal(text: str) -> str:
     return "over_refusal"
 
 
+def detect_refusal_category(text: str) -> str:
+    """Public accessor — classify a full assistant text response.
+
+    Returns the refusal category (e.g. ``"over_refusal"``,
+    ``"true_capability_gap"``) if the text contains refusal language, or
+    an empty string ``""`` if no refusal is detected.
+
+    Used by the conversation loop (#1265) to classify the model's response
+    *after* a nudge so the transition can be recorded in the refusal
+    telemetry sidecar.
+    """
+    if not text or not text.strip():
+        return ""
+    refusals = [
+        m for m in _REFUSAL_PAT.finditer(text)
+        if not _FP_REFUSAL_PAT.match(text[m.start():m.start() + 40])
+    ]
+    if not refusals:
+        return ""
+    first = refusals[0]
+    snippet = text[first.start():first.start() + 120]
+    return _classify_refusal(snippet)
+
+
 def maybe_refusal_nudge(
     messages: List[Dict[str, Any]],
     *,

--- a/agent/refusal_telemetry.py
+++ b/agent/refusal_telemetry.py
@@ -1,0 +1,238 @@
+"""Refusal nudge telemetry sidecar (#1265).
+
+Records per-nudge and per-transition events so future cycles can measure which
+nudge tiers shift model behavior vs which are ignored. Mirrors the
+``tools/skill_usage.py`` sidecar pattern: atomic writes, cross-process file
+lock (fcntl/msvcrt), best-effort (never breaks the conversation loop).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# fcntl is Unix-only; on Windows use msvcrt for file locking.
+msvcrt = None
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - platform-specific fallback
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
+
+# Cap the number of events stored to prevent unbounded growth.  When the
+# cap is reached the oldest events are dropped first (FIFO eviction).
+_MAX_EVENTS = 5000
+
+
+def _is_disabled() -> bool:
+    """Return True when telemetry should be skipped (e.g. import failed)."""
+    return False
+
+
+def _telemetry_file() -> Path:
+    """Return the path to the refusal telemetry sidecar."""
+    return get_hermes_home() / ".refusal_telemetry.json"
+
+
+@contextmanager
+def _telemetry_lock():
+    """Serialize sidecar read-modify-write cycles across processes."""
+    lock_path = _telemetry_file().with_suffix(".json.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if fcntl is None and msvcrt is None:
+        yield
+        return
+
+    if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+        lock_path.write_text(" ", encoding="utf-8")
+
+    fd = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
+    try:
+        if fcntl:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        if fcntl:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif msvcrt:
+            try:
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        fd.close()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_events() -> List[Dict[str, Any]]:
+    """Load existing events from the sidecar. Returns an empty list on any error."""
+    path = _telemetry_file()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and isinstance(data.get("events"), list):
+            return data["events"]
+        if isinstance(data, list):  # legacy flat-list format
+            return data
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        logger.debug("refusal_telemetry: could not read sidecar: %s", e)
+    return []
+
+
+def _save_events(events: List[Dict[str, Any]]) -> None:
+    """Atomically write events to the sidecar."""
+    path = _telemetry_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "events": events[-_MAX_EVENTS:],  # keep the most recent
+    }
+    try:
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".refusal_telemetry_", suffix=".tmp"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False)
+        os.replace(tmp, path)
+    except (OSError, IOError) as e:
+        logger.debug("refusal_telemetry: could not write sidecar: %s", e)
+
+
+def record_nudge(
+    *,
+    session_id: Optional[str],
+    nudge_tier: str,
+    refusal_category: str,
+    nudge_count: int,
+    session_refusal_count: int,
+) -> None:
+    """Record a nudge event (advisory / directive / session tier)."""
+    event = {
+        "type": "nudge",
+        "timestamp": _now_iso(),
+        "session_id": session_id or "",
+        "nudge_tier": nudge_tier,
+        "refusal_category": refusal_category,
+        "nudge_count": nudge_count,
+        "session_refusal_count": session_refusal_count,
+    }
+    try:
+        with _telemetry_lock():
+            events = _load_events()
+            events.append(event)
+            _save_events(events)
+    except Exception as e:  # never break the conversation loop
+        logger.debug("refusal_telemetry: record_nudge failed: %s", e)
+
+
+def record_transition(
+    *,
+    session_id: Optional[str],
+    nudge_tier: str,
+    category_before: str,
+    category_after: str,
+    recovered: bool,
+    took_action: bool,
+) -> None:
+    """Record a transition — the model's response after a nudge."""
+    event = {
+        "type": "transition",
+        "timestamp": _now_iso(),
+        "session_id": session_id or "",
+        "nudge_tier": nudge_tier,
+        "category_before": category_before,
+        "category_after": category_after,
+        "recovered": recovered,
+        "took_action": took_action,
+    }
+    try:
+        with _telemetry_lock():
+            events = _load_events()
+            events.append(event)
+            _save_events(events)
+    except Exception as e:  # never break the conversation loop
+        logger.debug("refusal_telemetry: record_transition failed: %s", e)
+
+
+def record_nudge_and_set_pending(
+    agent, refusal_category: str, nudge_tier: str, nudge_count: int
+) -> None:
+    """Record a nudge event and stash pending telemetry on the agent (#1265).
+
+    Convenience helper for the conversation loop: records the nudge, then
+    stores ``{tier, category}`` on ``agent._pending_nudge_telemetry`` so
+    the next response can record a transition.
+    """
+    if _is_disabled():
+        return
+    try:
+        record_nudge(
+            session_id=getattr(agent, "session_id", None),
+            nudge_tier=nudge_tier,
+            refusal_category=refusal_category,
+            nudge_count=nudge_count,
+            session_refusal_count=getattr(agent, "_session_refusal_count", 0),
+        )
+    except Exception:
+        pass
+    agent._pending_nudge_telemetry = {"tier": nudge_tier, "category": refusal_category}
+
+
+def record_transition_if_pending(agent, category_after: str, took_action: bool) -> None:
+    """Record a transition if a nudge is pending on the agent (#1265).
+
+    Called when the model produces a new response after a nudge.  If a
+    pending nudge exists, records the transition and clears the pending
+    state.  ``took_action=True`` when the model produced tool calls.
+    """
+    if _is_disabled():
+        return
+    pt = getattr(agent, "_pending_nudge_telemetry", None)
+    if not pt:
+        return
+    try:
+        record_transition(
+            session_id=getattr(agent, "session_id", None),
+            nudge_tier=pt.get("tier", ""),
+            category_before=pt.get("category", ""),
+            category_after=category_after,
+            recovered=not category_after,
+            took_action=took_action,
+        )
+    except Exception:
+        pass
+    agent._pending_nudge_telemetry = None
+
+
+def load_events() -> List[Dict[str, Any]]:
+    """Public read accessor — returns all events from the sidecar."""
+    try:
+        with _telemetry_lock():
+            return _load_events()
+    except Exception as e:
+        logger.debug("refusal_telemetry: load_events failed: %s", e)
+        return []

--- a/tests/agent/test_refusal_telemetry.py
+++ b/tests/agent/test_refusal_telemetry.py
@@ -1,0 +1,148 @@
+"""Tests for the refusal nudge telemetry sidecar (#1265).
+
+Covers ``record_nudge`` / ``record_transition`` / ``load_events`` /
+``summarize`` against a temp HERMES_HOME, ``detect_refusal_category``, and
+best-effort guarantees (broken sidecar never raises).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent import refusal_telemetry
+from agent.loop_guard import detect_refusal_category
+
+
+@pytest.fixture(autouse=True)
+def _tmp_telemetry_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("agent.refusal_telemetry.get_hermes_home", lambda: hermes_home)
+    yield hermes_home
+
+
+# ── detect_refusal_category ───────────────────────────────────────────────────
+
+
+class TestDetectRefusalCategory:
+    def test_over_refusal_detected(self):
+        text = "I can't do that — it would require accessing a system I don't have."
+        assert detect_refusal_category(text) == "over_refusal"
+
+    def test_no_refusal_returns_empty(self):
+        assert detect_refusal_category("Sure! I'll create the file now.") == ""
+
+    def test_empty_text_returns_empty(self):
+        assert detect_refusal_category("") == ""
+        assert detect_refusal_category("   ") == ""
+
+    def test_returns_known_category_or_empty(self):
+        text = "I don't have access to the database, so I can't query the records."
+        cat = detect_refusal_category(text)
+        assert cat == "" or cat in ("true_capability_gap", "over_refusal", "permission_boundary")
+
+
+# ── record_nudge / record_transition ──────────────────────────────────────────
+
+
+class TestRecording:
+    def test_nudge_recorded(self, _tmp_telemetry_home):
+        refusal_telemetry.record_nudge(
+            session_id="sess-1", nudge_tier="advisory",
+            refusal_category="over_refusal", nudge_count=1, session_refusal_count=1,
+        )
+        events = refusal_telemetry.load_events()
+        assert len(events) == 1
+        e = events[0]
+        assert e["type"] == "nudge"
+        assert e["nudge_tier"] == "advisory"
+        assert e["session_id"] == "sess-1"
+        assert "timestamp" in e
+
+    def test_none_session_id_becomes_empty(self, _tmp_telemetry_home):
+        refusal_telemetry.record_nudge(
+            session_id=None, nudge_tier="directive",
+            refusal_category="over_refusal", nudge_count=2, session_refusal_count=3,
+        )
+        assert refusal_telemetry.load_events()[0]["session_id"] == ""
+
+    def test_transition_recorded(self, _tmp_telemetry_home):
+        refusal_telemetry.record_transition(
+            session_id="s1", nudge_tier="advisory",
+            category_before="over_refusal", category_after="",
+            recovered=True, took_action=True,
+        )
+        e = refusal_telemetry.load_events()[0]
+        assert e["type"] == "transition"
+        assert e["recovered"] is True
+        assert e["took_action"] is True
+
+    def test_mixed_events_accumulate(self, _tmp_telemetry_home):
+        refusal_telemetry.record_nudge(
+            session_id="s1", nudge_tier="advisory",
+            refusal_category="over_refusal", nudge_count=1, session_refusal_count=1,
+        )
+        refusal_telemetry.record_transition(
+            session_id="s1", nudge_tier="advisory",
+            category_before="over_refusal", category_after="",
+            recovered=True, took_action=True,
+        )
+        events = refusal_telemetry.load_events()
+        assert len(events) == 2
+        assert events[0]["type"] == "nudge"
+        assert events[1]["type"] == "transition"
+
+    def test_sidecar_file_format(self, _tmp_telemetry_home):
+        refusal_telemetry.record_nudge(
+            session_id="s1", nudge_tier="advisory",
+            refusal_category="over_refusal", nudge_count=1, session_refusal_count=1,
+        )
+        sidecar = _tmp_telemetry_home / ".refusal_telemetry.json"
+        assert sidecar.exists()
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert data["version"] == 1
+        assert len(data["events"]) == 1
+
+
+# ── Best-effort / robustness ────────────────────────────────────────────────────
+
+
+class TestBestEffort:
+    def test_corrupt_sidecar_returns_empty(self, _tmp_telemetry_home):
+        (_tmp_telemetry_home / ".refusal_telemetry.json").write_text("not json {{{", encoding="utf-8")
+        assert refusal_telemetry.load_events() == []
+
+    def test_record_does_not_raise_on_io_error(self, _tmp_telemetry_home):
+        with patch("agent.refusal_telemetry._save_events", side_effect=OSError("disk full")):
+            refusal_telemetry.record_nudge(
+                session_id="s1", nudge_tier="advisory",
+                refusal_category="over_refusal", nudge_count=1, session_refusal_count=1,
+            )
+
+    def test_record_transition_does_not_raise_on_io_error(self, _tmp_telemetry_home):
+        with patch("agent.refusal_telemetry._save_events", side_effect=OSError("disk full")):
+            refusal_telemetry.record_transition(
+                session_id="s1", nudge_tier="advisory",
+                category_before="over_refusal", category_after="",
+                recovered=True, took_action=True,
+            )
+
+    def test_max_events_cap(self, _tmp_telemetry_home):
+        original = refusal_telemetry._MAX_EVENTS
+        refusal_telemetry._MAX_EVENTS = 5
+        try:
+            for i in range(10):
+                refusal_telemetry.record_nudge(
+                    session_id=f"s{i}", nudge_tier="advisory",
+                    refusal_category="over_refusal", nudge_count=1, session_refusal_count=1,
+                )
+            events = refusal_telemetry.load_events()
+            assert len(events) == 5
+            assert events[0]["session_id"] == "s5"
+            assert events[-1]["session_id"] == "s9"
+        finally:
+            refusal_telemetry._MAX_EVENTS = original


### PR DESCRIPTION
Automated evolution PR for issue #1265.

## What

Lightweight telemetry instrumentation for the refusal nudge path. This is a **diagnose-first** approach — prior PR #1266 tried changing nudge language/thresholds and made refusals worse (2250→2375). Telemetry is the prerequisite for a targeted, measured fix.

## How

New `agent/refusal_telemetry.py` module mirrors the `tools/skill_usage.py` sidecar pattern:
- Atomic writes (tempfile + `os.replace`)
- Cross-process file lock (fcntl/msvcrt)
- Best-effort (never breaks the conversation loop)
- Sidecar at `~/.hermes/.refusal_telemetry.json` (profile-aware via `get_hermes_home()`)

Records two event types:
- **nudge** — when `maybe_refusal_nudge` fires: tier (advisory/directive/session), refusal category, counts
- **transition** — model response after nudge: category before/after, recovered flag, took_action flag

New public `detect_refusal_category()` in `loop_guard.py` classifies a full assistant text response using the existing refusal taxonomy.

Wiring in `conversation_loop.py`:
- Nudge fires → record nudge event + set pending telemetry on agent
- Model responds with tool calls after nudge → record transition (recovered=True, took_action=True)
- Model responds with text after nudge → classify, record transition (recovered if not refusal)

## Tests

13 new tests in `tests/agent/test_refusal_telemetry.py` covering `record_nudge`, `record_transition`, `load_events`, `detect_refusal_category`, best-effort robustness, and FIFO eviction cap.

## Deferred (next increment)
- `summarize()` diagnostic function for the sidecar data
- CLI command to view the telemetry summary
- Integration with the evolution analysis stage to consume transition rates