### PR TITLE
feat: structured audit event log + JSONL export (Closes #1718)

### DIFF
--- a/agent/audit_log.py
+++ b/agent/audit_log.py
@@ -1,0 +1,103 @@
+"""Structured audit event log (EU AI Act Art. 12) — #1718.
+
+JSONL at ``$HERMES_HOME/logs/audit-events.jsonl`` recording tool calls as
+immutable records exportable for regulatory review.  Gated via
+``security.audit_log`` (default off), fail-open, profile-aware.
+"""
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+_log = logging.getLogger(__name__)
+_lock = threading.Lock()
+EVENT_TOOL_CALL_COMPLETE = "tool_call_complete"
+EVENT_TOOL_CALL_BLOCKED = "tool_call_blocked"
+_REDACTED = (
+    "access_token",
+    "refresh_token",
+    "code",
+    "code_verifier",
+    "state",
+    "ticket",
+    "cookie",
+    "Authorization",
+    "authorization",
+    "api_key",
+    "token",
+    "password",
+    "secret",
+    "GITHUB_TOKEN",
+)
+
+
+def _home() -> Path:
+    env = os.environ.get("HERMES_HOME")
+    return Path(env) if env else Path.home() / ".hermes"
+
+
+def _log_path() -> Path:
+    return _home() / "logs" / "audit-events.jsonl"
+
+
+def _is_enabled() -> bool:
+    """``security.audit_log`` via ``load_config_readonly()`` (not raw yaml)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return bool(
+            (load_config_readonly() or {}).get("security", {}).get("audit_log", False)
+        )
+    except Exception:
+        return False
+
+
+def log_audit_event(
+    event: str,
+    *,
+    session_id: str = "",
+    turn_id: str = "",
+    tool_call_id: str = "",
+    tool_name: str = "",
+    task_id: str = "",
+    **fields: Any,
+) -> None:
+    """Append one immutable JSONL audit event.  Gated + fail-open."""
+    if not _is_enabled():
+        return
+    safe = {k: v for k, v in fields.items() if k not in _REDACTED}
+    import datetime as _dt
+
+    entry = {
+        "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "event": event,
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "task_id": task_id,
+        **safe,
+    }
+    line = json.dumps(entry, separators=(",", ":"), default=str) + "\n"
+    try:
+        path = _log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _lock:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+    except Exception as e:
+        _log.warning("audit log write failed: %s", e)
+
+
+def export_audit_jsonl(output_path: Optional[str] = None) -> str:
+    """Copy the log to *output_path* (returning it) or return its contents."""
+    src = _log_path()
+    if output_path:
+        import shutil
+
+        shutil.copy2(str(src), output_path)
+        return output_path
+    return src.read_text(encoding="utf-8") if src.exists() else ""

--- a/model_tools.py
+++ b/model_tools.py
@@ -1741,6 +1741,28 @@ def handle_function_call(
         except Exception:
             pass
 
+        # Structured audit event (#1718) — tool calls as immutable JSONL
+        # events (EU AI Act Art. 12).  Gated + fail-open.
+        try:
+            from agent.audit_log import EVENT_TOOL_CALL_COMPLETE, log_audit_event
+
+            _status, _err_type, _ = _tool_result_observer_fields(result)
+            log_audit_event(
+                EVENT_TOOL_CALL_COMPLETE,
+                session_id=session_id or "",
+                turn_id=turn_id or "",
+                tool_call_id=tool_call_id or "",
+                tool_name=function_name,
+                task_id=task_id or "",
+                args=function_args,
+                duration_ms=duration_ms,
+                result=result[:4000] if isinstance(result, str) else result,
+                status=_status,
+                error_type=_err_type or "",
+            )
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:

--- a/tests/agent/test_audit_log.py
+++ b/tests/agent/test_audit_log.py
@@ -1,0 +1,72 @@
+"""Tests for the structured audit event log (#1718)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.audit_log import (
+    EVENT_TOOL_CALL_BLOCKED,
+    EVENT_TOOL_CALL_COMPLETE,
+    _log_path,
+    export_audit_jsonl,
+    log_audit_event,
+)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _enable(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "security:\n  audit_log: true\n", encoding="utf-8"
+    )
+
+
+def test_log_path_uses_hermes_home(home):
+    assert _log_path() == home / "logs" / "audit-events.jsonl"
+
+
+def test_disabled_by_default_writes_nothing(home):
+    log_audit_event("tool_call_start", tool_name="x")
+    assert not _log_path().exists()
+
+
+def test_writes_jsonl_and_redacts(home):
+    _enable(home)
+    log_audit_event(
+        EVENT_TOOL_CALL_COMPLETE,
+        session_id="s1",
+        turn_id="t1",
+        tool_call_id="c1",
+        tool_name="read_file",
+        task_id="task-x",
+        args={"path": "/etc/hosts"},
+        result="ok",
+        duration_ms=3,
+        status="success",
+        api_key="super-secret",
+    )
+    entry = json.loads(_log_path().read_text(encoding="utf-8"))
+    assert entry["event"] == "tool_call_complete"
+    assert entry["session_id"] == "s1" and entry["tool_name"] == "read_file"
+    assert entry["status"] == "success" and "ts" in entry
+    assert "api_key" not in entry
+
+
+def test_export(home):
+    _enable(home)
+    log_audit_event(EVENT_TOOL_CALL_BLOCKED, tool_name="exec")
+    out = home / "export.jsonl"
+    assert export_audit_jsonl(str(out)) == str(out) and out.exists()
+    text = export_audit_jsonl()
+    assert "tool_call_blocked" in text and text.strip().endswith("}")
+
+
+def test_write_failure_is_silent(home):
+    _enable(home)
+    (home / "logs").write_text("occupied", encoding="utf-8")
+    log_audit_event(EVENT_TOOL_CALL_COMPLETE, tool_name="x")


### PR DESCRIPTION
Automated evolution PR for issue #1718 (EU AI Act Article 12 compliance slice).

Config-gated structured audit event log capturing every tool call (name, args, result, status, duration) as immutable JSONL records exportable for legal/regulatory review.

**Rework of PR #1720** — the audit-log feature was sound but `_is_enabled()` used a raw `yaml.safe_load(config.yaml)` which tripped the config-read guard. Fixed: now uses `load_config_readonly()` which respects managed-scope overlay, env-var expansion, profile-aware pathing, and root-model normalization.

- `agent/audit_log.py` — JSONL writer + `export_audit_jsonl()` helper; redacts token-like fields; fail-open.
- Wired into `model_tools.handle_function_call` dispatch seam.
- Tests: write/redact, export, fail-open, disabled-by-default.

Closes #1718