### PR TITLE
feat: failure-detection predicate for context denoising (#1580 Slice A)

### DIFF
--- a/agent/failed_attempt_marker.py
+++ b/agent/failed_attempt_marker.py
@@ -1,0 +1,264 @@
+"""Failure-detection predicates for context denoising (#1580 — Slice A).
+
+When an agent retries a failed approach, the errored tool results and the
+assistant turns that produced them stay in the context window.  On the next
+compaction they are summarized like any other content, polluting the summary
+with failed-strategy detail that the model then treats as background (#1580).
+
+This module provides **pure, standalone predicates** that identify which
+message indices constitute a *failed attempt span* — a contiguous
+``assistant(tool_calls) → tool_result`` block where the tool result signals
+an error.  The compressor (Slice B, future) can prioritise these spans for
+removal or summarization, and the refinement loop (Slice C, future) can
+filter failed drafts.
+
+Detection reuses existing failure classifiers rather than introducing new
+heuristics:
+
+* ``tool_diagnostics.classify`` — regex taxonomy of error strings.
+* ``tool_diagnostics.payload_anomaly`` — structural payload checks.
+* ``replay_cleanup.is_interrupted_tool_result`` — interrupted-call signals.
+
+Design constraints
+------------------
+* **No side effects** — every function is a pure query over a message list.
+* **No imports from the compressor** — keeps the predicate testable in
+  isolation and avoids circular imports (the compressor will import *this*).
+* **Stable output** — the same message list always yields the same span set.
+* **Conservative** — only flag spans where the tool result is *clearly* an
+  error.  Ambiguous content is left alone; false positives would silently
+  discard useful context.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, FrozenSet, List, Sequence
+
+from agent import replay_cleanup, tool_diagnostics
+
+__all__ = [
+    "FailedAttemptSpan",
+    "identify_failed_attempt_spans",
+    "failed_attempt_indices",
+]
+
+
+class FailedAttemptSpan:
+    """A contiguous assistant → tool_result block that ended in failure.
+
+    Attributes
+    ----------
+    assistant_index:
+        Index of the ``assistant`` message carrying ``tool_calls``.
+    result_indices:
+        Indices of the ``tool`` messages that answered those calls.
+        At least one of these is a detected failure.
+    failure_categories:
+        Mapping ``result_index → (category, source)`` for every result that
+        was flagged, where *source* is one of
+        ``"classify"``, ``"payload_anomaly"``, ``"interrupted"``.
+    """
+
+    __slots__ = ("assistant_index", "result_indices", "failure_categories")
+
+    def __init__(
+        self,
+        assistant_index: int,
+        result_indices: Sequence[int],
+        failure_categories: Dict[int, tuple[str, str]],
+    ) -> None:
+        self.assistant_index = assistant_index
+        self.result_indices: tuple[int, ...] = tuple(result_indices)
+        self.failure_categories = dict(failure_categories)
+
+    @property
+    def all_indices(self) -> tuple[int, ...]:
+        """Every message index covered by this span (assistant + results)."""
+        return (self.assistant_index, *self.result_indices)
+
+    def __repr__(self) -> str:  # pragma: no cover — debugging aid
+        return (
+            f"FailedAttemptSpan(assistant={self.assistant_index}, "
+            f"results={self.result_indices}, "
+            f"failures={self.failure_categories})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FailedAttemptSpan):
+            return NotImplemented
+        return (
+            self.assistant_index == other.assistant_index
+            and self.result_indices == other.result_indices
+            and self.failure_categories == other.failure_categories
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.assistant_index, self.result_indices))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_to_text(content: Any) -> str:
+    """Best-effort flattening of a message ``content`` field to plain text.
+
+    Handles ``str``, ``list[dict]`` (multimodal / structured), and ``dict``
+    envelopes.  Anything else is stringified.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif "content" in part:
+                    parts.append(_content_to_text(part["content"]))
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        # Common envelope shapes: {"content": ...}, {"text": ...}
+        inner = content.get("content")
+        if inner is not None:
+            return _content_to_text(inner)
+        text = content.get("text")
+        return text if isinstance(text, str) else str(content)
+    return str(content)
+
+
+def _classify_tool_result(content: Any) -> tuple[str, str] | None:
+    """Return ``(category, source)`` if *content* is a failed tool result.
+
+    Tries the structural anomaly check first (most reliable — it does not
+    depend on error-string wording), then the regex classifier, then the
+    interrupted-result check.
+    """
+    anomaly = tool_diagnostics.payload_anomaly(content)
+    if anomaly is not None:
+        category, _hint = anomaly
+        return category, "payload_anomaly"
+
+    classified = tool_diagnostics.classify(_content_to_text(content))
+    if classified is not None:
+        category, _hint = classified
+        return category, "classify"
+
+    if replay_cleanup.is_interrupted_tool_result(content):
+        return "interrupted", "interrupted"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def identify_failed_attempt_spans(
+    messages: List[Dict[str, Any]],
+) -> List[FailedAttemptSpan]:
+    """Identify all failed-attempt spans in *messages*.
+
+    A *failed-attempt span* is a contiguous sequence starting at an
+    ``assistant`` message that carries ``tool_calls``, followed immediately
+    by one or more ``tool`` result messages, where **at least one** result
+    is classified as a failure by :func:`_classify_tool_result`.
+
+    Spans where *all* results are successful are not returned.  A span with
+    a mix of successes and failures is returned as-is (the whole attempt is
+    treated as failed because the agent pursued a path that produced at least
+    one error).
+
+    Parameters
+    ----------
+    messages:
+        The conversation message list (same shape as the OpenAI chat
+        completions ``messages`` array).
+
+    Returns
+    -------
+    list of :class:`FailedAttemptSpan`, ordered by ``assistant_index``.
+    """
+    spans: list[FailedAttemptSpan] = []
+    if not messages:
+        return spans
+
+    i = 0
+    n = len(messages)
+    while i < n:
+        msg = messages[i]
+        if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+            i += 1
+            continue
+
+        # Collect consecutive tool results after this assistant message.
+        result_indices: list[int] = []
+        j = i + 1
+        while j < n and messages[j].get("role") == "tool":
+            result_indices.append(j)
+            j += 1
+
+        if not result_indices:
+            # Dangling tool_calls with no results — not a failed *attempt*,
+            # the replay-cleanup path handles dangling tails separately.
+            i += 1
+            continue
+
+        failure_categories: dict[int, tuple[str, str]] = {}
+        for ridx in result_indices:
+            result_msg = messages[ridx]
+            content = result_msg.get("content")
+            hit = _classify_tool_result(content)
+            if hit is not None:
+                failure_categories[ridx] = hit
+
+        if failure_categories:
+            spans.append(
+                FailedAttemptSpan(
+                    assistant_index=i,
+                    result_indices=result_indices,
+                    failure_categories=failure_categories,
+                )
+            )
+
+        # Advance past the entire assistant→results block.
+        i = j
+
+    return spans
+
+
+def failed_attempt_indices(
+    messages: List[Dict[str, Any]],
+    *,
+    include_assistant: bool = True,
+) -> FrozenSet[int]:
+    """Convenience: flat set of all message indices in failed-attempt spans.
+
+    Parameters
+    ----------
+    messages:
+        The conversation message list.
+    include_assistant:
+        If ``True`` (default), include the ``assistant`` index of each span.
+        Set to ``False`` to get only the tool-result indices — useful when
+        the assistant turn carries reasoning worth preserving even though
+        the tool call failed.
+
+    Returns
+    -------
+    A frozenset of integer indices into *messages*.
+    """
+    indices: set[int] = set()
+    for span in identify_failed_attempt_spans(messages):
+        if include_assistant:
+            indices.add(span.assistant_index)
+        indices.update(span.result_indices)
+    return frozenset(indices)

--- a/tests/agent/test_failed_attempt_marker.py
+++ b/tests/agent/test_failed_attempt_marker.py
@@ -1,0 +1,273 @@
+"""Tests for agent.failed_attempt_marker (#1580 — Slice A).
+
+Covers:
+  - Pure span detection over representative message shapes.
+  - Failure classifier reuse (classify / payload_anomaly / interrupted).
+  - Conservative behaviour: successful attempts are NOT flagged.
+  - Edge cases: empty list, dangling tool_calls, multimodal content.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.failed_attempt_marker import (
+    FailedAttemptSpan,
+    failed_attempt_indices,
+    identify_failed_attempt_spans,
+)
+
+
+# ---------------------------------------------------------------------------
+# Message builders
+# ---------------------------------------------------------------------------
+
+
+def _assistant(tool_calls=None, content="Thinking..."):
+    """Build an assistant message, optionally with tool_calls."""
+    msg = {"role": "assistant", "content": content}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _tool_result(call_id: str, content):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _tc(call_id: str, name: str = "terminal", args: str = "{}"):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+def _user(text: str = "Do the thing"):
+    return {"role": "user", "content": text}
+
+
+# ---------------------------------------------------------------------------
+# identify_failed_attempt_spans
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyFailedAttemptSpans:
+    """Core span-detection logic."""
+
+    def test_empty_messages(self):
+        assert identify_failed_attempt_spans([]) == []
+
+    def test_no_tool_calls(self):
+        msgs = [_user(), _assistant(content="Hello")]
+        assert identify_failed_attempt_spans(msgs) == []
+
+    def test_successful_attempt_not_flagged(self):
+        """A fully successful assistant→tool block is NOT a failed span."""
+        msgs = [
+            _user(),
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "command succeeded\nexit code 0"),
+        ]
+        assert identify_failed_attempt_spans(msgs) == []
+
+    def test_runtime_error_flagged(self):
+        msgs = [
+            _user(),
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "Traceback (most recent call last):\n  File ... Error"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        assert spans[0].assistant_index == 1
+        assert 2 in spans[0].result_indices
+        assert spans[0].failure_categories[2][1] == "classify"
+
+    def test_permission_error_flagged(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "permission denied: /root/secret"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        cat, source = spans[0].failure_categories[1]
+        assert cat == "permission"
+        assert source == "classify"
+
+    def test_timeout_flagged(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "Error: timed out after 30s"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        cat, _ = spans[0].failure_categories[1]
+        assert cat == "timeout"
+
+    def test_not_found_flagged(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "grep: no such file or directory"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+
+    def test_empty_payload_flagged(self):
+        """payload_anomaly catches structurally-broken results."""
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", ""),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        cat, source = spans[0].failure_categories[1]
+        assert source == "payload_anomaly"
+
+    def test_null_payload_flagged(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "null"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+
+    def test_interrupted_flagged(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "[command interrupted]\nexit_code: 130"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        cat, source = spans[0].failure_categories[1]
+        assert source == "interrupted"
+
+    def test_mixed_success_failure_flagged(self):
+        """If ANY result in a multi-call block fails, the whole span flags."""
+        msgs = [
+            _assistant(tool_calls=[_tc("c1"), _tc("c2")]),
+            _tool_result("c1", "OK\nexit code 0"),
+            _tool_result("c2", "permission denied"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.assistant_index == 0
+        assert len(span.result_indices) == 2
+        # Only c2 (index 2) is a failure
+        assert 2 in span.failure_categories
+        assert 1 not in span.failure_categories
+
+    def test_multiple_independent_spans(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "Error: something failed"),
+            _assistant(tool_calls=[_tc("c2")]),
+            _tool_result("c2", "All good\nexit code 0"),
+            _assistant(tool_calls=[_tc("c3")]),
+            _tool_result("c3", "Traceback (most recent call last): ValueError"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 2
+        assert spans[0].assistant_index == 0
+        assert spans[1].assistant_index == 4
+
+    def test_dangling_tool_calls_skipped(self):
+        """assistant(tool_calls) with NO following tool results is skipped."""
+        msgs = [
+            _user(),
+            _assistant(tool_calls=[_tc("c1")]),
+            _user("next message"),
+        ]
+        assert identify_failed_attempt_spans(msgs) == []
+
+    def test_all_indices_property(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1"), _tc("c2")]),
+            _tool_result("c1", "error: failed"),
+            _tool_result("c2", "None"),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+        assert spans[0].all_indices == (0, 1, 2)
+
+    def test_multimodal_content_supported(self):
+        """List-shaped content (multimodal) is flattened before classification."""
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", [{"type": "text", "text": "Error: exit code 1"}]),
+        ]
+        spans = identify_failed_attempt_spans(msgs)
+        assert len(spans) == 1
+
+
+# ---------------------------------------------------------------------------
+# failed_attempt_indices
+# ---------------------------------------------------------------------------
+
+
+class TestFailedAttemptIndices:
+    """Convenience frozenset API."""
+
+    def test_empty(self):
+        assert failed_attempt_indices([]) == frozenset()
+
+    def test_returns_frozenset(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "permission denied"),
+        ]
+        result = failed_attempt_indices(msgs)
+        assert isinstance(result, frozenset)
+        assert result == frozenset({0, 1})
+
+    def test_exclude_assistant(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "Traceback (most recent call last): error"),
+        ]
+        result = failed_attempt_indices(msgs, include_assistant=False)
+        assert 0 not in result
+        assert 1 in result
+
+    def test_multiple_spans_combined(self):
+        msgs = [
+            _assistant(tool_calls=[_tc("c1")]),
+            _tool_result("c1", "error: failed"),
+            _assistant(tool_calls=[_tc("c2")]),
+            _tool_result("c2", "timed out"),
+        ]
+        result = failed_attempt_indices(msgs)
+        assert result == frozenset({0, 1, 2, 3})
+
+
+# ---------------------------------------------------------------------------
+# FailedAttemptSpan
+# ---------------------------------------------------------------------------
+
+
+class TestFailedAttemptSpan:
+    """Structural correctness of the span data class."""
+
+    def test_repr(self):
+        span = FailedAttemptSpan(
+            assistant_index=0,
+            result_indices=[1],
+            failure_categories={1: ("timeout", "classify")},
+        )
+        r = repr(span)
+        assert "assistant=0" in r
+        assert "results=(1,)" in r
+
+    def test_equality(self):
+        s1 = FailedAttemptSpan(0, [1], {1: ("timeout", "classify")})
+        s2 = FailedAttemptSpan(0, [1], {1: ("timeout", "classify")})
+        assert s1 == s2
+
+    def test_inequality(self):
+        s1 = FailedAttemptSpan(0, [1], {1: ("timeout", "classify")})
+        s2 = FailedAttemptSpan(0, [1], {1: ("permission", "classify")})
+        assert s1 != s2
+
+    def test_hashable(self):
+        span = FailedAttemptSpan(0, [1], {1: ("timeout", "classify")})
+        assert hash(span) is not None


### PR DESCRIPTION
## Summary

Slice A of #1580 — Active context-denoising to defeat contextual drag from failed attempts.

Implements a **standalone utility** (`agent/failed_attempt_marker.py`) that identifies failed-attempt spans in a conversation message list: `assistant(tool_calls) → tool_result` blocks where the tool result signals an error.

## Implementation

- **New module:** `agent/failed_attempt_marker.py` (264 lines)
- **Tests:** `tests/agent/test_failed_attempt_marker.py` (273 lines, 23 tests)
- **Reuses** existing failure classifiers — no new heuristics:
  - `tool_diagnostics.classify` — regex taxonomy of error strings
  - `tool_diagnostics.payload_anomaly` — structural payload checks
  - `replay_cleanup.is_interrupted_tool_result` — interrupted-call signals

## API

```python
from agent.failed_attempt_marker import identify_failed_attempt_spans, failed_attempt_indices

# Get structured span objects (assistant index + result indices + failure categories)
spans = identify_failed_attempt_spans(messages)

# Get flat set of indices for removal prioritization
indices = failed_attempt_indices(messages)
```

## Design principles

- **Pure functions** — no side effects, no imports from the compressor
- **Conservative** — only flags spans where the tool result is *clearly* an error
- **Successful attempts are NOT flagged** — avoids false positives
- **Mixed success/failure → span flagged** — the agent pursued a failed path

## Validation

- ✅ `ruff check` — clean
- ✅ `ruff format --check` — clean
- ✅ `pytest tests/agent/test_failed_attempt_marker.py` — 23/23 passed

## Child issue

#1736

## Deferred (next increment)

- **Slice B:** Wire `failed_attempt_indices()` into `ContextCompressor._prune_old_tool_results()` so failed traces are prioritized for removal at compaction time (~150 lines).
- **Slice C:** Filter failed drafts when re-entering critique-verify-revise refinement loops (~120 lines).

## Note on diff size

This PR is 537 insertions (264 source + 273 tests). The merge gate will flag it as `DIFF_TOO_LARGE` (>200 lines). The code is fully green and self-contained — leaving it open for human review rather than discarding completed work.