### PR TITLE
feat: enrich get_prompt 'Unknown prompt' errors with available prompts + skill_view hint (Closes #1687)

### DIFF
--- a/tests/tools/test_mcp_get_prompt_enrichment.py
+++ b/tests/tools/test_mcp_get_prompt_enrichment.py
@@ -1,0 +1,134 @@
+"""Tests for MCP get_prompt 'Unknown prompt' error enrichment (#1687).
+
+When the tqmemory MCP server returns 'Unknown prompt: <name>' (because the
+agent/cron asked for a name that is a skill, not a prompt — e.g.
+'evolution-implementation', 'issue-lookup', 'semantic_search'), the
+get_prompt handler must enrich the error JSON with:
+
+  1. ``available_prompts`` — the real prompt names on the server, and
+  2. ``hint`` — a recovery directive that suggests ``skill_view(name=...)``
+     for skill-like names, breaking the retry spiral.
+
+These tests exercise the production helper ``_enrich_missing_prompt_error``
+directly (mirrors the approach in ``test_mcp_error_enrichment.py`` for the
+tool handler), stubbing the MCP loop so no real asyncio/event-loop plumbing
+is required.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_enrichment_lists_available_prompts(monkeypatch):
+    """available_prompts must carry the real prompt names from the server."""
+    from tools import mcp_tool
+
+    server = MagicMock()
+    server._rpc_lock = MagicMock()
+
+    fake_prompts = [MagicMock(name="get_prompt"),
+                    MagicMock(name="list_prompts")]
+    for p, n in zip(fake_prompts, ["get_prompt", "list_prompts"]):
+        p.name = n
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", lambda fn, timeout=30: fake_prompts)
+    monkeypatch.setattr(mcp_tool, "_mark_server_call_started", lambda s: None)
+    monkeypatch.setattr(mcp_tool, "_paginate_full_list",
+                        lambda method, attr, sname: _async_result(fake_prompts))
+
+    extra = mcp_tool._enrich_missing_prompt_error(
+        server, "evolution-implementation", "tqmemory", 30.0
+    )
+    assert extra["available_prompts"] == ["get_prompt", "list_prompts"]
+
+
+def test_enrichment_hint_for_skill_like_name():
+    """A name with '-' must get the skill_view suggestion in the hint."""
+    from tools import mcp_tool
+
+    monkeypatch_holder = pytest.MonkeyPatch()
+    monkeypatch_holder.setattr(mcp_tool, "_run_on_mcp_loop", lambda fn, timeout=30: [])
+    monkeypatch_holder.setattr(mcp_tool, "_mark_server_call_started", lambda s: None)
+
+    extra = mcp_tool._enrich_missing_prompt_error(
+        MagicMock(), "issue-lookup", "tqmemory", 30.0
+    )
+    assert "skill_view(name='issue-lookup')" in extra["hint"]
+    assert "skills, not prompts" in extra["hint"]
+    monkeypatch_holder.undo()
+
+
+def test_enrichment_hint_for_underscore_name():
+    """A name with '_' must also get the skill_view suggestion."""
+    from tools import mcp_tool
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(mcp_tool, "_run_on_mcp_loop", lambda fn, timeout=30: [])
+    mp.setattr(mcp_tool, "_mark_server_call_started", lambda s: None)
+
+    extra = mcp_tool._enrich_missing_prompt_error(
+        MagicMock(), "semantic_search", "tqmemory", 30.0
+    )
+    assert "skill_view(name='semantic_search')" in extra["hint"]
+    mp.undo()
+
+
+def test_enrichment_hint_for_plain_name_no_skill_suggestion():
+    """A name without '-' or '_' must NOT get the skill_view suggestion."""
+    from tools import mcp_tool
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(mcp_tool, "_run_on_mcp_loop", lambda fn, timeout=30: [])
+    mp.setattr(mcp_tool, "_mark_server_call_started", lambda s: None)
+
+    extra = mcp_tool._enrich_missing_prompt_error(
+        MagicMock(), "getprompt", "tqmemory", 30.0
+    )
+    assert "skill_view" not in extra["hint"]
+    mp.undo()
+
+
+def test_enrichment_degrades_gracefully_when_list_fails():
+    """If the list_prompts call itself raises, available_prompts must be []
+    and the hint must still be a usable string (no exception escapes)."""
+    from tools import mcp_tool
+
+    def boom(fn, timeout=30):
+        raise RuntimeError("server gone")
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(mcp_tool, "_run_on_mcp_loop", boom)
+    mp.setattr(mcp_tool, "_mark_server_call_started", lambda s: None)
+
+    extra = mcp_tool._enrich_missing_prompt_error(
+        MagicMock(), "evolution-implementation", "tqmemory", 30.0
+    )
+    assert extra["available_prompts"] == []
+    assert "Use list_prompts" in extra["hint"]
+    mp.undo()
+
+
+def test_error_json_carries_enrichment_fields():
+    """The full tool_error JSON for an unknown-prompt failure must contain
+    both the original error text and the enrichment fields."""
+    from tools.registry import tool_error
+
+    base_msg = "MCP call failed: McpError: Unknown prompt: evolution-implementation"
+    extra = {"available_prompts": ["get_prompt"], "hint": "use skill_view(...)"}
+    payload = json.loads(tool_error(base_msg, **extra))
+    assert payload["error"] == base_msg
+    assert payload["available_prompts"] == ["get_prompt"]
+    assert "skill_view" in payload["hint"]
+
+
+class _async_result:
+    """Tiny awaitable stand-in for _paginate_full_list in tests that patch it."""
+    def __init__(self, value):
+        self._value = value
+
+    def __await__(self):
+        yield
+        return self._value

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5951,13 +5951,8 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             )
             unknown = _is_unknown_prompt_error(exc)
             if unknown:
-                try:
-                    extra = _enrich_missing_prompt_error(
-                        server, name, server_name, tool_timeout
-                    )
-                    return tool_error(err_msg, **extra)
-                except Exception:
-                    pass
+                # Build a backward-compatible hint that mentions skill_view and
+                # list_prompts (existing tests check payload["error"] for these).
                 hint = (
                     f"MCP server '{server_name}' has no prompt named "
                     f"'{unknown}'. This name may be a Hermes skill rather "
@@ -5966,6 +5961,14 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                     f"list available prompts with "
                     f"{mcp_prefixed_tool_name(server_name, 'list_prompts')}."
                 )
+                # Try to enrich with the list of actually-available prompts.
+                try:
+                    extra = _enrich_missing_prompt_error(
+                        server, name, server_name, tool_timeout
+                    )
+                    return tool_error(hint, **extra)
+                except Exception:
+                    pass
                 return tool_error(hint)
             return tool_error(err_msg)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1212,6 +1212,8 @@ class MissingMcpCommandError(NonMcpEndpointError):
     collapsing what used to be a 189-failure/scan retry storm (e.g.
     ``turbo-memory-mcp`` missing from ``PATH``) into one actionable error.
     """
+
+
 def _unwrap_exception_group(exc: BaseException) -> BaseException:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -3351,7 +3353,7 @@ class MCPServerTask:
                         else:
                             self.initialize_result = await asyncio.wait_for(
                                 session.initialize(), timeout=float(connect_timeout)
-                        )
+                            )
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
@@ -5797,6 +5799,60 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     return _handler
 
 
+def _enrich_missing_prompt_error(
+    server, requested_name: str, server_name: str, tool_timeout: float
+) -> dict:
+    """Build enrichment fields for an ``Unknown prompt`` error (#1687).
+
+    When the MCP server rejects a prompt name, the bare error message gives the
+    agent no recovery path — it retries with other non-existent names, wasting
+    tool calls.  This helper returns a dict with:
+
+    - ``available_prompts``: the real prompt names on the server (empty list if
+      the list call itself fails).
+    - ``hint``: a recovery directive.  If *requested_name* looks like a skill
+      (contains ``-`` or ``_``), the hint suggests ``skill_view(name=...)``; this
+      covers the common case where the agent/cron confuses a skill name
+      (``evolution-implementation``, ``semantic_search``) with a prompt name.
+
+    All exceptions are swallowed — enrichment is best-effort and must never
+    mask the original error.
+    """
+    available: list[str] = []
+    try:
+
+        async def _list():
+            _mark_server_call_started(server)
+            async with server._rpc_lock:
+                all_prompts = await _paginate_full_list(
+                    server.session.list_prompts, "prompts", server_name
+                )
+            return all_prompts
+
+        prompt_objs = _run_on_mcp_loop(_list, timeout=tool_timeout)
+        for p in prompt_objs:
+            if hasattr(p, "name") and p.name:
+                available.append(p.name)
+    except Exception:
+        available = []
+
+    hint = (
+        f"Prompt '{requested_name}' was not found. "
+        f"Use list_prompts to see all available prompts."
+    )
+    # Skill-like names (dashes or underscores) are almost certainly Hermes skills,
+    # not MCP prompts — suggest skill_view to break the retry spiral (#1687).
+    if "-" in requested_name or "_" in requested_name:
+        hint = (
+            f"'{requested_name}' looks like a skill name, not a prompt name. "
+            f"Try skill_view(name='{requested_name}') instead — "
+            f"skills, not prompts, use dash/underscore names. "
+            f"Use list_prompts to see all available prompts."
+        )
+
+    return {"available_prompts": available, "hint": hint}
+
+
 def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that gets a prompt by name from an MCP server."""
 
@@ -5863,11 +5919,19 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                 server_name,
                 exc,
             )
-            return tool_error(
-                _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-                )
+            err_msg = _sanitize_error(
+                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
             )
+            err_lower = _exc_str(exc).lower()
+            if "unknown prompt" in err_lower or "not found" in err_lower:
+                try:
+                    extra = _enrich_missing_prompt_error(
+                        server, name, server_name, tool_timeout
+                    )
+                    return tool_error(err_msg, **extra)
+                except Exception:
+                    pass  # enrichment is best-effort — fall through to plain error
+            return tool_error(err_msg)
 
     return _handler
 


### PR DESCRIPTION
## Summary

When the tqmemory MCP server returns `Unknown prompt: <name>` (because the agent/cron asked for a skill name like `evolution-implementation`, `issue-lookup`, or `semantic_search`), the `get_prompt` handler now enriches the error JSON with:

1. **`available_prompts`** — the real prompt names on the server (via `list_prompts`)
2. **`hint`** — a recovery directive that suggests `skill_view(name=...)` for dash/underscore names

This breaks the retry spiral where the agent gets an opaque error and retries with other non-existent prompt names.

## Implementation

- `_enrich_missing_prompt_error()` — best-effort helper that lists available prompts and generates a contextual hint.
- Modified the `except` block in `_make_get_prompt_handler` to combine main's `_is_unknown_prompt_error` detection with the enrichment helper, returning the backward-compatible hint in `payload['error']` plus enrichment fields as extra JSON keys.

## Conflict resolution

This branch was rebased onto current main (which already has `_is_unknown_prompt_error`), merging both approaches: the hint string goes in `error` (backward compat with test_get_prompt_unknown_prompt_hint) and `available_prompts` is an extra JSON field.

Closes #1687