### PR TITLE
feat(delegation): route subagents to best model per task dimension (#2317 rework)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1824,6 +1824,18 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # #2317 — LLM routing at subagent-delegation time. When enabled, each
+        # subagent is routed to the model that has historically performed best
+        # on its task dimension (coding / reasoning / creative / tool-use /
+        # general) via tools/model_routing_table.py, instead of always
+        # inheriting the parent's model. Fail-open: any routing error or
+        # misconfiguration falls back to the inherited model, so routing never
+        # breaks delegation. ``models`` lists the candidate model names to
+        # route among (empty = routing disabled regardless of ``enabled``).
+        "routing": {
+            "enabled": False,
+            "models": [],
+        },
     },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.

--- a/tests/tools/test_delegate_model_routing.py
+++ b/tests/tools/test_delegate_model_routing.py
@@ -1,0 +1,48 @@
+"""Tests for subagent model routing wiring (issue #2317).
+
+The routing abstraction (tools/model_routing_table.py) was shipped as dead
+code. This verifies the live call site in delegate_tool: when
+``delegation.routing.enabled`` is true, a subagent is routed to a model via
+the routing table; otherwise it inherits the parent's model. Fail-open: a
+routing error must never break delegation.
+"""
+
+import pytest
+
+from tools.delegate_tool import _route_subagent_model
+
+
+class TestRouteSubagentModel:
+    def test_disabled_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.delegate_tool._load_config",
+            lambda: {"routing": {"enabled": False}},
+        )
+        assert _route_subagent_model("write a poem", None, 0) is None
+
+    def test_enabled_no_models_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.delegate_tool._load_config",
+            lambda: {"routing": {"enabled": True, "models": []}},
+        )
+        assert _route_subagent_model("write a poem", None, 0) is None
+
+    def test_enabled_routes_to_model(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.delegate_tool._load_config",
+            lambda: {"routing": {"enabled": True, "models": ["model-a", "model-b"]}},
+        )
+        routed = _route_subagent_model("write a poem", None, 0)
+        assert routed in {"model-a", "model-b"}
+
+    def test_fail_open_on_config_error(self, monkeypatch):
+        def boom():
+            raise RuntimeError("config load failed")
+
+        monkeypatch.setattr("tools.delegate_tool._load_config", boom)
+        # A routing failure must never break delegation — returns None.
+        assert _route_subagent_model("write a poem", None, 0) is None
+
+    def test_fail_open_on_missing_routing_key(self, monkeypatch):
+        monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
+        assert _route_subagent_model("write a poem", None, 0) is None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1846,6 +1846,18 @@ def _build_child_agent(
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
+
+    # #2317 — LLM routing at subagent-delegation time. When
+    # ``delegation.routing.enabled`` is true, consult the per-task-dimension
+    # routing table (tools/model_routing_table.py) to pick the best model for
+    # this subagent's task type instead of always inheriting the parent's
+    # model. This is the live call site that makes the routing abstraction
+    # actually route. Fail-open: any routing error falls back to the inherited
+    # model so a routing misconfiguration never breaks delegation.
+    _routed_model = _route_subagent_model(goal, context, task_index)
+    if _routed_model:
+        effective_model = _routed_model
+
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
@@ -4680,6 +4692,47 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }
+
+
+def _route_subagent_model(
+    goal: str,
+    context: Optional[str],
+    task_index: int,
+) -> Optional[str]:
+    """Route a subagent to a model via the routing table (#2317).
+
+    When ``delegation.routing.enabled`` is true and ``delegation.routing.models``
+    lists candidate models, consult ``tools.model_routing_table.RoutingTable``
+    to pick the best model for this subagent's task type (classified from the
+    goal/context). Returns the routed model name, or None when routing is
+    disabled, misconfigured, or fails — the caller then inherits the parent's
+    model. Fail-open: a routing error must never break delegation.
+    """
+    try:
+        delegation_cfg = _load_config()
+        routing_cfg = delegation_cfg.get("routing") or {}
+        if not routing_cfg.get("enabled"):
+            return None
+        from tools.model_routing_table import RoutingTable, classify_task
+
+        _routing_models = routing_cfg.get("models") or []
+        if not _routing_models:
+            return None
+        _task = {"type": goal, "tags": [context or ""]}
+        _routing_table = RoutingTable(models=list(_routing_models))
+        _routed = _routing_table.select_model(_task)
+        if _routed:
+            logger.info(
+                "delegate_task: routing subagent %d to model %r "
+                "(task dimension %r) — #2317",
+                task_index,
+                _routed,
+                classify_task(_task),
+            )
+        return _routed
+    except Exception as _routing_err:
+        logger.debug("delegate_task: routing disabled/failed (%s)", _routing_err)
+        return None
 
 
 def _load_config() -> dict:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -355,6 +355,9 @@ delegation:
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # routing:                                 # #2317 — route subagents to the best model per task dimension
+  #   enabled: false                         #   (coding/reasoning/creative/tool-use/general). Fail-open.
+  #   models: []                             #   Candidate model names to route among (empty = disabled).
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints
@@ -368,6 +371,19 @@ delegation:
 ```
 
 When `base_url` points at an Anthropic-compatible endpoint — for example a path ending in `/anthropic`, an Azure Foundry Claude route, or a MiniMax `/anthropic` proxy — `api_mode` is auto-detected as `anthropic_messages` so the subagent uses the right wire format without you setting anything. Set `api_mode` explicitly when the auto-detection guess is wrong (rare).
+
+### Model routing for subagents (#2317)
+
+By default every subagent inherits the parent's model. When you want subagents routed to the model that has historically performed best on their task type, enable `delegation.routing`:
+
+```yaml
+delegation:
+  routing:
+    enabled: true
+    models: ["openai/gpt-5", "anthropic/claude-sonnet-4", "google/gemini-3-flash-preview"]
+```
+
+With routing enabled, each `delegate_task` call classifies the subagent's goal into a coarse task dimension (`coding`, `reasoning`, `creative`, `tool-use`, or `general`) and consults the per-task-dimension performance record (`tools/model_routing_table.py`) to pick the best model from `models`. The routing is **fail-open**: any routing error, misconfiguration, or empty `models` list falls back to the inherited parent model, so a routing problem never breaks delegation. Routing is off by default (`enabled: false`).
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.


### PR DESCRIPTION
Reworks #2317 (LLMRouter). The routing abstraction shipped as dead code; this wires it into a live subagent-delegation call site.

When `delegation.routing.enabled` is true, each `delegate_task` classifies the goal into a task dimension (coding/reasoning/creative/tool-use/general) and routes to the best historical model via `tools/model_routing_table.py`, instead of always inheriting the parent's model. Fail-open: any routing error falls back to the inherited model.

- `tools/delegate_tool.py`: `_route_subagent_model()` called in `_build_child_agent`.
- `hermes_cli/config_defaults.py`: `delegation.routing` defaults (enabled: false, models: []).
- `website/docs/user-guide/features/delegation.md`: documents the feature.
- `tests/tools/test_delegate_model_routing.py`: 5 tests.

Tests: `scripts/run_tests.sh tests/tools/test_delegate_model_routing.py tests/tools/test_delegate.py` — 179 passed.