### PR TITLE
fix(tests): stop the model-picker tests depending on today's curated snapshot

### DIFF
--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -69,8 +69,20 @@ class TestFetchOpenRouterModels:
             def read(self):
                 return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
 
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [
+                ("anthropic/claude-opus-4.8", ""),
+                ("qwen/qwen3.7-max", ""),
+                ("nvidia/nemotron-3-super-120b-a12b:free", ""),
+            ],
+        )
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == [
@@ -166,8 +178,20 @@ class TestFetchOpenRouterModels:
                     b']}'
                 )
 
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [
+                ("anthropic/claude-opus-4.8", ""),
+                ("qwen/qwen3.7-max", ""),
+                ("nvidia/nemotron-3-super-120b-a12b:free", ""),
+            ],
+        )
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
             models = fetch_openrouter_models(force_refresh=True)
 
         ids = [mid for mid, _ in models]


### PR DESCRIPTION
**main is red, and it is blocking every new PR.** #1664 and #1665 both fail on these two tests and nothing else.

`test_live_fetch_recomputes_free_tags` and `test_permissive_when_supported_parameters_missing` are not about the curated list — they assert free-tag recomputation and "missing `supported_parameters` means allow". But they let `fetch_openrouter_models` read the **real** curated source, and `get_curated_openrouter_models()` takes priority over `OPENROUTER_MODELS` whenever it returns anything.

That snapshot now holds 39 models and no longer lists `qwen/qwen3.7-max`. The fixture's model is filtered out *before* the assertion reaches the behaviour under test, so the failure has nothing to do with either test's subject.

The passing test sitting between them already had the fix: pin `OPENROUTER_MODELS` and stub `get_curated_openrouter_models` to `[]`. Applied the same pinning to both — they now test what their names say, and stay green as the snapshot moves.

`tests/hermes_cli/test_models.py`: **87 passed**.