### PR TITLE
fix: process tool spiral cap — classify status/error failures (Closes #2241)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -379,6 +379,22 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:
                 return True, f" [exit {exit_code}]"
+            # #2241 — process-specific failure patterns that don't carry an
+            # exit_code.  process_registry returns {"status": "not_found",
+            # "error": "No process with ID …"} for session-not-found,
+            # {"status": "error", "error": str(e)} for action failures, and
+            # {"success": False, "error": …} for write/submit rejections.
+            # Without these checks the early ``return False`` above swallows
+            # them, the streak counter never accumulates, and the spiral cap
+            # never fires — regressing to 18-deep (#2241).
+            if tool_name == "process":
+                status = data.get("status")
+                if status in ("not_found", "error", "already_exited"):
+                    return True, f" [{status}]"
+                if data.get("success") is False:
+                    return True, " [failed]"
+                if data.get("error") and not data.get("output"):
+                    return True, " [error]"
         return False, ""
 
     if tool_name == "memory":

--- a/tests/agent/test_process_spiral_cap.py
+++ b/tests/agent/test_process_spiral_cap.py
@@ -1,0 +1,142 @@
+"""Tests for the process tool spiral cap fix (#2241).
+
+The process tool returns JSON results where the failure signal is NOT a
+non-zero ``exit_code`` — it's a ``status`` field (``not_found``, ``error``,
+``already_exited``) or a ``success: False`` flag.  The original #1839 fix
+only checked ``exit_code``, so these other failure patterns were swallowed
+by an early ``return False`` and the cross-turn streak counter never
+accumulated, allowing the spiral cap to be bypassed (regression to 18-deep).
+
+These tests verify the expanded classification and that the cap fires.
+"""
+
+import json
+
+import pytest
+
+from agent.tool_guardrails import (
+    ToolCallGuardrailConfig,
+    ToolCallGuardrailController,
+    classify_tool_failure,
+)
+
+
+class TestProcessFailureClassification:
+    """Process results that lack exit_code but signal failure are now caught."""
+
+    def test_process_nonzero_exit_is_failure(self):
+        result = json.dumps({"exit_code": 1, "output": "error output"})
+        failed, label = classify_tool_failure("process", result)
+        assert failed is True
+        assert "exit 1" in label
+
+    def test_process_not_found_is_failure(self):
+        result = json.dumps({"status": "not_found", "error": "No process with ID s123"})
+        failed, label = classify_tool_failure("process", result)
+        assert failed is True
+        assert "not_found" in label
+
+    def test_process_error_status_is_failure(self):
+        result = json.dumps({"status": "error", "error": "Connection reset by peer"})
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is True
+
+    def test_process_already_exited_is_failure(self):
+        result = json.dumps({
+            "status": "already_exited",
+            "error": "Process has already finished",
+        })
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is True
+
+    def test_process_success_false_is_failure(self):
+        result = json.dumps({"success": False, "error": "write failed: stream closed"})
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is True
+
+    def test_process_error_without_output_is_failure(self):
+        """A process result with 'error' but no 'output' is a failure."""
+        result = json.dumps({"error": "stdin not available"})
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is True
+
+    def test_process_success_exit_zero_not_failure(self):
+        result = json.dumps({"exit_code": 0, "output": "all good"})
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is False
+
+    def test_process_poll_with_output_not_failure(self):
+        """A successful poll that has output should NOT be classified as a
+        failure even if it carries a status field."""
+        result = json.dumps({
+            "status": "running",
+            "output": "partial data...",
+            "exit_code": None,
+        })
+        failed, _ = classify_tool_failure("process", result)
+        assert failed is False
+
+
+class TestProcessSpiralCapFires:
+    """The spiral cap must fire after enough consecutive process failures."""
+
+    def test_cap_fires_after_5_cross_turn_failures(self):
+        """Simulating 5 consecutive process failures (one per API turn),
+        the 6th call should be blocked by the spiral_failure_cap."""
+        controller = ToolCallGuardrailController()
+        failing_result = json.dumps({
+            "status": "not_found",
+            "error": "No process with ID s1",
+        })
+        for _ in range(5):
+            controller.after_call(
+                "process", {"action": "poll", "session_id": "s1"}, failing_result
+            )
+            controller.reset_for_turn()
+
+        decision = controller.before_call(
+            "process", {"action": "poll", "session_id": "s1"}
+        )
+        assert decision.action in ("block", "halt")
+        assert decision.code in (
+            "spiral_prone_tool_failure_cap",
+            "session_hard_stop",
+        )
+
+    def test_cap_does_not_fire_on_successes(self):
+        """A run of successful process polls should NOT trigger the cap."""
+        controller = ToolCallGuardrailController()
+        ok_result = json.dumps({"exit_code": 0, "output": "running..."})
+        for _ in range(10):
+            controller.after_call(
+                "process", {"action": "poll", "session_id": "s1"}, ok_result
+            )
+            controller.reset_for_turn()
+
+        decision = controller.before_call(
+            "process", {"action": "poll", "session_id": "s1"}
+        )
+        assert decision.action != "block"
+
+    def test_18_deep_regression_bounded(self):
+        """Regression test: 18 consecutive process failures should be bounded
+        by the cap (default 5), not allowed to reach 18."""
+        controller = ToolCallGuardrailController()
+        failing_result = json.dumps({"status": "error", "error": "connection refused"})
+        blocked_at = None
+        for i in range(18):
+            decision = controller.before_call(
+                "process", {"action": "poll", "session_id": "s1"}
+            )
+            if decision.action == "block":
+                blocked_at = i
+                break
+            controller.after_call(
+                "process",
+                {"action": "poll", "session_id": "s1"},
+                failing_result,
+            )
+            controller.reset_for_turn()
+
+        assert blocked_at is not None, "Cap never fired after 18 failures"
+        assert blocked_at <= 5, f"Cap fired too late at {blocked_at}, expected <= 5"


### PR DESCRIPTION
Automated evolution PR for issue #2241.

## Summary
The process tool retry spiral regressed to 18-deep across 20 sessions because `classify_tool_failure` only checked `exit_code` for process results. The process tool returns failures via `status` fields (`not_found`, `error`, `already_exited`) and `success: False` flags — none of which carry an `exit_code`. These were swallowed by an early `return False`, so the cross-turn streak counter never accumulated and the `spiral_failure_cap=5` never fired.

## Root Cause
In `classify_tool_failure`, the combined terminal/process block (added by #1839) checked only `exit_code`. When a process result like `{"status": "not_found", "error": "No process with ID …"}` was passed, it had no `exit_code`, so the function returned `False, ""` (success) — never reaching the generic `"error"`-in-text check at the bottom.

## Fix
Added process-specific checks inside the terminal/process block:
- `status` in (`not_found`, `error`, `already_exited`) → failure
- `success: False` → failure
- `error` field present without `output` → failure

This ensures ALL process failure patterns are classified, the streak accumulates, and the cap fires at the configured threshold (5).

## Validation
- ruff check ✓, ruff format ✓
- 88 tests pass (11 new process tests + 77 existing guardrail tests)
- Regression test: 18 consecutive process failures are bounded at ≤5