### PR TITLE
feat: grade-weighted dream pass for evolution pipeline (Closes #1875)

### DIFF
--- a/scripts/evolution_dream_pass.py
+++ b/scripts/evolution_dream_pass.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Grade-weighted dream pass for the evolution pipeline (#1875, child of #1870).
+
+Phase 1 of grade-weighted memory retention ("dreaming"): reads recent cycle
+outcomes from ``metrics.jsonl`` and adjusts a file-backed note store so
+high-grade runs get promoted (weight raised) and revision-needed runs get a
+failure-mode tag. Pure file-based — no LLM, no MCP dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+PROMOTE_BUMP = 0.5  # weight increment for high-grade cycles
+WEIGHT_CAP = 2.0
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file (one JSON object per line), skipping blank/malformed."""
+    out: list[dict[str, Any]] = []
+    if not path.exists():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        s = raw.strip()
+        try:
+            obj = json.loads(s)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def load_records(metrics_file: Path) -> list[dict[str, Any]]:
+    """Read metrics.jsonl records (one JSON object per line)."""
+    return _load_jsonl(metrics_file)
+
+
+def load_notes(notes_file: Path) -> list[dict[str, Any]]:
+    """Read the file-backed note store (one JSON object per line)."""
+    return _load_jsonl(notes_file)
+
+
+def classify_cycle(rec: dict[str, Any]) -> str:
+    """high-grade: >=1 merged and ratio >=0.5; revision-needed: 0 merged & >=1
+    rejected; else neutral."""
+    merged = int(rec.get("merged", 0) or 0)
+    selected = int(rec.get("selected", 0) or 0)
+    rejected = int(rec.get("rejected", 0) or 0)
+    ratio = merged / selected if selected else 0.0
+    if merged >= 1 and ratio >= 0.5:
+        return "high-grade"
+    if merged == 0 and rejected >= 1:
+        return "revision-needed"
+    return "neutral"
+
+
+def dream_pass(
+    metrics_file: Path, notes_file: Path, *, recent: int = 7
+) -> dict[str, Any]:
+    """Run one grade-weighted dream pass; write ``dream_pass.json`` summary.
+
+    Promotes notes whose ``cycle`` matches a high-grade record (raise weight);
+    tags notes for revision-needed cycles with ``failure:unmerged``.
+    """
+    records = load_records(metrics_file)[-recent:]
+    grades = {r.get("date", "?"): classify_cycle(r) for r in records}
+    by_grade = {
+        g: [d for d, k in grades.items() if k == g]
+        for g in ("high-grade", "revision-needed", "neutral")
+    }
+    notes = load_notes(notes_file)
+    promoted = tagged = 0
+    g = by_grade
+    for n in notes:
+        tags = n.setdefault("tags", [])
+        if n.get("cycle") in g["high-grade"]:
+            w = min(WEIGHT_CAP, float(n.get("weight", 1.0)) + PROMOTE_BUMP)
+            n["weight"] = round(w, 2)
+            if "promoted" not in tags:
+                tags.append("promoted")
+            promoted += 1
+        elif n.get("cycle") in g["revision-needed"]:
+            if "failure:unmerged" not in tags:
+                tags.append("failure:unmerged")
+            tagged += 1
+    if notes:
+        txt = "".join(json.dumps(n) + "\n" for n in notes)
+        notes_file.write_text(txt, encoding="utf-8")
+    summary = {
+        "cycles_reviewed": len(records),
+        "high_grade": by_grade["high-grade"],
+        "revision_needed": by_grade["revision-needed"],
+        "neutral": by_grade["neutral"],
+        "notes_promoted": promoted,
+        "notes_tagged": tagged,
+    }
+    (metrics_file.parent / "dream_pass.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    evo = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("evolution")
+    dream_pass(evo / "metrics.jsonl", evo / "notes.jsonl")

--- a/tests/scripts/test_evolution_dream_pass.py
+++ b/tests/scripts/test_evolution_dream_pass.py
@@ -1,0 +1,87 @@
+"""Tests for the grade-weighted dream pass (#1875)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "scripts"))
+
+from evolution_dream_pass import classify_cycle, dream_pass, load_notes, load_records  # noqa: E402
+
+
+def _jl(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+
+def _cy(d: str, m: int, s: int, r: int) -> dict:
+    return {"date": d, "merged": m, "selected": s, "rejected": r}
+
+
+def _note(i: str, c: str, w: float = 1.0) -> dict:
+    return {"id": i, "cycle": c, "weight": w, "tags": []}
+
+
+def test_classify() -> None:
+    assert classify_cycle(_cy("d", 2, 3, 1)) == "high-grade"
+    assert classify_cycle(_cy("d", 0, 1, 2)) == "revision-needed"
+    assert classify_cycle(_cy("d", 0, 0, 0)) == "neutral"
+    assert classify_cycle(_cy("d", 1, 4, 0)) == "neutral"
+
+
+def test_dream_pass_promotes_and_tags(tmp_path: Path) -> None:
+    metrics, notes = tmp_path / "metrics.jsonl", tmp_path / "notes.jsonl"
+    _jl(
+        metrics,
+        [
+            _cy("2026-08-01", 2, 3, 1),
+            _cy("2026-08-02", 0, 1, 2),
+            _cy("2026-08-03", 0, 0, 0),
+        ],
+    )
+    _jl(
+        notes,
+        [
+            _note("n1", "2026-08-01"),
+            _note("n2", "2026-08-02"),
+            _note("n3", "2026-08-03"),
+        ],
+    )
+    s = dream_pass(metrics, notes)
+    assert s["cycles_reviewed"] == 3
+    assert s["high_grade"] == ["2026-08-01"] and s["revision_needed"] == ["2026-08-02"]
+    assert s["neutral"] == ["2026-08-03"]
+    assert s["notes_promoted"] == 1 and s["notes_tagged"] == 1
+    up = {n["id"]: n for n in load_notes(notes)}
+    assert up["n1"]["weight"] == 1.5 and "promoted" in up["n1"]["tags"]
+    assert "failure:unmerged" in up["n2"]["tags"]
+    assert up["n3"]["tags"] == [] and up["n3"]["weight"] == 1.0
+    assert (tmp_path / "dream_pass.json").exists()
+
+
+def test_empty_inputs(tmp_path: Path) -> None:
+    s = dream_pass(tmp_path / "metrics.jsonl", tmp_path / "notes.jsonl")
+    assert s["cycles_reviewed"] == 0 and s["notes_promoted"] == 0
+    assert s["notes_tagged"] == 0 and (tmp_path / "dream_pass.json").exists()
+
+
+def test_weight_cap_and_recent_limit(tmp_path: Path) -> None:
+    metrics, notes = tmp_path / "metrics.jsonl", tmp_path / "notes.jsonl"
+    _jl(metrics, [_cy(f"2026-08-{i:02d}", 2, 3, 1) for i in range(1, 11)])
+    _jl(notes, [_note(f"n{i}", f"2026-08-{i:02d}", 1.8) for i in range(1, 11)])
+    s = dream_pass(metrics, notes, recent=3)
+    assert s["cycles_reviewed"] == 3
+    up = {n["id"]: n for n in load_notes(notes)}
+    assert up["n8"]["weight"] == 2.0  # capped
+    assert up["n1"]["weight"] == 1.8  # outside recent window, untouched
+
+
+def test_load_records_skips_malformed(tmp_path: Path) -> None:
+    f = tmp_path / "metrics.jsonl"
+    f.write_text(
+        '{"date":"x","merged":1}\nnot-json\n\n{"date":"y"}\n', encoding="utf-8"
+    )
+    assert [r["date"] for r in load_records(f)] == ["x", "y"]


### PR DESCRIPTION
Automated evolution PR for issue #1875 (child of #1870).

## What
Add a scheduled dream pass to the evolution pipeline that reads recent cycle outcomes from metrics.jsonl and adjusts tqmemory notes. High-grade cycles get promoted (weight bump); revision-needed cycles get failure-mode tags.

## Implementation
- scripts/evolution_dream_pass.py (110 lines): Loads metrics records, classifies cycles (high-grade/revision-needed/neutral), adjusts note weights and tags. Writes dream_pass.json summary. No LLM, no MCP.
- tests/scripts/test_evolution_dream_pass.py (87 lines): 5 tests covering cycle classification, metrics loading, promotion/tagging, weight cap, and malformed record handling.

## Rework from prior PRs #1894 + #1948
PR #1894 failed (wrong import pattern — used 'from scripts.x import' instead of sys.path.insert). PR #1948 failed (327 lines, over 200-line cap). This rework: 197 total lines, correct sys.path.insert pattern.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>