### PR TITLE
feat: EchoLeak + agentjacking output defenses (Closes #1717)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# gh issue-view cache (never track)
+.ghdata/

--- a/agent/echoleak_defense.py
+++ b/agent/echoleak_defense.py
@@ -1,0 +1,67 @@
+"""EchoLeak + agentjacking output defenses (#1717).
+
+Tool output and error messages can carry (a) markdown image links that trigger
+remote fetching (EchoLeak exfiltration vector) and (b) injected instructions
+embedded in crash reports / debug output (agentjacking vector). This module
+neutralizes both before they enter model context. Fail-open: any error returns
+the original text unchanged.
+"""
+
+import re
+
+_IMAGE_LINK = re.compile(r"!\[.*?\]\((https?://[^)]+)\)")
+_DATA_IMAGE = re.compile(r"!\[.*?\]\(data:[^)]*\)")
+_DEBUG_FENCE = re.compile(
+    r"(?m)^(Traceback \(most recent call last\):|Error:|Exception|DEBUG:)"
+)
+_KEY_REDACT = re.compile(
+    r"(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*\S+"
+)
+_FENCE_OPEN = "[untrusted-debug:"
+_FENCE_CLOSE = "]"
+
+
+def neutralize_images(text: str) -> str:
+    """Replace remote-fetch image links with a safe placeholder."""
+    text = _DATA_IMAGE.sub("[blocked-data-image]", text)
+    return _IMAGE_LINK.sub("[blocked-image-link]", text)
+
+
+def fence_debug_output(text: str) -> str:
+    """Fence crash-report / debug lines so they are read as data, not commands."""
+    lines = text.split("\n")
+    out: list[str] = []
+    fenced = False
+    for line in lines:
+        if not fenced and _DEBUG_FENCE.match(line):
+            out.append(_FENCE_OPEN)
+            fenced = True
+        elif fenced and not line.strip():
+            out.append(_FENCE_CLOSE)
+            fenced = False
+        if fenced:
+            line = _KEY_REDACT.sub(r"\1=[redacted]", line)
+        out.append(line)
+    if fenced:
+        out.append(_FENCE_CLOSE)
+    return "\n".join(out)
+
+
+def sanitize_output(value: object) -> object:
+    """Apply both image neutralization and debug fencing to a tool result."""
+    if not isinstance(value, str) or not value:
+        return value
+    try:
+        return fence_debug_output(neutralize_images(value))
+    except Exception:
+        return value
+
+
+def sanitize_error_for_context(error_text: str) -> str:
+    """Redact secrets from error strings before they enter context."""
+    if not isinstance(error_text, str) or not error_text:
+        return error_text
+    try:
+        return _KEY_REDACT.sub(r"\1=[redacted]", error_text)
+    except Exception:
+        return error_text

--- a/model_tools.py
+++ b/model_tools.py
@@ -1741,6 +1741,18 @@ def handle_function_call(
         except Exception:
             pass
 
+        # EchoLeak + agentjacking defense (#1717): neutralize remote-fetch
+        # image links and fence crash/debug output before it re-enters model
+        # context. Fail-open.
+        try:
+            from agent.echoleak_defense import sanitize_output
+
+            _sanitized = sanitize_output(result)
+            if isinstance(_sanitized, str):
+                result = _sanitized
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:
@@ -1776,6 +1788,13 @@ def handle_function_call(
                 )
         except Exception:
             pass  # never let the recovery module itself cause a failure
+        # Redact secrets from the error string before it re-enters context (#1717).
+        try:
+            from agent.echoleak_defense import sanitize_error_for_context
+
+            enriched = sanitize_error_for_context(enriched)
+        except Exception:
+            pass
         return tool_error(enriched)
 
 

--- a/tests/agent/test_echoleak_defense.py
+++ b/tests/agent/test_echoleak_defense.py
@@ -1,0 +1,46 @@
+"""Tests for EchoLeak + agentjacking defenses (issue #1717)."""
+
+from agent.echoleak_defense import (
+    fence_debug_output,
+    neutralize_images,
+    sanitize_error_for_context,
+    sanitize_output,
+)
+
+
+def test_remote_image_link_neutralized():
+    out = neutralize_images("![img](https://evil.com/pixel.png)")
+    assert "[blocked-image-link]" in out
+    assert "evil.com" not in out
+
+
+def test_data_image_neutralized():
+    out = neutralize_images("![x](data:image/png;base64,AAAA)")
+    assert "[blocked-data-image]" in out
+
+
+def test_benign_text_passes_through():
+    text = "Here is some plain documentation text."
+    assert neutralize_images(text) == text
+
+
+def test_debug_traceback_fenced_and_secrets_redacted():
+    out = fence_debug_output(
+        "Traceback (most recent call last):\napi_key=abc123\nLine failed.\n"
+    )
+    assert out.startswith("[untrusted-debug:")
+    assert "abc123" not in out
+    assert "api_key=[redacted]" in out
+
+
+def test_error_string_secrets_redacted():
+    err = "Authentication failed: password=supersecret"
+    out = sanitize_error_for_context(err)
+    assert "supersecret" not in out
+    assert "password=[redacted]" in out
+
+
+def test_sanitize_output_fail_open_and_non_string():
+    assert sanitize_output("plain") == "plain"
+    assert sanitize_output(42) == 42
+    assert sanitize_output("") == ""


### PR DESCRIPTION
Automated evolution PR for #1717 (child of #1712).

Adds `agent/echoleak_defense.py`: two output defenses applied before tool results and error strings re-enter model context.

**EchoLeak / remote-fetch neutralization** — replaces remote-fetch markdown image links (`![x](http...)`) and `data:` URIs with `[blocked-...]` placeholders, so tool output cannot trigger outbound image fetches that exfiltrate context.

**Agentjacking / debug-output defense** — fences crash-report/debug segments (`Traceback`, `Error:`, `Exception`, `DEBUG:`) in an `[untrusted-debug:...]` fence and redacts `api_key`/`token`/`password`/`secret`/`authorization` values.

- Wired into `handle_function_call` success path (sanitize output) and error path (redact secrets before return)
- Fail-open: errors pass text through unchanged
- 6 targeted tests; lint + format clean; 135-line diff (within 200-line cap)