### PR TITLE
feat(memory): model-identity metadata + model-aware retrieval filtering (Closes #2234)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2898,6 +2898,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
 
+    # Stamp tqmemory writes with model-identity metadata (#2234).
+    try:
+        from agent.tqmemory_model_filter import is_tqmemory_write, stamp_model_metadata
+        if is_tqmemory_write(function_name):
+            function_args = stamp_model_metadata(function_args, getattr(agent, "model", None))
+    except Exception:
+        pass
+
     # Check plugin hooks for a block or approval directive before executing.
     block_message: Optional[str] = None
     if not pre_tool_block_checked:
@@ -3166,21 +3174,30 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
 
     if skip_tool_execution_middleware:
-        return _execute(function_args)
+        result = _execute(function_args)
+    else:
+        from hermes_cli.middleware import run_tool_execution_middleware
+        result = run_tool_execution_middleware(
+            function_name,
+            function_args,
+            lambda next_args: _execute(next_args if isinstance(next_args, dict) else function_args),
+            original_args=function_args,
+            task_id=effective_task_id or "",
+            session_id=getattr(agent, "session_id", "") or "",
+            tool_call_id=tool_call_id or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+        )
 
-    from hermes_cli.middleware import run_tool_execution_middleware
+    # Filter tqmemory reads by model family — down-weight cross-family notes (#2234).
+    try:
+        from agent.tqmemory_model_filter import is_tqmemory_read, filter_by_model_family
+        if is_tqmemory_read(function_name) and isinstance(result, str):
+            result = filter_by_model_family(result, getattr(agent, "model", None))
+    except Exception:
+        pass
 
-    return run_tool_execution_middleware(
-        function_name,
-        function_args,
-        lambda next_args: _execute(next_args if isinstance(next_args, dict) else function_args),
-        original_args=function_args,
-        task_id=effective_task_id or "",
-        session_id=getattr(agent, "session_id", "") or "",
-        tool_call_id=tool_call_id or "",
-        turn_id=getattr(agent, "_current_turn_id", "") or "",
-        api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-    )
+    return result
 
 
 

--- a/agent/tqmemory_model_filter.py
+++ b/agent/tqmemory_model_filter.py
@@ -1,0 +1,86 @@
+"""Model-identity metadata + model-aware retrieval filtering for tqmemory (#2234).
+
+Thin interceptor — does NOT touch the tqmemory MCP server. Both write-stamp
+and read-filter live in invoke_tool (the single chokepoint with agent.model).
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from agent.adversarial_verification import detect_model_family
+
+logger = logging.getLogger(__name__)
+
+_CROSS_FAMILY_PENALTY = 0.5
+
+_WRITE_TOOLS = frozenset({"mcp_tqmemory_remember_note", "mcp__tqmemory__remember_note"})
+_READ_TOOLS = frozenset({
+    "mcp_tqmemory_recent_context", "mcp_tqmemory_semantic_search",
+    "mcp__tqmemory__recent_context", "mcp__tqmemory__semantic_search",
+})
+
+
+def is_tqmemory_write(name: str) -> bool:
+    return name in _WRITE_TOOLS
+
+
+def is_tqmemory_read(name: str) -> bool:
+    return name in _READ_TOOLS
+
+
+def stamp_model_metadata(args: dict, model: Optional[str]) -> dict:
+    """Return *args* with model_identity/model_family in metadata (#2234). Never raises."""
+    try:
+        result = dict(args) if isinstance(args, dict) else {}
+        meta = dict(result.get("metadata") or {})
+        meta["model_identity"] = (model or "").strip()
+        meta["model_family"] = detect_model_family(model)
+        result["metadata"] = meta
+        return result
+    except Exception:
+        return args
+
+
+def filter_by_model_family(
+    result_json: str, consumer_model: Optional[str], *, penalty: float = _CROSS_FAMILY_PENALTY,
+) -> str:
+    """Down-weight cross-family notes in a tqmemory retrieval result (#2234).
+
+    Entries whose model_family differs from the consumer's get their relevance
+    multiplied by *penalty* (default 0.5), then entries are re-sorted by
+    relevance descending. Entries without metadata or an unknown consumer are
+    left untouched. Never raises — returns *result_json* unchanged on any error.
+    """
+    try:
+        data = json.loads(result_json)
+    except (json.JSONDecodeError, TypeError):
+        return result_json
+
+    consumer_family = detect_model_family(consumer_model)
+    if consumer_family == "unknown":
+        return result_json
+
+    entries = None
+    for key in ("notes", "entries", "results", "context"):
+        val = data.get(key) if isinstance(data, dict) else None
+        if isinstance(val, list):
+            entries = val
+            break
+    if entries is None:
+        return result_json
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        meta = entry.get("metadata") or {}
+        ef = meta.get("model_family") if isinstance(meta, dict) else None
+        if ef in ("", None, "unknown") or ef == consumer_family:
+            continue
+        entry["relevance"] = round(float(entry.get("relevance", 1.0)) * penalty, 4)
+
+    entries.sort(key=lambda e: float(e.get("relevance", 0.0)) if isinstance(e, dict) else 0.0, reverse=True)
+    try:
+        return json.dumps(data, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return result_json

--- a/tests/agent/test_tqmemory_model_filter.py
+++ b/tests/agent/test_tqmemory_model_filter.py
@@ -1,0 +1,65 @@
+"""Tests for model-identity metadata + model-aware retrieval filtering (#2234)."""
+
+import json
+
+from agent.tqmemory_model_filter import (
+    stamp_model_metadata, filter_by_model_family,
+    is_tqmemory_write, is_tqmemory_read,
+)
+
+
+def test_stamp_adds_identity_and_family():
+    result = stamp_model_metadata({"title": "t", "content": "c"}, "claude-sonnet-4-6")
+    m = result["metadata"]
+    assert m["model_identity"] == "claude-sonnet-4-6"
+    assert m["model_family"] == "anthropic"
+
+
+def test_stamp_preserves_existing_metadata():
+    result = stamp_model_metadata({"metadata": {"custom": "val"}}, "gpt-5.5")
+    assert result["metadata"]["custom"] == "val"
+    assert result["metadata"]["model_family"] == "openai"
+
+
+def test_stamp_no_model_is_unknown():
+    result = stamp_model_metadata({"content": "x"}, None)
+    assert result["metadata"]["model_family"] == "unknown"
+
+
+def test_filter_downweights_cross_family():
+    entries = [
+        {"id": 1, "relevance": 1.0, "metadata": {"model_family": "openai"}},
+        {"id": 2, "relevance": 1.0, "metadata": {"model_family": "anthropic"}},
+    ]
+    result = filter_by_model_family(json.dumps({"notes": entries}), "claude-sonnet-4-6")
+    notes = json.loads(result)["notes"]
+    assert notes[0]["id"] == 2 and notes[0]["relevance"] == 1.0  # same family first
+    assert notes[1]["id"] == 1 and notes[1]["relevance"] == 0.5  # cross-family penalized
+
+
+def test_filter_passthrough_unknown_metadata():
+    entries = [{"id": 1, "relevance": 1.0, "metadata": {}}]
+    result = filter_by_model_family(json.dumps({"notes": entries}), "gpt-5.5")
+    assert json.loads(result)["notes"][0]["relevance"] == 1.0
+
+
+def test_filter_malformed_json_is_noop():
+    assert filter_by_model_family("not json {{{", "gpt-5.5") == "not json {{{"
+
+
+def test_filter_no_consumer_model_is_noop():
+    entries = [{"id": 1, "relevance": 1.0, "metadata": {"model_family": "openai"}}]
+    result = filter_by_model_family(json.dumps({"notes": entries}), None)
+    assert json.loads(result)["notes"][0]["relevance"] == 1.0
+
+
+def test_filter_no_entries_key_is_noop():
+    result = filter_by_model_family(json.dumps({"status": "ok"}), "gpt-5.5")
+    assert json.loads(result) == {"status": "ok"}
+
+
+def test_tool_name_detection():
+    assert is_tqmemory_write("mcp_tqmemory_remember_note")
+    assert not is_tqmemory_write("mcp_tqmemory_recent_context")
+    assert is_tqmemory_read("mcp_tqmemory_recent_context")
+    assert not is_tqmemory_read("mcp_tqmemory_remember_note")


### PR DESCRIPTION
Automated evolution PR for issue #2234.

## Summary
Stamp tqmemory notes with the authoring model's identity at write time, and down-weight cross-family notes at read time so the consuming model retrieves entries compatible with its reasoning style.

## Fixes the PR #2325 dead-code defect
PR #2325 wrote `model_identity` metadata but the retrieval path never read it — the MCP handler closure (`tools/mcp_tool.py`) has no access to the consuming model. This PR places BOTH the write-stamp and the read-filter in `invoke_tool` (`agent/agent_runtime_helpers.py`), the single chokepoint that sees every MCP tool call AND holds `agent.model`.

## Changes
- **agent/tqmemory_model_filter.py** (NEW): `stamp_model_metadata()` — adds `model_identity` + `model_family` to note metadata at write time. `filter_by_model_family()` — down-weights cross-family entries by 0.5x relevance penalty and re-sorts. Both gracefully degrade on any error.
- **agent/agent_runtime_helpers.py**: wired stamp into the write path (after middleware, before dispatch) and filter into the read path (before return) in `invoke_tool()`.
- **tests/agent/test_tqmemory_model_filter.py** (NEW): 9 tests covering stamping, cross-family down-weighting, unknown metadata passthrough, malformed JSON, no-consumer-model noop, and tool-name detection.

## Design decisions
- **Down-weight, not hard-filter**: preserves cross-family handoffs (a legitimate use case). A 0.5 penalty keeps cross-family notes retrievable but ranked below same-family ones.
- **Uses existing `detect_model_family`** from `adversarial_verification.py` — no duplicated logic.
- **Graceful degradation**: every interceptor path wrapped in `try/except` — tqmemory without metadata or malformed results never break note persistence/retrieval.

## Verification
- `ruff check` ✓
- `pytest tests/agent/test_tqmemory_model_filter.py` — 9 passed ✓
- Diff: 183 insertions + 15 deletions = 198 lines (≤ 200 self-merge cap ✓)