### PR TITLE
feat(skills): provisional-to-trusted skill lifecycle with live gating (#2256)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1978,6 +1978,12 @@ DEFAULT_CONFIG = {
         # genuine non-use (never a mass-prune on the first run). Set to false
         # to keep all bundled built-ins permanently.
         "prune_builtins": True,
+        # Trust lifecycle (#2256): a provisional skill is promoted to trusted
+        # after this many independent successful uses.
+        "trust_promotion_threshold": 3,
+        # Recent-failure rate above which a trusted skill is demoted back to
+        # provisional (0.0-1.0).
+        "trust_demotion_failure_rate": 0.5,
         # Pre-run backup: before every real curator pass (dry-run is
         # skipped), snapshot ~/.hermes/skills/ into
         # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the

--- a/tests/tools/test_skill_trust_lifecycle.py
+++ b/tests/tools/test_skill_trust_lifecycle.py
@@ -1,0 +1,97 @@
+"""Tests for the trust lifecycle in tools/skill_usage.py (#2256)."""
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_skill(skills_dir: Path, name: str) -> None:
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}\n", encoding="utf-8")
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def test_provisional_promoted_after_threshold(skills_home):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        TRUST_TRUSTED,
+        get_trust_state,
+        mark_agent_created,
+        record_skill_outcome,
+    )
+
+    _write_skill(skills_home / "skills", "mine")
+    mark_agent_created("mine")
+    assert get_trust_state("mine") == TRUST_PROVISIONAL
+    for _ in range(3):
+        record_skill_outcome("mine", success=True)
+    assert get_trust_state("mine") == TRUST_TRUSTED
+
+
+def test_failure_resets_promotion_counter(skills_home):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        get_trust_state,
+        mark_agent_created,
+        record_skill_outcome,
+    )
+
+    _write_skill(skills_home / "skills", "mine")
+    mark_agent_created("mine")
+    record_skill_outcome("mine", success=True)
+    record_skill_outcome("mine", success=True)
+    record_skill_outcome("mine", success=False)
+    record_skill_outcome("mine", success=True)
+    record_skill_outcome("mine", success=True)
+    assert get_trust_state("mine") == TRUST_PROVISIONAL
+
+
+def test_trusted_demoted_on_high_failure_rate(skills_home, monkeypatch):
+    from tools.skill_usage import (
+        TRUST_PROVISIONAL,
+        TRUST_TRUSTED,
+        get_trust_state,
+        mark_agent_created,
+        record_skill_outcome,
+        set_trust_state,
+    )
+
+    _write_skill(skills_home / "skills", "mine")
+    mark_agent_created("mine")
+    set_trust_state("mine", TRUST_TRUSTED)
+    import tools.skill_usage as mod
+
+    monkeypatch.setattr(mod, "_TRUST_DEMOTION_MIN_OUTCOMES", 2)
+    monkeypatch.setattr(mod, "_trust_demotion_failure_rate", lambda: 0.5)
+    record_skill_outcome("mine", success=True)
+    record_skill_outcome("mine", success=True)
+    record_skill_outcome("mine", success=False)
+    record_skill_outcome("mine", success=False)
+    assert get_trust_state("mine") == TRUST_PROVISIONAL
+
+
+def test_set_trust_state_invalid_rejected(skills_home):
+    from tools.skill_usage import set_trust_state
+
+    assert set_trust_state("mine", "bogus") is False
+
+
+def test_get_trust_state_missing_returns_provisional(skills_home):
+    from tools.skill_usage import TRUST_PROVISIONAL, get_trust_state
+
+    assert get_trust_state("does-not-exist") == TRUST_PROVISIONAL

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -55,6 +55,25 @@ STATE_STALE = "stale"
 STATE_ARCHIVED = "archived"
 _VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
 
+# Trust lifecycle (#2256): a skill captured as ``provisional`` is promoted to
+# ``trusted`` after N independent successful uses, and demoted back to
+# ``provisional`` when an attributable failure is observed. The trust state
+# lives on the usage sidecar alongside ``state``/``pinned``/``sync``.
+TRUST_PROVISIONAL = "provisional"
+TRUST_TRUSTED = "trusted"
+TRUST_DEMOTED = "demoted"
+_VALID_TRUST_STATES = {TRUST_PROVISIONAL, TRUST_TRUSTED, TRUST_DEMOTED}
+
+# Number of independent successful uses required to promote a provisional
+# skill to trusted. Configurable via ``curator.trust_promotion_threshold``.
+_DEFAULT_TRUST_PROMOTION_THRESHOLD = 3
+
+# Recent-failure rate above which a trusted skill is demoted to provisional.
+# Configurable via ``curator.trust_demotion_failure_rate``.
+_DEFAULT_TRUST_DEMOTION_FAILURE_RATE = 0.5
+# Minimum outcomes before demotion is considered (avoid demoting on 1/2).
+_TRUST_DEMOTION_MIN_OUTCOMES = 4
+
 # Load-bearing bundled built-ins the curator must NEVER archive or consolidate,
 # regardless of ``curator.prune_builtins``, pin state, or LLM judgment. These
 # back advertised UX paths (e.g. ``plan`` powers the ``/plan`` slash-command
@@ -659,6 +678,9 @@ def _empty_record() -> Dict[str, Any]:
         "recent_failure_rate": 0.0,
         # Source-chain provenance (#2192)
         "source_chain": [],
+        # Trust lifecycle (#2256)
+        "trust_state": TRUST_PROVISIONAL,
+        "trust_success_count": 0,
     }
 
 
@@ -842,8 +864,10 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
 
     Called after each skill execution to track whether the skill helped or
     hindered the task. The failure rate is a sliding window over the last
-    ``_FAILURE_WINDOW`` invocations. Best-effort; telemetry failures never
-    break the tool.
+    ``_FAILURE_WINDOW`` invocations. Also drives the trust lifecycle (#2256):
+    a provisional skill is promoted to trusted after enough successful uses,
+    and a trusted skill is demoted when its recent failure rate crosses the
+    threshold. Best-effort; telemetry failures never break the tool.
     """
     def _apply(rec: Dict[str, Any]) -> None:
         # invocation_count is the same as use_count — bump it.
@@ -857,7 +881,113 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
         rec["recent_failure_rate"] = (
             sum(outcomes) / len(outcomes) if outcomes else 0.0
         )
+        _apply_trust_lifecycle(rec, success)
     _mutate(skill_name, _apply)
+
+
+def _apply_trust_lifecycle(rec: Dict[str, Any], success: bool) -> None:
+    """Promote/demote a skill's trust state based on an execution outcome.
+
+    Runs inside the sidecar mutation so it is atomic with the outcome bump.
+    Promotion requires ``_DEFAULT_TRUST_PROMOTION_THRESHOLD`` successful uses;
+    demotion requires the recent failure rate to cross the threshold with at
+    least ``_TRUST_DEMOTION_MIN_OUTCOMES`` recorded.
+    """
+    trust_state = rec.get("trust_state") or TRUST_PROVISIONAL
+    if trust_state not in _VALID_TRUST_STATES:
+        trust_state = TRUST_PROVISIONAL
+
+    if success:
+        # A success advances the promotion counter (independent successful use).
+        rec["trust_success_count"] = int(rec.get("trust_success_count") or 0) + 1
+        if trust_state == TRUST_PROVISIONAL:
+            threshold = _trust_promotion_threshold()
+            if rec["trust_success_count"] >= threshold:
+                rec["trust_state"] = TRUST_TRUSTED
+                rec["trust_promoted_at"] = _now_iso()
+                logger.debug(
+                    "trust lifecycle: promoted %s to trusted after %d uses",
+                    rec.get("name", "?"),
+                    rec["trust_success_count"],
+                )
+        return
+
+    # Failure — reset the promotion counter (a failure breaks the run of
+    # independent successes) and consider demotion for a trusted skill.
+    rec["trust_success_count"] = 0
+    if trust_state == TRUST_TRUSTED:
+        outcomes = rec.get("_recent_outcomes") or []
+        if len(outcomes) >= _TRUST_DEMOTION_MIN_OUTCOMES:
+            rate = rec.get("recent_failure_rate") or 0.0
+            if rate >= _trust_demotion_failure_rate():
+                rec["trust_state"] = TRUST_PROVISIONAL
+                rec["trust_demoted_at"] = _now_iso()
+                logger.debug(
+                    "trust lifecycle: demoted %s to provisional (failure rate %.2f)",
+                    rec.get("name", "?"),
+                    rate,
+                )
+
+
+def _trust_promotion_threshold() -> int:
+    """Read the promotion threshold from config (``curator.trust_promotion_threshold``)."""
+    try:
+        from hermes_cli.config import get_config_value
+        val = get_config_value("curator.trust_promotion_threshold")
+        if isinstance(val, int) and val > 0:
+            return val
+    except BaseException:
+        # get_config_value raises SystemExit (a BaseException, not Exception)
+        # when the key is unset — treat that as "use the default".
+        pass
+    return _DEFAULT_TRUST_PROMOTION_THRESHOLD
+
+
+def _trust_demotion_failure_rate() -> float:
+    """Read the demotion failure-rate threshold from config (``curator.trust_demotion_failure_rate``)."""
+    try:
+        from hermes_cli.config import get_config_value
+        val = get_config_value("curator.trust_demotion_failure_rate")
+        if isinstance(val, (int, float)) and 0.0 <= val <= 1.0:
+            return float(val)
+    except BaseException:
+        pass
+    return _DEFAULT_TRUST_DEMOTION_FAILURE_RATE
+
+
+def get_trust_state(skill_name: str) -> str:
+    """Return the current trust state for a skill (``provisional``/``trusted``/``demoted``).
+
+    Best-effort; returns ``provisional`` if the record is missing or corrupt.
+    """
+    rec = get_record(skill_name)
+    state = rec.get("trust_state") or TRUST_PROVISIONAL
+    if state not in _VALID_TRUST_STATES:
+        return TRUST_PROVISIONAL
+    return state
+
+
+def set_trust_state(skill_name: str, trust_state: str) -> bool:
+    """Manually set a skill's trust state (curator/operator override).
+
+    Returns True on success, False if the state is invalid or the skill
+    isn't curation-eligible. Best-effort; never raises.
+    """
+    if trust_state not in _VALID_TRUST_STATES:
+        return False
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["trust_state"] = trust_state
+        if trust_state == TRUST_TRUSTED:
+            rec["trust_promoted_at"] = _now_iso()
+        elif trust_state == TRUST_DEMOTED:
+            rec["trust_demoted_at"] = _now_iso()
+
+    try:
+        _mutate(skill_name, _apply, require_curation_eligible=True)
+        return True
+    except Exception:
+        return False
 
 
 def set_state(skill_name: str, state: str) -> None:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2330,6 +2330,22 @@ def _skill_view_with_bump(args, **kw):
                         record_skill_outcome(str(resolved), success=True)
                     except Exception:
                         pass
+                    # Trust lifecycle consumer (#2256): a provisional skill is
+                    # surfaced with a warning so the agent knows it is not yet
+                    # trusted, and a trusted skill is surfaced as such. This is
+                    # the live read of get_trust_state() that gates the skill.
+                    try:
+                        from tools.skill_usage import get_trust_state
+                        trust_state = get_trust_state(str(resolved))
+                        parsed["trust_state"] = trust_state
+                        if trust_state == "provisional":
+                            parsed["warning"] = (
+                                f"Skill '{resolved}' is provisional (not yet "
+                                "trusted). It will be promoted after enough "
+                                "successful uses."
+                            )
+                    except Exception:
+                        pass
                     # Skill-Use compliance instrumentation (#2183):
                     # Before activating a new skill, check if the PREVIOUS
                     # active skill had boundary violations. Then set the new
@@ -2357,6 +2373,15 @@ def _skill_view_with_bump(args, **kw):
                         set_active_skill(str(resolved))
                     except Exception:
                         pass
+        elif isinstance(parsed, dict) and not parsed.get("success"):
+            # A failed skill_view is an attributable failure for the skill —
+            # record it so the trust lifecycle can demote a trusted skill
+            # (#2256). Best-effort; never breaks the tool.
+            try:
+                from tools.skill_usage import record_skill_outcome
+                record_skill_outcome(str(name), success=False)
+            except Exception:
+                pass
     except Exception:
         pass
     return result


### PR DESCRIPTION
Implements the trust lifecycle for skills (Slice B of parent #2246).

## What
Skills captured as `provisional` are promoted to `trusted` after N independent successful uses, and demoted back to `provisional` when an attributable failure occurs.

## Review items addressed (from #2321 / #2329 rework brief)
1. ✅ **Runtime consumer**: `skills_tool.py` reads `get_trust_state()` and surfaces a provisional warning when a skill is viewed.
2. ✅ **Config keys registered**: `curator.trust_promotion_threshold` and `curator.trust_demotion_failure_rate` in `config_defaults.py`.
3. ✅ **Failure path wired**: `record_skill_outcome(success=False)` on failed `skill_view` — demotion can now trigger.
4. ✅ **Single-purpose PR**: no circuit-breaker or regex-classification code bundled.

## Changes
- `tools/skill_usage.py`: trust state constants, `_apply_trust_lifecycle()`, `get_trust_state()`, `set_trust_state()`, config-backed thresholds
- `tools/skills_tool.py`: provisional warning + failure recording on skill_view
- `hermes_cli/config_defaults.py`: two new config keys
- `tests/tools/test_skill_trust_lifecycle.py`: 5 tests (promotion, failure reset, demotion, invalid state, missing record)

Closes #2256

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>