### PR TITLE
fix(patch): disambiguate 'ambiguous' recovery — tell model NOT to retry same old_string (Closes #2334)

### DIFF
--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -48,13 +48,23 @@ class TestClassifyFileError:
         assert klass == "fuzzy_match" and ("Re-read" in rec or "EXACT" in rec)
 
     def test_ambiguous_match_is_classified(self):
-        """'Found N matches' errors get a specific error_class and recovery (#976)."""
+        """'Found N matches' errors get a specific error_class and recovery (#976).
+
+        The recovery must explicitly tell the model NOT to retry the same
+        old_string (it will match the same locations again) and steer toward
+        either more context or replace_all=True — the disambiguation context
+        (#1842/#1683) is only consumed when the hint points at WHICH locations
+        to verify, not just "add more context" (TDAD 'context over procedure').
+        """
         klass, rec = classify_file_error(
             "Found 3 matches for old_string at:\n  Line 10: def foo()\n"
             "Provide more context to make it unique, or use replace_all=True."
         )
         assert klass == "ambiguous_match"
-        assert "replace_all" in rec or "context" in rec
+        assert "Do NOT retry" in rec
+        assert "same old_string" in rec
+        assert "replace_all" in rec
+        assert "context" in rec
 
     def test_verification(self):
         klass, _ = classify_file_error("Post-write verification failed: could not re-read x")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -217,9 +217,12 @@ def classify_file_error(
         )
     if "found" in low and "matches" in low and "old_string" in low:
         return "ambiguous_match", (
-            "Multiple matches found. Include more surrounding context lines in "
-            "old_string to make it unique, or use replace_all=True if you want "
-            "all occurrences replaced."
+            "Multiple matches found — old_string is not unique. Do NOT retry "
+            "the same old_string (it will match the same locations again). "
+            "The error message lists the exact match lines (L<line>: <snippet>); "
+            "verify WHICH of those locations is the intended target, then either "
+            "add more surrounding context lines to old_string to make it unique, "
+            "or use replace_all=True if you intend to replace all occurrences."
         )
     # ── Sub-classify the fuzzy matcher's distinctive failure strings (#1586) ──
     # These previously fell through to the generic "error" bucket (the 'other'

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2435,11 +2435,13 @@ def patch_tool(
                 )
             elif is_ambiguous and not has_diagnostic:
                 result_dict["_hint"] = (
-                    "Multiple matches found. Use read_file to see the "
-                    "surrounding context at each match location, then "
-                    "provide a longer old_string that uniquely identifies "
-                    "the target. The error message above shows the line "
-                    "content at each match."
+                    "Multiple matches found — old_string is not unique. Do NOT "
+                    "retry the same old_string (it will match the same locations "
+                    "again). The error message above lists the exact match lines "
+                    "(L<line>: <snippet>); verify WHICH of those locations is the "
+                    "intended target, then provide a longer old_string with more "
+                    "surrounding context to make it unique, or use replace_all=True "
+                    "if you intend to replace all occurrences."
                 )
             elif (
                 not has_diagnostic


### PR DESCRIPTION
Automated evolution PR for issue #2334.

## Problem
The `ambiguous_match` recovery text told the model only to "add more context or use replace_all". The model read that as a retry signal and re-ran the **same** `old_string`, which matched the **same** locations again — producing a 21-deep retry spiral (229 ambiguous failures/7d across 27,321 sessions, 0.0084/session). This is a recurrence of #1842/#1683.

## Fix
The recovery now explicitly:
- says **"Do NOT retry the same old_string (it will match the same locations again)"**
- points at **WHICH** match locations to verify (`L<line>: <snippet>`)
- steers to more context OR `replace_all=True`

TDAD "context over procedure": the disambiguation context (#1842/#1683) is only consumed when the hint names the exact locations to verify, not just "add context".

## Files
- `tools/file_operations.py` — `classify_file_error` ambiguous_match recovery text
- `tools/file_tools.py` — `patch_tool` `_hint` for `is_ambiguous and not has_diagnostic`
- `tests/tools/test_file_error_classification.py` — strengthened assertions

## Checks
- `test_file_error_classification.py`: 26 passed
- `test_file_tools.py`: 58 passed
- `test_file_operations.py`: 110 passed (1 deselected — pre-existing root-environment failure in `test_sed_failure_produces_diagnosed_error` from #2333, fails identically on pristine origin/main; unrelated to this change)
- `ruff check`: clean

Closes #2334
