### PR TITLE
feat: durability-aware MCP adapter — checkpoint MCP tool calls (Closes #1782)

### DIFF
--- a/agent/mcp_durability_adapter.py
+++ b/agent/mcp_durability_adapter.py
@@ -1,0 +1,176 @@
+"""Durability-aware wrapper for MCP tool calls (#1782 / #1288).
+
+Routes MCP tool-call communication through a :class:`DurabilityBackend` so that
+if the process crashes mid-tool-call, the MCP interaction can be replayed /
+resumed from checkpoint rather than starting over.
+
+Design:
+- Before each MCP tool call, checkpoint ``{tool_name, args, call_id, status:
+  "pending"}`` via :meth:`DurabilityBackend.checkpoint` (i.e. ``run`` with a
+  deterministic ``checkpoint_id``).
+- On resume / replay, if a checkpointed MCP call exists that wasn't completed,
+  the adapter re-invokes the underlying tool handler.
+- On completion, the checkpoint is marked done (result stored), so a replay
+  skips re-execution.
+
+The adapter is a thin wrapper around a *callable* (the MCP tool handler
+produced by ``_make_tool_handler``). When no durability backend is configured
+(or the no-op backend is used), behavior is byte-identical to calling the
+handler directly — the wrapper is a pure passthrough.
+
+This module is deliberately framework-agnostic: it operates on a
+``tool_fn(args: dict) -> str`` callable and a
+:class:`~agent.durability.DurabilityBackend`, with no dependency on the MCP
+SDK or event loop. The live MCP wiring (in ``tools/mcp_tool.py``) can opt in
+by wrapping its handler with :func:`with_durability_checkpoint`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from agent.durability import DurabilityBackend, NoOpDurability
+
+logger = logging.getLogger(__name__)
+
+_CHECKPOINT_PREFIX = "mcp-tool-call"
+_PENDING = "pending"
+_DONE = "done"
+
+
+def _checkpoint_id(tool_name: str, call_id: str) -> str:
+    """Deterministic checkpoint id: ``mcp-tool-call-<hash>``.
+
+    Hashing (not raw concatenation) keeps the id within the filesystem-safe
+    charset enforced by ``FileDurabilityBackend._checkpoint_path`` even when
+    ``tool_name`` contains slashes or spaces.
+    """
+    raw = f"{tool_name}:{call_id}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"{_CHECKPOINT_PREFIX}-{digest}"
+
+
+class McpDurabilityAdapter:
+    """Wraps an MCP tool handler with durability checkpointing.
+
+    Parameters
+    ----------
+    tool_name:
+        The MCP tool name (for logging / checkpoint metadata).
+    tool_fn:
+        The underlying sync handler: ``fn(args: dict) -> str``.
+    backend:
+        A :class:`DurabilityBackend`. Defaults to :class:`NoOpDurability` so
+        the adapter is a no-op unless a real backend is injected.
+
+    Lifecycle
+    ---------
+    1. ``call(args, call_id)`` computes the checkpoint id.
+    2. If a completed result is already checkpointed → return it immediately
+       (replay / resume fast-path).
+    3. Otherwise, write a *pending* checkpoint, execute ``tool_fn``, then
+       overwrite with the *done* result.
+    4. If the process crashes between steps 3-write and 3-execute, the next
+       call with the same ``call_id`` sees a pending checkpoint and replays.
+    """
+
+    def __init__(
+        self,
+        tool_name: str,
+        tool_fn: Callable[[dict], str],
+        backend: Optional[DurabilityBackend] = None,
+    ) -> None:
+        self.tool_name = tool_name
+        self.tool_fn = tool_fn
+        self.backend: DurabilityBackend = backend or NoOpDurability()
+
+    # -- public API --------------------------------------------------------
+
+    def call(self, args: dict, call_id: str) -> str:
+        """Execute the MCP tool call with durability checkpointing.
+
+        Returns the tool result string. On replay (if a done checkpoint
+        exists for ``call_id``), returns the stored result without
+        re-invoking ``tool_fn``.
+        """
+        cp_id = _checkpoint_id(self.tool_name, call_id)
+        done_id = f"{cp_id}-done"
+
+        # Fast-path: a completed checkpoint already exists → replay.
+        existing = self.backend.resume_from(done_id)
+        if isinstance(existing, dict) and existing.get("status") == _DONE:
+            logger.debug(
+                "MCP durability: replaying completed checkpoint for %s (%s)",
+                self.tool_name,
+                call_id,
+            )
+            result = existing.get("result")
+            return result if isinstance(result, str) else str(result)
+
+        # Write pending checkpoint (only meaningful for real backends).
+        self._write_checkpoint(cp_id, _PENDING, args, call_id, result=None)
+
+        logger.debug(
+            "MCP durability: executing tool %s (call_id=%s)",
+            self.tool_name,
+            call_id,
+        )
+        result = self.tool_fn(args)
+
+        # Mark done — store the result so a replay returns it directly.
+        self._write_checkpoint(done_id, _DONE, args, call_id, result=result)
+        return result
+
+    # -- internals ---------------------------------------------------------
+
+    def _write_checkpoint(
+        self,
+        cp_id: str,
+        status: str,
+        args: dict,
+        call_id: str,
+        result: Optional[str],
+    ) -> None:
+        """Persist a checkpoint payload via ``backend.run``.
+
+        Uses ``run(fn, checkpoint_id)`` so the backend's own idempotency
+        applies: for ``FileDurabilityBackend``, ``run`` stores the payload on
+        first call and returns the cached value on subsequent calls with the
+        same id (read-on-exist). The ``call()`` method uses distinct ids for
+        the pending (``cp_id``) and done (``cp_id-done``) states so both
+        are persisted independently.
+        """
+        payload: Dict[str, Any] = {
+            "tool_name": self.tool_name,
+            "args": args,
+            "call_id": call_id,
+            "status": status,
+        }
+        if result is not None:
+            payload["result"] = result
+        self.backend.run(lambda: payload, checkpoint_id=cp_id)
+
+
+def with_durability_checkpoint(
+    tool_name: str,
+    tool_fn: Callable[[dict], str],
+    backend: Optional[DurabilityBackend] = None,
+) -> Callable[[dict], str]:
+    """Convenience factory: return a handler wrapped with durability.
+
+    The returned callable has signature ``fn(args: dict) -> str``, matching
+    the MCP tool-handler registry interface. A ``call_id`` is derived from
+    the args hash so replay is deterministic for identical invocations.
+    """
+    adapter = McpDurabilityAdapter(tool_name, tool_fn, backend)
+
+    def _wrapped(args: dict) -> str:
+        call_id = hashlib.sha256(
+            json.dumps(args, sort_keys=True, default=str).encode("utf-8"),
+        ).hexdigest()[:16]
+        return adapter.call(args, call_id)
+
+    return _wrapped

--- a/tests/agent/test_mcp_durability_adapter.py
+++ b/tests/agent/test_mcp_durability_adapter.py
@@ -1,0 +1,196 @@
+"""Tests for the durability-aware MCP adapter (Slice C, #1782 / #1288).
+
+Tests the checkpoint / replay lifecycle of :class:`McpDurabilityAdapter`
+against both :class:`NoOpDurability` (passthrough) and
+:class:`FileDurabilityBackend` (real checkpoint files), plus the
+:func:`with_durability_checkpoint` convenience wrapper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.durability import FileDurabilityBackend, NoOpDurability
+from agent.mcp_durability_adapter import (
+    McpDurabilityAdapter,
+    _checkpoint_id,
+    with_durability_checkpoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class RecordingBackend:
+    """Minimal DurabilityBackend that records calls in-memory."""
+
+    name = "recording"
+
+    def __init__(self) -> None:
+        self.checkpoints: dict[str, object] = {}
+
+    def run(self, fn, checkpoint_id=None):
+        if checkpoint_id is not None and checkpoint_id in self.checkpoints:
+            return self.checkpoints[checkpoint_id]
+        result = fn()
+        if checkpoint_id is not None:
+            self.checkpoints[checkpoint_id] = result
+        return result
+
+    def resume_from(self, checkpoint_id: str):
+        return self.checkpoints.get(checkpoint_id)
+
+
+def _make_fn(result: str = "ok", calls: list | None = None):
+    """Return a tool_fn that records its invocations."""
+
+    def _fn(args: dict) -> str:
+        if calls is not None:
+            calls.append(args)
+        return result
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# _checkpoint_id
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointId:
+    def test_deterministic(self):
+        assert _checkpoint_id("foo", "abc") == _checkpoint_id("foo", "abc")
+
+    def test_different_inputs_differ(self):
+        assert _checkpoint_id("foo", "abc") != _checkpoint_id("bar", "abc")
+        assert _checkpoint_id("foo", "abc") != _checkpoint_id("foo", "def")
+
+    def test_prefix(self):
+        assert _checkpoint_id("foo", "abc").startswith("mcp-tool-call-")
+
+
+# ---------------------------------------------------------------------------
+# NoOp backend — passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpPassthrough:
+    def test_executes_and_returns_result(self):
+        fn = _make_fn("hello")
+        adapter = McpDurabilityAdapter("search", fn, backend=NoOpDurability())
+        result = adapter.call({"q": "test"}, "call-1")
+        assert result == "hello"
+
+    def test_re_executes_on_replay_with_noop(self):
+        """NoOp stores nothing, so replay always re-executes."""
+        calls: list = []
+        fn = _make_fn("ok", calls)
+        adapter = McpDurabilityAdapter("search", fn, backend=NoOpDurability())
+        adapter.call({"q": "a"}, "call-1")
+        adapter.call({"q": "a"}, "call-1")
+        assert len(calls) == 2  # no caching
+
+
+# ---------------------------------------------------------------------------
+# Real backend — checkpoint + replay
+# ---------------------------------------------------------------------------
+
+
+class TestReplayWithRecordingBackend:
+    def test_replay_returns_cached_result(self):
+        calls: list = []
+        fn = _make_fn("result-data", calls)
+        backend = RecordingBackend()
+        adapter = McpDurabilityAdapter("lookup", fn, backend=backend)
+
+        first = adapter.call({"id": 42}, "call-1")
+        assert first == "result-data"
+        assert len(calls) == 1
+
+        # Replay with same call_id → cached, no re-execution.
+        second = adapter.call({"id": 42}, "call-1")
+        assert second == "result-data"
+        assert len(calls) == 1
+
+    def test_different_call_id_re_executes(self):
+        calls: list = []
+        fn = _make_fn("ok", calls)
+        backend = RecordingBackend()
+        adapter = McpDurabilityAdapter("lookup", fn, backend=backend)
+
+        adapter.call({"id": 1}, "call-A")
+        adapter.call({"id": 2}, "call-B")
+        assert len(calls) == 2
+
+    def test_checkpointed_pending_then_done(self):
+        fn = _make_fn("done-val")
+        backend = RecordingBackend()
+        adapter = McpDurabilityAdapter("write", fn, backend=backend)
+        adapter.call({"x": 1}, "call-1")
+
+        # The done checkpoint must exist.
+        cp_id = _checkpoint_id("write", "call-1")
+        done = backend.resume_from(f"{cp_id}-done")
+        assert isinstance(done, dict)
+        assert done["status"] == "done"
+        assert done["result"] == "done-val"
+        assert done["tool_name"] == "write"
+
+
+# ---------------------------------------------------------------------------
+# FileDurabilityBackend — end-to-end with real files
+# ---------------------------------------------------------------------------
+
+
+class TestFileBackendIntegration:
+    def test_crash_recovery_replays_from_file(self, tmp_path: Path):
+        backend = FileDurabilityBackend(base_dir=tmp_path)
+        calls: list = []
+        fn = _make_fn("persisted", calls)
+
+        adapter = McpDurabilityAdapter("fetch", fn, backend=backend)
+        result = adapter.call({"url": "http://x"}, "call-99")
+        assert result == "persisted"
+        assert len(calls) == 1
+
+        # Simulate crash: new adapter + backend with same dir, same call_id.
+        backend2 = FileDurabilityBackend(base_dir=tmp_path)
+        fn2 = _make_fn("SHOULD-NOT-CALL", calls)
+        adapter2 = McpDurabilityAdapter("fetch", fn2, backend=backend2)
+        result2 = adapter2.call({"url": "http://x"}, "call-99")
+        assert result2 == "persisted"
+        assert len(calls) == 1  # fn2 was never called
+
+
+# ---------------------------------------------------------------------------
+# with_durability_checkpoint wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestWithDurabilityCheckpoint:
+    def test_wrapper_signature_matches_handler(self):
+        fn = _make_fn("wrapped-ok")
+        wrapped = with_durability_checkpoint("tool", fn)
+        result = wrapped({"arg": 1})
+        assert result == "wrapped-ok"
+
+    def test_wrapper_replays_identical_args(self):
+        calls: list = []
+        fn = _make_fn("v1", calls)
+        backend = RecordingBackend()
+        wrapped = with_durability_checkpoint("tool", fn, backend=backend)
+
+        r1 = wrapped({"arg": 1})
+        r2 = wrapped({"arg": 1})
+        assert r1 == r2 == "v1"
+        assert len(calls) == 1  # second was replayed
+
+    def test_wrapper_different_args_re_execute(self):
+        calls: list = []
+        fn = _make_fn("v1", calls)
+        wrapped = with_durability_checkpoint("tool", fn, backend=RecordingBackend())
+        wrapped({"arg": 1})
+        wrapped({"arg": 2})
+        assert len(calls) == 2


### PR DESCRIPTION
Automated evolution PR for issue #1782 (Slice C of #1288 durability roadmap).

## What

Routes MCP tool-call communication through a `DurabilityBackend` so that
if the process crashes mid-tool-call, the MCP interaction can be replayed
from checkpoint rather than starting over.

Continues the #1288 Durability roadmap:
- Slice A (#1761): Composable capability interface + backend registry — **MERGED**
- Slice B (#1762): FileDurabilityBackend + wire into research — **MERGED**
- Slice C-funnel (#1775): Wire into evolution funnel — **MERGED**
- **Slice C-MCP (this PR)**: Checkpoint MCP server communication

## Design

```python
from agent.mcp_durability_adapter import with_durability_checkpoint

# Wrap any MCP tool handler — NoOp backend = byte-identical passthrough
handler = with_durability_checkpoint(search, original_handler, backend)
```

- `McpDurabilityAdapter`: wraps `tool_fn(args: dict) -> str`
- **Pending checkpoint** written before tool execution
- **Done checkpoint** (with result) written after completion
- **Replay fast-path**: returns cached result if done checkpoint exists
- Uses distinct checkpoint IDs for pending/done states (`run()` is read-on-exist)
- Framework-agnostic: no MCP SDK dependency, operates on plain callables
- NoOp backend = pure passthrough (behavior identical to calling `tool_fn` directly)

## Tests

`tests/agent/test_mcp_durability_adapter.py` — 12 tests:
- Checkpoint ID: determinism, uniqueness, prefix
- NoOp passthrough: execution + no-cache-on-replay
- RecordingBackend: cached replay, different call_id re-executes, pending→done
- FileBackend: end-to-end crash recovery replay with real filesystem
- Wrapper: signature, identical-args replay, different-args re-execute

All 12 tests pass. `ruff check` ✓, `ruff format` ✓.

## Size

372 lines (176 adapter + 196 tests) — exceeds 200-line autonomous merge cap.