### PR TITLE
feat: independent execution-evidence capture (Closes #1716)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# gh issue-view cache (never track)
+.ghdata/

--- a/agent/exec_evidence.py
+++ b/agent/exec_evidence.py
@@ -1,0 +1,78 @@
+"""Independent execution-evidence capture (#1716).
+
+Records what the agent *actually* did (tool calls with args + timestamps) to an
+append-only JSONL file, separate from the model's narrative, so an explanation
+can be cross-checked against recorded evidence. ``record_evidence`` appends a
+call; ``verify_claim`` checks whether a claimed action is backed by evidence.
+Fail-open: a missing/empty evidence store means "no evidence", never a crash.
+"""
+
+import json
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+_EVIDENCE_FILENAME = "logs/exec-evidence.jsonl"
+
+
+def evidence_path() -> Path:
+    return get_hermes_home() / _EVIDENCE_FILENAME
+
+
+def record_evidence(tool_name: str, args: dict | None = None) -> dict:
+    """Append one tool-call record to the evidence file and return it."""
+    path = evidence_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "ts": int(time.time()),
+        "tool": tool_name,
+        "args": _summarize(args or {}),
+    }
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+    return entry
+
+
+def _summarize(args: dict, max_chars: int = 200) -> str:
+    """Serialize args, truncated, so evidence stays small and safe to store."""
+    try:
+        text = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        text = str(args)
+    return text[:max_chars]
+
+
+def _iter_entries(path: Path):
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def verify_claim(tool_name: str, *, path: Path | None = None) -> bool:
+    """True if at least one recorded evidence entry names ``tool_name``."""
+    try:
+        for entry in _iter_entries(path or evidence_path()):
+            if entry.get("tool") == tool_name:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def evidence_count(*, path: Path | None = None) -> int:
+    """Number of recorded evidence entries (independent of any narrative)."""
+    count = 0
+    try:
+        for _ in _iter_entries(path or evidence_path()):
+            count += 1
+    except Exception:
+        return 0
+    return count

--- a/model_tools.py
+++ b/model_tools.py
@@ -1741,6 +1741,16 @@ def handle_function_call(
         except Exception:
             pass
 
+        # Independent execution-evidence capture: record what actually ran,
+        # separate from the model's narrative, so explanations can be
+        # cross-checked against recorded evidence (#1716). Fail-open.
+        try:
+            from agent.exec_evidence import record_evidence
+
+            record_evidence(function_name, function_args)
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:

--- a/tests/agent/test_exec_evidence.py
+++ b/tests/agent/test_exec_evidence.py
@@ -1,0 +1,47 @@
+"""Tests for independent execution-evidence capture (issue #1716)."""
+
+import json
+
+import pytest
+
+from agent import exec_evidence
+
+
+@pytest.fixture(autouse=True)
+def isolate_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def test_record_creates_entry(tmp_path):
+    entry = exec_evidence.record_evidence("terminal", {"command": "ls"})
+    assert entry["tool"] == "terminal"
+    assert "ls" in entry["args"]
+    assert exec_evidence.evidence_count() == 1
+
+
+def test_verify_claim_backed_by_evidence(tmp_path):
+    exec_evidence.record_evidence("read_file", {"path": "/etc/passwd"})
+    exec_evidence.record_evidence("terminal", {"command": "whoami"})
+    assert exec_evidence.verify_claim("terminal")
+    assert exec_evidence.verify_claim("read_file")
+    assert not exec_evidence.verify_claim("write_file")
+
+
+def test_verify_claim_false_for_empty_store(tmp_path):
+    assert not exec_evidence.verify_claim("anything")
+
+
+def test_args_truncation(tmp_path):
+    big = {"data": "x" * 500}
+    entry = exec_evidence.record_evidence("search", big)
+    assert len(entry["args"]) <= 200
+
+
+def test_corrupt_line_skipped(tmp_path):
+    exec_evidence.record_evidence("terminal", {"command": "ls"})
+    path = exec_evidence.evidence_path()
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write("NOT JSON\n")
+    assert exec_evidence.evidence_count() == 1


### PR DESCRIPTION
Automated evolution PR for #1716 (child of #1712).

Adds `agent/exec_evidence.py`: records what the agent actually did (tool name + summarized args + timestamp) to an append-only JSONL evidence file, independent of the model's narrative. `verify_claim()` cross-checks a claimed action against recorded evidence; `evidence_count()` reports how many calls ran.

- Separate from the model's narrative — trace-based, not self-reported
- Wired into `handle_function_call` alongside the tool-result path
- Args truncated (200 chars) to keep evidence small and safe
- Fail-open: missing/corrupt store means "no evidence", never a crash
- 5 targeted tests; lint + format clean; 138-line diff (within 200-line cap)