### PR TITLE
fix: terminal retry spiral — record error-indicating results as breaker failures (#2302)

### DIFF
--- a/agent/tool_error_recovery.py
+++ b/agent/tool_error_recovery.py
@@ -19,6 +19,7 @@ loop's semantics and risk cache-breaking mid-conversation.
 from __future__ import annotations
 
 import enum
+import json
 import logging
 import re
 from dataclasses import dataclass, field
@@ -434,3 +435,34 @@ def record_tool_outcome(tool_name: str, success: bool) -> None:
         breaker.record_success()
     else:
         breaker.record_failure()
+
+
+def result_indicates_failure(result: object) -> bool:
+    """Return True when a tool result string signals a failed call.
+
+    Some tools (notably ``terminal``) return a normal JSON result with an
+    error indicator (``exit_code != 0``, ``status: "error"``, or an
+    ``error`` field) instead of raising an exception. Callers that record
+    circuit-breaker outcomes must treat these as failures — otherwise the
+    breaker resets to 0 on every call and never trips, letting a retry
+    spiral run unchecked (#2302, 8th recurrence).
+
+    Non-JSON results and JSON that is not a dict are treated as success
+    (no error indicator present). Fail-open: any parse error returns False.
+    """
+    if not isinstance(result, str):
+        return False
+    try:
+        parsed = json.loads(result)
+    except Exception:
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    exit_code = parsed.get("exit_code")
+    if isinstance(exit_code, int) and exit_code != 0:
+        return True
+    if parsed.get("status") == "error":
+        return True
+    if parsed.get("error"):
+        return True
+    return False

--- a/model_tools.py
+++ b/model_tools.py
@@ -1976,11 +1976,24 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
-        # Record successful tool outcome for circuit-breaker tracking.
+        # Record tool outcome for circuit-breaker tracking.
+        #
+        # A tool that returns a normal JSON result is NOT necessarily a
+        # success: `terminal` returns exit_code != 0 (and `status: "error"`)
+        # for failed commands without raising, so it lands on this path and
+        # would otherwise reset the breaker to 0 every call — the breaker
+        # never accumulates consecutive failures and the retry spiral runs
+        # unchecked (#2302, 8th recurrence). Inspect the result for error
+        # indicators and record a failure when present.
         try:
-            from agent.tool_error_recovery import record_tool_outcome
+            from agent.tool_error_recovery import (
+                record_tool_outcome,
+                result_indicates_failure,
+            )
 
-            record_tool_outcome(function_name, success=True)
+            record_tool_outcome(
+                function_name, success=not result_indicates_failure(result)
+            )
         except Exception:
             pass
 

--- a/tests/agent/test_tool_circuit_breaker_gate.py
+++ b/tests/agent/test_tool_circuit_breaker_gate.py
@@ -15,6 +15,7 @@ from agent.tool_error_recovery import (
     CircuitBreaker,
     get_breaker,
     record_tool_outcome,
+    result_indicates_failure,
 )
 from tools.registry import registry
 
@@ -97,3 +98,64 @@ def test_circuit_breaker_threshold_configurable():
     assert not b.should_trip()
     b.record_failure()
     assert b.should_trip()
+
+
+# ── result_indicates_failure (#2302) ────────────────────────────────────
+
+
+def test_result_indicates_failure_terminal_exit_code():
+    """A terminal result with exit_code != 0 is a failure."""
+    assert result_indicates_failure(
+        json.dumps({"output": "boom", "exit_code": 1, "status": "error"})
+    )
+
+
+def test_result_indicates_failure_status_error():
+    """A result with status 'error' is a failure even without exit_code."""
+    assert result_indicates_failure(json.dumps({"output": "", "status": "error"}))
+
+
+def test_result_indicates_failure_error_field():
+    """A result with an error field is a failure."""
+    assert result_indicates_failure(json.dumps({"error": "command not found"}))
+
+
+def test_result_indicates_failure_success_exit_zero():
+    """exit_code == 0 and no error field is a success."""
+    assert not result_indicates_failure(
+        json.dumps({"output": "ok", "exit_code": 0, "status": "success"})
+    )
+
+
+def test_result_indicates_failure_non_json_is_success():
+    """Non-JSON results are treated as success (fail-open)."""
+    assert not result_indicates_failure("plain text output")
+    assert not result_indicates_failure(None)
+    assert not result_indicates_failure(123)
+
+
+def test_result_indicates_failure_non_dict_json_is_success():
+    """JSON that is not a dict has no error indicator."""
+    assert not result_indicates_failure(json.dumps(["a", "b"]))
+    assert not result_indicates_failure(json.dumps("just a string"))
+
+
+def test_result_indicates_failure_malformed_json_is_success():
+    """Malformed JSON is treated as success (fail-open)."""
+    assert not result_indicates_failure("{not valid json")
+
+
+def test_terminal_failure_accumulates_breaker():
+    """A terminal failure result must accumulate the breaker, not reset it.
+
+    Regression for #2302: previously the success path recorded success=True
+    unconditionally, so a terminal command returning exit_code != 0 reset
+    the breaker to 0 every call and the retry spiral never tripped.
+    """
+    for _ in range(5):
+        record_tool_outcome(
+            "terminal", success=not result_indicates_failure(
+                json.dumps({"output": "err", "exit_code": 1, "status": "error"})
+            )
+        )
+    assert get_breaker("terminal").should_trip()


### PR DESCRIPTION
Fixes #2302 (8th recurrence of the terminal retry spiral).

**Root cause:** `terminal` returns a normal JSON result with `exit_code != 0` (and `status: "error"`) for failed commands instead of raising an exception. It therefore landed on the `handle_function_call` success path, which called `record_tool_outcome(success=True)` unconditionally — resetting the circuit breaker to 0 on every call. The breaker never accumulated consecutive failures, never tripped, and the spiral ran unchecked to 67-deep.

**Fix:** Extract `result_indicates_failure()` into `agent/tool_error_recovery.py` and use it in `model_tools.py` so error-indicating JSON results are recorded as breaker failures. Add unit tests covering exit_code/status/error-field detection, fail-open on non-JSON/malformed, and a regression test proving terminal failures accumulate the breaker.

**Tests:** `scripts/run_tests.sh tests/agent/test_tool_circuit_breaker_gate.py` (15✓) and `tests/agent/test_tool_error_recovery.py` (25✓).