### PR TITLE
fix: enrich terminal timeout error with background-mode suggestion (Closes #1789)

### DIFF
--- a/tests/tools/test_terminal_timeout_hint.py
+++ b/tests/tools/test_terminal_timeout_hint.py
@@ -1,0 +1,34 @@
+"""Tests for terminal timeout error enrichment (#1789).
+
+The timeout error message now includes a background-mode suggestion so the
+model knows to re-run long commands with background=true instead of blind-
+retrying in foreground mode.
+"""
+
+
+class TestTimeoutErrorEnrichment:
+    """Verify the timeout error message includes actionable guidance."""
+
+    def test_timeout_error_mentions_background(self):
+        """The enriched timeout error should tell the model to use background
+        mode (#1789). We test the message format used by the terminal tool
+        when a command times out."""
+        effective_timeout = 180
+        enriched_error = (
+            f"Command timed out after {effective_timeout} seconds. "
+            "This command looks long-running — re-run with "
+            "background=true and notify_on_complete=true."
+        )
+        assert "timed out" in enriched_error.lower()
+        assert "background=true" in enriched_error
+        assert "notify_on_complete=true" in enriched_error
+        assert "re-run" in enriched_error.lower()
+
+    def test_timeout_error_includes_timeout_value(self):
+        """The timeout value should still be present in the enriched message."""
+        enriched_error = (
+            "Command timed out after 300 seconds. "
+            "This command looks long-running — re-run with "
+            "background=true and notify_on_complete=true."
+        )
+        assert "300 seconds" in enriched_error

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3329,7 +3329,11 @@ def terminal_tool(
                         result_dict = {
                             "output": "",
                             "exit_code": 124,
-                            "error": f"Command timed out after {effective_timeout} seconds",
+                            "error": (
+                                f"Command timed out after {effective_timeout} seconds. "
+                                "This command looks long-running — re-run with "
+                                "background=true and notify_on_complete=true."
+                            ),
                             "failure_class": classification.category.value,
                             "suggestion": classification.hint,
                             "should_retry": classification.should_retry,


### PR DESCRIPTION
Resolves #1789 - terminal timeout (206 failures/277 sessions). The model runs long-running tasks (test suites, builds) in foreground mode without background=true. When a timeout fires, the error message was just 'Command timed out after Xs' with no actionable guidance. Now enriched to: 'Command timed out after X seconds. This command looks long-running — re-run with background=true and notify_on_complete=true.' The hint field already mentioned background mode, but the model focuses on the error field. This puts the recommendation where the model reads it. Automated evolution PR for issue #1789.