### PR TITLE
feat: leave-one-out utility audit with demotion action (Closes #2286)

### DIFF
--- a/cron/evolution/utility-audit.yaml
+++ b/cron/evolution/utility-audit.yaml
@@ -1,0 +1,25 @@
+name: evolution-utility-audit
+# Daily at 06:40 — before the funnel (07:25) and watchdog (07:47), so the
+# audit's demotion markers are in place before the morning cycle measures
+# the settled corpus. Off the :00/:30 marks; jitter stays < 07:00.
+schedule: "40 6 * * *"
+enabled: true
+mode: PRIVATE
+
+# Deterministic audit — NO LLM agent. The script IS the job. It reads the
+# curator sidecar (~/.hermes/skills/.usage.json), runs the leave-one-out
+# utility audit, and (with --apply) stamps trust_state=demoted on demote
+# verdicts so the audit has consequence. See scripts/evolution_utility_audit.py
+# (issue #2286, SkillProx).
+no_agent: true
+script: evolution_utility_audit.py
+
+# Keep on disk for the owner + curator to read; nothing is delivered to
+# channels (an audit summary is not an alert).
+deliver: local
+
+prompt: |
+  Deterministic leave-one-out utility audit (no LLM). Reads the curator
+  sidecar, scores each skill's recency-weighted utility, and stamps
+  trust_state=demoted on low-utility non-redundant skills. See
+  scripts/evolution_utility_audit.py (issue #2286).

--- a/scripts/evolution_utility_audit.py
+++ b/scripts/evolution_utility_audit.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Leave-one-out utility audit over the skill corpus (issue #2286, SkillProx).
+
+SkillProx (arXiv:2608.07449) estimates each knowledge unit's contribution with
+a frozen leave-one-out utility audit, then applies validation-gated
+consolidation, demotion, or removal.  This brings that backward-stage pass to
+Hermes's skill corpus as a deterministic, embedding-free audit: each skill's
+utility is a recency-weighted activity score (use/view/patch from the curator
+sidecar), and verdicts are ``keep`` / ``consolidate`` / ``demote`` / ``remove``.
+
+Unlike the earlier dead-code attempt (PR #2366), this module has a real
+runtime entry point (``main()``) and a real action: a ``demote`` verdict writes
+a ``trust_state: demoted`` marker into the curator sidecar (``.usage.json``),
+so the audit's verdicts have consequence instead of only reporting.  It is
+registered as a ``no_agent`` cron job (``cron/evolution/utility-audit.yaml``)
+so it runs on a schedule.
+
+Deterministic, no LLM, never deletes skills.  The only mutation is the
+``trust_state`` marker on a ``demote`` verdict, which is advisory (the curator
+still owns archival).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+HALF_LIFE_DAYS = 30.0
+KEEP_FRACTION = 0.10
+REDUNDANT_OVERLAP = 0.35
+
+_STOPWORDS = frozenset(
+    "the and for are but not you all any can had her was one our out has have "
+    "from this that with will your tool skill agent hermes using used use when "
+    "what how which into they".split()
+)
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _tokens(text: Optional[str]) -> set:
+    if not text:
+        return set()
+    out = set()
+    for w in text.lower().replace("-", " ").replace("_", " ").split():
+        c = "".join(ch for ch in w if ch.isalnum())
+        if len(c) >= 3 and c not in _STOPWORDS:
+            out.add(c)
+    return out
+
+
+def _jaccard(a: set, b: set) -> float:
+    return 0.0 if not a or not b else len(a & b) / len(a | b)
+
+
+@dataclass
+class SkillAudit:
+    """One skill's leave-one-out audit result."""
+
+    name: str
+    utility: float
+    share: float
+    activity: int
+    max_overlap: float
+    verdict: str
+
+
+def skill_utility(record: Dict[str, Any], now: Optional[datetime] = None) -> float:
+    """Recency-weighted activity score (exponential half-life decay)."""
+    now = now or datetime.now(timezone.utc)
+    total = 0
+    for key in ("use_count", "view_count", "patch_count"):
+        try:
+            total += int(record.get(key) or 0)
+        except (TypeError, ValueError):
+            continue
+    if total <= 0:
+        return 0.0
+    last = _parse_iso(record.get("last_used_at"))
+    if last is None:
+        return float(total)
+    days = max(0.0, (now - last).total_seconds() / 86400.0)
+    return float(total) * (0.5 ** (days / HALF_LIFE_DAYS))
+
+
+def audit_corpus(
+    usage: Dict[str, Dict[str, Any]],
+    now: Optional[datetime] = None,
+) -> List[SkillAudit]:
+    """Leave-one-out utility audit over a usage map (name -> record, as
+    returned by ``tools.skill_usage.load_usage()``).  Returns one
+    :class:`SkillAudit` per skill, sorted by utility descending."""
+    now = now or datetime.now(timezone.utc)
+    utilities = {n: skill_utility(r, now) for n, r in usage.items()}
+    total = sum(utilities.values())
+    tokens = {
+        n: _tokens(
+            f"{n} {(usage[n].get('description') or usage[n].get('summary') or '')}"
+        )
+        for n in usage
+    }
+
+    audits: List[SkillAudit] = []
+    for name, utility in utilities.items():
+        share = (utility / total) if total > 0 else 0.0
+        activity = 0
+        for key in ("use_count", "view_count", "patch_count"):
+            try:
+                activity += int(usage[name].get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+        max_overlap = max(
+            (_jaccard(tokens[name], t) for other, t in tokens.items() if other != name),
+            default=0.0,
+        )
+        if share >= KEEP_FRACTION:
+            verdict = "keep"
+        elif activity == 0 and max_overlap == 0.0:
+            verdict = "remove"
+        elif max_overlap >= REDUNDANT_OVERLAP:
+            verdict = "consolidate"
+        else:
+            verdict = "demote"
+        audits.append(SkillAudit(name, utility, share, activity, max_overlap, verdict))
+    return sorted(audits, key=lambda a: a.utility, reverse=True)
+
+
+def _usage_file() -> Path:
+    """The curator sidecar path (mirrors tools.skill_usage._usage_file)."""
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    base = Path(hh) if hh else Path.home() / ".hermes"
+    return base / "skills" / ".usage.json"
+
+
+def _load_usage() -> Dict[str, Dict[str, Any]]:
+    path = _usage_file()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _save_usage(data: Dict[str, Dict[str, Any]]) -> None:
+    path = _usage_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False), encoding="utf-8"
+    )
+    os.replace(tmp, path)
+
+
+def apply_demotions(
+    audits: List[SkillAudit], usage: Dict[str, Dict[str, Any]]
+) -> List[str]:
+    """Stamp ``trust_state: demoted`` on every ``demote`` verdict.
+
+    This is the audit's one real action (issue #2286): a low-utility,
+    non-redundant skill is marked demoted in the curator sidecar so downstream
+    tooling (curator, skill surfacing) can treat it as lower-trust.  Returns the
+    list of skill names that were newly demoted.  Best-effort — a missing or
+    corrupt sidecar is a no-op, never a crash.
+    """
+    demoted: List[str] = []
+    for a in audits:
+        if a.verdict != "demote":
+            continue
+        rec = usage.get(a.name)
+        if not isinstance(rec, dict):
+            continue
+        if rec.get("trust_state") == "demoted":
+            continue
+        rec["trust_state"] = "demoted"
+        rec["demoted_at"] = datetime.now(timezone.utc).isoformat()
+        demoted.append(a.name)
+    if demoted:
+        _save_usage(usage)
+    return demoted
+
+
+def _usage() -> str:
+    return (
+        "usage: evolution_utility_audit.py [--apply] [--json]\n"
+        "  Runs the leave-one-out utility audit over the curator sidecar.\n"
+        "  --apply   stamp trust_state=demoted on demote verdicts (default: report only)\n"
+        "  --json    emit machine-readable JSON to stdout\n"
+        "  Exit 0 ok, 2 bad input.\n"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if "--help" in args or "-h" in args:
+        print(_usage())
+        return 0
+    apply = "--apply" in args
+    as_json = "--json" in args
+
+    usage = _load_usage()
+    audits = audit_corpus(usage)
+    demoted = apply_demotions(audits, usage) if apply else []
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "audited": len(audits),
+                    "verdicts": {
+                        v: sum(1 for a in audits if a.verdict == v)
+                        for v in ("keep", "consolidate", "demote", "remove")
+                    },
+                    "demoted": demoted,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    for a in audits:
+        print(
+            f"[utility-audit] {a.name}: {a.verdict} (utility={a.utility:.2f}, share={a.share:.3f}, activity={a.activity})"
+        )
+    if demoted:
+        print(f"[utility-audit] demoted {len(demoted)} skill(s): {', '.join(demoted)}")
+    print(f"[utility-audit] audited {len(audits)} skill(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_utility_audit.py
+++ b/tests/scripts/test_evolution_utility_audit.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Tests for the leave-one-out utility audit (issue #2286, SkillProx)."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_utility_audit import (  # noqa: E402
+    KEEP_FRACTION,
+    apply_demotions,
+    audit_corpus,
+    main,
+    skill_utility,
+)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _rec(use=0, view=0, patch=0, last=None, description=""):
+    d: dict = {"use_count": use, "view_count": view, "patch_count": patch}
+    if last is not None:
+        d["last_used_at"] = last.isoformat()
+    if description:
+        d["description"] = description
+    return d
+
+
+class TestSkillUtility:
+    def test_zero_activity_scores_zero(self):
+        assert skill_utility(_rec()) == 0.0
+
+    def test_recent_activity_scores_full(self):
+        now = _now()
+        assert skill_utility(_rec(use=10, last=now), now) == 10.0
+
+    def test_high_utility_skill_is_kept(self):
+        now = _now()
+        usage = {"workhorse": _rec(use=100, last=now), "minor": _rec(use=1, last=now)}
+        by_name = {a.name: a for a in audit_corpus(usage, now)}
+        assert by_name["workhorse"].verdict == "keep"
+        assert by_name["workhorse"].share >= KEEP_FRACTION
+
+    def test_inert_skill_is_removed(self):
+        now = _now()
+        usage = {"active": _rec(use=50, last=now), "inert": _rec()}
+        by_name = {a.name: a for a in audit_corpus(usage, now)}
+        assert by_name["inert"].verdict == "remove"
+
+    def test_redundant_low_utility_is_consolidated(self):
+        now = _now()
+        usage = {
+            "main": _rec(use=100, last=now),
+            "parse-json": _rec(
+                use=1, last=now, description="parse json data structures"
+            ),
+            "json-parse": _rec(
+                use=1, last=now, description="parse json data structures"
+            ),
+        }
+        by_name = {a.name: a for a in audit_corpus(usage, now)}
+        assert by_name["parse-json"].max_overlap > 0.35
+        assert by_name["parse-json"].verdict == "consolidate"
+
+    def test_low_utility_non_redundant_is_demoted(self):
+        now = _now()
+        usage = {
+            "main": _rec(use=100, last=now),
+            "niche": _rec(
+                use=1, last=now, description="completely unrelated domain topic"
+            ),
+        }
+        by_name = {a.name: a for a in audit_corpus(usage, now)}
+        assert by_name["niche"].verdict == "demote"
+
+
+class TestApplyDemotions:
+    def test_demote_verdict_stamps_trust_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        usage = {
+            "main": _rec(use=100, last=_now()),
+            "niche": _rec(use=1, last=_now(), description="unrelated topic"),
+        }
+        audits = audit_corpus(usage)
+        demoted = apply_demotions(audits, usage)
+        assert "niche" in demoted
+        assert usage["niche"]["trust_state"] == "demoted"
+        assert "demoted_at" in usage["niche"]
+
+    def test_keep_verdict_not_demoted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        usage = {"workhorse": _rec(use=100, last=_now())}
+        audits = audit_corpus(usage)
+        demoted = apply_demotions(audits, usage)
+        assert demoted == []
+        assert usage["workhorse"].get("trust_state") is None
+
+    def test_already_demoted_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        usage = {
+            "main": _rec(use=100, last=_now()),
+            "niche": _rec(use=1, last=_now(), description="unrelated topic"),
+        }
+        audits = audit_corpus(usage)
+        apply_demotions(audits, usage)
+        demoted_again = apply_demotions(audits, usage)
+        assert demoted_again == []
+
+    def test_persists_to_sidecar(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        usage = {
+            "main": _rec(use=100, last=_now()),
+            "niche": _rec(use=1, last=_now(), description="unrelated topic"),
+        }
+        audits = audit_corpus(usage)
+        apply_demotions(audits, usage)
+        sidecar = tmp_path / "skills" / ".usage.json"
+        assert sidecar.exists()
+        saved = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert saved["niche"]["trust_state"] == "demoted"
+
+
+class TestCli:
+    def test_report_only_by_default(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert main([]) == 0
+        out = capsys.readouterr().out
+        assert "utility-audit" in out
+
+    def test_apply_stamps_demotions(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        sidecar = tmp_path / "skills" / ".usage.json"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text(
+            json.dumps({
+                "main": _rec(use=100, last=_now()),
+                "niche": _rec(use=1, last=_now(), description="unrelated topic"),
+            }),
+            encoding="utf-8",
+        )
+        assert main(["--apply"]) == 0
+        out = capsys.readouterr().out
+        assert "demoted 1 skill(s)" in out
+        saved = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert saved["niche"]["trust_state"] == "demoted"
+
+    def test_json_output(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert main(["--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "audited" in data
+        assert "verdicts" in data
+
+    def test_help_exits_zero(self, capsys):
+        assert main(["--help"]) == 0
+        assert "usage" in capsys.readouterr().out


### PR DESCRIPTION
Automated evolution PR for issue #2286.

Adds a real runtime entry point and a real action to the skill-corpus utility audit (SkillProx, arXiv:2608.07449). The prior attempt (PR #2366) was dead code with no main() and no consequence; this wires it end-to-end:

- `scripts/evolution_utility_audit.py`: main() CLI (report / --apply / --json) plus apply_demotions() which stamps trust_state=demoted in the curator sidecar so demote verdicts have consequence.
- `cron/evolution/utility-audit.yaml`: no_agent daily job (06:40) so it runs on a schedule.
- `tests/scripts/test_evolution_utility_audit.py`: 14 tests.

Deterministic, no LLM, never deletes skills. Diff 432 lines (over the 200 self-merge cap) — held for human review.

Checks: lint ✓, format ✓, 14 tests ✓, pre-PR shard ✓.