### PR TITLE
feat: shared path-validation module + read_file integration (Closes #2293)

### DIFF
--- a/tests/tools/test_path_validation.py
+++ b/tests/tools/test_path_validation.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for the shared pure-Python path-validation module (#2293).
+
+Covers ``suggest_nearby_paths`` (existence check + similarity scoring +
+nearest-ancestor fallback) and ``format_nearby_hint`` (the #1587 inline
+"did you mean?" contract). Also verifies read_file_tool falls back to the
+shared module when the shell-based suggestion finds nothing.
+
+Run with:  python -m pytest tests/tools/test_path_validation.py -v
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tools.path_validation import format_nearby_hint, suggest_nearby_paths
+from tools.file_tools import read_file_tool
+
+
+class _TmpDir(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="test_pathval_")
+        for name in ("config.yaml", "config.yml", "settings.py", "README.md"):
+            with open(os.path.join(self._tmp, name), "w") as f:
+                f.write("x\n")
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+class TestSuggestNearbyPaths(_TmpDir):
+    def test_existing_path_returns_empty(self):
+        self.assertEqual(
+            suggest_nearby_paths(os.path.join(self._tmp, "config.yaml")), []
+        )
+
+    def test_similar_basename_suggested(self):
+        nearby = suggest_nearby_paths(os.path.join(self._tmp, "config.yam"))
+        self.assertTrue(nearby)
+        self.assertTrue(any("config.yaml" in p for p in nearby))
+
+    def test_missing_parent_walks_to_ancestor(self):
+        deep = os.path.join(self._tmp, "nope", "sub", "config.yaml")
+        nearby = suggest_nearby_paths(deep)
+        self.assertTrue(any("config.yaml" in p for p in nearby))
+
+    def test_max_results_respected(self):
+        nearby = suggest_nearby_paths(
+            os.path.join(self._tmp, "config.yam"), max_results=1
+        )
+        self.assertLessEqual(len(nearby), 1)
+
+
+class TestFormatNearbyHint(unittest.TestCase):
+    def test_empty_nearby_returns_none(self):
+        self.assertIsNone(format_nearby_hint("/x/y", []))
+
+    def test_hint_inlines_did_you_mean(self):
+        hint = format_nearby_hint("/x/y.py", ["/x/z.py"])
+        self.assertIn("File not found: /x/y.py", hint)
+        self.assertIn("Did you mean: /x/z.py", hint)
+
+
+class TestReadFileToolFallback(_TmpDir):
+    """read_file_tool must fall back to the shared module when the
+    shell-based _suggest_similar_files finds nothing."""
+
+    def test_fallback_surfaces_nearby_hint(self):
+        missing = os.path.join(self._tmp, "config.yam")
+        fake_ops = MagicMock()
+        fake_ops.read_file.return_value = MagicMock(
+            to_dict=lambda: {"error": f"File not found: {missing}", "similar_files": []}
+        )
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = read_file_tool(missing, task_id="test_fallback")
+        err = json.loads(result).get("error") or ""
+        self.assertIn("File not found", err)
+        self.assertIn("Did you mean", err)
+        self.assertIn("config.yaml", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -20,6 +20,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from tools.path_validation import format_nearby_hint, suggest_nearby_paths
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -1656,6 +1657,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # optimization; recording must stay side-effect-identical.
         _err = result_dict.get("error") or ""
         if isinstance(_err, str) and _err.startswith("File not found:"):
+            # #2293 — if the shell-based _suggest_similar_files found nothing
+            # (no similar_files), fall back to the shared pure-Python module
+            # so the agent still gets a nearby-files hint. This exercises the
+            # reusable path-validation layer in a real call site (Slice B
+            # extends it to terminal/search_files/patch).
+            if not result_dict.get("similar_files"):
+                _nearby = suggest_nearby_paths(str(_resolved))
+                _hint = format_nearby_hint(str(_resolved), _nearby)
+                if _hint:
+                    result_dict["error"] = _err + "\n\n" + _hint
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
             _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 

--- a/tools/path_validation.py
+++ b/tools/path_validation.py
@@ -1,0 +1,80 @@
+"""Shared pure-Python path validation + nearby-file surfacing.
+
+Foundation for the cross-tool file-not-found fix (#2242). Unlike the
+shell-based ``_suggest_similar_files`` in ``file_operations.py``, this
+module uses plain ``os``/``pathlib`` so any tool (read_file, terminal,
+search_files, patch) can reuse it without a shell backend. Slice A (#2293)
+integrates it into read_file; Slice B extends it to the other three tools.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+
+def suggest_nearby_paths(path: str, max_results: int = 5) -> List[str]:
+    """Return up to *max_results* paths near *path* the caller likely meant.
+
+    Pure-Python existence check + similarity scoring (no shell). Returns
+    ``[]`` if *path* exists. Otherwise scores parent-dir entries by name
+    similarity to the requested basename; if the parent doesn't exist, walks
+    up to the nearest existing ancestor and lists its entries.
+    """
+    p = Path(path)
+    if p.exists():
+        return []
+    dir_path, filename = p.parent, p.name
+    base_no_ext, ext = p.stem, p.suffix.lower()
+    lower = filename.lower()
+
+    entries: List[str] = []
+    target = dir_path
+    while True:
+        try:
+            entries = sorted(os.listdir(target))
+            break
+        except OSError:
+            parent = target.parent
+            if parent == target:
+                break
+            target = parent
+
+    scored: List[tuple] = []
+    for f in entries:
+        lf = f.lower()
+        score = 0
+        if lf == lower:
+            score = 100
+        elif os.path.splitext(f)[0].lower() == base_no_ext.lower():
+            score = 90
+        elif lf.startswith(lower) or lower.startswith(lf):
+            score = 70
+        elif lower in lf:
+            score = 60
+        elif lf in lower and len(lf) > 2:
+            score = 40
+        elif ext and os.path.splitext(f)[1].lower() == ext:
+            common = set(lower) & set(lf)
+            if len(common) >= max(len(lower), len(lf)) * 0.4:
+                score = 30
+        if score > 0:
+            scored.append((score, os.path.join(target, f)))
+
+    scored.sort(key=lambda x: -x[0])
+    return [fp for _, fp in scored[:max_results]]
+
+
+def format_nearby_hint(path: str, nearby: List[str]) -> Optional[str]:
+    """Build a human hint for a stale *path* given *nearby* candidates.
+
+    Returns ``None`` when *nearby* is empty. Mirrors the #1587 "did you
+    mean?" inline-suggestion contract so the hint is visible in the tool
+    error text, not a separate field.
+    """
+    if not nearby:
+        return None
+    return (
+        f"File not found: {path}\n\n"
+        f"Did you mean: {', '.join(nearby)}? "
+        "Re-run read_file with one of these paths instead of guessing."
+    )


### PR DESCRIPTION
Automated evolution PR for issue #2293.

Adds a reusable pure-Python path-validation module (tools/path_validation.py) that checks existence and surfaces nearby files/dirs as a hint, and wires it into read_file's not-found path as a fallback when the shell-based _suggest_similar_files finds nothing.

This is the foundation for the cross-tool file-not-found fix (#2242). Slice B extends the module to terminal/search_files/patch.

Closes #2293