### PR TITLE
feat: add broken_payload (USR) failure category to tool classifier (Closes #1495)

### DIFF
--- a/tests/tools/test_tool_failure_broken_payload.py
+++ b/tests/tools/test_tool_failure_broken_payload.py
@@ -1,0 +1,57 @@
+"""Tests for the broken-payload (USR) failure category (#1495).
+
+Verifies that the tool-failure classifier recognizes the ``[tool_error]``
+signal injected by ``make_tool_result_message`` when ``payload_anomaly()``
+flags a structurally broken tool payload, and that it maps to the
+``broken_payload`` category with a retryable disposition and a hint that
+explicitly warns against fabricating a safety rationale (Unfaithful Safety
+Refusal).
+"""
+
+from __future__ import annotations
+
+from tools.tool_failure_classifier import (
+    ToolFailureCategory,
+    classify_tool_failure,
+    matched_categories,
+)
+
+
+class TestBrokenPayloadClassification:
+    """The classifier must surface the USR signal as broken_payload."""
+
+    def test_tool_error_signal_classifies_as_broken_payload(self) -> None:
+        result = classify_tool_failure(
+            "web_search",
+            "[tool_error] Broken payload (type=empty_payload). "
+            "The tool returned an empty/null payload — it likely malfunctioned.",
+        )
+        assert result.category == ToolFailureCategory.broken_payload
+        assert result.should_retry
+
+    def test_hint_warns_against_safety_fabrication(self) -> None:
+        result = classify_tool_failure(
+            "mcp_tool",
+            "[tool_error] Broken payload (type=malformed_payload).",
+        )
+        assert "Do NOT fabricate a safety rationale" in result.hint
+        assert "Unfaithful Safety Refusal" in result.hint
+
+    def test_matched_categories_includes_broken_payload(self) -> None:
+        cats = matched_categories("[tool_error] Broken payload (type=empty_payload).")
+        assert ToolFailureCategory.broken_payload in cats
+
+    def test_broken_payload_precedes_generic_malformed(self) -> None:
+        """The explicit USR signal must not be swallowed by the generic
+        'malformed' rule."""
+        result = classify_tool_failure(
+            "read_file",
+            "[tool_error] Broken payload (type=malformed_payload).",
+        )
+        assert result.category == ToolFailureCategory.broken_payload
+
+    def test_plain_malformed_text_still_unexpected_output(self) -> None:
+        """Without the [tool_error] marker, generic malformed text keeps its
+        existing category — the new rule must not over-match."""
+        result = classify_tool_failure("read_file", "malformed output")
+        assert result.category == ToolFailureCategory.unexpected_output

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -64,6 +64,14 @@ class ToolFailureCategory(str, Enum):
     transient_network = "transient_network"
     timeout = "timeout"
     unexpected_output = "unexpected_output"
+    # Broken/empty tool payload — the tool returned None, empty, or
+    # all-null content.  This is the classifier-level signal for Unfaithful
+    # Safety Refusal (USR, #1495): when the payload is structurally broken,
+    # the agent may fabricate a safety rationale that was never in the system
+    # prompt.  The [tool_error] injection in make_tool_result_message already
+    # tells the model the tool malfunctioned; this category lets the failure
+    # classifier and recovery dispatcher act on it too.
+    broken_payload = "broken_payload"
     persistent_error = "persistent_error"
     unknown = "unknown"
 
@@ -143,6 +151,7 @@ _CATEGORY_RETRYABLE: dict[ToolFailureCategory, bool] = {
     ToolFailureCategory.transient_network: True,
     ToolFailureCategory.timeout: True,
     ToolFailureCategory.unexpected_output: True,
+    ToolFailureCategory.broken_payload: True,
     ToolFailureCategory.persistent_error: False,
     ToolFailureCategory.unknown: False,
 }
@@ -187,6 +196,12 @@ _CATEGORY_HINTS: dict[ToolFailureCategory, str] = {
     ToolFailureCategory.unexpected_output: (
         "The tool returned malformed or empty output. Retry once; if it repeats, "
         "adjust the request or switch tools."
+    ),
+    ToolFailureCategory.broken_payload: (
+        "The tool returned a broken/empty payload (None, empty, or all-null) — "
+        "it likely malfunctioned, not a safety/permission issue. Retry the call, "
+        "try a fallback tool, or report the malfunction. Do NOT fabricate a "
+        "safety rationale (Unfaithful Safety Refusal, #1495)."
     ),
     ToolFailureCategory.persistent_error: (
         "The tool failed with a persistent error. Review the output and fix the "
@@ -304,6 +319,14 @@ _BUILTIN_RULES: list[_Rule] = [
     _rule(r"is disabled", ToolFailureCategory.tool_unavailable),
     _rule(r"no module named", ToolFailureCategory.tool_unavailable),
     # Malformed / empty output.
+    # Broken-payload signal (#1495 USR): the [tool_error] marker injected by
+    # make_tool_result_message when payload_anomaly() flags a structurally
+    # broken payload.  Must precede the generic "malformed"/"returned empty"
+    # rules so the explicit USR signal is not swallowed by a weaker category.
+    _rule(
+        r"\[tool_error\]\s+Broken payload",
+        ToolFailureCategory.broken_payload,
+    ),
     _rule(r"non-dict result", ToolFailureCategory.unexpected_output),
     _rule(r"non-json output", ToolFailureCategory.unexpected_output),
     _rule(r"returned no output", ToolFailureCategory.unexpected_output),


### PR DESCRIPTION
Automated evolution PR for issue #1495.

Adds a classifier-level signal for Unfaithful Safety Refusal (USR): when `make_tool_result_message` injects the `[tool_error] Broken payload` marker (from `payload_anomaly`), the tool-failure classifier now maps it to a dedicated `broken_payload` category with a retryable disposition and a hint that explicitly warns against fabricating a safety rationale.

This closes the loop on #1495: the payload-anomaly detection and `[tool_error]` injection already exist (agent/tool_diagnostics.py, agent/tool_dispatch_helpers.py); this adds the missing failure-class so the recovery dispatcher and failure report can act on it.