### PR TITLE
feat: wire Durability into evolution funnel stage boundaries (Closes #1775)

### DIFF
--- a/agent/durability.py
+++ b/agent/durability.py
@@ -179,4 +179,20 @@ def default_registry() -> MemoryDurabilityRegistry:
     return _DEFAULT_REGISTRY
 
 
+def durable_run(
+    registry: MemoryDurabilityRegistry,
+    backend_name: Optional[str],
+    fn: Callable[[], Any],
+    checkpoint_id: Optional[str] = None,
+) -> Any:
+    """Resolve ``backend_name`` from ``registry`` and run ``fn`` through it.
+
+    When ``backend_name`` is unset/unknown the no-op default is used, so the
+    callable executes immediately with zero overhead — callers that have not
+    opted in behave identically. This is the convenience entry point Slice C
+    wires into the evolution-funnel stage boundaries.
+    """
+    return registry.resolve(backend_name).run(fn, checkpoint_id=checkpoint_id)
+
+
 _DEFAULT_REGISTRY = MemoryDurabilityRegistry()

--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +46,24 @@ def _counts_by(items: list, key: str) -> Dict[str, int]:
     return dict(c)
 
 
-def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
+def compute_funnel(
+    evolution_dir: Path,
+    date: str,
+    *,
+    durability_registry: Any = None,
+    durability_backend: Optional[str] = None,
+) -> Dict[str, Any]:
     """Build the funnel record for one date from whatever stage reports exist.
 
     Every field defaults to 0 / {} so a missing stage report never crashes the
     metric — it just shows that stage produced nothing recorded that day.
+
+    When ``durability_registry`` is provided with a non-no-op
+    ``durability_backend``, each stage-report load is checkpointed via
+    ``durable_run`` so a mid-funnel crash resumes from the last completed stage
+    checkpoint instead of re-reading every report from scratch. When the
+    registry is ``None`` (the default) behavior is byte-identical to the
+    non-durable path — no opt-in, no change.
     """
 
     # Stage reports are normally dicts, but some stages write a bare LIST (e.g.
@@ -61,10 +74,31 @@ def compute_funnel(evolution_dir: Path, date: str) -> Dict[str, Any]:
     def _as_dict(x: Any) -> Dict[str, Any]:
         return x if isinstance(x, dict) else {}
 
-    issues_raw = _load_json(issues_path := evolution_dir / "issues" / f"{date}.json")
-    analysis = _as_dict(_load_json(evolution_dir / "analysis" / f"{date}.json"))
-    integration = _as_dict(_load_json(evolution_dir / "integration" / f"{date}.json"))
-    introspection_raw = _load_json(evolution_dir / "introspection" / f"{date}.json")
+    def _stage_load(stage_name: str, path: Path) -> Any:
+        """Load a stage report, checkpointing it when durability is opted in."""
+        if durability_registry is not None:
+            from agent.durability import durable_run
+
+            return durable_run(
+                durability_registry,
+                durability_backend,
+                lambda: _load_json(path),
+                checkpoint_id=f"funnel-{date}-{stage_name}",
+            )
+        return _load_json(path)
+
+    issues_raw = _stage_load(
+        "issues", issues_path := evolution_dir / "issues" / f"{date}.json"
+    )
+    analysis = _as_dict(
+        _stage_load("analysis", evolution_dir / "analysis" / f"{date}.json")
+    )
+    integration = _as_dict(
+        _stage_load("integration", evolution_dir / "integration" / f"{date}.json")
+    )
+    introspection_raw = _stage_load(
+        "introspection", evolution_dir / "introspection" / f"{date}.json"
+    )
     issues = _as_dict(issues_raw)
 
     selected = analysis.get("selected_for_implementation") or []
@@ -463,7 +497,30 @@ def main(argv: list[str]) -> int:
             )
             return 1
 
-    record = compute_funnel(evolution_dir, date)
+    # ── Durability opt-in (Slice C #1775) ──────────────────────────────────
+    # When EVOLUTION_DURABILITY_BACKEND is set (e.g. "file"), the funnel
+    # checkpoints each stage-report load so a mid-funnel crash resumes from
+    # the last completed stage instead of re-reading every report. When unset
+    # or "noop", behavior is byte-identical to the non-durable path.
+    _durability_backend_name = os.environ.get(
+        "EVOLUTION_DURABILITY_BACKEND", ""
+    ).strip()
+    _durability_registry = None
+    if _durability_backend_name and _durability_backend_name != "noop":
+        try:
+            from agent.durability import FileDurabilityBackend, MemoryDurabilityRegistry
+
+            _durability_registry = MemoryDurabilityRegistry()
+            _durability_registry.register("file", FileDurabilityBackend())
+        except Exception:
+            _durability_registry = None  # fail-open: non-durable path
+
+    record = compute_funnel(
+        evolution_dir,
+        date,
+        durability_registry=_durability_registry,
+        durability_backend=_durability_backend_name or None,
+    )
 
     # Replace the integration stage's self-reported merge count with GitHub
     # truth when available: this counts owner-reviewed merges the self-report

--- a/tests/agent/test_durability_funnel.py
+++ b/tests/agent/test_durability_funnel.py
@@ -1,0 +1,111 @@
+"""E2E test for Slice C (#1775) — Durability wired into the evolution funnel.
+
+Simulates a mid-funnel crash and verifies resume from the last checkpoint.
+Uses a temp HERMES_HOME and real filesystem checkpoints (no mocks).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from agent.durability import FileDurabilityBackend, MemoryDurabilityRegistry
+
+_scripts_dir = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_scripts_dir) not in sys.path:
+    sys.path.insert(0, str(_scripts_dir))
+
+from evolution_funnel import compute_funnel  # noqa: E402
+
+
+def _ws(evolution_dir: Path, stage: str, date: str, data: object) -> None:
+    """Write a stage report file."""
+    d = evolution_dir / stage
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{date}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_funnel_durability_crash_resume(tmp_path: Path):
+    """Mid-funnel crash resumes from the last checkpoint, not from scratch."""
+    date = "2026-08-07"
+    edir = tmp_path / "evolution"
+    edir.mkdir(parents=True)
+
+    _ws(
+        edir,
+        "issues",
+        date,
+        {"issues_created": [{"number": 101}, {"number": 102}], "total_proposals": 10},
+    )
+    _ws(
+        edir,
+        "analysis",
+        date,
+        {
+            "selected_for_implementation": [
+                {"issue_number": 101, "selected_reason": "score"}
+            ],
+            "rejected": [],
+        },
+    )
+    _ws(edir, "integration", date, {"merged": [{"pr": 999}], "skipped": []})
+    _ws(edir, "introspection", date, [{"pattern": "retry_spiral", "count": 2}])
+
+    cp_dir = tmp_path / "checkpoints"
+    reg = MemoryDurabilityRegistry()
+    reg.register("file", FileDurabilityBackend(base_dir=cp_dir))
+
+    r1 = compute_funnel(edir, date, durability_registry=reg, durability_backend="file")
+    assert r1["issues_created"] == 2 and r1["selected"] == 1 and r1["merged"] == 1
+    assert r1["introspection_patterns"] == 1
+    assert len(list(cp_dir.glob("*.json"))) == 4
+
+    # Simulate crash: delete stage reports (checkpoints survive)
+    for stage in ("issues", "analysis", "integration", "introspection"):
+        f = edir / stage / f"{date}.json"
+        if f.exists():
+            f.unlink()
+
+    # Re-run: replays from checkpoints, not from deleted files
+    r2 = compute_funnel(edir, date, durability_registry=reg, durability_backend="file")
+    assert r2["issues_created"] == r1["issues_created"]
+    assert r2["selected"] == r1["selected"]
+    assert r2["merged"] == r1["merged"]
+    assert r2["introspection_patterns"] == r1["introspection_patterns"]
+    assert r2["selected_issue_ids"] == r1["selected_issue_ids"]
+
+
+def test_funnel_no_durability_is_noop(tmp_path: Path):
+    """Without durability opt-in, compute_funnel behaves identically."""
+    date = "2026-08-07"
+    edir = tmp_path / "evolution"
+    edir.mkdir(parents=True)
+    _ws(edir, "issues", date, {"issues_created": [{"number": 1}], "total_proposals": 3})
+    _ws(
+        edir,
+        "analysis",
+        date,
+        {"selected_for_implementation": [{"issue_number": 1}], "rejected": []},
+    )
+    record = compute_funnel(edir, date)
+    assert record["issues_created"] == 1 and record["selected"] == 1
+    assert record["merged"] == 0 and record["introspection_patterns"] == 0
+
+
+def test_funnel_noop_backend_unchanged(tmp_path: Path):
+    """Opting in with 'noop' backend is byte-identical to not opting in."""
+    date = "2026-08-07"
+    edir = tmp_path / "evolution"
+    edir.mkdir(parents=True)
+    _ws(
+        edir,
+        "issues",
+        date,
+        {"issues_created": [{"number": 1}, {"number": 2}], "total_proposals": 5},
+    )
+    _ws(edir, "analysis", date, {"selected_for_implementation": []})
+    reg = MemoryDurabilityRegistry()
+    record = compute_funnel(
+        edir, date, durability_registry=reg, durability_backend="noop"
+    )
+    assert record["issues_created"] == 2 and record["selected"] == 0
+    assert not list(tmp_path.rglob("durability"))


### PR DESCRIPTION
Automated evolution PR for issue #1775 (Slice C of #1288).

## What

Wires the composable Durability capability (Slices A #1761 + B #1762, merged) into the real evolution-funnel skill at stage-report load boundaries. `compute_funnel()` now accepts optional `durability_registry` + `durability_backend` kwargs; when opted in via the `EVOLUTION_DURABILITY_BACKEND` env var, each stage-report load (issues, analysis, integration, introspection) is checkpointed via `durable_run()` so a mid-funnel crash resumes from the last completed stage instead of re-reading every report from scratch.

## Changes

- **`agent/durability.py`** — add `durable_run()` convenience helper (resolves backend from registry, runs fn with checkpoint)
- **`scripts/evolution_funnel.py`** — wire each `_stage_load()` through `durable_run()`, opt-in via `EVOLUTION_DURABILITY_BACKEND` env var (no-op default preserved — byte-identical when unset)
- **`tests/agent/test_durability_funnel.py`** — 3 E2E tests: crash→resume from checkpoint, no-durability no-op invariant, noop-backend unchanged

## Verification

- lint ✓, format ✓
- 3 targeted tests ✓ (14 total durability tests ✓)
- Diff: 191 insertions + 7 deletions = 198 lines (≤ 200-line self-merge cap)

Closes #1775. This is the final slice of parent #1288.