### PR TITLE
fix(vision_analyze): decompose opaque 'other' errors into structured reasons (#2310)

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -896,3 +896,119 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# Structured error reasons (#2310)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredErrorReasons:
+    """#2310 — vision_analyze 'other' errors carry a structured reason +
+    recovery directive so the agent can distinguish 'retry later' from
+    'this input is invalid' (mirrors tool_call #2245 / patch #2244)."""
+
+    @pytest.mark.asyncio
+    async def test_insufficient_credits_reason(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("402 Payment Required: insufficient credits"),
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+        assert result["success"] is False
+        assert result["reason"] == "insufficient_credits"
+        assert "top up" in result["recovery"].lower()
+
+    @pytest.mark.asyncio
+    async def test_vision_not_supported_reason(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("model does not support image input"),
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+        assert result["success"] is False
+        assert result["reason"] == "vision_not_supported"
+        assert "vision-capable" in result["recovery"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_image_reason(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("invalid_request: image_url is malformed"),
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+        assert result["success"] is False
+        assert result["reason"] == "invalid_image"
+        assert "JPEG/PNG" in result["recovery"]
+
+    @pytest.mark.asyncio
+    async def test_other_reason_fallback(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("some completely unexpected backend error"),
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+        assert result["success"] is False
+        assert result["reason"] == "other"
+        assert "recovery" in result
+
+    @pytest.mark.asyncio
+    async def test_success_has_no_reason(self, tmp_path):
+        """A successful analysis must NOT carry error-only fields."""
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "A test image"
+        mock_response.choices = [mock_choice]
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+        assert result["success"] is True
+        assert "reason" not in result
+        assert "recovery" not in result

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1376,9 +1376,26 @@ async def vision_analyze_tool(
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
         err_str = str(e).lower()
+        # #2310 — structured reason + fallback directive so the agent can
+        # distinguish "retry later" from "this input is invalid" instead of
+        # an opaque "other" error. Each branch sets a reason and a recovery
+        # path; the generic bucket gets a conservative fallback.
+        reason = "other"
+        recovery = (
+            "The vision backend failed with an unclassified error. Check the "
+            "underlying error text; if it looks transient (network/timeout), "
+            "retry once — otherwise the input may be invalid. Do NOT retry "
+            "the same image+question repeatedly."
+        )
         if any(hint in err_str for hint in (
             "402", "insufficient", "payment required", "credits", "billing",
         )):
+            reason = "insufficient_credits"
+            recovery = (
+                "The vision provider is out of credits or requires payment. "
+                "Top up the API provider account, then retry — do NOT retry "
+                "until the account is funded."
+            )
             analysis = (
                 "Insufficient credits or payment required. Please top up your "
                 f"API provider account and try again. Error: {e}"
@@ -1388,11 +1405,24 @@ async def vision_analyze_tool(
             "content_policy", "multimodal",
             "unrecognized request argument", "image input",
         )):
+            reason = "vision_not_supported"
+            recovery = (
+                "The configured model does not support vision input. Switch "
+                "to a vision-capable model (e.g. via auxiliary.vision.provider "
+                "in config.yaml) or use a different approach — retrying the "
+                "same model will fail identically."
+            )
             analysis = (
                 f"{model} does not support vision or our request was not "
                 f"accepted by the server. Error: {e}"
             )
         elif "invalid_request" in err_str or "image_url" in err_str:
+            reason = "invalid_image"
+            recovery = (
+                "The image was rejected by the vision API — unsupported "
+                "format, corrupted, or too large. Convert to a smaller "
+                "JPEG/PNG and retry with the corrected image."
+            )
             analysis = (
                 "The vision API rejected the image. This can happen when the "
                 "image is in an unsupported format, corrupted, or still too "
@@ -1410,6 +1440,9 @@ async def vision_analyze_tool(
             "success": False,
             "error": error_msg,
             "analysis": analysis,
+            # #2310 — structured reason + recovery directive.
+            "reason": reason,
+            "recovery": recovery,
         }
         
         debug_call_data["error"] = error_msg


### PR DESCRIPTION
## Summary
Fixes #2310. 45 `vision_analyze` failures/7d fell into the generic "other" error bucket with no structured reason or recovery guidance, so the agent couldn't distinguish "retry later" from "this input is invalid."

## Changes
- **`tools/vision_tools.py`** — add `reason` + `recovery` keys to all four error branches in the `except` block:
  - `insufficient_credits`: top up account, don't retry until funded
  - `vision_not_supported`: switch to a vision-capable model
  - `invalid_image`: convert to smaller JPEG/PNG and retry
  - `other`: check error text, retry once if transient
- **`tests/tools/test_vision_tools.py`** — 5 new tests covering each reason branch plus the success-has-no-error-fields boundary.

## Verification
- `scripts/run_tests.sh tests/tools/test_vision_tools.py -q` → 37 passed, 0 failed.
- Mirrors the already-landed `tool_call` (#2245) and `patch` (#2244) treatment.