### PR TITLE
feat: content provenance tagging — trust-level metadata (Closes #1799)

### DIFF
--- a/tests/tools/test_content_provenance.py
+++ b/tests/tools/test_content_provenance.py
@@ -1,0 +1,147 @@
+"""Tests for tools/content_provenance.py — content provenance tagging (#1799)."""
+
+from tools.content_provenance import (
+    EXTERNAL,
+    TOOL_INVOKED,
+    USER,
+    ProvenanceTag,
+    TaggingRegistry,
+    TaggedContent,
+    resolve_trust_level,
+    tag_content,
+    wrap_external,
+)
+
+
+# ── resolve_trust_level ─────────────────────────────────────────────────
+
+
+class TestResolveTrustLevel:
+    def test_user(self):
+        assert resolve_trust_level("user") == USER
+
+    def test_human_alias(self):
+        assert resolve_trust_level("human") == USER
+
+    def test_tool_invoked(self):
+        assert resolve_trust_level("terminal") == TOOL_INVOKED
+        assert resolve_trust_level("read_file") == TOOL_INVOKED
+        assert resolve_trust_level("execute_code") == TOOL_INVOKED
+
+    def test_external(self):
+        assert resolve_trust_level("web_search") == EXTERNAL
+        assert resolve_trust_level("web_extract") == EXTERNAL
+        assert resolve_trust_level("github") == EXTERNAL
+        assert resolve_trust_level("email") == EXTERNAL
+        assert resolve_trust_level("mcp_server") == EXTERNAL
+
+    def test_empty_source_defaults_external(self):
+        assert resolve_trust_level("") == EXTERNAL
+        assert resolve_trust_level(None) == EXTERNAL
+
+
+# ── ProvenanceTag ───────────────────────────────────────────────────────
+
+
+class TestProvenanceTag:
+    def test_trust_rank_ordering(self):
+        assert ProvenanceTag(USER, "user").trust_rank == 0
+        assert ProvenanceTag(TOOL_INVOKED, "terminal").trust_rank == 1
+        assert ProvenanceTag(EXTERNAL, "web_search").trust_rank == 2
+
+    def test_unknown_trust_level(self):
+        tag = ProvenanceTag("bogus", "x")
+        assert tag.trust_rank == 3  # lowest trust
+
+    def test_frozen(self):
+        tag = ProvenanceTag(USER, "user")
+        import pytest
+
+        with pytest.raises(AttributeError):
+            tag.trust_level = EXTERNAL
+
+
+# ── tag_content + TaggedContent.render ──────────────────────────────────
+
+
+class TestTagContent:
+    def test_external_wraps_with_delimiters(self):
+        tc = tag_content("evil payload", "web_search", url="https://evil.com")
+        rendered = tc.render()
+        assert "<untrusted-content" in rendered
+        assert "evil payload" in rendered
+        assert "</untrusted-content>" in rendered
+
+    def test_external_includes_source_and_url(self):
+        tc = tag_content("data", "github", url="https://github.com/x")
+        rendered = tc.render()
+        assert 'source="github"' in rendered
+        assert 'url="https://github.com/x"' in rendered
+
+    def test_user_not_wrapped(self):
+        tc = tag_content("my message", "user")
+        assert tc.render() == "my message"
+
+    def test_tool_invoked_not_wrapped(self):
+        tc = tag_content("ls output", "terminal")
+        assert tc.render() == "ls output"
+
+    def test_trust_level_override(self):
+        tc = tag_content("x", "web_search", trust_level=USER)
+        assert tc.tag.trust_level == USER
+        assert tc.render() == "x"  # not wrapped as external
+
+    def test_external_no_url(self):
+        tc = tag_content("content", "mcp_server")
+        rendered = tc.render()
+        assert "<untrusted-content" in rendered
+        assert 'url="' not in rendered
+
+
+# ── wrap_external ───────────────────────────────────────────────────────
+
+
+class TestWrapExternal:
+    def test_convenience_function(self):
+        result = wrap_external("untrusted data", "web_search")
+        assert "<untrusted-content" in result
+        assert "untrusted data" in result
+
+
+# ── TaggingRegistry ─────────────────────────────────────────────────────
+
+
+class TestTaggingRegistry:
+    def test_add_and_external_sources(self):
+        reg = TaggingRegistry()
+        reg.add(ProvenanceTag(EXTERNAL, "web_search"))
+        reg.add(ProvenanceTag(EXTERNAL, "github"))
+        reg.add(ProvenanceTag(USER, "user"))
+        assert set(reg.external_sources) == {"web_search", "github"}
+
+    def test_has_external(self):
+        reg = TaggingRegistry()
+        assert not reg.has_external
+        reg.add(ProvenanceTag(USER, "user"))
+        assert not reg.has_external
+        reg.add(ProvenanceTag(EXTERNAL, "web_search"))
+        assert reg.has_external
+
+    def test_min_trust_level(self):
+        reg = TaggingRegistry()
+        reg.add(ProvenanceTag(USER, "user"))
+        reg.add(ProvenanceTag(TOOL_INVOKED, "terminal"))
+        reg.add(ProvenanceTag(EXTERNAL, "web_search"))
+        # min_trust_level returns the LOWEST trust (highest rank number)
+        assert reg.min_trust_level == EXTERNAL
+
+    def test_min_trust_level_empty(self):
+        reg = TaggingRegistry()
+        assert reg.min_trust_level == USER
+
+    def test_clear(self):
+        reg = TaggingRegistry()
+        reg.add(ProvenanceTag(EXTERNAL, "web_search"))
+        reg.clear()
+        assert not reg.has_external
+        assert reg.external_sources == []

--- a/tools/content_provenance.py
+++ b/tools/content_provenance.py
@@ -1,0 +1,178 @@
+"""Content provenance tagging — trust-level metadata on external content.
+
+#1799 — Slice 2 of Task Shield (#1659).
+
+Every piece of external content (search results, web pages, MCP outputs)
+carries a trust-level metadata tag. Three levels: ``user`` > ``tool-invoked``
+> ``external``. External content is wrapped in ``<untrusted-content>``
+delimiters when rendered so the LLM and safety filters can distinguish
+trust boundaries.
+
+This module is a standalone utility — content entry points (web_search,
+web_extract, mcp_tool) can import and use it. Integration with the Task
+Shield pre-execution validator (#1798) happens when Slice 1 merges.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# ── Trust levels ────────────────────────────────────────────────────────
+
+# Ordered from highest to lowest trust.
+USER = "user"  # user's own messages
+TOOL_INVOKED = "tool-invoked"  # results from tools the user explicitly invoked
+EXTERNAL = "external"  # search results, web pages, email bodies, MCP responses
+
+_TRUST_ORDER = [USER, TOOL_INVOKED, EXTERNAL]
+
+
+@dataclass(frozen=True)
+class ProvenanceTag:
+    """Immutable provenance metadata for a piece of content."""
+
+    trust_level: str
+    source: str  # e.g. "web_search", "github", "email", "mcp_server"
+    url: str = ""
+    fetched_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    @property
+    def trust_rank(self) -> int:
+        """Lower rank = higher trust. USER=0, TOOL_INVOKED=1, EXTERNAL=2."""
+        try:
+            return _TRUST_ORDER.index(self.trust_level)
+        except ValueError:
+            return len(_TRUST_ORDER)  # unknown = lowest trust
+
+
+def resolve_trust_level(source: str) -> str:
+    """Map a source string to a trust level.
+
+    >>> resolve_trust_level("user")
+    'user'
+    >>> resolve_trust_level("terminal")
+    'tool-invoked'
+    >>> resolve_trust_level("web_search")
+    'external'
+    """
+    if not source:
+        return EXTERNAL
+
+    source_lower = source.lower()
+
+    # User-originated content is the highest trust.
+    if source_lower in ("user", "human", "me"):
+        return USER
+
+    # Core agent tools the user explicitly invoked are medium trust.
+    _tool_invoked = frozenset({
+        "terminal",
+        "execute_code",
+        "read_file",
+        "search_files",
+        "write_file",
+        "patch",
+        "delegate_task",
+        "skill_view",
+        "session_search",
+    })
+    if source_lower in _tool_invoked:
+        return TOOL_INVOKED
+
+    # Everything else (web, email, MCP, social) is external/untrusted.
+    return EXTERNAL
+
+
+@dataclass
+class TaggedContent:
+    """Content wrapped with provenance metadata."""
+
+    content: str
+    tag: ProvenanceTag
+
+    def render(self) -> str:
+        """Render content for LLM context.
+
+        External content is wrapped in ``<untrusted-content>`` delimiters so
+        the LLM and downstream safety filters can distinguish trust boundaries.
+        User and tool-invoked content is rendered as-is (no wrapping).
+        """
+        if self.tag.trust_level == EXTERNAL:
+            delimiter_tag = f' source="{self.tag.source}"'
+            if self.tag.url:
+                delimiter_tag += f' url="{self.tag.url}"'
+            return f"<untrusted-content{delimiter_tag}>\n{self.content}\n</untrusted-content>"
+        return self.content
+
+
+def tag_content(
+    content: str,
+    source: str,
+    *,
+    trust_level: str | None = None,
+    url: str = "",
+) -> TaggedContent:
+    """Tag raw content with provenance metadata.
+
+    Args:
+        content: The raw text content.
+        source: Where the content came from (e.g. "web_search", "terminal").
+        trust_level: Override the auto-resolved trust level.
+        url: Optional URL the content was fetched from.
+
+    Returns:
+        A TaggedContent instance.
+    """
+    resolved = trust_level if trust_level is not None else resolve_trust_level(source)
+    tag = ProvenanceTag(trust_level=resolved, source=source, url=url)
+    return TaggedContent(content=content, tag=tag)
+
+
+def wrap_external(content: str, source: str = "external", url: str = "") -> str:
+    """One-shot convenience: tag and render external content.
+
+    Returns the rendered string with ``<untrusted-content>`` delimiters.
+    """
+    return tag_content(content, source, url=url).render()
+
+
+@dataclass
+class TaggingRegistry:
+    """Turn-level accumulator for auditing content entry points.
+
+    Tracks what content entered the context this turn, from where, and at
+    what trust level. Used for logging and safety audits.
+    """
+
+    _entries: list[ProvenanceTag] = field(default_factory=list)
+
+    def add(self, tag: ProvenanceTag) -> None:
+        self._entries.append(tag)
+
+    @property
+    def external_sources(self) -> list[str]:
+        """Source names of all external (untrusted) content this turn."""
+        return [t.source for t in self._entries if t.trust_level == EXTERNAL]
+
+    @property
+    def has_external(self) -> bool:
+        """Whether any external (untrusted) content was added this turn."""
+        return any(t.trust_level == EXTERNAL for t in self._entries)
+
+    @property
+    def min_trust_level(self) -> str:
+        """The lowest trust level among all entries (for gating decisions).
+
+        Returns the trust_level string of the entry with the HIGHEST rank
+        number (= lowest trust = most dangerous).
+        """
+        if not self._entries:
+            return USER
+        return max(self._entries, key=lambda t: t.trust_rank).trust_level
+
+    def clear(self) -> None:
+        self._entries.clear()


### PR DESCRIPTION
## Summary

Slice 2 of Task Shield (#1659). Implements content provenance tagging: every piece of external content entering the conversation context carries a trust-level metadata tag.

### Trust Levels (highest → lowest)
| Level | Description | Wrapped? |
|-------|-------------|----------|
| `user` | User's own messages | No |
| `tool-invoked` | Results from explicitly invoked tools (terminal, read_file, etc.) | No |
| `external` | Search results, web pages, email bodies, MCP responses | Yes — `<untrusted-content>` |

### Components
- **ProvenanceTag** — immutable metadata dataclass (trust_level, source, url, fetched_at)
- **resolve_trust_level()** — maps source strings to trust levels
- **tag_content() / TaggedContent.render()** — tag and render content
- **wrap_external()** — one-shot convenience for external content
- **TaggingRegistry** — turn-level accumulator for auditing content entry points

### Tests
20 tests covering: trust level resolution (user/tool/external/empty), tag rendering (external wraps, user/tool don't, URL inclusion), wrap_external, ProvenanceTag (rank ordering, frozen), TaggingRegistry (add, external_sources, has_external, min_trust_level, clear).

### Line count
325 lines total (178 module + 147 tests) — exceeds 200-line self-merge cap. Needs human review.

### Integration
Standalone module. Full integration with Task Shield pre-execution validator (#1798) happens when Slice 1 merges. Content entry points (web_search, web_extract, mcp_tool) can import and use `tag_content()` / `wrap_external()` immediately.

Closes #1799

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>