### PR TITLE
feat: trajectory-attribution provenance on skill promotion (Closes #2288)

### DIFF
--- a/scripts/evolution_skill_version.py
+++ b/scripts/evolution_skill_version.py
@@ -65,6 +65,13 @@ class SkillVersion:
     diff_ref: str = ""
     critic_ref: str = ""
     note: str = ""
+    # Trajectory attribution (#2288 — PoisonedEvolution).  Which task
+    # trajectories contributed to this skill's content.  Treating
+    # provisional→trusted promotion as a security boundary means recording
+    # the provenance of the skill's content so a cross-trajectory
+    # credit-assignment attack (a skill that looks causally useful and
+    # recurrent but was poisoned) can be audited after the fact.
+    trajectory_refs: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -78,6 +85,7 @@ class SkillVersion:
             "diff_ref": self.diff_ref,
             "critic_ref": self.critic_ref,
             "note": self.note,
+            "trajectory_refs": list(self.trajectory_refs),
         }
 
     @classmethod
@@ -92,6 +100,7 @@ class SkillVersion:
             diff_ref=str(data.get("diff_ref", "")),
             critic_ref=str(data.get("critic_ref", "")),
             note=str(data.get("note", "")),
+            trajectory_refs=list(data.get("trajectory_refs", []) or []),
         )
 
 
@@ -129,7 +138,9 @@ def load_versions(skill: str, store_dir: Optional[Path] = None) -> List[SkillVer
     return out
 
 
-def current_version(skill: str, store_dir: Optional[Path] = None) -> Optional[SkillVersion]:
+def current_version(
+    skill: str, store_dir: Optional[Path] = None
+) -> Optional[SkillVersion]:
     """The live version — the highest recorded, not merely the last written.
 
     Ordering by ``version`` rather than by file position means an out-of-order
@@ -151,6 +162,7 @@ def record_promotion(
     diff_ref: str = "",
     critic_ref: str = "",
     note: str = "",
+    trajectory_refs: Optional[List[str]] = None,
     promoted_at: Optional[str] = None,
     store_dir: Optional[Path] = None,
 ) -> SkillVersion:
@@ -171,12 +183,29 @@ def record_promotion(
         diff_ref=diff_ref,
         critic_ref=critic_ref,
         note=note,
+        trajectory_refs=list(trajectory_refs or []),
     )
     path = _path(skill, store_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
     return entry
+
+
+def provenance_ok(record: SkillVersion) -> bool:
+    """Security-boundary check on a promotion's trajectory attribution (#2288).
+
+    PoisonedEvolution (arXiv:2608.05563) shows a skill that looks causally
+    useful and recurrent can still be poisoned via cross-trajectory credit
+    assignment.  Treating provisional→trusted promotion as a security
+    boundary means a promotion should not be trusted if it carries NO
+    trajectory provenance at all — there is no way to audit which trajectories
+    contributed to its content.
+
+    Returns True when the record has at least one trajectory reference
+    (attribution is present and auditable), False when it has none.
+    """
+    return bool(record.trajectory_refs)
 
 
 def rollback_target(
@@ -213,7 +242,7 @@ def _usage() -> str:
     return (
         "usage: evolution_skill_version.py <command> [args]\n"
         "  record <skill> [--verdict V] [--diff REF] [--critic REF] [--note N]\n"
-        "         [--fixes a,b] [--regressions c,d]\n"
+        "         [--fixes a,b] [--regressions c,d] [--trajectories t1,t2]\n"
         "  current <skill>          which version is live, and what approved it\n"
         "  rollback <skill>         the version to revert to\n"
         "  history <skill>          every promotion, oldest first\n"
@@ -250,6 +279,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             note=_opt(args, "--note"),
             fixes=[x for x in _opt(args, "--fixes").split(",") if x],
             regressions=[x for x in _opt(args, "--regressions").split(",") if x],
+            trajectory_refs=[x for x in _opt(args, "--trajectories").split(",") if x],
         )
         print(json.dumps(entry.to_dict(), indent=2, sort_keys=True))
         return 0
@@ -266,8 +296,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     if cmd == "rollback":
         target = rollback_target(skill)
         if target is None:
-            print(f"[skill-version] {skill}: no earlier version to roll back to",
-                  file=sys.stderr)
+            print(
+                f"[skill-version] {skill}: no earlier version to roll back to",
+                file=sys.stderr,
+            )
             return 1
         print(json.dumps(target.to_dict(), indent=2, sort_keys=True))
         return 0

--- a/tests/scripts/test_evolution_skill_provenance.py
+++ b/tests/scripts/test_evolution_skill_provenance.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Tests for trajectory-attribution provenance on skill promotion (#2288).
+
+PoisonedEvolution (arXiv:2608.05563) shows a skill that looks causally useful
+and recurrent can still be poisoned via cross-trajectory credit assignment.
+Treating provisional→trusted promotion as a security boundary means recording
+which trajectories contributed to a skill's content, and refusing to trust a
+promotion that carries no attribution at all.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_skill_version import (  # noqa: E402
+    current_version,
+    load_versions,
+    main,
+    provenance_ok,
+    record_promotion,
+)
+
+
+class TestTrajectoryAttribution:
+    def test_trajectory_refs_are_stored(self, tmp_path):
+        v = record_promotion("s", trajectory_refs=["t1", "t2"], store_dir=tmp_path)
+        assert v.trajectory_refs == ["t1", "t2"]
+
+    def test_trajectory_refs_round_trip(self, tmp_path):
+        record_promotion("s", trajectory_refs=["t1", "t2"], store_dir=tmp_path)
+        loaded = load_versions("s", store_dir=tmp_path)[0]
+        assert loaded.trajectory_refs == ["t1", "t2"]
+
+    def test_trajectory_refs_serialized_in_dict(self, tmp_path):
+        v = record_promotion("s", trajectory_refs=["t1"], store_dir=tmp_path)
+        assert v.to_dict()["trajectory_refs"] == ["t1"]
+
+    def test_default_is_empty(self, tmp_path):
+        v = record_promotion("s", store_dir=tmp_path)
+        assert v.trajectory_refs == []
+
+    def test_old_records_without_field_load_as_empty(self, tmp_path):
+        """Backward compat: a promotion recorded before this field existed
+        must load with empty trajectory_refs, not crash."""
+        p = tmp_path / "s.jsonl"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"skill": "s", "version": 1}) + "\n")
+        assert load_versions("s", store_dir=tmp_path)[0].trajectory_refs == []
+
+
+class TestProvenanceGate:
+    def test_ok_when_attribution_present(self, tmp_path):
+        v = record_promotion("s", trajectory_refs=["t1"], store_dir=tmp_path)
+        assert provenance_ok(v) is True
+
+    def test_not_ok_when_no_attribution(self, tmp_path):
+        v = record_promotion("s", store_dir=tmp_path)
+        assert provenance_ok(v) is False
+
+    def test_cli_records_trajectories(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["record", "s", "--trajectories", "t1,t2"]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["trajectory_refs"] == ["t1", "t2"]
+        store = tmp_path / "skill_versions"
+        assert current_version("s", store_dir=store).trajectory_refs == ["t1", "t2"]


### PR DESCRIPTION
Automated evolution PR for issue #2288.

Treats provisional→trusted skill promotion as a security boundary (PoisonedEvolution, arXiv:2608.05563): records which task trajectories contributed to a skill's content via a new `trajectory_refs` field on the promotion record, and adds `provenance_ok()` so a promotion with no attribution at all is not trusted. Backward-compatible: old records load with empty trajectory_refs.