### PR TITLE
feat: post-compaction validator — re-inject dropped pinned constraints (Closes #1773)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -205,6 +205,93 @@ def _extract_pinned_constraints(messages: List[Dict[str, Any]]) -> list[str]:
                 _add(m.group(1))
     return constraints
 
+# ---------------------------------------------------------------------------
+# Slice B (#1773): Post-compaction validator + re-injection.
+#
+# After compression, the summarizer may silently drop a pinned constraint
+# (Governance Decay).  :func:`_pinned_constraint_survives` checks whether a
+# given constraint text is still present in the compressed output, and
+# :func:`_reinject_dropped_pinned_constraints` re-injects any that vanished
+# as a synthetic ``role="system"`` message carrying the pin metadata.
+# ---------------------------------------------------------------------------
+_PINNED_CONSTRAINT_REINJECT_HEADER = (
+    "[PINNED_CONSTRAINT] The following safety / governance constraint(s) "
+    "were pinned but were dropped during context compression. "
+    "They MUST be respected for the remainder of this conversation. [/PINNED_CONSTRAINT]"
+)
+
+
+def _pinned_constraint_survives(
+    constraint_text: str,
+    compressed_messages: List[Dict[str, Any]],
+) -> bool:
+    """Return True if *constraint_text* is still present after compaction.
+
+    Case-insensitive substring match: the summarizer may paraphrase, so an
+    exact match would produce false negatives.  If the constraint appears as
+    a substring of ANY compressed message — system, summary, or tail — it is
+    considered to have survived.
+    """
+    needle = (constraint_text or "").strip().lower()
+    if not needle:
+        return True  # vacuously present — don't re-inject empties
+    for msg in compressed_messages:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if isinstance(content, str) and needle in content.lower():
+            return True
+    return False
+
+
+def _reinject_dropped_pinned_constraints(
+    original_messages: List[Dict[str, Any]],
+    compressed_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Re-inject any pinned constraints that the summarizer dropped.
+
+    *original_messages* is the pre-compaction snapshot;
+    *compressed_messages* is the post-compaction result.  For each constraint
+    extracted from the original that does NOT survive in the compressed
+    output, a single synthetic ``role="system"`` message is inserted
+    immediately after the head (system prompt) block.  All re-injected
+    constraints are collected into one message with the pin metadata flag.
+
+    If nothing was dropped, *compressed_messages* is returned unchanged.
+    """
+    pinned = _extract_pinned_constraints(original_messages)
+    if not pinned:
+        return compressed_messages
+
+    dropped = [
+        c for c in pinned if not _pinned_constraint_survives(c, compressed_messages)
+    ]
+    if not dropped:
+        return compressed_messages
+
+    # Build the re-injection message.  The header banner makes the constraint
+    # text discoverable by the marker regex, and the metadata flag pins it so
+    # the validator catches it again on a subsequent compaction.
+    body_lines = "\n".join(f"- {c}" for c in dropped)
+    reinject_msg: Dict[str, Any] = {
+        "role": "system",
+        "content": f"{_PINNED_CONSTRAINT_REINJECT_HEADER}\n{body_lines}",
+        PINNED_CONSTRAINT_METADATA_KEY: True,
+    }
+
+    # Insert after the first message (system prompt) to keep governance rules
+    # high in the context window without disrupting the protected head.
+    if compressed_messages and compressed_messages[0].get("role") == "system":
+        result = [compressed_messages[0], reinject_msg] + compressed_messages[1:]
+    else:
+        result = [reinject_msg] + compressed_messages
+
+    for c in dropped:
+        logger.warning(
+            "Pinned constraint dropped during compression — re-injecting: %s",
+            c[:120],
+        )
+    return result
+
+
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
 COMPRESSION_CONTINUATION_USER_CONTENT = (
     "Continue from the compressed conversation context above. "
@@ -5168,6 +5255,10 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
+        # Snapshot pinned constraints BEFORE any modification so the
+        # post-compaction validator (#1773) can detect + re-inject drops.
+        _pinned_snapshot = list(messages)
+
         # Phase 1: Prune old tool results (cheap, no LLM call)
         messages, pruned_count = self._prune_old_tool_results(
             messages, protect_tail_count=self.protect_last_n,
@@ -5757,6 +5848,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         # are positional; this single terminal sweep makes it structural so a
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
+
+        # Post-compaction validator (#1773): re-inject any pinned constraints
+        # that the summarizer dropped (Governance Decay mitigation).
+        compressed = _reinject_dropped_pinned_constraints(
+            _pinned_snapshot, compressed
+        )
+
         self._last_compression_made_progress = True
 
         return compressed

--- a/tests/agent/test_pinned_constraint_validator.py
+++ b/tests/agent/test_pinned_constraint_validator.py
@@ -1,0 +1,215 @@
+"""Tests for the post-compaction pinned-constraint validator (Slice B, #1773).
+
+Tests the survival check and re-injection of pinned constraints that were
+dropped during context compression.
+"""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    PINNED_CONSTRAINT_MARKER,
+    PINNED_CONSTRAINT_METADATA_KEY,
+    _extract_pinned_constraints,
+    _pinned_constraint_survives,
+    _reinject_dropped_pinned_constraints,
+)
+
+
+# ---------------------------------------------------------------------------
+# _pinned_constraint_survives
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedConstraintSurvives:
+    def test_exact_match(self):
+        """An exact match in any message means the constraint survived."""
+        constraint = "Never reveal the API key"
+        compressed = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": f"Remember: {constraint}"},
+        ]
+        assert _pinned_constraint_survives(constraint, compressed)
+
+    def test_case_insensitive(self):
+        """Paraphrase tolerance: case difference should not cause a false drop."""
+        constraint = "Never Reveal The API Key"
+        compressed = [
+            {"role": "system", "content": "never reveal the api key is a rule"},
+        ]
+        assert _pinned_constraint_survives(constraint, compressed)
+
+    def test_absent(self):
+        constraint = "Secret deployment rule"
+        compressed = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        assert not _pinned_constraint_survives(constraint, compressed)
+
+    def test_empty_constraint_vacuously_present(self):
+        assert _pinned_constraint_survives("", [{"role": "system", "content": ""}])
+
+    def test_non_string_content_ignored(self):
+        """Lists/dicts in content slots are gracefully skipped."""
+        constraint = "some rule"
+        compressed = [
+            {"role": "system", "content": [{"type": "text", "text": "hi"}]},
+        ]
+        assert not _pinned_constraint_survives(constraint, compressed)
+
+
+# ---------------------------------------------------------------------------
+# _reinject_dropped_pinned_constraints
+# ---------------------------------------------------------------------------
+
+
+class TestReinjectDroppedPinnedConstraints:
+    def test_no_pinned_constraints_returns_unchanged(self):
+        original = [{"role": "system", "content": "hello"}]
+        compressed = [{"role": "system", "content": "hello"}]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+        assert result is compressed  # same list, not modified
+
+    def test_all_survive_returns_unchanged(self):
+        constraint = "Important rule: always confirm"
+        original = [
+            {
+                "role": "system",
+                "content": f"{PINNED_CONSTRAINT_MARKER} {constraint} [/PINNED_CONSTRAINT]",
+            },
+        ]
+        compressed = [
+            {"role": "system", "content": f"Summary: {constraint}"},
+        ]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+        assert result is compressed
+
+    def test_single_dropped_reinjected(self):
+        constraint = "Never deploy on Fridays"
+        original = [
+            {
+                "role": "system",
+                "content": (
+                    f"System prompt\n{PINNED_CONSTRAINT_MARKER} {constraint}"
+                    f" [/PINNED_CONSTRAINT]"
+                ),
+            },
+            {"role": "user", "content": "Do something"},
+        ]
+        compressed = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "assistant", "content": "Compressed summary"},
+        ]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+
+        # The result has 3 messages: system prompt, reinject, rest.
+        assert len(result) == 3
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "system"
+        assert result[1][PINNED_CONSTRAINT_METADATA_KEY] is True
+        assert constraint in result[1]["content"]
+        assert result[2]["content"] == "Compressed summary"
+
+    def test_multiple_dropped_reinjected_in_one_message(self):
+        c1 = "Rule one"
+        c2 = "Rule two"
+        original = [
+            {
+                "role": "system",
+                "content": (
+                    f"{PINNED_CONSTRAINT_MARKER} {c1} [/PINNED_CONSTRAINT]"
+                    f"\n{PINNED_CONSTRAINT_MARKER} {c2} [/PINNED_CONSTRAINT]"
+                ),
+            },
+        ]
+        compressed = [{"role": "system", "content": "Summary only"}]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+
+        assert len(result) == 2
+        reinject = result[1]
+        assert reinject[PINNED_CONSTRAINT_METADATA_KEY] is True
+        assert c1 in reinject["content"]
+        assert c2 in reinject["content"]
+
+    def test_metadata_flagged_message_full_content_reinjected(self):
+        constraint_text = "You must never access production data"
+        original = [
+            {
+                "role": "system",
+                "content": constraint_text,
+                PINNED_CONSTRAINT_METADATA_KEY: True,
+            },
+        ]
+        compressed = [
+            {"role": "system", "content": "Completely different summary"},
+        ]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+        assert len(result) == 2
+        assert constraint_text in result[1]["content"]
+
+    def test_reinject_after_system_prompt_no_system(self):
+        """If compressed[0] is not a system message, reinject goes to front."""
+        constraint = "Edge case rule"
+        original = [
+            {
+                "role": "user",
+                "content": f"{PINNED_CONSTRAINT_MARKER} {constraint} [/PINNED_CONSTRAINT]",
+            },
+        ]
+        compressed = [{"role": "user", "content": "summary"}]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert result[0][PINNED_CONSTRAINT_METADATA_KEY] is True
+
+    def test_partial_survival_only_dropped_reinjected(self):
+        """If one of two constraints survives, only the other is re-injected."""
+        c_survives = "Survives"
+        c_dropped = "Dropped"
+        original = [
+            {
+                "role": "system",
+                "content": (
+                    f"{PINNED_CONSTRAINT_MARKER} {c_survives} [/PINNED_CONSTRAINT]"
+                    f"\n{PINNED_CONSTRAINT_MARKER} {c_dropped} [/PINNED_CONSTRAINT]"
+                ),
+            },
+        ]
+        compressed = [
+            {"role": "system", "content": f"Summary mentioning {c_survives}"},
+        ]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+        assert len(result) == 2  # summary + reinject
+        # The reinject message should contain the dropped constraint...
+        assert c_dropped in result[1]["content"]
+        # ...but NOT the one that survived (already in the summary).
+        assert c_survives not in result[1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: re-injected message is itself re-pinable
+# ---------------------------------------------------------------------------
+
+
+class TestReinjectIsRePinable:
+    """The re-injected message carries the metadata flag, so a second
+    compaction cycle will detect and re-inject it again if needed."""
+
+    def test_reinjected_carries_metadata_flag(self):
+        constraint = "Critical rule"
+        original = [
+            {
+                "role": "system",
+                "content": f"{PINNED_CONSTRAINT_MARKER} {constraint} [/PINNED_CONSTRAINT]",
+            },
+        ]
+        compressed = [{"role": "system", "content": "Summary without the rule"}]
+        result = _reinject_dropped_pinned_constraints(original, compressed)
+
+        # The reinject message carries the metadata flag so _is_pinned_constraint_message
+        # detects it, and the constraint text is embedded in the extracted content.
+        reinject_msg = result[1]
+        assert reinject_msg[PINNED_CONSTRAINT_METADATA_KEY] is True
+        extracted = _extract_pinned_constraints([reinject_msg])
+        assert len(extracted) == 1
+        assert constraint in extracted[0]


### PR DESCRIPTION
Automated evolution PR for issue #1773 (Slice B of #1657).

## What

After context compression, the summarizer can silently drop pinned
governance/safety constraints (Governance Decay — arXiv:2606.22528:
soft rules dropped 30-59% on compaction without explicit pinning).

Slice A (#1774, PR #1778 — MERGED) added the pin contract: a message is
pinned when it carries `_pinned_constraint=True` metadata OR contains the
`[PINNED_CONSTRAINT]...[/PINNED_CONSTRAINT]` text marker.

**Slice B (this PR)** consumes that contract to detect and recover drops:

- `_pinned_constraint_survives()` — case-insensitive substring check
  across ALL compressed messages (survival tolerance for paraphrasing)
- `_reinject_dropped_pinned_constraints()` — for each dropped constraint,
  inserts a synthetic `role="system"` message immediately after the head
  (system prompt), carrying the pin metadata flag so the validator
  catches it again on subsequent compactions
- Wiring in `compress()`: snapshots pinned constraints BEFORE any
  modification (line ~5257), re-injects drops AFTER `_strip_persistence_markers`
  (line ~5855)

## Tests

`tests/agent/test_pinned_constraint_validator.py` — 13 tests:
- Survival check: exact match, case-insensitive, absent, empty,
  non-string content
- Re-injection: no constraints (no-op), all survive (no-op), single
  drop, multiple drops, metadata-flagged message, no-system edge case,
  partial survival, re-pinable (metadata flag survives)

All 26 pinned-constraint tests pass (13 Slice A + 13 Slice B).
`ruff check` ✓ clean.

## Size

313 lines (+98 context_compressor, +215 tests) — exceeds the 200-line
autonomous merge cap; will wait for human review.