### PR TITLE
feat: wire Durability into concrete backend — checkpoint/resume E2E (increment 1 of #1762)

### DIFF
--- a/agent/durability.py
+++ b/agent/durability.py
@@ -16,7 +16,9 @@ changes until a skill opts in.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 
@@ -111,3 +113,48 @@ def default_registry() -> MemoryDurabilityRegistry:
 
 
 _DEFAULT_REGISTRY = MemoryDurabilityRegistry()
+
+
+@dataclass
+class DiskDurability:
+    """File-backed backend: checkpoints results to ``checkpoint_dir`` on disk.
+
+    ``run`` stores the result of ``fn`` under ``<checkpoint_dir>/<id>.json`` so
+    a later ``resume_from`` can replay it after an interruption without
+    re-executing the callable. This is the concrete backend used by Slice B's
+    E2E proof (wiring a skill to durable execution).
+    """
+
+    checkpoint_dir: str
+    name: str = "disk"
+
+    def _path(self, checkpoint_id: str) -> str:
+        return os.path.join(self.checkpoint_dir, f"{checkpoint_id}.json")
+
+    def run(self, fn, checkpoint_id=None):  # noqa: ANN001
+        if checkpoint_id is not None and os.path.exists(self._path(checkpoint_id)):
+            return self.resume_from(checkpoint_id)
+        result = fn()
+        if checkpoint_id is not None:
+            os.makedirs(self.checkpoint_dir, exist_ok=True)
+            with open(self._path(checkpoint_id), "w", encoding="utf-8") as fh:
+                json.dump(result, fh)
+        return result
+
+    def resume_from(self, checkpoint_id):
+        """Return the recorded result for ``checkpoint_id`` or ``None`` if unknown."""
+        path = self._path(checkpoint_id)
+        if not os.path.exists(path):
+            return None
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+
+
+def durable_run(registry, backend_name, fn, checkpoint_id=None):  # noqa: ANN001
+    """Opt a callable into durable execution via the named backend.
+
+    Resolves ``backend_name`` from ``registry`` (falling back to the no-op
+    default), runs ``fn`` through it, and returns the result. This is the
+    single opt-in helper skills call to make a step checkpointed/resumable.
+    """
+    return registry.resolve(backend_name).run(fn, checkpoint_id=checkpoint_id)

--- a/tests/agent/test_durability_e2e.py
+++ b/tests/agent/test_durability_e2e.py
@@ -1,0 +1,61 @@
+"""E2E tests for Slice B — wiring Durability into a real backend with resume."""
+
+import os
+
+from agent.durability import (
+    DiskDurability,
+    MemoryDurabilityRegistry,
+    durable_run,
+)
+
+
+class _CountingSkill:
+    """A stand-in skill whose expensive step is made durable via opt-in."""
+
+    def __init__(self) -> None:
+        self.runs = 0
+
+    def step(self, value: int) -> dict:
+        self.runs += 1
+        return {"computed": value * 2}
+
+
+def test_disk_backend_checkpoint_then_resume_without_reexec(tmp_path):
+    """A checkpointed call resumes from disk after 'interruption' (no re-run)."""
+    skill = _CountingSkill()
+    registry = MemoryDurabilityRegistry()
+    registry.register("disk", DiskDurability(checkpoint_dir=str(tmp_path)))
+
+    first = durable_run(registry, "disk", lambda: skill.step(21), checkpoint_id="cp-1")
+    assert first == {"computed": 42}
+    assert skill.runs == 1
+
+    # Simulate interruption: a NEW skill instance, same checkpoint id. The
+    # backend must replay from disk without re-executing the callable.
+    fresh = _CountingSkill()
+    resumed = durable_run(
+        registry, "disk", lambda: fresh.step(21), checkpoint_id="cp-1"
+    )
+    assert resumed == {"computed": 42}
+    assert fresh.runs == 0  # never executed — replayed from checkpoint
+
+    # A real checkpoint file exists under the temp HERMES_HOME checkpoint dir.
+    assert os.path.exists(tmp_path / "cp-1.json")
+
+
+def test_disk_backend_unknown_checkpoint_returns_none(tmp_path):
+    """resume_from on a missing checkpoint returns None (nothing recorded)."""
+    backend = DiskDurability(checkpoint_dir=str(tmp_path))
+    assert backend.resume_from("missing") is None
+
+
+def test_durable_run_with_noop_backend_still_executes(tmp_path):
+    """A skill not opted in (noop) still runs, but is not checkpointed."""
+    skill = _CountingSkill()
+    registry = MemoryDurabilityRegistry()  # no backend registered -> noop default
+    result = durable_run(
+        registry, "does-not-exist", lambda: skill.step(5), checkpoint_id="cp-2"
+    )
+    assert result == {"computed": 10}
+    assert skill.runs == 1
+    assert not os.path.exists(tmp_path / "cp-2.json")


### PR DESCRIPTION
Automated evolution PR for issue #1762 (Slice B of #1288, depends on #1761 Slice A).

Wires the Durability capability into a concrete file-backed backend and proves the composable shape end-to-end:
- Adds `DiskDurability` (file-backed checkpoint backend) to `agent/durability.py`
- Adds `durable_run` — the single opt-in helper skills call to make a step checkpointed/resumable
- E2E test (`tests/agent/test_durability_e2e.py`): a checkpointed call resumes from disk after an "interruption" WITHOUT re-executing the callable; non-opted-in skills stay no-op (no checkpoint file written)

Base targets the #1761 branch (Slice A) since this depends on its unmerged interface; GitHub auto-retargets to main once PR #1764 merges, keeping this diff small (47-line module increment + one test file).

Deferred (next increment):
- Opt one real evolution-funnel skill/subagent into durable execution at a live call site (this slice proves the backend + helper; wiring the actual long-running stage is the remaining step to fully close #1288).