### PR TITLE
fix(search_files): decompose parse-error into structured sub-causes (#2308)

### DIFF
--- a/tests/tools/test_search_glob_redirect.py
+++ b/tests/tools/test_search_glob_redirect.py
@@ -271,3 +271,63 @@ class TestInvalidRegexEnrichment:
                 assert "Invalid regex" not in data["error"]
         except (json.JSONDecodeError, TypeError):
             pass
+
+
+class TestStructuredRegexErrorReasons:
+    """#2308 — search_files parse errors carry a structured reason + recovery
+    directive so the agent fixes the pattern instead of blind-retrying with
+    a near-identical one (74/7d, 17-deep spirals)."""
+
+    def test_unclosed_bracket_has_invalid_regex_syntax_reason(self):
+        result = _handle_search_files(
+            {"pattern": "[unclosed", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert data.get("reason") == "invalid_regex_syntax"
+        assert "recovery" in data
+        assert "malformed" in data["recovery"].lower()
+
+    def test_unclosed_group_has_invalid_regex_syntax_reason(self):
+        result = _handle_search_files(
+            {"pattern": "(", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert data.get("reason") == "invalid_regex_syntax"
+        assert "recovery" in data
+
+    def test_glob_negation_has_glob_as_regex_reason(self):
+        """A '[!' glob negation is invalid regex — classify as glob_as_regex."""
+        result = _handle_search_files(
+            {"pattern": "[!a-z", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert data.get("reason") == "glob_as_regex"
+        assert "target='files'" in data["recovery"] or "file_glob" in data["recovery"]
+
+    def test_lookbehind_has_unsupported_feature_reason(self):
+        """A variable-width lookbehind is rejected by Python re — classify
+        as unsupported_feature (ripgrep rejects it too)."""
+        result = _handle_search_files(
+            {"pattern": r"(?<=a+)b", "target": "content"},
+            task_id="test",
+        )
+        data = json.loads(result)
+        assert data.get("reason") == "unsupported_feature"
+        assert "recovery" in data
+
+    def test_valid_regex_has_no_reason(self):
+        """A valid regex must pass through to search_tool, not hit the
+        structured-error path."""
+        result = _handle_search_files(
+            {"pattern": r"\bfoo\b", "target": "content"},
+            task_id="test",
+        )
+        try:
+            data = json.loads(result)
+            if "error" in data:
+                assert "reason" not in data
+        except (json.JSONDecodeError, TypeError):
+            pass  # non-JSON -> went through to search_tool, correct

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -3123,6 +3123,80 @@ def _glob_to_regex(glob: str) -> str:
     return "".join(out)
 
 
+def _classify_regex_error(pattern: str, exc) -> tuple:
+    """#2308 — decompose a regex compile failure into a sub-cause + recovery.
+
+    The pre-validation in ``_handle_search_files`` catches patterns that fail
+    ``re.compile`` before ripgrep ever sees them, but the returned error was
+    a single generic bucket with no sub-cause and no recovery directive —
+    so the agent blind-retried with near-identical patterns (74/7d, 17-deep
+    spirals). This classifies the ``re.error`` message into a structured
+    reason with a corrected-pattern suggestion.
+
+    Returns ``(reason, recovery)`` where ``reason`` is one of:
+      - ``invalid_regex_syntax`` — malformed regex (unclosed bracket/group,
+        bad escape, dangling quantifier)
+      - ``glob_as_regex`` — a shell glob that slipped past the auto-convert
+        guard (e.g. a ``[!...]`` negation or a pattern the heuristic missed)
+      - ``unsupported_feature`` — a regex feature ripgrep/Python rejects
+      - ``other`` — unclassified compile failure
+    """
+    if exc is None:
+        return (
+            "other",
+            "The regex failed to compile. Read the error text, fix the "
+            "pattern, and re-run — do NOT retry the same pattern unchanged.",
+        )
+    low = str(exc).lower()
+    # #2308 — glob_as_regex is checked BEFORE invalid_regex_syntax because
+    # it is more specific: a pattern containing ``[!`` (glob negation
+    # syntax, which is invalid in Python regex) is almost certainly a
+    # shell glob the model intended as a filename pattern. We key on the
+    # pattern-level signal ``[!`` rather than the error message text,
+    # because "unterminated character set" fires for ANY unclosed ``[``,
+    # including plain malformed regex like ``[unclosed`` that has no glob
+    # intent.
+    if "[!" in pattern:
+        return (
+            "glob_as_regex",
+            "This looks like a shell glob (filename pattern) passed as a "
+            "regex — the '[!' glob negation syntax is not valid regex. Use "
+            "target='files' or move it to the file_glob parameter instead of "
+            "the regex pattern.",
+        )
+    # Unclosed character class / group / dangling quantifier — the classic
+    # malformed-regex family.
+    if any(tok in low for tok in (
+        "unterminated", "unclosed", "missing ), unterminated subpattern",
+        "nothing to repeat", "multiple repeat", "unexpected end of pattern",
+        "bad escape", "invalid escape", "trailing backslash",
+    )):
+        return (
+            "invalid_regex_syntax",
+            "The regex is malformed (unclosed bracket/group, bad escape, or "
+            "dangling quantifier). Fix the syntax — e.g. close the '[' or '(' "
+            "and escape literal metacharacters with '\\'. Do NOT retry the "
+            "same malformed pattern.",
+        )
+    # Lookbehind/lookahead or other engine-specific feature rejection.
+    if any(tok in low for tok in (
+        "look-behind", "lookbehind", "fixed-width", "variable-length",
+        "not supported", "unsupported", "invalid group",
+    )):
+        return (
+            "unsupported_feature",
+            "The regex uses a feature the search engine does not support "
+            "(e.g. variable-width lookbehind). Rewrite it with a supported "
+            "construct — do NOT retry the same pattern.",
+        )
+    return (
+        "other",
+        "The regex failed to compile for an unclassified reason. Read the "
+        "error text, fix the pattern, and re-run — do NOT retry the same "
+        "pattern unchanged.",
+    )
+
+
 def _handle_search_files(args, **kw):
     tid = kw.get("task_id") or "default"
     target_map = {"grep": "content", "find": "files"}
@@ -3165,8 +3239,16 @@ def _handle_search_files(args, **kw):
         try:
             re.compile(pattern)
             compile_reason = ""
+            # Defensive default — this branch is only reached when the
+            # pattern fails _is_valid_regex, so compile always raises, but
+            # keep the classifier result bound for the type checker.
+            reason, recovery = _classify_regex_error(pattern, None)
         except re.error as exc:
             compile_reason = str(exc)
+            # #2308 — decompose the compile failure into a structured
+            # sub-cause + recovery directive so the agent fixes the pattern
+            # instead of blind-retrying with a near-identical one.
+            reason, recovery = _classify_regex_error(pattern, exc)
         return json.dumps(
             {
                 "error": (
@@ -3178,6 +3260,9 @@ def _handle_search_files(args, **kw):
                     "or move it to the file_glob parameter instead of the regex pattern.\n"
                     "  - Re-run search_files with a corrected regex pattern."
                 ),
+                # #2308 — structured reason + recovery.
+                "reason": reason,
+                "recovery": recovery,
             },
             ensure_ascii=False,
         )


### PR DESCRIPTION
## Summary
Fixes #2308. 74 `search_files` parse errors/7d (17-deep spirals across 65 sessions) fell into a single generic error bucket with no sub-cause or recovery directive, so the agent blind-retried with near-identical patterns.

## Changes
- **`tools/file_tools.py`** — add `_classify_regex_error()` to decompose regex compile failures into structured sub-causes, each with a targeted recovery hint:
  - `invalid_regex_syntax`: malformed regex (unclosed bracket/group, bad escape, dangling quantifier)
  - `glob_as_regex`: shell glob `[!` negation syntax passed as regex
  - `unsupported_feature`: variable-width lookbehind rejected by the engine
  - `other`: unclassified compile failure
- The pre-validation error response now carries `reason` + `recovery` keys.
- `glob_as_regex` is checked first, keyed on `[!` in the pattern (not error-message tokens, which would misclassify plain `[unclosed` as a glob).
- **`tests/tools/test_search_glob_redirect.py`** — 5 new tests covering each reason plus the valid-regex pass-through boundary.

## Verification
- `scripts/run_tests.sh tests/tools/test_search_glob_redirect.py -q` → 37 passed, 0 failed.
- Broader suite (`test_search_glob_redirect.py` + `test_glob_to_regex.py` + `test_search_files.py`) → 61 passed, 0 failed (no regressions).