### PR TITLE
fix: detect stringified-array paths in coerce_tool_args for string-typed params (Closes #1681)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -861,6 +861,34 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
             continue
         if not expected and not _schema_allows_null(prop_schema):
             continue
+
+        # ── Stringified-array guard for string-typed params (#1681) ──
+        # When the schema declares ``"type": "string"`` (e.g. read_file's
+        # ``path``), the model sometimes emits a stringified JSON array
+        # like ``'["path/a", "path/b"]'``. Without this guard the literal
+        # array string reaches the tool → file-not-found → retry spiral.
+        # Detect the pattern and extract the first element (the most
+        # likely intended path). Only fires for string-typed params where
+        # ``_coerce_value`` is a no-op — the array-typed branch above
+        # already handles JSON arrays on array-typed fields.
+        if (
+            expected == "string"
+            and isinstance(value, str)
+            and value.lstrip().startswith("[")
+        ):
+            extracted = _extract_first_from_stringified_array(value)
+            if extracted is not None:
+                logger.info(
+                    "coerce_tool_args: %s.%s received a stringified JSON "
+                    "array string (%.80s...) for a string-typed param — "
+                    "extracting first element.",
+                    tool_name,
+                    key,
+                    value,
+                )
+                args[key] = extracted
+                continue
+
         coerced = _coerce_value(value, expected, schema=prop_schema)
         if coerced is not value:
             args[key] = coerced
@@ -968,6 +996,35 @@ def _normalize_json_strings_for_schema(value: Any, schema: Any) -> Any:
         return out if changed else value
 
     return value
+
+
+def _extract_first_from_stringified_array(value: str) -> Optional[str]:
+    """Extract the first element from a stringified JSON array (#1681).
+
+    When the model emits a string-typed param value that is actually a
+    JSON-encoded array (e.g. ``'["path/a", "path/b"]'``), extract the
+    first string element so the tool receives a usable scalar path
+    instead of the literal array string.
+
+    Returns the first string element, or ``None`` when the value is not a
+    parseable JSON array of strings (in which case the caller leaves the
+    original value untouched).
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value.strip())
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, list) or not parsed:
+        return None
+    # Only unwrap arrays of strings — a list of dicts/numbers on a
+    # string-typed param is a different error and should not be silently
+    # mangled into ``str(parsed[0])``.
+    first = parsed[0]
+    if isinstance(first, str):
+        return first
+    return None
 
 
 def _coerce_value(value: str, expected_type, schema: dict | None = None):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -31,23 +31,11 @@ class TestCoerceNumber:
     def test_negative_integer(self):
         assert _coerce_number("-7") == -7
 
-
-
-
     def test_integer_only_rejects_float(self):
         """When integer_only=True, "3.14" should stay as string."""
         result = _coerce_number("3.14", integer_only=True)
         assert result == "3.14"
         assert isinstance(result, str)
-
-
-
-
-
-
-
-
-
 
 
 class TestCoerceBoolean:
@@ -56,16 +44,10 @@ class TestCoerceBoolean:
     def test_true_lowercase(self):
         assert _coerce_boolean("true") is True
 
-
-
-
-
-
     def test_one_zero_not_coerced(self):
         """'1' and '0' are not boolean values."""
         assert _coerce_boolean("1") == "1"
         assert _coerce_boolean("0") == "0"
-
 
 
 class TestCoerceValue:
@@ -74,22 +56,10 @@ class TestCoerceValue:
     def test_integer_type(self):
         assert _coerce_value("5", "integer") == 5
 
-
-
-
-
-
-
-
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
         assert _coerce_value("[1, 2, 3]", "array") == [1, 2, 3]
-
-
-
-
-
 
 
 # ── Full coerce_tool_args with registry ───────────────────────────────────
@@ -117,9 +87,6 @@ class TestCoerceToolArgs:
             assert result["limit"] == 10
             assert isinstance(result["limit"], int)
 
-
-
-
     def test_leaves_already_correct_types(self):
         schema = self._mock_schema({"limit": {"type": "integer"}})
         with patch("model_tools.registry.get_schema", return_value=schema):
@@ -127,25 +94,8 @@ class TestCoerceToolArgs:
             result = coerce_tool_args("test_tool", args)
             assert result["limit"] == 10
 
-
     def test_empty_args(self):
         assert coerce_tool_args("test_tool", {}) == {}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def test_real_read_file_schema(self):
         """Test against the actual read_file schema from the registry."""
@@ -157,6 +107,69 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+    # ── Stringified-array on string-typed params (#1681) ────────────────
+
+    def test_stringified_array_on_string_param_extracts_first(self):
+        """Regression for #1681 — read_file path is type=str.
+
+        When the model emits ``'["path/a", "path/b"]'`` as the value of a
+        string-typed ``path`` param, coerce_tool_args should detect the
+        stringified array and extract the first element instead of passing
+        the literal array string to the tool.
+        """
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": '["path/a", "path/b"]'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "path/a"
+
+    def test_stringified_single_element_array_on_string_param(self):
+        """Single-element stringified array also unwrapped."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": '["only.py"]'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "only.py"
+
+    def test_plain_string_path_not_affected_by_array_guard(self):
+        """A normal string path must pass through unchanged."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "src/main.py"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "src/main.py"
+
+    def test_stringified_array_of_non_strings_left_alone(self):
+        """A JSON array of numbers on a string-typed param is NOT mangled."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "[1, 2, 3]"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "[1, 2, 3]"
+
+    def test_malformed_bracket_string_left_alone(self):
+        """A string starting with '[' but not valid JSON is untouched."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "[not-json-at-all"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "[not-json-at-all"
+
+    def test_stringified_array_on_union_string_array_parsed_as_list(self):
+        """Union type ['string', 'array'] — array branch fires first.
+
+        When the schema accepts both string and array, the array-wrapping
+        path (line 698) handles the JSON-encoded string and returns a native
+        list. This is correct behaviour — the tool can accept a list.
+        """
+        schema = self._mock_schema({
+            "path": {"type": ["string", "array"]},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": '["a.py", "b.py"]'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == ["a.py", "b.py"]
 
 
 # ── Schema-guided nested JSON-string normalization (cline/cline#11803) ─────
@@ -170,8 +183,6 @@ class TestSchemaAcceptsKind:
         assert _schema_accepts_kind({"type": "object"}, "object") is True
         assert _schema_accepts_kind({"type": "string"}, "array") is False
 
-
-
     def test_non_dict(self):
         assert _schema_accepts_kind(None, "array") is False
 
@@ -183,9 +194,6 @@ class TestNormalizeJsonStringsForSchema:
         schema = {"type": "array", "items": {"type": "string"}}
         out = _normalize_json_strings_for_schema('["git status", "bun test"]', schema)
         assert out == ["git status", "bun test"]
-
-
-
 
     def test_native_list_preserved_identity(self):
         schema = {"type": "array", "items": {"type": "object", "properties": {}}}
@@ -229,7 +237,6 @@ class TestCoerceToolArgsNested:
             result = coerce_tool_args("test_tool", args)
             assert result["items"] == [{"id": "1", "content": "x"}]
 
-
     def test_string_subfield_with_json_content_preserved(self):
         """A string-typed sub-field whose value looks like JSON must NOT be parsed."""
         schema = self._array_of_objects_schema()
@@ -238,11 +245,12 @@ class TestCoerceToolArgsNested:
             result = coerce_tool_args("test_tool", args)
             assert result["items"][0]["content"] == '{"not": "parsed"}'
 
-
-
     def test_real_todo_schema_element_strings(self):
         """Against the real todo schema from the registry."""
         import json as _json
-        args = {"todos": [_json.dumps({"id": "1", "content": "x", "status": "pending"})]}
+
+        args = {
+            "todos": [_json.dumps({"id": "1", "content": "x", "status": "pending"})]
+        }
         result = coerce_tool_args("todo", args)
         assert result["todos"][0] == {"id": "1", "content": "x", "status": "pending"}


### PR DESCRIPTION
## Summary

When the model emits a stringified JSON array like `'["path/a", "path/b"]'` as the value of a string-typed param (e.g. `read_file`'s `path`), `coerce_tool_args` previously passed the literal array string through unchanged. The tool then received `["path/a", "path/b"]` as a literal path → file-not-found → blind retry spiral.

**Evidence:** ~143 read_file file-not-found failures over 2008 sessions/7d (7.1% failure rate). A large share traces to this coercion-to-malformed-path pattern.

## Fix

Added a guard in `coerce_tool_args` (`model_tools.py`) that:
1. Detects when a string-typed param receives a value starting with `[`
2. Attempts to parse it as a JSON array
3. If it's an array of strings, extracts the first element as the intended path
4. Non-string arrays and malformed brackets are left untouched (no silent mangling)

Added `_extract_first_from_stringified_array()` helper that safely handles parsing.

## Tests

6 new test cases in `tests/run_agent/test_tool_arg_coercion.py`:
- Stringified array on string param → extracts first element
- Single-element stringified array → unwrapped
- Plain string path → unaffected
- Array of non-strings → left alone
- Malformed bracket string → left alone
- Union type `[string, array]` → array branch handles it correctly

## Validation
- `ruff check` ✓
- `ruff format --check` ✓
- `pytest tests/run_agent/test_tool_arg_coercion.py` — 25 passed ✓
- Diff: 124 insertions, 59 deletions (well under 200-line merge cap)

Closes #1681