### PR TITLE
feat: tamper-evident hash-chained audit trail + retention (Closes #1719)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# gh issue-view cache (never track)
+.ghdata/

--- a/agent/audit_trail.py
+++ b/agent/audit_trail.py
@@ -1,0 +1,121 @@
+"""Tamper-evident append-only audit trail (issue #1719).
+
+Hash-chained JSONL: each entry stores the SHA-256 of the previous entry's hash
+plus its payload, so tampering is detectable via ``verify()``. Retention via
+``security.audit.retention_days`` (default 90); ``prune()`` re-anchors the chain.
+"""
+
+import hashlib
+import json
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_RETENTION_DAYS = 90
+_GENESIS = "genesis"
+
+
+def retention_days() -> int:
+    """Return the configured retention window in days (fail-open to default)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = (load_config_readonly().get("security") or {}).get("audit") or {}
+        val = int(cfg.get("retention_days", DEFAULT_RETENTION_DAYS))
+        return val if val > 0 else DEFAULT_RETENTION_DAYS
+    except Exception:
+        return DEFAULT_RETENTION_DAYS
+
+
+def _audit_path() -> Path:
+    return get_hermes_home() / "logs" / "audit-trail.jsonl"
+
+
+def _hash(prev_hash: str, payload: str) -> str:
+    return hashlib.sha256((prev_hash + payload).encode("utf-8")).hexdigest()
+
+
+def _last_hash(path: Path) -> str:
+    if not path.exists():
+        return _GENESIS
+    for line in reversed(path.read_text(encoding="utf-8").splitlines()):
+        if line.strip():
+            try:
+                return json.loads(line)["hash"]
+            except (json.JSONDecodeError, KeyError):
+                return _GENESIS
+    return _GENESIS
+
+
+def append(record: dict, *, path: Path | None = None) -> dict:
+    """Append a record to the chained log and return it with hash fields."""
+    path = path or _audit_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(record, sort_keys=True)
+    prev = _last_hash(path)
+    entry = {
+        "ts": int(time.time()),
+        "prev_hash": prev,
+        "payload": payload,
+        "hash": _hash(prev, payload),
+    }
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+    return entry
+
+
+def verify(path: Path | None = None) -> tuple[bool, int]:
+    """Recompute the chain; return (valid, entry_count)."""
+    path = path or _audit_path()
+    if not path.exists():
+        return True, 0
+    prev, count = _GENESIS, 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            return False, count
+        if entry.get("prev_hash") != prev or entry.get("hash") != _hash(
+            prev, entry.get("payload", "")
+        ):
+            return False, count
+        prev = entry["hash"]
+        count += 1
+    return True, count
+
+
+def prune(*, now: float | None = None, path: Path | None = None) -> int:
+    """Drop entries older than the retention window; re-anchor the chain."""
+    path = path or _audit_path()
+    if not path.exists():
+        return 0
+    cutoff = (now if now is not None else time.time()) - retention_days() * 86400
+    kept, removed = [], 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ts = json.loads(line)["ts"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            kept.append(line)
+            continue
+        if ts < cutoff:
+            removed += 1
+        else:
+            kept.append(line)
+    if not removed:
+        return 0
+    reanchored, prev = [], _GENESIS
+    for line in kept:
+        entry = json.loads(line)
+        entry["prev_hash"] = prev
+        entry["hash"] = _hash(prev, entry["payload"])
+        reanchored.append(json.dumps(entry, sort_keys=True))
+        prev = entry["hash"]
+    out = "\n".join(reanchored) + ("\n" if reanchored else "")
+    path.write_text(out, encoding="utf-8")
+    return removed

--- a/tests/agent/test_audit_trail.py
+++ b/tests/agent/test_audit_trail.py
@@ -1,0 +1,73 @@
+"""Tests for the tamper-evident audit trail (issue #1719)."""
+
+import json
+
+import pytest
+
+from agent import audit_trail
+
+
+@pytest.fixture(autouse=True)
+def isolate_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def test_append_creates_chained_entries(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    first = audit_trail.append({"action": "read"}, path=log)
+    second = audit_trail.append({"action": "write"}, path=log)
+
+    assert first["prev_hash"] == audit_trail._GENESIS
+    assert second["prev_hash"] == first["hash"]
+    assert first["hash"] != second["hash"]
+    assert audit_trail.verify(log) == (True, 2)
+
+
+def test_verify_detects_tamper(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    audit_trail.append({"action": "read"}, path=log)
+
+    first = json.loads(log.read_text().splitlines()[0])
+    first["payload"] = json.dumps({"action": "EVIL"})
+    log.write_text(json.dumps(first, sort_keys=True) + "\n")
+
+    assert audit_trail.verify(log)[0] is False
+
+
+def test_prune_drops_old_and_reanchors(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    prev = audit_trail._GENESIS
+    lines = []
+    for ts, action in ((1000000, "old"), (99999999999, "new")):
+        payload = json.dumps({"ts": ts, "action": action}, sort_keys=True)
+        entry = {
+            "ts": ts,
+            "prev_hash": prev,
+            "payload": payload,
+            "hash": audit_trail._hash(prev, payload),
+        }
+        lines.append(json.dumps(entry, sort_keys=True))
+        prev = entry["hash"]
+    log.write_text("\n".join(lines) + "\n")
+
+    assert audit_trail.prune(now=99999999999, path=log) == 1
+    kept = json.loads(log.read_text().splitlines()[0])
+    assert kept["prev_hash"] == audit_trail._GENESIS and audit_trail.verify(log) == (
+        True,
+        1,
+    )
+
+
+def test_retention_days_default_and_config(tmp_path, monkeypatch):
+    assert audit_trail.retention_days() == audit_trail.DEFAULT_RETENTION_DAYS
+
+    (tmp_path / ".hermes" / "config.yaml").write_text(
+        "security:\n  audit:\n    retention_days: 30\n"
+    )
+    import hermes_cli.config as cfg
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    assert audit_trail.retention_days() == 30


### PR DESCRIPTION
Automated evolution PR for #1719 (EU AI Act Article 12 / child of #1711).

Adds `agent/audit_trail.py`: a hash-chained append-only JSONL audit trail. Each entry stores the SHA-256 of the previous entry's hash plus its payload, so tampering/reordering is detectable via `verify()`. Retention is configurable via `security.audit.retention_days` (default 90 days) for data-residency; `prune()` compacts old entries and re-anchors the chain.

- Hash-chaining integrity verification
- Configurable retention (default 90 days)
- Fail-open config read (matches #1718 pattern)
- 4 targeted tests; lint + format clean; 197-line diff (within 200-line autonomous-merge cap)