### PR TITLE
feat: decompose patch 'other' error bucket into sub-reasons (Closes #2244)

### DIFF
--- a/tests/tools/test_patch_other_bucket.py
+++ b/tests/tools/test_patch_other_bucket.py
@@ -1,0 +1,89 @@
+"""Tests for decomposing the patch 'other' error bucket (#2244).
+
+The generic "error" catch-all in classify_file_error was the 2nd largest
+patch failure mode (55 failures/7d). This test verifies that common
+sub-reasons — encoding/Unicode issues, line-ending conflicts, BOM markers,
+and concurrent modification — now classify into specific categories with
+targeted recovery hints instead of falling through to the generic bucket.
+"""
+
+from tools.file_operations import classify_file_error
+
+
+class TestEncodingErrorClassification:
+    def test_unicode_decode_error_classified(self):
+        error = "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff"
+        cls, hint = classify_file_error(error)
+        assert cls == "encoding_error"
+        assert "write_file" in hint or "encoding" in hint.lower()
+
+    def test_invalid_continuation_byte_classified(self):
+        error = "invalid continuation byte at position 42"
+        cls, _ = classify_file_error(error)
+        assert cls == "encoding_error"
+
+    def test_codec_cant_decode_classified(self):
+        error = "'utf-8' codec can't decode byte 0x80 in position 0"
+        cls, _ = classify_file_error(error)
+        assert cls == "encoding_error"
+
+
+class TestLineEndingConflictClassification:
+    def test_crlf_conflict_classified(self):
+        error = "Line ending mismatch: file uses CRLF"
+        cls, hint = classify_file_error(error)
+        assert cls == "line_ending_conflict"
+        assert "line ending" in hint.lower() or "write_file" in hint
+
+    def test_line_ending_hyphenated_classified(self):
+        error = "Line-ending conflict detected"
+        cls, _ = classify_file_error(error)
+        assert cls == "line_ending_conflict"
+
+
+class TestBomConflictClassification:
+    def test_bom_in_error_classified(self):
+        error = "BOM marker found at start of file"
+        cls, hint = classify_file_error(error)
+        assert cls == "bom_conflict"
+        assert "BOM" in hint or "write_file" in hint
+
+    def test_ufeff_classified(self):
+        error = "Unexpected U+FEFF character at position 0"
+        cls, _ = classify_file_error(error)
+        assert cls == "bom_conflict"
+
+
+class TestConcurrentModificationClassification:
+    def test_concurrent_modification_classified(self):
+        error = "concurrent modification detected"
+        cls, hint = classify_file_error(error)
+        assert cls == "concurrent_modification"
+        assert "re-read" in hint.lower() or "retry" in hint.lower()
+
+    def test_file_modified_since_read_classified(self):
+        error = "File was modified since last read"
+        cls, _ = classify_file_error(error)
+        assert cls == "concurrent_modification"
+
+    def test_stale_handle_classified(self):
+        error = "stale file handle"
+        cls, _ = classify_file_error(error)
+        assert cls == "concurrent_modification"
+
+
+class TestNoRegression:
+    """Existing classifications still work correctly."""
+
+    def test_permission_denied_still_works(self):
+        cls, _ = classify_file_error("Permission denied")
+        assert cls == "permission"
+
+    def test_not_found_still_works(self):
+        cls, _ = classify_file_error("File not found: /tmp/foo.txt")
+        assert cls == "not_found"
+
+    def test_generic_error_still_falls_through(self):
+        """Truly unknown errors still get the generic 'error' class."""
+        cls, _ = classify_file_error("Something completely unexpected happened")
+        assert cls == "error"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -269,6 +269,49 @@ def classify_file_error(
         return "read_error", (
             "The read failed. Check the path/permissions; don't repeat the same call blindly."
         )
+    # ── Decompose remaining "other" failures (#2244) ────────────────────
+    # 55 patch failures/7d fell through to the generic "error" catch-all
+    # below. These patterns capture the common sub-reasons that were never
+    # classified: encoding/Unicode issues, line-ending conflicts, BOM
+    # markers, and concurrent modification (file changed between read and
+    # write). Each gets a targeted recovery hint so the agent can correct
+    # without guessing.
+    if (
+        "unicode" in low
+        or "codec can't decode" in low
+        or "invalid byte" in low
+        or "invalid continuation byte" in low
+        or "can't decode" in low
+    ):
+        return "encoding_error", (
+            "The file has a byte sequence that can't be decoded as UTF-8. "
+            "It may be a non-UTF-8 encoding or contain invalid bytes. "
+            "Use write_file to replace the content, or handle the encoding "
+            "explicitly via execute_code."
+        )
+    if "line ending" in low or "crlf" in low or "line-ending" in low:
+        return "line_ending_conflict", (
+            "The file uses different line endings (CRLF vs LF) than "
+            "old_string. Re-read the file and copy the EXACT line endings, "
+            "or use write_file to replace the whole file."
+        )
+    if "bom" in low or "ufeff" in low or "u+feff" in low or "byte order mark" in low:
+        return "bom_conflict", (
+            "The file has a UTF-8 BOM (byte order mark) prefix that "
+            "interferes with the match. Re-read the file from line 1 and "
+            "include the BOM in old_string, or use write_file."
+        )
+    if (
+        ("concurrent" in low)
+        or ("modified" in low and "since" in low)
+        or ("changed" in low and "since" in low)
+        or ("stale" in low and "handle" in low)
+    ):
+        return "concurrent_modification", (
+            "The file was modified between the read and the write. "
+            "Re-read the current content and retry the patch against the "
+            "latest version."
+        )
     # Last resort: the structured diagnostic may still classify an otherwise
     # generic message before we fall back to the catch-all "error" bucket.
     finer = _class_from_structured_error(structured_error)


### PR DESCRIPTION
## Summary

Re-sliced cap-compliant version of PR #2265 (243 lines → **132 lines**, well under the 200-line merge gate).

The original PR #2265 included ~100 lines of incidental ruff formatting noise on pre-existing code. This re-slice keeps ONLY the functional classification logic + tests.

## Changes

Adds 4 new error sub-classifications to `classify_file_error` in `tools/file_operations.py` for patterns that previously fell through to the generic `error` catch-all (55 failures/7d per #2244):

| Sub-class | Triggers | Recovery hint |
|---|---|---|
| `encoding_error` | Unicode/codec/invalid byte | Use write_file or handle encoding via execute_code |
| `line_ending_conflict` | CRLF/line-ending mismatch | Re-read and copy exact line endings |
| `bom_conflict` | BOM/U+FEFF markers | Include BOM in old_string or use write_file |
| `concurrent_modification` | File changed since read/stale handle | Re-read current content and retry |

## Tests

13 new tests in `tests/tools/test_patch_other_bucket.py` — all pass ✓

```
13 passed in 0.36s
```

## Validation

- `ruff check .` ✓ (all checks passed)
- Targeted tests ✓ (13/13 passed)
- Diff: 132 insertions, 0 deletions — **under 200-line cap** ✓

## Relationship to existing PR

Supersedes PR #2265 (243 lines, blocked by merge gate since morning cycle). If this PR merges, PR #2265 should be closed.

Closes #2244

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>