### PR TITLE
fix(memory): decompose 'other' error bucket into reason subclasses with recovery hints (Closes #2349)

### DIFF
--- a/tests/agent/test_evolution_2026_08_03.py
+++ b/tests/agent/test_evolution_2026_08_03.py
@@ -140,12 +140,47 @@ class TestMemoryErrorDecomposition:
         result = json.loads(_memory_enriched_error(TypeError("bad type"), "add"))
         assert result["error_category"] == "serialization-error"
 
-    def test_unexpected_error_classified(self):
+    def test_runtime_error_classified_as_internal(self):
         from tools.memory_tool import _memory_enriched_error
 
         result = json.loads(_memory_enriched_error(RuntimeError("weird"), "add"))
-        assert result["error_category"] == "unexpected"
+        assert result["error_category"] == "internal-error"
         assert "RuntimeError" in result["recovery_hint"]
+        assert "Retry once" in result["recovery_hint"]
+
+    def test_runtime_error_lock_contention(self):
+        """RuntimeError with 'lock' in message → lock-contention (#2349)."""
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(
+            _memory_enriched_error(RuntimeError("File lock timeout"), "replace")
+        )
+        assert result["error_category"] == "lock-contention"
+        assert "concurrent write" in result["recovery_hint"]
+
+    def test_attribute_error_classified_as_state_mismatch(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(AttributeError("no attr"), "add"))
+        assert result["error_category"] == "entry-state-mismatch"
+
+    def test_unicode_decode_error_classified(self):
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(
+            _memory_enriched_error(
+                UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad"), "add"
+            )
+        )
+        assert result["error_category"] == "encoding-corruption"
+
+    def test_truly_unexpected_error_retry_hint(self):
+        """A novel exception type still gets 'Retry once' guidance (#2349)."""
+        from tools.memory_tool import _memory_enriched_error
+
+        result = json.loads(_memory_enriched_error(ImportError("novel"), "add"))
+        assert result["error_category"] == "unexpected"
+        assert "Retry" in result["recovery_hint"]
 
     def test_all_results_have_required_fields(self):
         """Every enriched error should include error, error_type, category, hint, action."""

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1728,6 +1728,14 @@ def _memory_enriched_error(exc: Exception, action: str) -> str:
     elif isinstance(exc, (PermissionError,)):
         category = "permission-denied"
         hint = "Check file permissions on the memory file in ~/.hermes/memory/."
+    elif isinstance(exc, (UnicodeDecodeError,)):
+        # Must precede ValueError — UnicodeDecodeError subclasses it (#2349).
+        category = "encoding-corruption"
+        hint = (
+            "The memory file contains non-UTF-8 bytes. Use a terminal command "
+            "to inspect the memory file, fix the encoding, then retry. The "
+            "file was not modified."
+        )
     elif isinstance(exc, (json.JSONDecodeError, ValueError)):
         category = "schema-mismatch"
         hint = "The memory file is corrupted. Consider using action='search' to verify state, then retry."
@@ -1737,9 +1745,39 @@ def _memory_enriched_error(exc: Exception, action: str) -> str:
     elif isinstance(exc, (TypeError,)):
         category = "serialization-error"
         hint = "The content could not be serialized. Simplify the content and retry."
+    elif isinstance(exc, (RuntimeError,)):
+        # File-lock contention, atomic_write failures, internal state errors.
+        # RuntimeError is the dominant "unexpected" type because the lock
+        # retry path and atomic_write_text wrapper raise it (#2332/#2349).
+        msg_lower = str(exc).lower()
+        if "lock" in msg_lower or "timeout" in msg_lower:
+            category = "lock-contention"
+            hint = (
+                "The memory file is locked by a concurrent write. Wait 1-2 "
+                "seconds and retry the same operation. If it persists, "
+                "proceed without memory — the fact can be saved in a later turn."
+            )
+        else:
+            category = "internal-error"
+            hint = (
+                f"Memory store internal error ({exc_type}). Retry once; if it "
+                f"fails identically, proceed with your reply and save memory "
+                f"later. Do NOT loop on the same memory call."
+            )
+    elif isinstance(exc, (AttributeError, IndexError, KeyError)):
+        category = "entry-state-mismatch"
+        hint = (
+            "The in-memory entry list is out of sync with disk (a concurrent "
+            "session may have written between your read and write). Call "
+            "action='search' to refresh the current state, then retry."
+        )
     else:
         category = "unexpected"
-        hint = f"Unexpected error ({exc_type}). Proceed without memory persistence if this repeats."
+        hint = (
+            f"Unexpected error ({exc_type}). Retry the memory operation once; "
+            f"if it fails identically, proceed with your reply and save the "
+            f"fact in a later turn. Do NOT repeat the same call more than once."
+        )
 
     logger.warning("memory_tool %s failed: %s: %s", action, exc_type, exc_msg)
 


### PR DESCRIPTION
## Summary

Child issue of **#2332** — decomposed from the combined PR #2339 which failed code review for mixing memory (#2332) and MCP (#2336) scope. This PR addresses **memory only**.

## Problem
The `memory` tool's `_memory_enriched_error` had a broad `unexpected` bucket catching `RuntimeError`, `AttributeError`, `IndexError`, `KeyError`, and `UnicodeDecodeError` — all lumped together with a generic "proceed without memory" hint. This was 98% of memory failures (186/7d across 27K sessions), causing blind 11-deep retry spirals.

## Fix
Expand `_memory_enriched_error` to classify these into concrete categories with targeted recovery hints:

| Exception | Category | Recovery Hint |
|-----------|----------|---------------|
| `RuntimeError` (lock/timeout in msg) | `lock-contention` | Wait 1-2s and retry; proceed if persists |
| `RuntimeError` (other) | `internal-error` | Retry once; don't loop |
| `AttributeError/IndexError/KeyError` | `entry-state-mismatch` | Call action='search' to refresh state |
| `UnicodeDecodeError` | `encoding-corruption` | Inspect file via terminal, fix encoding |

`UnicodeDecodeError` check is placed before `ValueError` (it subclasses `ValueError`).

The residual `unexpected` bucket hint now says "Retry once; do NOT repeat" instead of "proceed without memory".

## Scope
- **2 files**, 76 insertions, 3 deletions (79 lines — well under 200-line cap)
- `tools/memory_tool.py`: classification expansion (~40 lines)
- `tests/agent/test_evolution_2026_08_03.py`: 6 new/updated test cases

## Checks
- ✅ `ruff check` + `ruff format` — clean
- ✅ `pytest tests/agent/test_evolution_2026_08_03.py` — 25/25 passed

## Related
- Parent: #2332 (needs-split — this is the memory child)
- Sibling: #2336 (MCP error classification — separate child PR to follow)
- Prior failed: #2339 (combined memory + MCP, review said split)