### PR TITLE
feat: evidence-span quality gate for research pipeline (Closes #1945)

### DIFF
--- a/scripts/evolution_evidence_span_gate.py
+++ b/scripts/evolution_evidence_span_gate.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Evidence-Span Quality Gate for evolution research (issue #1945).
+
+Every research finding must carry a short verbatim quote from its source
+that directly supports the claim. Findings without verifiable evidence
+spans are flagged so the analysis stage can filter or downgrade them.
+
+Pure deterministic gate — no LLM, no network. Parses the research report
+markdown, extracts findings, checks each for required fields, and writes
+a JSON sidecar (``evidence_spans.json``) for the analysis stage.
+
+Usage: python scripts/evolution_evidence_span_gate.py [--evolution-dir DIR]
+"""
+
+from __future__ import annotations
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+_MAX_SPAN_LEN = 200
+_URL_RE = re.compile(r"https?://[^\s\])]+")
+_FINDING_HEADER_RE = re.compile(
+    r"^###\s+\[(FEATURE|IMPROVEMENT|FIX|BUG)\]\s+(.+)$", re.MULTILINE
+)
+_QUOTE_RE = re.compile(
+    r'(?:^>\s+(.+)$)|(?:"([^"]{10,200})")|(?:\u201c([^\u201d]{10,200})\u201d)',
+    re.MULTILINE,
+)
+
+
+def _default_evolution_dir() -> Path:
+    """Resolve the evolution profile directory (profile-aware)."""
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    hermes_home = Path(
+        os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes")
+    )
+    return hermes_home / "evolution"
+
+
+def parse_findings(markdown: str) -> List[Dict[str, Any]]:
+    """Extract individual findings from the research report markdown."""
+    headers = list(_FINDING_HEADER_RE.finditer(markdown))
+    findings: List[Dict[str, Any]] = []
+    for i, hdr in enumerate(headers):
+        start = hdr.end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(markdown)
+        body = markdown[start:end].strip()
+        urls = _URL_RE.findall(body)
+        qm = _QUOTE_RE.search(body)
+        qt = next((g for g in qm.groups() if g is not None), None) if qm else None
+        findings.append({
+            "title": hdr.group(2).strip(),
+            "type": hdr.group(1),
+            "body": body,
+            "source_urls": urls,
+            "has_quote": qt is not None,
+            "quote_text": qt,
+            "quote_too_long": len(qt) > _MAX_SPAN_LEN if qt else False,
+        })
+    return findings
+
+
+def evaluate_findings(findings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Evaluate findings against evidence-span requirements."""
+    detail: List[Dict[str, Any]] = []
+    wq = wu = nl = 0
+    for f in findings:
+        has_q, has_u, is_long = (
+            f["has_quote"],
+            bool(f["source_urls"]),
+            f["quote_too_long"],
+        )
+        if has_q:
+            wq += 1
+        else:
+            pass
+        if has_u:
+            wu += 1
+        if is_long:
+            nl += 1
+        verifiable = has_q and has_u and not is_long
+        detail.append({
+            "title": f["title"],
+            "type": f["type"],
+            "has_quote": has_q,
+            "has_url": has_u,
+            "quote_too_long": is_long,
+            "source_urls": f["source_urls"],
+            "verifiable": verifiable,
+            "quote_preview": (
+                f["quote_text"][:80] + "..."
+                if f["quote_text"] and len(f["quote_text"]) > 80
+                else f["quote_text"]
+            ),
+        })
+    total = len(findings)
+    both = sum(1 for d in detail if d["has_quote"] and d["has_url"])
+    return {
+        "total": total,
+        "with_quote": wq,
+        "without_quote": total - wq,
+        "with_url": wu,
+        "without_url": total - wu,
+        "too_long": nl,
+        "compliance_rate": round(both / total, 3) if total else 0.0,
+        "findings": detail,
+    }
+
+
+def run_gate(evolution_dir: Path | None = None) -> Dict[str, Any]:
+    """Run the evidence-span gate on the latest research report."""
+    if evolution_dir is None:
+        evolution_dir = _default_evolution_dir()
+    research_dir = evolution_dir / "research"
+    if not research_dir.exists():
+        return {"total": 0, "skipped": "no research directory"}
+    reports = sorted(
+        [p for p in research_dir.glob("*.md") if "backup" not in p.name.lower()],
+        key=lambda p: p.name,
+    )
+    if not reports:
+        return {"total": 0, "skipped": "no research report found"}
+    markdown = reports[-1].read_text(encoding="utf-8")
+    result = evaluate_findings(parse_findings(markdown))
+    result["report_file"] = reports[-1].name
+    out = evolution_dir / "evidence_spans.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    return result
+
+
+def format_summary(result: Dict[str, Any]) -> str:
+    """One-line summary for the pipeline log."""
+    if result.get("skipped"):
+        return f"[evidence-span-gate] skipped: {result['skipped']}"
+    return (
+        f"[evidence-span-gate] {result['total']} findings: "
+        f"compliance={result.get('compliance_rate', 0.0):.0%} "
+        f"(missing_quote={result.get('without_quote', 0)} "
+        f"missing_url={result.get('without_url', 0)} "
+        f"too_long={result.get('too_long', 0)})"
+    )
+
+
+def main(argv: List[str]) -> int:
+    evolution_dir: Path | None = None
+    args = argv[1:]
+    if "--evolution-dir" in args:
+        i = args.index("--evolution-dir")
+        if i + 1 < len(args):
+            evolution_dir = Path(args[i + 1])
+    print(format_summary(run_gate(evolution_dir)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_evidence_span_gate.py
+++ b/tests/scripts/test_evolution_evidence_span_gate.py
@@ -1,0 +1,93 @@
+"""Tests for the evidence-span quality gate (issue #1945)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from evolution_evidence_span_gate import (  # noqa: E402
+    evaluate_findings,
+    format_summary,
+    parse_findings,
+    run_gate,
+)
+
+_FINDING = {
+    "title": "T",
+    "type": "FEATURE",
+    "body": "",
+    "source_urls": ["https://x.com"],
+    "has_quote": True,
+    "quote_text": "q",
+    "quote_too_long": False,
+}
+
+
+def test_parse_extracts_headers_and_urls():
+    md = (
+        "### [FEATURE] One\n- **Source**: https://arxiv.org/abs/2604\nBody.\n\n"
+        "### [IMPROVEMENT] Two\nNo source.\n"
+    )
+    findings = parse_findings(md)
+    assert len(findings) == 2
+    assert findings[0]["type"] == "FEATURE"
+    assert len(findings[0]["source_urls"]) >= 1
+    assert findings[1]["type"] == "IMPROVEMENT"
+
+
+def test_parse_detects_quotes():
+    assert (
+        parse_findings('### [FEATURE] Q\n> "verbatim quote"\n')[0]["has_quote"] is True
+    )
+    assert parse_findings("### [FEATURE] Q\nplain text\n")[0]["has_quote"] is False
+    assert parse_findings("# no headers\nplain text\n") == []
+
+
+def test_evaluate_compliant_and_missing():
+    good = [dict(_FINDING)]
+    bad = [dict(_FINDING, has_quote=False, quote_text=None)]
+    no_url = [dict(_FINDING, source_urls=[])]
+    long_q = [dict(_FINDING, quote_text="x" * 250, quote_too_long=True)]
+    assert evaluate_findings(good)["findings"][0]["verifiable"] is True
+    assert evaluate_findings(bad)["findings"][0]["verifiable"] is False
+    assert evaluate_findings(no_url)["findings"][0]["verifiable"] is False
+    assert evaluate_findings(long_q)["too_long"] == 1
+    assert evaluate_findings(long_q)["findings"][0]["verifiable"] is False
+
+
+def test_evaluate_compliance_rate():
+    result = evaluate_findings([dict(_FINDING), dict(_FINDING, source_urls=[])])
+    assert result["total"] == 2
+    assert result["compliance_rate"] == 0.5
+
+
+def test_run_gate_writes_sidecar(tmp_path):
+    d = tmp_path / "research"
+    d.mkdir()
+    (d / "2026-01-01.md").write_text(
+        '# R\n\n### [FEATURE] Good\n> "Quote."\nSource: https://x.com\n\n'
+        "### [FEATURE] Bad\nNo quote or URL.\n",
+        encoding="utf-8",
+    )
+    result = run_gate(tmp_path)
+    assert result["total"] == 2
+    assert (tmp_path / "evidence_spans.json").exists()
+    assert json.loads((tmp_path / "evidence_spans.json").read_text())["total"] == 2
+
+
+def test_run_gate_skips_when_empty(tmp_path):
+    assert "skipped" in run_gate(tmp_path)
+    (tmp_path / "research").mkdir()
+    assert "skipped" in run_gate(tmp_path)
+
+
+def test_format_summary():
+    s = format_summary({
+        "total": 5,
+        "compliance_rate": 0.8,
+        "without_quote": 1,
+        "without_url": 0,
+        "too_long": 0,
+    })
+    assert "5 findings" in s and "80%" in s
+    assert "skipped" in format_summary({"skipped": "none"})


### PR DESCRIPTION
Automated evolution PR for issue #1945.

## What
Add a deterministic evidence-span quality gate to the evolution research pipeline. Every research finding must carry a verbatim quote from its source and a source URL. Findings without verifiable evidence spans are flagged in a JSON sidecar (evidence_spans.json) so the analysis stage can filter or downgrade unsupported claims before they reach the proposal pipeline.

## Implementation
- `scripts/evolution_evidence_span_gate.py`: Parses the latest research report markdown, extracts findings (### [TYPE] headers), checks each for: (1) a verbatim quote ≤200 chars, (2) source URLs, (3) compliance rate. Writes `evidence_spans.json` sidecar with per-finding verifiability flags. No LLM, no network — pure deterministic pipeline gate.
- `tests/scripts/test_evolution_evidence_span_gate.py`: 7 tests covering header/URL/quote parsing, compliance evaluation (compliant, missing-quote, missing-URL, too-long-quote, mixed), sidecar writing, skip conditions, and summary formatting.

## Note on size
255 lines (162 script + 93 test) exceeds the 200-line self-merge cap by 55 lines. The script is a single coherent unit; splitting it would make pieces non-functional.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>