### PR TITLE
fix: idempotency guard for side-effecting MCP tools (Closes #1924)

### DIFF
--- a/agent/idempotency.py
+++ b/agent/idempotency.py
@@ -1,0 +1,179 @@
+"""Idempotency guard for side-effecting MCP tools (#1924).
+
+When a side-effecting tool call (sending an email, creating a GitHub issue,
+posting a tweet) fails AFTER the effect was dispatched — e.g. a timeout
+after the request was sent — the agent's default is to retry.  But the effect
+may have already landed, producing a **duplicate**: a second email, a second
+issue, a second tweet.
+
+This module provides a verify-before-retry hint layer.  When the dispatch
+layer detects a post-dispatch failure on a side-effecting tool, it appends an
+``[idempotency]`` directive to the tool result telling the model to verify the
+effect before retrying.  The directive is advisory — it does not block the
+retry mechanically — but it turns a silent duplicate into a visible decision
+point.
+
+The module is pure + lazy-import (the MCP tools may not be available in all
+environments).  It never executes the verification call itself — it only
+returns the tool name + args the dispatch layer *could* use to verify, so the
+hint can reference the correct tool.
+
+Usage (in the dispatch layer's error path)::
+
+    from agent.idempotency import check_before_retry
+
+    verdict = check_before_retry(function_name, function_args, result)
+    if verdict is not None:
+        function_result += "\\n\\n" + verdict.feedback
+
+Intentionally lightweight: the registry is a plain dict and the whole module
+is standalone (no agent state required).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Side-effect registry ────────────────────────────────────────────────
+# Maps a side-effecting MCP tool name to metadata about how to verify whether
+# the effect landed.  These are the canonical tool names for the connected MCP
+# servers in this Hermes environment.
+_SIDE_EFFECT_REGISTRY: Dict[str, Dict[str, Any]] = {
+    "mcp__murable__agentmail__send_message": {
+        "verify_tool": "mcp__murable__agentmail__list_messages",
+        "effect_type": "email_send",
+    },
+    "mcp__murable__agentmail__create_draft": {
+        "verify_tool": "mcp__murable__agentmail__list_drafts",
+        "effect_type": "email_draft",
+    },
+    "mcp__murable__github__create_issue": {
+        "verify_tool": "mcp__murable__github__list_issues",
+        "effect_type": "github_issue",
+    },
+    "mcp__murable__x_twitter__create_tweet": {
+        "verify_tool": "mcp__murable__x_twitter__get_user_tweets",
+        "effect_type": "tweet",
+    },
+}
+
+# Error signatures that suggest the call may have dispatched before failing.
+# These are the dangerous cases: the server received and processed the request,
+# but the response was lost (timeout, connection drop, cancellation).
+_DISPATCH_ERROR_MARKERS = (
+    "timed out",
+    "timeout",
+    "deadline exceeded",
+    "connection reset",
+    "connection refused",
+    "connection closed",
+    "closedresourceerror",
+    "unreachable",
+    "cancelled",
+    "remote disconnected",
+    "broken pipe",
+)
+
+
+@dataclass
+class RetryVerdict:
+    """Result of an idempotency check on a failed side-effecting tool call.
+
+    Attributes:
+        feedback: The advisory message to append to the tool result.
+        verify_tool: The read-only tool name the agent can use to verify.
+        effect_type: Category of side effect (email_send, github_issue, etc.).
+    """
+
+    feedback: str
+    verify_tool: str = ""
+    effect_type: str = ""
+
+
+def is_side_effecting_tool(tool_name: str) -> bool:
+    """True when *tool_name* is in the side-effect registry."""
+    return tool_name in _SIDE_EFFECT_REGISTRY
+
+
+def _looks_like_post_dispatch_error(result: Any) -> bool:
+    """Heuristic: does this failure look like it happened AFTER dispatch?
+
+    The dangerous case: the tool call was sent to the server, the server
+    processed it, but the response didn't come back (timeout, connection drop).
+    In these cases the side effect may have landed despite the error.
+    """
+    if not isinstance(result, str):
+        return False
+    low = result.lower()
+    return any(marker in low for marker in _DISPATCH_ERROR_MARKERS)
+
+
+def check_before_retry(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: Any,
+    session_nonce: str = "",
+) -> Optional[RetryVerdict]:
+    """Decide whether a failed side-effecting tool call is safe to retry.
+
+    Returns ``None`` when:
+      - the tool is not side-effecting (not in registry) — caller decides
+      - the failure does NOT look like a post-dispatch error (normal errors
+        like invalid args are retryable and not an atomicity concern)
+
+    Returns a ``RetryVerdict`` when the failure looks like it may have
+    dispatched before failing (timeout, connection drop on a side-effecting
+    tool).  The verdict's ``feedback`` tells the model to verify the effect
+    before retrying, and that the conservative default is to NOT retry.
+
+    The cost of a duplicate side effect (double email to a real person) is
+    higher than the cost of a missed retry (the user re-sends manually), so
+    when in doubt, the feedback directs the agent to assume the effect landed.
+    """
+    entry = _SIDE_EFFECT_REGISTRY.get(tool_name)
+    if entry is None:
+        return None  # Not a side-effecting tool
+
+    if not _looks_like_post_dispatch_error(result):
+        return None  # Normal error — not an atomicity concern
+
+    effect_type = entry.get("effect_type", "side_effect")
+    verify_tool = entry.get("verify_tool", "")
+
+    feedback = (
+        f"[idempotency] The {effect_type} call failed after dispatch (likely "
+        f"timeout). The side effect MAY have already occurred — do NOT retry "
+        f"blindly. To verify, call `{verify_tool}` and check whether the "
+        f"effect landed before retrying. If you cannot verify, assume it "
+        f"succeeded and report the situation to the user."
+    )
+
+    return RetryVerdict(
+        feedback=feedback,
+        verify_tool=verify_tool,
+        effect_type=effect_type,
+    )
+
+
+def idempotency_key(
+    tool_name: str, args: Dict[str, Any], session_nonce: str = ""
+) -> str:
+    """Generate a deterministic key from tool + args + session.
+
+    Excludes transport metadata (clientId, sendAt) that may differ across
+    retries of the same logical action.  The key is stable for the same
+    (tool, args, session) triple so the dispatch layer can detect a retry.
+    """
+    key_fields = {k: v for k, v in args.items() if k not in ("clientId", "sendAt")}
+    payload = json.dumps(
+        {"tool": tool_name, "args": key_fields, "nonce": session_nonce},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:32]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1248,6 +1248,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
+            # #1924 — Idempotency guard for side-effecting MCP tools. When a
+            # tool that has a real-world side effect (send email, create issue,
+            # post tweet) fails AFTER dispatch (timeout, connection drop), the
+            # effect may have already landed. Append a directive telling the
+            # model to verify before retrying instead of blindly duplicating.
+            # Fail-open: any exception in the check is swallowed.
+            if is_error and isinstance(function_result, str):
+                try:
+                    from agent.idempotency import check_before_retry
+                    _idem_verdict = check_before_retry(
+                        function_name, function_args, function_result,
+                    )
+                    if _idem_verdict is not None:
+                        function_result += "\n\n" + _idem_verdict.feedback
+                except Exception:
+                    logging.debug("idempotency check failed", exc_info=True)
+
             # Track file-mutation outcome for the turn-end verifier.
             # `blocked` calls never actually ran — don't let a guardrail
             # block count as either a failure or a success.
@@ -1995,6 +2012,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
+
+        # #1924 — Idempotency guard (sequential path — see concurrent path above).
+        if _is_error_result and isinstance(function_result, str):
+            try:
+                from agent.idempotency import check_before_retry
+                _idem_verdict = check_before_retry(
+                    function_name, function_args, function_result,
+                )
+                if _idem_verdict is not None:
+                    function_result += "\n\n" + _idem_verdict.feedback
+            except Exception:
+                logging.debug("idempotency check failed", exc_info=True)
 
         # Track file-mutation outcome for the turn-end verifier.  See
         # the concurrent path for the rationale; both paths must feed

--- a/tests/agent/test_idempotency.py
+++ b/tests/agent/test_idempotency.py
@@ -1,0 +1,171 @@
+"""Tests for the idempotency guard (#1924).
+
+Pure unit tests — no agent state, no MCP server, no tool execution.
+Tests the classification logic, key generation, and the side-effect registry.
+"""
+
+import pytest
+from agent.idempotency import (
+    check_before_retry,
+    idempotency_key,
+    is_side_effecting_tool,
+    RetryVerdict,
+)
+
+
+class TestIdempotencyKey:
+    """Deterministic key generation from tool + args + session."""
+
+    def test_same_inputs_same_key(self):
+        args = {"to": ["a@b.com"], "subject": "hello", "inboxId": "123"}
+        k1 = idempotency_key("send_message", args, "session-1")
+        k2 = idempotency_key("send_message", args, "session-1")
+        assert k1 == k2
+
+    def test_different_session_different_key(self):
+        args = {"to": ["a@b.com"], "subject": "hello"}
+        k1 = idempotency_key("send_message", args, "session-1")
+        k2 = idempotency_key("send_message", args, "session-2")
+        assert k1 != k2
+
+    def test_different_args_different_key(self):
+        k1 = idempotency_key("send_message", {"subject": "a"}, "s1")
+        k2 = idempotency_key("send_message", {"subject": "b"}, "s1")
+        assert k1 != k2
+
+    def test_client_id_excluded_from_key(self):
+        """clientId is transport metadata, not part of the logical action."""
+        args1 = {"to": ["a@b.com"], "subject": "hi", "clientId": "abc"}
+        args2 = {"to": ["a@b.com"], "subject": "hi", "clientId": "xyz"}
+        assert idempotency_key("send_message", args1, "s1") == idempotency_key(
+            "send_message", args2, "s1"
+        )
+
+    def test_sendat_excluded_from_key(self):
+        """sendAt is transport metadata for scheduled sends."""
+        args1 = {"to": ["a@b.com"], "sendAt": "2025-01-01T00:00:00Z"}
+        args2 = {"to": ["a@b.com"], "sendAt": "2025-06-01T00:00:00Z"}
+        assert idempotency_key("send_message", args1, "s1") == idempotency_key(
+            "send_message", args2, "s1"
+        )
+
+    def test_key_is_hex(self):
+        key = idempotency_key("any_tool", {}, "s1")
+        assert len(key) == 32
+        int(key, 16)  # should not raise
+
+
+class TestIsSideEffectingTool:
+    def test_registered_side_effecting_tools(self):
+        assert is_side_effecting_tool("mcp__murable__agentmail__send_message")
+        assert is_side_effecting_tool("mcp__murable__agentmail__create_draft")
+        assert is_side_effecting_tool("mcp__murable__github__create_issue")
+        assert is_side_effecting_tool("mcp__murable__x_twitter__create_tweet")
+
+    def test_non_side_effecting(self):
+        assert not is_side_effecting_tool("read_file")
+        assert not is_side_effecting_tool("terminal")
+        assert not is_side_effecting_tool("search_files")
+        assert not is_side_effecting_tool("patch")
+        assert not is_side_effecting_tool("mcp__murable__agentmail__list_messages")
+
+
+class TestCheckBeforeRetry:
+    """The core verdict function."""
+
+    def test_non_side_effecting_returns_none(self):
+        """Non-side-effecting tools are not an atomicity concern."""
+        result = check_before_retry("read_file", {}, "timed out")
+        assert result is None
+
+    def test_normal_error_returns_none(self):
+        """Non-timeout errors on side-effecting tools are retryable."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__send_message",
+            {"inboxId": "123", "to": ["a@b.com"]},
+            "Error: invalid recipient address",
+        )
+        assert result is None
+
+    def test_timeout_on_email_returns_do_not_retry_verdict(self):
+        """Post-dispatch timeout on email → verify-before-retry directive."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__send_message",
+            {"inboxId": "123", "to": ["a@b.com"]},
+            "Error executing tool 'send_message': timed out after 30.0s",
+        )
+        assert result is not None
+        assert isinstance(result, RetryVerdict)
+        assert "do NOT retry" in result.feedback
+        assert result.effect_type == "email_send"
+        assert "list_messages" in result.verify_tool
+
+    def test_connection_reset_on_github_issue(self):
+        """Connection reset after issue creation → verify-before-retry."""
+        result = check_before_retry(
+            "mcp__murable__github__create_issue",
+            {"owner": "org", "repo": "r", "title": "t"},
+            "Connection reset by peer",
+        )
+        assert result is not None
+        assert result.effect_type == "github_issue"
+        assert "list_issues" in result.verify_tool
+
+    def test_deadline_exceeded_on_tweet(self):
+        """Deadline exceeded on tweet → verify-before-retry."""
+        result = check_before_retry(
+            "mcp__murable__x_twitter__create_tweet",
+            {"text": "hello"},
+            "deadline exceeded",
+        )
+        assert result is not None
+        assert result.effect_type == "tweet"
+        assert "get_user_tweets" in result.verify_tool
+
+    def test_broken_pipe_on_email(self):
+        """Broken pipe is a post-dispatch error."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__send_message",
+            {"inboxId": "123"},
+            "[Errno 32] Broken pipe",
+        )
+        assert result is not None
+
+    def test_non_string_result_returns_none(self):
+        """Non-string results (dicts, lists) are not checked."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__send_message",
+            {},
+            {"error": "timed out"},
+        )
+        assert result is None
+
+    def test_draft_timeout(self):
+        """Draft creation timeout → verify-before-retry."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__create_draft",
+            {"inboxId": "123"},
+            "Operation timed out",
+        )
+        assert result is not None
+        assert result.effect_type == "email_draft"
+
+    def test_feedback_mentions_verify_tool(self):
+        """The feedback must tell the model which tool to use for verification."""
+        result = check_before_retry(
+            "mcp__murable__github__create_issue",
+            {"owner": "o", "repo": "r"},
+            "Connection closed",
+        )
+        assert result is not None
+        assert "list_issues" in result.feedback
+
+    def test_feedback_contains_idempotency_tag(self):
+        """The directive must be tagged [idempotency] for visibility."""
+        result = check_before_retry(
+            "mcp__murable__agentmail__send_message",
+            {},
+            "timed out",
+        )
+        assert result is not None
+        assert "[idempotency]" in result.feedback


### PR DESCRIPTION
## Summary

When a side-effecting MCP tool call (send email, create GitHub issue, post tweet) fails AFTER dispatch — timeout, connection drop, deadline exceeded — the effect may have already landed server-side. The agent's default behavior is to retry, producing a **duplicate** side effect: a second email, a second issue, a second tweet.

This PR adds a **verify-before-retry advisory layer** that detects post-dispatch errors on side-effecting tools and appends an `[idempotency]` directive telling the model to verify the effect before retrying.

## Implementation

### New: `agent/idempotency.py` (176 lines)
- `_SIDE_EFFECT_REGISTRY` — maps 4 MCP tools to their read-only verify tools:
  | Tool | Verify Tool | Effect Type |
  |------|-------------|-------------|
  | `agentmail__send_message` | `agentmail__list_messages` | email_send |
  | `agentmail__create_draft` | `agentmail__list_drafts` | email_draft |
  | `github__create_issue` | `github__list_issues` | github_issue |
  | `x_twitter__create_tweet` | `x_twitter__get_user_tweets` | tweet |
- `check_before_retry()` — detects post-dispatch errors (timeout, connection reset, deadline exceeded, broken pipe, etc.) on side-effecting tools; returns a `RetryVerdict` with a directive to verify first
- `idempotency_key()` — deterministic key from tool + args + session (excludes transport metadata)
- **Conservative default**: when verification is unavailable, assume the effect landed — the cost of a duplicate email is higher than a missed retry

### Modified: `agent/tool_executor.py` (+29 lines)
- Integrated the idempotency check at **both** dispatch paths:
  1. **Concurrent path** (~line 1250): after `is_error` detection, before `make_tool_result_message`
  2. **Sequential path** (~line 2013): same integration point
- Both are **fail-open** (`try/except: pass`) and only fire on `is_error=True` + string results
- The check appends a `[idempotency]` directive to the tool result telling the model to verify before retrying

### Design: Advisory, Not Mechanical
The directive is **advisory** — it does not mechanically block retries. It turns a silent duplicate into a visible decision point. The model reads the directive and decides whether to call the verify tool (a read-only list/get) and check whether the effect landed before retrying.

## Test plan
- [x] `tests/agent/test_idempotency.py` — 18 tests covering:
  - Key generation (deterministic, session-scoped, clientId/sendAt excluded)
  - Side-effect registry membership
  - Post-dispatch error detection (timeout, connection reset, deadline exceeded, broken pipe)
  - Normal error passthrough (non-timeout errors are retryable)
  - Non-string result handling
  - Verify tool reference in feedback
- [x] Lint clean (ruff check)
- [x] Diff size: 379 lines total (29 changed + 350 new — within cap)

Closes #1924

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>