### PR TITLE
fix: guard against web_search retry spiral with consecutive-search streak (#1704)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -385,6 +385,11 @@ DEFAULT_CONFIG = {
         "extract_backend": "",  # per-capability override for web_extract (e.g. "native")
         "search_backend_fallback_chain": "",
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        # #1704 — after this many consecutive web_search calls with no
+        # intervening action/synthesis tool, append a fallback_directive to the
+        # result steering the model to synthesize results or change approach
+        # rather than re-querying. 0 disables. Range 0..20.
+        "search_streak_threshold": 5,
     },
     "browser": {
         "inactivity_timeout": 120,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -385,10 +385,7 @@ DEFAULT_CONFIG = {
         "extract_backend": "",  # per-capability override for web_extract (e.g. "native")
         "search_backend_fallback_chain": "",
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
-        # #1704 — after this many consecutive web_search calls with no
-        # intervening action/synthesis tool, append a fallback_directive to the
-        # result steering the model to synthesize results or change approach
-        # rather than re-querying. 0 disables. Range 0..20.
+        # #1704 — consecutive web_search calls before appending a fallback_directive steering the model to synthesize or change approach. 0 disables.
         "search_streak_threshold": 5,
     },
     "browser": {

--- a/model_tools.py
+++ b/model_tools.py
@@ -1520,6 +1520,16 @@ def handle_function_call(
             except Exception:
                 pass  # file_tools may not be loaded yet
 
+        # #1704 — reset the web_search consecutive-search streak whenever a
+        # non-web_search tool runs (the model acted on/abandoned results).
+        if function_name != "web_search":
+            try:
+                from tools.web_tools import reset_web_search_streak
+
+                reset_web_search_streak(session_id)
+            except Exception:
+                pass  # web_tools may not be loaded yet
+
         # Deterministic tool-argument contract check (issue #904). Re-checks
         # the final, post-coercion/post-middleware arguments against the
         # tool's own registered schema (``required`` fields, ``enum``

--- a/tests/tools/test_web_search_streak.py
+++ b/tests/tools/test_web_search_streak.py
@@ -1,9 +1,8 @@
 """Tests for the #1704 web_search consecutive-search streak guard.
 
-Mirrors the tool_search streak tests (#1144/#1373): a per-session counter of
-consecutive web_search calls with no intervening action/synthesis tool, which
-crosses ``web.search_streak_threshold`` and appends a ``fallback_directive``
-steering the model to synthesize or change approach.
+Mirrors tool_search streak tests (#1144/#1373): a per-session counter of
+consecutive web_search calls with no intervening action/synthesis tool that
+crosses ``web.search_streak_threshold`` and appends a ``fallback_directive``.
 """
 
 import json
@@ -20,86 +19,76 @@ def clear_streak():
     web_tools._web_search_streak.clear()
 
 
-class TestStreakCounter:
-    def test_note_increments_and_reset_clears(self):
-        from tools.web_tools import note_web_search, reset_web_search_streak
+def test_note_increments_and_reset_clears():
+    from tools.web_tools import note_web_search, reset_web_search_streak
 
-        assert note_web_search("sess-a") == 1
-        assert note_web_search("sess-a") == 2
-        reset_web_search_streak("sess-a")
-        assert note_web_search("sess-a") == 1  # fresh again
-
-    def test_none_session_not_tracked(self):
-        from tools.web_tools import _web_search_streak, note_web_search
-
-        assert note_web_search(None) == 0
-        assert _web_search_streak == {}
-
-    def test_empty_session_tracked_under_default_key(self):
-        """Runtime sends ``agent.session_id or ""`` — must still fire (#1373)."""
-        from tools.web_tools import (
-            _web_search_default_key,
-            _web_search_streak,
-            note_web_search,
-        )
-
-        assert note_web_search("") == 1
-        assert _web_search_streak[_web_search_default_key] == 1
-
-    def test_sessions_tracked_independently(self):
-        from tools.web_tools import note_web_search
-
-        assert note_web_search("x") == 1
-        assert note_web_search("y") == 1
-        assert note_web_search("x") == 2
+    assert note_web_search("sess-a") == 1
+    assert note_web_search("sess-a") == 2
+    reset_web_search_streak("sess-a")
+    assert note_web_search("sess-a") == 1  # fresh again
 
 
-class TestThresholdAndDirective:
-    def test_threshold_resolution(self, monkeypatch):
-        from tools.web_tools import (
-            DEFAULT_WEB_SEARCH_STREAK_THRESHOLD,
-            _get_web_search_streak_threshold,
-        )
+def test_none_session_not_tracked():
+    from tools.web_tools import _web_search_streak, note_web_search
 
-        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
-        assert _get_web_search_streak_threshold() == DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
-        monkeypatch.setattr(
-            "tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 0}
-        )
-        assert _get_web_search_streak_threshold() == 0  # 0 disables
-        monkeypatch.setattr(
-            "tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 999}
-        )
-        assert _get_web_search_streak_threshold() == 20  # clamped
+    assert note_web_search(None) == 0
+    assert _web_search_streak == {}
 
-    def test_directive_steers_to_synthesize(self):
-        from tools.web_tools import _web_search_fallback_directive
 
-        d = _web_search_fallback_directive(6)
-        assert "web_search 6 times" in d
-        assert "STOP re-querying" in d
-        assert "synthesize" in d
-        assert "web_extract" in d
+def test_empty_session_tracked_under_default_key():
+    """Runtime sends ``agent.session_id or ""`` — must still fire (#1373)."""
+    from tools.web_tools import (
+        _web_search_default_key,
+        _web_search_streak,
+        note_web_search,
+    )
 
-    def test_injected_directive_after_threshold(self, monkeypatch):
-        """Crossing the threshold yields a JSON-safe fallback_directive."""
-        from tools import web_tools
+    assert note_web_search("") == 1
+    assert _web_search_streak[_web_search_default_key] == 1
 
-        monkeypatch.setattr(
-            "tools.web_tools._get_web_search_streak_threshold", lambda: 3
-        )
-        web_tools._web_search_streak.clear()
-        web_tools.note_web_search("sess-d")
-        web_tools.note_web_search("sess-d")
-        streak = web_tools.note_web_search("sess-d")  # 3
 
-        payload = {"success": True, "data": {"web": [{"url": "x"}]}}
-        if web_tools._get_web_search_streak_threshold() > 0 and streak >= 3:
-            payload["fallback_directive"] = web_tools._web_search_fallback_directive(
-                streak
-            )
-        assert "STOP re-querying" in payload["fallback_directive"]
-        assert (
-            json.loads(json.dumps(payload))["fallback_directive"]
-            == payload["fallback_directive"]
-        )
+def test_threshold_resolution(monkeypatch):
+    from tools.web_tools import (
+        DEFAULT_WEB_SEARCH_STREAK_THRESHOLD,
+        _get_web_search_streak_threshold,
+    )
+
+    monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
+    assert _get_web_search_streak_threshold() == DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
+    cases = [
+        ({"search_streak_threshold": 0}, 0),  # 0 disables
+        ({"search_streak_threshold": 999}, 20),  # clamped to 20
+    ]
+    for cfg, expected in cases:
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda c=cfg: c)
+        assert _get_web_search_streak_threshold() == expected
+
+
+def test_directive_steers_to_synthesize():
+    from tools.web_tools import _web_search_fallback_directive
+
+    d = _web_search_fallback_directive(6)
+    assert "web_search 6 times" in d
+    assert "STOP re-querying" in d
+    assert "synthesize" in d
+    assert "web_extract" in d
+
+
+def test_injected_directive_after_threshold(monkeypatch):
+    """Crossing the threshold yields a JSON-safe fallback_directive."""
+    from tools import web_tools
+
+    monkeypatch.setattr("tools.web_tools._get_web_search_streak_threshold", lambda: 3)
+    web_tools._web_search_streak.clear()
+    web_tools.note_web_search("sess-d")
+    web_tools.note_web_search("sess-d")
+    streak = web_tools.note_web_search("sess-d")  # 3
+
+    payload = {"success": True, "data": {"web": [{"url": "x"}]}}
+    if web_tools._get_web_search_streak_threshold() > 0 and streak >= 3:
+        payload["fallback_directive"] = web_tools._web_search_fallback_directive(streak)
+    assert "STOP re-querying" in payload["fallback_directive"]
+    assert (
+        json.loads(json.dumps(payload))["fallback_directive"]
+        == payload["fallback_directive"]
+    )

--- a/tests/tools/test_web_search_streak.py
+++ b/tests/tools/test_web_search_streak.py
@@ -1,0 +1,96 @@
+"""Tests for the #1704 web_search consecutive-search streak guard.
+
+Mirrors the tool_search streak tests (#1144/#1373): a per-session counter of
+consecutive web_search calls with no intervening action/synthesis tool, which
+crosses ``web.search_streak_threshold`` and appends a ``fallback_directive``
+steering the model to synthesize or change approach.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_streak():
+    from tools import web_tools
+
+    web_tools._web_search_streak.clear()
+    yield
+    web_tools._web_search_streak.clear()
+
+
+class TestStreakCounter:
+    def test_note_increments_and_reset_clears(self):
+        from tools.web_tools import note_web_search, reset_web_search_streak
+
+        assert note_web_search("sess-a") == 1
+        assert note_web_search("sess-a") == 2
+        reset_web_search_streak("sess-a")
+        assert note_web_search("sess-a") == 1  # fresh again
+
+    def test_none_session_not_tracked(self):
+        from tools.web_tools import _web_search_streak, note_web_search
+
+        assert note_web_search(None) == 0
+        assert _web_search_streak == {}
+
+    def test_empty_session_tracked_under_default_key(self):
+        """Runtime sends ``agent.session_id or ""`` — must still fire (#1373)."""
+        from tools.web_tools import (
+            _web_search_default_key,
+            _web_search_streak,
+            note_web_search,
+        )
+
+        assert note_web_search("") == 1
+        assert _web_search_streak[_web_search_default_key] == 1
+
+    def test_sessions_tracked_independently(self):
+        from tools.web_tools import note_web_search
+
+        assert note_web_search("x") == 1
+        assert note_web_search("y") == 1
+        assert note_web_search("x") == 2
+
+
+class TestThresholdAndDirective:
+    def test_threshold_resolution(self, monkeypatch):
+        from tools.web_tools import (
+            DEFAULT_WEB_SEARCH_STREAK_THRESHOLD,
+            _get_web_search_streak_threshold,
+        )
+
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
+        assert (
+            _get_web_search_streak_threshold() == DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
+        )
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 0})
+        assert _get_web_search_streak_threshold() == 0  # 0 disables
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 999})
+        assert _get_web_search_streak_threshold() == 20  # clamped
+
+    def test_directive_steers_to_synthesize(self):
+        from tools.web_tools import _web_search_fallback_directive
+
+        d = _web_search_fallback_directive(6)
+        assert "web_search 6 times" in d
+        assert "STOP re-querying" in d
+        assert "synthesize" in d
+        assert "web_extract" in d
+
+    def test_injected_directive_after_threshold(self, monkeypatch):
+        """Crossing the threshold yields a JSON-safe fallback_directive."""
+        from tools import web_tools
+
+        monkeypatch.setattr("tools.web_tools._get_web_search_streak_threshold", lambda: 3)
+        web_tools._web_search_streak.clear()
+        web_tools.note_web_search("sess-d")
+        web_tools.note_web_search("sess-d")
+        streak = web_tools.note_web_search("sess-d")  # 3
+
+        payload = {"success": True, "data": {"web": [{"url": "x"}]}}
+        if web_tools._get_web_search_streak_threshold() > 0 and streak >= 3:
+            payload["fallback_directive"] = web_tools._web_search_fallback_directive(streak)
+        assert "STOP re-querying" in payload["fallback_directive"]
+        assert json.loads(json.dumps(payload))["fallback_directive"] == payload["fallback_directive"]

--- a/tests/tools/test_web_search_streak.py
+++ b/tests/tools/test_web_search_streak.py
@@ -62,12 +62,14 @@ class TestThresholdAndDirective:
         )
 
         monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
-        assert (
-            _get_web_search_streak_threshold() == DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
+        assert _get_web_search_streak_threshold() == DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 0}
         )
-        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 0})
         assert _get_web_search_streak_threshold() == 0  # 0 disables
-        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 999})
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config", lambda: {"search_streak_threshold": 999}
+        )
         assert _get_web_search_streak_threshold() == 20  # clamped
 
     def test_directive_steers_to_synthesize(self):
@@ -83,7 +85,9 @@ class TestThresholdAndDirective:
         """Crossing the threshold yields a JSON-safe fallback_directive."""
         from tools import web_tools
 
-        monkeypatch.setattr("tools.web_tools._get_web_search_streak_threshold", lambda: 3)
+        monkeypatch.setattr(
+            "tools.web_tools._get_web_search_streak_threshold", lambda: 3
+        )
         web_tools._web_search_streak.clear()
         web_tools.note_web_search("sess-d")
         web_tools.note_web_search("sess-d")
@@ -91,6 +95,11 @@ class TestThresholdAndDirective:
 
         payload = {"success": True, "data": {"web": [{"url": "x"}]}}
         if web_tools._get_web_search_streak_threshold() > 0 and streak >= 3:
-            payload["fallback_directive"] = web_tools._web_search_fallback_directive(streak)
+            payload["fallback_directive"] = web_tools._web_search_fallback_directive(
+                streak
+            )
         assert "STOP re-querying" in payload["fallback_directive"]
-        assert json.loads(json.dumps(payload))["fallback_directive"] == payload["fallback_directive"]
+        assert (
+            json.loads(json.dumps(payload))["fallback_directive"]
+            == payload["fallback_directive"]
+        )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -102,7 +102,11 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.url_safety import (
+    async_is_safe_url,
+    normalize_url_for_request,
+    sensitive_query_param_name,
+)
 import sys
 
 logger = logging.getLogger(__name__)
@@ -154,6 +158,7 @@ def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
         from hermes_cli.config import load_config
+
         # ``or {}``: a present-but-null ``web:`` section (YAML ``web:`` with no
         # body) makes ``.get("web", {})`` return None, which would break every
         # caller that does ``_load_web_config().get(...)``. Honor the ``-> dict``
@@ -175,9 +180,16 @@ def _load_web_config() -> dict:
 # ``has_xai_credentials()`` (env var OR auth.json OAuth), not a registered
 # WebSearchProvider. Keep the two sets aligned by hand: if xai ever ships as
 # a registered provider, drop it here so the registry path takes over.
-_LEGACY_WEB_BACKENDS = frozenset(
-    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
-)
+_LEGACY_WEB_BACKENDS = frozenset({
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "exa",
+    "searxng",
+    "brave-free",
+    "ddgs",
+    "xai",
+})
 
 
 def _registered_web_provider(backend: str):
@@ -235,7 +247,10 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in _LEGACY_WEB_BACKENDS or _registered_web_provider(configured) is not None:
+    if (
+        configured in _LEGACY_WEB_BACKENDS
+        or _registered_web_provider(configured) is not None
+    ):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -272,7 +287,9 @@ def _get_backend() -> str:
             if provider.is_available():
                 return provider.name
         except Exception as exc:  # noqa: BLE001 — a broken provider is skipped
-            logger.debug("web provider %r.is_available() raised: %s", provider.name, exc)
+            logger.debug(
+                "web provider %r.is_available() raised: %s", provider.name, exc
+            )
 
     return "firecrawl"  # default (backward compat)
 
@@ -584,7 +601,6 @@ def _web_search_fallback_directive(streak: int) -> str:
     )
 
 
-
 def convert_base64_images_to_links(text: str) -> str:
     """Replace inline base64 image blobs with labeled markdown links.
 
@@ -599,6 +615,7 @@ def convert_base64_images_to_links(text: str) -> str:
       ``(data:image/png;base64,AAAA...)``        -> ``[IMAGE]``
       bare ``data:image/...;base64,AAAA...``     -> ``[IMAGE]``
     """
+
     # 1. Markdown image with base64 source -> keep alt text, drop the blob.
     def _md_repl(m: "re.Match[str]") -> str:
         alt = (m.group("alt") or "").strip()
@@ -679,7 +696,7 @@ def _truncate_with_footer(
     # Snap the tail cut forward to the next newline for the same reason.
     nl = tail.find("\n")
     if 0 <= nl < tail_budget * 0.5:
-        tail = tail[nl + 1:]
+        tail = tail[nl + 1 :]
 
     total = len(content)
     stored_path = _store_full_text(url, content)
@@ -712,7 +729,6 @@ def _truncate_with_footer(
     model_text = head + "\n\n[... middle omitted — see footer ...]\n\n" + tail
     model_text += "\n" + "\n".join(footer_lines)
     return model_text, True
-
 
 
 # ─── Exa / Parallel inline helpers — moved into plugins ──────────────────────
@@ -871,8 +887,13 @@ def web_search_tool(
         # (the spiral is repeated *successful* re-queries, not failures).
         if not response_data.get("error") and response_data.get("success") is not False:
             streak = note_web_search(session_id)
-            if _get_web_search_streak_threshold() > 0 and streak >= _get_web_search_streak_threshold():
-                response_data["fallback_directive"] = _web_search_fallback_directive(streak)
+            if (
+                _get_web_search_streak_threshold() > 0
+                and streak >= _get_web_search_streak_threshold()
+            ):
+                response_data["fallback_directive"] = _web_search_fallback_directive(
+                    streak
+                )
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
         _debug.log_call("web_search_tool", debug_call_data)
@@ -982,7 +1003,7 @@ async def web_extract_tool(
         "original_response_size": 0,
         "final_response_size": 0,
         "truncation_metrics": [],
-        "processing_applied": []
+        "processing_applied": [],
     }
 
     try:
@@ -995,7 +1016,9 @@ async def web_extract_tool(
         for index, url in zip(normalized_indices, normalized_urls):
             if not await async_is_safe_url(url):
                 ssrf_blocked[index] = {
-                    "url": url, "title": "", "content": "",
+                    "url": url,
+                    "title": "",
+                    "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 }
             else:
@@ -1121,7 +1144,9 @@ async def web_extract_tool(
         debug_call_data["pages_extracted"] = pages_extracted
         debug_call_data["original_response_size"] = len(json.dumps(response))
 
-        effective_char_limit = char_limit if char_limit is not None else _get_extract_char_limit()
+        effective_char_limit = (
+            char_limit if char_limit is not None else _get_extract_char_limit()
+        )
         try:
             effective_char_limit = max(2000, min(int(effective_char_limit), 500_000))
         except (TypeError, ValueError):
@@ -1140,7 +1165,9 @@ async def web_extract_tool(
             if not raw_content:
                 continue
             clean = convert_base64_images_to_links(raw_content)
-            model_text, truncated = _truncate_with_footer(clean, url, effective_char_limit)
+            model_text, truncated = _truncate_with_footer(
+                clean, url, effective_char_limit
+            )
             result["content"] = model_text
             if truncated:
                 debug_call_data["pages_truncated"] += 1
@@ -1149,7 +1176,9 @@ async def web_extract_tool(
                     "original_size": len(clean),
                     "sent_size": len(model_text),
                 })
-                logger.info("%s (truncated %d -> %d chars)", url, len(clean), len(model_text))
+                logger.info(
+                    "%s (truncated %d -> %d chars)", url, len(clean), len(model_text)
+                )
             else:
                 logger.info("%s (%d chars, whole)", url, len(clean))
 
@@ -1182,7 +1211,7 @@ async def web_extract_tool(
 
         debug_call_data["final_response_size"] = len(cleaned_result)
         debug_call_data["processing_applied"].append("base64_image_conversion")
-        
+
         # Log debug information
         _debug.log_call("web_extract_tool", debug_call_data)
         _debug.save()
@@ -1250,6 +1279,7 @@ if __name__ == "__main__":
     web_available = check_web_api_key()
     tool_gateway_available = _is_tool_gateway_ready()
     from hermes_cli.config import get_env_value as _gev
+
     firecrawl_key_available = bool((_gev("FIRECRAWL_API_KEY") or "").strip())
     firecrawl_url_available = bool((_gev("FIRECRAWL_API_URL") or "").strip())
 
@@ -1269,7 +1299,9 @@ if __name__ == "__main__":
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
         elif firecrawl_url_available:
-            print(f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}")
+            print(
+                f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}"
+            )
         elif firecrawl_key_available:
             print("   Using direct Firecrawl cloud API")
         elif tool_gateway_available:
@@ -1287,8 +1319,10 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print("🛠️  Web tools ready for use!")
-    print(f"   Extract char limit: {_get_extract_char_limit()} chars "
-          "(pages over this are truncated; full text stored in cache/web)")
+    print(
+        f"   Extract char limit: {_get_extract_char_limit()} chars "
+        "(pages over this are truncated; full text stored in cache/web)"
+    )
 
     # Show debug mode status
     if _debug.active:
@@ -1310,7 +1344,9 @@ if __name__ == "__main__":
     print("  async def main():")
     print("      content = await web_extract_tool(['https://example.com'])")
     print("      # bigger budget for one call:")
-    print("      content = await web_extract_tool(['https://docs.python.org'], char_limit=40000)")
+    print(
+        "      content = await web_extract_tool(['https://docs.python.org'], char_limit=40000)"
+    )
     print("  asyncio.run(main())")
 
     print("\nDebug mode:")
@@ -1355,13 +1391,13 @@ WEB_EXTRACT_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
-                "maxItems": 5
+                "maxItems": 5,
             },
             "char_limit": {
                 "type": "integer",
                 "description": "Optional per-page character budget sent back (default 15000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
-                "minimum": 2000
-            }
+                "minimum": 2000,
+            },
         },
         "required": ["urls"],
     },

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -41,6 +41,7 @@ import logging
 import os
 import re
 import asyncio
+import threading
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx  # noqa: F401 — kept at module top so tests can patch tools.web_tools.httpx
 
@@ -515,6 +516,75 @@ def _get_extract_char_limit() -> int:
     return DEFAULT_EXTRACT_CHAR_LIMIT
 
 
+# ── #1704 — consecutive web_search streak guard ────────────────────────────
+# Mirrors tool_search's streak guard (#1144/#1373): a per-session counter of
+# consecutive web_search calls with no intervening action tool. Crossing
+# ``web.search_streak_threshold`` appends a fallback_directive steering the
+# model to synthesize or change approach. Resets on any non-web_search tool.
+# Keyed by session_id; an empty-string id falls back to a default key so the
+# feature fires in the production runtime (#1373 lesson); None opts out.
+_web_search_lock = threading.Lock()
+_web_search_streak: Dict[str, int] = {}
+
+#: Sentinel key for an empty-string session id.
+_web_search_default_key = "__default_web_search_session__"
+
+#: Default consecutive-search threshold (config-overridable via web.search_streak_threshold).
+DEFAULT_WEB_SEARCH_STREAK_THRESHOLD = 5
+
+
+def _web_search_streak_key(session_id: Optional[str]) -> Optional[str]:
+    """Resolve a session_id to a web_search streak-tracking key."""
+    if session_id is None:
+        return None
+    if session_id == "":
+        return _web_search_default_key
+    return session_id
+
+
+def _get_web_search_streak_threshold() -> int:
+    """Resolve the consecutive-search threshold from config, clamped 0..20."""
+    try:
+        configured = _load_web_config().get("search_streak_threshold")
+        if configured is not None:
+            return max(0, min(int(configured), 20))
+    except (TypeError, ValueError):
+        pass
+    return DEFAULT_WEB_SEARCH_STREAK_THRESHOLD
+
+
+def note_web_search(session_id: Optional[str]) -> int:
+    """Increment the consecutive web_search streak for ``session_id``."""
+    key = _web_search_streak_key(session_id)
+    if key is None:
+        return 0
+    with _web_search_lock:
+        _web_search_streak[key] = _web_search_streak.get(key, 0) + 1
+        return _web_search_streak[key]
+
+
+def reset_web_search_streak(session_id: Optional[str]) -> None:
+    """Reset the streak — the model acted on (or abandoned) results."""
+    key = _web_search_streak_key(session_id)
+    if key is None:
+        return
+    with _web_search_lock:
+        _web_search_streak.pop(key, None)
+
+
+def _web_search_fallback_directive(streak: int) -> str:
+    """The nudge appended to a web_search result when the streak is high."""
+    return (
+        f"You have run web_search {streak} times in a row without an intervening "
+        "action. STOP re-querying and either: (a) synthesize the results you "
+        "already have into a decision or write, (b) extract a specific page "
+        "with web_extract to get full content, or (c) try a fundamentally "
+        "different approach (terminal, files, or direct action) instead of "
+        "another web search."
+    )
+
+
+
 def convert_base64_images_to_links(text: str) -> str:
     """Replace inline base64 image blobs with labeled markdown links.
 
@@ -683,7 +753,9 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(
+    query: str, limit: int = 5, session_id: Optional[str] = None
+) -> str:
     """
     Search the web for information using available search API backend.
 
@@ -795,6 +867,12 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         debug_call_data["parameters"]["provider"] = response_data.get(
             "provider", provider.name if provider else None
         )
+        # #1704 — consecutive-search streak guard. Only on SUCCESSFUL searches
+        # (the spiral is repeated *successful* re-queries, not failures).
+        if not response_data.get("error") and response_data.get("success") is not False:
+            streak = note_web_search(session_id)
+            if _get_web_search_streak_threshold() > 0 and streak >= _get_web_search_streak_threshold():
+                response_data["fallback_directive"] = _web_search_fallback_directive(streak)
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
         _debug.log_call("web_search_tool", debug_call_data)
@@ -1294,7 +1372,9 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(
-        args.get("query", ""), limit=args.get("limit", 5)
+        args.get("query", ""),
+        limit=args.get("limit", 5),
+        session_id=kw.get("session_id"),
     ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -102,11 +102,7 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import (
-    async_is_safe_url,
-    normalize_url_for_request,
-    sensitive_query_param_name,
-)
+from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
 import sys
 
 logger = logging.getLogger(__name__)
@@ -158,7 +154,6 @@ def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
         from hermes_cli.config import load_config
-
         # ``or {}``: a present-but-null ``web:`` section (YAML ``web:`` with no
         # body) makes ``.get("web", {})`` return None, which would break every
         # caller that does ``_load_web_config().get(...)``. Honor the ``-> dict``
@@ -180,16 +175,9 @@ def _load_web_config() -> dict:
 # ``has_xai_credentials()`` (env var OR auth.json OAuth), not a registered
 # WebSearchProvider. Keep the two sets aligned by hand: if xai ever ships as
 # a registered provider, drop it here so the registry path takes over.
-_LEGACY_WEB_BACKENDS = frozenset({
-    "parallel",
-    "firecrawl",
-    "tavily",
-    "exa",
-    "searxng",
-    "brave-free",
-    "ddgs",
-    "xai",
-})
+_LEGACY_WEB_BACKENDS = frozenset(
+    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
+)
 
 
 def _registered_web_provider(backend: str):
@@ -247,10 +235,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if (
-        configured in _LEGACY_WEB_BACKENDS
-        or _registered_web_provider(configured) is not None
-    ):
+    if configured in _LEGACY_WEB_BACKENDS or _registered_web_provider(configured) is not None:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -287,9 +272,7 @@ def _get_backend() -> str:
             if provider.is_available():
                 return provider.name
         except Exception as exc:  # noqa: BLE001 — a broken provider is skipped
-            logger.debug(
-                "web provider %r.is_available() raised: %s", provider.name, exc
-            )
+            logger.debug("web provider %r.is_available() raised: %s", provider.name, exc)
 
     return "firecrawl"  # default (backward compat)
 
@@ -534,12 +517,12 @@ def _get_extract_char_limit() -> int:
 
 
 # ── #1704 — consecutive web_search streak guard ────────────────────────────
-# Mirrors tool_search's streak guard (#1144/#1373): a per-session counter of
-# consecutive web_search calls with no intervening action tool. Crossing
+# Per-session counter of consecutive web_search calls with no intervening
+# action tool (mirrors tool_search #1144/#1373). Crossing
 # ``web.search_streak_threshold`` appends a fallback_directive steering the
-# model to synthesize or change approach. Resets on any non-web_search tool.
-# Keyed by session_id; an empty-string id falls back to a default key so the
-# feature fires in the production runtime (#1373 lesson); None opts out.
+# model to synthesize or change approach; resets on any non-web_search tool.
+# Keyed by session_id; empty-string id → default key so it fires in the
+# production runtime (#1373 lesson); None opts out.
 _web_search_lock = threading.Lock()
 _web_search_streak: Dict[str, int] = {}
 
@@ -615,7 +598,6 @@ def convert_base64_images_to_links(text: str) -> str:
       ``(data:image/png;base64,AAAA...)``        -> ``[IMAGE]``
       bare ``data:image/...;base64,AAAA...``     -> ``[IMAGE]``
     """
-
     # 1. Markdown image with base64 source -> keep alt text, drop the blob.
     def _md_repl(m: "re.Match[str]") -> str:
         alt = (m.group("alt") or "").strip()
@@ -696,7 +678,7 @@ def _truncate_with_footer(
     # Snap the tail cut forward to the next newline for the same reason.
     nl = tail.find("\n")
     if 0 <= nl < tail_budget * 0.5:
-        tail = tail[nl + 1 :]
+        tail = tail[nl + 1:]
 
     total = len(content)
     stored_path = _store_full_text(url, content)
@@ -729,6 +711,7 @@ def _truncate_with_footer(
     model_text = head + "\n\n[... middle omitted — see footer ...]\n\n" + tail
     model_text += "\n" + "\n".join(footer_lines)
     return model_text, True
+
 
 
 # ─── Exa / Parallel inline helpers — moved into plugins ──────────────────────
@@ -883,8 +866,8 @@ def web_search_tool(
         debug_call_data["parameters"]["provider"] = response_data.get(
             "provider", provider.name if provider else None
         )
-        # #1704 — consecutive-search streak guard. Only on SUCCESSFUL searches
-        # (the spiral is repeated *successful* re-queries, not failures).
+        # #1704 — streak guard. Only on SUCCESSFUL searches (the spiral is
+        # repeated *successful* re-queries, not failures).
         if not response_data.get("error") and response_data.get("success") is not False:
             streak = note_web_search(session_id)
             if (
@@ -1003,7 +986,7 @@ async def web_extract_tool(
         "original_response_size": 0,
         "final_response_size": 0,
         "truncation_metrics": [],
-        "processing_applied": [],
+        "processing_applied": []
     }
 
     try:
@@ -1016,9 +999,7 @@ async def web_extract_tool(
         for index, url in zip(normalized_indices, normalized_urls):
             if not await async_is_safe_url(url):
                 ssrf_blocked[index] = {
-                    "url": url,
-                    "title": "",
-                    "content": "",
+                    "url": url, "title": "", "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 }
             else:
@@ -1144,9 +1125,7 @@ async def web_extract_tool(
         debug_call_data["pages_extracted"] = pages_extracted
         debug_call_data["original_response_size"] = len(json.dumps(response))
 
-        effective_char_limit = (
-            char_limit if char_limit is not None else _get_extract_char_limit()
-        )
+        effective_char_limit = char_limit if char_limit is not None else _get_extract_char_limit()
         try:
             effective_char_limit = max(2000, min(int(effective_char_limit), 500_000))
         except (TypeError, ValueError):
@@ -1165,9 +1144,7 @@ async def web_extract_tool(
             if not raw_content:
                 continue
             clean = convert_base64_images_to_links(raw_content)
-            model_text, truncated = _truncate_with_footer(
-                clean, url, effective_char_limit
-            )
+            model_text, truncated = _truncate_with_footer(clean, url, effective_char_limit)
             result["content"] = model_text
             if truncated:
                 debug_call_data["pages_truncated"] += 1
@@ -1176,9 +1153,7 @@ async def web_extract_tool(
                     "original_size": len(clean),
                     "sent_size": len(model_text),
                 })
-                logger.info(
-                    "%s (truncated %d -> %d chars)", url, len(clean), len(model_text)
-                )
+                logger.info("%s (truncated %d -> %d chars)", url, len(clean), len(model_text))
             else:
                 logger.info("%s (%d chars, whole)", url, len(clean))
 
@@ -1211,7 +1186,7 @@ async def web_extract_tool(
 
         debug_call_data["final_response_size"] = len(cleaned_result)
         debug_call_data["processing_applied"].append("base64_image_conversion")
-
+        
         # Log debug information
         _debug.log_call("web_extract_tool", debug_call_data)
         _debug.save()
@@ -1279,7 +1254,6 @@ if __name__ == "__main__":
     web_available = check_web_api_key()
     tool_gateway_available = _is_tool_gateway_ready()
     from hermes_cli.config import get_env_value as _gev
-
     firecrawl_key_available = bool((_gev("FIRECRAWL_API_KEY") or "").strip())
     firecrawl_url_available = bool((_gev("FIRECRAWL_API_URL") or "").strip())
 
@@ -1299,9 +1273,7 @@ if __name__ == "__main__":
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
         elif firecrawl_url_available:
-            print(
-                f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}"
-            )
+            print(f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}")
         elif firecrawl_key_available:
             print("   Using direct Firecrawl cloud API")
         elif tool_gateway_available:
@@ -1319,10 +1291,8 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print("🛠️  Web tools ready for use!")
-    print(
-        f"   Extract char limit: {_get_extract_char_limit()} chars "
-        "(pages over this are truncated; full text stored in cache/web)"
-    )
+    print(f"   Extract char limit: {_get_extract_char_limit()} chars "
+          "(pages over this are truncated; full text stored in cache/web)")
 
     # Show debug mode status
     if _debug.active:
@@ -1344,9 +1314,7 @@ if __name__ == "__main__":
     print("  async def main():")
     print("      content = await web_extract_tool(['https://example.com'])")
     print("      # bigger budget for one call:")
-    print(
-        "      content = await web_extract_tool(['https://docs.python.org'], char_limit=40000)"
-    )
+    print("      content = await web_extract_tool(['https://docs.python.org'], char_limit=40000)")
     print("  asyncio.run(main())")
 
     print("\nDebug mode:")
@@ -1391,13 +1359,13 @@ WEB_EXTRACT_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
-                "maxItems": 5,
+                "maxItems": 5
             },
             "char_limit": {
                 "type": "integer",
                 "description": "Optional per-page character budget sent back (default 15000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
-                "minimum": 2000,
-            },
+                "minimum": 2000
+            }
         },
         "required": ["urls"],
     },


### PR DESCRIPTION
Automated evolution PR for issue #1704.

Implements a per-session consecutive web_search streak guard. When the model runs web_search N times in a row with no intervening action/synthesis tool, the result gains a `fallback_directive` steering it to synthesize, extract, or change approach instead of re-querying.

- Adds `note_web_search`/`reset_web_search_streak` streak tracking in tools/web_tools.py, keyed by session_id (empty-string id falls back to a default key so it fires in production; None opts out).
- Injects `fallback_directive` after `web.search_streak_threshold` consecutive successful searches.
- Resets the streak in model_tools.py on any non-web_search tool call.
- New config `web.search_streak_threshold` (default 5, 0 disables, clamped 0..20).
- Tests: tests/tools/test_web_search_streak.py (6 tests).

Closes #1704