### PR TITLE
feat: deterministic skill consolidation pass wired into curator (Closes #2184)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1676,6 +1676,20 @@ def run_curator_review(
                     )
                 else:
                     prompt = f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n{candidate_list}"
+                # Deterministic pre-clustering pass (#2184) — feeds similarity
+                # groups to the LLM so it can consolidate without searching the
+                # full candidate space. Zero LLM cost; runs inline.
+                try:
+                    from tools.skill_consolidation import (
+                        run_consolidation_pass,
+                        render_clusters_for_prompt,
+                    )
+                    cons = run_consolidation_pass()
+                    cluster_hints = render_clusters_for_prompt(cons)
+                    if cluster_hints:
+                        prompt += f"\n\n{cluster_hints}"
+                except Exception:
+                    pass
                 llm_meta = _run_llm_review(prompt)
                 final_summary = (
                     f"{prefix}{auto_summary}; llm: {llm_meta.get('summary', 'no change')}"

--- a/tests/tools/test_skill_consolidation.py
+++ b/tests/tools/test_skill_consolidation.py
@@ -1,11 +1,6 @@
-"""Tests for tools/skill_consolidation.py — deterministic skill clustering.
+"""Tests for tools/skill_consolidation.py — deterministic skill clustering."""
 
-Tests the clustering logic in isolation (no live skill files needed) and
-verifies the pass is wired into the curator review.
-"""
-
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from tools.skill_consolidation import (
     _tokenize,
@@ -16,163 +11,43 @@ from tools.skill_consolidation import (
 )
 
 
-class TestTokenize:
-    def test_basic(self):
-        tokens = _tokenize("Fine-tuning LoRA models")
-        assert "fine" in tokens
-        assert "tuning" in tokens
-        assert "lora" in tokens
-        assert "models" in tokens
-
-    def test_drops_short_words(self):
-        tokens = _tokenize("a b c dd ee foo")
-        assert "foo" in tokens
-        assert "a" not in tokens
-        assert "b" not in tokens
-        assert "dd" not in tokens
-
-    def test_drops_stopwords(self):
-        tokens = _tokenize("the skill for agent")
-        assert "the" not in tokens
-        assert "skill" not in tokens
-        assert "agent" not in tokens
-        assert "for" not in tokens
-
-    def test_handles_hyphens(self):
-        tokens = _tokenize("pre-commit validation")
-        assert "pre" in tokens
-        assert "commit" in tokens
-        assert "validation" in tokens
-
-    def test_empty(self):
-        assert _tokenize("") == set()
-        assert _tokenize(None) == set()
+def test_tokenize():
+    assert {"fine", "tuning", "lora"} <= _tokenize("Fine-tuning LoRA")
+    assert _tokenize("") == set() and _tokenize(None) == set()
+    assert not (_tokenize("the skill a foo") & {"the", "skill", "a"})
 
 
-class TestJaccard:
-    def test_identical(self):
-        s = {"a", "b", "c"}
-        assert _jaccard(s, s) == 1.0
-
-    def test_disjoint(self):
-        assert _jaccard({"a"}, {"b"}) == 0.0
-
-    def test_partial(self):
-        # {a,b} vs {a,b,c} → 2/3
-        assert _jaccard({"a", "b"}, {"a", "b", "c"}) == pytest.approx(2 / 3)
-
-    def test_empty(self):
-        assert _jaccard(set(), {"a"}) == 0.0
-        assert _jaccard(set(), set()) == 0.0
+def test_jaccard():
+    assert _jaccard({"a", "b"}, {"a", "b"}) == 1.0
+    assert _jaccard({"a"}, {"b"}) == 0.0
+    assert _jaccard(set(), {"a"}) == 0.0
 
 
-class TestCluster:
-    def test_clusters_similar(self):
-        tokens = {
-            "a": {"lora", "fine", "tuning"},
-            "b": {"lora", "fine", "training"},
-            "c": {"docker", "container"},
-        }
-        clusters = _cluster(["a", "b", "c"], tokens, threshold=0.35)
-        # a and b share 2/4 tokens → Jaccard 0.5 > 0.35 → same cluster
-        assert len(clusters) == 1
-        assert set(clusters[0]) == {"a", "b"}
-
-    def test_no_clusters_when_dissimilar(self):
-        tokens = {
-            "a": {"lora", "fine"},
-            "b": {"docker", "container"},
-        }
-        clusters = _cluster(["a", "b"], tokens, threshold=0.35)
-        assert clusters == []
-
-    def test_single_linkage(self):
-        """a~b, b~c, a not directly ~ c → still one cluster via b."""
-        tokens = {
-            "a": {"lora", "fine", "tuning"},
-            "b": {"lora", "fine", "training"},
-            "c": {"lora", "training", "adapter"},
-        }
-        # a~b: 2/4=0.5, b~c: 2/4=0.5, a~c: 1/5=0.2
-        clusters = _cluster(["a", "b", "c"], tokens, threshold=0.35)
-        assert len(clusters) == 1
-        assert set(clusters[0]) == {"a", "b", "c"}
+def test_cluster():
+    tokens = {"a": {"lora", "fine", "tuning"}, "b": {"lora", "fine", "training"}, "c": {"docker"}}
+    clusters = _cluster(["a", "b", "c"], tokens, threshold=0.35)
+    assert len(clusters) == 1 and set(clusters[0]) == {"a", "b"}
+    # single-linkage: a~b, b~c → one cluster
+    tokens["c"] = {"lora", "training", "adapter"}
+    assert len(_cluster(["a", "b", "c"], tokens, threshold=0.35)) == 1
 
 
-class TestRunConsolidationPass:
-    def test_empty_report(self):
-        with patch("tools.skill_consolidation.skill_usage") as mock_su:
-            mock_su.curated_report.return_value = []
-            result = run_consolidation_pass()
-            assert result["clusters"] == []
-            assert result["total_skills"] == 0
-
-    def test_single_skill(self):
-        with patch("tools.skill_consolidation.skill_usage") as mock_su:
-            mock_su.curated_report.return_value = [
-                {"name": "lora", "state": "active", "activity_count": 5},
-            ]
-            result = run_consolidation_pass()
-            assert result["clusters"] == []
-
-    def test_two_similar_skills_cluster(self):
-        rows = [
-            {"name": "lora-finetuning", "state": "active", "activity_count": 10},
-            {"name": "lora-training", "state": "active", "activity_count": 5},
-        ]
-        with (
-            patch("tools.skill_consolidation.skill_usage") as mock_su,
-            patch("tools.skill_consolidation._build_skill_tokens") as mock_tokens,
-        ):
-            mock_su.curated_report.return_value = rows
-            mock_tokens.return_value = {
-                "lora-finetuning": {"lora", "fine", "tuning"},
-                "lora-training": {"lora", "fine", "training"},
-            }
-            result = run_consolidation_pass()
-            assert len(result["clusters"]) == 1
-            cluster = result["clusters"][0]
-            assert set(cluster["members"]) == {"lora-finetuning", "lora-training"}
-            # Umbrella = highest activity
-            assert cluster["suggested_umbrella"] == "lora-finetuning"
-
-    def test_stale_skills_excluded(self):
-        rows = [
-            {"name": "a", "state": "stale", "activity_count": 10},
-            {"name": "b", "state": "stale", "activity_count": 5},
-        ]
-        with patch("tools.skill_consolidation.skill_usage") as mock_su:
-            mock_su.curated_report.return_value = rows
-            result = run_consolidation_pass()
-            assert result["clusters"] == []
+def test_run_consolidation_pass():
+    with patch("tools.skill_consolidation.skill_usage") as mock_su:
+        mock_su.curated_report.return_value = []
+        assert run_consolidation_pass()["clusters"] == []
+    rows = [{"name": "lora-ft", "state": "active", "activity_count": 10},
+            {"name": "lora-tr", "state": "active", "activity_count": 5}]
+    with patch("tools.skill_consolidation.skill_usage") as mock_su, \
+         patch("tools.skill_consolidation._build_skill_tokens") as mock_tok:
+        mock_su.curated_report.return_value = rows
+        mock_tok.return_value = {"lora-ft": {"lora", "fine"}, "lora-tr": {"lora", "fine"}}
+        result = run_consolidation_pass()
+        assert len(result["clusters"]) == 1
+        assert result["clusters"][0]["suggested_umbrella"] == "lora-ft"
 
 
-class TestRenderClusters:
-    def test_empty(self):
-        assert render_clusters_for_prompt({"clusters": []}) == ""
-
-    def test_renders_clusters(self):
-        result = {
-            "clusters": [
-                {"members": ["a", "b"], "suggested_umbrella": "a", "member_count": 2},
-            ],
-        }
-        text = render_clusters_for_prompt(result)
-        assert "Cluster 1" in text
-        assert "a" in text
-        assert "b" in text
-        assert "suggested umbrella: a" in text
-
-
-class TestCuratorWiring:
-    """Verify run_consolidation_pass is called from the curator review."""
-
-    def test_import_and_call(self):
-        """The curator module references run_consolidation_pass."""
-        from agent import curator
-
-        # The import exists in the source — we verify the function is
-        # importable from the curator's import path.
-        from tools.skill_consolidation import run_consolidation_pass as rcp
-
-        assert callable(rcp)
+def test_render_clusters():
+    assert render_clusters_for_prompt({"clusters": []}) == ""
+    text = render_clusters_for_prompt({"clusters": [{"members": ["a", "b"], "suggested_umbrella": "a", "member_count": 2}]})
+    assert "Cluster 1" in text and "suggested umbrella: a" in text

--- a/tests/tools/test_skill_consolidation.py
+++ b/tests/tools/test_skill_consolidation.py
@@ -1,0 +1,178 @@
+"""Tests for tools/skill_consolidation.py — deterministic skill clustering.
+
+Tests the clustering logic in isolation (no live skill files needed) and
+verifies the pass is wired into the curator review.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.skill_consolidation import (
+    _tokenize,
+    _jaccard,
+    _cluster,
+    run_consolidation_pass,
+    render_clusters_for_prompt,
+)
+
+
+class TestTokenize:
+    def test_basic(self):
+        tokens = _tokenize("Fine-tuning LoRA models")
+        assert "fine" in tokens
+        assert "tuning" in tokens
+        assert "lora" in tokens
+        assert "models" in tokens
+
+    def test_drops_short_words(self):
+        tokens = _tokenize("a b c dd ee foo")
+        assert "foo" in tokens
+        assert "a" not in tokens
+        assert "b" not in tokens
+        assert "dd" not in tokens
+
+    def test_drops_stopwords(self):
+        tokens = _tokenize("the skill for agent")
+        assert "the" not in tokens
+        assert "skill" not in tokens
+        assert "agent" not in tokens
+        assert "for" not in tokens
+
+    def test_handles_hyphens(self):
+        tokens = _tokenize("pre-commit validation")
+        assert "pre" in tokens
+        assert "commit" in tokens
+        assert "validation" in tokens
+
+    def test_empty(self):
+        assert _tokenize("") == set()
+        assert _tokenize(None) == set()
+
+
+class TestJaccard:
+    def test_identical(self):
+        s = {"a", "b", "c"}
+        assert _jaccard(s, s) == 1.0
+
+    def test_disjoint(self):
+        assert _jaccard({"a"}, {"b"}) == 0.0
+
+    def test_partial(self):
+        # {a,b} vs {a,b,c} → 2/3
+        assert _jaccard({"a", "b"}, {"a", "b", "c"}) == pytest.approx(2 / 3)
+
+    def test_empty(self):
+        assert _jaccard(set(), {"a"}) == 0.0
+        assert _jaccard(set(), set()) == 0.0
+
+
+class TestCluster:
+    def test_clusters_similar(self):
+        tokens = {
+            "a": {"lora", "fine", "tuning"},
+            "b": {"lora", "fine", "training"},
+            "c": {"docker", "container"},
+        }
+        clusters = _cluster(["a", "b", "c"], tokens, threshold=0.35)
+        # a and b share 2/4 tokens → Jaccard 0.5 > 0.35 → same cluster
+        assert len(clusters) == 1
+        assert set(clusters[0]) == {"a", "b"}
+
+    def test_no_clusters_when_dissimilar(self):
+        tokens = {
+            "a": {"lora", "fine"},
+            "b": {"docker", "container"},
+        }
+        clusters = _cluster(["a", "b"], tokens, threshold=0.35)
+        assert clusters == []
+
+    def test_single_linkage(self):
+        """a~b, b~c, a not directly ~ c → still one cluster via b."""
+        tokens = {
+            "a": {"lora", "fine", "tuning"},
+            "b": {"lora", "fine", "training"},
+            "c": {"lora", "training", "adapter"},
+        }
+        # a~b: 2/4=0.5, b~c: 2/4=0.5, a~c: 1/5=0.2
+        clusters = _cluster(["a", "b", "c"], tokens, threshold=0.35)
+        assert len(clusters) == 1
+        assert set(clusters[0]) == {"a", "b", "c"}
+
+
+class TestRunConsolidationPass:
+    def test_empty_report(self):
+        with patch("tools.skill_consolidation.skill_usage") as mock_su:
+            mock_su.curated_report.return_value = []
+            result = run_consolidation_pass()
+            assert result["clusters"] == []
+            assert result["total_skills"] == 0
+
+    def test_single_skill(self):
+        with patch("tools.skill_consolidation.skill_usage") as mock_su:
+            mock_su.curated_report.return_value = [
+                {"name": "lora", "state": "active", "activity_count": 5},
+            ]
+            result = run_consolidation_pass()
+            assert result["clusters"] == []
+
+    def test_two_similar_skills_cluster(self):
+        rows = [
+            {"name": "lora-finetuning", "state": "active", "activity_count": 10},
+            {"name": "lora-training", "state": "active", "activity_count": 5},
+        ]
+        with (
+            patch("tools.skill_consolidation.skill_usage") as mock_su,
+            patch("tools.skill_consolidation._build_skill_tokens") as mock_tokens,
+        ):
+            mock_su.curated_report.return_value = rows
+            mock_tokens.return_value = {
+                "lora-finetuning": {"lora", "fine", "tuning"},
+                "lora-training": {"lora", "fine", "training"},
+            }
+            result = run_consolidation_pass()
+            assert len(result["clusters"]) == 1
+            cluster = result["clusters"][0]
+            assert set(cluster["members"]) == {"lora-finetuning", "lora-training"}
+            # Umbrella = highest activity
+            assert cluster["suggested_umbrella"] == "lora-finetuning"
+
+    def test_stale_skills_excluded(self):
+        rows = [
+            {"name": "a", "state": "stale", "activity_count": 10},
+            {"name": "b", "state": "stale", "activity_count": 5},
+        ]
+        with patch("tools.skill_consolidation.skill_usage") as mock_su:
+            mock_su.curated_report.return_value = rows
+            result = run_consolidation_pass()
+            assert result["clusters"] == []
+
+
+class TestRenderClusters:
+    def test_empty(self):
+        assert render_clusters_for_prompt({"clusters": []}) == ""
+
+    def test_renders_clusters(self):
+        result = {
+            "clusters": [
+                {"members": ["a", "b"], "suggested_umbrella": "a", "member_count": 2},
+            ],
+        }
+        text = render_clusters_for_prompt(result)
+        assert "Cluster 1" in text
+        assert "a" in text
+        assert "b" in text
+        assert "suggested umbrella: a" in text
+
+
+class TestCuratorWiring:
+    """Verify run_consolidation_pass is called from the curator review."""
+
+    def test_import_and_call(self):
+        """The curator module references run_consolidation_pass."""
+        from agent import curator
+
+        # The import exists in the source — we verify the function is
+        # importable from the curator's import path.
+        from tools.skill_consolidation import run_consolidation_pass as rcp
+
+        assert callable(rcp)

--- a/tools/skill_consolidation.py
+++ b/tools/skill_consolidation.py
@@ -1,0 +1,234 @@
+"""Deterministic skill consolidation — embedding-free clustering by description similarity.
+
+Complements the curator's LLM umbrella-building pass by pre-clustering similar
+skills BEFORE the expensive LLM fork. The LLM pass then receives clusters as
+hints, reducing the candidate search space and making consolidation tractable
+for large skill libraries.
+
+Inspired by EvoLib (arXiv:2605.14477) — consolidation across task types is what
+makes accumulated knowledge beneficial, as opposed to raw-trajectory retrieval
+which is net-negative on heterogeneous tasks.
+
+Design:
+  - No external embeddings (avoids a model dependency). Uses token-overlap
+    Jaccard similarity on skill descriptions + tags, which is cheap, deterministic,
+    and sufficient for grouping obviously-similar skills.
+  - Returns cluster suggestions, never mutates skills directly. The LLM pass
+    (or a human) decides whether to merge.
+  - Wired into ``run_curator_review`` so it runs on every enabled curator pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from tools import skill_usage
+
+logger = logging.getLogger(__name__)
+
+# Minimum Jaccard similarity for two skills to be in the same cluster.
+_SIMILARITY_THRESHOLD = 0.35
+# Minimum cluster size — singletons are not useful consolidation candidates.
+_MIN_CLUSTER_SIZE = 2
+
+
+def _tokenize(text: Optional[str]) -> Set[str]:
+    """Split text into a lowercase token set, dropping short/common words."""
+    if not text:
+        return set()
+    # Simple split on non-alphanumeric — good enough for description overlap.
+    tokens = set()
+    for word in text.lower().replace("-", " ").replace("_", " ").split():
+        # Keep tokens >= 3 chars, drop a small stopword set.
+        clean = "".join(c for c in word if c.isalnum())
+        if len(clean) >= 3 and clean not in _STOPWORDS:
+            tokens.add(clean)
+    return tokens
+
+
+_STOPWORDS = frozenset({
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "any",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "has",
+    "have",
+    "from",
+    "this",
+    "that",
+    "with",
+    "will",
+    "your",
+    "tool",
+    "skill",
+    "agent",
+    "hermes",
+    "using",
+    "used",
+    "use",
+    "when",
+    "what",
+    "how",
+    "which",
+    "into",
+    "they",
+})
+
+
+def _jaccard(a: Set[str], b: Set[str]) -> float:
+    """Jaccard similarity between two token sets."""
+    if not a or not b:
+        return 0.0
+    intersection = a & b
+    union = a | b
+    return len(intersection) / len(union) if union else 0.0
+
+
+def _build_skill_tokens(rows: List[Dict[str, Any]]) -> Dict[str, Set[str]]:
+    """Extract a token set for each skill from its description + tags."""
+    # Lazy import to avoid circular dependency at module load.
+    from tools.skills_tool import _find_all_skills
+
+    # Build a name → metadata lookup from the full skill scan.
+    meta_by_name: Dict[str, Dict[str, Any]] = {}
+    try:
+        for skill_meta in _find_all_skills():
+            if isinstance(skill_meta, dict):
+                n = skill_meta.get("name", "")
+                if n:
+                    meta_by_name[n] = skill_meta
+    except Exception:
+        pass
+
+    result: Dict[str, Set[str]] = {}
+    for row in rows:
+        name = row.get("name", "")
+        if not name:
+            continue
+        desc = ""
+        tags = ""
+        skill_meta = meta_by_name.get(name)
+        if isinstance(skill_meta, dict):
+            desc = str(skill_meta.get("description", ""))
+            meta = skill_meta.get("metadata", {})
+            if isinstance(meta, dict):
+                hermes_meta = meta.get("hermes", {})
+                if isinstance(hermes_meta, dict):
+                    tag_list = hermes_meta.get("tags", [])
+                    if isinstance(tag_list, list):
+                        tags = " ".join(str(t) for t in tag_list)
+        tokens = _tokenize(desc) | _tokenize(tags)
+        tokens |= _tokenize(name)
+        result[name] = tokens
+    return result
+
+
+def _cluster(
+    names: List[str], tokens: Dict[str, Set[str]], threshold: float
+) -> List[List[str]]:
+    """Group names into clusters by greedy single-linkage Jaccard similarity."""
+    visited: Set[str] = set()
+    clusters: List[List[str]] = []
+    for name in names:
+        if name in visited:
+            continue
+        cluster = [name]
+        visited.add(name)
+        # Greedy: find all unvisited names similar to any member.
+        changed = True
+        while changed:
+            changed = False
+            for other in names:
+                if other in visited:
+                    continue
+                for member in cluster:
+                    sim = _jaccard(tokens.get(member, set()), tokens.get(other, set()))
+                    if sim >= threshold:
+                        cluster.append(other)
+                        visited.add(other)
+                        changed = True
+                        break
+        if len(cluster) >= _MIN_CLUSTER_SIZE:
+            clusters.append(cluster)
+    return clusters
+
+
+def run_consolidation_pass(
+    threshold: float = _SIMILARITY_THRESHOLD,
+) -> Dict[str, Any]:
+    """Run a deterministic consolidation pass over curator-managed skills.
+
+    Clusters similar skills by description/tag overlap and returns cluster
+    suggestions. Does NOT mutate skills — the LLM pass or a human decides
+    whether to merge.
+
+    Returns a dict with:
+      - ``clusters``: list of cluster dicts, each with ``members`` and
+        ``suggested_umbrella`` (the member with the highest activity).
+      - ``total_skills``: number of curated skills examined.
+      - ``clustered_skills``: number of skills in a cluster of size >= 2.
+    """
+    try:
+        rows = skill_usage.curated_report()
+    except Exception as e:
+        logger.debug("consolidation: curated_report() failed: %s", e)
+        return {"clusters": [], "total_skills": 0, "clustered_skills": 0}
+
+    # Only cluster active skills — stale/archived ones are not useful candidates.
+    active_rows = [r for r in rows if r.get("state", "active") == "active"]
+    if len(active_rows) < _MIN_CLUSTER_SIZE:
+        return {
+            "clusters": [],
+            "total_skills": len(rows),
+            "clustered_skills": 0,
+        }
+
+    names = [r.get("name", "") for r in active_rows if r.get("name")]
+    tokens = _build_skill_tokens(active_rows)
+    raw_clusters = _cluster(names, tokens, threshold)
+
+    # Build cluster dicts with a suggested umbrella (highest-activity member).
+    activity_by_name = {
+        r.get("name", ""): r.get("activity_count", 0) for r in active_rows
+    }
+    clusters: List[Dict[str, Any]] = []
+    for members in raw_clusters:
+        umbrella = max(members, key=lambda n: activity_by_name.get(n, 0))
+        clusters.append({
+            "members": sorted(members),
+            "suggested_umbrella": umbrella,
+            "member_count": len(members),
+        })
+
+    clustered_count = sum(c["member_count"] for c in clusters)
+    return {
+        "clusters": clusters,
+        "total_skills": len(rows),
+        "clustered_skills": clustered_count,
+    }
+
+
+def render_clusters_for_prompt(result: Dict[str, Any]) -> str:
+    """Render cluster suggestions as a text block for the LLM review prompt."""
+    clusters = result.get("clusters", [])
+    if not clusters:
+        return ""
+    lines = ["Pre-clustered similarity groups (deterministic — review for merge):"]
+    for i, c in enumerate(clusters, 1):
+        members = ", ".join(c.get("members", []))
+        umbrella = c.get("suggested_umbrella", "")
+        lines.append(f"  Cluster {i}: [{members}] — suggested umbrella: {umbrella}")
+    return "\n".join(lines)

--- a/tools/skill_consolidation.py
+++ b/tools/skill_consolidation.py
@@ -1,115 +1,56 @@
-"""Deterministic skill consolidation — embedding-free clustering by description similarity.
+"""Deterministic skill consolidation — embedding-free clustering by similarity.
 
-Complements the curator's LLM umbrella-building pass by pre-clustering similar
-skills BEFORE the expensive LLM fork. The LLM pass then receives clusters as
-hints, reducing the candidate search space and making consolidation tractable
-for large skill libraries.
-
-Inspired by EvoLib (arXiv:2605.14477) — consolidation across task types is what
-makes accumulated knowledge beneficial, as opposed to raw-trajectory retrieval
-which is net-negative on heterogeneous tasks.
-
-Design:
-  - No external embeddings (avoids a model dependency). Uses token-overlap
-    Jaccard similarity on skill descriptions + tags, which is cheap, deterministic,
-    and sufficient for grouping obviously-similar skills.
-  - Returns cluster suggestions, never mutates skills directly. The LLM pass
-    (or a human) decides whether to merge.
-  - Wired into ``run_curator_review`` so it runs on every enabled curator pass.
+Pre-clusters similar skills BEFORE the LLM umbrella-building pass. Inspired by
+EvoLib (arXiv:2605.14477). Uses token-overlap Jaccard; never mutates skills.
+Wired into run_curator_review.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 from tools import skill_usage
 
 logger = logging.getLogger(__name__)
 
-# Minimum Jaccard similarity for two skills to be in the same cluster.
 _SIMILARITY_THRESHOLD = 0.35
-# Minimum cluster size — singletons are not useful consolidation candidates.
 _MIN_CLUSTER_SIZE = 2
+
+_STOPWORDS = frozenset(
+    "the and for are but not you all any can had her was one our out has have "
+    "from this that with will your tool skill agent hermes using used use when "
+    "what how which into they".split()
+)
 
 
 def _tokenize(text: Optional[str]) -> Set[str]:
-    """Split text into a lowercase token set, dropping short/common words."""
+    """Lowercase token set, dropping short/common words."""
     if not text:
         return set()
-    # Simple split on non-alphanumeric — good enough for description overlap.
     tokens = set()
     for word in text.lower().replace("-", " ").replace("_", " ").split():
-        # Keep tokens >= 3 chars, drop a small stopword set.
         clean = "".join(c for c in word if c.isalnum())
         if len(clean) >= 3 and clean not in _STOPWORDS:
             tokens.add(clean)
     return tokens
 
 
-_STOPWORDS = frozenset({
-    "the",
-    "and",
-    "for",
-    "are",
-    "but",
-    "not",
-    "you",
-    "all",
-    "any",
-    "can",
-    "had",
-    "her",
-    "was",
-    "one",
-    "our",
-    "out",
-    "has",
-    "have",
-    "from",
-    "this",
-    "that",
-    "with",
-    "will",
-    "your",
-    "tool",
-    "skill",
-    "agent",
-    "hermes",
-    "using",
-    "used",
-    "use",
-    "when",
-    "what",
-    "how",
-    "which",
-    "into",
-    "they",
-})
-
-
 def _jaccard(a: Set[str], b: Set[str]) -> float:
-    """Jaccard similarity between two token sets."""
     if not a or not b:
         return 0.0
-    intersection = a & b
-    union = a | b
-    return len(intersection) / len(union) if union else 0.0
+    return len(a & b) / len(a | b)
 
 
 def _build_skill_tokens(rows: List[Dict[str, Any]]) -> Dict[str, Set[str]]:
-    """Extract a token set for each skill from its description + tags."""
-    # Lazy import to avoid circular dependency at module load.
+    """Token set per skill from description + tags."""
     from tools.skills_tool import _find_all_skills
 
-    # Build a name → metadata lookup from the full skill scan.
     meta_by_name: Dict[str, Dict[str, Any]] = {}
     try:
-        for skill_meta in _find_all_skills():
-            if isinstance(skill_meta, dict):
-                n = skill_meta.get("name", "")
-                if n:
-                    meta_by_name[n] = skill_meta
+        for sm in _find_all_skills():
+            if isinstance(sm, dict) and sm.get("name"):
+                meta_by_name[sm["name"]] = sm
     except Exception:
         pass
 
@@ -118,28 +59,22 @@ def _build_skill_tokens(rows: List[Dict[str, Any]]) -> Dict[str, Set[str]]:
         name = row.get("name", "")
         if not name:
             continue
-        desc = ""
-        tags = ""
-        skill_meta = meta_by_name.get(name)
-        if isinstance(skill_meta, dict):
-            desc = str(skill_meta.get("description", ""))
-            meta = skill_meta.get("metadata", {})
+        desc, tags = "", ""
+        sm = meta_by_name.get(name)
+        if isinstance(sm, dict):
+            desc = str(sm.get("description", ""))
+            meta = sm.get("metadata", {})
             if isinstance(meta, dict):
-                hermes_meta = meta.get("hermes", {})
-                if isinstance(hermes_meta, dict):
-                    tag_list = hermes_meta.get("tags", [])
-                    if isinstance(tag_list, list):
-                        tags = " ".join(str(t) for t in tag_list)
-        tokens = _tokenize(desc) | _tokenize(tags)
-        tokens |= _tokenize(name)
-        result[name] = tokens
+                hm = meta.get("hermes", {})
+                tl = hm.get("tags", []) if isinstance(hm, dict) else []
+                if isinstance(tl, list):
+                    tags = " ".join(str(t) for t in tl)
+        result[name] = _tokenize(desc) | _tokenize(tags) | _tokenize(name)
     return result
 
 
-def _cluster(
-    names: List[str], tokens: Dict[str, Set[str]], threshold: float
-) -> List[List[str]]:
-    """Group names into clusters by greedy single-linkage Jaccard similarity."""
+def _cluster(names: List[str], tokens: Dict[str, Set[str]], threshold: float) -> List[List[str]]:
+    """Greedy single-linkage Jaccard clustering."""
     visited: Set[str] = set()
     clusters: List[List[str]] = []
     for name in names:
@@ -147,7 +82,6 @@ def _cluster(
             continue
         cluster = [name]
         visited.add(name)
-        # Greedy: find all unvisited names similar to any member.
         changed = True
         while changed:
             changed = False
@@ -155,8 +89,7 @@ def _cluster(
                 if other in visited:
                     continue
                 for member in cluster:
-                    sim = _jaccard(tokens.get(member, set()), tokens.get(other, set()))
-                    if sim >= threshold:
+                    if _jaccard(tokens.get(member, set()), tokens.get(other, set())) >= threshold:
                         cluster.append(other)
                         visited.add(other)
                         changed = True
@@ -166,69 +99,35 @@ def _cluster(
     return clusters
 
 
-def run_consolidation_pass(
-    threshold: float = _SIMILARITY_THRESHOLD,
-) -> Dict[str, Any]:
-    """Run a deterministic consolidation pass over curator-managed skills.
-
-    Clusters similar skills by description/tag overlap and returns cluster
-    suggestions. Does NOT mutate skills — the LLM pass or a human decides
-    whether to merge.
-
-    Returns a dict with:
-      - ``clusters``: list of cluster dicts, each with ``members`` and
-        ``suggested_umbrella`` (the member with the highest activity).
-      - ``total_skills``: number of curated skills examined.
-      - ``clustered_skills``: number of skills in a cluster of size >= 2.
-    """
+def run_consolidation_pass(threshold: float = _SIMILARITY_THRESHOLD) -> Dict[str, Any]:
+    """Cluster curator-managed skills by similarity. Returns cluster suggestions
+    (members + suggested umbrella). Never mutates skills."""
     try:
         rows = skill_usage.curated_report()
     except Exception as e:
         logger.debug("consolidation: curated_report() failed: %s", e)
         return {"clusters": [], "total_skills": 0, "clustered_skills": 0}
 
-    # Only cluster active skills — stale/archived ones are not useful candidates.
-    active_rows = [r for r in rows if r.get("state", "active") == "active"]
-    if len(active_rows) < _MIN_CLUSTER_SIZE:
-        return {
-            "clusters": [],
-            "total_skills": len(rows),
-            "clustered_skills": 0,
-        }
+    active = [r for r in rows if r.get("state", "active") == "active"]
+    if len(active) < _MIN_CLUSTER_SIZE:
+        return {"clusters": [], "total_skills": len(rows), "clustered_skills": 0}
 
-    names = [r.get("name", "") for r in active_rows if r.get("name")]
-    tokens = _build_skill_tokens(active_rows)
-    raw_clusters = _cluster(names, tokens, threshold)
-
-    # Build cluster dicts with a suggested umbrella (highest-activity member).
-    activity_by_name = {
-        r.get("name", ""): r.get("activity_count", 0) for r in active_rows
-    }
-    clusters: List[Dict[str, Any]] = []
-    for members in raw_clusters:
-        umbrella = max(members, key=lambda n: activity_by_name.get(n, 0))
-        clusters.append({
-            "members": sorted(members),
-            "suggested_umbrella": umbrella,
-            "member_count": len(members),
-        })
-
-    clustered_count = sum(c["member_count"] for c in clusters)
-    return {
-        "clusters": clusters,
-        "total_skills": len(rows),
-        "clustered_skills": clustered_count,
-    }
+    names = [r.get("name", "") for r in active if r.get("name")]
+    raw = _cluster(names, _build_skill_tokens(active), threshold)
+    activity = {r.get("name", ""): r.get("activity_count", 0) for r in active}
+    clusters = [
+        {"members": sorted(m), "suggested_umbrella": max(m, key=lambda n: activity.get(n, 0)), "member_count": len(m)}
+        for m in raw
+    ]
+    return {"clusters": clusters, "total_skills": len(rows), "clustered_skills": sum(c["member_count"] for c in clusters)}
 
 
 def render_clusters_for_prompt(result: Dict[str, Any]) -> str:
-    """Render cluster suggestions as a text block for the LLM review prompt."""
+    """Render clusters as text for the LLM review prompt."""
     clusters = result.get("clusters", [])
     if not clusters:
         return ""
     lines = ["Pre-clustered similarity groups (deterministic — review for merge):"]
     for i, c in enumerate(clusters, 1):
-        members = ", ".join(c.get("members", []))
-        umbrella = c.get("suggested_umbrella", "")
-        lines.append(f"  Cluster {i}: [{members}] — suggested umbrella: {umbrella}")
+        lines.append(f"  Cluster {i}: [{', '.join(c.get('members', []))}] — suggested umbrella: {c.get('suggested_umbrella', '')}")
     return "\n".join(lines)


### PR DESCRIPTION
Automated evolution PR for issue #2184.

## What

Adds `tools/skill_consolidation.py` with `run_consolidation_pass()` — a deterministic, embedding-free clustering pass that groups similar curator-managed skills by description/tag Jaccard similarity BEFORE the expensive LLM umbrella-building pass. Cluster hints are appended to the LLM review prompt, reducing the search space.

## Wiring

`run_consolidation_pass()` is called from `agent/curator.py` inside `run_curator_review()` right before the LLM review fork. It runs inline (zero LLM cost) and its output is fed to the LLM prompt as pre-clustered similarity groups.

## Why

Inspired by EvoLib (arXiv:2605.14477) — consolidation across task types is what makes accumulated knowledge beneficial, as opposed to raw-trajectory retrieval which is net-negative on heterogeneous tasks. The prior PR #2202 was closed because `run_consolidation_pass()` had zero call sites. This PR wires it into the curator review loop.

Closes #2184