### PR TITLE
feat: meta-skill variant tracking instrumentation (Closes #1876)

### DIFF
--- a/scripts/evolution_meta_skill_trace.py
+++ b/scripts/evolution_meta_skill_trace.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Meta-skill variant tracking — Phase 1 instrumentation (#1876, child of #1872).
+
+Records per-cycle which analysis-prompt/procedure variant was used and what
+downstream skill-quality delta resulted.  This is the data the slow meta-skill
+optimization loop (MetaSkill-Evolve, arXiv:2607.05297) needs before any
+meta-skill optimization can happen.  Phase 1 only collects signal.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_VARIANT_ID = "default-v1"
+
+
+def _evolution_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return Path(hh) / "evolution" if hh else Path.home() / ".hermes" / "evolution"
+
+
+def trace_path(evolution_dir: Optional[Path] = None) -> Path:
+    return (evolution_dir or _evolution_dir()) / "meta-skill-traces.jsonl"
+
+
+@dataclass
+class MetaSkillTrace:
+    """One per-cycle variant-outcome record."""
+
+    date: str = ""
+    variant_id: str = DEFAULT_VARIANT_ID
+    selected: int = 0
+    merged: int = 0
+    selected_issue_ids: List[int] = field(default_factory=list)
+    merged_issue_ids: List[int] = field(default_factory=list)
+    skills_created: int = 0
+    skills_merged: int = 0
+    realized_impact: str = ""
+    effort_budget: float = 3.0
+    timestamp: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = time.time()
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "MetaSkillTrace":
+        return cls(**{
+            k: d.get(k, cls.__dataclass_fields__[k].default)
+            for k in d
+            if k in cls.__dataclass_fields__
+        })
+
+
+def append_trace(trace: MetaSkillTrace, evolution_dir: Optional[Path] = None) -> Path:
+    """Append a trace record to ``meta-skill-traces.jsonl``."""
+    p = trace_path(evolution_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(asdict(trace), separators=(",", ":")) + "\n")
+    return p
+
+
+def load_traces(evolution_dir: Optional[Path] = None) -> List[MetaSkillTrace]:
+    """Load all traces. Missing file → empty list."""
+    p = trace_path(evolution_dir)
+    if not p.exists():
+        return []
+    traces: List[MetaSkillTrace] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+            if isinstance(d, dict):
+                traces.append(MetaSkillTrace.from_dict(d))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return traces
+
+
+def variant_summary(
+    traces: List[MetaSkillTrace], min_cycles: int = 3
+) -> Dict[str, Dict[str, Any]]:
+    """Aggregate per-variant outcome metrics for the slow loop."""
+    by_variant: Dict[str, List[MetaSkillTrace]] = {}
+    for t in traces:
+        by_variant.setdefault(t.variant_id, []).append(t)
+    summary: Dict[str, Dict[str, Any]] = {}
+    for vid, records in sorted(by_variant.items()):
+        sel = sum(r.selected for r in records)
+        mrg = sum(r.merged for r in records)
+        summary[vid] = {
+            "cycles": len(records),
+            "total_selected": sel,
+            "total_merged": mrg,
+            "merge_rate": round(mrg / sel, 3) if sel else 0.0,
+            "insufficient_data": len(records) < min_cycles,
+        }
+    return summary

--- a/tests/scripts/test_evolution_meta_skill_trace.py
+++ b/tests/scripts/test_evolution_meta_skill_trace.py
@@ -1,0 +1,80 @@
+"""Tests for meta-skill variant tracking instrumentation (#1876)."""
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from scripts.evolution_meta_skill_trace import (
+    DEFAULT_VARIANT_ID,
+    MetaSkillTrace,
+    append_trace,
+    load_traces,
+    trace_path,
+    variant_summary,
+)
+
+
+def test_append_and_load_roundtrip(tmp_path: Path):
+    t = MetaSkillTrace(
+        date="2026-08-09",
+        variant_id="v2",
+        selected=3,
+        merged=2,
+        selected_issue_ids=[1870, 1871],
+        merged_issue_ids=[1870],
+    )
+    p = append_trace(t, evolution_dir=tmp_path)
+    assert p == trace_path(tmp_path)
+    loaded = load_traces(evolution_dir=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].variant_id == "v2"
+    assert loaded[0].selected == 3
+    assert loaded[0].merged == 2
+
+
+def test_default_variant_id():
+    assert MetaSkillTrace(date="2026-08-09").variant_id == DEFAULT_VARIANT_ID
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path):
+    assert load_traces(evolution_dir=tmp_path) == []
+
+
+def test_malformed_lines_skipped(tmp_path: Path):
+    p = trace_path(tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(asdict(MetaSkillTrace(date="d1", variant_id="v1")))
+        + "\nnot json\n"
+        + json.dumps(asdict(MetaSkillTrace(date="d2", variant_id="v1")))
+        + "\n",
+        encoding="utf-8",
+    )
+    loaded = load_traces(evolution_dir=tmp_path)
+    assert len(loaded) == 2
+
+
+def test_variant_summary_aggregates():
+    traces = [
+        MetaSkillTrace(date="d1", variant_id="v1", selected=4, merged=2),
+        MetaSkillTrace(date="d2", variant_id="v1", selected=3, merged=3),
+        MetaSkillTrace(date="d3", variant_id="v2", selected=2, merged=0),
+    ]
+    s = variant_summary(traces, min_cycles=2)
+    assert s["v1"]["cycles"] == 2
+    assert s["v1"]["total_selected"] == 7
+    assert s["v1"]["total_merged"] == 5
+    assert s["v1"]["merge_rate"] == round(5 / 7, 3)
+    assert s["v1"]["insufficient_data"] is False
+    assert s["v2"]["insufficient_data"] is True
+
+
+def test_variant_summary_empty():
+    assert variant_summary([]) == {}
+
+
+def test_to_dict_from_dict_roundtrip():
+    t = MetaSkillTrace(date="d", variant_id="v3", selected=5, merged=4)
+    t2 = MetaSkillTrace.from_dict(asdict(t))
+    assert t2.variant_id == t.variant_id
+    assert t2.selected == t.selected


### PR DESCRIPTION
Automated evolution PR for issue #1876 (child of #1872).

Phase 1 instrumentation for recursive meta-skill evolution. Records per-cycle which analysis-prompt/procedure variant was used and what downstream skill-quality delta resulted — the data the slow meta-skill optimization loop (MetaSkill-Evolve, arXiv:2607.05297) needs before any meta-skill optimization can happen.

**No behavioral change — instrumentation only. No LLM, no network.**

Changes:
- `scripts/evolution_meta_skill_trace.py`: MetaSkillTrace dataclass, append_trace, load_traces, variant_summary
- `tests/scripts/test_evolution_meta_skill_trace.py`: 7 tests (roundtrip, defaults, malformed lines, summary aggregation)

Closes #1876