### PR TITLE
fix: terminal parse-error bare-string fallback + enriched error (#1647)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -76,19 +76,38 @@ _MAX_TOOL_WORKERS = 8
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
 
 
-def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
+def _parse_tool_arguments(
+    raw_arguments: Any, tool_name: str = ""
+) -> tuple[dict, Optional[str]]:
+    """Parse model-emitted arguments without repairing or coercing them.
+
+    Bare-string fallback for the terminal tool (#1647): models frequently emit
+    the command as a plain string (a quoted JSON string ``"ls -la"``, or an
+    unquoted ``ls -la`` that fails ``json.loads``) instead of the schema's
+    ``{"command": ...}`` object. Both shapes are mapped onto the ``command``
+    field so a well-formed command executes instead of being rejected as a
+    parse error — the terminal parse-error bucket was 285 failures/7d with no
+    way for the agent to self-correct.
+    """
+    parse_error = None
     try:
         arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
+    except (json.JSONDecodeError, TypeError) as exc:
         arguments = None
+        parse_error = exc
     if isinstance(arguments, dict):
         return arguments, None
+    if tool_name == "terminal":
+        bare = arguments if isinstance(arguments, str) else raw_arguments
+        if isinstance(bare, str) and bare.strip():
+            return {"command": bare.strip()}, None
+    detail = f" {type(parse_error).__name__}: {parse_error}" if parse_error else ""
     return {}, json.dumps(
         {
             "error": "Invalid tool arguments",
             "message": (
-                "Tool arguments must be a valid JSON object; tool was not executed."
+                f"Tool arguments for '{tool_name or 'tool'}' must be a valid JSON "
+                f"object; tool was not executed.{detail}"
             ),
         },
         ensure_ascii=False,
@@ -364,7 +383,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments, tool_name=function_name
         )
 
         if malformed_args_result is not None:
@@ -1076,7 +1095,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments, tool_name=function_name
         )
         if malformed_args_result is not None:
             messages.append(

--- a/tests/run_agent/test_terminal_parse_error_1647.py
+++ b/tests/run_agent/test_terminal_parse_error_1647.py
@@ -1,0 +1,57 @@
+"""Tests for issue #1647 (terminal parse-error bare-string fallback).
+
+Terminal tool calls frequently arrive as bare strings from the model instead
+of the schema's JSON object shape. This asserts the fallback: a quoted or
+unquoted command string maps onto the ``command`` field and executes instead
+of being rejected as a parse error, while non-terminal tools keep the strict
+object-only contract (with a tool-name + parse-detail enriched error).
+"""
+
+import json
+
+from agent.tool_executor import _parse_tool_arguments
+
+
+class TestTerminalBareStringFallback:
+    def test_valid_json_object_still_parses(self):
+        """A normal JSON object argument dict passes through unchanged."""
+        args, err = _parse_tool_arguments(
+            '{"command": "ls -la", "timeout": 10}', tool_name="terminal"
+        )
+        assert err is None
+        assert args == {"command": "ls -la", "timeout": 10}
+
+    def test_quoted_bare_string_becomes_command(self):
+        """A quoted JSON string ('"ls -la"') maps to the command field."""
+        args, err = _parse_tool_arguments('"ls -la"', tool_name="terminal")
+        assert err is None
+        assert args == {"command": "ls -la"}
+
+    def test_unquoted_bare_string_becomes_command(self):
+        """An unquoted command that fails json.loads maps to the command field."""
+        args, err = _parse_tool_arguments("ls -la /tmp", tool_name="terminal")
+        assert err is None
+        assert args == {"command": "ls -la /tmp"}
+
+    def test_empty_bare_string_rejected(self):
+        """An empty/whitespace bare string still produces a parse error."""
+        args, err = _parse_tool_arguments("   ", tool_name="terminal")
+        assert args == {}
+        assert err is not None
+        assert "tool was not executed" in err
+
+    def test_non_terminal_tool_unchanged(self):
+        """Bare-string fallback only applies to the terminal tool."""
+        args, err = _parse_tool_arguments("not json", tool_name="web_search")
+        assert args == {}
+        assert err is not None
+        assert "web_search" in err  # tool name surfaced for self-correction
+
+    def test_error_includes_parse_detail_for_self_correction(self):
+        """The error message names the tool and the underlying parse failure."""
+        args, err = _parse_tool_arguments("[[[", tool_name="web_search")
+        assert args == {}
+        assert err is not None
+        payload = json.loads(err)
+        assert "web_search" in payload["message"]
+        assert "JSONDecodeError" in payload["message"]


### PR DESCRIPTION
Closes #1647

## Problem
The terminal tool's parse-error bucket is the second-largest terminal failure sub-bucket (285 failures/7d, rate 0.0184/session). Models frequently emit the command as a bare string (quoted '"ls -la"' or unquoted 'ls -la') instead of the schema's `{"command": ...}` object. These were rejected as parse errors with no indication of which field was malformed, so the agent could not self-correct and spiralled (up to 55 consecutive retries).

## Fix
In `agent/tool_executor.py` `_parse_tool_arguments`:
1. **Bare-string fallback** for the terminal tool: a quoted or unquoted command string maps onto the `command` field and executes instead of being rejected.
2. **Enriched parse-error message**: the error now names the tool and includes the underlying exception type (e.g. `JSONDecodeError`) so the agent can correct it on retry.

## Tests
`tests/run_agent/test_terminal_parse_error_1647.py` — 6 tests covering valid-object passthrough, quoted/unquoted bare strings, empty-string rejection, non-terminal unchanged, and error enrichment.

## Verification
`pytest tests/run_agent/test_run_agent.py::TestConcurrentToolExecution tests/run_agent/test_tool_arg_coercion.py tests/run_agent/test_terminal_parse_error_1647.py` — all pass.

Note: the spiral-prone tool cap already includes `terminal` (item 3 of #1647), so this PR covers items 1 and 2.