### PR TITLE
feat: eval harness Step 2 — agent runner with trajectory capture (Closes #1515)

### DIFF
--- a/scripts/eval_runner.py
+++ b/scripts/eval_runner.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 """Agent runner for the eval harness (issue #1515, Step 2).
 
-Provides ``EvalTrajectory`` — a dataclass capturing the full execution record
-of running the agent against an ``EvalTask`` — and ``run_eval_task()``, the
-core runner function that executes a task and records the trajectory.
-
-This is the execution layer of the eval harness foundation. It does NOT
-define tasks (Step 1 / #1514) or score results (Step 4).
-
-Dependencies: ``scripts/eval_tasks.py`` (Step 1 / #1514).
+Provides ``EvalTrajectory`` and ``run_eval_task()`` — the execution layer
+of the eval harness foundation. Does NOT define tasks or score results.
 """
 
 from __future__ import annotations
@@ -25,16 +19,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EvalTrajectory:
-    """Full execution record of running the agent against one EvalTask.
-
-    Fields per the issue spec:
-    - task_id: which EvalTask was run
-    - tool_calls: list of {tool, args, result, timestamp} dicts
-    - model_turns: number of model round-trips
-    - final_answer: the agent's final text output
-    - duration_seconds: wall-clock time
-    - error: exception if the agent crashed, else None
-    """
+    """Full execution record of running the agent against one EvalTask."""
 
     task_id: str
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)
@@ -42,11 +27,9 @@ class EvalTrajectory:
     final_answer: str = ""
     duration_seconds: float = 0.0
     error: Optional[str] = None
-    # Metadata for reproducibility
     agent_config: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Serialize to a plain dict suitable for JSON output."""
         return {
             "task_id": self.task_id,
             "tool_calls": list(self.tool_calls),
@@ -58,16 +41,11 @@ class EvalTrajectory:
         }
 
     def to_jsonl(self) -> str:
-        """Serialize to a single JSONL line (newline-terminated JSON)."""
         return json.dumps(self.to_dict(), ensure_ascii=False) + "\n"
 
 
 def _make_recorder() -> Tuple[list, Callable]:
-    """Build a callback and its backing list for capturing tool calls.
-
-    The callback signature matches the agent's tool-call hook:
-    ``callback(tool_name: str, args: dict, result: str)``.
-    """
+    """Build a tool-call capture callback and its backing list."""
     calls: list = []
 
     def _record(tool_name: str, args: Any = None, result: Any = None) -> None:
@@ -75,7 +53,7 @@ def _make_recorder() -> Tuple[list, Callable]:
             {
                 "tool": tool_name,
                 "args": args if isinstance(args, dict) else {"_raw": str(args)},
-                "result": str(result)[:2000],  # truncate large results
+                "result": str(result)[:2000],
                 "timestamp": time.time(),
             }
         )
@@ -87,24 +65,7 @@ def run_eval_task(
     task: Any,
     agent_config: Optional[Dict[str, Any]] = None,
 ) -> EvalTrajectory:
-    """Execute the agent against an ``EvalTask`` and capture the trajectory.
-
-    Parameters
-    ----------
-    task
-        An ``EvalTask`` instance (from ``scripts/eval_tasks.py``).
-    agent_config
-        Pinned base configuration for reproducibility. Keys:
-        - model: model identifier (default "test-pinned")
-        - tools: list of enabled tool names (default: ["read_file", "search_files"])
-        - system_prompt: system prompt text (default: minimal)
-        - max_turns: maximum model round-trips (default: 5)
-
-    Returns
-    -------
-    EvalTrajectory
-        The full execution record.
-    """
+    """Execute the agent against an ``EvalTask`` and capture the trajectory."""
     cfg = agent_config or {}
     pinned_config: Dict[str, Any] = {
         "model": cfg.get("model", "test-pinned"),
@@ -136,38 +97,25 @@ def _execute_agent_loop(
     prompt: str,
     config: Dict[str, Any],
     record_call: Callable,
-) -> tuple[str, int]:
-    """Minimal agent execution loop for eval purposes.
+) -> Tuple[str, int]:
+    """Minimal deterministic agent loop for eval reproducibility.
 
-    This is a SIMPLIFIED loop that:
-    1. Processes the prompt
-    2. Optionally calls tools (in test mode, tools are stubbed)
-    3. Returns a final answer
-
-    In production, this would drive the real agent session. For eval
-    reproducibility, the loop is deterministic given the same config.
-
-    Returns (final_answer, model_turns).
+    In production this would drive the real agent session.
     """
     max_turns = config.get("max_turns", 5)
     tools = config.get("tools", [])
     turns = 0
-
     answer_parts: List[str] = []
 
-    # Simulate a minimal reasoning + tool-call cycle.
-    # In the real harness this would invoke the model + tool dispatcher.
     for turn_idx in range(max_turns):
         turns += 1
         if turn_idx == 0 and tools:
-            # First turn: simulate a tool call to gather information
             record_call(
                 tools[0],
                 {"prompt": prompt[:200]},
                 f"[stub result for {tools[0]}]",
             )
             continue
-        # Final turn: produce answer
         answer_parts.append(f"Processed: {prompt[:100]}")
         break
 

--- a/scripts/eval_runner.py
+++ b/scripts/eval_runner.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Agent runner for the eval harness (issue #1515, Step 2).
+
+Provides ``EvalTrajectory`` — a dataclass capturing the full execution record
+of running the agent against an ``EvalTask`` — and ``run_eval_task()``, the
+core runner function that executes a task and records the trajectory.
+
+This is the execution layer of the eval harness foundation. It does NOT
+define tasks (Step 1 / #1514) or score results (Step 4).
+
+Dependencies: ``scripts/eval_tasks.py`` (Step 1 / #1514).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EvalTrajectory:
+    """Full execution record of running the agent against one EvalTask.
+
+    Fields per the issue spec:
+    - task_id: which EvalTask was run
+    - tool_calls: list of {tool, args, result, timestamp} dicts
+    - model_turns: number of model round-trips
+    - final_answer: the agent's final text output
+    - duration_seconds: wall-clock time
+    - error: exception if the agent crashed, else None
+    """
+
+    task_id: str
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    model_turns: int = 0
+    final_answer: str = ""
+    duration_seconds: float = 0.0
+    error: Optional[str] = None
+    # Metadata for reproducibility
+    agent_config: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON output."""
+        return {
+            "task_id": self.task_id,
+            "tool_calls": list(self.tool_calls),
+            "model_turns": self.model_turns,
+            "final_answer": self.final_answer,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "error": self.error,
+            "agent_config": dict(self.agent_config),
+        }
+
+    def to_jsonl(self) -> str:
+        """Serialize to a single JSONL line (newline-terminated JSON)."""
+        return json.dumps(self.to_dict(), ensure_ascii=False) + "\n"
+
+
+def _make_recorder() -> Tuple[list, Callable]:
+    """Build a callback and its backing list for capturing tool calls.
+
+    The callback signature matches the agent's tool-call hook:
+    ``callback(tool_name: str, args: dict, result: str)``.
+    """
+    calls: list = []
+
+    def _record(tool_name: str, args: Any = None, result: Any = None) -> None:
+        calls.append(
+            {
+                "tool": tool_name,
+                "args": args if isinstance(args, dict) else {"_raw": str(args)},
+                "result": str(result)[:2000],  # truncate large results
+                "timestamp": time.time(),
+            }
+        )
+
+    return calls, _record
+
+
+def run_eval_task(
+    task: Any,
+    agent_config: Optional[Dict[str, Any]] = None,
+) -> EvalTrajectory:
+    """Execute the agent against an ``EvalTask`` and capture the trajectory.
+
+    Parameters
+    ----------
+    task
+        An ``EvalTask`` instance (from ``scripts/eval_tasks.py``).
+    agent_config
+        Pinned base configuration for reproducibility. Keys:
+        - model: model identifier (default "test-pinned")
+        - tools: list of enabled tool names (default: ["read_file", "search_files"])
+        - system_prompt: system prompt text (default: minimal)
+        - max_turns: maximum model round-trips (default: 5)
+
+    Returns
+    -------
+    EvalTrajectory
+        The full execution record.
+    """
+    cfg = agent_config or {}
+    pinned_config: Dict[str, Any] = {
+        "model": cfg.get("model", "test-pinned"),
+        "tools": cfg.get("tools", ["read_file", "search_files"]),
+        "system_prompt": cfg.get("system_prompt", "You are a test agent."),
+        "max_turns": cfg.get("max_turns", 5),
+    }
+
+    task_id = getattr(task, "id", str(task))
+    prompt = getattr(task, "prompt", str(task))
+    traj = EvalTrajectory(task_id=task_id, agent_config=pinned_config)
+
+    tool_calls, recorder = _make_recorder()
+    start = time.time()
+
+    try:
+        answer, turns = _execute_agent_loop(prompt, pinned_config, recorder)
+        traj.final_answer = answer
+        traj.model_turns = turns
+    except Exception as exc:
+        traj.error = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+
+    traj.duration_seconds = time.time() - start
+    traj.tool_calls = tool_calls
+    return traj
+
+
+def _execute_agent_loop(
+    prompt: str,
+    config: Dict[str, Any],
+    record_call: Callable,
+) -> tuple[str, int]:
+    """Minimal agent execution loop for eval purposes.
+
+    This is a SIMPLIFIED loop that:
+    1. Processes the prompt
+    2. Optionally calls tools (in test mode, tools are stubbed)
+    3. Returns a final answer
+
+    In production, this would drive the real agent session. For eval
+    reproducibility, the loop is deterministic given the same config.
+
+    Returns (final_answer, model_turns).
+    """
+    max_turns = config.get("max_turns", 5)
+    tools = config.get("tools", [])
+    turns = 0
+
+    answer_parts: List[str] = []
+
+    # Simulate a minimal reasoning + tool-call cycle.
+    # In the real harness this would invoke the model + tool dispatcher.
+    for turn_idx in range(max_turns):
+        turns += 1
+        if turn_idx == 0 and tools:
+            # First turn: simulate a tool call to gather information
+            record_call(
+                tools[0],
+                {"prompt": prompt[:200]},
+                f"[stub result for {tools[0]}]",
+            )
+            continue
+        # Final turn: produce answer
+        answer_parts.append(f"Processed: {prompt[:100]}")
+        break
+
+    return "\n".join(answer_parts), turns

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Unit tests for the eval harness agent runner (issue #1515, Step 2)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import os
+
+import pytest
+
+# Ensure scripts/ is on the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from eval_runner import EvalTrajectory, run_eval_task  # noqa: E402
+from eval_tasks import EvalTask, load_task_set  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# EvalTrajectory dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestEvalTrajectoryDataclass:
+    def test_default_fields(self):
+        traj = EvalTrajectory(task_id="test-1")
+        assert traj.task_id == "test-1"
+        assert traj.tool_calls == []
+        assert traj.model_turns == 0
+        assert traj.final_answer == ""
+        assert traj.duration_seconds == 0.0
+        assert traj.error is None
+        assert traj.agent_config == {}
+
+    def test_to_dict(self):
+        traj = EvalTrajectory(
+            task_id="t1",
+            tool_calls=[{"tool": "read_file", "args": {}, "result": "ok", "timestamp": 1.0}],
+            model_turns=2,
+            final_answer="42",
+            duration_seconds=1.5,
+            agent_config={"model": "test"},
+        )
+        d = traj.to_dict()
+        assert d["task_id"] == "t1"
+        assert len(d["tool_calls"]) == 1
+        assert d["model_turns"] == 2
+        assert d["final_answer"] == "42"
+        assert d["duration_seconds"] == 1.5
+        assert d["error"] is None
+        assert d["agent_config"]["model"] == "test"
+
+    def test_to_jsonl(self):
+        traj = EvalTrajectory(task_id="t1", final_answer="hello")
+        line = traj.to_jsonl()
+        assert line.endswith("\n")
+        parsed = json.loads(line)
+        assert parsed["task_id"] == "t1"
+        assert parsed["final_answer"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# run_eval_task — basic execution
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvalTask:
+    def test_returns_trajectory_with_task_id(self):
+        task = EvalTask(id="test-1", prompt="What is 2+2?")
+        traj = run_eval_task(task)
+        assert isinstance(traj, EvalTrajectory)
+        assert traj.task_id == "test-1"
+
+    def test_captures_tool_calls(self):
+        task = EvalTask(id="test-2", prompt="List files", expected_tools=["search_files"])
+        traj = run_eval_task(task, agent_config={"tools": ["search_files"]})
+        assert len(traj.tool_calls) >= 1
+        assert traj.tool_calls[0]["tool"] == "search_files"
+
+    def test_captures_final_answer(self):
+        task = EvalTask(id="test-3", prompt="Say hello")
+        traj = run_eval_task(task)
+        assert traj.final_answer != ""
+
+    def test_records_model_turns(self):
+        task = EvalTask(id="test-4", prompt="Read a file")
+        traj = run_eval_task(task)
+        assert traj.model_turns >= 1
+
+    def test_duration_is_positive(self):
+        task = EvalTask(id="test-5", prompt="Quick task")
+        traj = run_eval_task(task)
+        assert traj.duration_seconds > 0
+
+    def test_no_error_on_success(self):
+        task = EvalTask(id="test-6", prompt="Easy task")
+        traj = run_eval_task(task)
+        assert traj.error is None
+
+
+# ---------------------------------------------------------------------------
+# Agent config pinning
+# ---------------------------------------------------------------------------
+
+
+class TestAgentConfigPinning:
+    def test_default_config(self):
+        task = EvalTask(id="test-cfg-1", prompt="test")
+        traj = run_eval_task(task)
+        assert traj.agent_config["model"] == "test-pinned"
+        assert "read_file" in traj.agent_config["tools"]
+        assert traj.agent_config["max_turns"] == 5
+
+    def test_custom_config(self):
+        task = EvalTask(id="test-cfg-2", prompt="test")
+        custom = {
+            "model": "custom-model",
+            "tools": ["search_files"],
+            "system_prompt": "Custom prompt",
+            "max_turns": 3,
+        }
+        traj = run_eval_task(task, agent_config=custom)
+        assert traj.agent_config["model"] == "custom-model"
+        assert traj.agent_config["tools"] == ["search_files"]
+        assert traj.agent_config["system_prompt"] == "Custom prompt"
+        assert traj.agent_config["max_turns"] == 3
+
+    def test_config_recorded_in_trajectory(self):
+        task = EvalTask(id="test-cfg-3", prompt="test")
+        traj = run_eval_task(task, agent_config={"model": "pinned-v2"})
+        assert "model" in traj.agent_config
+        assert traj.agent_config["model"] == "pinned-v2"
+
+
+# ---------------------------------------------------------------------------
+# Trajectory serialization
+# ---------------------------------------------------------------------------
+
+
+class TestTrajectorySerialization:
+    def test_full_trajectory_serializes(self):
+        task = EvalTask(id="test-ser-1", prompt="test prompt for serialization")
+        traj = run_eval_task(task)
+        d = traj.to_dict()
+        # Re-serialize to JSON and back
+        raw = json.dumps(d)
+        parsed = json.loads(raw)
+        assert parsed["task_id"] == "test-ser-1"
+
+    def test_jsonl_line_is_valid_json(self):
+        task = EvalTask(id="test-ser-2", prompt="test")
+        traj = run_eval_task(task)
+        line = traj.to_jsonl().strip()
+        parsed = json.loads(line)
+        assert parsed["task_id"] == "test-ser-2"
+
+
+# ---------------------------------------------------------------------------
+# Integration with real task set
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationWithTaskSet:
+    def test_runs_against_real_tasks(self):
+        tasks = load_task_set("1.0")
+        assert len(tasks) >= 3
+        for task in tasks[:2]:  # run first 2 to keep test fast
+            traj = run_eval_task(task)
+            assert traj.task_id == task.id
+            assert traj.error is None

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -9,162 +9,74 @@ import os
 
 import pytest
 
-# Ensure scripts/ is on the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from eval_runner import EvalTrajectory, run_eval_task  # noqa: E402
 from eval_tasks import EvalTask, load_task_set  # noqa: E402
 
 
-# ---------------------------------------------------------------------------
-# EvalTrajectory dataclass
-# ---------------------------------------------------------------------------
-
-
-class TestEvalTrajectoryDataclass:
+class TestEvalTrajectory:
     def test_default_fields(self):
-        traj = EvalTrajectory(task_id="test-1")
-        assert traj.task_id == "test-1"
+        traj = EvalTrajectory(task_id="t1")
         assert traj.tool_calls == []
         assert traj.model_turns == 0
-        assert traj.final_answer == ""
-        assert traj.duration_seconds == 0.0
         assert traj.error is None
-        assert traj.agent_config == {}
 
     def test_to_dict(self):
-        traj = EvalTrajectory(
-            task_id="t1",
-            tool_calls=[{"tool": "read_file", "args": {}, "result": "ok", "timestamp": 1.0}],
-            model_turns=2,
-            final_answer="42",
-            duration_seconds=1.5,
-            agent_config={"model": "test"},
-        )
+        traj = EvalTrajectory(task_id="t1", final_answer="42", model_turns=1)
         d = traj.to_dict()
         assert d["task_id"] == "t1"
-        assert len(d["tool_calls"]) == 1
-        assert d["model_turns"] == 2
         assert d["final_answer"] == "42"
-        assert d["duration_seconds"] == 1.5
-        assert d["error"] is None
-        assert d["agent_config"]["model"] == "test"
+        assert d["model_turns"] == 1
 
-    def test_to_jsonl(self):
+    def test_to_jsonl_roundtrip(self):
         traj = EvalTrajectory(task_id="t1", final_answer="hello")
-        line = traj.to_jsonl()
-        assert line.endswith("\n")
-        parsed = json.loads(line)
+        parsed = json.loads(traj.to_jsonl())
         assert parsed["task_id"] == "t1"
         assert parsed["final_answer"] == "hello"
 
 
-# ---------------------------------------------------------------------------
-# run_eval_task — basic execution
-# ---------------------------------------------------------------------------
-
-
 class TestRunEvalTask:
-    def test_returns_trajectory_with_task_id(self):
-        task = EvalTask(id="test-1", prompt="What is 2+2?")
-        traj = run_eval_task(task)
+    def test_returns_trajectory(self):
+        traj = run_eval_task(EvalTask(id="t1", prompt="What is 2+2?"))
         assert isinstance(traj, EvalTrajectory)
-        assert traj.task_id == "test-1"
+        assert traj.task_id == "t1"
 
     def test_captures_tool_calls(self):
-        task = EvalTask(id="test-2", prompt="List files", expected_tools=["search_files"])
-        traj = run_eval_task(task, agent_config={"tools": ["search_files"]})
+        traj = run_eval_task(
+            EvalTask(id="t2", prompt="List files", expected_tools=["search_files"]),
+            agent_config={"tools": ["search_files"]},
+        )
         assert len(traj.tool_calls) >= 1
         assert traj.tool_calls[0]["tool"] == "search_files"
 
-    def test_captures_final_answer(self):
-        task = EvalTask(id="test-3", prompt="Say hello")
-        traj = run_eval_task(task)
+    def test_captures_final_answer_and_turns(self):
+        traj = run_eval_task(EvalTask(id="t3", prompt="Say hello"))
         assert traj.final_answer != ""
-
-    def test_records_model_turns(self):
-        task = EvalTask(id="test-4", prompt="Read a file")
-        traj = run_eval_task(task)
         assert traj.model_turns >= 1
-
-    def test_duration_is_positive(self):
-        task = EvalTask(id="test-5", prompt="Quick task")
-        traj = run_eval_task(task)
         assert traj.duration_seconds > 0
-
-    def test_no_error_on_success(self):
-        task = EvalTask(id="test-6", prompt="Easy task")
-        traj = run_eval_task(task)
         assert traj.error is None
 
 
-# ---------------------------------------------------------------------------
-# Agent config pinning
-# ---------------------------------------------------------------------------
-
-
-class TestAgentConfigPinning:
+class TestConfigPinning:
     def test_default_config(self):
-        task = EvalTask(id="test-cfg-1", prompt="test")
-        traj = run_eval_task(task)
+        traj = run_eval_task(EvalTask(id="c1", prompt="test"))
         assert traj.agent_config["model"] == "test-pinned"
         assert "read_file" in traj.agent_config["tools"]
-        assert traj.agent_config["max_turns"] == 5
 
     def test_custom_config(self):
-        task = EvalTask(id="test-cfg-2", prompt="test")
-        custom = {
-            "model": "custom-model",
-            "tools": ["search_files"],
-            "system_prompt": "Custom prompt",
-            "max_turns": 3,
-        }
-        traj = run_eval_task(task, agent_config=custom)
-        assert traj.agent_config["model"] == "custom-model"
-        assert traj.agent_config["tools"] == ["search_files"]
-        assert traj.agent_config["system_prompt"] == "Custom prompt"
+        traj = run_eval_task(
+            EvalTask(id="c2", prompt="test"),
+            agent_config={"model": "v2", "max_turns": 3},
+        )
+        assert traj.agent_config["model"] == "v2"
         assert traj.agent_config["max_turns"] == 3
 
-    def test_config_recorded_in_trajectory(self):
-        task = EvalTask(id="test-cfg-3", prompt="test")
-        traj = run_eval_task(task, agent_config={"model": "pinned-v2"})
-        assert "model" in traj.agent_config
-        assert traj.agent_config["model"] == "pinned-v2"
 
-
-# ---------------------------------------------------------------------------
-# Trajectory serialization
-# ---------------------------------------------------------------------------
-
-
-class TestTrajectorySerialization:
-    def test_full_trajectory_serializes(self):
-        task = EvalTask(id="test-ser-1", prompt="test prompt for serialization")
-        traj = run_eval_task(task)
-        d = traj.to_dict()
-        # Re-serialize to JSON and back
-        raw = json.dumps(d)
-        parsed = json.loads(raw)
-        assert parsed["task_id"] == "test-ser-1"
-
-    def test_jsonl_line_is_valid_json(self):
-        task = EvalTask(id="test-ser-2", prompt="test")
-        traj = run_eval_task(task)
-        line = traj.to_jsonl().strip()
-        parsed = json.loads(line)
-        assert parsed["task_id"] == "test-ser-2"
-
-
-# ---------------------------------------------------------------------------
-# Integration with real task set
-# ---------------------------------------------------------------------------
-
-
-class TestIntegrationWithTaskSet:
+class TestIntegration:
     def test_runs_against_real_tasks(self):
         tasks = load_task_set("1.0")
-        assert len(tasks) >= 3
-        for task in tasks[:2]:  # run first 2 to keep test fast
+        for task in tasks[:2]:
             traj = run_eval_task(task)
             assert traj.task_id == task.id
             assert traj.error is None


### PR DESCRIPTION
Automated evolution PR for issue #1515.

## Summary

Step 2 of the eval harness foundation (#1481). Builds on Step 1 (#1514, landed) which defined EvalTask and the versioned task set.

## Changes

- EvalTrajectory dataclass: captures tool_calls, model_turns, final_answer, duration_seconds, error, agent_config
- run_eval_task(): executes agent loop and records full trajectory
- Trajectory serialization: to_dict() and to_jsonl()
- Agent config pinning for reproducible runs
- Minimal deterministic execution loop (real agent integration deferred to Step 3)

## Tests

- tests/test_eval_runner.py — 9 unit tests (all pass)
- ruff check clean