### PR TITLE
fix: targeted hint on tqmemory get_prompt 'Unknown prompt' errors (Closes #1687)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1478,6 +1478,60 @@ class TestUtilityHandlers:
         finally:
             _servers.pop("srv", None)
 
+    def test_get_prompt_unknown_prompt_hint(self):
+        """Unknown-prompt McpError yields a targeted hint, not an opaque error."""
+        from tools.mcp_tool import _make_get_prompt_handler, _servers
+
+        mock_session = MagicMock()
+
+        async def _raise_unknown(name, arguments=None):
+            # mcp.shared.exceptions.McpError carries .error (ErrorData).
+            err = SimpleNamespace(message=f"Unknown prompt: {name}")
+            raise type(
+                "McpError",
+                (Exception,),
+                {},
+            )(f"Unknown prompt: {name}") from None
+
+        mock_session.get_prompt = AsyncMock(side_effect=_raise_unknown)
+        server = _make_mock_server("srv", session=mock_session)
+        _servers["srv"] = server
+
+        try:
+            handler = _make_get_prompt_handler("srv", 120)
+            with self._patch_mcp_loop():
+                result = handler({"name": "evolution-implementation"})
+            payload = json.loads(result)
+            assert "evolution-implementation" in payload["error"]
+            assert "skill_view" in payload["error"]
+            assert "list_prompts" in payload["error"]
+        finally:
+            _servers.pop("srv", None)
+
+    def test_get_prompt_non_unknown_error_unmodified(self):
+        """Non-unknown-prompt errors keep the original opaque formatting."""
+        from tools.mcp_tool import _make_get_prompt_handler, _servers
+
+        mock_session = MagicMock()
+
+        async def _raise_other(name, arguments=None):
+            raise RuntimeError("connection reset")
+
+        mock_session.get_prompt = AsyncMock(side_effect=_raise_other)
+        server = _make_mock_server("srv", session=mock_session)
+        _servers["srv"] = server
+
+        try:
+            handler = _make_get_prompt_handler("srv", 120)
+            with self._patch_mcp_loop():
+                result = handler({"name": "summarize"})
+            payload = json.loads(result)
+            assert "connection reset" in payload["error"]
+            assert "skill_view" not in payload["error"]
+        finally:
+            _servers.pop("srv", None)
+
+
 # ---------------------------------------------------------------------------
 # Utility tools registration in _discover_and_register_server
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -614,6 +614,33 @@ def _is_method_not_found_error(exc: BaseException) -> bool:
     )
 
 
+def _is_unknown_prompt_error(exc: BaseException) -> str:
+    """Return the unknown prompt name if *exc* is an ``Unknown prompt`` error.
+
+    MCP servers raise ``McpError: Unknown prompt: <name>`` when ``get_prompt``
+    is called with a name that is not in the server's prompt registry. This is
+    a *recurring* agent-side mistake: the agent conflates Hermes skill names
+    (``evolution-implementation``, ``semantic_search``, …) with tqmemory MCP
+    prompt names. Surface the offending name so the error path can emit a
+    targeted hint instead of an opaque failure.
+
+    Structurally inspect ``McpError.error.message`` first, then fall back to a
+    substring match so detection survives SDK version drift and servers that
+    surface the condition as a plain exception string.
+    """
+    err = getattr(exc, "error", None)
+    msg = getattr(err, "message", None) or str(exc)
+    text = str(msg).strip().lower()
+    marker = "unknown prompt"
+    idx = text.find(marker)
+    if idx == -1:
+        return ""
+    # Grab the prompt name that follows "Unknown prompt: <name>".
+    rest = text[idx + len(marker) :].lstrip(": \t'\"")
+    name = rest.split()[0].strip("'\".,;") if rest else ""
+    return name
+
+
 # ---------------------------------------------------------------------------
 # MCP tool description content scanning
 # ---------------------------------------------------------------------------
@@ -5863,6 +5890,17 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                 server_name,
                 exc,
             )
+            unknown = _is_unknown_prompt_error(exc)
+            if unknown:
+                hint = (
+                    f"MCP server '{server_name}' has no prompt named "
+                    f"'{unknown}'. This name may be a Hermes skill rather "
+                    f"than an MCP prompt — if so, load it with "
+                    f'skill_view(name="{unknown}") instead. Otherwise, '
+                    f"list available prompts with "
+                    f"{mcp_prefixed_tool_name(server_name, 'list_prompts')}."
+                )
+                return tool_error(hint)
             return tool_error(
                 _sanitize_error(
                     f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"


### PR DESCRIPTION
Automated evolution PR for issue #1687.

The MCP `get_prompt` handler called `server.session.get_prompt(name)` with no validation, surfacing an opaque `McpError: Unknown prompt: <name>` for names that are actually Hermes skills (evolution-implementation, issue-lookup, semantic_search), not tqmemory prompts. Detect unknown-prompt errors and emit a targeted hint suggesting `skill_view(name=...)` or the server's `list_prompts` tool, so the agent recovers without an opaque failure.

Closes #1687