### PR TITLE
fix(lifecycle_guard): catch ValueError on null-byte paths in _resolve_terminal_script_path (Closes #2319)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -107,8 +107,6 @@ _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
 
 
-
-
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
@@ -170,8 +168,15 @@ def contains_launchctl_submit_command(command: str) -> bool:
     return False
 
 
-def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Optional[Path]:
+    # ValueError: "embedded null character in path" — pathlib.Path raises
+    # ValueError (not OSError) on NUL in path. This mirrors the
+    # (OSError, ValueError) guard at os.open() (line 261) and
+    # script_path.resolve() (line 320) established by PR #2311. #2303. #2319.
+    try:
+        path = Path(candidate).expanduser()
+    except (OSError, ValueError):
+        return None
     if not path.is_absolute():
         path = Path(cwd or Path.cwd()) / path
     return path
@@ -192,7 +197,9 @@ def _iter_referenced_shell_scripts(
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:
-                yield _resolve_terminal_script_path(segment[index + 1], cwd)
+                resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         if executable_name in _SHELL_EXECUTABLES:
@@ -216,7 +223,9 @@ def _iter_referenced_shell_scripts(
                 "-c",
                 "--command",
             }:
-                yield _resolve_terminal_script_path(arguments[arg_index], cwd)
+                resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -226,7 +235,9 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                resolved = _resolve_terminal_script_path(executable, cwd)
+                if resolved is not None:
+                    yield resolved
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -361,8 +372,6 @@ def contains_gateway_lifecycle_command_or_referenced_script(
         visited=set(),
         read_remote_script=read_remote_script,
     )
-
-
 
 
 def _resolve_script_path(script_path: str) -> Path:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -724,6 +724,29 @@ class TestLifecycleGuardModule:
         result = _read_referenced_script(Path("evil\x00path.sh"))
         assert result == (None, False)
 
+    def test_resolve_terminal_script_path_null_byte_path(self):
+        """#2319: Path(candidate).expanduser() raises ValueError (not OSError)
+        when candidate contains an embedded null byte (observed on the prod
+        Python where expanduser() routes through getpwuid/lstat). Before the
+        fix, _resolve_terminal_script_path had no guard, so the ValueError
+        propagated up and crashed the terminal tool (~87s wasted per crash,
+        4 hard occurrences documented in introspection P5).
+
+        Now ValueError is caught alongside OSError, returning None. The three
+        caller sites in _iter_referenced_shell_scripts skip a None return
+        (treating a null-byte path as "nothing to scan", mirroring #2303).
+
+        The test candidate uses a leading '~' so expanduser() exercises its
+        system-call path — the exact route that produced the crash on the
+        prod host (a bare null byte without '~' is not touched by expanduser
+        on newer CPython and would not reproduce).
+        """
+        from cron.lifecycle_guard import _resolve_terminal_script_path
+
+        # expanduser() processes '~' via getpwuid; a NUL byte there raises
+        # ValueError: embedded null byte — the prod-host crash signature.
+        assert _resolve_terminal_script_path("~\x00evil.sh", None) is None
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path


### PR DESCRIPTION
## Summary

Sibling of #2303. PR #2311 guarded two of three null-byte call sites in `cron/lifecycle_guard.py` — `_read_referenced_script` (line 261) and `_resolve_script_path` (line 320) — but the THIRD call site `_resolve_terminal_script_path` (line 174, `Path(candidate).expanduser()`) was missed.

On the prod Python, `expanduser()` routes `~` through `getpwuid`/`lstat`, which raises **`ValueError`** (not `OSError`) on an embedded NUL byte. Uncaught, it propagated and crashed the terminal tool — **~87s wasted per crash, 4 hard occurrences** (introspection P5).

## Fix

Mirror PR #2311's pattern: wrap `expanduser()` in `except (OSError, ValueError)`, return `None`. The three caller sites in `_iter_referenced_shell_scripts` now skip a `None` (treating a null-byte path as "nothing to scan", same as a missing/unreadable file).

```python
def _resolve_terminal_script_path(candidate, cwd) -> Optional[Path]:
    try:
        path = Path(candidate).expanduser()
    except (OSError, ValueError):
        return None
    ...
```

## Files Changed
- `cron/lifecycle_guard.py` — guard at line 174 + 3 caller sites updated to skip `None`
- `tests/hermes_cli/test_gateway_restart_loop.py` — new test `test_resolve_terminal_script_path_null_byte_path`

## Validation
- ✅ Targeted suite: 84 passed (`tests/hermes_cli/test_gateway_restart_loop.py`)
- ✅ `ruff check` + `ruff format --check` clean
- ✅ Diff: 41 insertions, 9 deletions (well under 200-line merge cap)

## Test note

The test candidate uses a leading `~` (`~\x00evil.sh`) so `expanduser()` exercises its system-call path — the exact route that produced the prod-host crash. A bare null byte without `~` is not touched by `expanduser()` on newer CPython and would not reproduce the failure.

Closes #2319