### PR TITLE
fix: catch ValueError on null-byte paths in lifecycle_guard (Closes #2303)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: "embedded null character in path" — os.open() raises
+        # ValueError (not OSError) when the path contains a null byte. This
+        # mirrors the (OSError, ValueError) pattern already used at the
+        # script_path.resolve() call site (#2303).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -705,6 +705,25 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_read_referenced_script_null_byte_path(self):
+        """#2303: os.open() on a path with an embedded null byte raises
+        ValueError (not OSError). Before the fix, _read_referenced_script
+        only caught OSError, so the ValueError propagated and crashed the
+        terminal tool (~55 min wasted across 7 occurrences).
+
+        Now ValueError is caught alongside OSError, returning (None, False)
+        — treating a null-byte path as "nothing to scan", same as a missing
+        or unreadable file.
+        """
+        from pathlib import Path
+
+        from cron.lifecycle_guard import _read_referenced_script
+
+        # A path containing an embedded NUL byte — os.open() raises
+        # ValueError: embedded null character in path
+        result = _read_referenced_script(Path("evil\x00path.sh"))
+        assert result == (None, False)
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path


### PR DESCRIPTION
## Summary

`_read_referenced_script` in `cron/lifecycle_guard.py` called `os.open(path, flags)` inside a `try/except OSError` block. When `path` contains an embedded null byte, `os.open()` raises **`ValueError`** (not `OSError`), which propagated uncaught and crashed the terminal tool.

**Evidence:** 7 occurrences across 3 sessions (~55 minutes wasted). Stack traces from `errors.log`:
```
File "cron/lifecycle_guard.py", line 260, in _read_referenced_script
    descriptor = os.open(path, flags)
ValueError: open: embedded null character in path
```

## Fix

One-line fix: change `except OSError` to `except (OSError, ValueError)` at line 261. This mirrors the existing `(OSError, ValueError)` pattern already used at the `script_path.resolve()` call site (line 316) and at the binary-content detection (line 281).

## Files Changed
- `cron/lifecycle_guard.py` — 1-line fix + 4-line comment (lines 261-265)
- `tests/hermes_cli/test_gateway_restart_loop.py` — new test `test_read_referenced_script_null_byte_path`

## Validation
- ✅ Targeted test: `test_read_referenced_script_null_byte_path` passes
- ✅ Full lifecycle guard test suite: 83 passed
- ✅ `ruff check` clean
- ✅ Diff: 24 insertions, 1 deletion (well under 200-line merge cap)

Closes #2303