### PR TITLE
feat: enable Anthropic server-side compaction (Closes #1688)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -340,6 +340,45 @@ _CONTEXT_1M_BETA = "context-1m-2025-08-07"
 # See https://platform.claude.com/docs/en/build-with-claude/fast-mode
 _FAST_MODE_BETA = "fast-mode-2026-02-01"
 
+# Server-side compaction beta. Enables ``context_management.edits`` with
+# ``compact_20260112`` on Claude 4.6+. Note the hyphens in the header name
+# vs the underscores in the request-body type identifier — getting this
+# wrong silently disables the feature.
+_COMPACTION_BETA = "compact-2026-01-12"
+
+# Cache of server-side compaction config (`compaction.enabled`, optional
+# `compaction.instructions`). Loaded once per process; config edits require a
+# restart to take effect — acceptable for a static feature gate + hint.
+_compaction_config_cache: Optional[tuple] = None
+_compaction_config_loaded = False
+
+
+def _compaction_config() -> tuple:
+    """Return ``(enabled, instructions)`` from the ``compaction`` config section.
+
+    ``enabled`` defaults True; a config-load failure also defaults to enabled so
+    a broken config never silently disables the feature. ``instructions`` is the
+    optional summarization hint ("" = use Anthropic's built-in summarizer).
+    """
+    global _compaction_config_cache, _compaction_config_loaded
+    if _compaction_config_loaded:
+        return _compaction_config_cache or (True, "")
+    enabled, instructions = True, ""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        section = (load_config_readonly() or {}).get("compaction")
+        if isinstance(section, dict):
+            enabled = section.get("enabled", True)
+            raw = section.get("instructions", "")
+            instructions = raw if isinstance(raw, str) else ""
+    except Exception:
+        enabled, instructions = True, ""
+    finally:
+        _compaction_config_loaded = True
+        _compaction_config_cache = (bool(enabled), instructions)
+    return _compaction_config_cache
+
 # Additional beta headers required for OAuth/subscription auth.
 # Matches what Claude Code (and pi-ai / OpenCode) send.
 _OAUTH_ONLY_BETAS = [
@@ -2917,6 +2956,38 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    # ── Server-side compaction (compact_20260112) ────────────────────
+    # GA on Claude 4.6+ (adaptive thinking). Anthropic summarizes the
+    # conversation server-side when input tokens cross the trigger
+    # threshold. Applied ONLY on the native Anthropic provider with a
+    # compaction-capable (adaptive-thinking, 4.6+) Claude model — third-party
+    # anthropic_messages endpoints (MiniMax, Kimi, DeepSeek, Nous Portal) and
+    # legacy manual-thinking Claude families reject the beta/parameter.
+    # Opt out via config `compaction.enabled: false`.
+    _compaction_enabled, _compaction_instructions = _compaction_config()
+    if (
+        _compaction_enabled
+        and not _is_third_party_anthropic_endpoint(base_url)
+        and _supports_adaptive_thinking(model)
+    ):
+        edit: Dict[str, Any] = {"type": "compact_20260112"}
+        if _compaction_instructions:
+            edit["instructions"] = _compaction_instructions
+        kwargs["context_management"] = {"edits": [edit]}
+        # Merge the compaction beta into the per-request header so it co-exists
+        # with fast mode / OAuth betas (per-request extra_headers override the
+        # client-level anthropic-beta header, so include ALL applicable betas).
+        existing_betas = []
+        if isinstance(kwargs.get("extra_headers"), dict):
+            _existing = kwargs["extra_headers"].get("anthropic-beta")
+            if isinstance(_existing, str) and _existing:
+                existing_betas = [b for b in _existing.split(",") if b]
+        if _COMPACTION_BETA not in existing_betas:
+            existing_betas.append(_COMPACTION_BETA)
+        kwargs.setdefault("extra_headers", {})["anthropic-beta"] = ",".join(
+            existing_betas
+        )
 
     return kwargs
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -713,6 +713,20 @@ DEFAULT_CONFIG = {
     "prompt_caching": {
         "cache_ttl": "5m",
     },
+    # Anthropic server-side context compaction (compact_20260112, GA on Claude
+    # 4.6+). When enabled, Hermes sends `context_management.edits:
+    # [{"type":"compact_20260112"}]` + the `compact-2026-01-12` beta header on
+    # native-Anthropic Claude 4.6+ requests so Anthropic summarizes the
+    # conversation server-side when input tokens cross the trigger threshold
+    # (min 50K, default 150K). Applied ONLY to the genuine Anthropic provider
+    # with an adaptive-thinking (4.6+) Claude model — third-party
+    # anthropic_messages endpoints (MiniMax, Kimi, DeepSeek, Nous Portal) and
+    # older Claude families are never touched. Set `enabled: false` to opt out.
+    # `instructions` is optional custom summarization guidance sent to Claude.
+    "compaction": {
+        "enabled": True,
+        "instructions": "",
+    },
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1031,6 +1031,105 @@ class TestBuildAnthropicKwargs:
         assert "fast-mode-2026-02-01" not in beta_header
 
 
+class TestServerSideCompaction:
+    """Server-side compaction (compact_20260112) on native Anthropic 4.6+."""
+
+    def _build(self, model, base_url=None):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        return build_anthropic_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            base_url=base_url,
+        )
+
+    def test_native_adaptive_claude_enables_compaction(self):
+        from agent.anthropic_adapter import _COMPACTION_BETA
+
+        kwargs = self._build("claude-opus-4-6")
+        assert kwargs["context_management"] == {
+            "edits": [{"type": "compact_20260112"}]
+        }
+        beta_header = (kwargs.get("extra_headers") or {}).get("anthropic-beta", "")
+        assert _COMPACTION_BETA in beta_header
+
+    def test_native_adaptive_claude_sonnet_enables_compaction(self):
+        kwargs = self._build("claude-sonnet-4-6")
+        assert kwargs["context_management"] == {
+            "edits": [{"type": "compact_20260112"}]
+        }
+
+    def test_third_party_endpoint_skips_compaction(self):
+        """MiniMax/Kimi/Foundry must not receive the Anthropic beta/param."""
+        for base_url in (
+            "https://api.minimax.io/anthropic/v1",
+            "https://api.kimi.com/coding",
+        ):
+            kwargs = self._build("claude-opus-4-6", base_url=base_url)
+            assert "context_management" not in kwargs
+            beta_header = (kwargs.get("extra_headers") or {}).get(
+                "anthropic-beta", ""
+            )
+            assert "compact-2026-01-12" not in beta_header
+
+    def test_legacy_manual_thinking_claude_skips_compaction(self):
+        """Claude 3.x / 4.5 (manual thinking) predate the compaction API."""
+        for model in ("claude-sonnet-4-5", "claude-3-5-sonnet"):
+            kwargs = self._build(model)
+            assert "context_management" not in kwargs
+
+    def test_disabled_via_config_skips_compaction(self):
+        from agent import anthropic_adapter
+
+        with patch.object(anthropic_adapter, "_compaction_config", return_value=(False, "")):
+            kwargs = self._build("claude-opus-4-6")
+        assert "context_management" not in kwargs
+        beta_header = (kwargs.get("extra_headers") or {}).get("anthropic-beta", "")
+        assert "compact-2026-01-12" not in beta_header
+
+    def test_custom_instructions_added(self):
+        from agent import anthropic_adapter
+
+        with patch.object(
+            anthropic_adapter,
+            "_compaction_config",
+            return_value=(True, "Preserve code snippets and technical decisions."),
+        ):
+            kwargs = self._build("claude-opus-4-6")
+        assert kwargs["context_management"] == {
+            "edits": [
+                {
+                    "type": "compact_20260112",
+                    "instructions": "Preserve code snippets and technical decisions.",
+                }
+            ]
+        }
+
+    def test_compaction_beta_merges_with_fast_mode_beta(self):
+        """Compaction + fast-mode beta headers must co-exist in one header."""
+        from agent.anthropic_adapter import (
+            _COMPACTION_BETA,
+            _FAST_MODE_BETA,
+            build_anthropic_kwargs,
+        )
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            fast_mode=True,
+        )
+        assert kwargs.get("extra_body", {}).get("speed") == "fast"
+        beta_header = (kwargs.get("extra_headers") or {}).get("anthropic-beta", "")
+        assert _COMPACTION_BETA in beta_header
+        assert _FAST_MODE_BETA in beta_header
+
+
 
 
 

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -283,7 +283,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         assert _FAST_MODE_BETA in kwargs["extra_headers"].get("anthropic-beta", "")
 
     def test_fast_mode_off_no_speed(self):
-        from agent.anthropic_adapter import build_anthropic_kwargs
+        from agent.anthropic_adapter import build_anthropic_kwargs, _COMPACTION_BETA
 
         kwargs = build_anthropic_kwargs(
             model="claude-opus-4-6",
@@ -295,7 +295,12 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         )
         assert kwargs.get("extra_body", {}).get("speed") is None
         assert "speed" not in kwargs
-        assert "extra_headers" not in kwargs
+        # The fast-mode beta must NOT be present when fast mode is off.
+        beta_header = (kwargs.get("extra_headers") or {}).get("anthropic-beta", "")
+        assert "fast-mode-2026-02-01" not in beta_header
+        # Server-side compaction (default-on for native Claude 4.6+) legitimately
+        # adds its own beta header — assert that co-existence.
+        assert _COMPACTION_BETA in beta_header
 
     def test_fast_mode_skipped_for_third_party_endpoint(self):
         from agent.anthropic_adapter import build_anthropic_kwargs


### PR DESCRIPTION
Automated evolution PR for issue #1688.

## What
Enables Anthropic's server-side **Compaction API** (`compact_20260112`) for genuine Anthropic API calls. Hermes now sends:

- `context_management: {"edits": [{"type": "compact_20260112"}]}`
- the `anthropic-beta: compact-2026-01-12` header

on native-Anthropic requests with a **Claude 4.6+ (adaptive-thinking)** model, so Anthropic summarizes the conversation server-side when input tokens cross the trigger threshold (min 50K, default 150K).

## Gating (third-party providers unaffected)
Applied ONLY when ALL hold:
- config `compaction.enabled` is true (default true; opt out via `compaction.enabled: false`)
- the endpoint is genuine Anthropic (`_is_third_party_anthropic_endpoint` false) — MiniMax, Kimi, DeepSeek, Nous Portal, Foundry, Bedrock are excluded
- the model is adaptive-thinking 4.6+ Claude (`_supports_adaptive_thinking` true) — Claude 3.x/4.5 legacy manual-thinking families excluded

Optional `compaction.instructions` config supplies custom summarization guidance.

## Files
- `agent/anthropic_adapter.py` — `_COMPACTION_BETA`, `_compaction_config()`, injection in `build_anthropic_kwargs` (merges with fast-mode/OAuth betas)
- `hermes_cli/config_defaults.py` — `compaction` config section (default enabled)
- `tests/agent/test_anthropic_adapter.py` — 7 new `TestServerSideCompaction` tests
- `tests/cli/test_fast_command.py` — updated fast-mode test to assert beta coexistence

## Validation
- `ruff check .` — pass (blocking CI gate)
- `tests/agent/test_anthropic_adapter.py` — 91 passed
- `tests/cli/test_fast_command.py` — 19 passed

Note: the pre-PR `tests/hermes_cli` shard reports a pre-existing failure (`test_runtime_zai`, zai provider api_mode) that reproduces identically on clean `main` without these changes — unrelated to this PR.

Closes #1688