### PR TITLE
fix: classify search_files/terminal parse errors as non-retryable (Closes #1942 #1944)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -104,9 +104,7 @@ _NONRETRY_THRESHOLD = 2
 #     no matches is legitimately retryable with a broadened/different query (the
 #     ``not_found`` recovery hint itself advises "broaden the search"), so a
 #     hard non-retryable stop would over-block legitimate absent-symbol lookups.
-#     The real search_files spiral driver is regex/glob parse errors, which
-#     classify as ``runtime_error`` and are already handled by the per-tool fail
-#     threshold (3) + repo_map diversion hint from #973.
+#     (search_files parse_error IS non-retryable — see the entry below.)
 _NON_RETRYABLE_BY_TOOL: dict[str, frozenset[str]] = {
     "read_file": frozenset({"not_found"}),
     "patch": frozenset({"not_found", "ambiguous"}),
@@ -115,6 +113,22 @@ _NON_RETRYABLE_BY_TOOL: dict[str, frozenset[str]] = {
     # Marking parse_error non-retryable for write_file makes the loop_guard
     # fire after 2 consecutive occurrences, bounding the spiral.
     "write_file": frozenset({"parse_error"}),
+    # #1942 — terminal parse_error: shell syntax errors (e.g. "rg: regex parse
+    # error", "unexpected token") are deterministic — re-running the same
+    # command produces the same failure.  The terminal failure classifier
+    # (terminal_failure_classifier.py) already marks these should_retry=False,
+    # but the loop_guard's _is_non_retryable check uses the tool_diagnostics
+    # taxonomy which classifies them as parse_error.  Without this entry the
+    # loop_guard fires one cycle later (at the generic fail threshold instead
+    # of the non-retryable threshold of 2), allowing extra spiral iterations.
+    "terminal": frozenset({"parse_error"}),
+    # #1944 — search_files regex/glob parse errors: the same invalid pattern
+    # will fail identically on every retry. tool_diagnostics now classifies
+    # rg/grep pattern-rejection messages as parse_error (previously they fell
+    # through to runtime_error, which is retryable). Marking parse_error as
+    # non-retryable for search_files bounds the spiral at 2 instead of the
+    # generic idempotent fail threshold of 4.
+    "search_files": frozenset({"parse_error"}),
 }
 
 

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -59,6 +59,24 @@ _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
         "retry — fix the syntax error or re-read the source, do NOT blind-retry the same content.",
     ),
     (
+        # #1944 — search_files regex/glob parse errors: the tool wraps rg/grep
+        # errors as "Search failed: rg: regex parse error, …". These are
+        # deterministic — the exact same pattern will fail identically on every
+        # retry — but they were misclassified as ``runtime_error`` (via the
+        # generic "error:" match) which is retryable. Match the actual
+        # rg/grep syntax-failure signatures and classify as ``parse_error``.
+        # Must run BEFORE the runtime_error catch-all (which matches "error:").
+        re.compile(
+            r"\b(regex parse error|invalid regular expression|"
+            r"unrecognized repeat|unbalanced|unclosed|invalid repetition|"
+            r"rg:.*error|grep:.*error)\b",
+            re.I,
+        ),
+        "parse_error",
+        "Invalid regex/glob pattern — the same pattern will fail identically on retry. "
+        "Fix the pattern syntax, or use search_files with target='files' for glob patterns.",
+    ),
+    (
         re.compile(
             r"permission denied|access denied|not permitted|forbidden|refusing to write|operation not permitted|EACCES",
             re.I,

--- a/tests/agent/test_search_files_parse_error.py
+++ b/tests/agent/test_search_files_parse_error.py
@@ -1,0 +1,113 @@
+"""Tests for search_files/terminal parse_error classification (#1942, #1944).
+
+Before this change, search_files regex/glob parse errors (e.g.
+"rg: regex parse error: unclosed group") were classified as ``runtime_error``
+by the generic "error:" catch-all rule in tool_diagnostics._RULES.
+``runtime_error`` is retryable, so the loop_guard's non-retryable fast-path
+never fired, and the agent spiraled on the same broken pattern.
+
+This test verifies:
+  1. Regex parse errors from search_files → ``parse_error`` (not runtime_error)
+  2. ``parse_error`` is non-retryable for both ``search_files`` and ``terminal``
+  3. Normal search failures (empty results, exit code 2 from grep) still
+     classify correctly — NOT as parse_error (would over-block legitimate
+     retryable searches).
+"""
+
+import pytest
+from agent.tool_diagnostics import classify
+from agent.loop_guard import _is_non_retryable, _NON_RETRYABLE_BY_TOOL
+
+
+class TestSearchFilesParseErrorClassification:
+    """#1944 — search_files regex/glob parse errors → parse_error, not runtime_error."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Search failed: rg: regex parse error: unclosed character class",
+            "rg: regex parse error, invalid repetition operator",
+            "grep: Invalid regular expression",
+            "Search failed: error: unclosed parenthesis",
+            "Search failed: error: unbalanced group",
+            "rg: unrecognized repeat operator",
+        ],
+    )
+    def test_regex_parse_error_classified_as_parse_error(self, message):
+        """Each regex/glob failure message must classify as parse_error."""
+        result = classify(message)
+        assert result is not None, f"Expected classification for: {message}"
+        assert result[0] == "parse_error", (
+            f"Expected parse_error for {message!r}, got {result[0]}"
+        )
+
+    def test_parse_error_recovery_hint_mentions_fix(self):
+        """The recovery hint should guide the agent to fix the pattern."""
+        result = classify("rg: regex parse error: unclosed group")
+        assert result is not None
+        _category, hint = result
+        assert "pattern" in hint.lower() or "regex" in hint.lower()
+
+    def test_normal_search_failure_not_parse_error(self):
+        """A generic exit-code-2 from grep/search must NOT be parse_error.
+
+        Grep uses exit code 2 for file-not-found and other non-syntax errors.
+        These are legitimately retryable with a different query/path.
+        """
+        result = classify("exit code 2")
+        if result is not None:
+            assert result[0] != "parse_error", (
+                "Generic exit-code-2 should not classify as parse_error"
+            )
+
+    def test_empty_search_result_not_parse_error(self):
+        """A 'no matches found' result is not_found, not parse_error."""
+        result = classify("no matches found")
+        if result is not None:
+            assert result[0] != "parse_error"
+
+
+class TestSearchFilesNonRetryable:
+    """#1944 — search_files parse_error is non-retryable (spiral-bounded at 2)."""
+
+    def test_search_files_parse_error_is_non_retryable(self):
+        assert _is_non_retryable("search_files", "parse_error") is True
+
+    def test_search_files_not_found_is_retryable(self):
+        """Empty results are legitimately retryable with a broader query."""
+        assert _is_non_retryable("search_files", "not_found") is False
+
+    def test_search_files_runtime_error_is_retryable(self):
+        """Generic runtime errors on search_files are NOT auto-non-retryable."""
+        assert _is_non_retryable("search_files", "runtime_error") is False
+
+    def test_search_files_in_non_retryable_registry(self):
+        assert "search_files" in _NON_RETRYABLE_BY_TOOL
+        assert "parse_error" in _NON_RETRYABLE_BY_TOOL["search_files"]
+
+
+class TestTerminalParseErrorNonRetryable:
+    """#1942 — terminal parse_error is non-retryable."""
+
+    def test_terminal_parse_error_is_non_retryable(self):
+        assert _is_non_retryable("terminal", "parse_error") is True
+
+    def test_terminal_runtime_error_is_retryable(self):
+        """Generic runtime errors on terminal are NOT auto-non-retryable."""
+        assert _is_non_retryable("terminal", "runtime_error") is False
+
+    def test_terminal_in_non_retryable_registry(self):
+        assert "terminal" in _NON_RETRYABLE_BY_TOOL
+        assert "parse_error" in _NON_RETRYABLE_BY_TOOL["terminal"]
+
+
+class TestPatchAmbiguousStillWorks:
+    """#1943 — ensure the existing patch ambiguous classification still works."""
+
+    def test_patch_ambiguous_is_non_retryable(self):
+        assert _is_non_retryable("patch", "ambiguous") is True
+
+    def test_patch_ambiguous_classified(self):
+        result = classify("Found 3 matches for old_string")
+        assert result is not None
+        assert result[0] == "ambiguous"


### PR DESCRIPTION
## Summary

search_files regex/glob parse errors (rg: regex parse error, grep: Invalid regular expression, unclosed/unbalanced/unrecognized) were misclassified as ``runtime_error`` by the generic "error:" catch-all in ``tool_diagnostics._RULES``. Since ``runtime_error`` is retryable, the loop_guard's non-retryable fast-path never fired — the agent spiraled on the same broken pattern until the generic idempotent fail threshold (4) kicked in.

**Root cause:** The rule matching "error:" appears before any regex-specific pattern, so "rg: regex **parse error**" matched the generic error rule instead of a parse-error rule.

**Fix:**
1. Add a regex/glob parse-error classification rule in ``tool_diagnostics.py``, positioned **before** the ``runtime_error`` catch-all.
2. Add ``search_files`` and ``terminal`` to ``_NON_RETRYABLE_BY_TOOL`` for ``parse_error``, bounding the spiral at 2 consecutive occurrences.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| search_files: "rg: regex parse error: unclosed group" | ``runtime_error`` (retryable) → spiral to threshold 4 | ``parse_error`` (non-retryable) → spiral bounded at 2 |
| terminal: "syntax error near unexpected token" | ``runtime_error`` (retryable in loop_guard) → spiral to threshold 2* | ``parse_error`` (non-retryable in loop_guard) → spiral bounded at 2 |
| search_files: "no matches found" (empty result) | ``not_found`` (retryable) ✓ | unchanged ✓ |
| search_files: "exit code 2" (grep file-not-found) | ``runtime_error`` (retryable) ✓ | unchanged ✓ |

*terminal syntax errors were already classified by terminal_failure_classifier.py as should_retry=False, but loop_guard now also gets the non-retryable fast-path.

## Test plan
- [x] ``tests/agent/test_search_files_parse_error.py`` — 18 tests covering classification + non-retryable behavior
- [x] Existing ``test_tool_diagnostics.py`` + ``test_loop_guard.py`` — 139 passed
- [x] Lint clean (ruff check)
- [x] Diff size: 38 lines (within auto-merge cap)

Closes #1942, Closes #1944

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>