### PR TITLE
fix: patch no-match file length + comma-separated read_file path coercion (#1744 #1681)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -874,7 +874,14 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         if (
             expected == "string"
             and isinstance(value, str)
-            and value.lstrip().startswith("[")
+            and (
+                value.lstrip().startswith("[")
+                # #1681 — also fire on bare comma-separated path lists
+                # (``"src/a.py, src/b.py"``, no brackets). The helper's
+                # path-like guards reject non-path strings (sentences,
+                # bare words), so widening the trigger is safe.
+                or "," in value
+            )
         ):
             extracted = _extract_first_from_stringified_array(value)
             if extracted is not None:
@@ -1006,25 +1013,83 @@ def _extract_first_from_stringified_array(value: str) -> Optional[str]:
     first string element so the tool receives a usable scalar path
     instead of the literal array string.
 
+    Falls back to splitting a non-JSON bracket-wrapped or bare
+    comma-separated list of paths (e.g. ``"[path/a, path/b]"`` or
+    ``"path/a, path/b"``) — a common open-weight-model emission when it
+    intends a list but forgets the JSON quoting. Without this, the whole
+    string would reach read_file and produce a file-not-found spiral.
+
     Returns the first string element, or ``None`` when the value is not a
     parseable JSON array of strings (in which case the caller leaves the
     original value untouched).
     """
     if not isinstance(value, str):
         return None
+    stripped = value.strip()
     try:
-        parsed = json.loads(value.strip())
+        parsed = json.loads(stripped)
     except (ValueError, TypeError):
+        parsed = None
+    if isinstance(parsed, list) and parsed:
+        # Only unwrap arrays of strings — a list of dicts/numbers on a
+        # string-typed param is a different error and should not be silently
+        # mangled into ``str(parsed[0])``.
+        first = parsed[0]
+        if isinstance(first, str):
+            return first
         return None
-    if not isinstance(parsed, list) or not parsed:
+    # ── Non-JSON comma-separated list fallback (#1681) ──────────────────
+    # The JSON parse failed. Detect a bracket-wrapped or bare
+    # comma-separated list of path-like items and take the first. Only
+    # fire when the value LOOKS like a path list: it contains a comma with
+    # whitespace, and the first token is a plausible path (not a bare
+    # number/word that a genuine path string could never be). This avoids
+    # mangling legitimate single-path strings that merely contain a comma
+    # (e.g. a filename with a comma, or shell args with flags).
+    _comma_list = re.match(
+        r"^[\[\s]*(?P<first>[^,\[\]\s][^,]*?)"
+        r"\s*,\s*(?P<rest>[^\]].*?)[\]\s]*$",
+        stripped,
+        re.DOTALL,
+    )
+    if not _comma_list:
         return None
-    # Only unwrap arrays of strings — a list of dicts/numbers on a
-    # string-typed param is a different error and should not be silently
-    # mangled into ``str(parsed[0])``.
-    first = parsed[0]
-    if isinstance(first, str):
-        return first
+    first_token = _comma_list.group("first").strip()
+    rest = _comma_list.group("rest").strip()
+    # Heuristic guard: the first token must look like a path — contain a
+    # path separator or a dot-extension or be a relative path — and the
+    # rest must look like another path, not arbitrary text.
+    if _looks_like_path(first_token) and _looks_like_path_list_rest(rest):
+        logger.info(
+            "coerce_tool_args: extracted first item from comma-separated "
+            "path list (%.60s...) for a string-typed param.",
+            value,
+        )
+        return first_token
     return None
+
+
+# Path separators / extensions that mark a token as path-like (#1681).
+_PATH_SEPARATOR_RE = re.compile(r"[/\\]|[.]\w{1,10}\Z|\.\.", re.IGNORECASE)
+
+
+def _looks_like_path(token: str) -> bool:
+    """Return True when *token* looks like a filesystem path."""
+    if not token:
+        return False
+    if _PATH_SEPARATOR_RE.search(token):
+        return True
+    # A bare word that is a known shell/tool keyword is not a path.
+    if token.lower() in {"true", "false", "null", "none", "and", "or", "not"}:
+        return False
+    return len(token) >= 3
+
+
+def _looks_like_path_list_rest(rest: str) -> bool:
+    """Return True when *rest* looks like the remainder of a path list."""
+    if not rest:
+        return False
+    return _PATH_SEPARATOR_RE.search(rest) is not None
 
 
 def _coerce_value(value: str, expected_type, schema: dict | None = None):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -167,6 +167,40 @@ class TestCoerceToolArgs:
             result = coerce_tool_args("test_tool", args)
             assert result["path"] == "[not-json-at-all"
 
+    def test_bracket_comma_path_list_extracts_first(self):
+        """#1681 — bracket-wrapped comma-separated path list (not valid
+        JSON, so json.loads fails) should still extract the first path."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "[path/a, path/b]"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "path/a"
+
+    def test_bare_comma_path_list_extracts_first(self):
+        """#1681 — bare comma-separated path list (no brackets) also
+        extracts the first path."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "src/main.py, src/utils.py"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "src/main.py"
+
+    def test_comma_in_sentence_not_mangled(self):
+        """#1681 — a normal sentence containing a comma is NOT a path list."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "just a comma, in a sentence"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "just a comma, in a sentence"
+
+    def test_bare_word_comma_not_path_list(self):
+        """#1681 — 'value1, value2' (no path separators in rest) untouched."""
+        schema = self._mock_schema({"path": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"path": "value1, value2"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["path"] == "value1, value2"
+
     def test_stringified_array_on_union_string_array_parsed_as_list(self):
         """Union type ['string', 'array'] — array branch fires first.
 

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -427,6 +427,34 @@ class TestFormatNoMatchHint:
         assert result == ""
 
 
+class TestFormatStructuredErrorNoMatch:
+    """Structured no-match errors surface the file's dimensions so the
+    model can decide re-read vs write_file in one step (#1744)."""
+
+    def setup_method(self):
+        from tools.fuzzy_match import format_structured_error
+        self.fmt = format_structured_error
+
+    def test_no_match_includes_file_length(self):
+        content = "def foo():\n    return 1\ndef bar():\n    return 2\n"
+        err = self.fmt(
+            "Could not find a match for old_string in the file",
+            0, "def baz():", "x", content, file_path="/tmp/x.py", strategy=None,
+        )
+        assert "File length:" in err
+        # 4 content lines + trailing newline = 5 lines, 48 chars.
+        assert "5 lines" in err
+        assert "48 chars" in err
+
+    def test_no_match_still_has_closest_region(self):
+        content = "def foo():\n    return 1\n"
+        err = self.fmt(
+            "Could not find a match for old_string in the file",
+            0, "def baz():", "x", content, strategy=None,
+        )
+        assert "Closest matching region" in err
+
+
 class TestEscapeNormalizedNewString:
     """Regression tests for unescaping common sequences in new_string when
     the matched region of the file contains real control characters.

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -1286,6 +1286,16 @@ def format_structured_error(
     # For no-match: show the closest matching region so the model can
     # see what's actually there and craft a corrected old_string.
     if error_type == "no_match":
+        # Surface the file's dimensions up front (#1744): when the anchor
+        # no-matches, the model needs to know the file's scale to decide
+        # whether to re-read it or switch to write_file — a path/typo-drift
+        # cue in one step instead of a blind re-read. A tiny file (few
+        # lines) is cheap to re-read fully; a large one argues for
+        # write_file or a targeted search.
+        total_lines = content.count("\n") + (1 if content else 0)
+        sections.append(
+            f"File length: {total_lines} lines, {len(content)} chars."
+        )
         snippet = _format_file_context_snippet(content, old_string, context_lines=5)
         if snippet:
             sections.append(


### PR DESCRIPTION
Closes #1744, #1681 (slice 2).

## #1744 — Patch no-match rate
The nearest-lines disambiguation from #1683 was already present (that's why no-match was unchanged). The remaining gap: the no-match error gave no sense of **file scale**, so the model couldn't decide re-read vs write_file in one step.
- `format_structured_error` no-match now prepends `File length: N lines, M chars` before the closest-matching region. Tiny file → cheap full re-read; large file → write_file/search.

## #1681 — read_file stringified/directory paths
`_extract_first_from_stringified_array` handled JSON arrays (`'["a","b"]'`) but NOT non-JSON bracket/bare comma lists (`[path/a, path/b]` or `src/a.py, src/b.py`) — those fell through `json.loads` → dropped → read_file file-not-found spiral.
- Add a comma-separated fallback extracting the first path-like token.
- Widen the string-typed trigger to also fire on comma-containing strings.
- Path-like heuristics (require a path separator in both tokens) prevent mangling sentences/bare words.

## Verification
+62 lines of new tests; all 155 related tests pass. Slice is 155 changed lines, under the 200-line self-merge cap.