### PR TITLE
fix: surface push failure in review_create_pr instead of swallowing (Closes #1682)

### DIFF
--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -467,8 +467,15 @@ def review_create_pr(cwd: str) -> dict:
     """Create a PR for the current branch (push first), letting gh fill title/body."""
     try:
         _review_push(cwd)
-    except RuntimeError:
-        pass
+    except RuntimeError as exc:
+        # Don't swallow the push failure (#1682). Previously the bare
+        # ``except RuntimeError: pass`` let gh pr create run on an un-pushed
+        # branch, which fails with an opaque GraphQL 'Head sha can't be
+        # blank'. Surface an actionable message instead.
+        raise RuntimeError(
+            f"Failed to push branch before creating PR ({exc}). "
+            f"Run 'git push' first, then retry."
+        ) from exc
     created, out = _gh(cwd, ["pr", "create", "--fill"])
     if not created:
         raise RuntimeError("gh pr create failed (is gh installed and authenticated?)")


### PR DESCRIPTION
## Summary

`review_create_pr` in `hermes_cli/web_git.py` called `_review_push(cwd)` but swallowed its `RuntimeError` with `except RuntimeError: pass`. When the push failed silently, `gh pr create` ran on an un-pushed branch and failed with an opaque GraphQL `'Head sha can't be blank'` error — aborting the implementation cycle and stranding completed work.

## Fix

Replaced the bare `except RuntimeError: pass` with a re-raise that:
1. Includes the original error message
2. Adds an actionable hint: `'Run git push first, then retry.'`

This gives the agent (or human) an actionable message instead of an opaque GraphQL failure downstream.

## Evidence

Observed across multiple implementation sessions in the evolution pipeline: the agent completes work, push silently fails, `gh pr create` produces an opaque GraphQL error, and the PR is abandoned — wasting a full implementation cycle.

## Validation
- `ruff check` ✓
- Diff: 9 insertions, 2 deletions (well under 200-line merge cap)
- No existing tests for `review_create_pr` — the fix is a minimal error-handling change

Closes #1682