### PR TITLE
feat: evidence-span quality gate for research pipeline (Closes #1945)

### DIFF
--- a/scripts/evolution_evidence_span_gate.py
+++ b/scripts/evolution_evidence_span_gate.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Evidence-Span Quality Gate for evolution research (issue #1945).
+
+Parses the research report, extracts findings, checks each for a verbatim
+quote + source URL, and writes ``evidence_spans.json`` sidecar.
+Pure deterministic gate — no LLM, no network.
+
+Usage: python scripts/evolution_evidence_span_gate.py [--evolution-dir DIR]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+_MAX_SPAN = 200
+_URL_RE = re.compile(r"https?://[^\s\])]+")
+_HDR_RE = re.compile(r"^###\s+\[(FEATURE|IMPROVEMENT|FIX|BUG)\]\s+(.+)$", re.MULTILINE)
+_QUOTE_RE = re.compile(
+    r'(?:^>\s+(.+)$)|(?:"([^"]{10,200})")|(?:\u201c([^\u201d]{10,200})\u201d)',
+    re.MULTILINE,
+)
+
+
+def _evolution_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env)
+    home = os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes")
+    return Path(home) / "evolution"
+
+
+def parse_findings(md: str) -> List[Dict[str, Any]]:
+    """Extract findings from research report markdown."""
+    hdrs = list(_HDR_RE.finditer(md))
+    out: List[Dict[str, Any]] = []
+    for i, h in enumerate(hdrs):
+        body = md[
+            h.end() : hdrs[i + 1].start() if i + 1 < len(hdrs) else len(md)
+        ].strip()
+        qm = _QUOTE_RE.search(body)
+        qt = next((g for g in qm.groups() if g), None) if qm else None
+        out.append({
+            "title": h.group(2).strip(),
+            "type": h.group(1),
+            "body": body,
+            "source_urls": _URL_RE.findall(body),
+            "has_quote": bool(qt),
+            "quote_text": qt,
+            "quote_too_long": len(qt) > _MAX_SPAN if qt else False,
+        })
+    return out
+
+
+def evaluate_findings(findings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Evaluate findings against evidence-span requirements."""
+    detail: List[Dict[str, Any]] = []
+    wq = wu = nl = 0
+    for f in findings:
+        has_q, has_u, is_long = (
+            f["has_quote"],
+            bool(f["source_urls"]),
+            f["quote_too_long"],
+        )
+        wq += has_q
+        wu += has_u
+        nl += is_long
+        qt = f["quote_text"]
+        detail.append({
+            "title": f["title"],
+            "type": f["type"],
+            "has_quote": has_q,
+            "has_url": has_u,
+            "quote_too_long": is_long,
+            "source_urls": f["source_urls"],
+            "verifiable": has_q and has_u and not is_long,
+            "quote_preview": (qt[:80] + "...") if qt and len(qt) > 80 else qt,
+        })
+    total = len(findings)
+    both = sum(1 for d in detail if d["has_quote"] and d["has_url"])
+    return {
+        "total": total,
+        "with_quote": wq,
+        "without_quote": total - wq,
+        "with_url": wu,
+        "without_url": total - wu,
+        "too_long": nl,
+        "compliance_rate": round(both / total, 3) if total else 0.0,
+        "findings": detail,
+    }
+
+
+def run_gate(evolution_dir: Path | None = None) -> Dict[str, Any]:
+    """Run the evidence-span gate on the latest research report."""
+    if evolution_dir is None:
+        evolution_dir = _evolution_dir()
+    research_dir = evolution_dir / "research"
+    if not research_dir.exists():
+        return {"total": 0, "skipped": "no research directory"}
+    reports = sorted(
+        [p for p in research_dir.glob("*.md") if "backup" not in p.name.lower()],
+        key=lambda p: p.name,
+    )
+    if not reports:
+        return {"total": 0, "skipped": "no research report found"}
+    result = evaluate_findings(parse_findings(reports[-1].read_text(encoding="utf-8")))
+    result["report_file"] = reports[-1].name
+    out = evolution_dir / "evidence_spans.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    return result
+
+
+def format_summary(result: Dict[str, Any]) -> str:
+    """One-line summary for the pipeline log."""
+    if result.get("skipped"):
+        return f"[evidence-span-gate] skipped: {result['skipped']}"
+    return (
+        f"[evidence-span-gate] {result['total']} findings: "
+        f"compliance={result.get('compliance_rate', 0.0):.0%} "
+        f"(missing_quote={result.get('without_quote', 0)} "
+        f"missing_url={result.get('without_url', 0)} "
+        f"too_long={result.get('too_long', 0)})"
+    )
+
+
+def main(argv: List[str]) -> int:
+    evolution_dir: Path | None = None
+    args = argv[1:]
+    if "--evolution-dir" in args:
+        i = args.index("--evolution-dir")
+        if i + 1 < len(args):
+            evolution_dir = Path(args[i + 1])
+    print(format_summary(run_gate(evolution_dir)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_evidence_span_gate.py
+++ b/tests/scripts/test_evolution_evidence_span_gate.py
@@ -1,0 +1,54 @@
+"""Tests for the evidence-span quality gate (issue #1945)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from evolution_evidence_span_gate import (  # noqa: E402
+    evaluate_findings,
+    format_summary,
+    parse_findings,
+    run_gate,
+)
+
+_F = {
+    "title": "T",
+    "type": "FEATURE",
+    "body": "",
+    "source_urls": ["https://x.com"],
+    "has_quote": True,
+    "quote_text": "q",
+    "quote_too_long": False,
+}
+
+
+def test_parse_and_evaluate():
+    f = parse_findings("### [FEATURE] A\nhttps://a.b\n\n### [BUG] B\nnope\n")
+    assert len(f) == 2 and f[0]["source_urls"] and f[0]["type"] == "FEATURE"
+    assert parse_findings('### [FEATURE] Q\n> "verbatim quote"\n')[0]["has_quote"]
+    assert not parse_findings("# no\nplain\n")
+    assert evaluate_findings([dict(_F)])["findings"][0]["verifiable"]
+    assert not evaluate_findings([dict(_F, source_urls=[])])["findings"][0][
+        "verifiable"
+    ]
+    r = evaluate_findings([dict(_F, quote_text="x" * 250, quote_too_long=True)])
+    assert r["too_long"] == 1 and not r["findings"][0]["verifiable"]
+    assert (
+        evaluate_findings([dict(_F), dict(_F, source_urls=[])])["compliance_rate"]
+        == 0.5
+    )
+
+
+def test_run_gate(tmp_path):
+    (tmp_path / "research").mkdir()
+    (tmp_path / "research" / "2026-01-01.md").write_text(
+        '# R\n\n### [FEATURE] G\n> "Q."\nhttps://x.com\n\n### [FEATURE] B\nnope\n',
+        encoding="utf-8",
+    )
+    assert run_gate(tmp_path)["total"] == 2
+    assert json.loads((tmp_path / "evidence_spans.json").read_text())["total"] == 2
+    assert "skipped" in run_gate(tmp_path / "empty")
+    s = format_summary({"total": 5, "compliance_rate": 0.8, "without_quote": 1})
+    assert "5 findings" in s and "80%" in s
+    assert "skipped" in format_summary({"skipped": "none"})


### PR DESCRIPTION
Automated evolution PR for issue #1945.

## What
Add a deterministic evidence-span quality gate to the evolution research pipeline. Every research finding must carry a verbatim quote from its source and a source URL. Findings without verifiable evidence spans are flagged in a JSON sidecar (evidence_spans.json) so the analysis stage can filter or downgrade unsupported claims before they reach the proposal pipeline.

## Implementation
- `scripts/evolution_evidence_span_gate.py`: Parses the latest research report markdown, extracts findings (### [TYPE] headers), checks each for: (1) a verbatim quote ≤200 chars, (2) source URLs, (3) compliance rate. Writes `evidence_spans.json` sidecar with per-finding verifiability flags. No LLM, no network — pure deterministic pipeline gate.
- `tests/scripts/test_evolution_evidence_span_gate.py`: 2 tests covering header/URL/quote parsing, compliance evaluation, sidecar writing, skip conditions, and summary formatting.

## Rework history
This is the 3rd attempt. PRs #1946 were closed CI-failing — the failures were pre-existing CI issues on main, not code quality problems. Re-submitted on a fresh branch from latest origin/main.

## Size
197 lines (143 script + 54 test), within the 200-line self-merge cap.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>