### PR TITLE
fix: make exit_code=124 wall-clock timeout non-retryable (Closes #2191)

### DIFF
--- a/tests/tools/test_terminal_failure_classifier.py
+++ b/tests/tools/test_terminal_failure_classifier.py
@@ -45,15 +45,28 @@ class TestClassifyPermissionDenied:
 
 
 class TestClassifyTimeout:
-    def test_exit_code_124(self):
+    def test_exit_code_124_non_retryable(self):
+        """exit_code=124 (wall-clock timeout) is non-retryable — the same
+        command will time out again (issue #2191)."""
         result = classifier.classify_terminal_failure("sleep 10", 124, "", "")
-        assert result.category == classifier.FailureCategory.timeout
-        assert result.should_retry is True
+        assert result.category == classifier.FailureCategory.timeout_deterministic
+        assert result.should_retry is False
 
-    def test_first_timeout_is_retryable(self):
-        """A single timeout (consecutive_count=1) is retryable."""
+    def test_exit_code_124_non_retryable_introspection(self):
+        """exit_code=124 with consecutive_count=0 is still non-retryable.
+        Wall-clock timeouts do not benefit from retry (issue #2191)."""
         result = classifier.classify_terminal_failure(
-            "sleep 10", 124, "", "", consecutive_count=1
+            "slowcmd", 124, "", "", consecutive_count=0
+        )
+        assert result.category == classifier.FailureCategory.timeout_deterministic
+        assert result.should_retry is False
+        assert "Change at least one of" in result.hint
+
+    def test_text_based_timeout_is_retryable(self):
+        """A text-based timeout (e.g. 'connection timed out' from curl) is a
+        transient network condition — retryable on first occurrence."""
+        result = classifier.classify_terminal_failure(
+            "curl http://example.test", 28, "", "connection timed out"
         )
         assert result.category == classifier.FailureCategory.timeout
         assert result.should_retry is True
@@ -258,22 +271,24 @@ class TestTerminalToolForegroundFailures:
     def test_transient_timeout_retries_then_stops(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "local")
         monkeypatch.setattr(terminal_tool.time, "sleep", lambda _s: None)
-        # Four consecutive timeouts: initial + 3 retries should exhaust the loop.
+        # Text-based timeout (connection timed out) is retryable — 4 calls:
+        # initial + 3 retries should exhaust the loop.  exit_code=124 (wall-
+        # clock timeout) is non-retryable and tested separately (#2191).
         fake = FakeEnvironment([
-            {"output": "", "returncode": 124},
-            {"output": "", "returncode": 124},
-            {"output": "", "returncode": 124},
-            {"output": "", "returncode": 124},
+            {"output": "connection timed out", "returncode": 28},
+            {"output": "connection timed out", "returncode": 28},
+            {"output": "connection timed out", "returncode": 28},
+            {"output": "connection timed out", "returncode": 28},
         ])
         monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
         monkeypatch.setattr(terminal_tool, "_last_activity", {"default": 0})
 
         result = terminal_tool.terminal_tool(
-            "slowcmd", timeout=1, task_id="test-streak"
+            "curl http://slow.test", timeout=1, task_id="test-streak"
         )
         data = json.loads(result)
 
-        assert data["exit_code"] == 124
+        assert data["exit_code"] == 28
         assert data["failure_class"] == "timeout"
         assert (
             data["should_retry"] is False

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -250,9 +250,11 @@ class TestClassificationShape:
 class TestTerminalDelegation:
     def test_exit_124_is_timeout(self):
         result = tfc.classify_tool_failure("terminal", "", exit_code=124)
-        assert result.category == tfc.ToolFailureCategory.timeout
+        # exit_code=124 (wall-clock timeout) is non-retryable — same command
+        # will time out again (issue #2191).
+        assert result.category == tfc.ToolFailureCategory.persistent_error
         assert result.tool_type == tfc.ToolType.terminal
-        assert result.should_retry is True
+        assert result.should_retry is False
 
     def test_exit_127_is_tool_unavailable(self):
         result = tfc.classify_tool_failure(

--- a/tools/terminal_failure_classifier.py
+++ b/tools/terminal_failure_classifier.py
@@ -145,12 +145,34 @@ def classify_terminal_failure(
     text = _output_text(stdout, stderr)
     base_cmd = _base_command(command)
 
-    # Transient timeout / partial output is safe to retry with backoff.
-    # After 2 consecutive identical timeouts (was 3) the failure is
-    # deterministic — the same command with the same parameters cannot
-    # succeed.  Promote to ``timeout_deterministic`` so the agent gets a
-    # distinct signal to change parameters or switch tools (issue #1091).
-    if exit_code == 124 or any(p.search(text) for p in _TIMEOUT_PATTERNS):
+    # Wall-clock timeout: exit_code 124 is the ``timeout`` command's kill
+    # signal.  It is inherently non-retryable — the same command with the
+    # same parameters will take the same amount of time and time out again.
+    # Retrying amplifies a single 120s timeout into ~494s of wasted
+    # wall-clock (issue #2191).  Classify as ``timeout_deterministic`` so the
+    # agent gets a distinct signal to change parameters or switch tools.
+    # Text-based timeouts (e.g. curl "connection timed out") are transient
+    # network conditions and remain retryable on first occurrence.
+    text_based_timeout = any(p.search(text) for p in _TIMEOUT_PATTERNS)
+    if exit_code == 124:
+        return TerminalFailureClassification(
+            category=FailureCategory.timeout_deterministic,
+            hint=(
+                "The command exceeded the wall-clock timeout (exit_code=124). "
+                "Re-running the same command unchanged will time out again. "
+                "Change at least one of: the command, the working directory, "
+                "the timeout value, or the flags. Alternatively, run it in "
+                "the background with notify_on_complete=true, use "
+                "execute_code, or split the work into smaller steps."
+            ),
+            should_retry=False,
+        )
+
+    # Text-based timeout (e.g. "connection timed out" from curl) — a
+    # transient network condition that may recover on retry with backoff.
+    # After 2 consecutive identical timeouts the failure is deterministic;
+    # promote to ``timeout_deterministic`` (issue #1091).
+    if text_based_timeout:
         if consecutive_count >= 2:
             return TerminalFailureClassification(
                 category=FailureCategory.timeout_deterministic,


### PR DESCRIPTION
## Summary

exit_code=124 (the `timeout` command's wall-clock kill signal) was classified as retryable on first occurrence, causing the terminal tool's internal retry loop to re-execute the same timed-out command 2 more times — amplifying a single 120s timeout into ~494s of wasted wall-clock.

## Fix
Split the timeout branch: exit_code=124 (wall-clock) is now non-retryable; text-based timeouts (e.g. curl connection timed out) remain retryable.

## Files
- tools/terminal_failure_classifier.py
- tests/tools/test_terminal_failure_classifier.py
- tests/tools/test_tool_failure_classifier.py

## Validation
- ruff check . passed
- 120 classifier tests passed
- 97 terminal/spiral tests passed

Closes #2191

Automated evolution PR.