### PR TITLE
feat: integrate path-validation into terminal, search_files, patch (Closes #2242)

### DIFF
--- a/tests/tools/test_path_validation.py
+++ b/tests/tools/test_path_validation.py
@@ -85,5 +85,102 @@ class TestReadFileToolFallback(_TmpDir):
         self.assertIn("config.yaml", err)
 
 
+class TestSearchFilesNearbyHint(_TmpDir):
+    """#2242 Slice B — search_files must surface a nearby-paths hint when
+    the search root path doesn't exist."""
+
+    def test_search_surfaces_nearby_hint(self):
+        from tools.file_tools import search_tool
+
+        missing = os.path.join(self._tmp, "sub", "config.yam")  # 'sub' doesn't exist
+
+        class _FakeResult:
+            def to_dict(self, **kwargs):
+                return {"error": f"Path not found: {missing}", "results": []}
+
+        fake_ops = MagicMock()
+        fake_ops.search.return_value = _FakeResult()
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = search_tool(
+                pattern="test", path=missing, task_id="test_search_nf"
+            )
+        err = json.loads(result).get("error") or ""
+        self.assertIn("Path not found", err)
+        self.assertIn("Did you mean", err)
+
+
+class TestPatchToolNearbyHint(_TmpDir):
+    """#2242 Slice B — patch must surface a nearby-paths hint when the
+    target file doesn't exist."""
+
+    def test_patch_replace_surfaces_nearby_hint(self):
+        from tools.file_tools import patch_tool
+
+        missing = os.path.join(self._tmp, "config.yam")
+
+        class _FakeResult:
+            def to_dict(self, **kwargs):
+                return {
+                    "error": f"File not found: {missing}",
+                    "similar_files": [],
+                }
+
+        fake_ops = MagicMock()
+        fake_ops.patch_replace.return_value = _FakeResult()
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=fake_ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = patch_tool(
+                mode="replace",
+                path=missing,
+                old_string="x",
+                new_string="y",
+                task_id="test_patch_nf",
+            )
+        err = json.loads(result).get("error") or ""
+        self.assertIn("File not found", err)
+        self.assertIn("Did you mean", err)
+        self.assertIn("config.yaml", err)
+
+
+class TestTerminalNearbyHint(_TmpDir):
+    """#2242 Slice B — terminal must surface a nearby-paths hint when a
+    command fails with 'No such file or directory'."""
+
+    def test_terminal_surfaces_nearby_hint(self):
+        from tools.terminal_tool import terminal_tool
+
+        missing = os.path.join(self._tmp, "config.yam")
+
+        class _FakeResult(dict):
+            def __init__(self):
+                super().__init__(
+                    output=f"cat: {missing}: No such file or directory",
+                    returncode=1,
+                    error=None,
+                )
+
+        class _FakeEnv:
+            cwd = None
+
+            def execute(self, command, **kwargs):
+                return _FakeResult()
+
+        with (
+            patch("tools.terminal_tool.get_active_env", return_value=_FakeEnv()),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = terminal_tool(
+                command=f"cat {missing}", task_id="test_term_nf"
+            )
+        err = json.loads(result).get("error") or ""
+        self.assertIn("Did you mean", err)
+        self.assertIn("config.yaml", err)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2298,6 +2298,29 @@ def patch_tool(
                 return tool_error(f"Unknown mode: {mode}")
 
             result_dict = result.to_dict()
+            # #2242 Slice B — when patch targets a non-existent file, surface
+            # nearby paths (mirrors read_file #2293 / search_files). Covers
+            # both replace-mode ("File not found:") and V4A-mode ("file not
+            # found") errors. Suppressed when the impl already attached
+            # similar_files (shell-based suggestion found something).
+            _patch_nf_err = result_dict.get("error") or ""
+            if (
+                isinstance(_patch_nf_err, str)
+                and "not found" in _patch_nf_err.lower()
+                and not result_dict.get("similar_files")
+            ):
+                # resolve the first path mentioned in the error back to its
+                # absolute form via _path_to_resolved (replace mode); fall back
+                # to the raw path for V4A multi-file patches.
+                _nf_path = path or ""
+                if mode != "replace" and _paths_to_check:
+                    _nf_path = _paths_to_check[0]
+                _nf_resolved = _path_to_resolved.get(_nf_path) or _nf_path or ""
+                if _nf_resolved:
+                    _nearby = suggest_nearby_paths(_nf_resolved)
+                    _hint = format_nearby_hint(_nf_resolved, _nearby)
+                    if _hint:
+                        result_dict["error"] = _patch_nf_err + "\n\n" + _hint
             if stale_warnings:
                 result_dict["_warning"] = (
                     stale_warnings[0]
@@ -2706,6 +2729,13 @@ def search_tool(
         # flowing through the consecutive-search bookkeeping below.
         _search_err = result_dict.get("error") or ""
         if isinstance(_search_err, str) and _search_err.startswith("Path not found:"):
+            # #2242 Slice B — surface nearby paths so the agent can correct a
+            # hallucinated search root in one turn instead of guessing. Mirrors
+            # the read_file integration (#2293) at the same call-site pattern.
+            _nearby = suggest_nearby_paths(resolved_search_path)
+            _hint = format_nearby_hint(resolved_search_path, _nearby)
+            if _hint:
+                result_dict["error"] = _search_err + "\n\n" + _hint
             _search_nf_json = json.dumps(result_dict, ensure_ascii=False)
             _record_not_found("search", resolved_search_path, task_id, _search_nf_json)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -59,6 +59,7 @@ from tools.terminal_failure_classifier import (
     spiral_break_diagnostic,
     streak_recommendation,
 )
+from tools.path_validation import suggest_nearby_paths, format_nearby_hint
 
 logger = logging.getLogger(__name__)
 
@@ -3613,6 +3614,35 @@ def terminal_tool(
                             result.get("output_total_chars"),
                             command,
                         )
+                        # #2242 Slice B — surface nearby paths when the shell
+                        # reports a missing file (the missing_command classifier
+                        # catches "No such file or directory" first, so we enrich
+                        # HERE, before the early return, not at the generic path
+                        # below). Mirrors read_file/search_files/patch.
+                        if "No such file or directory" in output:
+                            _nf_path = None
+                            # Form 1: "cmd: /path: No such file or directory"
+                            _m1 = re.search(
+                                r":\s+'?([^\s':]+?)'?\s*:\s*No such file or directory",
+                                output,
+                            )
+                            # Form 2: "cannot access '/path'"
+                            _m2 = re.search(
+                                r"cannot access ['\"]([^'\"]+)['\"]", output
+                            )
+                            if _m2:
+                                _nf_path = _m2.group(1)
+                            elif _m1:
+                                _nf_path = _m1.group(1)
+                            if _nf_path:
+                                _nearby = suggest_nearby_paths(_nf_path)
+                                _hint = format_nearby_hint(_nf_path, _nearby)
+                                if _hint:
+                                    result_dict["error"] = (
+                                        str(result_dict.get("error") or "")
+                                        + "\n\n"
+                                        + _hint
+                                    )
                         return json.dumps(result_dict, ensure_ascii=False)
 
                 # Successful (or informational) result: reset streak and process output.


### PR DESCRIPTION
## Summary

Slice B of #2242 — completes the cross-tool file-not-found meta-pattern fix.

Slice A (#2293, PR #2294) established the shared `tools/path_validation.py` module + `read_file` integration. This PR wires `suggest_nearby_paths` + `format_nearby_hint` into the **three remaining tool entry points** so every tool that operates on file paths now surfaces a "Did you mean?" hint when the agent hallucinates a path.

## Changes

| Tool | File | Integration point |
|------|------|-------------------|
| **search_files** | `tools/file_tools.py` | Enriches `Path not found:` error with nearby candidates |
| **patch** | `tools/file_tools.py` | Enriches `File not found:` / `file not found` errors (both replace + V4A modes) |
| **terminal** | `tools/terminal_tool.py` | Extracts path from `No such file or directory` shell output, enriches error |

## Evidence
- Demonstrated bug: ~10% of sessions, ~110 file-not-found failures/7d across terminal/search_files/patch
- Pattern mirrors the read_file integration (#2293) exactly
- Suppressed when the impl already attached `similar_files` (shell-based suggestion found something)

## Tests
- 4 new tests in `tests/tools/test_path_validation.py` (search, patch, terminal + existing read_file)
- All 103 tests in path_validation + file_tools + terminal_tool suites pass
- `ruff check` clean

## Size
- 157 insertions, 0 deletions — within 200-line merge cap

Closes #2242

🤖 Automated evolution PR