### PR TITLE
fix: return actionable diagnostic for replace-mode with empty old_string (#1703)

### DIFF
--- a/tests/tools/test_patch_empty_old_string.py
+++ b/tests/tools/test_patch_empty_old_string.py
@@ -1,0 +1,118 @@
+"""Tests for the #1703 patch replace-mode + empty old_string loop guard.
+
+When the model calls the patch tool in replace mode with an EMPTY (falsy)
+old_string, no valid replace can ever match — it is a usage error, not a match
+failure. The guard returns a targeted, actionable diagnostic at the tool
+boundary and tracks consecutive identical failures per task+path so the second
+one escalates to a hard STOP — breaking the 5-8 call retry spiral at 2.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_trackers():
+    """Reset the module-level trackers so counts start at zero regardless of
+    prior test order."""
+    from tools.file_tools import (
+        _empty_old_string_lock,
+        _empty_old_string_tracker,
+        _patch_failure_lock,
+        _patch_failure_tracker,
+    )
+
+    with _empty_old_string_lock:
+        _empty_old_string_tracker.clear()
+    with _patch_failure_lock:
+        _patch_failure_tracker.clear()
+    yield
+    with _empty_old_string_lock:
+        _empty_old_string_tracker.clear()
+    with _patch_failure_lock:
+        _patch_failure_tracker.clear()
+
+
+class TestEmptyOldStringGuard:
+    def _patch(self, task_id, path, old_string=None, new_string="x", mode="replace"):
+        from tools.file_tools import _handle_patch
+
+        args = {"mode": mode, "path": str(path), "new_string": new_string}
+        if old_string is not None:
+            args["old_string"] = old_string
+        return json.loads(_handle_patch(args, task_id=task_id))
+
+    def test_empty_old_string_returns_actionable_diagnostic(self, tmp_path):
+        """An empty old_string in replace mode yields a targeted diagnostic
+        naming the fix (non-empty old_string / mode=patch) — not the generic
+        'old_string and new_string required'."""
+        target = tmp_path / "f.py"
+        target.write_text("def foo():\n    return 1\n")
+
+        result = self._patch("t1", target, old_string="")
+        assert result.get("error"), "expected an error envelope"
+        err = result["error"]
+        assert "non-empty old_string" in err, err
+        assert "mode=patch" in err, err
+        # The diagnostic is clearly non-retryable in intent.
+        assert "cannot be matched" in err, err
+
+    def test_omitted_old_string_also_guarded(self, tmp_path):
+        """An omitted old_string (None) is treated the same as empty — the
+        model passed replace mode without a search target."""
+        target = tmp_path / "g.py"
+        target.write_text("x = 1\n")
+
+        result = self._patch("t2", target, old_string=None)
+        assert result.get("error")
+        assert "non-empty old_string" in result["error"]
+
+    def test_second_consecutive_empty_escalates_to_stop(self, tmp_path):
+        """The second consecutive empty-old_string failure on the same path
+        escalates with a hard STOP — breaking the spiral at 2 instead of 8."""
+        target = tmp_path / "h.py"
+        target.write_text("y = 2\n")
+
+        r1 = self._patch("t3", target, old_string="")
+        assert "STOP" not in (r1.get("error") or ""), r1
+
+        r2 = self._patch("t3", target, old_string="")
+        assert "STOP" in (r2.get("error") or ""), r2
+        assert "2nd consecutive" in (r2.get("error") or ""), r2
+
+    def test_different_paths_independent_counters(self, tmp_path):
+        """An empty-old_string failure on one path must not escalate a
+        different path's counter."""
+        a = tmp_path / "a.py"
+        a.write_text("a = 1\n")
+        b = tmp_path / "b.py"
+        b.write_text("b = 2\n")
+
+        self._patch("t4", a, old_string="")
+        self._patch("t4", a, old_string="")  # a now at 2 → escalates
+
+        r_b_first = self._patch("t4", b, old_string="")
+        assert "STOP" not in (r_b_first.get("error") or ""), (
+            "b's counter inherited a's escalation"
+        )
+
+    def test_non_empty_old_string_resets_empty_counter(self, tmp_path):
+        """Once the model supplies a non-empty old_string (a real match), the
+        empty-old_string counter for that path resets — a later empty call
+        starts back at 1 (no STOP)."""
+        target = tmp_path / "j.py"
+        target.write_text("def foo():\n    return 1\n")
+
+        self._patch("t5", target, old_string="")
+        self._patch("t5", target, old_string="")  # streak 2
+        # A valid replace: supplies a real old_string → resets the empty counter.
+        r_valid = self._patch(
+            "t5", target, old_string="return 1", new_string="return 99"
+        )
+        assert not r_valid.get("error"), r_valid
+
+        r_after = self._patch("t5", target, old_string="")
+        assert "STOP" not in (r_after.get("error") or ""), (
+            "empty counter should have reset after a valid old_string"
+        )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -893,6 +893,66 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
             task_failures.pop(rp, None)
 
 
+# ── #1703 — empty-old_string loop guard ────────────────────────────────────
+# When the model calls the patch tool in replace mode with an EMPTY (falsy)
+# old_string, no valid replace can ever match — it is a usage error, not a
+# match failure. The old "is None" guard at the top of patch_tool let an empty
+# string fall through to patch_replace, which returned a generic error the
+# model then retried 5-8 times (#1703). We return a targeted, actionable
+# diagnostic at the tool boundary, and track consecutive identical failures
+# per task+path so the second one escalates to a hard STOP — breaking the
+# spiral at 2 instead of 8.
+_empty_old_string_lock = threading.Lock()
+_empty_old_string_tracker: dict = {}  # {task_id: {path: count}}
+
+
+def _record_empty_old_string(task_id: str, path: str) -> int:
+    """Increment and return the consecutive empty-old_string count for a path."""
+    with _empty_old_string_lock:
+        per_task = _empty_old_string_tracker.setdefault(task_id, {})
+        if len(per_task) >= 64 and path not in per_task:
+            try:
+                first_key = next(iter(per_task))
+                del per_task[first_key]
+            except StopIteration:
+                pass
+        per_task[path] = per_task.get(path, 0) + 1
+        return per_task[path]
+
+
+def _reset_empty_old_string(task_id: str, path: str) -> None:
+    """Clear the empty-old_string counter for a path — called when the model
+    supplies a non-empty old_string (it has moved past the empty shape) or
+    when a patch to that path succeeds."""
+    if not path:
+        return
+    with _empty_old_string_lock:
+        per_task = _empty_old_string_tracker.get(task_id)
+        if per_task:
+            per_task.pop(path, None)
+
+
+def _empty_old_string_error(path: str, task_id: str) -> str:
+    """Non-retryable diagnostic for replace-mode with an empty old_string."""
+    count = _record_empty_old_string(task_id, path)
+    msg = (
+        "replace mode requires a non-empty old_string. The old_string is the "
+        "exact text to find and replace in the file; an empty string cannot be "
+        "matched. Either supply the text to replace, or use mode=patch (V4A "
+        "format) for insertions."
+    )
+    if count >= 2:
+        suffix = {2: "nd", 3: "rd"}.get(count % 10, "th")
+        msg += (
+            f" STOP: this is the {count}{suffix} consecutive replace-mode call with an "
+            f"empty old_string on {path!r}. Do not retry this shape — re-read the "
+            f"file to see the exact text, then supply a real old_string, or use "
+            f"mode=patch / write_file instead."
+        )
+    return tool_error(msg)
+
+
+
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
 # caps, a 10k-read session would accumulate ~1.5MB of dict/set state that
@@ -1962,7 +2022,16 @@ def patch_tool(
             if mode == "replace":
                 if not path:
                     return tool_error("path required")
-                if old_string is None or new_string is None:
+                # #1703 — a replace-mode call with an EMPTY (falsy) old_string is
+                # a usage error, not a match failure. Return a targeted,
+                # non-retryable diagnostic at the boundary instead of letting
+                # the generic error below feed a 5-8 call retry spiral. A
+                # non-empty old_string clears any prior empty-string counter for
+                # this path (the model moved past the bad shape).
+                if not old_string:
+                    return _empty_old_string_error(path, task_id)
+                _reset_empty_old_string(task_id, path)
+                if new_string is None:
                     return tool_error("old_string and new_string required")
                 # Hard stop: refuse further patch attempts to a file that has
                 # already exceeded the consecutive-failure threshold (#1037).


### PR DESCRIPTION
Automated evolution PR for issue #1703.

When the model calls the patch tool in replace mode with an EMPTY (falsy) old_string, no valid replace can ever match — it is a usage error, not a match failure. The previous `is None` guard let an empty string fall through to patch_replace, returning a generic error the model retried 5-8 times (#1703).

This PR returns a targeted, actionable diagnostic at the tool boundary and tracks consecutive identical failures per task+path so the second one escalates to a hard STOP — breaking the spiral at 2 instead of 8.

- `_empty_old_string_error` returns a non-retryable diagnostic naming the fix (non-empty old_string, or mode=patch for insertions).
- `_record_empty_old_string`/`_reset_empty_old_string` track consecutive empty-old_string calls per task+path; the 2nd escalates with a STOP directive.
- A non-empty old_string resets the counter (the model moved past the bad shape).
- Tests: tests/tools/test_patch_empty_old_string.py (5 tests).

Closes #1703