### PR TITLE
ci(attribution): map Hermes Evolution Bot commit email

### DIFF
--- a/contributors/emails/evolution-bot@hermes-agent.local
+++ b/contributors/emails/evolution-bot@hermes-agent.local
@@ -1,0 +1,2 @@
+Lexus2016
+# Hermes evolution pipeline bot — commits authored on behalf of repo owner


### PR DESCRIPTION
The evolution pipeline authors commits as `Hermes Evolution Bot` with an email that has no entry in `contributors/emails/` nor the frozen `LEGACY_AUTHOR_MAP`. As a result `Check contributors / check-attribution` fails on **every** PR the pipeline opens — currently #1619, #1618, #1617, #1613.

Adds the one-file-per-email mapping via `scripts/add_contributor.py` (the supported path; `AUTHOR_MAP` stays frozen).

Unblocks 4 open PRs.