### PR TITLE
feat: tool-call log with semantic-intent field classification (#2236)

### DIFF
--- a/docs/security/tool-call-replay-fork.md
+++ b/docs/security/tool-call-replay-fork.md
@@ -1,0 +1,58 @@
+# Tool-call log & replay-or-fork semantics (#2225 / #2236)
+
+## Problem
+
+Hermes supports background tasks, context compaction, and session resume — all
+of which checkpoint agent state and restore it later. On restore, the agent's
+**local** state rolls back, but **external side effects from tool calls may
+have already executed** (an email was sent, a payment was charged, a single-use
+token was consumed). Worse, the LLM re-synthesizes a "subtly different" tool
+call after restore (new UUID, nonce, or trace_id), which defeats server-side
+idempotency detection — so the side effect happens twice.
+
+This was formally characterized as **semantic rollback attacks** (Action
+Replay + Authority Resurrection) and demonstrated at 100% success on comparable
+agent frameworks (LangGraph, CrewAI, AutoGen).
+
+## Solution: replay-or-fork semantics
+
+A tool-call log records every call to a **non-atomic** tool (irreversible side
+effect) with its arguments split into two classes:
+
+- **semantic-intent** fields — what the user actually wants (`recipient`,
+  `amount`, `memo`). Two calls with the same semantic intent are *the same
+  action* and must not be re-executed after a restore.
+- **syntactic-noise** fields — per-call randomness (`trace_id`, `nonce`,
+  `request_id`) that should NOT be treated as intent.
+
+A stable **idempotency key** is derived from the semantic-intent fields alone.
+On checkpoint-restore:
+
+- **Same intent** (same idempotency key) → replay the cached result, do NOT
+  re-execute the side effect.
+- **Different intent** (different key) → block + surface to the caller (fork).
+
+## Status
+
+- **Slice A (#2236)** — MERGED. `tools/tool_call_log.py`: non-atomic tool
+  registry, field classifier, idempotency-key inference, thread-safe
+  append-only log. Standalone — records and classifies only.
+- **Slice B (#2237)** — PENDING. Wires replay-or-fork into the MCP dispatch
+  path and adds restore-scenario integration tests. Depends on Slice A.
+
+## Usage (Slice A)
+
+```python
+from tools.tool_call_log import get_default_log, is_non_atomic
+
+log = get_default_log()
+
+# Record a non-atomic call (before or after execution):
+if is_non_atomic("agentmail__send_message"):
+    log.record("agentmail__send_message", {"to": "a@b.com", "subject": "hi"})
+
+# Check whether this exact intent has already executed:
+if log.has_executed("agentmail__send_message", {"to": "a@b.com", "subject": "hi"}):
+    # Slice B will replay the cached result here instead of re-executing.
+    ...
+```

--- a/tests/tools/test_tool_call_log.py
+++ b/tests/tools/test_tool_call_log.py
@@ -1,0 +1,260 @@
+"""Unit tests for the tool-call log + field classifier (Slice A, #2236)."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from tools.tool_call_log import (
+    NON_ATOMIC_TOOLS,
+    ToolCallLog,
+    classify_fields,
+    get_default_log,
+    infer_idempotency_key,
+    is_non_atomic,
+    register_non_atomic_tool,
+    reset_default_log,
+)
+
+
+# ── is_non_atomic ───────────────────────────────────────────────────────
+
+
+class TestIsNonAtomic:
+    def test_registered_bare_name(self) -> None:
+        assert is_non_atomic("agentmail__send_message") is True
+
+    def test_registered_mcp_prefixed(self) -> None:
+        assert is_non_atomic("mcp__agentmail__send_message") is True
+
+    def test_case_insensitive(self) -> None:
+        assert is_non_atomic("AgentMail__Send_Message") is True
+        assert is_non_atomic("MCP__AgentMail__Send_Message") is True
+
+    def test_atomic_tool_returns_false(self) -> None:
+        assert is_non_atomic("web_search") is False
+        assert is_non_atomic("read_file") is False
+        assert is_non_atomic("mcp__tavily__search") is False
+
+    def test_unknown_tool_returns_false(self) -> None:
+        assert is_non_atomic("nonexistent_tool") is False
+
+    def test_dynamically_registered(self) -> None:
+        register_non_atomic_tool(
+            "custom__irreversible",
+            semantic_fields=("target",),
+        )
+        try:
+            assert is_non_atomic("custom__irreversible") is True
+            assert is_non_atomic("mcp__custom__irreversible") is True
+        finally:
+            NON_ATOMIC_TOOLS.pop("custom__irreversible", None)
+
+
+# ── classify_fields ─────────────────────────────────────────────────────
+
+
+class TestClassifyFields:
+    def test_semantic_fields_captured(self) -> None:
+        result = classify_fields(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi", "body": "hello"},
+        )
+        assert result.semantic == {"to": "a@b.com", "subject": "hi", "body": "hello"}
+        assert result.noise == {}
+
+    def test_noise_fields_captured(self) -> None:
+        result = classify_fields(
+            "agentmail__send_message",
+            {"to": "a@b.com", "trace_id": "abc123", "request_id": "xyz"},
+        )
+        assert "to" in result.semantic
+        assert "trace_id" in result.noise
+        assert "request_id" in result.noise
+
+    def test_generic_noise_patterns_detected(self) -> None:
+        # nonce is a noise pattern even without an explicit registry entry.
+        register_non_atomic_tool(
+            "temp__tool",
+            semantic_fields=("amount",),
+        )
+        try:
+            result = classify_fields(
+                "temp__tool",
+                {"amount": 5, "nonce": "n1", "correlation_id": "c1"},
+            )
+            assert result.semantic == {"amount": 5}
+            assert "nonce" in result.noise
+            assert "correlation_id" in result.noise
+        finally:
+            NON_ATOMIC_TOOLS.pop("temp__tool", None)
+
+    def test_unknown_field_defaults_to_noise(self) -> None:
+        result = classify_fields(
+            "agentmail__send_message",
+            {"to": "a@b.com", "mystery_field": "x"},
+        )
+        assert "to" in result.semantic
+        assert "mystery_field" in result.noise
+
+    def test_case_insensitive_field_keys(self) -> None:
+        result = classify_fields(
+            "agentmail__send_message",
+            {"TO": "a@b.com", "Trace_ID": "t"},
+        )
+        assert "TO" in result.semantic
+        assert "Trace_ID" in result.noise
+
+    def test_empty_arguments(self) -> None:
+        result = classify_fields("agentmail__send_message", {})
+        assert result.semantic == {}
+        assert result.noise == {}
+
+
+# ── infer_idempotency_key ───────────────────────────────────────────────
+
+
+class TestIdempotencyKey:
+    def test_same_intent_same_key(self) -> None:
+        args_a = {"to": "a@b.com", "subject": "hi", "trace_id": "t1"}
+        args_b = {"to": "a@b.com", "subject": "hi", "trace_id": "t2"}
+        assert infer_idempotency_key(
+            "agentmail__send_message", args_a
+        ) == infer_idempotency_key("agentmail__send_message", args_b)
+
+    def test_different_intent_different_key(self) -> None:
+        args_a = {"to": "a@b.com", "subject": "hi"}
+        args_b = {"to": "c@d.com", "subject": "hi"}
+        assert infer_idempotency_key(
+            "agentmail__send_message", args_a
+        ) != infer_idempotency_key("agentmail__send_message", args_b)
+
+    def test_key_stable_across_dict_ordering(self) -> None:
+        args_a = {"to": "a@b.com", "subject": "hi"}
+        args_b = {"subject": "hi", "to": "a@b.com"}
+        assert infer_idempotency_key(
+            "agentmail__send_message", args_a
+        ) == infer_idempotency_key("agentmail__send_message", args_b)
+
+    def test_key_includes_tool_name(self) -> None:
+        args = {"name": "repo"}
+        k1 = infer_idempotency_key("github__create_repo", args)
+        assert k1.startswith("github__create_repo:")
+
+
+# ── ToolCallLog ─────────────────────────────────────────────────────────
+
+
+class TestToolCallLog:
+    def test_record_and_lookup(self) -> None:
+        log = ToolCallLog()
+        entry = log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi"},
+        )
+        assert entry.tool_name == "agentmail__send_message"
+        found = log.lookup(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi", "trace_id": "noise"},
+        )
+        assert found is not None
+        assert found.idempotency_key == entry.idempotency_key
+
+    def test_has_executed_true_after_record(self) -> None:
+        log = ToolCallLog()
+        log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi"},
+        )
+        assert log.has_executed(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi", "nonce": "n"},
+        )
+
+    def test_has_executed_false_for_different_intent(self) -> None:
+        log = ToolCallLog()
+        log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi"},
+        )
+        assert not log.has_executed(
+            "agentmail__send_message",
+            {"to": "other@b.com", "subject": "hi"},
+        )
+
+    def test_record_atomic_tool_raises(self) -> None:
+        log = ToolCallLog()
+        with pytest.raises(ValueError):
+            log.record("web_search", {"query": "test"})
+
+    def test_first_writer_wins_on_repeat(self) -> None:
+        log = ToolCallLog()
+        first = log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "first"},
+        )
+        # Second record with same intent but different noise — existing kept.
+        second = log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "first", "trace_id": "t2"},
+        )
+        assert second is first
+        assert len(log.all_entries()) == 1
+
+    def test_result_digest_updated_on_repeat(self) -> None:
+        log = ToolCallLog()
+        args = {"to": "a@b.com", "subject": "hi"}
+        log.record("agentmail__send_message", args)
+        before = log.lookup("agentmail__send_message", args)
+        assert before is not None
+        assert before.result_digest is None
+        log.record("agentmail__send_message", args, result={"status": "sent"})
+        after = log.lookup("agentmail__send_message", args)
+        assert after is not None
+        assert after.result_digest is not None
+
+    def test_clear(self) -> None:
+        log = ToolCallLog()
+        log.record("agentmail__send_message", {"to": "a@b.com", "subject": "hi"})
+        assert len(log.all_entries()) == 1
+        log.clear()
+        assert len(log.all_entries()) == 0
+
+    def test_thread_safe_concurrent_record(self) -> None:
+        import threading
+
+        log = ToolCallLog()
+        errors: list[Exception] = []
+
+        def writer(idx: int) -> None:
+            try:
+                log.record(
+                    "agentmail__send_message",
+                    {"to": f"user{idx}@b.com", "subject": "hi"},
+                )
+            except Exception as exc:  # pragma: no cover — assert path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errors == []
+        assert len(log.all_entries()) == 10
+
+
+# ── default log singleton ───────────────────────────────────────────────
+
+
+class TestDefaultLog:
+    def test_singleton_identity(self) -> None:
+        assert get_default_log() is get_default_log()
+
+    def test_reset_clears(self) -> None:
+        log = get_default_log()
+        log.record("agentmail__send_message", {"to": "x@y.com", "subject": "z"})
+        assert len(log.all_entries()) >= 1
+        reset_default_log()
+        assert len(log.all_entries()) == 0

--- a/tools/tool_call_log.py
+++ b/tools/tool_call_log.py
@@ -1,0 +1,326 @@
+"""Tool-call log with semantic-intent / syntactic-noise field classification.
+
+#2236 — Slice A of replay-or-fork semantics (#2225).
+
+Non-atomic tools (those with irreversible real-world side effects — sending an
+email, charging a payment, consuming a single-use token) are cataloged. Every
+call to such a tool is recorded with two classes of arguments:
+
+- **semantic-intent** fields — what the user actually wants to happen
+  (``recipient``, ``amount``, ``memo``). Two calls with the same semantic
+  intent are *the same action* and must not be re-executed after a restore.
+- **syntactic-noise** fields — per-call randomness that should NOT be treated
+  as intent (``trace_id``, ``nonce``, ``request_id``). The LLM re-synthesizes
+  these on every call, so a bare argument hash would wrongly signal "different
+  call" after restore and defeat server-side idempotency detection.
+
+The analyzer classifies each field and infers a stable **idempotency key**
+from the semantic-intent fields alone. Slice B (#2237) will consult this key
+at checkpoint-restore time to replay-or-fork.
+
+This module is standalone — it records and classifies only. Wiring into the
+MCP dispatch path happens in Slice B.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Non-atomic tool registry ────────────────────────────────────────────
+#
+# Tools with irreversible real-world side effects. A checkpoint-restore that
+# re-runs one of these can cause a duplicate send, double charge, or token
+# resurrection. Read-only / idempotent tools (search, read, list) are NOT
+# listed — replaying them is harmless.
+
+# Canonical tool names. The MCP prefix mirrors how tools are surfaced to the
+# agent (``mcp__<server>__<tool>``); bare names cover non-MCP built-ins.
+NON_ATOMIC_TOOLS: Dict[str, "NonAtomicToolSpec"] = {}
+
+
+@dataclass(frozen=True)
+class NonAtomicToolSpec:
+    """Catalog entry for an irreversible tool.
+
+    ``semantic_fields`` — argument keys that define the action's intent.
+    ``noise_fields`` — argument keys that are per-call randomness.
+    Unlisted fields default to noise (safer: only an explicit match counts
+    as repeated intent).
+    """
+
+    name: str
+    semantic_fields: tuple[str, ...] = ()
+    noise_fields: tuple[str, ...] = ()
+
+
+def register_non_atomic_tool(
+    name: str,
+    semantic_fields: tuple[str, ...] = (),
+    noise_fields: tuple[str, ...] = (),
+) -> None:
+    """Register a tool as non-atomic (irreversible side effect)."""
+    spec = NonAtomicToolSpec(
+        name=name,
+        semantic_fields=tuple(f.lower() for f in semantic_fields),
+        noise_fields=tuple(f.lower() for f in noise_fields),
+    )
+    NON_ATOMIC_TOOLS[name.lower()] = spec
+
+
+# Seed registry with the known irreversible tool families. The canonical
+# names mirror the MCP server tool-naming convention used elsewhere.
+register_non_atomic_tool(
+    "agentmail__send_message",
+    semantic_fields=("to", "subject", "body", "cc", "bcc"),
+    noise_fields=("message_id", "request_id", "trace_id"),
+)
+register_non_atomic_tool(
+    "agentmail__send_draft",
+    semantic_fields=("draft_id", "to"),
+    noise_fields=("request_id",),
+)
+register_non_atomic_tool(
+    "github__create_issue",
+    semantic_fields=("owner", "repo", "title", "body"),
+    noise_fields=("client_mutation_id",),
+)
+register_non_atomic_tool(
+    "github__create_repo",
+    semantic_fields=("name", "owner"),
+    noise_fields=("client_mutation_id",),
+)
+register_non_atomic_tool(
+    "stripe__create_payment",
+    semantic_fields=("amount", "currency", "customer", "description"),
+    noise_fields=("idempotency_key", "request_id", "nonce"),
+)
+
+# Generic noise-field suffixes — any field matching these is noise regardless
+# of the tool. Catches per-call randomness without an explicit registry entry.
+_NOISE_FIELD_PATTERNS = (
+    "trace_id",
+    "request_id",
+    "nonce",
+    "idempotency_key",
+    "client_mutation_id",
+    "correlation_id",
+    "x_request_id",
+)
+
+
+def is_non_atomic(tool_name: str) -> bool:
+    """Return True if ``tool_name`` is registered as non-atomic.
+
+    Matching is case-insensitive and also recognizes the MCP
+    ``mcp__<server>__<tool>`` form by stripping the prefix.
+    """
+    key = tool_name.lower()
+    if key in NON_ATOMIC_TOOLS:
+        return True
+    if "__" in key:
+        # mcp__server__tool → try the server__tool tail
+        parts = key.split("__")
+        if len(parts) >= 2:
+            tail = "__".join(parts[-2:])
+            if tail in NON_ATOMIC_TOOLS:
+                return True
+            bare = parts[-1]
+            if bare in NON_ATOMIC_TOOLS:
+                return True
+    return False
+
+
+def _get_spec(tool_name: str) -> Optional[NonAtomicToolSpec]:
+    key = tool_name.lower()
+    if key in NON_ATOMIC_TOOLS:
+        return NON_ATOMIC_TOOLS[key]
+    if "__" in key:
+        parts = key.split("__")
+        if len(parts) >= 2:
+            tail = "__".join(parts[-2:])
+            if tail in NON_ATOMIC_TOOLS:
+                return NON_ATOMIC_TOOLS[tail]
+            bare = parts[-1]
+            if bare in NON_ATOMIC_TOOLS:
+                return NON_ATOMIC_TOOLS[bare]
+    return None
+
+
+# ── Field classifier ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ClassifiedFields:
+    """Result of splitting a tool call's arguments by intent class."""
+
+    semantic: Dict[str, Any] = field(default_factory=dict)
+    noise: Dict[str, Any] = field(default_factory=dict)
+
+
+def classify_fields(tool_name: str, arguments: Dict[str, Any]) -> ClassifiedFields:
+    """Split ``arguments`` into semantic-intent and syntactic-noise fields.
+
+    A field is semantic if it is listed in the tool's ``semantic_fields``.
+    A field is noise if it matches a noise pattern OR is listed in
+    ``noise_fields``. Fields that match neither default to **noise** —
+    this is the safe direction, because treating an unknown field as intent
+    would suppress a legitimate re-execution.
+    """
+    spec = _get_spec(tool_name)
+    arguments = arguments or {}
+    semantic: Dict[str, Any] = {}
+    noise: Dict[str, Any] = {}
+
+    for raw_key, value in arguments.items():
+        key = str(raw_key).lower()
+        if spec and key in spec.semantic_fields:
+            semantic[raw_key] = value
+        elif spec and key in spec.noise_fields:
+            noise[raw_key] = value
+        elif any(pat in key for pat in _NOISE_FIELD_PATTERNS):
+            noise[raw_key] = value
+        else:
+            # Unknown field → default to noise (safe direction).
+            noise[raw_key] = value
+
+    return ClassifiedFields(semantic=semantic, noise=noise)
+
+
+# ── Idempotency key inference ───────────────────────────────────────────
+
+
+def infer_idempotency_key(tool_name: str, arguments: Dict[str, Any]) -> str:
+    """Return a stable idempotency key derived from semantic-intent fields.
+
+    Two calls produce the SAME key iff their semantic intent is identical,
+    regardless of syntactic-noise fields. Used by Slice B (#2237) to decide
+    replay (same key) vs fork (different key) on checkpoint-restore.
+    """
+    classified = classify_fields(tool_name, arguments)
+    # Sort keys for deterministic serialization.
+    payload = json.dumps(classified.semantic, sort_keys=True, default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"{tool_name.lower()}:{digest[:16]}"
+
+
+# ── Tool-call log ────────────────────────────────────────────────────────
+
+
+@dataclass
+class LoggedToolCall:
+    """A recorded non-atomic tool call."""
+
+    tool_name: str
+    arguments: Dict[str, Any]
+    idempotency_key: str
+    classified: ClassifiedFields
+    recorded_at: str
+    result_digest: Optional[str] = None  # set when the result is observed
+
+
+class ToolCallLog:
+    """Thread-safe append-only log of non-atomic tool calls.
+
+    The log is keyed by idempotency key so a restore-time lookup can answer
+    "has this exact intent already executed?" in O(1). Slice B consults this
+    to replay-or-fork.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._entries: Dict[str, LoggedToolCall] = {}
+
+    def record(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        result: Any = None,
+    ) -> LoggedToolCall:
+        """Record a non-atomic tool call. No-op for atomic tools.
+
+        Returns the :class:`LoggedToolCall`. If the same idempotency key
+        already exists, the existing entry is preserved (first-writer-wins)
+        and its ``result_digest`` is updated if a ``result`` is supplied.
+        """
+        if not is_non_atomic(tool_name):
+            # Atomic tools are never logged — replay is harmless.
+            raise ValueError(f"{tool_name!r} is not a non-atomic tool")
+
+        classified = classify_fields(tool_name, arguments)
+        key = infer_idempotency_key(tool_name, arguments)
+        entry = LoggedToolCall(
+            tool_name=tool_name,
+            arguments=dict(arguments or {}),
+            idempotency_key=key,
+            classified=classified,
+            recorded_at=datetime.now(timezone.utc).isoformat(),
+            result_digest=_digest_result(result),
+        )
+        with self._lock:
+            existing = self._entries.get(key)
+            if existing is not None:
+                if result is not None:
+                    existing.result_digest = entry.result_digest
+                return existing
+            self._entries[key] = entry
+        return entry
+
+    def lookup(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Optional[LoggedToolCall]:
+        """Return the logged entry for this intent, or None if unseen."""
+        key = infer_idempotency_key(tool_name, arguments)
+        with self._lock:
+            return self._entries.get(key)
+
+    def has_executed(self, tool_name: str, arguments: Dict[str, Any]) -> bool:
+        """True if a call with identical semantic intent is logged."""
+        return self.lookup(tool_name, arguments) is not None
+
+    def all_entries(self) -> List[LoggedToolCall]:
+        with self._lock:
+            return list(self._entries.values())
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+def _digest_result(result: Any) -> Optional[str]:
+    if result is None:
+        return None
+    try:
+        payload = json.dumps(result, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        payload = str(result)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+# Module-level singleton — the default log used by the agent session.
+# Slice B will reset/restore this on checkpoint-restore.
+_default_log: Optional[ToolCallLog] = None
+_default_log_lock = threading.Lock()
+
+
+def get_default_log() -> ToolCallLog:
+    """Return the process-wide default :class:`ToolCallLog`."""
+    global _default_log
+    with _default_log_lock:
+        if _default_log is None:
+            _default_log = ToolCallLog()
+        return _default_log
+
+
+def reset_default_log() -> ToolCallLog:
+    """Clear and return the default log (used on checkpoint-restore)."""
+    log = get_default_log()
+    log.clear()
+    return log


### PR DESCRIPTION
Automated evolution PR for issue **#2236** — Slice A of replay-or-fork semantics (parent **#2225**).

## What this lands

A standalone module (`tools/tool_call_log.py`) that:
1. **Catalogs non-atomic tools** — irreversible real-world side effects (agentmail send, github write, stripe payment). Read-only/idempotent tools are excluded.
2. **Classifies call arguments** into *semantic-intent* (recipient, amount, memo) vs *syntactic-noise* (trace_id, nonce, request_id). Unknown fields default to noise (safe direction).
3. **Infers a stable idempotency key** from semantic-intent fields alone — two calls share a key iff their intent is identical, regardless of syntactic noise.
4. **Records calls** in a thread-safe, append-only, O(1)-lookup log keyed by idempotency key.

No changes to the existing dispatch path — Slice B (#2237) will wire replay-or-fork into the MCP path using this foundation.

## Why

On checkpoint-restore, the agent's local state rolls back but external side effects may have already executed. The LLM re-synthesizes a "subtly different" call (new nonce/trace_id) that defeats server-side idempotency detection, so the side effect fires twice. ACRFence (arXiv:2603.20625) demonstrated this at 100% success on LangGraph/CrewAI/AutoGen. This slice builds the classification + logging substrate; Slice B adds the restore-time replay-or-fork decision.

## Validation

- `ruff check .` — clean
- `ruff format --check` — clean
- `pytest tests/tools/test_tool_call_log.py` — 26 passed
- `pytest tests/tools/test_mcp_resource_content.py` — 14 passed (no regression)
- Diff: 644 lines (326 module + 260 tests + 58 docs)

## Size note

644 insertions exceeds the 200-line autonomous self-merge cap. Slice A is a self-contained new module (no existing-file edits to trim); it is the smallest coherent slice of the replay-or-fork feature — the classifier, registry, log, and tests are interdependent and cannot be usefully split further without breaking the unit-test contract. Requesting human review for a cap exception; alternatively, a reviewer may flag this as acceptable for a foundational module that unblocks Slice B.

Closes #2236

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>