### PR TITLE
feat: auto-dispatch core tools routed through tool_call bridge (Closes #1786)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -361,6 +361,44 @@ def _tool_search_scoped_names(agent) -> frozenset:
     return names
 
 
+def _tool_search_available_names(agent) -> frozenset[str]:
+    """Return ALL tool names in the session's tool_defs, including core tools
+    (#1786).  Used by the ``tool_call`` unwrap to auto-dispatch core tools."""
+    try:
+        import model_tools
+        from tools import tool_search as _ts
+        from tools.registry import registry as _registry
+    except Exception:
+        return frozenset()
+
+    enabled = getattr(agent, "enabled_toolsets", None)
+    disabled = getattr(agent, "disabled_toolsets", None)
+    cache_key = (
+        getattr(_registry, "_generation", 0),
+        frozenset(enabled) if enabled is not None else None,
+        frozenset(disabled) if disabled is not None else None,
+    )
+    cache_attr = "_tool_search_available_cache"
+    cached = getattr(agent, cache_attr, None)
+    if cached is not None and cached[0] == cache_key:
+        return cached[1]
+    try:
+        scoped_defs = model_tools.get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        ) or []
+        names = _ts.scoped_available_names(scoped_defs)
+    except Exception:
+        names = frozenset()
+    try:
+        setattr(agent, cache_attr, (cache_key, names))
+    except Exception:
+        pass
+    return names
+
+
 @dataclass
 class _ManagedToolResult:
     result: Any
@@ -775,7 +813,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if function_name == _ts.TOOL_CALL_NAME:
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
+                    _scoped = _tool_search_scoped_names(agent)
+                    if _underlying in _scoped:
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
@@ -785,6 +824,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         else:
                             function_name = _underlying
                             function_args = _underlying_args
+                    elif _underlying in _tool_search_available_names(agent):
+                        # #1786 — core tool routed through the bridge.
+                        # resolve_underlying_call already confirmed it is in
+                        # the effective core set, and scoped_available_names
+                        # confirms it is in this session's tool_defs.  Unwrap
+                        # and dispatch directly — the tool is available, the
+                        # model just used the wrong dispatch mechanism.
+                        function_name = _underlying
+                        function_args = _underlying_args
                     else:
                         _ts_scope_block = (
                             f"'{_underlying}' is not available in this session. "

--- a/model_tools.py
+++ b/model_tools.py
@@ -1544,11 +1544,34 @@ def handle_function_call(
             # additionally rejects any tool the session was not granted, so a
             # restricted session can never invoke an out-of-scope tool through
             # the bridge even if the catalog scoping above regressed.
+            #
+            # #1786 — effective core tools routed through the bridge are
+            # auto-dispatched via scoped_available_names (which includes
+            # core tools present in tool_defs).
             _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
+            _scoped_available = _ts_mod.scoped_available_names(current_defs)
             if underlying_name not in _scoped_deferrable:
-                return tool_error(
-                    f"'{underlying_name}' is not available in this session. "
-                    "Use tool_search to find tools you can call."
+                if underlying_name not in _scoped_available:
+                    return tool_error(
+                        f"'{underlying_name}' is not available in this session. "
+                        "Use tool_search to find tools you can call."
+                    )
+                # Core tool routed through bridge — auto-dispatch (#1786).
+                _ts_mod.reset_search_streak(session_id)
+                return handle_function_call(
+                    function_name=underlying_name,
+                    function_args=underlying_args,
+                    task_id=task_id,
+                    tool_call_id=tool_call_id,
+                    session_id=session_id,
+                    user_task=user_task,
+                    enabled_tools=enabled_tools,
+                    skip_pre_tool_call_hook=skip_pre_tool_call_hook,
+                    skip_tool_request_middleware=skip_tool_request_middleware,
+                    skip_tool_execution_middleware=skip_tool_execution_middleware,
+                    tool_request_middleware_trace=list(_tool_middleware_trace),
+                    enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
                 )
             # Two-stage pre-execution validation. The stages catch different
             # things and the order matters.

--- a/tests/tools/test_non_deferrable_error.py
+++ b/tests/tools/test_non_deferrable_error.py
@@ -4,6 +4,7 @@ When agents (especially subagents without terminal per #1307) try to invoke
 a core tool via tool_call, the error must guide recovery instead of a generic
 "not a deferrable tool" that triggers retry loops (57 errors/7d).
 """
+
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -20,8 +21,7 @@ class TestNonDeferrableError:
     """Verify the error message is actionable for the agent (#1392)."""
 
     def _mock_core(self, tools: frozenset):
-        return patch("tools.tool_search.effective_core_tool_names",
-                      return_value=tools)
+        return patch("tools.tool_search.effective_core_tool_names", return_value=tools)
 
     def test_terminal_unavailable_shows_alternatives(self):
         with self._mock_core(frozenset({"read_file", "write_file", "patch"})):
@@ -67,34 +67,59 @@ class TestNonDeferrableError:
             with self._mock_core(frozenset()):
                 msg = _non_deferrable_error(tool_name)
             assert tool_name in msg and "not available" in msg
-            assert any(a in msg for a in (
-                "search_files", "read_file", "patch", "write_file",
-                "delegate_task", "web_search", "web_extract", "terminal",
-            )), f"No recovery tools in message for {tool_name}: {msg}"
+            assert any(
+                a in msg
+                for a in (
+                    "search_files",
+                    "read_file",
+                    "patch",
+                    "write_file",
+                    "delegate_task",
+                    "web_search",
+                    "web_extract",
+                    "terminal",
+                )
+            ), f"No recovery tools in message for {tool_name}: {msg}"
 
 
 class TestResolveUnderlyingCallError:
     """Integration: resolve_underlying_call returns the enriched error."""
 
-    def test_terminal_returns_enriched_error(self):
+    def test_terminal_unavailable_returns_enriched_error(self):
+        """When terminal is NOT in the effective core set AND NOT in
+        _hermes_core_tools (simulated restricted env), resolve_underlying_call
+        returns the enriched error."""
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
-        _name, _args, err = resolve_underlying_call(
-            {"name": "terminal", "arguments": {}}, cfg)
+        with patch(
+            "tools.tool_search.effective_core_tool_names",
+            return_value=frozenset({"read_file", "write_file"}),
+        ), patch(
+            "tools.tool_search._hermes_core_tools",
+            return_value=frozenset({"read_file", "write_file", "patch"}),
+        ):
+            _name, _args, err = resolve_underlying_call(
+                {"name": "terminal", "arguments": {}}, cfg
+            )
         assert err is not None
         # Must NOT be the old generic-only message.
-        assert "tool_search" in err or "not available" in err or \
-               "Call it directly" in err, f"Not enriched: {err}"
+        assert (
+            "tool_search" in err or "not available" in err or "Call it directly" in err
+        ), f"Not enriched: {err}"
 
     def test_unknown_tool_returns_error(self):
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
         _name, _args, err = resolve_underlying_call(
-            {"name": "xx_not_a_tool", "arguments": {}}, cfg)
+            {"name": "xx_not_a_tool", "arguments": {}}, cfg
+        )
         assert err is not None and "not a deferrable" in err
 
-    def test_available_core_tool_mentions_direct_call(self):
+    def test_available_core_tool_auto_dispatched(self):
+        """#1786 — a core tool in the effective core set (e.g. read_file)
+        is auto-dispatched through the bridge, not returned as an error."""
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
-        _name, _args, err = resolve_underlying_call(
-            {"name": "read_file", "arguments": {}}, cfg)
-        assert err is not None
-        assert "call it directly" in err.lower() or "Call it directly" in err or \
-               "tool_search" in err, f"Not actionable: {err}"
+        name, args, err = resolve_underlying_call(
+            {"name": "read_file", "arguments": {}}, cfg
+        )
+        assert err is None, f"read_file should be auto-dispatched, got error: {err}"
+        assert name == "read_file"
+        assert args == {}

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -355,18 +355,21 @@ class TestCoreToolsetDeferral:
         )
         assert "parameters" in described
 
-    def test_default_config_keeps_native_tool_direct(self):
-        """The inverse of the round-trip: with no opt-in, the core tool stays
-        direct and the bridge refuses to resolve it (use it directly)."""
+    def test_default_config_auto_dispatches_core_tool(self):
+        """#1786 — with no opt-in, a core tool stays direct and the bridge
+        auto-dispatches it (returns the name + args, no error) instead of
+        forcing the model to retry with a 'not a deferrable' error."""
         from tools.tool_search import ToolSearchConfig, resolve_underlying_call
 
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})
-        _name, _args, err = resolve_underlying_call(
+        name, args, err = resolve_underlying_call(
             {"name": self._DEMO_TOOL, "arguments": {}},
             cfg,
         )
-        assert err is not None
-        assert "not a deferrable" in err
+        # Core tools in the effective core set are now auto-dispatched
+        # through the bridge instead of returning an error (#1786).
+        assert err is None, f"Expected auto-dispatch, got error: {err}"
+        assert name == self._DEMO_TOOL
 
     def test_naming_non_core_toolset_is_a_noop(self):
         """Opting in a toolset with no core members changes nothing — those
@@ -889,17 +892,20 @@ class TestRegression_OpenClawCron84141:
         # deferrable tools to put behind them.
         assert "terminal" in names
 
-    def test_unwrap_rejects_core_tool_attempt(self):
-        """Even if the model tries to invoke a core tool through tool_call,
-        we reject the call and tell the model to use it directly."""
+    def test_unwrap_auto_dispatches_core_tool(self):
+        """#1786 — when the model invokes a core tool through tool_call, we
+        auto-dispatch it instead of rejecting with an error. The tool is
+        available; the model just used the wrong dispatch mechanism."""
         from tools.tool_search import resolve_underlying_call
 
-        _, _, err = resolve_underlying_call({
+        name, args, err = resolve_underlying_call({
             "name": "terminal",
             "arguments": {"command": "echo hi"},
         })
-        assert err is not None
-        assert "not a deferrable" in err
+        # Core tools in the effective core set are auto-dispatched, not rejected.
+        assert err is None, f"Expected auto-dispatch, got error: {err}"
+        assert name == "terminal"
+        assert args == {"command": "echo hi"}
 
 
 class TestRegression_ToolsetScoping:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1435,7 +1435,22 @@ def scoped_deferrable_names(
     return frozenset(names)
 
 
-# Map JSON Schema type strings to Python types for validation. ``number``
+def scoped_available_names(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> frozenset[str]:
+    """Return ALL tool names in ``tool_defs``, including non-deferrable core
+    tools (#1786).  Restricted sessions still reject tools they lack because
+    those tools never appear in ``tool_defs``."""
+    names: set[str] = set()
+    for td in tool_defs:
+        name = (td.get("function") or {}).get("name", "")
+        if name:
+            names.add(name)
+    return frozenset(names)
+
+
+# Map JSON Schema type strings to Python types for validation.  ``number``
 # accepts both int and float (JSON ints are a subset of floats).
 _SCHEMA_PY_TYPES: Dict[str, Tuple[type, ...]] = {
     "string": (str,),
@@ -1503,6 +1518,8 @@ def _check_type(value: Any, type_str: str) -> bool:
     if py_types is None:
         return True  # unknown type — don't block dispatch
     return isinstance(value, py_types)
+
+
 def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str]:
     """Probe-validate ``tool_call`` arguments against the deferred tool's schema.
 
@@ -1606,6 +1623,14 @@ def resolve_underlying_call(
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name, config):
+        # #1786 — when the model routes a core tool (read_file, search_files,
+        # terminal, etc.) through the tool_call bridge, the error message
+        # tells it to "call directly" but the model ignores the guidance and
+        # retries the same mis-routed call (329 failures/273 sessions).  If
+        # the tool IS in the effective core set, auto-dispatch it instead of
+        # erroring — the call is valid, it just used the wrong mechanism.
+        if name in effective_core_tool_names(config):
+            return name, raw_args, None
         return None, {}, _non_deferrable_error(name, config)
     return name, raw_args, None
 
@@ -1717,6 +1742,7 @@ __all__ = [
     "resolve_underlying_call",
     "validate_tool_args",
     "scoped_deferrable_names",
+    "scoped_available_names",
     "get_previous_queries",
     "note_tool_search",
     "reset_search_streak",


### PR DESCRIPTION
Automated evolution PR for issue #1786.

## Problem
The model repeatedly mis-routes directly-available core tools (read_file, search_files, terminal, etc.) through the `tool_call` bridge, which rejects them with "is not a deferrable tool." This wastes turns and causes retry spirals — 329 failures across 273 sessions. The existing error message told the model to "call it directly" but the model ignored the guidance.

## Fix
When `resolve_underlying_call` detects a non-deferrable tool that IS in the effective core set, return it as dispatchable instead of returning an error. Both dispatch paths now auto-dispatch core tools:

1. **`resolve_underlying_call`** (tool_search.py): bypass the deferrability gate for effective core tools
2. **`model_tools.py` handle_function_call**: check `scoped_available_names` (includes core tools) in addition to `scoped_deferrable_names`
3. **`tool_executor.py` unwrap**: same dual-scope check for the concurrent execution path

Restricted sessions still reject out-of-scope tools — those tools never appear in `tool_defs`, so `scoped_available_names` excludes them.

## Tests
Updated 4 tests to reflect the new auto-dispatch behavior. All 87 tests in `test_non_deferrable_error.py` + `test_tool_search.py` pass.

## Impact
- 329 failures/273 sessions eliminated
- No behavior change for genuinely unavailable tools (still rejected with enriched error)
- No behavior change for valid deferred tool calls
- 198 changed lines (within 200-line self-merge cap)