### PR TITLE
feat: pinned-constraint mechanism — mark system-prompt rules as non-evictable (Closes #1774)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -139,6 +139,72 @@ COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
 _DB_PERSISTED_MARKER = "_db_persisted"
 
+# ---------------------------------------------------------------------------
+# Pinned-constraint mechanism (#1774 / Governance Decay, arXiv:2606.22528)
+#
+# A *pinned constraint* is a governance / safety / deployment-specific rule
+# that MUST survive every context-window rotation.  Without explicit pinning,
+# the summarizer silently drops soft rules 30-59 % of the time (Governance
+# Decay).  A message is pinned when it carries ``_pinned_constraint = True``
+# metadata OR its content contains the ``[PINNED_CONSTRAINT]`` text marker.
+#
+# Slice A (this block) defines the contract + parser only.  Slice B (#1773)
+# consumes the extracted set to re-inject anything the summarizer dropped.
+# ---------------------------------------------------------------------------
+PINNED_CONSTRAINT_METADATA_KEY = "_pinned_constraint"
+PINNED_CONSTRAINT_MARKER = "[PINNED_CONSTRAINT]"
+_PINNED_CONSTRAINT_RE = re.compile(
+    re.escape(PINNED_CONSTRAINT_MARKER)
+    + r"\s*(.*?)"                       # capture the constraint text
+    + r"\s*\[/PINNED_CONSTRAINT\]",     # closing tag
+    re.DOTALL,
+)
+
+
+def _is_pinned_constraint_message(msg: Dict[str, Any]) -> bool:
+    """Return True when *msg* carries the pinned-constraint signal."""
+    if not isinstance(msg, dict):
+        return False
+    if msg.get(PINNED_CONSTRAINT_METADATA_KEY):
+        return True
+    content = msg.get("content")
+    if isinstance(content, str) and PINNED_CONSTRAINT_MARKER in content:
+        return True
+    return False
+
+
+def _extract_pinned_constraints(messages: List[Dict[str, Any]]) -> list[str]:
+    """Extract the ordered set of pinned-constraint texts from *messages*.
+
+    Works for both pin signals: the ``_pinned_constraint`` metadata flag
+    (the whole message content becomes the constraint) and the inline
+    ``[PINNED_CONSTRAINT] … [/PINNED_CONSTRAINT]`` text marker (only the
+    tagged span is captured).  Returns de-duplicated, order-of-first-appearance.
+    """
+    constraints: list[str] = []
+    seen: set[str] = set()
+
+    def _add(text: str) -> None:
+        text = (text or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            constraints.append(text)
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        # Metadata-flagged messages contribute their full content.
+        if msg.get(PINNED_CONSTRAINT_METADATA_KEY):
+            if isinstance(content, str) and content.strip():
+                _add(content)
+            continue
+        # Inline text markers contribute only the tagged spans.
+        if isinstance(content, str):
+            for m in _PINNED_CONSTRAINT_RE.finditer(content):
+                _add(m.group(1))
+    return constraints
+
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
 COMPRESSION_CONTINUATION_USER_CONTENT = (
     "Continue from the compressed conversation context above. "

--- a/tests/agent/test_pinned_constraint_pin_mechanism.py
+++ b/tests/agent/test_pinned_constraint_pin_mechanism.py
@@ -1,0 +1,88 @@
+"""Tests for the pinned-constraint pin mechanism (Slice A, #1774).
+
+Tests only the parser / extractor — the contract that lets a deployment
+mark governance rules as non-evictable.  Re-injection (Slice B #1773) is
+tested separately.
+"""
+
+from agent.context_compressor import (
+    PINNED_CONSTRAINT_MARKER,
+    PINNED_CONSTRAINT_METADATA_KEY,
+    _extract_pinned_constraints,
+    _is_pinned_constraint_message,
+)
+
+
+class TestIsPinnedConstraintMessage:
+    def test_metadata_flag_true(self):
+        msg = {"role": "system", "content": "Never merge without tests.", PINNED_CONSTRAINT_METADATA_KEY: True}
+        assert _is_pinned_constraint_message(msg) is True
+
+    def test_text_marker_present(self):
+        msg = {"role": "system", "content": f"Rule: {PINNED_CONSTRAINT_MARKER} cap=200 [/PINNED_CONSTRAINT] done"}
+        assert _is_pinned_constraint_message(msg) is True
+
+    def test_plain_message_not_pinned(self):
+        assert _is_pinned_constraint_message({"role": "user", "content": "Hello world"}) is False
+
+    def test_non_dict_and_none_content_not_pinned(self):
+        assert _is_pinned_constraint_message("not a dict") is False  # type: ignore[arg-type]
+        assert _is_pinned_constraint_message(None) is False  # type: ignore[arg-type]
+        assert _is_pinned_constraint_message({"role": "assistant", "content": None}) is False
+
+
+class TestExtractPinnedConstraints:
+    def test_extracts_metadata_flagged_message(self):
+        messages = [
+            {"role": "system", "content": "Always verify before merge.", PINNED_CONSTRAINT_METADATA_KEY: True},
+            {"role": "user", "content": "hi"},
+        ]
+        assert _extract_pinned_constraints(messages) == ["Always verify before merge."]
+
+    def test_extracts_inline_text_marker(self):
+        msg = {"role": "system", "content": f"Guidelines: {PINNED_CONSTRAINT_MARKER} Max 200 lines [/PINNED_CONSTRAINT] ok"}
+        assert _extract_pinned_constraints([msg]) == ["Max 200 lines"]
+
+    def test_extracts_multiple_inline_markers_in_order(self):
+        msg = {
+            "role": "system",
+            "content": (
+                f"{PINNED_CONSTRAINT_MARKER} Rule A [/PINNED_CONSTRAINT] "
+                f"and {PINNED_CONSTRAINT_MARKER} Rule B [/PINNED_CONSTRAINT]"
+            ),
+        }
+        assert _extract_pinned_constraints([msg]) == ["Rule A", "Rule B"]
+
+    def test_no_constraints_empty_and_non_dict(self):
+        assert _extract_pinned_constraints([]) == []
+        assert _extract_pinned_constraints(["garbage", None, 42]) == []  # type: ignore[list-item]
+        assert _extract_pinned_constraints([
+            {"role": "system", "content": "You are a helpful assistant."},
+        ]) == []
+
+    def test_deduplicates_same_constraint(self):
+        messages = [
+            {"role": "system", "content": "Rule A.", PINNED_CONSTRAINT_METADATA_KEY: True},
+            {"role": "assistant", "content": "Rule A.", PINNED_CONSTRAINT_METADATA_KEY: True},
+        ]
+        assert _extract_pinned_constraints(messages) == ["Rule A."]
+
+    def test_mixed_metadata_and_inline(self):
+        messages = [
+            {"role": "system", "content": "From metadata.", PINNED_CONSTRAINT_METADATA_KEY: True},
+            {"role": "user", "content": f"{PINNED_CONSTRAINT_MARKER} From inline [/PINNED_CONSTRAINT]"},
+        ]
+        assert _extract_pinned_constraints(messages) == ["From metadata.", "From inline"]
+
+    def test_multiline_constraint_extracted(self):
+        constraint = "Line one.\nLine two.\nLine three."
+        msg = {"role": "system", "content": f"{PINNED_CONSTRAINT_MARKER} {constraint} [/PINNED_CONSTRAINT]"}
+        assert _extract_pinned_constraints([msg]) == [constraint]
+
+    def test_malformed_marker_without_close_is_ignored(self):
+        msg = {"role": "system", "content": f"{PINNED_CONSTRAINT_MARKER} no closing tag here"}
+        assert _extract_pinned_constraints([msg]) == []
+
+    def test_strips_whitespace(self):
+        msg = {"role": "system", "content": f"{PINNED_CONSTRAINT_MARKER}   spaced rule   [/PINNED_CONSTRAINT]"}
+        assert _extract_pinned_constraints([msg]) == ["spaced rule"]


### PR DESCRIPTION
## Summary

Implements **Slice A** of the Governance Decay security fix (#1657): defines a pin mechanism that lets deployments mark governance / safety / deployment-specific rules as **non-evictable** across context-window rotations.

## Background

Governance Decay (arXiv:2606.22528) demonstrates that context compaction silently erases soft deployment-specific safety rules (merge caps, verification-separation, tool scoping), raising violation rates from **0% → 30-59%**. This slice creates the foundational pin contract that Slice B (#1773) will consume for post-compaction re-injection.

## Changes

**`agent/context_compressor.py`** (+66 lines):
- `PINNED_CONSTRAINT_METADATA_KEY` — metadata flag `_pinned_constraint = True`
- `PINNED_CONSTRAINT_MARKER` — inline text marker `[PINNED_CONSTRAINT] … [/PINNED_CONSTRAINT]`
- `_is_pinned_constraint_message()` — detects both pin signals
- `_extract_pinned_constraints()` — parser that extracts the ordered, de-duplicated constraint set from any message list

**`tests/agent/test_pinned_constraint_pin_mechanism.py`** (new, +88 lines):
- 13 tests covering: metadata detection, text marker detection, inline multi-marker extraction, deduplication, mixed metadata+inline, multiline constraints, malformed markers (ignored), whitespace stripping, edge cases (empty list, non-dict entries, None content)

## Validation
- `ruff check` ✓
- `pytest tests/agent/test_pinned_constraint_pin_mechanism.py` — 13/13 ✓
- Diff: +154 lines (under 200-line autonomous merge cap) ✓

Closes #1774