### PR TITLE
fix: read_file directory+coercion hints and pre-PR push check (Closes #1681, #1682)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1023,6 +1023,37 @@ def _schema_allows_null(schema: dict | None) -> bool:
     return False
 
 
+def _split_path_list(value: str) -> Optional[List[str]]:
+    """Split a comma-separated / bracket-wrapped list of bare path-like items.
+
+    Models occasionally emit a path list as ``"a.py, b.py"`` or ``"[/a, /b]"``
+    where a native JSON array was expected (#1681). ``json.loads`` fails on
+    these because bare paths aren't quoted, so they previously fell through to
+    the caller's single-element-wrap fallback — read_file then got a literal
+    malformed string like ``"[/a, /b]"`` as a single path, producing a
+    file-not-found spiral.
+
+    Returns a list of trimmed items when the string looks like a path list
+    (≥2 comma-separated items, or a single item inside brackets), else ``None``
+    so the caller keeps its existing single-element fallback. Single-path
+    values (``"/a.py"``) return ``None`` — they must NOT be split, since a
+    path itself can contain commas rarely but the common case is a lone path.
+    """
+    if not value or not value.strip():
+        return None
+    s = value.strip()
+    # Unwrap a single bracket pair: "[/a, /b]" -> "/a, /b".
+    if s.startswith("[") and s.endswith("]"):
+        s = s[1:-1].strip()
+    items = [part.strip().strip("'\"") for part in s.split(",") if part.strip()]
+    # Only treat it as a path list when we actually split into multiple items.
+    # A lone item (single path, possibly comma-less) must stay a single string
+    # so a path that merely contains a bracket or comma is not mangled.
+    if len(items) >= 2:
+        return items
+    return None
+
+
 def _coerce_json(value: str, expected_python_type: type):
     """Parse *value* as JSON when the schema expects an array or object.
 
@@ -1052,10 +1083,23 @@ def _coerce_json(value: str, expected_python_type: type):
     try:
         parsed = json.loads(value)
     except (ValueError, TypeError) as exc:
-        # Demote to debug: the caller (coerce_tool_args) already handles
-        # the fallback by wrapping non-JSON strings in a single-element
-        # list.  Logging a warning here on every failure was the primary
-        # source of log spam — the wrap fallback is the intended path.
+        # The value isn't JSON. Before falling through to the caller's
+        # single-element-wrap fallback, try splitting a comma-separated /
+        # bracket-wrapped list of bare path-like items (#1681). Models
+        # sometimes emit ``path="a.py, b.py"`` (or ``"[/a, /b]"``) where a
+        # JSON array was expected; splitting turns it into a real batch list
+        # instead of a literal malformed path that read_file would treat as
+        # a single "File not found" spiral.
+        if expected_python_type is list:
+            items = _split_path_list(value)
+            if items is not None:
+                logger.debug(
+                    "coerce_tool_args: split comma-separated list string for expected "
+                    "type list: %r -> %r",
+                    value,
+                    items,
+                )
+                return items
         logger.debug(
             "coerce_tool_args: failed to parse string as JSON for expected type %s: %s",
             expected_python_type.__name__,

--- a/scripts/evolution_pre_pr_test_runner.py
+++ b/scripts/evolution_pre_pr_test_runner.py
@@ -57,6 +57,118 @@ DEFAULT_FALLBACK_KWARGS = "not slow and not docker"
 
 _LOG_DIR_TEMPLATE = "~/.hermes/evolution/pre-pr-test-results"
 
+# ── Pre-flight: branch push check (#1682) ─────────────────────────────────────
+# Before `gh pr create`, verify the current branch exists on the remote and has
+# at least one commit ahead of base. A missing/skipped push produces an opaque
+# GraphQL error ("Head sha can't be blank", "No commits between main and
+# <branch>") that aborts the implementation cycle. This check surfaces the root
+# cause (branch not pushed) *before* the PR-creation step so the agent can
+# retry the push instead of abandoning the completed work.
+
+
+@dataclass
+class PushCheckResult:
+    """Outcome of the pre-flight branch-push check (#1682)."""
+
+    __test__ = False  # not a pytest test class
+
+    ok: bool
+    message: str
+    branch: str = ""
+    base: str = "main"
+
+
+def check_branch_pushed(
+    repo_root: Path,
+    *,
+    base: str = "main",
+    remote: str = "origin",
+    runner: Optional[Callable] = None,
+) -> PushCheckResult:
+    """Verify the current branch is pushed and has commits ahead of *base*.
+
+    Pure except for subprocess IO; the runner is injectable for offline tests.
+    Returns ``PushCheckResult(ok=True)`` when the branch exists on the remote
+    and has ≥1 commit ahead of base. Otherwise returns ``ok=False`` with an
+    actionable message telling the caller to ``git push`` first — the root
+    cause of the #1682 GraphQL errors ("Head sha can't be blank" / "No commits
+    between main and <branch>").
+
+    Never raises — all git failures are caught and surfaced as ``ok=False``.
+    """
+    import subprocess as _sp
+
+    def _run(args: list[str]) -> tuple[int, str, str]:
+        if runner is not None:
+            return runner(args)
+        try:
+            proc = _sp.run(
+                args, capture_output=True, text=True, cwd=str(repo_root),
+            )
+            return proc.returncode, proc.stdout, proc.stderr
+        except Exception as exc:  # pragma: no cover — never crash the pipeline
+            return 1, "", str(exc)
+
+    # 1. Current branch name
+    rc, out, err = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if rc != 0 or not out.strip():
+        return PushCheckResult(
+            ok=False,
+            message=f"Could not determine the current branch: {err.strip() or 'git rev-parse failed'}",
+        )
+    branch = out.strip()
+
+    # Detached HEAD — no branch to push.
+    if branch == "HEAD":
+        return PushCheckResult(
+            ok=False,
+            message="Detached HEAD — checkout a branch before creating a PR.",
+            branch=branch,
+            base=base,
+        )
+
+    # 2. Does the branch exist on the remote?
+    rc, out, err = _run(
+        ["git", "ls-remote", "--heads", remote, branch]
+    )
+    if rc != 0 or not out.strip():
+        return PushCheckResult(
+            ok=False,
+            message=(
+                f"Branch '{branch}' does not exist on remote '{remote}'. "
+                f"Run: git push -u {remote} {branch} — "
+                f"gh pr create will fail with 'Head sha can't be blank' until pushed."
+            ),
+            branch=branch,
+            base=base,
+        )
+
+    # 3. At least one commit ahead of base?
+    rc, out, err = _run(
+        ["git", "rev-list", "--count", f"{base}..{branch}"]
+    )
+    ahead = 0
+    if rc == 0 and out.strip().isdigit():
+        ahead = int(out.strip())
+    if ahead < 1:
+        return PushCheckResult(
+            ok=False,
+            message=(
+                f"Branch '{branch}' has no commits ahead of '{base}'. "
+                f"Commit your changes and push before creating a PR "
+                f"('No commits between {base} and {branch}' GraphQL error)."
+            ),
+            branch=branch,
+            base=base,
+        )
+
+    return PushCheckResult(
+        ok=True,
+        message=f"Branch '{branch}' is pushed with {ahead} commit(s) ahead of '{base}'.",
+        branch=branch,
+        base=base,
+    )
+
 # Source-root to test-root mapping: each source prefix maps to the
 # corresponding test directory prefix, so agent/... → tests/agent/...,
 # hermes_cli/... → tests/hermes_cli/..., etc.
@@ -473,6 +585,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=False,
         help="Stop after the first failing shard (default: run all shards)",
     )
+    parser.add_argument(
+        "--check-pushed",
+        action="store_true",
+        default=False,
+        help="Also verify the current branch is pushed with commits ahead of base "
+        "before running tests (pre-PR gate for the autonomous pipeline; default: off)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -527,6 +646,23 @@ def main(argv: Optional[List[str]] = None) -> int:
     if not repo_root.exists():
         print(f"ERROR: repo root {repo_root} does not exist", file=sys.stderr)
         return 2
+
+    # ── Pre-flight: branch push check (#1682) ─────────────────────────────
+    # Opt-in via --check-pushed so the runner's primary purpose (running tests
+    # locally) is never blocked for a user testing on an un-pushed branch. The
+    # autonomous PR-creation path enables it: an un-pushed branch would fail
+    # `gh pr create` with an opaque GraphQL error ("Head sha can't be blank" /
+    # "No commits between main and <branch>") and abort the cycle; surface it
+    # now so the agent can `git push` before burning a PR attempt.
+    if args.check_pushed:
+        push = check_branch_pushed(repo_root)
+        if not push.ok:
+            print(f"\nPRE-FLIGHT FAILED: {push.message}", file=sys.stderr)
+            print(
+                f"Run `git push` for branch '{push.branch or '<current>'}' before creating a PR.",
+                file=sys.stderr,
+            )
+            return 3
 
     # Resolve log dir
     if args.log_dir:

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -86,6 +86,17 @@ class TestCoerceValue:
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
         assert _coerce_value("[1, 2, 3]", "array") == [1, 2, 3]
 
+    def test_array_type_comma_separated_path_list(self):
+        """Comma-separated bare paths are split into a list, not kept as a
+        literal malformed single path (#1681)."""
+        assert _coerce_value("a.py, b.py", "array") == ["a.py", "b.py"]
+        assert _coerce_value("[/a, /b]", "array") == ["/a", "/b"]
+
+    def test_array_type_single_path_not_split(self):
+        """A lone path must stay a single string, never mangled into a list."""
+        assert _coerce_value("/a.py", "array") == "/a.py"
+        assert _coerce_value("a,", "array") == "a,"  # single trailing comma → lone item
+
 
 
 

--- a/tests/scripts/test_evolution_pre_pr_test_runner.py
+++ b/tests/scripts/test_evolution_pre_pr_test_runner.py
@@ -20,10 +20,12 @@ from evolution_pre_pr_test_runner import (  # noqa: E402
     DEFAULT_TIMEOUT,
     SRC_TO_TEST_PREFIX,
     GateReport,
+    PushCheckResult,
     TestShard,
     TestResult,
     _basename_to_test_basename,
     _resolve_test_path,
+    check_branch_pushed,
     get_fallback_shard,
     map_changed_files_to_shards,
     run_gate,
@@ -319,6 +321,75 @@ class TestDataObjects:
         assert report.results == []
         assert report.passed is False
         assert report.note == ""
+
+
+# ── Test: pre-flight branch push check (#1682) ───────────────────────────────
+
+class TestCheckBranchPushed:
+    """check_branch_pushed maps git states to actionable PushCheckResults.
+
+    The runner is injected, so these run fully offline. The invariant under
+    test: an un-pushed branch (the #1682 root cause of the 'Head sha can't be
+    blank' GraphQL error) is surfaced as ok=False with a 'git push' hint,
+    never as a silent pass.
+    """
+
+    def _fake_runner(self, commands: dict):
+        """Build a runner returning canned (rc, stdout, stderr) per command."""
+        def _run(args):
+            cmd = tuple(args)
+            if cmd in commands:
+                return commands[cmd]
+            return (1, "", "unexpected command")
+        return _run
+
+    def test_pushed_with_commits_ahead_ok(self):
+        runner = self._fake_runner({
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): (0, "evolution/x\n", ""),
+            ("git", "ls-remote", "--heads", "origin", "evolution/x"): (0, "abc123\trefs/heads/evolution/x\n", ""),
+            ("git", "rev-list", "--count", "main..evolution/x"): (0, "3\n", ""),
+        })
+        result = check_branch_pushed(Path("/repo"), runner=runner)
+        assert result.ok is True
+        assert result.branch == "evolution/x"
+        assert "3 commit" in result.message
+
+    def test_branch_not_on_remote_fails_with_push_hint(self):
+        runner = self._fake_runner({
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): (0, "evolution/x\n", ""),
+            ("git", "ls-remote", "--heads", "origin", "evolution/x"): (0, "", ""),
+        })
+        result = check_branch_pushed(Path("/repo"), runner=runner)
+        assert result.ok is False
+        assert "git push" in result.message
+        assert "Head sha can't be blank" in result.message
+
+    def test_no_commits_ahead_fails(self):
+        runner = self._fake_runner({
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): (0, "evolution/x\n", ""),
+            ("git", "ls-remote", "--heads", "origin", "evolution/x"): (0, "abc123\trefs/heads/evolution/x\n", ""),
+            ("git", "rev-list", "--count", "main..evolution/x"): (0, "0\n", ""),
+        })
+        result = check_branch_pushed(Path("/repo"), runner=runner)
+        assert result.ok is False
+        assert "no commits ahead" in result.message.lower()
+        assert "No commits between" in result.message
+
+    def test_detached_head_fails(self):
+        runner = self._fake_runner({
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): (0, "HEAD\n", ""),
+        })
+        result = check_branch_pushed(Path("/repo"), runner=runner)
+        assert result.ok is False
+        assert "detached" in result.message.lower()
+
+    def test_git_error_does_not_raise(self):
+        runner = self._fake_runner({
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): (1, "", "fatal: not a git repository"),
+        })
+        result = check_branch_pushed(Path("/repo"), runner=runner)
+        assert result.ok is False
+        assert "could not determine" in result.message.lower()
 
 
 # ── Test: SRC_TO_TEST_PREFIX shape ───────────────────────────────────────────

--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -64,6 +64,22 @@ class TestClassifyFileError:
         klass, _ = classify_file_error("Binary file - cannot display as text.")
         assert klass == "binary"
 
+    def test_directory(self):
+        """read_file on a directory yields the actionable 'directory' class (#1681)."""
+        klass, rec = classify_file_error(
+            "Cannot read a directory: /tmp/x is a directory, not a file."
+        )
+        assert klass == "directory"
+        assert "search_files" in rec
+
+    def test_directory_variant_patch(self):
+        """The patch operation variant routes to the same directory class."""
+        klass, rec = classify_file_error(
+            "Cannot patch a directory: /tmp/dir is a directory, not a file."
+        )
+        assert klass == "directory"
+        assert "search_files" in rec
+
     def test_unknown_falls_back_to_error(self):
         klass, rec = classify_file_error("something inexplicable happened")
         assert klass == "error" and "CHANGE the call" in rec

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -183,6 +183,13 @@ def classify_file_error(
             "The path is protected/denied and can't be elevated. Use an allowed "
             "path — do NOT retry the same one."
         )
+    if "is a directory" in low or "directory, not a file" in low:
+        return "directory", (
+            "The path is a directory, not a file — read_file expects a file. "
+            "To list or read the directory's contents, use search_files "
+            "(target='files') to find files within it; do NOT retry read_file "
+            "on the same directory path."
+        )
     if "binary file" in low:
         return "binary", (
             "This is a binary file. Don't read it as text; use a tool suited to the "


### PR DESCRIPTION
## Summary

Two additive introspection fixes for the core tool failure signal and the autonomous PR-creation pipeline.

### #1681 — read_file directory + coercion hints

`read_file` has the highest core-tool failure rate (~7.1%, 143 failures / 2008 sessions / 7d). Two sub-patterns trace to the file-not-found spiral:

1. **Directory path** — `_diagnose_read_failure` already produces a clear `"Cannot read a directory: ... is a directory, not a file."` message, but `classify_file_error` had **no directory arm**, so it fell through to the generic `error` class with the unhelpful "CHANGE the call" recovery. Added a `directory` class whose recovery tells the agent to use `search_files` instead of retrying `read_file`.

2. **Stringified / comma-separated path lists** — for the union `["string","array"]` path schema, `coerce_tool_args`/`_coerce_json` correctly parsed valid JSON arrays but **silently dropped** comma-separated (`"a.py, b.py"`) or bracket-wrapped (`"[/a, /b]"`) bare path lists, falling to the single-element-wrap fallback. `read_file` then got a literal malformed string as a single path → file-not-found spiral. Added `_split_path_list` which splits a ≥2-item path list into a real batch list; a lone path is left untouched.

### #1682 — pre-PR push pre-flight check

The autonomous pipeline occasionally calls `gh pr create` on a branch whose commits were never pushed, hitting opaque GraphQL errors (`Head sha can't be blank`, `No commits between main and <branch>`) that abort the whole implementation cycle. Added `check_branch_pushed()` to `scripts/evolution_pre_pr_test_runner.py` — a pure, testable pre-flight that verifies the current branch exists on the remote and has ≥1 commit ahead of base, surfacing a `git push` hint before the PR attempt. Wired behind `--check-pushed` (opt-in) so local test runs on un-pushed branches are never blocked.

## Verification

- 82 targeted tests pass (coercion + classification + pre-PR runner)
- 115 related file-operation tests pass
- Exact `_diagnose_read_failure` output strings classify as `directory`
- `--check-pushed` correctly fails pre-push and passes post-push

## Files

- `model_tools.py` — `_split_path_list` + comma-separated fallback in `_coerce_json`
- `tools/file_operations.py` — `directory` arm in `classify_file_error`
- `scripts/evolution_pre_pr_test_runner.py` — `check_branch_pushed()` + `--check-pushed`
- 3 test files updated