### PR TITLE
feat: active context-denoising for failed-attempt tool results (Closes #1580)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -34,6 +34,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_tokens_rough,
 )
+from agent.failed_attempt_marker import failed_attempt_indices
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
@@ -2757,6 +2758,18 @@ class ContextCompressor(ContextEngine):
             if modified:
                 result[idx] = {**msg, "tool_calls": new_tcs}
             return modified
+
+        # Pass 1b: Prioritise failed-attempt tool results for removal (#1580).
+        # Failed tool calls (tracebacks, non-zero exits, explicit errors)
+        # contribute contextual drag — the model re-reads the error and often
+        # retries the same approach.  Demote them *first*, even inside the
+        # pruneable region, so their bulky error output becomes a 1-line summary
+        # before the general pass runs.
+        failed_indices = set(failed_attempt_indices(result))
+        if failed_indices:
+            for i in sorted(failed_indices):
+                if i < prune_boundary:
+                    _demote_tool_result_at(i)
 
         # Pass 2: Replace old tool results with informative summaries
         for i in range(max(0, prune_boundary)):

--- a/agent/failed_attempt_marker.py
+++ b/agent/failed_attempt_marker.py
@@ -1,0 +1,122 @@
+"""Detect failed-attempt spans in conversation messages.
+
+A *failed attempt* is a tool call whose result indicates an error —
+an exception traceback, a non-zero exit code, a file-not-found, or an
+explicit ``"error"`` field.  These spans pollute subsequent reasoning
+(the model often re-reads the error and retries the same approach).
+Marking them lets ``ContextCompressor._prune_old_tool_results``
+prioritise their removal during compaction, reducing *contextual drag*
+from failed branches (#1580).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+# ---------------------------------------------------------------------------
+# Error-signal patterns
+# ---------------------------------------------------------------------------
+
+# Tracebacks / Python exceptions
+_TRACEBACK_RE = re.compile(r"Traceback \(most recent call last\)", re.IGNORECASE)
+_EXCEPTION_RE = re.compile(r"\b([A-Z]\w*Error|[A-Z]\w*Exception): ", re.MULTILINE)
+
+# Shell / terminal non-zero exit
+_EXIT_CODE_RE = re.compile(r"exit[_ ]code[\"']?\s*[:=]\s*([1-9]\d*)", re.IGNORECASE)
+_PROCESS_EXIT_RE = re.compile(
+    r"\bexit(?:ed)?(?:\s+code)?\s+(?:with\s+)?(?:code\s+)?([1-9]\d*)", re.IGNORECASE
+)
+
+# Common error phrases in tool results (JSON {"error": ...}, plain text, etc.)
+_ERROR_KEY_RE = re.compile(r'"error"\s*:\s*"', re.IGNORECASE)
+_ERROR_LABEL_RE = re.compile(
+    r"^\s*(?:error|exception|failed|failure)\b", re.IGNORECASE | re.MULTILINE
+)
+
+# Explicit status fields
+_STATUS_ERROR_RE = re.compile(r'"status"\s*:\s*"(?:error|failed)"', re.IGNORECASE)
+
+# Loop-guard / retry-exhausted messages
+_LOOP_GUARD_RE = re.compile(r"\[loop-guard\]", re.IGNORECASE)
+
+_COMPILED_PATTERNS = (
+    _TRACEBACK_RE,
+    _EXCEPTION_RE,
+    _EXIT_CODE_RE,
+    _PROCESS_EXIT_RE,
+    _ERROR_KEY_RE,
+    _ERROR_LABEL_RE,
+    _STATUS_ERROR_RE,
+    _LOOP_GUARD_RE,
+)
+
+
+def _is_failed_content(content: Any) -> bool:
+    """Return True if *content* (str / list / dict) signals a failure."""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, dict):
+        # Multimodal / structured tool result
+        if content.get("error"):
+            return True
+        if content.get("status") in ("error", "failed"):
+            return True
+        text = content.get("text_summary") or content.get("content") or ""
+        if not isinstance(text, str):
+            text = str(text)
+    elif isinstance(content, list):
+        # Multimodal parts — check text parts
+        text = " ".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    else:
+        return False
+
+    if not text:
+        return False
+
+    # Quick length gate — very short results rarely carry useful error signals
+    # and matching them produces false positives (e.g. the word "Error" in a
+    # 20-char completion).
+    if len(text) < 30:
+        return False
+
+    return any(p.search(text) for p in _COMPILED_PATTERNS)
+
+
+def failed_attempt_indices(messages: List[Dict[str, Any]]) -> List[int]:
+    """Return indices of tool-result messages that are failed attempts.
+
+    Parameters
+    ----------
+    messages
+        The conversation message list (same format the compressor sees).
+
+    Returns
+    -------
+    list[int]
+        Sorted ascending list of indices whose ``role == "tool"`` and whose
+        content matches at least one error signal.
+    """
+    if not messages:
+        return []
+
+    indices: List[int] = []
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "tool":
+            continue
+        if _is_failed_content(msg.get("content")):
+            indices.append(i)
+    return indices
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+__all__ = ["failed_attempt_indices"]

--- a/tests/agent/test_failed_attempt_marker.py
+++ b/tests/agent/test_failed_attempt_marker.py
@@ -1,0 +1,208 @@
+"""Tests for failed-attempt detection and context denoising (#1580).
+
+Verifies:
+1. ``failed_attempt_indices`` correctly identifies error-bearing tool results.
+2. ``ContextCompressor._prune_old_tool_results`` prioritises failed attempts
+   for removal — they are demoted *before* the general pruning pass runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from agent.failed_attempt_marker import failed_attempt_indices
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for failed_attempt_indices
+# ---------------------------------------------------------------------------
+
+
+class TestFailedAttemptIndices:
+    """Direct unit tests for the predicate."""
+
+    def test_empty_messages(self):
+        assert failed_attempt_indices([]) == []
+
+    def test_no_tool_messages(self):
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert failed_attempt_indices(msgs) == []
+
+    def test_successful_tool_result_not_flagged(self):
+        msgs = [
+            {"role": "tool", "content": "x" * 200, "tool_call_id": "c1"},
+        ]
+        assert failed_attempt_indices(msgs) == []
+
+    def test_traceback_detected(self):
+        content = (
+            "Traceback (most recent call last):\n"
+            '  File "/app/foo.py", line 10, in <module>\n'
+            "    raise ValueError('bad')\n"
+            "ValueError: bad\n"
+        )
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_nonzero_exit_code_detected(self):
+        content = '{"output": "", "error": "command failed", "exit_code": 1}'
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_error_json_key_detected(self):
+        content = '{"status": "error", "error": "FileNotFoundError: /tmp/missing.txt"}'
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_loop_guard_detected(self):
+        content = (
+            "[loop-guard] The `terminal` tool (mutating) has failed "
+            "2 times in a row with the same approach. STOP repeating it."
+        )
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_short_content_not_flagged(self):
+        """Very short results (<30 chars) are not flagged to avoid FPs."""
+        msgs = [{"role": "tool", "content": "Error: nope", "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == []
+
+    def test_multimodal_text_part_with_error(self):
+        content = [
+            {
+                "type": "text",
+                "text": "Process exited with code 127 — command not found",
+            },
+        ]
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_dict_error_field(self):
+        content = {"error": "something went wrong and here is a longer message"}
+        msgs = [{"role": "tool", "content": content, "tool_call_id": "c1"}]
+        assert failed_attempt_indices(msgs) == [0]
+
+    def test_multiple_messages_mixed(self):
+        ok = "x" * 300
+        err = "Traceback (most recent call last):\nValueError: bad\n" + "z" * 100
+        msgs = [
+            {"role": "user", "content": "do something"},
+            {"role": "tool", "content": ok, "tool_call_id": "c1"},
+            {"role": "assistant", "content": "next"},
+            {"role": "tool", "content": err, "tool_call_id": "c2"},
+            {"role": "user", "content": "again"},
+        ]
+        assert failed_attempt_indices(msgs) == [3]
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: _prune_old_tool_results prioritises failed attempts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_compressor():
+    """Minimal ContextCompressor — only _prune_old_tool_results is needed."""
+    from agent.context_compressor import ContextCompressor
+
+    # Bypass __init__ (which needs a config/client) — we only call one method.
+    c = ContextCompressor.__new__(ContextCompressor)
+    return c
+
+
+class TestFailedAttemptPruning:
+    """Verify that failed tool results are demoted before successful ones."""
+
+    def test_failed_result_pruned_before_successful(self, stub_compressor):
+        """Both results are large and in the pruneable region, but the
+        failed one should be demoted first (Pass 1b) so its verbose error
+        output becomes a 1-line summary."""
+        ok_content = "def hello():\n    return 'world'\n" + "x" * 500
+        err_content = (
+            "Traceback (most recent call last):\n"
+            '  File "/app/main.py", line 42\n'
+            "    result = do_thing()\n"
+            "ConnectionError: refused\n" + "detail " * 80
+        )
+        messages = [
+            {"role": "tool", "content": err_content, "tool_call_id": "call_err"},
+            {"role": "tool", "content": ok_content, "tool_call_id": "call_ok"},
+            {
+                "role": "assistant",
+                "content": "done",
+                "tool_calls": [
+                    {
+                        "id": "call_err",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "make test"}',
+                        },
+                    },
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "main.py"}',
+                        },
+                    },
+                ],
+            },
+            {"role": "user", "content": "continue"},
+        ]
+        result, pruned = stub_compressor._prune_old_tool_results(
+            messages, protect_tail_count=2
+        )
+        # Both should be pruned, but the key assertion is that the error
+        # result was demoted — its content should no longer be the full traceback.
+        assert pruned >= 1
+        assert "Traceback" not in result[0]["content"]
+
+    def test_failed_result_in_protected_tail_not_pruned(self, stub_compressor):
+        """A failed result inside the protected tail should survive."""
+        err_content = (
+            "Traceback (most recent call last):\nValueError: bad\n" + "z" * 300
+        )
+        messages = [
+            {"role": "assistant", "content": "start"},
+            {"role": "tool", "content": err_content, "tool_call_id": "c1"},
+            {"role": "user", "content": "continue"},
+        ]
+        result, pruned = stub_compressor._prune_old_tool_results(
+            messages, protect_tail_count=2
+        )
+        # Tool result is at index 1, prune_boundary = 3 - 2 = 1, so index 1
+        # is NOT in the pruneable region (i < prune_boundary is False).
+        assert pruned == 0
+        assert result[1]["content"] == err_content
+
+    def test_no_failed_attempts_no_extra_pruning(self, stub_compressor):
+        """When there are no failed attempts, behaviour is unchanged."""
+        ok_content = "x" * 500
+        messages = [
+            {"role": "tool", "content": ok_content, "tool_call_id": "c1"},
+            {
+                "role": "assistant",
+                "content": "done",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "user", "content": "continue"},
+        ]
+        result, pruned = stub_compressor._prune_old_tool_results(
+            messages, protect_tail_count=2
+        )
+        # Standard Pass 2 prunes the large result
+        assert pruned == 1


### PR DESCRIPTION
Automated evolution PR for issue #1580 — context-denoising to defeat contextual drag from failed attempts.

New module agent/failed_attempt_marker.py detects error-bearing tool results (tracebacks, non-zero exits, explicit error JSON, loop-guard messages). Wired into ContextCompressor._prune_old_tool_results as Pass 1b: failed-attempt spans are demoted to 1-line summaries before the general pruning pass.

Addresses owner rework brief: PR #1737 was closed as dead code (zero call sites). This PR ships Slice A (marker) + Slice B (wiring) together with a real non-test call site at line ~2770.