### PR TITLE
feat: cold-start trap guard in evaluator tie-breaking — increment 1 of #1509

### DIFF
--- a/scripts/evolution_evaluator.py
+++ b/scripts/evolution_evaluator.py
@@ -122,22 +122,60 @@ def score_candidate(scores: Dict[str, Any], rubric: Dict[str, float]) -> float:
     return num / den
 
 
+def _evaluation_count(candidate: Any) -> int:
+    """Return a candidate's declared evaluation history (number of prior runs).
+
+    Absent or non-numeric -> 1 (treated as a cold-start / first-run config).
+    The value is used only to break *ties* — see ``evaluate_candidates``.
+    """
+    if isinstance(candidate, dict):
+        raw = candidate.get("evaluation_count", 1)
+        try:
+            return max(1, int(raw))
+        except (TypeError, ValueError):
+            return 1
+    return 1
+
+
 def evaluate_candidates(
     candidates: List[Dict[str, Any]],
     rubric: Optional[Dict[str, float]] = None,
 ) -> List[Tuple[int, float]]:
     """Score every candidate, returning ``(original_index, fused_score)`` pairs
-    sorted best-first. Ties keep the earlier (lower-index) candidate first, so
-    selection is stable and an earlier worker pass is preferred on a tie."""
+    sorted best-first.
+
+    Cold-start trap (#1509): an uninitialized comparison ties deterministically
+    toward the earliest config, which in the 729-config harness study happened to
+    be a degenerate one. A first-run config's single score is NOT representative,
+    so crediting it on a tie distorts the comparison. Fix (owner-approved):
+    when candidates declare an ``evaluation_count`` (prior runs), a score tie is
+    broken in favor of the MORE-established candidate (higher count) before the
+    index fallback — a cold-start config loses ties it should not win. If NO
+    candidate declares a count (existing callers), behavior is unchanged: ties
+    keep the earlier (lower-index) candidate first.
+    """
     rubric = rubric or DEFAULT_RUBRIC
+    declared = [isinstance(c, dict) and "evaluation_count" in c for c in candidates]
+    use_history = any(declared)
     scored: List[Tuple[int, float]] = []
     for i, cand in enumerate(candidates):
         cand_scores = cand.get("scores", {}) if isinstance(cand, dict) else {}
         if not isinstance(cand_scores, dict):
             cand_scores = {}
         scored.append((i, score_candidate(cand_scores, rubric)))
-    # Sort by score desc, then original index asc (stable tie-break to earlier).
-    scored.sort(key=lambda pair: (-pair[1], pair[0]))
+    if use_history:
+        # Tie-break: higher evaluation_count (more representative) first, then
+        # original index as a stable fallback. Counts only decide EQUAL scores.
+        scored.sort(
+            key=lambda pair: (
+                -pair[1],
+                -_evaluation_count(candidates[pair[0]]),
+                pair[0],
+            )
+        )
+    else:
+        # Sort by score desc, then original index asc (stable tie-break to earlier).
+        scored.sort(key=lambda pair: (-pair[1], pair[0]))
     return scored
 
 

--- a/tests/scripts/test_evolution_evaluator.py
+++ b/tests/scripts/test_evolution_evaluator.py
@@ -77,12 +77,80 @@ class TestEvaluateCandidates:
         assert all(score == 0.0 for _, score in ranking)
 
 
+class TestEvaluateCandidatesColdStart:
+    """Cold-start trap (#1509): a first-run config's single score is not
+    representative, so it must not win a tie against a more-established config."""
+
+    def test_tie_prefers_higher_evaluation_count_over_cold_start(self):
+        # Both score the same, but candidate 1 is a cold-start first-run (count 1)
+        # while candidate 0 has run 5 times. The established config must win the
+        # tie, NOT the earlier index.
+        cands = [
+            {"evaluation_count": 5, "scores": {"relevance": 0.5}},
+            {"evaluation_count": 1, "scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 0  # higher count wins, despite being index 0
+
+    def test_cold_start_loses_tie_even_when_later_index(self):
+        # Established config at index 1 beats a cold-start at index 0 on a tie —
+        # reversing the old index-first behavior so a degenerate first config
+        # cannot be credited.
+        cands = [
+            {"evaluation_count": 1, "scores": {"relevance": 0.5}},
+            {"evaluation_count": 3, "scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 1
+
+    def test_counts_do_not_override_actual_score_difference(self):
+        # A cold-start config with a genuinely higher score still wins — the guard
+        # only breaks TIES, it does not veto a better result.
+        cands = [
+            {"evaluation_count": 1, "scores": {"relevance": 0.9}},
+            {"evaluation_count": 9, "scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 0
+
+    def test_no_declared_counts_keeps_legacy_index_behavior(self):
+        # Existing callers (no evaluation_count anywhere) are unchanged: a tie
+        # still favors the earlier index, exactly as before #1509.
+        cands = [
+            {"scores": {"relevance": 0.5}},
+            {"scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 0
+
+    def test_malformed_count_degrades_to_cold_start(self):
+        # Non-numeric count is treated as a cold-start (count 1) and loses ties.
+        cands = [
+            {"evaluation_count": "nope", "scores": {"relevance": 0.5}},
+            {"evaluation_count": 2, "scores": {"relevance": 0.5}},
+        ]
+        ranking = evaluate_candidates(cands)
+        assert ranking[0][0] == 1
+
+
 class TestDecideVerdicts:
     def _cand(self, val):
-        return {"scores": {"relevance": val, "evidence": val, "specificity": val, "correctness": val}}
+        return {
+            "scores": {
+                "relevance": val,
+                "evidence": val,
+                "specificity": val,
+                "correctness": val,
+            }
+        }
 
     def test_accept_when_best_meets_threshold(self):
-        r = decide([self._cand(0.6), self._cand(0.8)], threshold=0.75, current_pass=1, max_passes=3)
+        r = decide(
+            [self._cand(0.6), self._cand(0.8)],
+            threshold=0.75,
+            current_pass=1,
+            max_passes=3,
+        )
         assert r["verdict"] == ACCEPT
         assert r["best_index"] == 1
         assert r["best_score"] == 0.8
@@ -106,7 +174,9 @@ class TestDecideVerdicts:
         # counter up to max_passes must end in a terminal (non-OPTIMIZE) verdict.
         max_passes = 4
         verdicts = [
-            decide([self._cand(0.1)], threshold=0.9, current_pass=p, max_passes=max_passes)["verdict"]
+            decide(
+                [self._cand(0.1)], threshold=0.9, current_pass=p, max_passes=max_passes
+            )["verdict"]
             for p in range(1, max_passes + 1)
         ]
         assert verdicts[:-1] == [OPTIMIZE] * (max_passes - 1)
@@ -152,9 +222,19 @@ class TestCli:
 
     def test_accept_exit_code_and_json(self, tmp_path, capsys):
         p = tmp_path / "cands.json"
-        p.write_text(json.dumps([{"scores": {"relevance": 0.9, "evidence": 0.9,
-                                              "specificity": 0.9, "correctness": 0.9}}]),
-                     encoding="utf-8")
+        p.write_text(
+            json.dumps([
+                {
+                    "scores": {
+                        "relevance": 0.9,
+                        "evidence": 0.9,
+                        "specificity": 0.9,
+                        "correctness": 0.9,
+                    }
+                }
+            ]),
+            encoding="utf-8",
+        )
         rc = main(["evolution_evaluator.py", "--threshold", "0.75", str(p)])
         payload = json.loads(capsys.readouterr().out)
         assert rc == EXIT_ACCEPT
@@ -163,21 +243,38 @@ class TestCli:
     def test_optimize_exit_code(self, tmp_path):
         p = tmp_path / "cands.json"
         p.write_text(json.dumps([{"scores": {"relevance": 0.4}}]), encoding="utf-8")
-        rc = main(["evolution_evaluator.py", "--threshold", "0.75",
-                   "--pass", "1", "--max-passes", "3", str(p)])
+        rc = main([
+            "evolution_evaluator.py",
+            "--threshold",
+            "0.75",
+            "--pass",
+            "1",
+            "--max-passes",
+            "3",
+            str(p),
+        ])
         assert rc == EXIT_OPTIMIZE
 
     def test_stop_budget_exit_code(self, tmp_path):
         p = tmp_path / "cands.json"
         p.write_text(json.dumps([{"scores": {"relevance": 0.4}}]), encoding="utf-8")
-        rc = main(["evolution_evaluator.py", "--threshold", "0.75",
-                   "--pass", "3", "--max-passes", "3", str(p)])
+        rc = main([
+            "evolution_evaluator.py",
+            "--threshold",
+            "0.75",
+            "--pass",
+            "3",
+            "--max-passes",
+            "3",
+            str(p),
+        ])
         assert rc == EXIT_STOP_BUDGET
 
     def test_stdin_and_candidates_wrapper(self, monkeypatch, capsys):
         rc, out = self._run(
             ["evolution_evaluator.py", "--threshold", "0.5"],
-            monkeypatch, capsys,
+            monkeypatch,
+            capsys,
             stdin_text=json.dumps({"candidates": [{"scores": {"relevance": 0.9}}]}),
         )
         assert rc == EXIT_ACCEPT


### PR DESCRIPTION
Automated evolution PR for issue #1509 — first coherent slice of the Harness Control System hardening roadmap.

Implements the **cold-start trap** guard: a first-run config's single score is not representative, so it must not win a score tie it should not win. In the 729-config harness study (arxiv 2607.25415), uninitialized argmax ties resolved deterministically to action 0 — a degenerate config. `scripts/evolution_evaluator.py` had the same trap: `evaluate_candidates` broke ties toward the earliest (index-0) candidate. When a candidate declares an `evaluation_count` (prior runs), a tie now favors the more-established (higher-count) config before the index fallback.

Crash-isolation (the other approved slice) is already merged in PR #1561 — this PR does not touch it.

Deferred (next increment):
- Cache-measurement pitfall (DSPy LM disk-cache cost tracking) — owner explicitly deferred this (comment 2026-08-03T18:00Z): the fork's prompt path is mid-sync (#1526), and measuring cache behaviour against a half-synced prompt path would produce numbers that expire when the sync completes. Needs the upstream sync integrated first.

Verified locally: 51 tests pass (evaluator + optimizer), ruff check + format clean. Diff 165 lines, within the autonomous merge cap.