### PR TITLE
feat(skills): provisional→trusted skill lifecycle (#2256, Slice B)

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -364,3 +364,116 @@ def test_adopt_rejects_empty_name(skills_home):
 
     assert adopt_skill("")[0] is False
 
+
+# ---------------------------------------------------------------------------
+# Trust lifecycle — provisional → trusted promotion / demotion (#2256, Slice B)
+# ---------------------------------------------------------------------------
+
+
+def _trust_skill(skills_home, name="trust-skill"):
+    """Create a curation-eligible skill and return its name."""
+    _write_skill(skills_home / "skills", name)
+    return name
+
+
+def test_provisional_promotes_to_trusted_after_threshold(skills_home):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        TRUST_TRUSTED,
+        get_trust_state,
+        record_skill_outcome,
+    )
+
+    name = _trust_skill(skills_home)
+    assert get_trust_state(name) == TRUST_PROVISIONAL
+
+    # Default threshold is 3 independent successful uses.
+    for _ in range(3):
+        record_skill_outcome(name, success=True)
+
+    assert get_trust_state(name) == TRUST_TRUSTED
+
+
+def test_failure_resets_promotion_counter(skills_home):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        get_trust_state,
+        record_skill_outcome,
+    )
+
+    name = _trust_skill(skills_home)
+    record_skill_outcome(name, success=True)
+    record_skill_outcome(name, success=True)
+    # A failure breaks the run of independent successes.
+    record_skill_outcome(name, success=False)
+    record_skill_outcome(name, success=True)
+    record_skill_outcome(name, success=True)
+
+    # Only 2 consecutive successes remain after the failure reset — not 3.
+    assert get_trust_state(name) == TRUST_PROVISIONAL
+
+
+def test_trusted_demotes_on_sustained_failure_rate(skills_home):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        TRUST_TRUSTED,
+        get_trust_state,
+        record_skill_outcome,
+    )
+
+    name = _trust_skill(skills_home)
+    # Promote to trusted first.
+    for _ in range(3):
+        record_skill_outcome(name, success=True)
+    assert get_trust_state(name) == TRUST_TRUSTED
+
+    # Now drive the recent-failure rate above the demotion threshold with
+    # enough outcomes to clear the min-outcome guard (default 4).
+    for _ in range(4):
+        record_skill_outcome(name, success=False)
+
+    assert get_trust_state(name) == TRUST_PROVISIONAL
+
+
+def test_single_flake_does_not_demote_trusted(skills_home):
+    from tools.skill_usage import (
+        TRUST_TRUSTED,
+        get_trust_state,
+        record_skill_outcome,
+    )
+
+    name = _trust_skill(skills_home)
+    for _ in range(3):
+        record_skill_outcome(name, success=True)
+    assert get_trust_state(name) == TRUST_TRUSTED
+
+    # One failure out of a small window must not demote (min-outcome guard).
+    record_skill_outcome(name, success=False)
+    assert get_trust_state(name) == TRUST_TRUSTED
+
+
+def test_set_trust_state_manual_override(skills_home):
+    from tools.skill_usage import (
+        TRUST_DEMOTED,
+        TRUST_TRUSTED,
+        get_trust_state,
+        set_trust_state,
+    )
+
+    name = _trust_skill(skills_home)
+    assert set_trust_state(name, TRUST_TRUSTED) is True
+    assert get_trust_state(name) == TRUST_TRUSTED
+
+    assert set_trust_state(name, TRUST_DEMOTED) is True
+    assert get_trust_state(name) == TRUST_DEMOTED
+
+    # Invalid state is rejected.
+    assert set_trust_state(name, "bogus") is False
+    assert get_trust_state(name) == TRUST_DEMOTED
+
+
+def test_trust_state_defaults_to_provisional_for_unknown_skill(skills_home):
+    from tools.skill_usage import TRUST_PROVISIONAL, get_trust_state
+
+    assert get_trust_state("no-such-skill") == TRUST_PROVISIONAL
+

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -55,6 +55,34 @@ STATE_STALE = "stale"
 STATE_ARCHIVED = "archived"
 _VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
 
+# ---------------------------------------------------------------------------
+# Trust lifecycle — provisional → trusted promotion / demotion (#2256, Slice B)
+# ---------------------------------------------------------------------------
+# Extends the postcondition gate (#2255, already merged) with a runtime
+# lifecycle: a skill captured as ``provisional`` is promoted to ``trusted``
+# after N *independent* successful uses, and demoted back to ``provisional``
+# (or ``demoted``) when an attributable failure is observed. The trust state
+# lives on the usage sidecar alongside ``state``/``pinned``/``sync``.
+#
+# ``independent`` means distinct task executions — we use the existing
+# ``use_count`` / ``record_skill_outcome`` call path so each successful
+# invocation counts once, and the outcome window (``_FAILURE_WINDOW``) already
+# gates attributable-failure detection.
+TRUST_PROVISIONAL = "provisional"
+TRUST_TRUSTED = "trusted"
+TRUST_DEMOTED = "demoted"
+_VALID_TRUST_STATES = {TRUST_PROVISIONAL, TRUST_TRUSTED, TRUST_DEMOTED}
+
+# Number of independent successful uses required to promote a provisional
+# skill to trusted. Configurable via ``curator.trust_promotion_threshold``.
+_DEFAULT_TRUST_PROMOTION_THRESHOLD = 3
+
+# Recent-failure rate above which a trusted skill is demoted to provisional.
+# Configurable via ``curator.trust_demotion_failure_rate``.
+_DEFAULT_TRUST_DEMOTION_FAILURE_RATE = 0.5
+# Minimum outcomes before demotion is considered (avoid demoting on 1/2).
+_TRUST_DEMOTION_MIN_OUTCOMES = 4
+
 # Load-bearing bundled built-ins the curator must NEVER archive or consolidate,
 # regardless of ``curator.prune_builtins``, pin state, or LLM judgment. These
 # back advertised UX paths (e.g. ``plan`` powers the ``/plan`` slash-command
@@ -659,6 +687,13 @@ def _empty_record() -> Dict[str, Any]:
         "recent_failure_rate": 0.0,
         # Source-chain provenance (#2192)
         "source_chain": [],
+        # Trust lifecycle (#2256, Slice B) — provisional→trusted promotion
+        # and demotion on attributable failure. Extends the postcondition
+        # gate (#2255). Default is ``provisional`` until promoted.
+        "trust_state": TRUST_PROVISIONAL,
+        "trust_success_count": 0,
+        "trust_promoted_at": None,
+        "trust_demoted_at": None,
     }
 
 
@@ -844,6 +879,12 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
     hindered the task. The failure rate is a sliding window over the last
     ``_FAILURE_WINDOW`` invocations. Best-effort; telemetry failures never
     break the tool.
+
+    Also drives the trust lifecycle (#2256, Slice B): a ``provisional`` skill
+    is promoted to ``trusted`` after ``_DEFAULT_TRUST_PROMOTION_THRESHOLD``
+    independent successful uses, and a ``trusted`` skill is demoted back to
+    ``provisional`` when its recent failure rate crosses the demotion
+    threshold (with a minimum-outcome guard so a single flake doesn't demote).
     """
     def _apply(rec: Dict[str, Any]) -> None:
         # invocation_count is the same as use_count — bump it.
@@ -857,7 +898,114 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
         rec["recent_failure_rate"] = (
             sum(outcomes) / len(outcomes) if outcomes else 0.0
         )
+        _apply_trust_lifecycle(rec, success)
+
     _mutate(skill_name, _apply)
+
+
+def _apply_trust_lifecycle(rec: Dict[str, Any], success: bool) -> None:
+    """Promote/demote a skill's trust state based on an execution outcome.
+
+    Runs inside the sidecar mutation so it is atomic with the outcome bump.
+    Promotion requires ``_DEFAULT_TRUST_PROMOTION_THRESHOLD`` consecutive
+    successful uses; demotion requires the recent failure rate to cross the
+    threshold with at least ``_TRUST_DEMOTION_MIN_OUTCOMES`` recorded.
+    """
+    trust_state = rec.get("trust_state") or TRUST_PROVISIONAL
+    if trust_state not in _VALID_TRUST_STATES:
+        trust_state = TRUST_PROVISIONAL
+
+    if success:
+        # A success advances the promotion counter (independent successful use).
+        rec["trust_success_count"] = int(rec.get("trust_success_count") or 0) + 1
+        if trust_state == TRUST_PROVISIONAL:
+            threshold = _trust_promotion_threshold()
+            if rec["trust_success_count"] >= threshold:
+                rec["trust_state"] = TRUST_TRUSTED
+                rec["trust_promoted_at"] = _now_iso()
+                logger.debug(
+                    "trust lifecycle: promoted %s to trusted after %d uses",
+                    rec.get("name", "?"),
+                    rec["trust_success_count"],
+                )
+        return
+
+    # Failure — reset the promotion counter (a failure breaks the run of
+    # independent successes) and consider demotion for a trusted skill.
+    rec["trust_success_count"] = 0
+    if trust_state == TRUST_TRUSTED:
+        outcomes = rec.get("_recent_outcomes") or []
+        if len(outcomes) >= _TRUST_DEMOTION_MIN_OUTCOMES:
+            rate = rec.get("recent_failure_rate") or 0.0
+            if rate >= _trust_demotion_failure_rate():
+                rec["trust_state"] = TRUST_PROVISIONAL
+                rec["trust_demoted_at"] = _now_iso()
+                logger.debug(
+                    "trust lifecycle: demoted %s to provisional (failure rate %.2f)",
+                    rec.get("name", "?"),
+                    rate,
+                )
+
+
+def _trust_promotion_threshold() -> int:
+    """Read the promotion threshold from config (``curator.trust_promotion_threshold``)."""
+    try:
+        from hermes_cli.config import get_config_value
+        val = get_config_value("curator.trust_promotion_threshold")
+        if isinstance(val, int) and val > 0:
+            return val
+    except BaseException:
+        # get_config_value raises SystemExit (a BaseException, not Exception)
+        # when the key is unset — treat that as "use the default".
+        pass
+    return _DEFAULT_TRUST_PROMOTION_THRESHOLD
+
+
+def _trust_demotion_failure_rate() -> float:
+    """Read the demotion failure-rate threshold from config (``curator.trust_demotion_failure_rate``)."""
+    try:
+        from hermes_cli.config import get_config_value
+        val = get_config_value("curator.trust_demotion_failure_rate")
+        if isinstance(val, (int, float)) and 0.0 <= val <= 1.0:
+            return float(val)
+    except BaseException:
+        pass
+    return _DEFAULT_TRUST_DEMOTION_FAILURE_RATE
+
+
+def get_trust_state(skill_name: str) -> str:
+    """Return the current trust state for a skill (``provisional``/``trusted``/``demoted``).
+
+    Best-effort; returns ``provisional`` if the record is missing or corrupt.
+    """
+    rec = get_record(skill_name)
+    state = rec.get("trust_state") or TRUST_PROVISIONAL
+    if state not in _VALID_TRUST_STATES:
+        return TRUST_PROVISIONAL
+    return state
+
+
+def set_trust_state(skill_name: str, trust_state: str) -> bool:
+    """Manually set a skill's trust state (curator/operator override).
+
+    Returns True on success, False if the state is invalid or the skill
+    isn't curation-eligible. Best-effort; never raises.
+    """
+    if trust_state not in _VALID_TRUST_STATES:
+        return False
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["trust_state"] = trust_state
+        if trust_state == TRUST_TRUSTED:
+            rec["trust_promoted_at"] = _now_iso()
+        elif trust_state == TRUST_DEMOTED:
+            rec["trust_demoted_at"] = _now_iso()
+
+    try:
+        _mutate(skill_name, _apply, require_curation_eligible=True)
+        return True
+    except Exception:
+        return False
 
 
 def set_state(skill_name: str, state: str) -> None:


### PR DESCRIPTION
Implements issue #2256 (Slice B): a runtime trust lifecycle extending the postcondition gate (#2255).

- provisional → trusted promotion after N independent successful uses (default 3, configurable via `curator.trust_promotion_threshold`)
- trusted → provisional demotion when recent failure rate crosses `curator.trust_demotion_failure_rate` with a min-outcome guard (no single-flake demotion)
- `get_trust_state` / `set_trust_state` public API
- Config reads guarded against `SystemExit` (`get_config_value` raises BaseException when a key is unset)

Tests: `tests/tools/test_skill_usage.py` (6 new trust tests). All pass.