### PR TITLE
fix: classify terminal syntax errors as deterministic non-retryable (#1743)

### DIFF
--- a/tests/tools/test_terminal_failure_classifier.py
+++ b/tests/tools/test_terminal_failure_classifier.py
@@ -117,6 +117,43 @@ class TestClassifyPersistentError:
         assert result.should_retry is False
 
 
+class TestClassifySyntaxError:
+    """Syntax errors are deterministic and must not be blind-retried (#1743)."""
+
+    def test_syntax_error_text_pattern(self):
+        """Bash 'syntax error near unexpected token' is non-retryable."""
+        result = classifier.classify_terminal_failure(
+            "if then", 2, "", "bash: syntax error near unexpected token"
+        )
+        assert result.category == classifier.FailureCategory.persistent_error
+        assert result.should_retry is False
+        assert "Syntax" in result.hint
+
+    def test_interpreter_exit_2_is_syntax(self):
+        """Python exit code 2 (interpreter) is treated as a syntax error."""
+        result = classifier.classify_terminal_failure(
+            'python3 -c "if true print(1)"', 2, "", ""
+        )
+        assert result.category == classifier.FailureCategory.persistent_error
+        assert result.should_retry is False
+        assert "Syntax" in result.hint
+
+    def test_grep_exit_2_not_syntax(self):
+        """grep exit 2 is a generic error (file-not-found), NOT a syntax
+        error — must not get the syntax hint."""
+        result = classifier.classify_terminal_failure(
+            "grep foo missing.txt", 2, "", ""
+        )
+        assert result.category == classifier.FailureCategory.unknown
+        assert "Syntax" not in result.hint
+
+    def test_syntax_error_hint_says_not_to_retry(self):
+        result = classifier.classify_terminal_failure(
+            "bash -c 'for i in; do'", 2, "", "syntax error"
+        )
+        assert "Do NOT retry" in result.hint
+
+
 class TestClassifyInformationalCommands:
     @pytest.mark.parametrize(
         "command, exit_code",

--- a/tools/terminal_failure_classifier.py
+++ b/tools/terminal_failure_classifier.py
@@ -45,6 +45,15 @@ _MISSING_CMD_PATTERNS = (
     re.compile(r"could not find command", re.IGNORECASE),
 )
 
+# Syntax-error patterns — shell/interpreter syntax errors are deterministic;
+# re-running the same command unchanged will fail identically (#1743).
+_SYNTAX_ERROR_PATTERNS = (
+    re.compile(r"syntax error", re.IGNORECASE),
+    re.compile(r"unexpected token", re.IGNORECASE),
+    re.compile(r"unexpected end of file", re.IGNORECASE),
+    re.compile(r"SyntaxError:", re.IGNORECASE),
+)
+
 _PERMISSION_DENIED_PATTERNS = (
     re.compile(r"permission denied", re.IGNORECASE),
     re.compile(r"operation not permitted", re.IGNORECASE),
@@ -185,6 +194,35 @@ def classify_terminal_failure(
             hint=(
                 "Permission denied. Check file permissions, run from a "
                 "directory you own, or ask the user before escalating privileges."
+            ),
+            should_retry=False,
+        )
+
+    # Syntax error — deterministic, non-retryable (#1743). Shell/interpreter
+    # syntax errors (exit code 2 from bash, SyntaxError from Python, "unexpected
+    # token" from node) reproduce identically on every run. Classify them
+    # distinctly so the agent gets a targeted "fix the command" hint instead of
+    # the generic persistent_error message that leaves it guessing.
+    #
+    # Pattern-based: NOT gated on exit_code == 2 alone, because grep/tar/diff
+    # use exit code 2 for generic errors (file-not-found, archive corruption)
+    # that are NOT syntax errors. Only fire when the output text contains a
+    # syntax-error signature, OR when exit_code == 2 AND the base command is
+    # a known interpreter (bash, python, node, …) whose exit-2 is syntax.
+    _INTERPRETER_COMMANDS = frozenset({
+        "bash", "sh", "zsh", "dash", "ksh",
+        "python", "python3", "python2",
+        "node", "ruby", "perl", "php",
+    })
+    has_syntax_text = any(p.search(text) for p in _SYNTAX_ERROR_PATTERNS)
+    if has_syntax_text or (exit_code == 2 and base_cmd in _INTERPRETER_COMMANDS):
+        return TerminalFailureClassification(
+            category=FailureCategory.persistent_error,
+            hint=(
+                "Syntax error in the command or script. Re-running unchanged "
+                "will fail identically. Fix the syntax (quoting, brackets, "
+                "operators), or use execute_code to run the corrected logic. "
+                "Do NOT retry the same command."
             ),
             should_retry=False,
         )


### PR DESCRIPTION
Closes #1743 (slice 1).

## Problem
The terminal circuit breaker classified exit 127 (missing_command), 126 (permission_denied), timeouts, and signal-kill as non-retryable — but **syntax errors** (exit code 2, or 'syntax error'/'unexpected token' output) fell through to generic persistent_error. The agent got no targeted cue that the command itself is malformed and re-running won't help, feeding the non-zero-exit retry spiral.

## Fix
- Add `_SYNTAX_ERROR_PATTERNS` (`syntax error`, `unexpected token`, `unexpected end of file`, `SyntaxError:`).
- Classify as deterministic non-retryable persistent_error with a targeted 'fix the syntax / use execute_code / do NOT retry the same command' hint.
- **Not** gated on bare `exit_code == 2` — grep/tar/diff use exit-2 for generic errors (file-not-found, archive corruption) that aren't syntax. Fires only on syntax-error text OR exit-2 from a known interpreter (bash/sh/python/node/ruby/perl/php).

## Verification
+37 lines of new classifier tests; all 155 related tests pass. Slice is 75 changed lines, under the 200-line self-merge cap.