### PR TITLE
fix: enforce terminal retry_spiral as non-retryable (Closes #2302)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -128,7 +128,7 @@ _NON_RETRYABLE_BY_TOOL: dict[str, frozenset[str]] = {
     # taxonomy which classifies them as parse_error.  Without this entry the
     # loop_guard fires one cycle later (at the generic fail threshold instead
     # of the non-retryable threshold of 2), allowing extra spiral iterations.
-    "terminal": frozenset({"parse_error"}),
+    "terminal": frozenset({"parse_error", "retry_spiral"}),
     # #1944 — search_files regex/glob parse errors: the same invalid pattern
     # will fail identically on every retry. tool_diagnostics now classifies
     # rg/grep pattern-rejection messages as parse_error (previously they fell

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -80,6 +80,29 @@ _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
         "Fix the pattern syntax, or use search_files with target='files' for glob patterns.",
     ),
     (
+        # #2302 — terminal retry-spiral diagnostic. When terminal_tool detects
+        # the SAME command failing identically N times in a row, it escalates
+        # the result to a ``retry_spiral`` diagnostic (spiral_break_diagnostic).
+        # That diagnostic message contains the word "failed" which would
+        # otherwise match the runtime_error catch-all (line ~164) — classifying
+        # it as retryable ``runtime_error``. But a retry spiral is the MOST
+        # deterministic failure class there is: the same command WILL fail
+        # identically again. Match the diagnostic's signature text and classify
+        # as ``retry_spiral`` so loop_guard can enforce it as non-retryable
+        # (via ``_NON_RETRYABLE_BY_TOOL["terminal"]``). Must run BEFORE the
+        # runtime_error catch-all.
+        re.compile(
+            r"\bretry spiral detected\b",
+            re.I,
+        ),
+        "retry_spiral",
+        "This command has failed identically multiple times in a row — it is "
+        "deterministic and retrying it unchanged WILL fail again. Stop retrying: "
+        "read the error, fix the root cause, change the command or its arguments, "
+        "or switch to a different tool (read_file, execute_code, process, "
+        "web_search). Do NOT retry the same command.",
+    ),
+    (
         # #2168 — tool-level refusal: the tool or backend actively refused
         # the request (HTTP 403, access blocked, refused, rejected). Distinct
         # from ``permission`` (filesystem OS-level denial): a refusal is the

--- a/tests/agent/test_loop_guard_per_tool_nonretryable.py
+++ b/tests/agent/test_loop_guard_per_tool_nonretryable.py
@@ -114,6 +114,37 @@ class TestSearchFilesNoResultStaysRetryable:
         assert n is not None and "non-retryable" not in n
 
 
+class TestTerminalRetrySpiralNonRetryable:
+    """#2302 — terminal retry_spiral must be enforced as non-retryable.
+
+    When terminal_tool escalates an identical-failure spiral, it sets
+    ``failure_class = "retry_spiral"`` in the result JSON and replaces the
+    error text with a "Retry spiral detected: ..." diagnostic. tool_diagnostics
+    classifies that text as ``retry_spiral``, and loop_guard must treat it as
+    non-retryable so the guard fires at the 2-call threshold instead of the
+    much-higher generic fail threshold (observed: 67 consecutive retries).
+    """
+
+    _SPIRAL_MSG = (
+        "Retry spiral detected: this exact command has failed identically "
+        "4 times in a row (threshold 3). It is failing deterministically — "
+        "running it again unchanged will produce the same failure."
+    )
+
+    def test_is_non_retryable(self):
+        assert _is_non_retryable("terminal", "retry_spiral")
+
+    def test_two_spiral_results_trip_hard_stop(self):
+        n = maybe_nudge(_fail_run("terminal", 2, self._SPIRAL_MSG))
+        assert n is not None and "non-retryable" in n and "retry_spiral" in n
+
+    def test_two_spiral_results_warrant_cron_hard_stop(self):
+        assert run_warrants_cron_hard_stop(_fail_run("terminal", 2, self._SPIRAL_MSG))
+
+    def test_single_spiral_is_quiet(self):
+        assert maybe_nudge(_fail_run("terminal", 1, self._SPIRAL_MSG)) is None
+
+
 class TestGlobalClassesStillApplyToPerToolTools:
     def test_read_file_permission_trips_non_retryable(self):
         n = maybe_nudge(_fail_run("read_file", 2, "permission denied"))

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -47,6 +47,18 @@ class TestClassify:
         )
         assert classify("process exited, exit code: 1")[0] == "runtime_error"
 
+    def test_retry_spiral_diagnostic_classified_correctly(self):
+        """#2302 — the spiral-break diagnostic must classify as ``retry_spiral``,
+        NOT ``runtime_error`` (the message contains "failed" which would
+        otherwise match the runtime_error catch-all)."""
+        msg = (
+            "Retry spiral detected: this exact command has failed identically "
+            "4 times in a row (threshold 3). It is failing deterministically."
+        )
+        cat, hint = classify(msg)
+        assert cat == "retry_spiral"
+        assert "deterministic" in hint.lower()
+
 
 class TestInlineDiagnosticsEnabled:
     def test_default_off_with_empty_config(self, monkeypatch):


### PR DESCRIPTION
## Summary

The terminal retry-spiral diagnostic was emitted but never enforced — the 8th documented recurrence of this defect class (67 consecutive retries in a single session, 662 failures/7d).

## Root Cause

`terminal_tool.py` (line 3594) sets `failure_class = "retry_spiral"` when the identical-failure budget is exceeded, and replaces the error text with the `spiral_break_diagnostic()` message. But `loop_guard` determines the failure category via `tool_diagnostics.classify()`, which is a **regex heuristic over the result text** — it does not read the `failure_class` JSON field. The spiral diagnostic message contains the word "failed", which matched the `runtime_error` catch-all rule (a retryable class). So `loop_guard` counted each spiral iteration as an ordinary retryable failure and waited for the much-higher generic fail threshold to fire — allowing 67 consecutive retries.

## Fix (3 parts, 68 lines)

| File | Change |
|------|--------|
| `agent/tool_diagnostics.py` | Add `"retry_spiral"` classification rule matching the spiral diagnostic signature (`"Retry spiral detected"`), placed BEFORE the `runtime_error` catch-all so the word "failed" no longer misclassifies it as retryable |
| `agent/loop_guard.py` | Add `"retry_spiral"` to `_NON_RETRYABLE_BY_TOOL["terminal"]` so the guard fires at the 2-call non-retryable threshold |
| `tests/agent/test_tool_diagnostics.py` + `tests/agent/test_loop_guard_per_tool_nonretryable.py` | Coverage for the new classification + enforcement |

## Validation

- `ruff check` ✓ (all 4 files)
- `ruff format --check` ✓ (my files; pre-existing format debt in `loop_guard.py` line 92 is on `origin/main` and unchanged)
- Targeted tests: 164 passed (`test_loop_guard.py` + `test_tool_diagnostics.py` + `test_loop_guard_per_tool_nonretryable.py`)
- Existing spiral tests: 117 passed (`test_terminal_retry_spiral.py` + `test_loop_guard.py`)
- Landability: 68 changed lines (well under 200-line cap)

Closes #2302