### PR TITLE
feat: provisional→trusted lifecycle promotion/demotion for skills (Closes #2256)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -77,6 +77,10 @@ DEFAULT_ARCHIVE_AFTER_DAYS = 90
 # consolidation pass is opt-in.
 DEFAULT_CONSOLIDATE = False
 
+# Provisional→trusted lifecycle defaults (#2256).
+DEFAULT_TRUST_PROMOTION_THRESHOLD = 3
+DEFAULT_TRUST_DEMOTION_FAILURE_RATE = 0.5
+
 
 # ---------------------------------------------------------------------------
 # .curator_state — persistent scheduler + status
@@ -215,6 +219,24 @@ def get_consolidate() -> bool:
     """
     cfg = _load_config()
     return bool(cfg.get("consolidate", DEFAULT_CONSOLIDATE))
+
+
+def get_trust_promotion_threshold() -> int:
+    """Consecutive successes to promote provisional→trusted (#2256)."""
+    cfg = _load_config()
+    try:
+        return int(cfg.get("trust_promotion_threshold", DEFAULT_TRUST_PROMOTION_THRESHOLD))
+    except (TypeError, ValueError):
+        return DEFAULT_TRUST_PROMOTION_THRESHOLD
+
+
+def get_trust_demotion_failure_rate() -> float:
+    """Failure-rate threshold to demote trusted→provisional (#2256)."""
+    cfg = _load_config()
+    try:
+        return float(cfg.get("trust_demotion_failure_rate", DEFAULT_TRUST_DEMOTION_FAILURE_RATE))
+    except (TypeError, ValueError):
+        return DEFAULT_TRUST_DEMOTION_FAILURE_RATE
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1978,6 +1978,9 @@ DEFAULT_CONFIG = {
         # genuine non-use (never a mass-prune on the first run). Set to false
         # to keep all bundled built-ins permanently.
         "prune_builtins": True,
+        # Provisional→trusted lifecycle (#2256)
+        "trust_promotion_threshold": 3,
+        "trust_demotion_failure_rate": 0.5,
         # Pre-run backup: before every real curator pass (dry-run is
         # skipped), snapshot ~/.hermes/skills/ into
         # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the

--- a/tests/tools/test_skill_trust_lifecycle.py
+++ b/tests/tools/test_skill_trust_lifecycle.py
@@ -1,0 +1,85 @@
+"""Tests for provisional→trusted skill lifecycle (#2256)."""
+
+from tools.skill_usage import (
+    _apply_trust_transition,
+    get_trust_state,
+    DEFAULT_TRUST_PROMOTION_THRESHOLD,
+    DEFAULT_TRUST_DEMOTION_FAILURE_RATE,
+)
+
+
+def _prov_rec():
+    """A minimal provisional record for testing."""
+    return {
+        "trust_state": "provisional",
+        "consecutive_successes": 0,
+        "recent_failure_rate": 0.0,
+    }
+
+
+def _trusted_rec():
+    """A minimal trusted record for testing."""
+    return {
+        "trust_state": "trusted",
+        "consecutive_successes": 5,
+        "recent_failure_rate": 0.0,
+    }
+
+
+def test_promotion_after_threshold_successes():
+    """A provisional skill promotes after N consecutive successes."""
+    rec = _prov_rec()
+    for _ in range(DEFAULT_TRUST_PROMOTION_THRESHOLD):
+        _apply_trust_transition(rec, success=True)
+    assert rec["trust_state"] == "trusted"
+
+
+def test_no_premature_promotion():
+    """One success below threshold stays provisional."""
+    rec = _prov_rec()
+    _apply_trust_transition(rec, success=True)
+    assert rec["trust_state"] == "provisional"
+
+
+def test_failure_resets_counter():
+    """A failure resets consecutive_successes to 0 (no demotion if still low rate)."""
+    rec = _prov_rec()
+    _apply_trust_transition(rec, success=True)
+    assert rec["consecutive_successes"] == 1
+    rec["recent_failure_rate"] = 0.1  # below demotion threshold
+    _apply_trust_transition(rec, success=False)
+    assert rec["consecutive_successes"] == 0
+    assert rec["trust_state"] == "provisional"
+
+
+def test_demotion_on_high_failure_rate():
+    """A trusted skill with failure_rate >= threshold demotes to provisional."""
+    rec = _trusted_rec()
+    rec["recent_failure_rate"] = DEFAULT_TRUST_DEMOTION_FAILURE_RATE
+    _apply_trust_transition(rec, success=False)
+    assert rec["trust_state"] == "provisional"
+    assert rec["consecutive_successes"] == 0
+
+
+def test_no_demotion_below_threshold():
+    """A trusted skill with failure_rate < threshold stays trusted."""
+    rec = _trusted_rec()
+    rec["recent_failure_rate"] = 0.1  # below 0.5 threshold
+    _apply_trust_transition(rec, success=False)
+    assert rec["trust_state"] == "trusted"
+
+
+def test_get_trust_state_default_trusted():
+    """Pre-existing skills without the field default to trusted (no mass-demotion)."""
+    assert get_trust_state("nonexistent-skill-xyz") == "trusted"
+
+
+def test_get_trust_state_reads_record(monkeypatch):
+    """get_trust_state reads the persisted trust_state field."""
+    import tools.skill_usage as su
+
+    monkeypatch.setattr(su, "load_usage", lambda: {"test-skill": {"trust_state": "provisional"}})
+    assert su.get_trust_state("test-skill") == "provisional"
+
+    monkeypatch.setattr(su, "load_usage", lambda: {"test-skill": {"trust_state": "trusted"}})
+    assert su.get_trust_state("test-skill") == "trusted"

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -659,6 +659,9 @@ def _empty_record() -> Dict[str, Any]:
         "recent_failure_rate": 0.0,
         # Source-chain provenance (#2192)
         "source_chain": [],
+        # Provisional→trusted lifecycle (#2256)
+        "trust_state": "provisional",
+        "consecutive_successes": 0,
     }
 
 
@@ -836,6 +839,10 @@ def set_source_run_id(skill_name: str, run_id: str) -> None:
 # Window for recent_failure_rate — track the last N invocation outcomes.
 _FAILURE_WINDOW = 10
 
+# Provisional→trusted lifecycle defaults (#2256). Overridable via curator config.
+DEFAULT_TRUST_PROMOTION_THRESHOLD = 3
+DEFAULT_TRUST_DEMOTION_FAILURE_RATE = 0.5
+
 
 def record_skill_outcome(skill_name: str, success: bool) -> None:
     """Update invocation_count and recent_failure_rate from an execution outcome (#2190).
@@ -844,6 +851,10 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
     hindered the task. The failure rate is a sliding window over the last
     ``_FAILURE_WINDOW`` invocations. Best-effort; telemetry failures never
     break the tool.
+
+    Also drives the provisional→trusted lifecycle (#2256): successes bump
+    ``consecutive_successes`` and promote at the configured threshold; a
+    failure resets the counter and may demote.
     """
     def _apply(rec: Dict[str, Any]) -> None:
         # invocation_count is the same as use_count — bump it.
@@ -857,7 +868,65 @@ def record_skill_outcome(skill_name: str, success: bool) -> None:
         rec["recent_failure_rate"] = (
             sum(outcomes) / len(outcomes) if outcomes else 0.0
         )
+        # Provisional→trusted lifecycle transitions (#2256)
+        _apply_trust_transition(rec, success)
+
     _mutate(skill_name, _apply)
+
+
+def _apply_trust_transition(rec: Dict[str, Any], success: bool) -> None:
+    """Mutate *rec* for provisional→trusted lifecycle (#2256)."""
+    state = rec.get("trust_state", "trusted")
+    if success:
+        rec["consecutive_successes"] = int(rec.get("consecutive_successes") or 0) + 1
+        if state == "provisional":
+            threshold = _get_promotion_threshold()
+            if rec["consecutive_successes"] >= threshold:
+                rec["trust_state"] = "trusted"
+    else:
+        rec["consecutive_successes"] = 0
+        if state == "trusted":
+            rate = rec.get("recent_failure_rate", 0.0)
+            demotion_rate = _get_demotion_failure_rate()
+            if rate >= demotion_rate:
+                rec["trust_state"] = "provisional"
+
+
+def get_trust_state(skill_name: str) -> str:
+    """Return the trust state of a skill: ``provisional`` or ``trusted``.
+
+    Defaults to ``trusted`` for pre-existing skills that predate the lifecycle
+    field (#2256) or have no usage record — they are assumed trusted so the
+    upgrade does not mass-demote the library. Only skills that were created
+    AFTER this field shipped carry ``provisional`` from their empty record.
+    """
+    try:
+        data = load_usage()
+        rec = data.get(skill_name)
+        if not isinstance(rec, dict):
+            return "trusted"  # no usage record at all → legacy/trusted
+        state = rec.get("trust_state", "trusted")
+        return state if state in ("provisional", "trusted", "demoted") else "trusted"
+    except Exception:
+        return "trusted"
+
+
+def _get_promotion_threshold() -> int:
+    """Read ``curator.trust_promotion_threshold`` from config (#2256)."""
+    try:
+        from agent.curator import get_trust_promotion_threshold
+        return get_trust_promotion_threshold()
+    except Exception:
+        return DEFAULT_TRUST_PROMOTION_THRESHOLD
+
+
+def _get_demotion_failure_rate() -> float:
+    """Read ``curator.trust_demotion_failure_rate`` from config (#2256)."""
+    try:
+        from agent.curator import get_trust_demotion_failure_rate
+        return get_trust_demotion_failure_rate()
+    except Exception:
+        return DEFAULT_TRUST_DEMOTION_FAILURE_RATE
 
 
 def set_state(skill_name: str, state: str) -> None:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2316,6 +2316,19 @@ def _skill_view_with_bump(args, **kw):
                 from tools.skill_usage import bump_use, bump_view
 
                 bump_view(str(resolved))
+                # Provisional→trusted lifecycle consumer (#2256): warn (not
+                # block) when loading a provisional skill so the agent knows
+                # this skill has not yet earned trusted status.
+                try:
+                    from tools.skill_usage import get_trust_state
+                    if get_trust_state(str(resolved)) == "provisional":
+                        parsed["trust_state"] = "provisional"
+                        parsed.setdefault("warnings", []).append(
+                            "This skill is PROVISIONAL — it has not yet earned "
+                            "trusted status. Verify its output carefully."
+                        )
+                except Exception:
+                    pass
                 # A full skill_view tool call is the agent actively loading the
                 # skill to act on it — that counts as use, not just a browse.
                 # A schema_only load is a cheap preview (tier 2), so it bumps
@@ -2352,6 +2365,14 @@ def _skill_view_with_bump(args, **kw):
                                 complied=not violated,
                                 boundary_violated=violated,
                             )
+                            # Wire the failure path into the trust lifecycle
+                            # (#2256): a boundary violation is an attributable
+                            # failure that feeds demotion telemetry.
+                            try:
+                                from tools.skill_usage import record_skill_outcome
+                                record_skill_outcome(prev_skill, success=not violated)
+                            except Exception:
+                                pass
                         # Record compliance for the skill being loaded now.
                         record_compliance(str(resolved), triggered=True, complied=True)
                         set_active_skill(str(resolved))


### PR DESCRIPTION
Automated evolution PR for issue #2256.

## Summary
New skills start as `provisional`, promote to `trusted` after N consecutive successful uses (default 3), and demote back to `provisional` when `recent_failure_rate` exceeds the threshold (default 0.5).

## Addresses all 4 code-review items from PR #2331 closure

1. **Runtime consumer** (`tools/skills_tool.py`): reads `get_trust_state()` when loading a skill and emits a `PROVISIONAL` warning so the agent knows the skill hasn't earned trusted status yet. Warn-only — does not block mid-task.

2. **Config keys registered** (`hermes_cli/config_defaults.py`): `curator.trust_promotion_threshold` and `curator.trust_demotion_failure_rate` with getter functions in `agent/curator.py`. No more `get_config_value` → `SystemExit`.

3. **Failure path wired** (`tools/skills_tool.py`): `record_skill_outcome()` is now called with `success=not violated` from the boundary-violation detection block, so demotion can actually trigger (previously only ever called with `success=True`).

4. **Single-purpose PR** — no omnibus bundling like #2321.

## Design decisions
- **Backfill default = `trusted`**: existing skills without the field are treated as trusted (no mass-provisional on upgrade). Only skills created AFTER this ships via `mark_agent_created` become provisional.
- **Warn-only gating**: choosing *warn* avoids needing a control-flow change in the skill loading path.
- **No new module**: all logic lives in `skill_usage.py` where `record_skill_outcome` already is.

## Verification
- `ruff check` ✓
- `pytest tests/tools/test_skill_trust_lifecycle.py` — 7 passed ✓
- Diff: **200 insertions** (≤ 200 self-merge cap ✓)