### PR TITLE
feat(patch): decompose ambiguous_match into reason subclasses (Closes #2354)

### DIFF
--- a/tests/tools/test_file_error_classification.py
+++ b/tests/tools/test_file_error_classification.py
@@ -47,24 +47,20 @@ class TestClassifyFileError:
         )
         assert klass == "fuzzy_match" and ("Re-read" in rec or "EXACT" in rec)
 
-    def test_ambiguous_match_is_classified(self):
-        """'Found N matches' errors get a specific error_class and recovery (#976).
+    def test_ambiguous_match_decomposed_replace_all(self):
+        """'Found N matches' errors mentioning replace_all → replace_all_intent (#2354).
 
-        The recovery must explicitly tell the model NOT to retry the same
-        old_string (it will match the same locations again) and steer toward
-        either more context or replace_all=True — the disambiguation context
-        (#1842/#1683) is only consumed when the hint points at WHICH locations
-        to verify, not just "add more context" (TDAD 'context over procedure').
+        The ambiguous_match bucket is decomposed into subclasses so the
+        recovery hint tells the model exactly what to change. This error
+        mentions replace_all → the model likely wants all occurrences.
         """
         klass, rec = classify_file_error(
             "Found 3 matches for old_string at:\n  Line 10: def foo()\n"
             "Provide more context to make it unique, or use replace_all=True."
         )
-        assert klass == "ambiguous_match"
-        assert "Do NOT retry" in rec
-        assert "same old_string" in rec
+        assert klass == "replace_all_intent"
         assert "replace_all" in rec
-        assert "context" in rec
+        assert "Do NOT" in rec
 
     def test_verification(self):
         klass, _ = classify_file_error("Post-write verification failed: could not re-read x")
@@ -177,15 +173,15 @@ class TestResultToDict:
         d = PatchResult(success=False, error="Failed to parse patch: x").to_dict()
         assert d["error_class"] == "patch_parse" and "recovery" in d
 
-    def test_patch_result_ambiguous_match_classified(self):
-        """PatchResult with ambiguous-match error gets error_class (#976)."""
+    def test_patch_result_ambiguous_decomposed_replace_all(self):
+        """PatchResult with ambiguous-match error mentioning replace_all (#2354)."""
         d = PatchResult(
             success=False,
             error="Found 3 matches for old_string at:\n  Line 10: x\n"
             "Provide more context to make it unique, or use replace_all=True.",
         ).to_dict()
-        assert d["error_class"] == "ambiguous_match"
-        assert "replace_all" in d["recovery"] or "context" in d["recovery"]
+        assert d["error_class"] == "replace_all_intent"
+        assert "replace_all" in d["recovery"]
 
     def test_patch_result_success_clean(self):
         d = PatchResult(success=True, diff="--- a").to_dict()

--- a/tests/tools/test_patch_ambiguous_subclasses.py
+++ b/tests/tools/test_patch_ambiguous_subclasses.py
@@ -1,0 +1,81 @@
+"""Tests for decomposing the patch 'ambiguous_match' error bucket (#2354).
+
+The bucket is split into 3 actionable subclasses, each with explicit
+anti-retry language to break the 21-deep retry spirals (229 failures/7d).
+Child of #2334.
+"""
+
+from tools.file_operations import PatchResult, classify_file_error
+
+
+class TestReplaceAllIntent:
+    """Error mentions replace_all → model likely wants all occurrences."""
+
+    def test_replace_all_in_error(self):
+        error = (
+            "Found 3 matches for old_string:\n  Line 10: x\n"
+            "Use replace_all=True to replace all."
+        )
+        cls, hint = classify_file_error(error)
+        assert cls == "replace_all_intent"
+        assert "replace_all" in hint
+        assert "Do NOT" in hint
+
+
+class TestInsufficientContext:
+    """Error mentions more context → steer to re-read and add context."""
+
+    def test_more_context_keyword(self):
+        error = "Found 5 matches for old_string. Include more context."
+        cls, hint = classify_file_error(error)
+        assert cls == "ambiguous_insufficient_context"
+        assert "read_file" in hint or "re-read" in hint
+        assert "Do NOT" in hint
+
+    def test_longer_keyword(self):
+        error = "Found 4 matches for old_string. Use a longer old_string."
+        cls, _ = classify_file_error(error)
+        assert cls == "ambiguous_insufficient_context"
+
+
+class TestNotUnique:
+    """Generic ambiguous-match (no keywords) → explicit anti-retry."""
+
+    def test_generic_ambiguous(self):
+        error = "Found 3 matches for old_string at:\n  Line 10: x\n  Line 20: x"
+        cls, hint = classify_file_error(error)
+        assert cls == "ambiguous_not_unique"
+        assert "Do NOT" in hint
+        assert "same old_string" in hint
+
+
+class TestPatchResultSubclasses:
+    """Subclasses propagate through PatchResult.to_dict()."""
+
+    def test_replace_all_intent_via_patch_result(self):
+        d = PatchResult(
+            success=False,
+            error="Found 3 matches for old_string. Use replace_all=True.",
+        ).to_dict()
+        assert d["error_class"] == "replace_all_intent"
+
+    def test_not_unique_via_patch_result(self):
+        d = PatchResult(
+            success=False,
+            error="Found 2 matches for old_string at:\n  Line 1: foo\n  Line 2: foo",
+        ).to_dict()
+        assert d["error_class"] == "ambiguous_not_unique"
+
+
+class TestNoRegression:
+    """Existing classifications still work alongside the new subclasses."""
+
+    def test_fuzzy_match_unchanged(self):
+        cls, _ = classify_file_error(
+            "Could not find a match for old_string in the file"
+        )
+        assert cls == "fuzzy_match"
+
+    def test_permission_unchanged(self):
+        cls, _ = classify_file_error("Permission denied")
+        assert cls == "permission"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -216,13 +216,28 @@ def classify_file_error(
             "see actual state before editing again."
         )
     if "found" in low and "matches" in low and "old_string" in low:
-        return "ambiguous_match", (
-            "Multiple matches found — old_string is not unique. Do NOT retry "
-            "the same old_string (it will match the same locations again). "
-            "The error message lists the exact match lines (L<line>: <snippet>); "
-            "verify WHICH of those locations is the intended target, then either "
-            "add more surrounding context lines to old_string to make it unique, "
-            "or use replace_all=True if you intend to replace all occurrences."
+        # #2354: decompose ambiguous_match into actionable subclasses, each with
+        # explicit anti-retry language to break the 21-deep retry spirals.
+        if "replace_all" in low:
+            return "replace_all_intent", (
+                "Multiple matches found and the resolution suggests replace_all. "
+                "If you intend to replace ALL occurrences, re-send the patch with "
+                "replace_all=True. Do NOT retry the same old_string with "
+                "replace_all unset — it will fail the same way."
+            )
+        if "more context" in low or "surrounding context" in low or "longer" in low:
+            return "ambiguous_insufficient_context", (
+                "old_string is too short to be unique — multiple regions match. "
+                "Re-read the file with read_file, then include more surrounding "
+                "context lines (function signature, class name, unique nearby "
+                "lines) so only one location matches. Do NOT retry the same "
+                "old_string — it is inherently ambiguous."
+            )
+        return "ambiguous_not_unique", (
+            "Multiple matches found for old_string — it is not unique. Do NOT "
+            "retry the same old_string (it will match the same locations again). "
+            "Either add more surrounding context to make it unique, or use "
+            "replace_all=True if you intend to replace all occurrences."
         )
     # ── Sub-classify the fuzzy matcher's distinctive failure strings (#1586) ──
     # These previously fell through to the generic "error" bucket (the 'other'


### PR DESCRIPTION
Decompose the ambiguous_match error bucket into 3 actionable subclasses with explicit anti-retry language. Supersedes CONFLICTING PR #2356 (213L) with a clean 138L reimplementation. Closes #2354