### PR TITLE
fix: add write_file to spiral-prone tools + enrich parse-error as non-retryable (Closes #1840)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -97,6 +97,14 @@ _SPIRAL_PRONE_TOOLS = frozenset({
     # 5) that halts the turn regardless of hard_stop_enabled, bounding the
     # retry spiral and forcing a strategy switch.
     "patch",
+    # #1840 — write_file parse-error spirals: 48 failures/7d, 15-deep across
+    # 11 sessions. write_file's syntax gate refuses malformed JSON/YAML/TOML
+    # content (non-retryable — the same content will always fail), but the
+    # tool was not in the spiral-prone set so consecutive refusals never
+    # accumulated toward the cap. Adding write_file activates the always-on
+    # spiral_failure_cap so the model is forced to fix the content or switch
+    # strategies instead of blind-retrying the same malformed payload.
+    "write_file",
 })
 
 # #1585 — number of consecutive successes required before a spiral-prone

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -657,12 +657,13 @@ def test_bot_detection_spiral_halts_at_cap():
 def test_browser_cap_leaves_native_tool_hard_stop_semantics_unchanged():
     """The always-on browser cap must not leak into non-spiral-prone native
     tools: with hard_stop OFF, a non-spiral same-tool failure spiral still
-    only warns (never halts).  Note: terminal and execute_code ARE now
-    spiral-prone (see test_spiral_* below), so we use write_file here."""
+    only warns (never halts).  Note: terminal, execute_code, read_file,
+    write_file, and patch ARE now spiral-prone (see test_spiral_* below),
+    so we use send_message here."""
     controller = ToolCallGuardrailController()  # hard_stop off
     decisions = [
         controller.after_call(
-            "write_file", {"path": f"p-{i}"}, '{"error":"boom"}', failed=True
+            "send_message", {"message": f"m-{i}"}, '{"error":"boom"}', failed=True
         )
         for i in range(10)
     ]
@@ -996,12 +997,12 @@ def test_spiral_cap_reset_for_turn_clears_streak():
 
 def test_spiral_cap_does_not_affect_non_spiral_tools():
     """The spiral cap only applies to spiral-prone tools (terminal,
-    execute_code, read_file) — not to write_file, patch, etc."""
+    execute_code, read_file, write_file, patch) — not to send_message, etc."""
     controller = ToolCallGuardrailController()
     last = None
     for _ in range(10):
         last = controller.after_call(
-            "write_file", {"path": "x"}, '{"error":"boom"}', failed=True
+            "send_message", {"message": "x"}, '{"error":"boom"}', failed=True
         )
     assert last is not None
     assert last.action != "halt"
@@ -1121,14 +1122,14 @@ def test_cross_turn_browser_cap_blocks_after_reset():
 
 def test_cross_turn_does_not_affect_non_spiral_tools():
     """The cross-turn enforcement only applies to spiral-prone and browser
-    tools — not to write_file, patch, etc."""
+    tools — not to send_message, etc."""
     controller = ToolCallGuardrailController()
     for _ in range(10):
         controller.after_call(
-            "write_file", {"path": "x"}, '{"error":"boom"}', failed=True
+            "send_message", {"message": "x"}, '{"error":"boom"}', failed=True
         )
     controller.reset_for_turn()
-    assert controller.before_call("write_file", {"path": "x"}).action == "allow"
+    assert controller.before_call("send_message", {"message": "x"}).action == "allow"
 
 
 def test_cross_turn_process_spiral_cap_fires():

--- a/tests/agent/test_write_file_spiral.py
+++ b/tests/agent/test_write_file_spiral.py
@@ -1,0 +1,44 @@
+"""Tests for write_file spiral-prone tool registration (#1840).
+
+write_file was missing from _SPIRAL_PRONE_TOOLS, so parse-error failures
+(structural syntax validation failures) never accumulated toward the
+spiral_failure_cap. This test verifies:
+1. write_file is in the spiral-prone set (so the cap fires)
+2. write_file has a fallback directive defined
+"""
+
+from agent.tool_guardrails import (
+    ToolCallGuardrailConfig,
+    _TOOL_FALLBACK_DIRECTIVE,
+    ToolCallGuardrailController,
+)
+
+
+def test_write_file_is_spiral_prone():
+    """write_file must be in _SPIRAL_PRONE_TOOLS so parse-error spirals
+    accumulate toward the cap (#1840)."""
+    cfg = ToolCallGuardrailConfig()
+    assert "write_file" in cfg.spiral_prone_tools
+
+
+def test_write_file_has_fallback_directive():
+    """write_file must have a fallback directive for when the cap fires."""
+    assert "write_file" in _TOOL_FALLBACK_DIRECTIVE
+    assert len(_TOOL_FALLBACK_DIRECTIVE["write_file"]) > 10
+
+
+def test_write_file_spiral_cap_fires():
+    """Consecutive write_file failures must trigger the spiral cap.
+    After reaching the cap, the tool is session-hard-stopped — an even
+    stronger enforcement than the per-turn cap."""
+    controller = ToolCallGuardrailController()
+    for _ in range(5):
+        controller.before_call("write_file", {"path": "/tmp/test.json"})
+        controller.after_call(
+            "write_file",
+            {"path": "/tmp/test.json"},
+            '{"error": "Refusing to write: syntax validation failed"}',
+        )
+    d = controller.before_call("write_file", {"path": "/tmp/test.json"})
+    assert d.action == "block"
+    assert d.code in ("spiral_prone_tool_failure_cap", "session_hard_stop")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1860,7 +1860,11 @@ class ShellFileOperations(FileOperations):
                     error=(
                         f"Refusing to write '{path}': candidate content fails "
                         f"{ext} syntax validation ({_lint_err}). The file was "
-                        "NOT created or modified. Fix the content and retry."
+                        "NOT created or modified. "
+                        "Non-retryable: the same content will always fail "
+                        "validation. Fix the structural error (e.g. unbalanced "
+                        "braces, trailing commas, invalid escape sequences) "
+                        "or use a terminal heredoc to write the raw bytes."
                     )
                 )
 


### PR DESCRIPTION
## Summary

write_file parse-error spirals (48 failures/7d, 15-deep, 4x regression of #1490) persisted because write_file was missing from _SPIRAL_PRONE_TOOLS. The syntax gate's non-retryable refusals (malformed JSON/YAML/TOML) never accumulated toward the spiral_failure_cap, allowing up to 15 consecutive blind retries.

## Changes
- **agent/tool_guardrails.py**: Added write_file to _SPIRAL_PRONE_TOOLS
- **tools/file_operations.py**: Enriched syntax-gate refusal with non-retryable directive
- **tests/agent/test_write_file_spiral.py**: New tests
- **tests/agent/test_tool_guardrails.py**: Updated 3 tests using write_file as non-spiral example

Automated evolution PR for issue #1840.