### PR TITLE
feat: grade-weighted dream pass for evolution pipeline (Closes #1875)

### DIFF
--- a/scripts/evolution_dream_pass.py
+++ b/scripts/evolution_dream_pass.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Dream pass — grade-weighted memory retention for the evolution pipeline.
+
+Phase 1 of issue #1870/#1875: a deterministic, no-LLM scheduled pass that
+reads recent evolution cycle outcomes from ``metrics.jsonl`` and adjusts
+tqmemory notes to reflect their quality. High-grade cycles get their notes
+promoted to global scope; revision-needed cycles get their notes deprecated
+with a failure-mode tag.
+
+The pass reads the last N cycles from ``metrics.jsonl``, classifies each as
+'high-grade' / 'revision-needed' / 'neutral', and applies adjustments via
+direct file operations on the tqmemory notes directory (no MCP dependency).
+
+Usage: python scripts/evolution_dream_pass.py [--max-cycles N]
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _evolution_dir() -> Path:
+    """Resolve the evolution directory (profile-aware)."""
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    hermes_home = Path(
+        os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes")
+    )
+    return hermes_home / "evolution"
+
+
+def _hermes_home() -> Path:
+    return _evolution_dir().parent
+
+
+def load_recent_metrics(max_cycles: int = 10) -> List[Dict[str, Any]]:
+    """Load the last N entries from metrics.jsonl."""
+    metrics_path = _evolution_dir() / "metrics.jsonl"
+    if not metrics_path.exists():
+        return []
+    lines = (
+        metrics_path.read_text(encoding="utf-8", errors="replace").strip().splitlines()
+    )
+    entries: List[Dict[str, Any]] = []
+    for line in lines[-max_cycles:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def classify_cycle(entry: Dict[str, Any]) -> str:
+    """Classify a cycle: 'high-grade', 'revision-needed', or 'neutral'."""
+    merged = int(entry.get("merged", 0) or 0)
+    skipped = int(entry.get("skipped", 0) or 0)
+    rejected = int(entry.get("rejected", 0) or 0)
+    selected = int(entry.get("selected", 0) or 0)
+    if merged > 0 and skipped == 0 and rejected <= 2:
+        return "high-grade"
+    if skipped > 0 or rejected > 5:
+        return "revision-needed"
+    if selected > 0 and merged == 0:
+        return "revision-needed"
+    return "neutral"
+
+
+def find_cycle_notes(date: str) -> List[str]:
+    """Find tqmemory note IDs associated with a given cycle date."""
+    for subdir in ("tqmemory/notes", "turbo_quant_memory/notes"):
+        notes_dir = _hermes_home() / subdir
+        if notes_dir.exists():
+            break
+    else:
+        return []
+    note_ids: List[str] = []
+    for note_file in notes_dir.glob("*.json"):
+        try:
+            data = json.loads(note_file.read_text(encoding="utf-8"))
+            source_refs = data.get("source_refs", [])
+            if any(f"evolution-cycle-{date}" in str(ref) for ref in source_refs):
+                note_ids.append(data.get("id", note_file.stem))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return note_ids
+
+
+def adjust_note_grade(note_id: str, grade: str, date: str) -> bool:
+    """Adjust a tqmemory note based on its cycle grade. Returns True if adjusted."""
+    if grade == "neutral":
+        return False
+    # Direct file-based adjustment (no MCP dependency).
+    for subdir in ("tqmemory/notes", "turbo_quant_memory/notes"):
+        notes_dir = _hermes_home() / subdir
+        if notes_dir.exists():
+            break
+    else:
+        return False
+    note_file = notes_dir / f"{note_id}.json"
+    if not note_file.exists():
+        return False
+    try:
+        data = json.loads(note_file.read_text(encoding="utf-8"))
+        if grade == "high-grade":
+            data["scope"] = "global"
+        elif grade == "revision-needed":
+            data["deprecated"] = True
+            data["deprecation_reason"] = f"grade-failure-mode:cycle-{date}"
+        note_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
+def run_dream_pass(max_cycles: int = 10) -> Dict[str, Any]:
+    """Run one dreaming pass: classify recent cycles and adjust notes."""
+    metrics = load_recent_metrics(max_cycles)
+    if not metrics:
+        return {"status": "noop", "reason": "no metrics found", "adjusted": 0}
+    summary: Dict[str, Any] = {
+        "status": "ok",
+        "cycles_checked": len(metrics),
+        "high_grade": 0,
+        "revision_needed": 0,
+        "neutral": 0,
+        "notes_promoted": 0,
+        "notes_deprecated": 0,
+        "errors": 0,
+    }
+    for entry in metrics:
+        date = entry.get("date", "")
+        if not date:
+            continue
+        grade = classify_cycle(entry)
+        key = grade.replace("-", "_")
+        summary[key] = summary.get(key, 0) + 1
+        for nid in find_cycle_notes(date):
+            try:
+                adjusted = adjust_note_grade(nid, grade, date)
+                if adjusted and grade == "high-grade":
+                    summary["notes_promoted"] += 1
+                elif adjusted and grade == "revision-needed":
+                    summary["notes_deprecated"] += 1
+            except Exception:
+                summary["errors"] += 1
+    result_path = _evolution_dir() / "dream-pass-result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    max_cycles = 10
+    args = (argv or sys.argv)[1:]
+    if "--max-cycles" in args:
+        i = args.index("--max-cycles")
+        if i + 1 < len(args):
+            try:
+                max_cycles = int(args[i + 1])
+            except ValueError:
+                pass
+    try:
+        result = run_dream_pass(max_cycles)
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as exc:
+        print(f"dream pass failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_evolution_dream_pass.py
+++ b/tests/scripts/test_evolution_dream_pass.py
@@ -1,0 +1,148 @@
+"""Tests for the grade-weighted dream pass (issue #1875)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from evolution_dream_pass import (  # noqa: E402
+    classify_cycle,
+    find_cycle_notes,
+    load_recent_metrics,
+    run_dream_pass,
+)
+
+
+def test_classify_high_grade():
+    assert (
+        classify_cycle({"merged": 2, "skipped": 0, "rejected": 1, "selected": 2})
+        == "high-grade"
+    )
+
+
+def test_classify_revision_needed_skips():
+    assert (
+        classify_cycle({"merged": 1, "skipped": 2, "rejected": 0, "selected": 3})
+        == "revision-needed"
+    )
+
+
+def test_classify_revision_needed_no_merge():
+    assert (
+        classify_cycle({"merged": 0, "skipped": 0, "rejected": 3, "selected": 2})
+        == "revision-needed"
+    )
+
+
+def test_classify_neutral():
+    assert (
+        classify_cycle({"merged": 0, "skipped": 0, "rejected": 0, "selected": 0})
+        == "neutral"
+    )
+
+
+def test_classify_high_grade_threshold():
+    assert (
+        classify_cycle({"merged": 1, "skipped": 0, "rejected": 3, "selected": 1})
+        != "high-grade"
+    )
+
+
+def test_load_metrics_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert load_recent_metrics() == []
+
+
+def test_load_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    (evo / "metrics.jsonl").write_text(
+        json.dumps({"date": "2026-01-01", "merged": 1})
+        + "\n"
+        + json.dumps({"date": "2026-01-02", "merged": 0})
+        + "\n"
+    )
+    results = load_recent_metrics()
+    assert len(results) == 2
+    assert results[0]["date"] == "2026-01-01"
+
+
+def test_load_metrics_max(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    lines = "\n".join(
+        json.dumps({"date": f"2026-01-{i:02d}", "merged": i}) for i in range(1, 6)
+    )
+    (evo / "metrics.jsonl").write_text(lines + "\n")
+    results = load_recent_metrics(max_cycles=2)
+    assert len(results) == 2
+    assert results[-1]["date"] == "2026-01-05"
+
+
+def test_find_notes_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert find_cycle_notes("2026-01-01") == []
+
+
+def test_find_notes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    notes = tmp_path / "tqmemory" / "notes"
+    notes.mkdir(parents=True)
+    (notes / "n1.json").write_text(
+        json.dumps({
+            "id": "note-1",
+            "source_refs": ["evolution-cycle-2026-01-01", "file://foo.py"],
+        })
+    )
+    (notes / "n2.json").write_text(
+        json.dumps({"id": "note-2", "source_refs": ["evolution-cycle-2026-02-01"]})
+    )
+    assert find_cycle_notes("2026-01-01") == ["note-1"]
+
+
+def test_run_dream_pass_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    result = run_dream_pass()
+    assert result["status"] == "noop"
+    assert result["adjusted"] == 0
+
+
+def test_run_dream_pass_high_grade(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    (evo / "metrics.jsonl").write_text(
+        json.dumps({
+            "date": "2026-01-01",
+            "merged": 2,
+            "skipped": 0,
+            "rejected": 1,
+            "selected": 2,
+        })
+        + "\n"
+    )
+    result = run_dream_pass()
+    assert result["status"] == "ok"
+    assert result["high_grade"] == 1
+    assert (evo / "dream-pass-result.json").exists()
+
+
+def test_run_dream_pass_revision_needed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    evo = tmp_path / "evolution"
+    evo.mkdir()
+    (evo / "metrics.jsonl").write_text(
+        json.dumps({
+            "date": "2026-01-01",
+            "merged": 0,
+            "skipped": 2,
+            "rejected": 0,
+            "selected": 3,
+        })
+        + "\n"
+    )
+    result = run_dream_pass()
+    assert result["revision_needed"] == 1
+    assert result["high_grade"] == 0


### PR DESCRIPTION
Automated evolution PR for issue #1875 (needs-work rework of PR #1894).

## What
Reworked the grade-weighted dream pass that reads recent evolution cycle outcomes from `metrics.jsonl` and adjusts tqmemory notes. High-grade cycles get their notes promoted to global scope; revision-needed cycles get their notes deprecated with a failure-mode tag.

## Rework from PR #1894
PR #1894 was closed due to CI failures (test slices 1-3, 5-6, 8 failed). Root cause: the test file used `from scripts.evolution_dream_pass import` which doesn't resolve in the subprocess-per-file test runner. Fixed by:
1. Using `sys.path.insert` pattern (matching all other evolution test files)
2. Making functions public (removed leading underscores for testable APIs)
3. Removed MCP server dependency — uses direct file-based note adjustment instead
4. Profile-aware path resolution via `HERMES_HOME` / `EVOLUTION_PROFILE_DIR`

## Implementation
- `scripts/evolution_dream_pass.py`: Loads recent metrics, classifies cycles (high-grade/revision-needed/neutral), finds associated tqmemory notes, adjusts note scope/deprecation. No LLM, no MCP dependency.
- `tests/scripts/test_evolution_dream_pass.py`: 13 tests covering cycle classification, metrics loading, note discovery, and full pass execution (noop + high-grade + revision-needed).

## Note on size
327 lines (179 script + 148 test) exceeds the 200-line self-merge cap. The dream pass is a single coherent unit; splitting it would make pieces non-functional.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>