### PR TITLE
feat: tool-call dedup tracker to reduce unnecessary tool calls (#2282)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3504,6 +3504,14 @@ def compress_context(
             reset_skill_view_dedup(task_id)
         except Exception:
             pass
+        # Same for the tool-call dedup tracker (#2282): after compression
+        # the prior result is summarised away, so a re-read/re-search is
+        # legitimate and must not be flagged as a duplicate.
+        try:
+            from agent.tool_dedup import reset_tool_dedup
+            reset_tool_dedup(task_id)
+        except Exception:
+            pass
 
         logger.info(
             "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
@@ -3665,6 +3673,12 @@ def _compress_context_via_codex_app_server(
         from tools.file_tools import reset_file_dedup
 
         reset_file_dedup(task_id)
+    except Exception:
+        pass
+    try:
+        from agent.tool_dedup import reset_tool_dedup
+
+        reset_tool_dedup(task_id)
     except Exception:
         pass
 

--- a/agent/tool_dedup.py
+++ b/agent/tool_dedup.py
@@ -1,0 +1,360 @@
+"""Tool-call deduplication tracker (When2Tool, issue #2282).
+
+Reduces unnecessary tool calls by tracking recent *successful* tool
+invocations per session and surfacing a hint when the model re-issues the
+same tool+arguments combination that already succeeded.
+
+This is the cache-safe, prompt-free slice of the When2Tool proposal. It
+deliberately does NOT inject a self-check prompt mid-conversation (that
+would break prompt caching and message-role alternation) and does NOT
+require hidden-state access (that only applies to local open-weight
+models). Instead it records what actually ran and succeeded, and lets the
+model decide whether to reuse the prior result.
+
+Design invariants:
+
+* **Side-effect-free on the conversation.** The tracker only *returns* a
+  hint string that the caller may append to a tool result. It never
+  mutates the system prompt, never injects a synthetic user message, and
+  never alters message-role alternation.
+* **Fail-open.** Any error resolving config, normalizing args, or reading
+  state results in *no hint* — the tracker can never block a legitimate
+  call. It is advisory, not a gate.
+* **Session-scoped.** State is keyed by ``session_id`` so one session's
+  calls never leak into another (subagents, kanban workers, and gateway
+  sessions stay isolated).
+* **Success-only.** Only *successful* prior calls are recorded, so a
+  previously-failed call is never treated as "already done".
+* **Bounded.** Per-session history is capped (LRU-ish) so memory does not
+  grow without bound over a long session.
+
+The module depends only on the Python standard library, is import-safe,
+and is unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from collections import OrderedDict
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+#: Default config. Overridable via ``tool_dedup.enabled`` in config.yaml or
+#: the ``HERMES_TOOL_DEDUP`` env var.
+DEFAULT_CONFIG: Dict[str, Any] = {
+    # Master switch. Default ON (advisory + fail-open, so it is low-risk).
+    "enabled": True,
+    # How many distinct tool+args entries to remember per session.
+    "max_entries_per_session": 64,
+    # Only flag a repeat if the prior successful call happened within this
+    # many *distinct* tool calls ago (a loose recency window). 0 disables
+    # the recency check (flag any prior success).
+    "recency_window": 20,
+}
+
+_TOOL_DEDUP_ENV = "HERMES_TOOL_DEDUP"
+
+#: Tool categories the tracker applies to. These are the read/search/web
+#: tools the When2Tool finding targets — the ones most often called
+#: redundantly when the answer is already in context.
+_TRACKED_TOOLS = {
+    "read_file",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "tavily_search",
+    "browser_navigate",
+}
+
+#: Argument keys that are volatile per-call and must be stripped before
+#: computing the dedup key (they would otherwise make every call look
+#: unique). ``task_id``/``session_id`` are transport plumbing, not part of
+#: the tool's semantic identity.
+_VOLATILE_ARG_KEYS = {"task_id", "session_id", "tool_call_id", "turn_id"}
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+class _SessionTracker:
+    """Per-session record of recent successful tool calls.
+
+    Thread-safe. ``_history`` is an ``OrderedDict`` keyed by a stable hash
+    of (tool, normalized-args); the value is the number of distinct tool
+    calls since that entry was last seen (used for the recency window).
+    """
+
+    __slots__ = ("_history", "_lock", "_call_count")
+
+    def __init__(self) -> None:
+        self._history: "OrderedDict[str, int]" = OrderedDict()
+        self._lock = threading.Lock()
+        self._call_count = 0
+
+    def record(self, key: str, max_entries: int) -> None:
+        """Record a successful call, resetting its recency counter."""
+        with self._lock:
+            self._call_count += 1
+            self._history[key] = 0
+            self._history.move_to_end(key)
+            # Bound memory: drop the oldest entries beyond the cap.
+            while len(self._history) > max_entries:
+                self._history.popitem(last=False)
+
+    def recent(self, key: str, window: int) -> Optional[int]:
+        """Return the recency (distinct calls since) of *key*, or None.
+
+        ``window`` <= 0 means "any prior success counts". Returns the
+        recency distance if the key is present and within the window.
+        """
+        with self._lock:
+            if key not in self._history:
+                return None
+            dist = self._history[key]
+            if window > 0 and dist > window:
+                return None
+            return dist
+
+    def tick(self) -> None:
+        """Advance the recency counter for all tracked entries.
+
+        Called once per tracked tool call (successful or not) so the
+        recency window measures *distinct tool calls*, not wall-clock time.
+        """
+        with self._lock:
+            self._call_count += 1
+            for k in list(self._history.keys()):
+                self._history[k] += 1
+
+    def clear(self) -> None:
+        with self._lock:
+            self._history.clear()
+            self._call_count = 0
+
+
+#: Process-global registry of per-session trackers. Keyed by session_id
+#: (``"default"`` when none is provided). Guarded by ``_REGISTRY_LOCK``.
+_REGISTRY: Dict[str, _SessionTracker] = {}
+_REGISTRY_LOCK = threading.Lock()
+
+
+def _tracker_for(session_id: Optional[str]) -> _SessionTracker:
+    sid = session_id or "default"
+    with _REGISTRY_LOCK:
+        tr = _REGISTRY.get(sid)
+        if tr is None:
+            tr = _SessionTracker()
+            _REGISTRY[sid] = tr
+        return tr
+
+
+# ---------------------------------------------------------------------------
+# Config gate
+# ---------------------------------------------------------------------------
+
+
+def tool_dedup_enabled() -> bool:
+    """Whether the tool-call dedup tracker is active.
+
+    Default **ON** (advisory + fail-open, so it is low-risk). Escape
+    hatches (in priority order):
+
+    * ``HERMES_TOOL_DEDUP`` env var — ``0``/``false``/``no``/``off``
+      disables; any truthy value forces ON.
+    * ``tool_dedup.enabled`` in ``config.yaml`` — set ``false`` to disable
+      persistently.
+
+    Any failure resolving config -> ON (the safe default for an advisory,
+    fail-open tracker).
+    """
+    env = os.environ.get(_TOOL_DEDUP_ENV)
+    if env is not None:
+        return env.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config() or {}
+    except Exception:
+        return True
+    section = cfg.get("tool_dedup") if isinstance(cfg, dict) else None
+    if isinstance(section, dict) and "enabled" in section:
+        return bool(section.get("enabled"))
+    return True
+
+
+def _config_value(key: str, default: Any) -> Any:
+    try:
+        from hermes_cli.config import load_config as _load_config
+
+        cfg = _load_config() or {}
+    except Exception:
+        return default
+    section = cfg.get("tool_dedup") if isinstance(cfg, dict) else None
+    if isinstance(section, dict) and key in section:
+        return section.get(key)
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Key computation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_args(args: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a stable, sortable copy of *args* for dedup keying.
+
+    Strips volatile transport keys and normalizes values (recursively
+    sorts dict keys, converts non-JSON types to strings) so that
+    semantically-identical calls hash the same regardless of argument
+    ordering or incidental type differences.
+    """
+    if not isinstance(args, dict):
+        return {}
+    cleaned: Dict[str, Any] = {}
+    for k, v in args.items():
+        if k in _VOLATILE_ARG_KEYS:
+            continue
+        cleaned[k] = _normalize_value(v)
+    return cleaned
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _normalize_value(v) for k, v in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    # Fall back to a stable string for anything else (paths, enums, etc.).
+    try:
+        return str(value)
+    except Exception:
+        return "<unserializable>"
+
+
+def _dedup_key(function_name: str, args: Optional[Dict[str, Any]]) -> str:
+    """Stable hash of (tool, normalized-args) for dedup tracking."""
+    payload = json.dumps(
+        {"tool": function_name, "args": _normalize_args(args)},
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_tool_dedup(
+    function_name: str,
+    function_args: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return a hint string if *function_name*+args was recently successful.
+
+    Returns ``None`` when there is no recent successful duplicate (or when
+    the tracker is disabled / the tool is not tracked / an error occurs).
+    The returned string is advisory — the caller may append it to the tool
+    result so the model can decide whether to reuse the prior result.
+
+    Calls with no meaningful arguments (empty or all-volatile) are never
+    flagged: an empty-args call carries no reusable result, so there is
+    nothing to reuse.
+    """
+    if function_name not in _TRACKED_TOOLS:
+        return None
+    if not tool_dedup_enabled():
+        return None
+    try:
+        normalized = _normalize_args(function_args)
+        if not normalized:
+            return None
+        window = int(_config_value("recency_window", DEFAULT_CONFIG["recency_window"]))
+        key = _dedup_key(function_name, function_args)
+        tr = _tracker_for(session_id)
+        dist = tr.recent(key, window)
+        if dist is None:
+            return None
+        return (
+            f"[dedup] You already called {function_name} with these arguments "
+            f"{dist} tool-call(s) ago and it succeeded. Reuse that result "
+            "instead of calling it again unless the underlying data may have "
+            "changed."
+        )
+    except Exception as exc:  # fail-open
+        logger.debug("tool_dedup check error: %s", exc)
+        return None
+
+
+def record_tool_call(
+    function_name: str,
+    function_args: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
+    success: bool = True,
+) -> None:
+    """Record a tool call for dedup tracking.
+
+    *success=True* records the (tool, args) key so a later identical call
+    is flagged. *success=False* only advances the recency counter (a failed
+    call must not be treated as "already done"). Non-tracked tools only
+    advance the counter so the recency window measures distinct calls.
+    """
+    if not tool_dedup_enabled():
+        return
+    try:
+        tr = _tracker_for(session_id)
+        if function_name in _TRACKED_TOOLS:
+            if success:
+                max_entries = int(
+                    _config_value(
+                        "max_entries_per_session",
+                        DEFAULT_CONFIG["max_entries_per_session"],
+                    )
+                )
+                tr.record(_dedup_key(function_name, function_args), max_entries)
+            else:
+                tr.tick()
+        else:
+            tr.tick()
+    except Exception as exc:  # fail-open
+        logger.debug("tool_dedup record error: %s", exc)
+
+
+def reset_tool_dedup(session_id: Optional[str] = None) -> None:
+    """Clear dedup state for a session (or all sessions when *None*).
+
+    Called after context compression — the prior result has been summarised
+    away, so the model legitimately needs to re-read/re-search.
+    """
+    try:
+        if session_id is None:
+            with _REGISTRY_LOCK:
+                for tr in _REGISTRY.values():
+                    tr.clear()
+        else:
+            _tracker_for(session_id).clear()
+    except Exception as exc:  # fail-open
+        logger.debug("tool_dedup reset error: %s", exc)
+
+
+__all__ = [
+    "DEFAULT_CONFIG",
+    "check_tool_dedup",
+    "record_tool_call",
+    "reset_tool_dedup",
+    "tool_dedup_enabled",
+]

--- a/model_tools.py
+++ b/model_tools.py
@@ -1875,6 +1875,46 @@ def handle_function_call(
             middleware_trace=list(_tool_middleware_trace),
         )
 
+        # Tool-call dedup tracker (When2Tool, #2282): record this call's
+        # outcome and, if it is a repeat of a recently-successful call,
+        # append an advisory hint so the model can reuse the prior result
+        # instead of re-running the tool. Fail-open and cache-safe — it
+        # only appends to the result string, never mutates the system
+        # prompt or message roles.
+        try:
+            from agent.tool_dedup import check_tool_dedup, record_tool_call
+
+            # Derive success from the *raw* result BEFORE appending any
+            # hint, so an error result is never misclassified as "ok".
+            _dedup_status, _, _ = _tool_result_observer_fields(result)
+            # Check for a duplicate of a *prior* successful call BEFORE
+            # recording this one, so the current call never flags itself.
+            _dedup_hint = check_tool_dedup(
+                function_name, function_args, session_id=session_id
+            )
+            if _dedup_hint and isinstance(result, str):
+                # Embed the hint inside the JSON result dict (following the
+                # `_warning` key pattern in file_tools.py) so downstream
+                # consumers that call json.loads(result) still see valid
+                # JSON.  Fall back to raw append for non-JSON results.
+                try:
+                    _parsed = json.loads(result)
+                    if isinstance(_parsed, dict):
+                        _parsed["_dedup_hint"] = _dedup_hint
+                        result = json.dumps(_parsed, ensure_ascii=False)
+                    else:
+                        result = result + "\n" + _dedup_hint
+                except (json.JSONDecodeError, TypeError):
+                    result = result + "\n" + _dedup_hint
+            record_tool_call(
+                function_name,
+                function_args,
+                session_id=session_id,
+                success=(_dedup_status == "ok"),
+            )
+        except Exception as _dedup_err:
+            logger.debug("tool_dedup wiring error: %s", _dedup_err)
+
         # Source-chain provenance (#2192): record tool-call sources during
         # background-review forks so the skill's origin chain is traceable.
         try:

--- a/tests/agent/test_tool_dedup.py
+++ b/tests/agent/test_tool_dedup.py
@@ -1,0 +1,152 @@
+"""Tests for agent.tool_dedup — the When2Tool tool-call dedup tracker (#2282)."""
+
+import pytest
+
+from agent.tool_dedup import (
+    DEFAULT_CONFIG,
+    check_tool_dedup,
+    record_tool_call,
+    reset_tool_dedup,
+    tool_dedup_enabled,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset the process-global registry between tests."""
+    reset_tool_dedup(None)
+    yield
+    reset_tool_dedup(None)
+
+
+# ── Config gate ──────────────────────────────────────────────────────────
+
+
+def test_enabled_by_default(monkeypatch):
+    """No env var and no config section -> ON (advisory, fail-open)."""
+    monkeypatch.delenv("HERMES_TOOL_DEDUP", raising=False)
+    assert tool_dedup_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "FALSE"])
+def test_env_disables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_TOOL_DEDUP", val)
+    assert tool_dedup_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_env_enables(monkeypatch, val):
+    monkeypatch.setenv("HERMES_TOOL_DEDUP", val)
+    assert tool_dedup_enabled() is True
+
+
+def test_config_disables_when_env_absent(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_DEDUP", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"tool_dedup": {"enabled": False}},
+    )
+    assert tool_dedup_enabled() is False
+
+
+def test_config_load_error_defaults_on(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_DEDUP", raising=False)
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    assert tool_dedup_enabled() is True
+
+
+# ── Core dedup behavior ──────────────────────────────────────────────────
+
+
+def test_no_hint_on_first_call():
+    """A first call is never flagged as a duplicate."""
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is None
+
+
+def test_hint_on_immediate_repeat():
+    """A repeat of a recently-successful call returns a hint."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    hint = check_tool_dedup("read_file", {"path": "/tmp/a.py"})
+    assert hint is not None
+    assert "read_file" in hint
+    assert "Reuse that result" in hint
+
+
+def test_no_hint_after_failed_call():
+    """A failed call must not be treated as 'already done'."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=False)
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is None
+
+
+def test_no_hint_for_different_args():
+    """Different arguments are not a duplicate."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    assert check_tool_dedup("read_file", {"path": "/tmp/b.py"}) is None
+
+
+def test_no_hint_for_different_tool():
+    """Different tool with same args is not a duplicate."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    assert check_tool_dedup("search_files", {"path": "/tmp/a.py"}) is None
+
+
+def test_arg_order_insensitive():
+    """Semantically-identical calls hash the same regardless of arg order."""
+    record_tool_call("search_files", {"path": "/tmp", "pattern": "foo"}, success=True)
+    hint = check_tool_dedup("search_files", {"pattern": "foo", "path": "/tmp"})
+    assert hint is not None
+
+
+def test_volatile_args_stripped():
+    """Transport keys (task_id/session_id) do not break dedup identity."""
+    record_tool_call(
+        "read_file",
+        {"path": "/tmp/a.py", "task_id": "t1", "session_id": "s1"},
+        success=True,
+    )
+    hint = check_tool_dedup(
+        "read_file",
+        {"path": "/tmp/a.py", "task_id": "t2", "session_id": "s2"},
+    )
+    assert hint is not None
+
+
+def test_session_isolation():
+    """One session's calls never leak into another."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, session_id="sess-a", success=True)
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}, session_id="sess-b") is None
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}, session_id="sess-a") is not None
+
+
+def test_untracked_tool_never_hints():
+    """Tools outside the tracked set are never flagged."""
+    record_tool_call("terminal", {"command": "ls"}, success=True)
+    assert check_tool_dedup("terminal", {"command": "ls"}) is None
+
+
+def test_recency_window_expires():
+    """A repeat beyond the recency window is not flagged."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    # Advance the counter past the default window (20) with other calls.
+    for _ in range(DEFAULT_CONFIG["recency_window"] + 1):
+        record_tool_call("terminal", {"command": "echo x"}, success=True)
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is None
+
+
+def test_reset_clears_hints():
+    """reset_tool_dedup clears state so a re-read is legitimate."""
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is not None
+    reset_tool_dedup("default")
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is None
+
+
+def test_disabled_tracker_never_hints(monkeypatch):
+    """When disabled, no hint is produced and nothing is recorded."""
+    monkeypatch.setenv("HERMES_TOOL_DEDUP", "0")
+    record_tool_call("read_file", {"path": "/tmp/a.py"}, success=True)
+    assert check_tool_dedup("read_file", {"path": "/tmp/a.py"}) is None

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -30,6 +30,21 @@ def _disable_arg_contract_for_dispatch_tests(monkeypatch):
     monkeypatch.setenv("HERMES_TOOL_ARG_CONTRACT", "0")
 
 
+# The tool-call dedup tracker (#2282) keeps a process-global per-session
+# registry. Many dispatch tests here call the same tool+args (e.g.
+# ``web_search {"q": "test"}``) with no session_id, so they share the
+# "default" session and a prior test's recorded call would surface a
+# ``_dedup_hint`` in a later test's exact-match assertion. Reset the
+# registry before each test so the tracker never leaks across tests.
+@pytest.fixture(autouse=True)
+def _reset_tool_dedup_registry():
+    from agent.tool_dedup import reset_tool_dedup
+
+    reset_tool_dedup(None)
+    yield
+    reset_tool_dedup(None)
+
+
 # =========================================================================
 # handle_function_call
 # =========================================================================


### PR DESCRIPTION
## Summary
Implements the cache-safe, prompt-free slice of the **When2Tool** proposal (#2282): a per-session tracker that records successful read/search/web tool calls and surfaces an advisory hint when the model re-issues the same tool+arguments combination that already succeeded.

## What's included
- **`agent/tool_dedup.py`** (new): session-scoped, thread-safe, bounded (LRU-ish) tracker. Fail-open (never blocks a call), success-only (a failed call is never treated as done), arg-order-insensitive, volatile transport keys (`task_id`/`session_id`/`tool_call_id`/`turn_id`) stripped. Config-gated via `tool_dedup.enabled` (default ON) or `HERMES_TOOL_DEDUP` env var.
- **`model_tools.py`**: wired `check_tool_dedup` + `record_tool_call` into `handle_function_call` after the `post_tool_call` hook. The hint is embedded as a `_dedup_hint` key inside the JSON result dict (following the existing `_warning` pattern in `file_tools.py`) so downstream `json.loads(result)` consumers stay valid.
- **`agent/conversation_compression.py`**: resets the tracker on context compression (both the standard and codex-app-server paths) so a post-compression re-read/re-search is legitimate and not flagged.
- **Tests**: 24 unit tests for the tracker (`tests/agent/test_tool_dedup.py`) + an autouse registry reset in `test_model_tools.py` to prevent cross-test leakage.

## Design decisions (aligned with AGENTS.md)
- **Cache-safe**: the tracker only appends to the tool result string; it never mutates the system prompt, never injects a synthetic user message, and never alters message-role alternation.
- **Fail-open**: any error resolving config/args/state yields *no hint* — the tracker can never block a legitimate call.
- **Session-scoped**: subagents, kanban workers, and gateway sessions stay isolated.
- **Deliberately NOT implemented**: the prompt-based pre-call self-check (would break prompt caching / message-role alternation) and the hidden-state linear probe (requires local open-weight model access, which Hermes' closed-model API path doesn't have).

## Verification
- `tests/agent/test_tool_dedup.py`: 24 passed
- `tests/test_model_tools.py`, `tests/agent/test_tool_arg_contract.py`, `tests/agent/test_tool_error_recovery.py`, `tests/agent/test_exec_evidence.py`, `tests/agent/test_loop_guard.py`, `tests/tools/test_file_read_guards.py`: all pass (278 total)

Closes #2282