### PR TITLE
fix: restrict comma-guard to path-like params only (#1768)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -880,7 +880,10 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                 # (``"src/a.py, src/b.py"``, no brackets). The helper's
                 # path-like guards reject non-path strings (sentences,
                 # bare words), so widening the trigger is safe.
-                or "," in value
+                or (
+                    "," in value
+                    and _is_path_like_param(key)
+                )
             )
         ):
             extracted = _extract_first_from_stringified_array(value)
@@ -1083,6 +1086,19 @@ def _looks_like_path(token: str) -> bool:
     if token.lower() in {"true", "false", "null", "none", "and", "or", "not"}:
         return False
     return len(token) >= 3
+
+
+_PATH_LIKE_PARAM_RE = re.compile(
+    r"path|file|url|dir|dest|src|dst|target|glob|pattern|prefix|output|input",
+    re.IGNORECASE,
+)
+
+
+def _is_path_like_param(key: str) -> bool:
+    """Return True when *key* names a param that typically holds a path/URL."""
+    if not key:
+        return False
+    return _PATH_LIKE_PARAM_RE.search(key) is not None
 
 
 def _looks_like_path_list_rest(rest: str) -> bool:

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -201,6 +201,13 @@ class TestCoerceToolArgs:
             result = coerce_tool_args("test_tool", args)
             assert result["path"] == "value1, value2"
 
+    def test_content_param_with_commas_not_truncated(self):
+        schema = self._mock_schema({"content": {"type": "string"}})
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"content": "line one, line two, line three"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["content"] == "line one, line two, line three"
+
     def test_stringified_array_on_union_string_array_parsed_as_list(self):
         """Union type ['string', 'array'] — array branch fires first.
 


### PR DESCRIPTION
## Problem

The stringified-array guard for string-typed params (#1681, PR #1751) fired on ANY string parameter containing a comma. This silently truncated legitimate multi-line content passed to write_file, patch, execute_code and other tools whose string params (content, code, new_string, prompt) routinely contain commas.

### Reproduction

write_file content with a comma gets truncated at the first comma. This caused silent data loss with no error signal - files were written truncated, patches were applied partially, code was executed incomplete.

## Fix

Only trigger the comma-separated fallback when the param name looks path-like. Added _is_path_like_param(key) that checks the param name against a regex of path-like keywords: path, file, url, dir, dest, src, dst, target, glob, pattern, prefix, output, input.

The JSON-array trigger (value starts with open bracket) remains unchanged - that path is safe because it requires actual JSON array syntax.

## Test

Added regression test test_content_param_with_commas_not_truncated verifying that a content param with commas is preserved intact. All 32 existing coercion tests still pass.