### PR TITLE
feat: add composable Durability capability interface + backend registry (Closes #1761)

### DIFF
--- a/agent/durability.py
+++ b/agent/durability.py
@@ -1,0 +1,113 @@
+"""Composable ``Durability`` capability for skills/subagents.
+
+Mirrors the Pydantic AI v2.14 durability-capability pattern
+(``TemporalDurability`` / ``DBOSDurability`` / ``PrefectDurability``): a
+durability backend checkpoints model requests and tool calls inside a
+durable-execution context and can resume from a checkpoint after an
+interruption. Outside such a context the agent behaves identically (no-op
+default).
+
+Hermes already ships monolithic durable execution (Checkpoints v2, gateway
+auto-resume). This module is the composable slice: a capability attached per
+skill/subagent rather than wrapping the whole agent. Slice B (#1762) wires this
+into one real skill. Interface + registry only — nothing in the live workflow
+changes until a skill opts in.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class DurabilityBackend(Protocol):
+    """Pluggable durable-execution backend.
+
+    Checkpoints an arbitrary callable so it can be resumed from a recorded
+    checkpoint after an interruption. ``resume_from`` returns the recorded
+    result when available, else ``None``.
+    """
+
+    name: str
+
+    def run(self, fn: Callable[[], Any], checkpoint_id: Optional[str] = None) -> Any:
+        """Run ``fn``, checkpointing it if supported; replay from ``checkpoint_id``."""
+        ...
+
+    def resume_from(self, checkpoint_id: str) -> Any:
+        """Return the recorded result for ``checkpoint_id`` or ``None`` if unknown."""
+        ...
+
+
+@dataclass
+class NoOpDurability:
+    """Default backend: durable-execution is a no-op (current behavior).
+
+    ``run`` executes the callable immediately; nothing is checkpointed and
+    ``resume_from`` always returns ``None``. Fallback keeps behavior
+    byte-identical until a skill opts in.
+    """
+
+    name: str = "noop"
+
+    def run(self, fn: Callable[[], Any], checkpoint_id: Optional[str] = None) -> Any:
+        return fn()
+
+    def resume_from(self, checkpoint_id: str) -> Any:
+        return None
+
+
+@dataclass
+class Durability:
+    """Composable durability capability attachable to a skill/subagent.
+
+    ``enabled`` distinguishes "opted in with the no-op backend" from "not opted
+    in at all".
+    """
+
+    backend: DurabilityBackend = field(default_factory=NoOpDurability)
+    enabled: bool = False
+
+
+class MemoryDurabilityRegistry:
+    """In-process backend registry with a no-op default.
+
+    ``resolve`` returns the configured backend for a requested type name, or the
+    ``NoOpDurability`` when the name is unknown or empty — keeping the default
+    path identical for any skill that has not opted in.
+    """
+
+    def __init__(self) -> None:
+        self._backends: Dict[str, DurabilityBackend] = {}
+
+    def register(self, name: str, backend: DurabilityBackend) -> None:
+        self._backends[name] = backend
+
+    def get(self, name: str) -> Optional[DurabilityBackend]:
+        return self._backends.get(name)
+
+    def resolve(self, name: Optional[str]) -> DurabilityBackend:
+        """Return the named backend, or the no-op default when unset/unknown."""
+        if not name:
+            return NoOpDurability()
+        backend = self._backends.get(name)
+        return backend if backend is not None else NoOpDurability()
+
+    def available(self) -> Dict[str, str]:
+        return {name: backend.name for name, backend in self._backends.items()}
+
+
+def default_registry() -> MemoryDurabilityRegistry:
+    """Return the process-wide durability backend registry.
+
+    A module-level singleton so opting-in skills share one registry. Tests that
+    need isolation construct their own ``MemoryDurabilityRegistry`` instead.
+    """
+    return _DEFAULT_REGISTRY
+
+
+_DEFAULT_REGISTRY = MemoryDurabilityRegistry()

--- a/tests/agent/test_durability.py
+++ b/tests/agent/test_durability.py
@@ -1,0 +1,86 @@
+"""Tests for agent/durability.py — the composable Durability capability."""
+
+from agent.durability import (
+    Durability,
+    MemoryDurabilityRegistry,
+    NoOpDurability,
+)
+
+
+class _RecordingBackend:
+    """Standalone DurabilityBackend that records calls and can replay results."""
+
+    def __init__(self, name: str = "recording") -> None:
+        self.name = name
+        self.runs = []
+        self.resumes = []
+        self._stored = {}
+
+    def run(self, fn, checkpoint_id=None):  # noqa: ANN001
+        self.runs.append(checkpoint_id)
+        if checkpoint_id and checkpoint_id in self._stored:
+            return self._stored[checkpoint_id]
+        result = fn()
+        if checkpoint_id is not None:
+            self._stored[checkpoint_id] = result
+        return result
+
+    def resume_from(self, checkpoint_id):  # noqa: ANN001
+        self.resumes.append(checkpoint_id)
+        return self._stored.get(checkpoint_id)
+
+
+def test_noop_default_and_unknown_backend_are_noop():
+    """Default/unknown backends execute immediately and never checkpoint."""
+    registry = MemoryDurabilityRegistry()
+    backend = registry.resolve(None)
+    assert isinstance(backend, NoOpDurability)
+    assert isinstance(registry.resolve("temporal"), NoOpDurability)
+    calls = []
+    assert backend.run(lambda: calls.append(1) or "value") == "value"
+    assert calls == [1]  # executed exactly once
+    assert backend.resume_from("any") is None
+
+
+def test_registry_register_get_roundtrip():
+    """Registering a backend and fetching it by name returns the same object."""
+    registry = MemoryDurabilityRegistry()
+    backend = _RecordingBackend("temporal")
+    registry.register("temporal", backend)
+    assert registry.get("temporal") is backend
+    assert registry.resolve("temporal") is backend
+    assert registry.available() == {"temporal": "temporal"}
+
+
+def test_opt_in_resolves_configured_backend():
+    """A skill opting into a named backend gets that backend, per-capability."""
+    registry = MemoryDurabilityRegistry()
+    registry.register("dbos", _RecordingBackend("dbos"))
+    cap = Durability(backend=registry.resolve("dbos"), enabled=True)
+    assert cap.enabled is True
+    assert cap.backend.name == "dbos"
+    assert not isinstance(cap.backend, NoOpDurability)
+
+
+def test_durability_is_per_skill_composable():
+    """Capability attaches per-skill: one opted in, another not."""
+    registry = MemoryDurabilityRegistry()
+    registry.register("temporal", _RecordingBackend("temporal"))
+    opted_in = Durability(backend=registry.resolve("temporal"), enabled=True)
+    not_opted = Durability()  # default: disabled no-op
+    assert opted_in.enabled is True
+    assert not_opted.enabled is False
+    assert isinstance(not_opted.backend, NoOpDurability)
+    calls = []
+    assert not_opted.backend.run(lambda: calls.append(1) or "x", "cp-1") == "x"
+    assert calls == [1]
+
+
+def test_checkpoint_resume_roundtrip():
+    """A backend stores a result under a checkpoint id and replays it."""
+    backend = _RecordingBackend()
+    assert backend.run(lambda: {"step": "done"}, checkpoint_id="cp-1") == {
+        "step": "done"
+    }
+    assert backend.resume_from("cp-1") == {"step": "done"}
+    assert _RecordingBackend().resume_from("cp-9") is None


### PR DESCRIPTION
Automated evolution PR for issue #1761.

Slice A of decomposed parent #1288 (durable-execution capability). Adds `agent/durability.py`: the `DurabilityBackend` Protocol, `NoOpDurability` no-op default, `MemoryDurabilityRegistry`, and the per-skill `Durability` capability — mirroring the Pydantic AI v2.14 durability-capability pattern.

- Interface + registry only; no live workflow wiring (that is Slice B, #1762).
- No-op default keeps non-durable behavior byte-identical until a skill opts in.
- Unit tests (5) assert: default is no-op, unknown backend resolves to no-op, opt-in per-skill returns the configured backend, checkpoint/resume roundtrip, per-skill composability.

Closes #1761