### PR TITLE
fix(read_file): decompose 'other' error bucket — route sed failures through _diagnose_read_failure (Closes #2333)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1252,3 +1252,25 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+
+class TestReadFileSedFailureEnrichment:
+    """#2333: when sed fails after wc -c succeeded, the error must carry a
+    concrete category (permission/directory/missing) — not opaque 'other'.
+    """
+
+    def test_sed_failure_produces_diagnosed_error(self, tmp_path):
+        """A file that passes wc -c but fails sed should get _diagnose_read_failure."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Create a file, then make it unreadable (chmod 000)
+        f = tmp_path / "noperm.txt"
+        f.write_text("content\n")
+        f.chmod(0o000)
+        try:
+            result = ops.read_file(str(f))
+            # Should NOT be the opaque "Failed to read file" message
+            assert result.error is not None
+            # Should contain a diagnostic category (permission, not found, etc.)
+            assert "Failed to read file:" not in result.error
+        finally:
+            f.chmod(0o644)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1546,7 +1546,15 @@ class ShellFileOperations(FileOperations):
         read_result = self._exec(read_cmd)
 
         if read_result.exit_code != 0:
-            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
+            # #2333 — the file passed wc -c (exists) and binary detection,
+            # but sed failed. This was an opaque "other" error (217/7d,
+            # 20-deep spiral). Probe WHY it failed so the agent gets a
+            # concrete category instead of blind-retrying.
+            _err, _sim = self._diagnose_read_failure(path, operation="read")
+            return ReadResult(
+                error=_err or f"Failed to read file: {read_result.stdout}",
+                similar_files=_sim,
+            )
         read_output = _strip_terminal_fence_leaks(read_result.stdout)
         # Strip a leading UTF-8 BOM so the model never sees a phantom U+FEFF
         # before the first real character. Only meaningful on the first


### PR DESCRIPTION
Automated evolution PR for issue #2333.

## Problem
When `sed` fails after `wc -c` succeeded (permission denied, race condition, encoding issue), `read_file` returned an opaque `'Failed to read file: <stdout>'` error with no recovery hint — causing 217 failures/7d and a 20-deep retry spiral.

## Fix
Route the sed-failure path through `_diagnose_read_failure()` which probes `test -e` / `test -d` to classify the failure as:
- **Permission denied** (file exists, not a directory) → concrete message
- **Directory** (path is a dir) → concrete message  
- **Missing** (race: file deleted between stat and read) → not_found with similar-file suggestions

## Tests
1 test verifying that a chmod-000 file produces a diagnosed error (not opaque "Failed to read file").

## Scope
Focused PR for JUST #2333 (read_file error decomposition). No bundled changes. Follows the pattern established by merged #2349 and #2351.