### PR TITLE
feat: post-compaction trajectory evaluation signal (Closes #2185)

### DIFF
--- a/agent/compaction_eval.py
+++ b/agent/compaction_eval.py
@@ -1,0 +1,162 @@
+"""Post-compaction trajectory evaluation signal (#2185, Phase 1).
+
+Records whether the post-compaction trajectory succeeds so the pipeline
+can correlate summary quality with downstream task outcomes.
+
+This is the Phase 1 evaluation signal from CompactionRL (arXiv:2607.05378).
+Phase 2 (mutable compaction skill + evolution-pipeline training) is deferred.
+
+The module records two events to a sidecar JSON (~/.hermes/compaction_eval.json):
+1. Compaction event: timestamp, token reduction, message count change
+2. Turn outcome: success/failure/interrupted after compaction
+
+Design:
+  - Sidecar JSON, not inline state — keeps eval data out of conversation state.
+  - Best-effort: failures log at DEBUG and return silently.
+  - Each record is keyed by turn_id so the compaction event and its outcome
+    can be correlated.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_MAX_RECORDS = 200  # cap to prevent unbounded growth
+
+
+def _eval_file() -> Path:
+    return get_hermes_home() / "compaction_eval.json"
+
+
+def _load() -> List[Dict[str, Any]]:
+    path = _eval_file()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def _save(records: List[Dict[str, Any]]) -> None:
+    path = _eval_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(
+        json.dumps(records[-_MAX_RECORDS:], ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)
+
+
+def record_compaction_event(
+    turn_id: str,
+    session_id: str = "",
+    messages_before: int = 0,
+    messages_after: int = 0,
+    tokens_before: int = 0,
+    tokens_after: int = 0,
+) -> None:
+    """Record that a compaction event occurred during a turn (#2185).
+
+    Called after compaction completes. The turn_id links this event to the
+    later outcome recorded by record_post_compaction_outcome().
+    Best-effort; failures log at DEBUG and return silently.
+    """
+    if not turn_id:
+        return
+    try:
+        records = _load()
+        records.append({
+            "turn_id": turn_id[:200],
+            "session_id": (session_id or "")[:200],
+            "event": "compaction",
+            "messages_before": messages_before,
+            "messages_after": messages_after,
+            "tokens_before": tokens_before,
+            "tokens_after": tokens_after,
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        })
+        _save(records)
+    except Exception as e:
+        logger.debug("record_compaction_event failed: %s", e, exc_info=True)
+
+
+def record_post_compaction_outcome(
+    turn_id: str,
+    success: bool,
+    interrupted: bool = False,
+    failed: bool = False,
+) -> None:
+    """Record the outcome of a turn that included compaction (#2185).
+
+    Called from finalize_turn when the turn exits. Only records if the
+    turn had a compaction event (matched by turn_id).
+    Best-effort; failures log at DEBUG and return silently.
+    """
+    if not turn_id:
+        return
+    try:
+        records = _load()
+        # Find the compaction event for this turn_id.
+        has_compaction = any(
+            r.get("turn_id") == turn_id and r.get("event") == "compaction"
+            for r in records
+        )
+        if not has_compaction:
+            return
+        records.append({
+            "turn_id": turn_id[:200],
+            "event": "outcome",
+            "success": success,
+            "interrupted": interrupted,
+            "failed": failed,
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        })
+        _save(records)
+    except Exception as e:
+        logger.debug("record_post_compaction_outcome failed: %s", e, exc_info=True)
+
+
+def get_eval_summary() -> Dict[str, Any]:
+    """Return a summary of compaction evaluation data.
+
+    Used by the pipeline / curator to surface which summary patterns
+    correlate with success.
+    """
+    records = _load()
+    compaction_events = [r for r in records if r.get("event") == "compaction"]
+    outcomes = [r for r in records if r.get("event") == "outcome"]
+    # Match outcomes to compaction events by turn_id.
+    outcome_by_turn = {r["turn_id"]: r for r in outcomes}
+    matched = 0
+    successes = 0
+    failures = 0
+    interrupted = 0
+    for ev in compaction_events:
+        outcome = outcome_by_turn.get(ev["turn_id"])
+        if outcome:
+            matched += 1
+            if outcome.get("success"):
+                successes += 1
+            elif outcome.get("failed"):
+                failures += 1
+            elif outcome.get("interrupted"):
+                interrupted += 1
+    return {
+        "total_compactions": len(compaction_events),
+        "total_outcomes": len(outcomes),
+        "matched": matched,
+        "successes": successes,
+        "failures": failures,
+        "interrupted": interrupted,
+        "success_rate": successes / matched if matched else None,
+    }

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2319,6 +2319,20 @@ def compress_context(
         # go through agent._emit_warning and are never suppressed here.
         if _compaction_status_emitted:
             _emit_compaction_done(agent)
+        # Record compaction evaluation event (#2185 Phase 1).
+        # Best-effort; never blocks the compaction lifecycle.
+        try:
+            from agent.compaction_eval import record_compaction_event
+            _turn_id = getattr(agent, "_current_turn_id", "") or ""
+            _sess_id = getattr(agent, "session_id", "") or ""
+            _cc = getattr(agent.context_compressor, "compression_count", 0)
+            record_compaction_event(
+                turn_id=_turn_id,
+                session_id=_sess_id,
+                messages_after=len(compressed) if isinstance(compressed, list) else 0,
+            )
+        except Exception:
+            pass
 
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -844,4 +844,18 @@ def finalize_turn(
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
 
+    # Record post-compaction trajectory outcome (#2185 Phase 1).
+    # Only records if this turn had a compaction event (matched by turn_id).
+    try:
+        from agent.compaction_eval import record_post_compaction_outcome
+        _success = bool(final_response) and not interrupted and not failed
+        record_post_compaction_outcome(
+            turn_id=turn_id or "",
+            success=_success,
+            interrupted=interrupted,
+            failed=failed,
+        )
+    except Exception:
+        pass
+
     return result

--- a/tests/agent/test_compaction_eval.py
+++ b/tests/agent/test_compaction_eval.py
@@ -1,0 +1,110 @@
+"""Tests for post-compaction trajectory evaluation signal (#2185 Phase 1).
+
+Verifies that:
+- Compaction events are recorded to the sidecar JSON
+- Post-compaction outcomes are recorded and matched to compaction events
+- The eval summary correctly computes success rate
+- Outcomes without a matching compaction event are not recorded
+- The record cap prevents unbounded growth
+"""
+
+import json
+
+import pytest
+
+from agent.compaction_eval import (
+    get_eval_summary,
+    record_compaction_event,
+    record_post_compaction_outcome,
+    _eval_file,
+    _load,
+    _MAX_RECORDS,
+)
+
+
+class TestRecordCompactionEvent:
+    def test_record_compaction_event(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_compaction_event(
+            turn_id="turn-1",
+            session_id="sess-1",
+            messages_before=50,
+            messages_after=15,
+        )
+        records = _load()
+        assert len(records) == 1
+        assert records[0]["event"] == "compaction"
+        assert records[0]["turn_id"] == "turn-1"
+        assert records[0]["messages_after"] == 15
+
+    def test_empty_turn_id_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_compaction_event(turn_id="", session_id="s")
+        assert _load() == []
+
+
+class TestRecordPostCompactionOutcome:
+    def test_outcome_matched_to_compaction(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_compaction_event(turn_id="turn-1", session_id="s")
+        record_post_compaction_outcome(turn_id="turn-1", success=True)
+        records = _load()
+        assert len(records) == 2
+        assert records[1]["event"] == "outcome"
+        assert records[1]["success"] is True
+
+    def test_outcome_without_compaction_not_recorded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_post_compaction_outcome(turn_id="turn-99", success=True)
+        records = _load()
+        assert len(records) == 0
+
+    def test_failed_outcome(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_compaction_event(turn_id="turn-2", session_id="s")
+        record_post_compaction_outcome(turn_id="turn-2", success=False, failed=True)
+        records = _load()
+        assert records[1]["failed"] is True
+        assert records[1]["success"] is False
+
+
+class TestEvalSummary:
+    def test_summary_with_matched_events(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # 2 compactions: 1 success, 1 failure
+        record_compaction_event(turn_id="t1", session_id="s")
+        record_post_compaction_outcome(turn_id="t1", success=True)
+        record_compaction_event(turn_id="t2", session_id="s")
+        record_post_compaction_outcome(turn_id="t2", success=False, failed=True)
+
+        summary = get_eval_summary()
+        assert summary["total_compactions"] == 2
+        assert summary["matched"] == 2
+        assert summary["successes"] == 1
+        assert summary["failures"] == 1
+        assert summary["success_rate"] == 0.5
+
+    def test_summary_no_data(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        summary = get_eval_summary()
+        assert summary["total_compactions"] == 0
+        assert summary["success_rate"] is None
+
+    def test_summary_unmatched_compaction(self, tmp_path, monkeypatch):
+        """Compaction without outcome (turn still running) not counted."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_compaction_event(turn_id="t1", session_id="s")
+        summary = get_eval_summary()
+        assert summary["total_compactions"] == 1
+        assert summary["matched"] == 0
+        assert summary["success_rate"] is None
+
+
+class TestRecordCap:
+    def test_cap_prevents_unbounded_growth(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Write more than _MAX_RECORDS entries
+        for i in range(_MAX_RECORDS + 50):
+            record_compaction_event(turn_id=f"t{i}", session_id="s")
+        records = _load()
+        assert len(records) <= _MAX_RECORDS


### PR DESCRIPTION
Automated evolution PR for issue #2185 — Phase 1 only.

## Summary

Records compaction events and post-compaction turn outcomes to a sidecar JSON (`~/.hermes/compaction_eval.json`) so the pipeline can correlate summary quality with downstream task success. This is the Phase 1 evaluation signal from CompactionRL (arXiv:2607.05378).

The compaction rubric itself already exists (#1568 SelfCompact, arXiv:2606.23525) — this PR adds the missing evaluation signal.

## Changes (300 lines — exceeds self-merge cap, needs human review)

- **`agent/compaction_eval.py`** (new): `record_compaction_event()`, `record_post_compaction_outcome()`, `get_eval_summary()` — sidecar JSON persistence with 200-record cap.
- **`agent/conversation_compression.py`**: Records compaction event at lifecycle completion (turn_id, session_id, message count).
- **`agent/turn_finalizer.py`**: Records turn outcome at finalization (success/failure/interrupted), matched by turn_id.
- **`tests/agent/test_compaction_eval.py`** (new): 9 tests covering event recording, outcome matching, eval summary, record cap.

## Acceptance Criteria

- [x] Post-compaction trajectory success is recorded as an evaluation signal
- [x] Compaction prompt includes an explicit rubric (Phase 1) — already exists (#1568)
- [ ] Compaction prompt is a mutable skill file (Phase 2) — deferred to a later cycle

## Scope

Phase 1 only. Phase 2 (mutable compaction skill + evolution-pipeline training) is a separate, higher-effort increment — not bundled.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>