### PR TITLE
fix(cron): sort find_latest_digest by filename not st_mtime (Closes #1767)

### DIFF
--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -174,7 +174,13 @@ def _preflight_enabled(cfg: Optional[Any] = None) -> bool:
 def find_latest_digest(
     stage: str, hermes_home: Optional[Path] = None
 ) -> Optional[Path]:
-    """Return the most recent digest file for an evolution stage, or None."""
+    """Return the most recent digest file for an evolution stage, or None.
+
+    Digest filenames follow a sortable date-encoded convention
+    (``YYYY-MM-DD.json`` / ``.md``, optionally with ``-pass<N>`` / ``-tick<N>``
+    suffixes).  Sorting by filename instead of ``st_mtime`` avoids flaky
+    results when files are touched or copied after creation (#1767).
+    """
     if stage not in _EVOLUTION_STAGES:
         return None
     ext = _EVOLUTION_STAGES[stage]
@@ -183,7 +189,7 @@ def find_latest_digest(
         return None
     candidates = sorted(
         (p for p in stage_dir.iterdir() if p.is_file() and p.suffix == ext),
-        key=lambda p: p.stat().st_mtime,
+        key=lambda p: p.name,
         reverse=True,
     )
     return candidates[0] if candidates else None

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -170,8 +170,28 @@ class TestDigestFallback:
         new = stage_dir / "2026-06-23.json"
         old.write_text("old")
         new.write_text("new")
+        # Regression for #1767: touch() on both files resets mtimes to ~now,
+        # making mtime-based sorting ambiguous.  Filename-based sorting is
+        # stable regardless of mtime.
         old.touch()
         new.touch()
+        assert ep.find_latest_digest("introspection", tmp_path) == new
+
+    def test_find_latest_digest_ignores_mtime(self, tmp_path):
+        """Even when an older digest has a newer mtime, it must not win (#1767)."""
+        import os
+        import time
+
+        stage_dir = tmp_path / "evolution" / "introspection"
+        stage_dir.mkdir(parents=True)
+        old = stage_dir / "2026-06-20.json"
+        new = stage_dir / "2026-06-23.json"
+        new.write_text("new")
+        old.write_text("old")
+        # Make the older file's mtime much newer — mtime sort would pick it.
+        ts = time.time()
+        os.utime(old, (ts + 3600, ts + 3600))
+        os.utime(new, (ts, ts))
         assert ep.find_latest_digest("introspection", tmp_path) == new
 
     def test_load_digest_as_fallback(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the flaky `test_find_latest_digest` test that was blocking PR #1748 CI (slice 8/8).

**Root cause:** `find_latest_digest()` sorted candidate files by `st_mtime`. The test created an old file and a new file, then called `touch()` on both — resetting both mtimes to ~now and making mtime-based sorting ambiguous/flaky.

**Fix:** Digest filenames follow a sortable date-encoded convention (`YYYY-MM-DD.json` / `.md`, optionally with `-pass<N>` / `-tick<N>` suffixes). Sorting by `p.name` gives stable, correct chronological order regardless of filesystem mtime state.

## Changes

- `cron/evolution_preflight.py`: `find_latest_digest()` now sorts by `p.name` instead of `p.stat().st_mtime` (+ updated docstring)
- `tests/cron/test_evolution_preflight.py`: added `test_find_latest_digest_ignores_mtime` regression test + clarifying comment in existing test

## Validation

- ✅ All 5 `TestDigestFallback` tests pass locally
- ✅ `ruff check` clean
- ✅ 30 changed lines (well under 200-line self-merge cap)

## Impact

Unblocks PR #1748 (`feat: active context-denoising for failed-attempt tool results`, Closes #1580) whose CI was red solely due to this pre-existing flaky test — the PR's actual changes (agent/context_compressor.py, agent/failed_attempt_marker.py) are unrelated to the failure.

Closes #1767