### PR TITLE
fix(tool_describe): decompose opaque 'other' errors into structured reasons (#2309)

### DIFF
--- a/tests/tools/test_tool_describe_fuzzy.py
+++ b/tests/tools/test_tool_describe_fuzzy.py
@@ -133,3 +133,82 @@ class TestDispatchToolDescribeFuzzy:
         )
         assert "error" in result
         assert "required" in result["error"]
+
+
+class TestDispatchToolDescribeStructuredReasons:
+    """#2309 — tool_describe 'other' errors carry a structured reason +
+    recovery directive so the agent gets a concrete path instead of an
+    opaque error (mirrors the tool_call #2245 / patch #2244 treatment)."""
+
+    @patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+    def test_typo_error_has_reason_and_recovery(self, _mock):
+        defs = [_make_tool_def("github_create_issue")]
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "github_create"},
+                current_tool_defs=defs,
+                config=None,
+            )
+        )
+        assert result.get("reason") == "not_available"
+        assert "recovery" in result
+        assert "tool_search" in result["recovery"].lower()
+
+    def test_non_deferrable_error_has_reason_and_recovery(self):
+        defs = [_make_tool_def("mcp_search_web")]
+        with patch(
+            "tools.tool_search.is_deferrable_tool_name",
+            side_effect=lambda name, config=None: name == "mcp_search_web",
+        ):
+            result = json.loads(
+                dispatch_tool_describe(
+                    {"name": "mcp_search"},
+                    current_tool_defs=defs,
+                    config=None,
+                )
+            )
+            assert result.get("reason") == "not_deferrable"
+            assert "recovery" in result
+            assert "tool_search" in result["recovery"].lower()
+
+    def test_completely_wrong_name_has_reason_and_recovery(self):
+        """A completely unknown name is not deferrable, so it routes to the
+        not_deferrable branch — not not_available."""
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "zzzzzzzzzz"},
+                current_tool_defs=[_make_tool_def("web_search")],
+                config=None,
+            )
+        )
+        assert result.get("reason") == "not_deferrable"
+        assert "recovery" in result
+        assert "tool_search" in result["recovery"].lower()
+
+    @patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+    def test_deferrable_but_not_registered_has_reason_and_recovery(self, _mock):
+        """When the name IS deferrable but not in the tool list and no fuzzy
+        matches exist, it routes to not_available with no suggestions."""
+        result = json.loads(
+            dispatch_tool_describe(
+                {"name": "mcp_some_obscure_tool_xyz"},
+                current_tool_defs=[_make_tool_def("web_search")],
+                config=None,
+            )
+        )
+        assert result.get("reason") == "not_available"
+        assert "recovery" in result
+        assert "suggestions" not in result
+
+    def test_success_has_no_reason_or_recovery(self):
+        """A successful describe must NOT carry error-only fields."""
+        with patch("tools.tool_search.is_deferrable_tool_name", return_value=True):
+            result = json.loads(
+                dispatch_tool_describe(
+                    {"name": "my_tool"},
+                    current_tool_defs=[_make_tool_def("my_tool")],
+                    config=None,
+                )
+            )
+            assert "reason" not in result
+            assert "recovery" not in result

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1388,6 +1388,15 @@ def _dispatch_tool_describe_inner(
                         f"tool_describe or tool_call."
                     ),
                     "suggestions": suggestions,
+                    # #2309 — structured reason + recovery so the agent gets
+                    # a concrete path instead of an opaque "other" error.
+                    "reason": "not_deferrable",
+                    "recovery": (
+                        "This tool is not in the deferred set — it may already be in "
+                        "your active toolset (call it directly) or it may be misspelled. "
+                        "Use a suggested name with tool_describe or tool_call, or re-run "
+                        "tool_search to list available deferred tools."
+                    ),
                 },
                 ensure_ascii=False,
             )
@@ -1396,6 +1405,12 @@ def _dispatch_tool_describe_inner(
                 "error": (
                     f"'{name}' is not a deferrable tool. If you see it in the tools list "
                     "already, call it directly; otherwise check the spelling against tool_search."
+                ),
+                "reason": "not_deferrable",
+                "recovery": (
+                    "This tool is not in the deferred set. If it is in your active "
+                    "toolset, call it directly. Otherwise re-run tool_search to find "
+                    "the correct name — do NOT retry tool_describe with the same name."
                 ),
             },
             ensure_ascii=False,
@@ -1425,12 +1440,25 @@ def _dispatch_tool_describe_inner(
                     f"or tool_call."
                 ),
                 "suggestions": suggestions,
+                # #2309 — structured reason + recovery.
+                "reason": "not_available",
+                "recovery": (
+                    "The tool name is deferrable but not in the current toolset scope. "
+                    "Use a suggested name, or re-run tool_search to refresh the deferred "
+                    "catalog — do NOT retry tool_describe with the same name unchanged."
+                ),
             },
             ensure_ascii=False,
         )
     return json.dumps(
         {
             "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
+            "reason": "not_available",
+            "recovery": (
+                "The tool name is deferrable but not registered in the current session. "
+                "Re-run tool_search to refresh the deferred catalog, then use the exact "
+                "name returned — do NOT retry tool_describe with the same name."
+            ),
         },
         ensure_ascii=False,
     )


### PR DESCRIPTION
## Summary
Fixes #2309. 100 `tool_describe` failures/7d fell into the generic "other" error bucket with no structured reason or recovery guidance, so the agent couldn't tell whether to retry, re-search, or abandon the tool.

## Changes
- **`tools/tool_search.py`** — add `reason` + `recovery` keys to all four error paths in `_dispatch_tool_describe_inner`:
  - `not_deferrable`: tool not in the deferred set — call directly or re-search
  - `not_available`: deferrable but not in current scope — re-run `tool_search`
- **`tests/tools/test_tool_describe_fuzzy.py`** — 5 new tests covering each error path plus the success-has-no-error-fields boundary.

## Verification
- `scripts/run_tests.sh tests/tools/test_tool_describe_fuzzy.py -q` → 16 passed, 0 failed.
- `scripts/run_tests.sh tests/tools/test_tool_search.py -q` → 81 passed, 0 failed (no regressions).
- Mirrors the already-landed `tool_call` (#2245) and `patch` (#2244) treatment.