### PR TITLE
feat: workspace-trust gate for skill/plugin hook execution (Closes #1389)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -471,25 +471,64 @@ class PluginContext:
         entry = entries.get(plugin_id) or {}
         return bool(entry.get("allow_tool_override", False))
 
+    def _within_trusted_plugin_root(self) -> bool:
+        """Return True if this plugin really lives under the user profile dir.
+
+        ``source`` alone is not enough: a symlink planted inside
+        ``<HERMES_HOME>/plugins/`` is scanned as ``source="user"`` while its
+        code lives anywhere on disk. Resolve both sides and require genuine
+        containment, so the symlinked-directory vector from #1389 cannot
+        inherit profile trust.
+        """
+        raw_path = getattr(self.manifest, "path", None)
+        if not raw_path:
+            return False
+        try:
+            plugin_path = Path(raw_path).resolve(strict=True)
+            trusted_root = (get_hermes_home() / "plugins").resolve(strict=True)
+        except OSError:
+            return False
+        return plugin_path == trusted_root or trusted_root in plugin_path.parents
+
     def _hook_trust_allowed(self) -> bool:
         """Return True if this plugin is trusted to register hooks (#1389).
 
-        Mirrors ``_tool_override_allowed``: bundled plugins are trusted by
-        default; every other source requires ``allow_hooks: true`` under
-        ``plugins.entries.<plugin_id>`` in config.yaml.
+        Trusted by default:
+
+        * ``bundled`` — ships inside the Hermes repo itself.
+        * ``user`` — lives under ``<HERMES_HOME>/plugins/``, the profile
+          directory #1389 designates as trusted, and is opted in by name via
+          ``plugins.enabled``. Containment is verified against the resolved
+          path, not just the source label.
+
+        Untrusted by default — ``project`` (the cloned-repo vector),
+        ``entrypoint`` (pip supply chain), and anything unknown. These need
+        an explicit opt-in::
+
+            plugins:
+              entries:
+                "project:my-plugin":
+                  allow_hooks: true
+
+        The opt-in key is deliberately ``<source>:<plugin_id>`` rather than a
+        bare plugin id: a bare id would let a project plugin that takes the
+        name of an approved one inherit its approval.
         """
         source = getattr(self.manifest, "source", "") or ""
         if source == "bundled":
+            return True
+        if source == "user" and self._within_trusted_plugin_root():
             return True
         try:
             from hermes_cli.config import load_config
 
             cfg = load_config() or {}
         except Exception:
+            # Fail closed — better to drop the hook than silently grant it.
             return False
         plugin_id = self.manifest.key or self.manifest.name
         entries = (cfg.get("plugins") or {}).get("entries") or {}
-        entry = entries.get(plugin_id) or {}
+        entry = entries.get(f"{source}:{plugin_id}") or {}
         return bool(entry.get("allow_hooks", False))
 
     # -- message injection --------------------------------------------------
@@ -1182,9 +1221,11 @@ class PluginContext:
         Unknown hook names produce a warning but are still stored so
         forward-compatible plugins don't break.
 
-        **Workspace-trust gate (#1389):** hooks from non-bundled sources
-        are blocked unless explicitly approved via ``allow_hooks: true``
-        under ``plugins.entries.<plugin_id>`` in config.yaml.
+        **Workspace-trust gate (#1389):** hooks from untrusted sources
+        (``project``, ``entrypoint``, unknown) are blocked unless approved
+        via ``allow_hooks: true`` under
+        ``plugins.entries.<source>:<plugin_id>`` in config.yaml. See
+        :meth:`_hook_trust_allowed` for the full trust model.
         """
         if hook_name not in VALID_HOOKS:
             logger.warning(
@@ -1194,18 +1235,32 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
+        source = getattr(self.manifest, "source", "") or ""
+        plugin_id = self.manifest.key or self.manifest.name
         if not self._hook_trust_allowed():
             logger.warning(
-                "Plugin '%s' (source='%s') hook registration blocked — "
+                "Plugin '%s' (source='%s') hook '%s' blocked — "
                 "workspace trust required. Set "
-                "'plugins.entries.%s.allow_hooks: true' in config.yaml to approve.",
+                "'plugins.entries.\"%s:%s\".allow_hooks: true' in config.yaml "
+                "to approve.",
                 self.manifest.name,
-                getattr(self.manifest, "source", ""),
-                self.manifest.key or self.manifest.name,
+                source,
+                hook_name,
+                source,
+                plugin_id,
             )
             return
         self._manager._hooks.setdefault(hook_name, []).append(callback)
-        logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
+        # Audit trail (#1389 requirement 3): every accepted hook is recorded
+        # with the source that earned it, so an operator can reconstruct what
+        # was allowed to run and why.
+        logger.info(
+            "Hook registered: plugin='%s' hook='%s' source='%s' trust='%s'",
+            self.manifest.name,
+            hook_name,
+            source,
+            "default" if source in ("bundled", "user") else "explicit-opt-in",
+        )
 
     # -- middleware registration -------------------------------------------
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -471,6 +471,27 @@ class PluginContext:
         entry = entries.get(plugin_id) or {}
         return bool(entry.get("allow_tool_override", False))
 
+    def _hook_trust_allowed(self) -> bool:
+        """Return True if this plugin is trusted to register hooks (#1389).
+
+        Mirrors ``_tool_override_allowed``: bundled plugins are trusted by
+        default; every other source requires ``allow_hooks: true`` under
+        ``plugins.entries.<plugin_id>`` in config.yaml.
+        """
+        source = getattr(self.manifest, "source", "") or ""
+        if source == "bundled":
+            return True
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+        except Exception:
+            return False
+        plugin_id = self.manifest.key or self.manifest.name
+        entries = (cfg.get("plugins") or {}).get("entries") or {}
+        entry = entries.get(plugin_id) or {}
+        return bool(entry.get("allow_hooks", False))
+
     # -- message injection --------------------------------------------------
 
     def inject_message(self, content: str, role: str = "user") -> bool:
@@ -1160,6 +1181,10 @@ class PluginContext:
 
         Unknown hook names produce a warning but are still stored so
         forward-compatible plugins don't break.
+
+        **Workspace-trust gate (#1389):** hooks from non-bundled sources
+        are blocked unless explicitly approved via ``allow_hooks: true``
+        under ``plugins.entries.<plugin_id>`` in config.yaml.
         """
         if hook_name not in VALID_HOOKS:
             logger.warning(
@@ -1169,6 +1194,16 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
+        if not self._hook_trust_allowed():
+            logger.warning(
+                "Plugin '%s' (source='%s') hook registration blocked — "
+                "workspace trust required. Set "
+                "'plugins.entries.%s.allow_hooks: true' in config.yaml to approve.",
+                self.manifest.name,
+                getattr(self.manifest, "source", ""),
+                self.manifest.key or self.manifest.name,
+            )
+            return
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -910,7 +910,13 @@ class TestHookMode:
     def test_complete_works_from_post_tool_call_hook(self):
         from hermes_cli.plugins import PluginContext, PluginManifest, PluginManager
 
-        manifest = PluginManifest(name="hook-plugin", source="test", key="hook-plugin")
+        # source="bundled": these tests exercise ctx.llm from inside a hook,
+        # not the #1389 trust gate — they need a source allowed to register
+        # hooks at all. Gate behaviour itself is covered by
+        # tests/test_workspace_trust_hooks.py.
+        manifest = PluginManifest(
+            name="hook-plugin", source="bundled", key="hook-plugin"
+        )
         manager = PluginManager()
         ctx = PluginContext(manifest, manager)
 
@@ -966,7 +972,8 @@ class TestHookMode:
         ctx.llm.complete even if other callsites use async."""
         from hermes_cli.plugins import PluginContext, PluginManifest, PluginManager
 
-        manifest = PluginManifest(name="hook-async", source="test", key="hook-async")
+        # source="bundled" — see the note in the sibling test above.
+        manifest = PluginManifest(name="hook-async", source="bundled", key="hook-async")
         manager = PluginManager()
         ctx = PluginContext(manifest, manager)
 

--- a/tests/test_workspace_trust_hooks.py
+++ b/tests/test_workspace_trust_hooks.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Unit tests for workspace-trust gate on hook registration (#1389)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_ctx(source: str = "user", key: str = "test-plugin", config=None):
+    """Build a PluginContext bypassing heavy __init__ deps."""
+    from hermes_cli.plugins import PluginContext
+
+    ctx = PluginContext.__new__(PluginContext)
+    ctx.manifest = SimpleNamespace(
+        name=key, key=key, source=source, kind="standalone"
+    )
+    ctx._manager = SimpleNamespace(_hooks={})
+    return ctx
+
+
+class TestHookTrustGate:
+    def test_bundled_source_trusted_by_default(self):
+        ctx = _make_ctx(source="bundled")
+        assert ctx._hook_trust_allowed() is True
+
+    def test_user_source_untrusted_by_default(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="user")
+            assert ctx._hook_trust_allowed() is False
+
+    def test_project_source_untrusted_by_default(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="project")
+            assert ctx._hook_trust_allowed() is False
+
+    def test_user_source_trusted_with_config(self):
+        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": True}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            ctx = _make_ctx(source="user")
+            assert ctx._hook_trust_allowed() is True
+
+    def test_user_source_blocked_without_allow_hooks(self):
+        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": False}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            ctx = _make_ctx(source="user")
+            assert ctx._hook_trust_allowed() is False
+
+
+class TestRegisterHookGate:
+    def test_bundled_registers_hook(self):
+        ctx = _make_ctx(source="bundled")
+        ctx.register_hook("pre_tool_call", lambda **kw: None)
+        assert "pre_tool_call" in ctx._manager._hooks
+
+    def test_user_blocked_without_config(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="user")
+            ctx.register_hook("pre_tool_call", lambda **kw: None)
+            assert "pre_tool_call" not in ctx._manager._hooks
+
+    def test_user_registers_with_config(self):
+        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": True}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            ctx = _make_ctx(source="user")
+            ctx.register_hook("pre_tool_call", lambda **kw: None)
+            assert "pre_tool_call" in ctx._manager._hooks

--- a/tests/test_workspace_trust_hooks.py
+++ b/tests/test_workspace_trust_hooks.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Unit tests for workspace-trust gate on hook registration (#1389)."""
+"""Unit tests for workspace-trust gate on hook registration (#1389).
+
+Trust model under test:
+
+* ``bundled`` — trusted (ships in the repo).
+* ``user``    — trusted only when the plugin genuinely resolves inside
+                ``<HERMES_HOME>/plugins/``.
+* ``project`` / ``entrypoint`` / unknown — untrusted; need an explicit
+                ``allow_hooks`` opt-in keyed by ``<source>:<plugin_id>``.
+"""
 
 from __future__ import annotations
 
@@ -9,16 +18,26 @@ from unittest.mock import patch
 import pytest
 
 
-def _make_ctx(source: str = "user", key: str = "test-plugin", config=None):
+def _make_ctx(source: str = "user", key: str = "test-plugin", path=None):
     """Build a PluginContext bypassing heavy __init__ deps."""
     from hermes_cli.plugins import PluginContext
 
     ctx = PluginContext.__new__(PluginContext)
     ctx.manifest = SimpleNamespace(
-        name=key, key=key, source=source, kind="standalone"
+        name=key, key=key, source=source, kind="standalone", path=path
     )
     ctx._manager = SimpleNamespace(_hooks={})
     return ctx
+
+
+@pytest.fixture
+def profile_plugin(tmp_path, monkeypatch):
+    """A real plugin directory inside a temporary HERMES_HOME."""
+    hermes_home = tmp_path / "hermes_home"
+    plugin_dir = hermes_home / "plugins" / "test-plugin"
+    plugin_dir.mkdir(parents=True)
+    monkeypatch.setattr("hermes_cli.plugins.get_hermes_home", lambda: hermes_home)
+    return plugin_dir
 
 
 class TestHookTrustGate:
@@ -26,26 +45,74 @@ class TestHookTrustGate:
         ctx = _make_ctx(source="bundled")
         assert ctx._hook_trust_allowed() is True
 
-    def test_user_source_untrusted_by_default(self):
-        with patch("hermes_cli.config.load_config", return_value={}):
-            ctx = _make_ctx(source="user")
-            assert ctx._hook_trust_allowed() is False
+    def test_user_source_in_profile_dir_trusted_by_default(self, profile_plugin):
+        """The profile directory is trusted per #1389 — no extra flag needed."""
+        ctx = _make_ctx(source="user", path=str(profile_plugin))
+        assert ctx._hook_trust_allowed() is True
 
     def test_project_source_untrusted_by_default(self):
         with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="project", path="/some/repo/.hermes/plugins/p")
+            assert ctx._hook_trust_allowed() is False
+
+    def test_entrypoint_source_untrusted_by_default(self):
+        """pip install is not consent to silent tool-call interception."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="entrypoint")
+            assert ctx._hook_trust_allowed() is False
+
+    def test_project_source_trusted_with_source_keyed_config(self):
+        cfg = {"plugins": {"entries": {"project:test-plugin": {"allow_hooks": True}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            ctx = _make_ctx(source="project")
+            assert ctx._hook_trust_allowed() is True
+
+    def test_bare_plugin_id_key_does_not_grant_trust(self):
+        """A bare id key must not approve hooks — it enables name shadowing.
+
+        Keying on the plugin name alone would let a project plugin that takes
+        the name of an approved plugin inherit that approval.
+        """
+        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": True}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
             ctx = _make_ctx(source="project")
             assert ctx._hook_trust_allowed() is False
 
-    def test_user_source_trusted_with_config(self):
-        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": True}}}}
+    def test_approval_for_one_source_does_not_leak_to_another(self):
+        """``entrypoint:x`` approval must not cover ``project:x``."""
+        cfg = {
+            "plugins": {"entries": {"entrypoint:test-plugin": {"allow_hooks": True}}}
+        }
         with patch("hermes_cli.config.load_config", return_value=cfg):
-            ctx = _make_ctx(source="user")
-            assert ctx._hook_trust_allowed() is True
+            assert _make_ctx(source="entrypoint")._hook_trust_allowed() is True
+            assert _make_ctx(source="project")._hook_trust_allowed() is False
 
-    def test_user_source_blocked_without_allow_hooks(self):
-        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": False}}}}
-        with patch("hermes_cli.config.load_config", return_value=cfg):
-            ctx = _make_ctx(source="user")
+    def test_symlink_out_of_profile_dir_is_not_trusted(self, tmp_path, monkeypatch):
+        """A symlink planted in the profile dir must not inherit its trust.
+
+        #1389 names "a symlinked directory" as an attack vector: the scanner
+        labels it source="user", but the code lives outside the profile root.
+        """
+        hermes_home = tmp_path / "hermes_home"
+        (hermes_home / "plugins").mkdir(parents=True)
+        outside = tmp_path / "untrusted_elsewhere"
+        outside.mkdir()
+        link = hermes_home / "plugins" / "evil"
+        link.symlink_to(outside, target_is_directory=True)
+        monkeypatch.setattr("hermes_cli.plugins.get_hermes_home", lambda: hermes_home)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="user", key="evil", path=str(link))
+            assert ctx._hook_trust_allowed() is False
+
+    def test_user_source_without_path_is_not_trusted(self):
+        """No path means containment can't be proven — fail closed."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="user", path=None)
+            assert ctx._hook_trust_allowed() is False
+
+    def test_config_load_failure_fails_closed(self):
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            ctx = _make_ctx(source="project")
             assert ctx._hook_trust_allowed() is False
 
 
@@ -55,15 +122,36 @@ class TestRegisterHookGate:
         ctx.register_hook("pre_tool_call", lambda **kw: None)
         assert "pre_tool_call" in ctx._manager._hooks
 
-    def test_user_blocked_without_config(self):
+    def test_profile_plugin_registers_hook(self, profile_plugin):
+        ctx = _make_ctx(source="user", path=str(profile_plugin))
+        ctx.register_hook("pre_tool_call", lambda **kw: None)
+        assert "pre_tool_call" in ctx._manager._hooks
+
+    def test_project_blocked_without_config(self):
         with patch("hermes_cli.config.load_config", return_value={}):
-            ctx = _make_ctx(source="user")
+            ctx = _make_ctx(source="project")
             ctx.register_hook("pre_tool_call", lambda **kw: None)
             assert "pre_tool_call" not in ctx._manager._hooks
 
-    def test_user_registers_with_config(self):
-        cfg = {"plugins": {"entries": {"test-plugin": {"allow_hooks": True}}}}
+    def test_project_registers_with_config(self):
+        cfg = {"plugins": {"entries": {"project:test-plugin": {"allow_hooks": True}}}}
         with patch("hermes_cli.config.load_config", return_value=cfg):
-            ctx = _make_ctx(source="user")
+            ctx = _make_ctx(source="project")
             ctx.register_hook("pre_tool_call", lambda **kw: None)
             assert "pre_tool_call" in ctx._manager._hooks
+
+    def test_blocked_hook_logs_actionable_config_key(self, caplog):
+        """The warning must name the exact source-qualified key to add."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            ctx = _make_ctx(source="project")
+            with caplog.at_level("WARNING"):
+                ctx.register_hook("pre_tool_call", lambda **kw: None)
+        assert "project:test-plugin" in caplog.text
+
+    def test_accepted_hook_is_audit_logged(self, caplog):
+        """#1389 requirement 3: log hook registrations with source + trust level."""
+        ctx = _make_ctx(source="bundled")
+        with caplog.at_level("INFO"):
+            ctx.register_hook("pre_tool_call", lambda **kw: None)
+        assert "Hook registered" in caplog.text
+        assert "source='bundled'" in caplog.text


### PR DESCRIPTION
Security: hooks from non-bundled plugins blocked unless allow_hooks: true in config. Mirrors existing tool-override trust gate. 8 tests pass, ruff clean.