### PR TITLE
feat: pre-commit validation gate blocks admission of malformed skills (Closes #2189)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -375,8 +375,15 @@ class TestSkillManageDispatcher:
                  patch("tools.skill_usage.is_hub_installed", return_value=False), \
                  patch("tools.skill_usage.is_bundled",
                        side_effect=lambda skill_name: skill_name == "bundled"):
-                skill_manage(action="create", name="umbrella", content=VALID_SKILL_CONTENT)
-                skill_manage(action="create", name="bundled", content=VALID_SKILL_CONTENT)
+                # Bypass the validation gate (#2189) for the create steps —
+                # this test exercises the DELETE path, not skill admission.
+                from tools.skill_manager_tool import _skill_gate_bypass as _bypass
+                _tok = _bypass.set(True)
+                try:
+                    skill_manage(action="create", name="umbrella", content=VALID_SKILL_CONTENT)
+                    skill_manage(action="create", name="bundled", content=VALID_SKILL_CONTENT)
+                finally:
+                    _bypass.reset(_tok)
                 raw = skill_manage(
                     action="delete",
                     name="bundled",

--- a/tests/tools/test_skill_validation_gate.py
+++ b/tests/tools/test_skill_validation_gate.py
@@ -1,0 +1,191 @@
+"""Tests for the pre-commit validation gate (#2189).
+
+Auto-created (background-review-origin) skills must pass structural
+validation BEFORE being admitted to the active library.  A failing skill is
+NOT marked agent-created and its directory is rolled back.
+"""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.skill_manager_tool import (
+    skill_manage,
+    validate_skill_content,
+)
+from tools.skill_provenance import (
+    BACKGROUND_REVIEW,
+    reset_current_write_origin,
+    set_current_write_origin,
+)
+
+
+@contextmanager
+def _skill_dir(tmp_path):
+    """Patch SKILLS_DIR + get_all_skills_dirs so _find_skill uses tmp_path."""
+    with (
+        patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path),
+        patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]),
+    ):
+        yield
+
+
+# A structurally valid skill (passes the validation gate).
+VALID_SKILL = """\
+---
+name: good-auto-skill
+description: Use when analyzing repo structure for refactoring.
+---
+
+# Good Auto Skill
+
+Step 1: Read the repository map to understand module dependencies.
+Step 2: Identify circular imports and god-files.
+Step 3: Propose a decomposition into focused modules.
+"""
+
+# Too short — body below minimum.
+SHORT_BODY_SKILL = """\
+---
+name: short-skill
+description: Use when doing something specific for routing.
+---
+
+# Short
+
+Do it.
+"""
+
+# Placeholder body.
+PLACEHOLDER_SKILL = """\
+---
+name: placeholder-skill
+description: Use when processing user requests automatically.
+---
+
+# Placeholder Skill
+
+TODO: write the actual instructions here.
+This is a placeholder for now and will be filled in later.
+"""
+
+# Description too short (single word).
+SHORT_DESC_SKILL = """\
+---
+name: short-desc
+description: Helper
+---
+
+# Short Desc Skill
+
+This skill has enough body content to pass the length check but the
+description is only a single word, which is not a useful trigger phrase.
+"""
+
+# --- validate_skill_content (unit) -----------------------------------------
+
+
+class TestValidateSkillContent:
+    def test_valid_skill_passes(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage("create", "good-auto-skill", content=VALID_SKILL)
+            assert validate_skill_content("good-auto-skill") is None
+
+    def test_short_body_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage("create", "short-skill", content=SHORT_BODY_SKILL)
+            err = validate_skill_content("short-skill")
+            assert err is not None
+            assert "too short" in err.lower()
+
+    def test_placeholder_body_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage("create", "placeholder-skill", content=PLACEHOLDER_SKILL)
+            err = validate_skill_content("placeholder-skill")
+            assert err is not None
+            assert "placeholder" in err.lower() or "todo" in err.lower()
+
+    def test_short_description_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage("create", "short-desc", content=SHORT_DESC_SKILL)
+            err = validate_skill_content("short-desc")
+            assert err is not None
+            assert "description" in err.lower()
+
+    def test_nonexistent_skill_returns_error(self, tmp_path):
+        with _skill_dir(tmp_path):
+            err = validate_skill_content("does-not-exist")
+            assert err is not None
+            assert "not found" in err.lower()
+
+
+# --- Integration: validation gate blocks admission (#2189) -----------------
+
+
+class TestValidationGateBlocksAdmission:
+    """The validation gate must BLOCK admission of failing auto-created skills:
+    the skill is NOT marked agent-created and its directory is rolled back."""
+
+    def test_background_review_create_valid_skill_admitted(self, tmp_path):
+        """A valid auto-created skill IS admitted (marked agent-created)."""
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _skill_dir(tmp_path):
+                raw = skill_manage("create", "good-auto-skill", content=VALID_SKILL)
+                result = json.loads(raw)
+                assert result["success"] is True, result
+                # Skill dir persists.
+                assert (tmp_path / "good-auto-skill" / "SKILL.md").exists()
+                # Marked agent-created.
+                from tools.skill_usage import get_record
+
+                rec = get_record("good-auto-skill")
+                assert rec.get("created_by") is not None
+        finally:
+            reset_current_write_origin(token)
+
+    def test_background_review_create_short_skill_blocked(self, tmp_path):
+        """A short-body auto-created skill is BLOCKED — not admitted, rolled back."""
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _skill_dir(tmp_path):
+                raw = skill_manage("create", "short-skill", content=SHORT_BODY_SKILL)
+                result = json.loads(raw)
+                assert result["success"] is False, result
+                assert "validation gate" in result["error"].lower()
+                # Skill dir was rolled back.
+                assert not (tmp_path / "short-skill").exists()
+                # NOT marked agent-created.
+                from tools.skill_usage import get_record
+
+                rec = get_record("short-skill")
+                assert rec.get("created_by") in {None, "", False}
+        finally:
+            reset_current_write_origin(token)
+
+    def test_background_review_create_placeholder_skill_blocked(self, tmp_path):
+        """A placeholder auto-created skill is BLOCKED."""
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _skill_dir(tmp_path):
+                raw = skill_manage(
+                    "create", "placeholder-skill", content=PLACEHOLDER_SKILL
+                )
+                result = json.loads(raw)
+                assert result["success"] is False
+                assert "validation gate" in result["error"].lower()
+                assert not (tmp_path / "placeholder-skill").exists()
+        finally:
+            reset_current_write_origin(token)
+
+    def test_foreground_create_short_skill_not_gated(self, tmp_path):
+        """Foreground (user-directed) creates are NOT gated — only background-review."""
+        with _skill_dir(tmp_path):
+            raw = skill_manage("create", "short-skill", content=SHORT_BODY_SKILL)
+            result = json.loads(raw)
+            # Foreground create succeeds — validation gate does not apply.
+            assert result["success"] is True, result
+            assert (tmp_path / "short-skill" / "SKILL.md").exists()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -148,6 +148,115 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
         logger.warning("Security scan failed for %s: %s", skill_dir, e, exc_info=True)
     return None
 
+
+# ---------------------------------------------------------------------------
+# Pre-commit validation gate (#2189)
+# ---------------------------------------------------------------------------
+# Auto-created (background-review-origin) skills must pass a structural
+# validation check BEFORE being admitted to the active library.  A skill that
+# fails validation is NOT marked agent-created and its directory is rolled
+# back.  This is the structural-safety mechanism for self-evolution
+# (arXiv:2608.05810): a malformed or placeholder skill must never reach the
+# active library where it could degrade routing.
+
+# Minimum body length for a structurally valid skill (chars after frontmatter).
+_MIN_SKILL_BODY_CHARS = 80
+
+# Phrases that signal a placeholder / incomplete skill body.
+_PLACEHOLDER_MARKERS = (
+    "lorem ipsum",
+    "todo:",
+    "placeholder",
+    "tbd",
+    "your content here",
+    "[describe",
+    "[insert",
+    "[add ",
+)
+
+
+def validate_skill_content(name: str) -> Optional[str]:
+    """Structural validation of an auto-created skill AFTER it is written to
+    disk but BEFORE it is admitted (marked agent-created).
+
+    Returns an error string describing the validation failure, or ``None`` if
+    the skill passes.  This is a STATIC structural check (frontmatter fields
+    are already validated during ``_create_skill``; this pass focuses on
+    body quality signals that catch degenerate auto-created skills).
+
+    Called from the skill-admission path only for background-review-origin
+    skills (detected via ``is_background_review()``).
+    """
+    skill_dir = _find_skill(name)
+    if not skill_dir:
+        return f"Skill '{name}' not found for validation."
+    skill_md = Path(skill_dir["path"]) / "SKILL.md"
+    if not skill_md.exists():
+        return f"SKILL.md missing for skill '{name}'."
+
+    try:
+        content = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return f"Could not read SKILL.md for skill '{name}': {e}"
+
+    fm, body = _parse_frontmatter(content)
+    body = (body or "").strip()
+
+    if len(body) < _MIN_SKILL_BODY_CHARS:
+        return (
+            f"Skill body is too short ({len(body)} chars, minimum "
+            f"{_MIN_SKILL_BODY_CHARS}). Auto-created skills must contain "
+            f"substantive procedural instructions, not a stub."
+        )
+
+    lower_body = body.lower()
+    for marker in _PLACEHOLDER_MARKERS:
+        if marker in lower_body:
+            return (
+                f"Skill body contains placeholder marker '{marker}'. "
+                f"Auto-created skills must contain complete, actionable "
+                f"instructions."
+            )
+
+    # Description must be a real sentence, not a single token.
+    desc = ""
+    if isinstance(fm, dict):
+        desc = str(fm.get("description", "")).strip()
+    if len(desc.split()) < 3:
+        return (
+            f"Skill description is too short ('{desc}'). It must be a "
+            f"meaningful trigger phrase of at least 3 words for reliable "
+            f"routing."
+        )
+
+    return None
+
+
+def _rollback_skill_dir(name: str) -> None:
+    """Remove a just-created skill directory (validation-gate rollback, #2189).
+
+    Used when ``validate_skill_content`` rejects an auto-created skill: the
+    skill was written to disk by ``_create_skill`` but must NOT be admitted.
+    Best-effort — a rollback failure is logged but does not raise.
+    """
+    try:
+        found = _find_skill(name)
+        if not found:
+            return
+        skill_dir = Path(found["path"])
+        if skill_dir.exists():
+            shutil.rmtree(skill_dir, ignore_errors=True)
+            parent = skill_dir.parent
+            skills_root = _skills_dir()
+            try:
+                if parent != skills_root and parent.exists() and not any(parent.iterdir()):
+                    parent.rmdir()
+            except Exception:
+                pass
+    except Exception as e:
+        logger.warning("Rollback of skill '%s' failed: %s", name, e)
+
+
 import yaml
 
 
@@ -1596,6 +1705,30 @@ def skill_manage(
             from tools.skill_provenance import is_background_review
             if action == "create":
                 if is_background_review():
+                    # Pre-commit validation gate (#2189): auto-created skills
+                    # must pass structural validation BEFORE admission.  A
+                    # failing skill is NOT marked agent-created and its
+                    # directory is rolled back so it never reaches the active
+                    # library.  This is blocking — not a warning.
+                    # Bypassed during approved-pending replay (same as the
+                    # write-approval gate above).
+                    if not _skill_gate_bypass.get():
+                        validation_error = validate_skill_content(name)
+                        if validation_error:
+                            logger.warning(
+                                "Validation gate BLOCKED auto-created skill '%s': %s",
+                                name, validation_error,
+                            )
+                            _rollback_skill_dir(name)
+                            return json.dumps({
+                                "success": False,
+                                "error": (
+                                    f"Validation gate rejected auto-created skill "
+                                    f"'{name}': {validation_error} The skill was "
+                                    f"NOT admitted. Fix the structural issues and "
+                                    f"retry."
+                                ),
+                            }, ensure_ascii=False)
                     mark_agent_created(name)
                     # Record the source run ID for provenance tracking (#2190).
                     try:


### PR DESCRIPTION
Automated evolution PR for issue #2189.

## Summary

Auto-created (background-review-origin) skills now must pass a structural validation check BEFORE being admitted to the active library. A skill that fails validation is NOT marked agent-created and its directory is rolled back.

## Changes

**`tools/skill_manager_tool.py`:**
- Added `validate_skill_content(name)` — structural validation (body length ≥80 chars, no placeholder markers, description ≥3 words)
- Added `_rollback_skill_dir(name)` — removes a just-created skill directory on validation failure
- Wired the validation gate into the admission path: on `not passed`, the skill is NOT marked agent-created, its directory is rolled back, and an error is returned. This is **blocking**, not a warning.
- Validation gate is bypassed during approved-pending replay (`_skill_gate_bypass`), same as the write-approval gate.
- Foreground (user-directed) creates are exempt — gate fires only for `is_background_review()`.

**`tests/tools/test_skill_validation_gate.py`** (new):
- Unit tests for `validate_skill_content()` (valid pass, short body fail, placeholder fail, short description fail, nonexistent skill)
- Integration tests: background-review valid skill admitted + marked agent-created, short skill blocked + rolled back + NOT marked, placeholder skill blocked, foreground create NOT gated

**`tests/tools/test_skill_manager_tool.py`:**
- One test updated to bypass the validation gate (exercises the DELETE path, not skill admission)

## Rework brief addressed

PR #2217 was closed because the validation result was discarded (logger.warning without return). This PR makes admission truly blocking — a failing skill is never admitted.

Closes #2189

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>