### PR TITLE
fix: stagger evolution cron schedules to reduce provider HTTP 429s (Closes #1673)

### DIFF
--- a/cron/evolution/analysis.yaml
+++ b/cron/evolution/analysis.yaml
@@ -1,5 +1,5 @@
 name: evolution-analysis
-schedule: "0 1,5,9,13,17,21 * * *"  # Every 4h (was daily 21:00). Raises processing throughput vs ~25 issues/day generation. 21:00 slot still follows introspection (20:00). Watchdog STAGES mirrors the FIRST slot (1).
+schedule: "15 1,5,9,13,17,21 * * *"  # Every 4h at :15 (was daily 21:00; was :00). Minute offset (:15) so this LLM stage never fires in the same minute as hydra (:05/:35) or implementation (:20) — issue #1673 (HTTP 429 stampedes). Hour slots unchanged; 21:00 slot still follows introspection (20:50). Watchdog STAGES mirrors the FIRST slot hour (1).
 enabled: true
 mode: PRIVATE
 

--- a/cron/evolution/hydra.yaml
+++ b/cron/evolution/hydra.yaml
@@ -1,9 +1,13 @@
 name: evolution-hydra
-# Every 30 minutes — the Hydra's many heads constantly check for fresh
-# material in the knowledge pool. The pre-check script (evolution_hydra_gate.py)
-# suppresses the LLM when there's nothing new, so this costs zero tokens on
-# the vast majority of ticks.
-schedule: "*/30 * * * *"
+# Every 30 minutes at :05/:35 — the Hydra's many heads constantly check for
+# fresh material in the knowledge pool. The pre-check script
+# (evolution_hydra_gate.py) suppresses the LLM when there's nothing new, so
+# this costs zero tokens on the vast majority of ticks.
+# Offset to :05/:35 (instead of :00/:30) so the hydra's LLM dispatch never
+# collides with the other hourly :00 LLM stages (analysis/implementation/
+# integration/research) in the same wall-clock minute — issue #1673 (HTTP 429
+# rate-limit stampedes from overlapping cron fires).
+schedule: "5,35 * * * *"
 enabled: true
 mode: PRIVATE
 

--- a/cron/evolution/implementation.yaml
+++ b/cron/evolution/implementation.yaml
@@ -1,5 +1,5 @@
 name: evolution-implementation
-schedule: "0 2,6,10,14,18,22 * * *"  # Every 4h, +1h after analysis (1,5,9,...). Watchdog STAGES mirrors the FIRST slot (2).
+schedule: "20 2,6,10,14,18,22 * * *"  # Every 4h at :20, +1h after analysis (1,5,9,...). Minute offset (:20) so this LLM stage never fires in the same minute as analysis (:15) or integration (:40) — issue #1673 (HTTP 429 stampedes). Hour slots unchanged. Watchdog STAGES mirrors the FIRST slot hour (2).
 enabled: true
 mode: PRIVATE
 

--- a/cron/evolution/integration.yaml
+++ b/cron/evolution/integration.yaml
@@ -1,5 +1,5 @@
 name: evolution-integration
-schedule: "0 3,7,11,15,19,23 * * *"  # Every 4h, +1h after implementation (2,6,10,...) so CI settles. Watchdog STAGES mirrors the FIRST slot (3).
+schedule: "40 3,7,11,15,19,23 * * *"  # Every 4h at :40, +1h after implementation (2,6,10,...) so CI settles. Minute offset (:40) so this LLM stage never fires in the same minute as implementation (:20) — issue #1673 (HTTP 429 stampedes). Hour slots unchanged. Watchdog STAGES mirrors the FIRST slot hour (3).
 enabled: true
 mode: PRIVATE
 

--- a/cron/evolution/introspection.yaml
+++ b/cron/evolution/introspection.yaml
@@ -1,5 +1,5 @@
 name: evolution-introspection
-schedule: "0 20 * * *"  # Daily at 8 PM — before analysis (21:00) so findings feed it
+schedule: "50 20 * * *"  # Daily at 8:50 PM — before analysis (21:15) so findings feed it. Minute offset (:50) so this LLM stage never collides with hydra in the same minute — issue #1673.
 enabled: true
 mode: PUBLIC
 

--- a/cron/evolution/issues.yaml
+++ b/cron/evolution/issues.yaml
@@ -1,5 +1,5 @@
 name: evolution-issues
-schedule: "0 12 * * *"  # Daily at 12 PM
+schedule: "45 12 * * *"  # Daily at 12:45 PM (offset from :00 so this LLM stage never collides with hydra in the same minute — issue #1673).
 enabled: true
 mode: PUBLIC
 

--- a/cron/evolution/research.yaml
+++ b/cron/evolution/research.yaml
@@ -1,5 +1,5 @@
 name: evolution-research
-schedule: "0 9 * * *"  # Daily at 9 AM
+schedule: "30 9 * * *"  # Daily at 9:30 AM (offset from :00 so this LLM stage never collides with hydra/analysis in the same minute — issue #1673).
 enabled: true
 mode: PUBLIC
 

--- a/cron/evolution/upstream-sync.yaml
+++ b/cron/evolution/upstream-sync.yaml
@@ -1,5 +1,5 @@
 name: evolution-upstream-sync
-schedule: "0 8 * * *"  # checked daily 8 AM (before research 09:00); merges ONLY when upstream published a new RELEASE since last sync — most days finds BEHIND==0 and stops. Release-tracking (not upstream/main): upstream lands ~300 commits/day, so chasing main stalled the sync; a tagged release (~weekly) is a bounded, stabilized batch.
+schedule: "10 8 * * *"  # checked daily 8:10 AM (offset from :00 so this LLM stage never collides with hydra in the same minute — issue #1673; still before research 09:30); merges ONLY when upstream published a new RELEASE since last sync — most days finds BEHIND==0 and stops. Release-tracking (not upstream/main): upstream lands ~300 commits/day, so chasing main stalled the sync; a tagged release (~weekly) is a bounded, stabilized batch.
 enabled: true
 mode: PRIVATE
 


### PR DESCRIPTION
Automated evolution PR for issue #1673 — provider rate limiting (zai/glm-5.2).

Staggers the evolution pipeline LLM-hitting cron jobs to distinct minute offsets so concurrent jobs no longer all fire in the same wall-clock second and hit the provider rate limit (~90 HTTP 429/day, clusters at hour boundaries).

- hydra `*/30` -> `5,35`
- analysis `0 1,5,9,13,17,21` -> `15 1,5,9,13,17,21`
- implementation `0 2,6,10,...` -> `20 2,6,10,...`
- integration `0 3,7,11,...` -> `40 3,7,11,...`
- research `0 9` -> `30 9`
- issues `0 12` -> `45 12`
- introspection `0 20` -> `50 20`
- upstream-sync `0 8` -> `10 8`

Deterministic no_agent jobs (funnel/watchdog/meta-analysis/etc.) do not call the LLM provider and are already off the :00 mark. Hour slots unchanged — the watchdog STAGES mirror test and stage ordering hold. Config-only, 28 changed lines. Retry policy untouched (per acceptance criteria).