### PR TITLE
feat: enrich parse-error messages + terminal bare-string fallback + memory error decomposition (Closes #1647, #1648)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -95,9 +95,9 @@ def _parse_tool_arguments(
             {
                 "error": "Missing tool arguments",
                 "message": (
-                    "No arguments were provided. Check the tool's parameter "
-                    "schema and provide a valid JSON object with all required "
-                    "fields."
+                    "The tool was not executed. No arguments were provided. "
+                    "Check the tool's parameter schema and provide a valid "
+                    "JSON object with all required fields."
                 ),
             },
             ensure_ascii=False,
@@ -125,9 +125,10 @@ def _parse_tool_arguments(
             {
                 "error": "Invalid tool arguments (JSON parse error)",
                 "message": (
-                    f"Tool arguments could not be parsed as JSON: {exc.msg} "
-                    f"at position {exc.pos}. Provide a valid JSON object "
-                    f"with the correct field names and types for this tool."
+                    f"The tool was not executed. Its arguments could not be "
+                    f"parsed as JSON: {exc.msg} at position {exc.pos}. "
+                    f"Provide a valid JSON object with the correct field "
+                    f"names and types for this tool."
                 ),
             },
             ensure_ascii=False,
@@ -137,9 +138,10 @@ def _parse_tool_arguments(
             {
                 "error": "Invalid tool arguments (wrong type)",
                 "message": (
-                    f"Tool arguments must be a JSON string, got "
-                    f"{type(raw_arguments).__name__}. Provide a valid JSON "
-                    f"object with the correct field names for this tool."
+                    f"The tool was not executed. Its arguments must be a "
+                    f"JSON string, got {type(raw_arguments).__name__}. "
+                    f"Provide a valid JSON object with the correct field "
+                    f"names for this tool."
                 ),
             },
             ensure_ascii=False,
@@ -153,9 +155,9 @@ def _parse_tool_arguments(
         {
             "error": "Invalid tool arguments (not a JSON object)",
             "message": (
-                f"Tool arguments parsed as {type(arguments).__name__}, but "
-                f"a JSON object is required. Wrap the arguments in curly "
-                f'braces: {{"field": value}}.'
+                f"The tool was not executed. Its arguments parsed as "
+                f"{type(arguments).__name__}, but a JSON object is required. "
+                f'Wrap the arguments in curly braces: {{"field": value}}.'
             ),
         },
         ensure_ascii=False,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -76,19 +76,86 @@ _MAX_TOOL_WORKERS = 8
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
 
 
-def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
+def _parse_tool_arguments(
+    raw_arguments: Any, function_name: str = ""
+) -> tuple[dict, Optional[str]]:
+    """Parse model-emitted arguments without repairing or coercing them.
+
+    When parsing fails, the error message identifies *why* it failed so the
+    model can correct the malformed field on retry instead of blind-retrying
+    the same payload (issue #1647 — 285 terminal parse-error failures / 7d).
+
+    For the terminal tool specifically, if the raw payload is a bare string
+    (a common model failure mode — emitting ``ls -la`` instead of
+    ``{"command": "ls -la"}``), we extract it as the ``command`` argument
+    so the command executes instead of producing a parse error.
+    """
+    if raw_arguments is None:
+        return {}, json.dumps(
+            {
+                "error": "Missing tool arguments",
+                "message": (
+                    "No arguments were provided. Check the tool's parameter "
+                    "schema and provide a valid JSON object with all required "
+                    "fields."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    # Bare-string fallback for terminal (issue #1647): models sometimes emit
+    # a bare command string instead of a JSON object.  Extract it so the
+    # command runs instead of producing a parse-error spiral.
+    if function_name == "terminal" and isinstance(raw_arguments, str):
+        stripped = raw_arguments.strip()
+        if stripped and not stripped.startswith("{"):
+            logger.info(
+                "terminal tool received bare-string arguments — "
+                "extracting as command (len=%d)",
+                len(stripped),
+            )
+            return {"command": stripped}, None
+
     try:
         arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
-        arguments = None
+    except json.JSONDecodeError as exc:
+        # Enriched error: identify the parse position so the model can fix
+        # the specific malformed field instead of blind-retrying.
+        return {}, json.dumps(
+            {
+                "error": "Invalid tool arguments (JSON parse error)",
+                "message": (
+                    f"Tool arguments could not be parsed as JSON: {exc.msg} "
+                    f"at position {exc.pos}. Provide a valid JSON object "
+                    f"with the correct field names and types for this tool."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    except TypeError:
+        return {}, json.dumps(
+            {
+                "error": "Invalid tool arguments (wrong type)",
+                "message": (
+                    f"Tool arguments must be a JSON string, got "
+                    f"{type(raw_arguments).__name__}. Provide a valid JSON "
+                    f"object with the correct field names for this tool."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
     if isinstance(arguments, dict):
         return arguments, None
+
+    # Parsed successfully but not a dict (e.g. a JSON list or scalar).
     return {}, json.dumps(
         {
-            "error": "Invalid tool arguments",
+            "error": "Invalid tool arguments (not a JSON object)",
             "message": (
-                "Tool arguments must be a valid JSON object; tool was not executed."
+                f"Tool arguments parsed as {type(arguments).__name__}, but "
+                f"a JSON object is required. Wrap the arguments in curly "
+                f'braces: {{"field": value}}.'
             ),
         },
         ensure_ascii=False,
@@ -364,7 +431,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments, function_name
         )
 
         if malformed_args_result is not None:
@@ -1076,7 +1143,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments, function_name
         )
         if malformed_args_result is not None:
             messages.append(

--- a/tests/agent/test_evolution_2026_08_03.py
+++ b/tests/agent/test_evolution_2026_08_03.py
@@ -1,0 +1,204 @@
+"""Tests for the 2026-08-03 evolution cycle fixes.
+
+Covers:
+- #1647: terminal parse-error enrichment + bare-string fallback
+- #1648: memory tool 'other' error decomposition with recovery hint
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agent.tool_executor import _parse_tool_arguments
+
+
+# ── #1647: parse-error enrichment ──────────────────────────────
+
+
+class TestParseToolArgumentsEnrichment:
+    """Verify _parse_tool_arguments returns enriched error messages."""
+
+    def test_valid_json_dict_passes_through(self):
+        """A valid JSON dict should parse with no error."""
+        args, err = _parse_tool_arguments('{"command": "ls -la"}')
+        assert err is None
+        assert args == {"command": "ls -la"}
+
+    def test_json_parse_error_is_enriched(self):
+        """Malformed JSON should produce an error identifying the parse position."""
+        args, err = _parse_tool_arguments('{"command": bad json}')
+        assert err is not None
+        result = json.loads(err)
+        assert "JSON parse error" in result["error"]
+        assert "position" in result["message"]
+
+    def test_non_dict_json_is_identified(self):
+        """A JSON list should produce a 'not a JSON object' error."""
+        args, err = _parse_tool_arguments("[1, 2, 3]")
+        assert err is not None
+        result = json.loads(err)
+        assert "not a JSON object" in result["error"]
+
+    def test_none_arguments_produces_missing_error(self):
+        """None arguments should produce a 'Missing' error."""
+        args, err = _parse_tool_arguments(None)
+        assert err is not None
+        result = json.loads(err)
+        assert "Missing" in result["error"]
+
+    def test_non_string_arguments_produces_type_error(self):
+        """A non-string argument should produce a type error."""
+        args, err = _parse_tool_arguments(42)
+        assert err is not None
+        result = json.loads(err)
+        assert "wrong type" in result["error"]
+
+
+class TestTerminalBareStringFallback:
+    """Verify the terminal bare-string fallback (issue #1647)."""
+
+    def test_bare_string_terminal_is_extracted_as_command(self):
+        """A bare command string for terminal should be extracted as {'command': ...}."""
+        args, err = _parse_tool_arguments("ls -la /tmp", function_name="terminal")
+        assert err is None
+        assert args == {"command": "ls -la /tmp"}
+
+    def test_bare_string_terminal_with_pipes(self):
+        """Bare string with pipes should work too."""
+        args, err = _parse_tool_arguments(
+            "grep foo bar | wc -l", function_name="terminal"
+        )
+        assert err is None
+        assert args == {"command": "grep foo bar | wc -l"}
+
+    def test_json_object_terminal_still_works(self):
+        """A valid JSON object for terminal should parse normally."""
+        args, err = _parse_tool_arguments(
+            '{"command": "echo hello"}', function_name="terminal"
+        )
+        assert err is None
+        assert args == {"command": "echo hello"}
+
+    def test_bare_string_non_terminal_still_errors(self):
+        """Bare string for non-terminal tools should still error."""
+        args, err = _parse_tool_arguments("some text", function_name="read_file")
+        assert err is not None
+
+    def test_empty_string_terminal_errors(self):
+        """Empty string should not be extracted as a command."""
+        args, err = _parse_tool_arguments("", function_name="terminal")
+        assert err is not None
+
+    def test_function_name_defaults_to_empty_string(self):
+        """Calling without function_name should not crash."""
+        args, err = _parse_tool_arguments('{"key": "value"}')
+        assert err is None
+        assert args == {"key": "value"}
+
+
+# ── #1648: memory error decomposition ──────────────────────────
+
+
+class TestMemoryErrorDecomposition:
+    """Verify _memory_enriched_error classifies exception types."""
+
+    def test_timeout_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(TimeoutError("file lock"), "add"))
+        assert result["error_category"] == "timeout"
+        assert result["error_type"] == "TimeoutError"
+        assert "locked" in result["recovery_hint"].lower()
+        assert result["success"] is False
+
+    def test_permission_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(
+            _memory_enriched_error(PermissionError("denied"), "replace")
+        )
+        assert result["error_category"] == "permission-denied"
+        assert result["error_type"] == "PermissionError"
+
+    def test_value_error_classified_as_schema(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(ValueError("bad data"), "add"))
+        assert result["error_category"] == "schema-mismatch"
+
+    def test_os_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(OSError("disk full"), "remove"))
+        assert result["error_category"] == "io-error"
+
+    def test_type_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(TypeError("bad type"), "add"))
+        assert result["error_category"] == "serialization-error"
+
+    def test_unexpected_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(RuntimeError("weird"), "add"))
+        assert result["error_category"] == "unexpected"
+        assert "RuntimeError" in result["recovery_hint"]
+
+    def test_all_results_have_required_fields(self):
+        """Every enriched error should include error, error_type, category, hint, action."""
+        from tools.memory_tool import _memory_enriched_error
+
+        for exc in [
+            TimeoutError("x"),
+            PermissionError("x"),
+            ValueError("x"),
+            OSError("x"),
+            RuntimeError("x"),
+        ]:
+            result = json.loads(_memory_enriched_error(exc, "add"))
+            for field in (
+                "error",
+                "error_type",
+                "error_category",
+                "recovery_hint",
+                "action",
+                "success",
+            ):
+                assert field in result, (
+                    f"Missing field {field} for {type(exc).__name__}"
+                )
+            assert result["success"] is False
+
+
+class TestMemoryToolErrorIntegration:
+    """Verify memory_tool dispatches enriched errors on store exceptions."""
+
+    def test_add_failure_returns_enriched_error(self):
+        from tools.memory_tool import memory_tool, MemoryStore
+
+        store = MagicMock(spec=MemoryStore)
+        store.add.side_effect = OSError("disk full")
+        result = json.loads(memory_tool(action="add", content="test", store=store))
+        assert result["error_category"] == "io-error"
+        assert result["success"] is False
+
+    def test_replace_failure_returns_enriched_error(self):
+        from tools.memory_tool import memory_tool, MemoryStore
+
+        store = MagicMock(spec=MemoryStore)
+        store.replace.side_effect = PermissionError("denied")
+        result = json.loads(
+            memory_tool(action="replace", old_text="old", content="new", store=store)
+        )
+        assert result["error_category"] == "permission-denied"
+
+    def test_remove_failure_returns_enriched_error(self):
+        from tools.memory_tool import memory_tool, MemoryStore
+
+        store = MagicMock(spec=MemoryStore)
+        store.remove.side_effect = TimeoutError("lock")
+        result = json.loads(memory_tool(action="remove", old_text="x", store=store))
+        assert result["error_category"] == "timeout"

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -93,6 +93,13 @@ def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
     assert [message["tool_call_id"] for message in messages] == ["call-bad", "call-good"]
     assert len([message for message in messages if message["tool_call_id"] == "call-bad"]) == 1
 
-    assert '"error": "Invalid tool arguments"' in messages[0]["content"]
+    # The error string is now sub-classified (#1647): "(JSON parse error)",
+    # "(wrong type)", "(not a JSON object)". Assert the prefix, since which
+    # sub-class fires depends on the parametrized bad_arguments and is covered
+    # by tests/agent/test_evolution_2026_08_03.py.
+    assert '"error": "Invalid tool arguments' in messages[0]["content"]
     assert "JSON object" in messages[0]["content"]
+    # The model must be able to tell "the call never ran" from "the call ran
+    # and failed" — otherwise it cannot know whether to retry it.
+    assert "tool was not executed" in messages[0]["content"].lower()
     assert json.loads(messages[1]["content"]) == {"ok": "valid"}

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1631,6 +1631,53 @@ def _missing_old_text_error(store: "MemoryStore", target: str, action: str) -> s
     )
 
 
+def _memory_enriched_error(exc: Exception, action: str) -> str:
+    """Decompose an unclassified memory failure into a category with recovery hint.
+
+    Issue #1648: 98% of memory failures are classified as opaque 'other'.
+    This maps the underlying exception type to a concrete category + recovery
+    suggestion so the agent can act instead of blind-retrying.
+    """
+    exc_type = type(exc).__name__
+    exc_msg = str(exc)[:300]
+
+    # Classify by exception family
+    if isinstance(exc, (TimeoutError,)):
+        category = "timeout"
+        hint = (
+            "The memory file may be locked by another process. Wait a moment and retry."
+        )
+    elif isinstance(exc, (PermissionError,)):
+        category = "permission-denied"
+        hint = "Check file permissions on the memory file in ~/.hermes/memory/."
+    elif isinstance(exc, (json.JSONDecodeError, ValueError)):
+        category = "schema-mismatch"
+        hint = "The memory file is corrupted. Consider using action='search' to verify state, then retry."
+    elif isinstance(exc, (OSError, IOError)):
+        category = "io-error"
+        hint = "Disk I/O failed. Retry once; if it persists, proceed without memory persistence."
+    elif isinstance(exc, (TypeError,)):
+        category = "serialization-error"
+        hint = "The content could not be serialized. Simplify the content and retry."
+    else:
+        category = "unexpected"
+        hint = f"Unexpected error ({exc_type}). Proceed without memory persistence if this repeats."
+
+    logger.warning("memory_tool %s failed: %s: %s", action, exc_type, exc_msg)
+
+    return json.dumps(
+        {
+            "success": False,
+            "error": exc_msg,
+            "error_type": exc_type,
+            "error_category": category,
+            "recovery_hint": hint,
+            "action": action,
+        },
+        ensure_ascii=False,
+    )
+
+
 def memory_tool(
     action: str = None,
     target: str = "memory",
@@ -1747,17 +1794,30 @@ def memory_tool(
         return gate_result
 
     if action == "add":
-        result = store.add(
-            target, content, source_class=source_class, trust_tier=trust_tier
-        )
+        try:
+            result = store.add(
+                target, content, source_class=source_class, trust_tier=trust_tier
+            )
+        except Exception as exc:
+            return _memory_enriched_error(exc, "add")
 
     elif action == "replace":
-        result = store.replace(
-            target, old_text, content, source_class=source_class, trust_tier=trust_tier
-        )
+        try:
+            result = store.replace(
+                target,
+                old_text,
+                content,
+                source_class=source_class,
+                trust_tier=trust_tier,
+            )
+        except Exception as exc:
+            return _memory_enriched_error(exc, "replace")
 
     elif action == "remove":
-        result = store.remove(target, old_text)
+        try:
+            result = store.remove(target, old_text)
+        except Exception as exc:
+            return _memory_enriched_error(exc, "remove")
 
     else:
         return tool_error(


### PR DESCRIPTION
Automated evolution PR for issues #1647 and #1648.

## Changes

### #1647 — Terminal parse-error enrichment (285 failures/7d)
- **Enriched `_parse_tool_arguments()`**: error messages now identify the specific failure reason (JSON parse error with position, wrong type, not a JSON object, missing arguments) so the model can correct the malformed field on retry instead of blind-retrying
- **Bare-string fallback for terminal**: when the model emits a bare command string (e.g. `ls -la`) instead of `{"command": "ls -la"}`, it is extracted as the command so the terminal executes instead of producing a parse-error spiral
- Spiral cap already active (`terminal` in `_SPIRAL_PRONE_TOOLS`)

### #1648 — Memory tool 'other' error decomposition (133 failures/7d, 98% of memory failures)
- **New `_memory_enriched_error()`**: classifies uncaught exceptions into concrete categories (timeout, permission-denied, schema-mismatch, io-error, serialization-error, unexpected) with a recovery hint per category
- **Wrapped add/replace/remove dispatch** in try/except so store exceptions return structured error responses instead of propagating unclassified
- Spiral cap already active (`memory` in `_SPIRAL_PRONE_TOOLS`)

## Files
- `agent/tool_executor.py`: enriched `_parse_tool_arguments` + bare-string fallback + call site updates
- `tools/memory_tool.py`: `_memory_enriched_error` + dispatch wrapping
- `tests/agent/test_evolution_2026_08_03.py`: 21 tests covering all changes

## Checks
- ruff check ✓
- ruff format ✓ (memory_tool, test file; tool_executor has pre-existing format issues)
- targeted tests ✓ (21 passed)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>