### PR TITLE
fix: decompose memory and MCP tool_call opaque 'other' error buckets (#2332, #2336)

### DIFF
--- a/tests/agent/test_evolution_2026_08_03.py
+++ b/tests/agent/test_evolution_2026_08_03.py
@@ -140,12 +140,13 @@ class TestMemoryErrorDecomposition:
         result = json.loads(_memory_enriched_error(TypeError("bad type"), "add"))
         assert result["error_category"] == "serialization-error"
 
-    def test_unexpected_error_classified(self):
+    def test_runtime_error_classified(self):
         from tools.memory_tool import _memory_enriched_error
 
         result = json.loads(_memory_enriched_error(RuntimeError("weird"), "add"))
-        assert result["error_category"] == "unexpected"
+        assert result["error_category"] == "internal-error"
         assert "RuntimeError" in result["recovery_hint"]
+        assert "Retry once" in result["recovery_hint"]
 
     def test_all_results_have_required_fields(self):
         """Every enriched error should include error, error_type, category, hint, action."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -579,6 +579,48 @@ def _exc_str(exc: BaseException) -> str:
     return text if text else repr(exc)
 
 
+def _classify_mcp_call_failure(exc: BaseException) -> str:
+    """Return a recovery-hint suffix for an MCP tool-call exception (#2336).
+
+    MCP tool errors are returned as ``tool_error()`` strings inside the
+    handler, NOT raised — so they bypass ``classify_tool_exception`` in
+    ``model_tools.py`` entirely. The model sees only the opaque
+    ``MCP call failed: Type: msg`` with zero recovery guidance, producing
+    13-deep retry spirals (291 failures/7d). This inline classifier
+    appends a bracketed hint so the model can choose the right action.
+    """
+    exc_msg = str(exc).lower()
+    exc_type = type(exc).__name__
+
+    # Connection / transport failures — may recover on retry
+    if isinstance(exc, (ConnectionError, OSError)) or "connection" in exc_msg:
+        return (
+            " [Connection to MCP server failed. Retry tool_call once; "
+            "if it fails again the server may be down — use tool_search "
+            "to find an alternative tool.]"
+        )
+    # Timeout — bounded retry
+    if "timeout" in exc_msg or "timed out" in exc_msg:
+        return (
+            " [The MCP tool call timed out. Retry once with a simpler "
+            "request; if it times out again, try a lighter-weight alternative.]"
+        )
+    # ClosedResourceError — server crashed, needs reconnect
+    if "closedresource" in exc_type.lower() or "closed" in exc_msg:
+        return (
+            " [The MCP server's transport was closed (server crashed or "
+            "restarted). Wait a few seconds for auto-reconnect, or use "
+            "tool_search for an alternative.]"
+        )
+    # Method not found — schema drift
+    if "method not found" in exc_msg or "not found" in exc_msg:
+        return (
+            " [The MCP server doesn't recognize this tool. Use tool_search "
+            "and tool_describe to confirm the current tool name and schema.]"
+        )
+    return ""  # No enrichment for truly novel errors
+
+
 # JSON-RPC "method not found" — the error a server returns when it does not
 # implement a requested method (e.g. a tool-capable server that never wired up
 # the optional ``ping`` utility). Defined locally with a fallback so detection
@@ -5898,7 +5940,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             )
             return tool_error(
                 _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}{_classify_mcp_call_failure(exc)}"
                 )
             )
 
@@ -5964,7 +6006,7 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
             )
             return tool_error(
                 _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}{_classify_mcp_call_failure(exc)}"
                 )
             )
 
@@ -6037,7 +6079,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             )
             return tool_error(
                 _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}{_classify_mcp_call_failure(exc)}"
                 )
             )
 
@@ -6116,7 +6158,7 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
             )
             return tool_error(
                 _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}{_classify_mcp_call_failure(exc)}"
                 )
             )
 
@@ -6244,7 +6286,7 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                 exc,
             )
             err_msg = _sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}{_classify_mcp_call_failure(exc)}"
             )
             unknown = _is_unknown_prompt_error(exc)
             if unknown:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1737,9 +1737,46 @@ def _memory_enriched_error(exc: Exception, action: str) -> str:
     elif isinstance(exc, (TypeError,)):
         category = "serialization-error"
         hint = "The content could not be serialized. Simplify the content and retry."
+    elif isinstance(exc, (RuntimeError,)):
+        # File-lock contention, atomic_write failures, internal state errors.
+        # RuntimeError is the dominant "unexpected" type because the lock
+        # retry path and atomic_write_text wrapper raise it (#2332).
+        msg_lower = str(exc).lower()
+        if "lock" in msg_lower or "timeout" in msg_lower:
+            category = "lock-contention"
+            hint = (
+                "The memory file is locked by a concurrent write. Wait 1-2 "
+                "seconds and retry the same operation. If it persists, "
+                "proceed without memory — the fact can be saved in a later turn."
+            )
+        else:
+            category = "internal-error"
+            hint = (
+                f"Memory store internal error ({exc_type}). Retry once; if it "
+                f"fails identically, proceed with your reply and save memory "
+                f"later. Do NOT loop on the same memory call."
+            )
+    elif isinstance(exc, (AttributeError, IndexError, KeyError)):
+        category = "entry-state-mismatch"
+        hint = (
+            "The in-memory entry list is out of sync with disk (a concurrent "
+            "session may have written between your read and write). Call "
+            "action='search' to refresh the current state, then retry."
+        )
+    elif isinstance(exc, (UnicodeDecodeError,)):
+        category = "encoding-corruption"
+        hint = (
+            "The memory file contains non-UTF-8 bytes. Use a terminal command "
+            "to inspect the memory file, fix the encoding, then retry. The "
+            "file was not modified."
+        )
     else:
         category = "unexpected"
-        hint = f"Unexpected error ({exc_type}). Proceed without memory persistence if this repeats."
+        hint = (
+            f"Unexpected error ({exc_type}). Retry the memory operation once; "
+            f"if it fails identically, proceed with your reply and save the "
+            f"fact in a later turn. Do NOT repeat the same call more than once."
+        )
 
     logger.warning("memory_tool %s failed: %s: %s", action, exc_type, exc_msg)
 


### PR DESCRIPTION
Two introspection bugs where the error classifier exists but is structurally bypassed or incomplete, leaving the dominant failure mode opaque.

## Changes

**#2332 — memory `other` bucket (186/7d, 98% of failures)**
- `RuntimeError` was the dominant unclassified type — file-lock contention, atomic_write failures, and internal state errors all raised RuntimeError, which fell to the opaque `"unexpected"` bucket
- Added 3 new `isinstance` subclasses in `_memory_enriched_error`: `lock-contention` (wait+retry), `internal-error` (retry once), `entry-state-mismatch` (refresh via search), `encoding-corruption` (inspect file)
- Strengthened the final `else` fallback to include a one-shot retry directive instead of the passive "proceed without memory"

**#2336 — tool_call/MCP `other` (291/7d, 13-deep spiral)**
- **Root cause**: MCP tool errors are returned as `tool_error()` strings inside the handler — they never raise, so they bypass `classify_tool_exception` entirely. The #2245 fix enriched the exception handler at `model_tools.py:2061`, but MCP errors never reach it.
- Added `_classify_mcp_call_failure()` inline at all 5 `MCP call failed` return sites: classifies connection failures, timeouts, ClosedResourceError, and method-not-found with bracketed recovery hints

## Validation
- `ruff check` ✓ (lint CI gate green)
- 111 targeted tests pass (memory error decomposition, MCP empty error message, memory tool)
- Diff: 96 lines (88+8), within the 200-line merge cap

Closes #2332
Closes #2336

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>