### PR TITLE
fix: spiral cap failure detection for process/terminal/patch/write_file (#1839 #1840 #1841 #1842)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1318,8 +1318,12 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
     data = safe_json_loads(result)
 
-    # Terminal: non-zero exit code is the canonical failure signal.
-    if tool_name == "terminal":
+    # Terminal and process: non-zero exit code is the canonical failure
+    # signal. The process tool (action=poll/log/wait) returns a JSON dict
+    # with exit_code but no "error" key when the background process exits
+    # non-zero — without this check those results are misclassified as
+    # successes and the spiral cap never fires (#1839).
+    if tool_name in ("terminal", "process"):
         if isinstance(data, dict):
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -109,7 +109,12 @@ _NONRETRY_THRESHOLD = 2
 #     threshold (3) + repo_map diversion hint from #973.
 _NON_RETRYABLE_BY_TOOL: dict[str, frozenset[str]] = {
     "read_file": frozenset({"not_found"}),
-    "patch": frozenset({"not_found"}),
+    "patch": frozenset({"not_found", "ambiguous"}),
+    # #1840 — write_file parse-errors are deterministic: the same malformed
+    # JSON/YAML/TOML content will fail validation identically on every retry.
+    # Marking parse_error non-retryable for write_file makes the loop_guard
+    # fire after 2 consecutive occurrences, bounding the spiral.
+    "write_file": frozenset({"parse_error"}),
 }
 
 

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -29,6 +29,35 @@ _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
         "A required binary/command is missing. Check prerequisites first "
         "(`which <cmd>` / install it), or use a different tool — do NOT repeat the same command.",
     ),
+    # #1842 — patch-ambiguous: old_string matches multiple locations.
+    # The same old_string will match the same locations on retry, so
+    # this is deterministic — the agent must add context, not blind-retry.
+    # Must run BEFORE permission: the write_file parse-error message
+    # contains "Refusing to write" which would otherwise match permission.
+    (
+        re.compile(
+            r"\b(found \d+ matches|multiple matches found)\b",
+            re.I,
+        ),
+        "ambiguous",
+        "old_string matched multiple locations. Add more surrounding context to make it "
+        "unique, or use replace_all=true — do NOT retry the same old_string.",
+    ),
+    (
+        # #1840 — write_file/patch parse-errors: malformed content (JSON,
+        # YAML, TOML) fails syntax validation deterministically. The same
+        # malformed content will fail identically on every retry.
+        # Must run BEFORE permission: "Refusing to write" in the error
+        # message would otherwise match the permission regex.
+        re.compile(
+            r"\b(jsondecodeerror|yamlerror|tomldecodeerror|parseerror|syntaxerror|"
+            r"invalid (json|yaml|toml)|syntax validation|fails? \.(json|yaml|yml|toml) syntax)\b",
+            re.I,
+        ),
+        "parse_error",
+        "Content failed syntax validation. The malformed content will fail identically on "
+        "retry — fix the syntax error or re-read the source, do NOT blind-retry the same content.",
+    ),
     (
         re.compile(
             r"permission denied|access denied|not permitted|forbidden|refusing to write|operation not permitted|EACCES",

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -97,6 +97,13 @@ _SPIRAL_PRONE_TOOLS = frozenset({
     # 5) that halts the turn regardless of hard_stop_enabled, bounding the
     # retry spiral and forcing a strategy switch.
     "patch",
+    # #1840 — write_file parse-errors: 48 failures in 7d with 15-deep
+    # spirals. The fail-closed syntax gate returns a validation error
+    # (JSON/YAML/TOML parse failure) that is deterministic — the same
+    # malformed content will fail identically on retry. Adding write_file
+    # here activates the always-on spiral_failure_cap (default 5) so the
+    # agent is forced to fix the content instead of blind-retrying.
+    "write_file",
 })
 
 # #1585 — number of consecutive successes required before a spiral-prone
@@ -361,7 +368,12 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     if file_mutation_result_landed(tool_name, result):
         return False, ""
 
-    if tool_name == "terminal":
+    # Terminal and process: non-zero exit code is the canonical failure
+    # signal. The process tool (action=poll/log/wait) returns a JSON dict
+    # with exit_code but no "error" key when the background process exits
+    # non-zero — without this check those results are misclassified as
+    # successes and the spiral cap never fires (#1839).
+    if tool_name in ("terminal", "process"):
         data = safe_json_loads(result)
         if isinstance(data, dict):
             exit_code = data.get("exit_code")
@@ -1032,13 +1044,13 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
 # loop or policy interceptors: "use <alternative> instead".
 _TOOL_FALLBACK_DIRECTIVE: dict[str, str] = {
     "read_file": "use search_files to locate the file, or vision_analyze for binary/image files",
-    "terminal": "run a read-only diagnostic (pwd, ls) before retrying, or switch to read_file/patch",
+    "terminal": "run a read-only diagnostic (pwd, ls) before retrying, or switch to read_file/patch; for timeouts, use background=true with notify_on_complete=true instead of retrying in foreground",
     "execute_code": "install missing packages via terminal, or verify the interpreter/venv first",
     "web_search": "try web_extract on a known URL, or refine the query terms",
     "web_extract": "try web_search to find alternative URLs, or use the browser tool",
     "search_files": "no results found repeatedly — switch strategy: (a) use target=files mode instead of content, (b) broaden the directory path, (c) try a different glob pattern instead of regex, or (d) ask the user for the correct path",
     "patch": "use read_file to verify the exact text before patching, or use write_file",
-    "write_file": "verify the directory exists with terminal, or use patch for targeted edits",
+    "write_file": "verify the directory exists with terminal, or use patch for targeted edits; for parse-errors, fix the syntax in the content argument — the same malformed content will fail identically on retry",
     "process": "use process action=list to find the correct session_id before retrying",
     # #739 — media tools: a failed visual call is usually a bad path/format or an
     # unavailable provider, not something a blind retry fixes. Route to a check

--- a/tests/agent/test_evolution_spiral_fixes.py
+++ b/tests/agent/test_evolution_spiral_fixes.py
@@ -1,0 +1,105 @@
+"""Tests for evolution spiral-cap and error-enrichment fixes (#1839, #1840, #1841, #1842)."""
+
+import json
+
+from agent.display import _detect_tool_failure
+from agent.loop_guard import _is_non_retryable, _NON_RETRYABLE_BY_TOOL
+from agent.tool_diagnostics import classify
+from agent.tool_guardrails import (
+    classify_tool_failure,
+    _SPIRAL_PRONE_TOOLS,
+    _TOOL_FALLBACK_DIRECTIVE,
+)
+from agent.loop_guard import _NON_RETRYABLE
+
+
+class TestProcessFailureDetection:
+    """#1839: process non-zero exit_code must be counted as failure."""
+
+    def test_classify_tool_failure_process_nonzero_exit(self):
+        result = json.dumps({"session_id": "abc", "status": "exited", "exit_code": 1})
+        failed, suffix = classify_tool_failure("process", result)
+        assert failed is True
+        assert "exit 1" in suffix
+
+    def test_classify_tool_failure_process_zero_exit(self):
+        result = json.dumps({"session_id": "abc", "status": "exited", "exit_code": 0})
+        assert classify_tool_failure("process", result)[0] is False
+
+    def test_classify_tool_failure_process_running(self):
+        result = json.dumps({"session_id": "abc", "status": "running"})
+        assert classify_tool_failure("process", result)[0] is False
+
+    def test_detect_tool_failure_process_nonzero_exit(self):
+        result = json.dumps({"session_id": "abc", "status": "exited", "exit_code": -1})
+        failed, suffix = _detect_tool_failure("process", result)
+        assert failed is True
+        assert "exit" in suffix.lower()
+
+    def test_detect_tool_failure_process_error_with_exit(self):
+        result = json.dumps({"status": "not_found", "exit_code": 1, "error": "No process with ID xyz"})
+        failed, suffix = _detect_tool_failure("process", result)
+        assert failed is True
+        assert "No process" in suffix
+
+
+class TestWriteFileSpiralCap:
+    """#1840: write_file in spiral-prone tools + parse_error non-retryable."""
+
+    def test_write_file_in_spiral_prone_tools(self):
+        assert "write_file" in _SPIRAL_PRONE_TOOLS
+
+    def test_parse_error_non_retryable_for_write_file(self):
+        assert _is_non_retryable("write_file", "parse_error") is True
+
+    def test_parse_error_retryable_for_terminal(self):
+        assert _is_non_retryable("terminal", "parse_error") is False
+
+    def test_write_file_in_non_retryable_by_tool(self):
+        assert "parse_error" in _NON_RETRYABLE_BY_TOOL.get("write_file", frozenset())
+
+
+class TestTerminalTimeoutShouldRetry:
+    """#1841: terminal timeout should_retry=False."""
+
+    def test_timeout_error_should_retry_false(self):
+        result = json.dumps({"output": "", "exit_code": 124, "error": "Command timed out after 180 seconds. This command looks long-running — re-run with background=true and notify_on_complete=true.", "should_retry": False})
+        data = json.loads(result)
+        assert data["should_retry"] is False
+        assert "timed out" in data["error"].lower()
+        assert "background=true" in data["error"]
+
+    def test_timeout_non_retryable_globally(self):
+        assert "timeout" in _NON_RETRYABLE
+
+    def test_terminal_fallback_directive_mentions_background(self):
+        assert "background=true" in _TOOL_FALLBACK_DIRECTIVE.get("terminal", "")
+
+
+class TestPatchAmbiguousDiagnostics:
+    """#1842: patch ambiguous category + non-retryable + parse_error."""
+
+    def test_classify_ambiguous_error(self):
+        msg = "Found 3 matches for old_string at:\n  Line 10: def foo()\n  Line 25: def foo()"
+        result = classify(msg)
+        assert result is not None
+        assert result[0] == "ambiguous"
+
+    def test_ambiguous_non_retryable_for_patch(self):
+        assert _is_non_retryable("patch", "ambiguous") is True
+
+    def test_ambiguous_not_non_retryable_for_terminal(self):
+        assert _is_non_retryable("terminal", "ambiguous") is False
+
+    def test_patch_non_retryable_by_tool(self):
+        tool_classes = _NON_RETRYABLE_BY_TOOL.get("patch", frozenset())
+        assert "ambiguous" in tool_classes
+        assert "not_found" in tool_classes
+
+    def test_classify_parse_error_json(self):
+        msg = "Refusing to write 'config.json': candidate content fails .json syntax validation (JSONDecodeError: Expecting value: line 1, column 1)."
+        assert classify(msg)[0] == "parse_error"
+
+    def test_classify_parse_error_yaml(self):
+        msg = "Refusing to write 'config.yaml': candidate content fails .yaml syntax validation (YAMLError: while parsing a block mapping)."
+        assert classify(msg)[0] == "parse_error"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -1419,12 +1419,14 @@ def format_structured_error(
             )
 
     # For ambiguous: the error message already lists the match locations,
-    # so we just add a recovery hint.
+    # so we add a recovery hint with a concrete fallback directive (#1842).
     if error_type == "ambiguous":
         sections.append(
             "Recovery: provide a longer old_string with more surrounding "
             "context lines to make the match unique, or use replace_all=True "
-            "if you intend to replace all occurrences."
+            "if you intend to replace all occurrences. "
+            "Fallback: use read_file to see the exact text at the matched "
+            "lines, then include enough surrounding context to disambiguate."
         )
 
     # For escape-drift: the error already explains the issue; add a

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3427,7 +3427,11 @@ def terminal_tool(
                             ),
                             "failure_class": classification.category.value,
                             "suggestion": classification.hint,
-                            "should_retry": classification.should_retry,
+                            # #1841 — timeouts are deterministic: the same
+                            # long-running command will time out again on retry.
+                            # Mark should_retry=False so the model does not
+                            # blind-retry the identical foreground command.
+                            "should_retry": False,
                             "terminal_streak": streak,
                         }
                         rec = streak_recommendation(streak)


### PR DESCRIPTION
Automated evolution PR fixing 4 [FIX] regression issues with a shared root cause: the guardrail failure detection system was not counting specific tool failure classes, so spiral caps never fired.

## Root Cause

All 4 issues share a common root cause: the `classify_tool_failure` and `_detect_tool_failure` functions only checked `exit_code != 0` for `tool_name == "terminal"`. The **process** tool returns JSON with `exit_code` but no `"error"` key, so its failures were misclassified as successes — the spiral cap never fired. Additionally, `write_file` was missing from `_SPIRAL_PRONE_TOOLS`, `patch:ambiguous` and `write_file:parse_error` were missing from the non-retryable taxonomy, and terminal timeout `should_retry` was not set to `False`.

## Changes

### #1839 — Process spiral cap regressed (18-deep)
- `agent/display.py`: `_detect_tool_failure` now checks `exit_code != 0` for both `terminal` AND `process`
- `agent/tool_guardrails.py`: `classify_tool_failure` same fix

### #1840 — write_file parse-error spirals (48 failures, 4× regression)
- `agent/tool_guardrails.py`: Added `write_file` to `_SPIRAL_PRONE_TOOLS`
- `agent/loop_guard.py`: Added `parse_error` to `_NON_RETRYABLE_BY_TOOL` for `write_file`
- `agent/tool_diagnostics.py`: Added `parse_error` category regex

### #1841 — Terminal timeout fix #1789 ineffective (225 failures)
- `tools/terminal_tool.py`: Set `should_retry: False` for timeout errors (was `classification.should_retry`)
- `agent/tool_guardrails.py`: Enriched terminal fallback directive to mention `background=true`

### #1842 — patch-ambiguous 221 failures with 21-deep spirals
- `agent/tool_diagnostics.py`: Added `ambiguous` category regex
- `agent/loop_guard.py`: Added `ambiguous` to `_NON_RETRYABLE_BY_TOOL` for `patch`
- `tools/fuzzy_match.py`: Enriched recovery hint with fallback directive

## Tests
- `tests/agent/test_evolution_spiral_fixes.py`: 18 tests covering all 4 fixes

## Checks
- Lint: ✓ (ruff check)
- Tests: ✓ (18/18 passed)

Closes #1839
Closes #1840
Closes #1841
Closes #1842

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>