### PR TITLE
feat: skill-use boundary violation instrumentation (Closes #2183)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1883,6 +1883,15 @@ def handle_function_call(
         except Exception:
             pass
 
+        # Skill-Use boundary instrumentation (#2183): record each tool call
+        # made while a skill is active so check_boundary_violations can
+        # detect forbidden-tool usage when the skill is deactivated.
+        try:
+            from tools.skill_compliance import record_tool_call_for_active_skill
+            record_tool_call_for_active_skill(function_name)
+        except Exception:
+            pass
+
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
         # returning a string from transform_tool_result. Runs after

--- a/tests/tools/test_skill_compliance.py
+++ b/tests/tools/test_skill_compliance.py
@@ -1,0 +1,147 @@
+"""Tests for skill compliance instrumentation (#2183)."""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from tools.skill_compliance import (
+    check_boundary_violations,
+    record_compliance,
+    quality_summary,
+    reset_compliance,
+    set_active_skill,
+    get_active_skill,
+    record_tool_call_for_active_skill,
+    get_active_skill_tool_calls,
+    _read_forbidden_tools,
+)
+
+SKILL_WITH_FORBIDDEN = """\
+---
+name: restricted-skill
+description: Use when doing restricted operations safely.
+metadata:
+  hermes:
+    forbidden_tools:
+      - terminal
+      - write_file
+---
+# Restricted Skill
+Do the task without using terminal or write_file.
+"""
+
+SKILL_NO_FORBIDDEN = """\
+---
+name: open-skill
+description: Use when doing open operations freely.
+---
+# Open Skill
+Do the task with any tools.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_compliance()
+    set_active_skill(None)
+    yield
+    reset_compliance()
+    set_active_skill(None)
+
+
+@contextmanager
+def _skill_dir(tmp_path):
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        yield
+
+
+class TestReadForbiddenTools:
+    def test_reads_forbidden_from_frontmatter(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "restricted-skill", content=SKILL_WITH_FORBIDDEN)
+            assert _read_forbidden_tools("restricted-skill") == {"terminal", "write_file"}
+
+    def test_empty_when_none_declared(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "open-skill", content=SKILL_NO_FORBIDDEN)
+            assert _read_forbidden_tools("open-skill") == set()
+
+    def test_empty_for_nonexistent(self):
+        assert _read_forbidden_tools("nope") == set()
+
+
+class TestCheckBoundaryViolations:
+    def test_detects_violation(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "restricted-skill", content=SKILL_WITH_FORBIDDEN)
+            assert check_boundary_violations("restricted-skill", ["read_file", "terminal"]) is True
+
+    def test_no_violation_all_allowed(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "restricted-skill", content=SKILL_WITH_FORBIDDEN)
+            assert check_boundary_violations("restricted-skill", ["read_file"]) is False
+
+    def test_no_violation_no_forbidden(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "open-skill", content=SKILL_NO_FORBIDDEN)
+            assert check_boundary_violations("open-skill", ["terminal"]) is False
+
+
+class TestRecordCompliance:
+    def test_records_trigger_comply(self):
+        record_compliance("s", triggered=True, complied=True)
+        s = quality_summary()["s"]
+        assert s["trigger_count"] == 1 and s["comply_count"] == 1 and s["boundary_violation_count"] == 0
+
+    def test_records_violation(self):
+        record_compliance("s", triggered=True, complied=False, boundary_violated=True)
+        assert quality_summary()["s"]["boundary_violation_count"] == 1
+
+    def test_accumulates(self):
+        record_compliance("s", triggered=True, complied=True)
+        record_compliance("s", triggered=True, complied=False, boundary_violated=True)
+        s = quality_summary()["s"]
+        assert s["trigger_count"] == 2 and s["comply_count"] == 1 and s["boundary_violation_count"] == 1
+
+
+class TestActiveSkillTracking:
+    def test_set_get_active(self):
+        set_active_skill("s")
+        assert get_active_skill() == "s"
+
+    def test_track_calls_when_active(self):
+        set_active_skill("s")
+        record_tool_call_for_active_skill("read_file")
+        record_tool_call_for_active_skill("terminal")
+        assert get_active_skill_tool_calls() == ["read_file", "terminal"]
+
+    def test_noop_when_inactive(self):
+        record_tool_call_for_active_skill("read_file")
+        assert get_active_skill_tool_calls() == []
+
+    def test_reset_on_new_skill(self):
+        set_active_skill("a")
+        record_tool_call_for_active_skill("read_file")
+        set_active_skill("b")
+        assert get_active_skill_tool_calls() == []
+
+
+class TestEndToEnd:
+    def test_violation_detected_and_recorded(self, tmp_path):
+        with _skill_dir(tmp_path):
+            from tools.skill_manager_tool import skill_manage
+            skill_manage("create", "restricted-skill", content=SKILL_WITH_FORBIDDEN)
+            set_active_skill("restricted-skill")
+            record_tool_call_for_active_skill("read_file")
+            record_tool_call_for_active_skill("terminal")
+            violated = check_boundary_violations("restricted-skill", get_active_skill_tool_calls())
+            record_compliance("restricted-skill", triggered=True, complied=not violated, boundary_violated=violated)
+            s = quality_summary()["restricted-skill"]
+            assert s["boundary_violation_count"] == 1 and s["comply_count"] == 0

--- a/tools/skill_compliance.py
+++ b/tools/skill_compliance.py
@@ -1,0 +1,109 @@
+"""Skill-Use compliance instrumentation (#2183) — arXiv:2608.04828.
+
+Tracks trigger, compliance, and boundary facets per skill invocation.
+Skills may declare ``metadata.hermes.forbidden_tools`` in frontmatter;
+this module detects violations when those tools are called.
+"""
+
+import contextvars
+import logging
+import re
+from pathlib import Path
+from typing import List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+_compliance_records: dict = {}
+_active_skill: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "active_skill", default=None,
+)
+_tool_calls = contextvars.ContextVar("skill_tool_calls")
+
+
+def _get_calls() -> list:
+    try:
+        c = _tool_calls.get()
+        return c if isinstance(c, list) else []
+    except LookupError:
+        return []
+
+
+def set_active_skill(name: Optional[str]) -> None:
+    _active_skill.set(name)
+    _tool_calls.set([])
+
+
+def get_active_skill() -> Optional[str]:
+    return _active_skill.get()
+
+
+def record_tool_call_for_active_skill(tool_name: str) -> None:
+    if not _active_skill.get():
+        return
+    calls = _get_calls()
+    calls.append(tool_name)
+    _tool_calls.set(calls)
+
+
+def get_active_skill_tool_calls() -> List[str]:
+    return list(_get_calls())
+
+
+def _read_forbidden_tools(name: str) -> Set[str]:
+    try:
+        from tools.skill_manager_tool import _find_skill
+        found = _find_skill(name)
+        if not found:
+            return set()
+        skill_md = Path(found["path"]) / "SKILL.md"
+        if not skill_md.exists():
+            return set()
+        content = skill_md.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return set()
+
+    if not content.startswith("---"):
+        return set()
+    end = re.search(r"\n---\s*\n", content[3:])
+    if not end:
+        return set()
+    try:
+        import yaml
+        parsed = yaml.safe_load(content[3:end.start() + 3])
+    except Exception:
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+    meta = parsed.get("metadata") or {}
+    hermes = (meta.get("hermes") or {}) if isinstance(meta, dict) else {}
+    forbidden = hermes.get("forbidden_tools") or []
+    return {str(t).lower() for t in forbidden} if isinstance(forbidden, list) else set()
+
+
+def check_boundary_violations(skill_name: str, tool_calls_made: List[str]) -> bool:
+    forbidden = _read_forbidden_tools(skill_name)
+    if not forbidden:
+        return False
+    observed = {str(t).lower() for t in tool_calls_made}
+    return bool(observed & forbidden)
+
+
+def record_compliance(skill_name: str, *, triggered: bool = True,
+                      complied: bool = True, boundary_violated: bool = False) -> None:
+    rec = _compliance_records.setdefault(skill_name, {
+        "trigger_count": 0, "comply_count": 0, "boundary_violation_count": 0,
+    })
+    if triggered:
+        rec["trigger_count"] += 1
+    if complied:
+        rec["comply_count"] += 1
+    if boundary_violated:
+        rec["boundary_violation_count"] += 1
+
+
+def quality_summary() -> dict:
+    return dict(_compliance_records)
+
+
+def reset_compliance() -> None:
+    _compliance_records.clear()

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2330,6 +2330,33 @@ def _skill_view_with_bump(args, **kw):
                         record_skill_outcome(str(resolved), success=True)
                     except Exception:
                         pass
+                    # Skill-Use compliance instrumentation (#2183):
+                    # Before activating a new skill, check if the PREVIOUS
+                    # active skill had boundary violations. Then set the new
+                    # skill as active so subsequent tool calls are tracked.
+                    try:
+                        from tools.skill_compliance import (
+                            check_boundary_violations,
+                            get_active_skill,
+                            get_active_skill_tool_calls,
+                            record_compliance,
+                            set_active_skill,
+                        )
+                        prev_skill = get_active_skill()
+                        if prev_skill and prev_skill != str(resolved):
+                            prev_calls = get_active_skill_tool_calls()
+                            violated = check_boundary_violations(prev_skill, prev_calls)
+                            record_compliance(
+                                prev_skill,
+                                triggered=True,
+                                complied=not violated,
+                                boundary_violated=violated,
+                            )
+                        # Record compliance for the skill being loaded now.
+                        record_compliance(str(resolved), triggered=True, complied=True)
+                        set_active_skill(str(resolved))
+                    except Exception:
+                        pass
     except Exception:
         pass
     return result


### PR DESCRIPTION
Automated evolution PR for issue #2183.

## Summary

Skills may declare `metadata.hermes.forbidden_tools` in frontmatter. This PR implements boundary-violation detection: when the agent calls a forbidden tool while a skill is active, the violation is recorded in per-skill compliance counters.

## Changes

**`tools/skill_compliance.py`** (new): `check_boundary_violations()`, `record_compliance()`, `quality_summary()`, active-skill ContextVar tracking.

**`model_tools.py`:** `record_tool_call_for_active_skill()` called in post-dispatch path — records every tool call made while a skill is active.

**`tools/skills_tool.py`:** `_skill_view_with_bump` checks the PREVIOUS skill's boundary on skill switch, records compliance, and activates the new skill.

**`tests/tools/test_skill_compliance.py`** (new): 14 tests covering forbidden-tools parsing, boundary detection, compliance recording, active-skill tracking, and end-to-end violation flow.

## Rework brief addressed

PR #2215 was closed because `check_boundary_violations()` had no production caller. This PR wires it into the skill execution path via ContextVar-based active-skill tracking + post-dispatch tool-call recording.

Note: diff is 292 lines (exceeds 200-line self-merge cap). All tests green, lint clean — needs human review for merge.

Closes #2183

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>