### PR TITLE
feat(tool-call-log): replay-or-fork dispatch in live MCP path (#2237)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3120,6 +3120,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     else:
         def _execute(next_args: dict) -> Any:
+            # #2237 (Slice B) — replay-or-fork: before executing a non-atomic
+            # tool, check whether this exact semantic intent already succeeded
+            # (result observed). If so, replay the prior outcome instead of
+            # re-executing — a checkpoint-restore must not duplicate a
+            # real-world side effect (second email, double charge). A call
+            # whose intent differs from anything logged forks (executes
+            # normally) and is never silently re-run as a duplicate.
+            try:
+                from tools.tool_call_log import replay_or_fork
+
+                _replay = replay_or_fork(function_name, next_args)
+                if _replay is not None:
+                    return _replay
+            except Exception:
+                pass  # fail-open: never block a tool on log bookkeeping
             # #2236 — record non-atomic tool calls in the live dispatch path
             # (rework: the prior PR shipped the module as dead code). Guarded
             # by is_non_atomic() because record() raises for atomic tools.

--- a/tests/tools/test_tool_call_log.py
+++ b/tests/tools/test_tool_call_log.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import copy
+import json
 
 import pytest
+from unittest.mock import patch
 
 from tools.tool_call_log import (
     NON_ATOMIC_TOOLS,
@@ -14,6 +16,7 @@ from tools.tool_call_log import (
     infer_idempotency_key,
     is_non_atomic,
     register_non_atomic_tool,
+    replay_or_fork,
     reset_default_log,
 )
 
@@ -258,6 +261,59 @@ class TestDefaultLog:
         assert len(log.all_entries()) >= 1
         reset_default_log()
         assert len(log.all_entries()) == 0
+
+
+# ── replay-or-fork decision (Slice B, #2237) ─────────────────────────────
+
+
+class TestReplayOrFork:
+    def test_atomic_tool_never_replays(self) -> None:
+        assert replay_or_fork("web_search", {"query": "x"}) is None
+
+    def test_unknown_tool_never_replays(self) -> None:
+        assert replay_or_fork("nonexistent_tool", {}) is None
+
+    def test_unseen_non_atomic_forks(self) -> None:
+        # No prior record -> execute normally (fork).
+        assert replay_or_fork("agentmail__send_message", {"to": "a@b.com"}) is None
+
+    def test_same_intent_after_success_replays(self) -> None:
+        log = ToolCallLog()
+        args = {"to": "a@b.com", "subject": "hi"}
+        log.record("agentmail__send_message", args, result={"status": "sent"})
+        with patch("tools.tool_call_log.get_default_log", return_value=log):
+            out = replay_or_fork(
+                "agentmail__send_message",
+                {"to": "a@b.com", "subject": "hi", "trace_id": "noise"},
+            )
+        assert out is not None
+        payload = json.loads(out)
+        assert payload["replayed"] is True
+        assert payload["tool"] == "agentmail__send_message"
+
+    def test_different_intent_forks(self) -> None:
+        log = ToolCallLog()
+        log.record(
+            "agentmail__send_message",
+            {"to": "a@b.com", "subject": "hi"},
+            result={"status": "sent"},
+        )
+        with patch("tools.tool_call_log.get_default_log", return_value=log):
+            out = replay_or_fork(
+                "agentmail__send_message", {"to": "other@b.com", "subject": "hi"}
+            )
+        assert out is None
+
+    def test_recorded_but_unobserved_forks(self) -> None:
+        # Recorded but result never observed (digest None) -> not yet
+        # succeeded, so it must execute (fork), not replay.
+        log = ToolCallLog()
+        log.record("agentmail__send_message", {"to": "a@b.com", "subject": "hi"})
+        with patch("tools.tool_call_log.get_default_log", return_value=log):
+            out = replay_or_fork(
+                "agentmail__send_message", {"to": "a@b.com", "subject": "hi"}
+            )
+        assert out is None
 
 
 # ── dispatch-path integration (rework of #2236) ─────────────────────────

--- a/tools/tool_call_log.py
+++ b/tools/tool_call_log.py
@@ -304,6 +304,50 @@ def _digest_result(result: Any) -> Optional[str]:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
+# ── Replay-or-fork decision (Slice B, #2237) ─────────────────────────────
+
+
+def replay_or_fork(tool_name: str, arguments: Dict[str, Any]) -> Optional[str]:
+    """Decide replay vs fork for a non-atomic tool call.
+
+    Returns a JSON string to **replay** (the call already executed with this
+    exact semantic intent and its result was observed) or ``None`` to
+    **execute normally** (fork). Read-only / atomic tools always return
+    ``None`` — replaying them is harmless and they are never logged.
+
+    Slice B (#2237): after a checkpoint-restore, a previously-succeeded
+    non-atomic call must NOT be re-executed (that would duplicate a real-world
+    side effect — a second email, a double charge). This consults the
+    tool-call log's idempotency key to answer "has this exact intent already
+    executed successfully?". A call whose intent differs from anything logged
+    returns ``None`` (fork) so it is never silently re-run as a duplicate.
+    """
+    if not is_non_atomic(tool_name):
+        return None
+    log = get_default_log()
+    existing = log.lookup(tool_name, arguments)
+    # Only replay calls whose result was actually observed (result_digest set).
+    # A call that was recorded but never completed (digest None) is treated as
+    # not-yet-succeeded and allowed to execute (fork).
+    if existing is not None and existing.result_digest is not None:
+        return json.dumps(
+            {
+                "success": True,
+                "replayed": True,
+                "tool": tool_name,
+                "idempotency_key": existing.idempotency_key,
+                "note": (
+                    "This non-atomic tool call already executed with identical "
+                    "semantic intent (see idempotency_key). Replaying the prior "
+                    "result instead of re-executing to avoid a duplicate "
+                    "real-world side effect."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    return None
+
+
 # Module-level singleton — the default log used by the agent session.
 # Slice B will reset/restore this on checkpoint-restore.
 _default_log: Optional[ToolCallLog] = None


### PR DESCRIPTION
Implements #2237 (Slice B of #2225).

Wires `replay_or_fork()` into `invoke_tool`'s `_execute` so a non-atomic tool with the same semantic intent replays its cached result instead of re-executing (no duplicate side effects), and a different intent forks (normal execution). Fail-open: log bookkeeping never blocks a tool.

- `tools/tool_call_log.py`: `replay_or_fork()` replays only when `result_digest` is set.
- `agent/agent_runtime_helpers.py`: `invoke_tool._execute` calls `replay_or_fork` before executing non-atomic tools.
- `tests/tools/test_tool_call_log.py`: 34 tests.

Tests: `scripts/run_tests.sh tests/tools/test_tool_call_log.py` — 34 passed.