### PR TITLE
fix: enrich tool_call bridge error for core tools (Closes #1786)

### DIFF
--- a/tests/tools/test_non_deferrable_error.py
+++ b/tests/tools/test_non_deferrable_error.py
@@ -53,7 +53,34 @@ class TestNonDeferrableError:
     def test_unknown_tool_generic_message(self):
         msg = _non_deferrable_error("xx_definitely_not_a_tool_xx")
         assert "not a deferrable tool" in msg
+        assert "xx_definitely_not_a_tool_xx" in msg
         assert "tool_search" in msg or "call it directly" in msg
+
+    def test_core_tool_not_in_alternatives_gets_call_directly(self):
+        """Core tools absent from _CORE_TOOL_ALTERNATIVES but present in the
+        effective core set must still get the enriched 'call directly' message
+        (#1786)."""
+        with self._mock_core(frozenset({"read_file", "write_file"})):
+            msg = _non_deferrable_error("read_file")
+        assert "core tool" in msg
+        assert "Call 'read_file' directly" in msg
+        assert "Do not use tool_call for core tools" in msg
+
+    def test_search_files_gets_call_directly(self):
+        """search_files is a core tool not in _CORE_TOOL_ALTERNATIVES —
+        it must get the enriched message (#1786)."""
+        with self._mock_core(frozenset({"read_file", "search_files"})):
+            msg = _non_deferrable_error("search_files")
+        assert "core tool" in msg
+        assert "Call 'search_files' directly" in msg
+
+    def test_unknown_tool_names_tool_explicitly(self):
+        """Unknown tools should still get a helpful message that names the
+        tool explicitly (#1786)."""
+        with self._mock_core(frozenset({"read_file"})):
+            msg = _non_deferrable_error("completely_bogus_tool")
+        assert "completely_bogus_tool" in msg
+        assert "not a deferrable tool" in msg
 
     def test_case_insensitive_lookup_preserves_name(self):
         with self._mock_core(frozenset({"Terminal"})):
@@ -96,5 +123,5 @@ class TestResolveUnderlyingCallError:
         _name, _args, err = resolve_underlying_call(
             {"name": "read_file", "arguments": {}}, cfg)
         assert err is not None
-        assert "call it directly" in err.lower() or "Call it directly" in err or \
-               "tool_search" in err, f"Not actionable: {err}"
+        assert "directly" in err.lower() or "tool_search" in err, \
+            f"Not actionable: {err}"

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -950,6 +950,10 @@ def bridge_tool_schemas(
         "Invoke a deferred tool by name with the given arguments. Argument shape "
         f"matches the tool's schema (see `{TOOL_DESCRIBE_NAME}`). Policy, hooks, "
         "and approvals run exactly as for any directly-listed tool."
+        "\n\nIMPORTANT: tool_call is ONLY for deferred tools found via "
+        "tool_search. Core tools that are already in your tools list "
+        "(read_file, write_file, patch, search_files, terminal, etc.) must "
+        "be called directly — do NOT route them through tool_call."
     )
 
     return [
@@ -1675,13 +1679,23 @@ def _non_deferrable_error(name: str, config: Optional[ToolSearchConfig] = None) 
         )
 
     # Case 1: any other non-deferrable tool (visible core tool, bridge tool,
-    # or unresolvable name).  Tell the agent to call it directly if visible
-    # or check spelling.
+    # or unresolvable name).  If the tool is a known core tool that is simply
+    # not in _CORE_TOOL_ALTERNATIVES (e.g. read_file, search_files), give the
+    # same enriched "call directly" message as Case 2 (#1786).
+    effective = effective_core_tool_names(config)
+    if name in effective:
+        return (
+            f"'{name}' is a core tool, not a deferrable tool. "
+            f"Call '{name}' directly — it is already in your tools list. "
+            "Do not use tool_call for core tools."
+        )
+    # Genuinely unknown / misspelled tool — name it explicitly so the agent
+    # can correct its next attempt instead of retrying blindly.
     return (
-        f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
-        "list already, call it directly instead of via tool_call. "
-        "If it is not in your tools list, check the spelling or use tool_search "
-        "to find available deferred tools."
+        f"'{name}' is not a deferrable tool. If '{name}' appears in the "
+        "model-facing tools list already, call it directly instead of via "
+        "tool_call. If it is not in your tools list, check the spelling or "
+        "use tool_search to find available deferred tools."
     )
 
 


### PR DESCRIPTION
## Summary

Resolves #1786 — tool_call bridge mis-routing (329 failures/273 sessions).

The model repeatedly routes core tools (read_file, search_files, etc.) through the tool_call bridge, which rejects them with a generic error. The generic fallback did not name the tool or explicitly say "call directly" for tools not in the _CORE_TOOL_ALTERNATIVES dict.

### Changes
- Check effective_core_tool_names in the fallback branch of _non_deferrable_error and give the enriched "call directly" message
- Update generic fallback to name the tool explicitly
- Add system-prompt clarification in bridge_tool_schemas distinguishing core vs deferred tools

### Evidence
- 329 failures / 273 sessions (61% are "X is not a deferrable tool")
- Max 13 consecutive identical retries per session

Automated evolution PR for issue #1786.