### PR TITLE
fix: MCP provider billing/quota failover with 30min cooldown (Closes #2193)

### DIFF
--- a/tests/tools/test_mcp_quota_failover_2193.py
+++ b/tests/tools/test_mcp_quota_failover_2193.py
@@ -1,0 +1,91 @@
+"""Tests for MCP provider billing/quota failover (issue #2193).
+
+When an MCP server returns HTTP 402 / 'Payment Required' / 'quota exhausted',
+the server is marked quota-exhausted with a 30min cooldown. Subsequent calls
+short-circuit with a diagnostic hint directing the agent to alternative
+providers (tavily, scrapling, web_search). Clears on successful call.
+"""
+
+import time
+from unittest.mock import patch
+
+import tools.mcp_tool as mcp_tool
+from tools.mcp_tool import (
+    _clear_quota_exhausted,
+    _is_quota_error,
+    _mark_quota_exhausted,
+    _quota_cooldown_active,
+    _quota_fallback_hint,
+    _server_quota_exhausted_until,
+)
+
+
+class TestIsQuotaError:
+    def test_402(self):
+        assert _is_quota_error("HTTP 402: Payment Required") is True
+
+    def test_payment_required(self):
+        assert _is_quota_error("Payment Required") is True
+
+    def test_quota_exhausted(self):
+        assert _is_quota_error("quota exhausted") is True
+
+    def test_subscription_required(self):
+        assert _is_quota_error("subscription required for this model") is True
+
+    def test_upgrade_for_access(self):
+        assert _is_quota_error("upgrade for access") is True
+
+    def test_normal_error_not_quota(self):
+        assert _is_quota_error("connection refused") is False
+
+    def test_empty_string(self):
+        assert _is_quota_error("") is False
+
+    def test_none(self):
+        assert _is_quota_error("") is False  # empty/None treated same
+
+    def test_case_insensitive(self):
+        assert _is_quota_error("PAYMENT REQUIRED") is True
+        assert _is_quota_error("Quota Exhausted") is True
+
+
+class TestQuotaCooldown:
+    def test_mark_and_check(self):
+        _server_quota_exhausted_until.pop("test-srv", None)
+        assert not _quota_cooldown_active("test-srv")
+        _mark_quota_exhausted("test-srv")
+        assert _quota_cooldown_active("test-srv")
+
+    def test_clear(self):
+        _mark_quota_exhausted("test-srv")
+        assert _quota_cooldown_active("test-srv")
+        _clear_quota_exhausted("test-srv")
+        assert not _quota_cooldown_active("test-srv")
+
+    def test_clear_when_not_set(self):
+        _server_quota_exhausted_until.pop("test-srv", None)
+        _clear_quota_exhausted("test-srv")  # should not raise
+
+    def test_expiry(self):
+        """Cooldown auto-clears after the TTL elapses."""
+        _server_quota_exhausted_until["test-srv"] = time.monotonic() - 1
+        assert not _quota_cooldown_active("test-srv")
+        assert "test-srv" not in _server_quota_exhausted_until
+
+
+class TestQuotaFallbackHint:
+    def test_mentions_alternatives(self):
+        _mark_quota_exhausted("jina")
+        hint = _quota_fallback_hint("jina")
+        assert "quota-exhausted" in hint
+        assert "tavily" in hint
+        assert "Do NOT retry" in hint
+
+    def test_mentions_server_name(self):
+        _mark_quota_exhausted("my-mcp-server")
+        hint = _quota_fallback_hint("my-mcp-server")
+        assert "my-mcp-server" in hint
+
+    def teardown_method(self):
+        _server_quota_exhausted_until.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4237,6 +4237,72 @@ def _reset_server_error(server_name: str) -> None:
     _server_breaker_opened_at.pop(server_name, None)
 
 
+# ── Provider billing/quota failover (issue #2193) ──────────────────────────
+# When an MCP server returns HTTP 402 / 'Payment Required' / 'quota exhausted',
+# the provider's billing has lapsed — retrying within seconds is futile (the
+# quota recovers on hourly/daily cycles, not seconds).  This is distinct from
+# the generic circuit breaker (60s cooldown): quota exhaustion gets a 30min
+# cooldown plus a diagnostic hint directing the agent to alternative providers.
+_MCP_QUOTA_COOLDOWN_SEC = 1800.0  # 30 minutes
+_server_quota_exhausted_until: Dict[str, float] = {}
+
+_QUOTA_ERROR_SIGNATURES = (
+    "402",
+    "payment required",
+    "quota exhausted",
+    "quota exceeded",
+    "billing",
+    "subscription required",
+    "upgrade for access",
+    "insufficient quota",
+    "insufficient credits",
+    "rate limit exceeded",
+    "usage limit",
+)
+
+
+def _is_quota_error(text: str) -> bool:
+    """Check whether *text* indicates a billing/quota failure (issue #2193)."""
+    lower = (text or "").lower()
+    return any(sig in lower for sig in _QUOTA_ERROR_SIGNATURES)
+
+
+def _mark_quota_exhausted(server_name: str) -> None:
+    """Mark *server_name* as quota-exhausted with a 30min cooldown."""
+    _server_quota_exhausted_until[server_name] = (
+        time.monotonic() + _MCP_QUOTA_COOLDOWN_SEC
+    )
+
+
+def _clear_quota_exhausted(server_name: str) -> None:
+    """Clear the quota-exhausted flag (on successful call)."""
+    _server_quota_exhausted_until.pop(server_name, None)
+
+
+def _quota_cooldown_active(server_name: str) -> bool:
+    """True if *server_name* is still in its quota-exhaustion cooldown."""
+    until = _server_quota_exhausted_until.get(server_name)
+    if until is None:
+        return False
+    if time.monotonic() >= until:
+        _server_quota_exhausted_until.pop(server_name, None)
+        return False
+    return True
+
+
+def _quota_fallback_hint(server_name: str) -> str:
+    """Build a diagnostic hint directing the agent to alternative providers."""
+    until = _server_quota_exhausted_until.get(server_name, 0.0)
+    remaining = max(1, int(until - time.monotonic()))
+    return (
+        f"MCP server '{server_name}' is quota-exhausted (HTTP 402 / billing). "
+        f"Do NOT retry this server for ~{remaining}s. "
+        f"Use alternative web-access tools: tavily (web search), "
+        f"scrapling/web_extract (page fetch), or web_search. "
+        f"The quota typically recovers on an hourly or daily cycle."
+    )
+
+
 def _signal_reconnect(server: Any) -> bool:
     """Ask a server task to rebuild its transport, thread-safely.
 
@@ -5578,6 +5644,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 )
             # Cooldown elapsed → fall through as a half-open probe.
 
+        # Quota-exhaustion short-circuit (issue #2193): if this server
+        # returned HTTP 402 / billing failure recently, skip the call
+        # entirely and direct the agent to alternative providers.
+        if _quota_cooldown_active(server_name):
+            return tool_error(_quota_fallback_hint(server_name))
+
         server = _get_connected_server_for_call(server_name)
         if not server:
             _bump_server_error(server_name)
@@ -5674,6 +5746,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # retry with slightly different arguments in a loop (19 failed
                 # sessions/7d). The directive tells them to re-check the schema.
                 error_text = error_text or "MCP tool returned an error"
+                # Quota/billing detection (issue #2193): HTTP 402 / Payment
+                # Required means the MCP provider's billing has lapsed. Mark
+                # the server quota-exhausted with a 30min cooldown so the
+                # agent is directed to alternative providers instead of
+                # retrying a billing failure every few seconds.
+                if _is_quota_error(error_text):
+                    _mark_quota_exhausted(server_name)
+                    return tool_error(_quota_fallback_hint(server_name))
                 lower_err = error_text.lower()
                 if (
                     "not_found" in lower_err
@@ -5773,8 +5853,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
+                    _clear_quota_exhausted(server_name)  # issue #2193
             except (json.JSONDecodeError, TypeError):
                 _reset_server_error(server_name)  # non-JSON = success
+                _clear_quota_exhausted(server_name)  # issue #2193
             return result
         except InterruptedError:
             return _interrupted_call_result()
@@ -5804,6 +5886,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return recovered
 
             _bump_server_error(server_name)
+            # Quota detection in exception path (issue #2193): some MCP
+            # servers raise billing errors as exceptions rather than
+            # CallToolResult.isError.  Detect and mark quota-exhausted.
+            if _is_quota_error(str(exc)):
+                _mark_quota_exhausted(server_name)
+                return tool_error(_quota_fallback_hint(server_name))
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name,


### PR DESCRIPTION
## Summary

When an MCP server returns HTTP 402 / Payment Required / quota exhausted, the server is marked quota-exhausted with a 30min cooldown. Subsequent calls short-circuit with a diagnostic hint directing the agent to alternative providers.

## Changes
- `tools/mcp_tool.py`: `_server_quota_exhausted_until` dict, `_is_quota_error()`, `_mark_quota_exhausted()`, `_clear_quota_exhausted()`, `_quota_cooldown_active()`, `_quota_fallback_hint()` + wiring at 4 call sites (handler short-circuit, isError detection, exception detection, success clear)
- `tests/tools/test_mcp_quota_failover_2193.py`: 15 tests

## Validation
- ruff check passed
- 15 new tests passed

Closes #2193

Automated evolution PR.