### PR TITLE
fix(#1611): make provider_dead deterministic, keep not_found per-tool

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -76,7 +76,16 @@ _EXIT_CODE_RE = re.compile(r"exit code[:\s]+([1-9]\d*)", re.IGNORECASE)
 # change-and-retry classes (not_found, runtime_error) where a corrected retry can
 # legitimately succeed. Two of these in a row already warrants a hard stop, below
 # the generic fail_threshold.
-_NON_RETRYABLE = frozenset({"timeout", "permission", "missing_command", "limit"})
+#
+# ``provider_dead`` joined the set in #1611: it means the configured search
+# provider is not returning results at all (DuckDuckGo/Brave/SearXNG unreachable
+# or erroring). Unlike ``not_found``, rewording the query cannot help — the
+# provider is down for every query — and the recovery hint already tells the
+# agent to switch search_backend rather than retry. Leaving it out let
+# provider outages present as ordinary per-query failures and spiral.
+_NON_RETRYABLE = frozenset(
+    {"timeout", "permission", "missing_command", "limit", "provider_dead"}
+)
 _NONRETRY_THRESHOLD = 2
 
 # #1612 — Per-tool non-retryable failure classes. The global ``_NON_RETRYABLE``

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -57,8 +57,14 @@ _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
         "or raise the relevant config limit; a near-identical retry will fail the same way.",
     ),
     (
+        # Only genuine backend-unreachable signals belong here. A bare
+        # "no results" used to match, which mislabelled every empty local
+        # search_files result as a dead web-search provider (#1611) — the two
+        # need opposite recoveries: an empty local search should be retried
+        # with a broader query, a dead provider should not be retried at all.
+        # Bare "no results" now falls through to the not_found rule below.
         re.compile(
-            r"\bno results\b|\bno results found\b|duckduckgo search failed|brave search returned http|could not reach .* search|searxng returned http",
+            r"duckduckgo search failed|brave search returned http|could not reach .* search|searxng returned http",
             re.I,
         ),
         "provider_dead",

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -146,6 +146,43 @@ class TestNonRetryableTrigger:
         # Falls through to generic fail path: 2 failures >= mutating fail_threshold=2
         assert n is not None and "failed 2 times" in n
 
+    def test_two_dead_search_providers_stop_hard(self):
+        """#1611 — a down search provider fails identically for every query.
+
+        Rewording cannot help while the backend is unreachable, so this must
+        trip the deterministic stop rather than spiral per-query.
+        """
+        n = maybe_nudge(
+            _run("search_web", 2, result="DuckDuckGo search failed (HTTP 502)")
+        )
+        assert n is not None and "non-retryable" in n and "provider_dead" in n
+
+    def test_empty_local_search_is_not_provider_dead(self):
+        """#1611 — an empty local search must not read as a dead web provider.
+
+        ``no results`` used to match the provider_dead rule, so every empty
+        ``search_files`` looked like an unreachable search backend. The two
+        need opposite recoveries: broaden the query vs. stop retrying entirely.
+        """
+        from agent.tool_diagnostics import classify
+
+        assert classify("no results found")[0] == "not_found"
+
+    def test_terminal_not_found_is_not_globally_non_retryable(self):
+        """#1611 — ``not_found`` must NOT join the global deterministic set.
+
+        A ``not_found`` from a terminal command can be a transient condition a
+        corrected retry resolves, and a search returning no matches is
+        legitimately retryable with a broader query. Permanence is per-tool, so
+        it stays in ``_NON_RETRYABLE_BY_TOOL`` (read_file, patch) — a global
+        entry would over-block. Two terminal not_founds therefore fall through
+        to the generic fail path, not the non-retryable hard stop.
+        """
+        n = maybe_nudge(
+            _run("terminal", 2, result="cat: data.csv: No such file or directory")
+        )
+        assert n is None or "non-retryable" not in n
+
 
 class TestEscalatedInterrupt:
     """#432 — mono-tool spirals beyond the repeat threshold get an escalated


### PR DESCRIPTION
Reworked after review against `main`.

**What changed vs. the original PR.** It added both `not_found` and `provider_dead` to the global `_NON_RETRYABLE` set. Both were wrong as written:

- **`not_found` — dropped.** `main`'s `_NON_RETRYABLE_BY_TOOL` (#1612, already merged) covers it precisely where it is permanent (`read_file`, `patch`) and *deliberately excludes* `search_files`, where an empty result is legitimately retryable with a broader query. A global entry would over-block those, plus terminal `not_found`s that a corrected retry resolves.
- **`provider_dead` — kept, but only after fixing a latent bug.** A down search backend does fail identically for every query, so it belongs in the set. But adding it surfaced this: the `provider_dead` regex matched a bare `no results`, so **every empty local `search_files` result was classified as an unreachable web-search provider**. Those two want opposite recoveries (broaden the query vs. stop retrying entirely) — and once `provider_dead` is non-retryable, that mislabel would hard-stop ordinary empty searches, the exact case #1612 protected.

**So:** narrow the `provider_dead` pattern to genuine backend-unreachable signals (bare `no results` now falls through to `not_found`, which is what it actually means), then add `provider_dead` to the global set.

Tests cover the dead-provider hard stop, the empty-local-search classification, and that terminal `not_found` stays out of the global set. 161 tests pass across the loop-guard, diagnostics, and provider suites.

Closes #1611. #1612 was already closed by the per-tool work in main.