### PR TITLE
fix: wire terminal exit_code into non-retryable classifier (Closes #2335)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7908,7 +7908,29 @@ class AIAgent:
         if failed and not decision.should_halt:
             from tools.tool_failure_classifier import classify_tool_failure
 
-            _nr = classify_tool_failure(tool_name, function_result)
+            # #2335 — pass the terminal exit code through so the classifier uses
+            # its rich exit-code/signal logic instead of falling back to text
+            # matching. Without it, a wall-clock timeout ("Command timed out
+            # after N seconds", exit_code=124) is classified by the generic
+            # "timed out" text rule as retryable (should_retry=True), so the
+            # always-on non-retryable diagnostic below never fires and the
+            # agent keeps re-running the identical long command — the retry
+            # amplification path. With exit_code=124 the classifier returns
+            # timeout_deterministic (non-retryable, #2191) and the model gets
+            # the explicit stop signal.
+            _exit_code = None
+            if tool_name == "terminal":
+                try:
+                    _parsed = json.loads(function_result)
+                    if isinstance(_parsed, dict) and isinstance(
+                        _parsed.get("exit_code"), int
+                    ):
+                        _exit_code = _parsed["exit_code"]
+                except (ValueError, TypeError):
+                    _exit_code = None
+            _nr = classify_tool_failure(
+                tool_name, function_result, exit_code=_exit_code
+            )
             if not _nr.should_retry:
                 _nr_line = f"\n\n⚠️ Non-retryable: {_nr.category.value}. {_nr.hint}"
                 if "Non-retryable:" not in function_result:

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -287,6 +287,32 @@ class TestTerminalDelegation:
         assert result.should_retry is False
         assert result.tool_type == tfc.ToolType.terminal
 
+    def test_wall_clock_timeout_with_exit_code_is_non_retryable(self):
+        """#2335 — terminal timeout with exit_code=124 must be non-retryable.
+
+        The run_agent #2233 non-retryable diagnostic branch extracts
+        exit_code from the terminal result JSON and passes it through.
+        Without exit_code, the same timeout text is classified by the
+        generic "timed out" text rule as retryable — the retry
+        amplification path. This test documents the contract: exit_code=124
+        must yield non-retryable, while the same text WITHOUT exit_code
+        is retryable (demonstrating the gap the wiring closes).
+        """
+        timeout_json = (
+            '{"output": "", "exit_code": 124, "error": '
+            '"Command timed out after 120 seconds."}'
+        )
+        # WITH exit_code=124 — non-retryable (deterministic timeout)
+        with_code = tfc.classify_tool_failure("terminal", timeout_json, exit_code=124)
+        assert with_code.should_retry is False
+        assert with_code.category == tfc.ToolFailureCategory.persistent_error
+
+        # WITHOUT exit_code — text-based match yields retryable timeout.
+        # This is the pre-#2335 behavior the wiring fix prevents.
+        without_code = tfc.classify_tool_failure("terminal", timeout_json)
+        assert without_code.should_retry is True
+        assert without_code.category == tfc.ToolFailureCategory.timeout
+
 
 # ---------------------------------------------------------------------------
 # Extensibility


### PR DESCRIPTION
Automated evolution PR for issue #2335.

## Problem
The run_agent #2233 always-on non-retryable diagnostic called `classify_tool_failure(tool_name, function_result)` WITHOUT `exit_code`. For terminal tools, the rich exit-code/signal path in the classifier is gated on `exit_code is not None`, so it was skipped. A wall-clock timeout ("Command timed out after N seconds", exit_code=124) fell through to the generic "timed out" text rule -> `ToolFailureCategory.timeout` -> `should_retry=True`. The non-retryable diagnostic never fired, so the agent kept re-running the identical long command — the retry amplification path (304 timeouts/7d).

## Fix
Extract `exit_code` from the terminal result JSON and pass it through to `classify_tool_failure`. With exit_code=124 the classifier returns `timeout_deterministic` -> `persistent_error` (non-retryable, #2191), and the model gets the explicit Non-retryable stop signal.

## Verification
- `classify_tool_failure('terminal', timeout_json)` (no exit_code): timeout, should_retry=True (old behavior)
- `classify_tool_failure('terminal', timeout_json, exit_code=124)`: persistent_error, should_retry=False (new behavior)
- 73 tests pass in tests/tools/test_tool_failure_classifier.py
- ruff check clean (only pre-existing #noqa warning on line 110)
- Diff: 50 lines (under 200-line cap)
