### PR TITLE
feat: wire Durability capability into evolution-funnel skill (Closes #1775)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -424,6 +424,24 @@ def cycle_date(now) -> str:
     return day.isoformat()
 
 
+def _compute_funnel_durable(evolution_dir: Path, date: str) -> Dict[str, Any]:
+    """Run ``compute_funnel`` with filesystem checkpointing (Durability #1288).
+
+    If a checkpoint for this date's funnel already exists, resume from it
+    (skip re-computation after a crash mid-cycle). Otherwise compute, persist
+    the result, and return it. Falls back to direct execution if the
+    durability module is unavailable — byte-identical default behavior.
+    """
+    try:
+        from agent.durability import FileDurabilityBackend
+
+        backend = FileDurabilityBackend()
+        checkpoint_id = f"funnel-{date}"
+        return backend.run(lambda: compute_funnel(evolution_dir, date), checkpoint_id)
+    except Exception:
+        return compute_funnel(evolution_dir, date)
+
+
 def main(argv: list[str]) -> int:
     evolution_dir = Path(
         os.environ.get(
@@ -463,7 +481,7 @@ def main(argv: list[str]) -> int:
             )
             return 1
 
-    record = compute_funnel(evolution_dir, date)
+    record = _compute_funnel_durable(evolution_dir, date)
 
     # Replace the integration stage's self-reported merge count with GitHub
     # truth when available: this counts owner-reviewed merges the self-report

--- a/tests/scripts/test_evolution_funnel_durability.py
+++ b/tests/scripts/test_evolution_funnel_durability.py
@@ -1,0 +1,68 @@
+"""Tests for the Durability wiring in evolution_funnel (Slice C, #1775).
+
+Verifies _compute_funnel_durable wraps compute_funnel in
+FileDurabilityBackend, replays checkpoints on resume, and falls back to
+direct compute when the backend is unavailable.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import evolution_funnel as ef  # noqa: E402
+
+
+class TestDurabilityWiring:
+    """Tests that _compute_funnel_durable wraps compute_funnel correctly."""
+
+    def test_durable_compute_returns_same_result_as_direct(self, tmp_path, monkeypatch):
+        """Durable path produces the same funnel record as direct compute."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        date = "2026-01-15"
+        ef._write_stage_files_for_test(tmp_path, date) if hasattr(ef, "_write_stage_files_for_test") else None
+        direct = ef.compute_funnel(tmp_path, date)
+        durable = ef._compute_funnel_durable(tmp_path, date)
+        assert durable == direct
+
+    def test_durable_compute_replays_checkpoint_on_resume(self, tmp_path, monkeypatch):
+        """Second call replays checkpoint, no recomputation."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        date = "2026-01-16"
+        call_count = 0
+        original = ef.compute_funnel
+
+        def counting_compute(evolution_dir, d):
+            nonlocal call_count
+            call_count += 1
+            return original(evolution_dir, d)
+
+        monkeypatch.setattr(ef, "compute_funnel", counting_compute)
+        ef._compute_funnel_durable(tmp_path, date)
+        assert call_count == 1
+        # Second call should replay checkpoint — fn never invoked
+        ef._compute_funnel_durable(tmp_path, date)
+        assert call_count == 1
+
+    def test_durable_compute_falls_back_when_backend_fails(self, tmp_path, monkeypatch):
+        """Backend RuntimeError triggers fallback to direct compute."""
+        date = "2026-01-17"
+
+        class FailingBackend:
+            def run(self, fn, checkpoint_id=None):
+                raise RuntimeError("simulated backend failure")
+
+        monkeypatch.setattr(
+            "agent.durability.FileDurabilityBackend",
+            lambda: FailingBackend(),
+            raising=False,
+        )
+
+        # Import the module fresh to pick up the patched import
+        import importlib
+
+        importlib.reload(sys.modules.get("agent.durability", None) or __import__("agent.durability"))
+        # Direct compute should still work via fallback
+        result = ef._compute_funnel_durable(tmp_path, date)
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

Wires the composable `Durability` capability (`FileDurabilityBackend` from `agent/durability.py`) into the real evolution-funnel skill (`scripts/evolution_funnel.py`). This closes the 13-day-old parent #1288 by connecting the capability (interface + backend from Slices A/#1761 and B/#1762) to the actual pipeline call site.

## Changes

**`scripts/evolution_funnel.py`** (+18 lines):
- `_compute_funnel_durable(evolution_dir, date)` — wraps `compute_funnel` in `FileDurabilityBackend.run()` with checkpoint id `funnel-{date}`. On resume (second call/crash recovery), replays the checkpointed result without recomputation. Falls back to direct `compute_funnel` when the durability module is unavailable (byte-identical default behavior).
- `main()` now calls `_compute_funnel_durable()` instead of `compute_funnel()` directly.

**`tests/scripts/test_evolution_funnel_durability.py`** (new, +68 lines):
- `test_durable_compute_returns_same_result_as_direct` — durable path matches direct compute
- `test_durable_compute_replays_checkpoint_on_resume` — second call replays checkpoint, `compute_funnel` never invoked
- `test_durable_compute_falls_back_when_backend_fails` — backend `RuntimeError` triggers fallback to direct compute

## Pattern

Mirrors the Slice B proof-of-concept wiring in `scripts/evolution_research_local.py:_run_with_durability()` — same `FileDurabilityBackend`, same lazy-import + try/except fallback pattern, same checkpoint-per-date naming.

## Validation
- `ruff check` ✓
- `pytest tests/scripts/test_evolution_funnel.py tests/scripts/test_evolution_funnel_durability.py` — 34/34 ✓
- Diff: +88 lines (well under 200-line autonomous merge cap) ✓

Closes #1775