### PR TITLE
feat(security): provenance gate on provisional→trusted skill promotion (Closes #2288)

### DIFF
--- a/tests/tools/test_skill_provenance_chain.py
+++ b/tests/tools/test_skill_provenance_chain.py
@@ -1,9 +1,16 @@
 """Tests for source-chain provenance (tools/skill_provenance.py)."""
 
 from tools.skill_provenance import (
-    set_current_write_origin, reset_current_write_origin,
-    init_source_chain, reset_source_chain, add_provenance_entry,
-    get_recorded_chain, get_skill_provenance, BACKGROUND_REVIEW,
+    set_current_write_origin,
+    reset_current_write_origin,
+    init_source_chain,
+    reset_source_chain,
+    add_provenance_entry,
+    get_recorded_chain,
+    get_skill_provenance,
+    BACKGROUND_REVIEW,
+    provenance_ok,
+    record_promotion,
 )
 
 
@@ -46,3 +53,72 @@ def test_untrusted_classification():
 
 def test_get_skill_provenance_empty():
     assert get_skill_provenance("nonexistent-skill-xyz") == []
+
+
+def test_provenance_ok_empty_chain():
+    """No chain at all → rejected (no attribution)."""
+    ok, reason = provenance_ok(chain=[])
+    assert ok is False
+    assert "no source_chain" in reason
+
+
+def test_provenance_ok_no_trusted_sources():
+    """Chain with only untrusted sources → rejected."""
+    chain = [
+        {
+            "source_type": "web_extract",
+            "source_id": "https://evil.example.com",
+            "trusted": False,
+        },
+        {"source_type": "web_search", "source_id": "query", "trusted": False},
+    ]
+    ok, reason = provenance_ok(chain=chain)
+    assert ok is False
+    assert "no trusted sources" in reason
+
+
+def test_provenance_ok_has_trusted_source():
+    """Chain with at least one trusted source → passes."""
+    chain = [
+        {
+            "source_type": "web_extract",
+            "source_id": "https://example.com",
+            "trusted": False,
+        },
+        {"source_type": "terminal", "source_id": "/tmp/proof", "trusted": True},
+    ]
+    ok, reason = provenance_ok(chain=chain)
+    assert ok is True
+    assert reason == ""
+
+
+def test_provenance_ok_all_trusted():
+    """Chain where every source is trusted → passes."""
+    chain = [
+        {"source_type": "read_file", "source_id": "/tmp/a", "trusted": True},
+        {"source_type": "execute_code", "source_id": "cell1", "trusted": True},
+    ]
+    ok, _ = provenance_ok(chain=chain)
+    assert ok is True
+
+
+def test_provenance_ok_reads_live_chain():
+    """provenance_ok() with no arg reads the live ContextVar chain."""
+    token = init_source_chain()
+    try:
+        ok, reason = provenance_ok()
+        assert ok is False  # empty live chain
+        wtoken = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            add_provenance_entry("search_files", "/tmp")
+            ok, _ = provenance_ok()
+            assert ok is True  # trusted source present
+        finally:
+            reset_current_write_origin(wtoken)
+    finally:
+        reset_source_chain(token)
+
+
+def test_record_promotion_best_effort():
+    """record_promotion never raises even for a nonexistent skill."""
+    record_promotion("nonexistent-skill-xyz", reason="test")

--- a/tests/tools/test_skill_validation_gate.py
+++ b/tests/tools/test_skill_validation_gate.py
@@ -18,7 +18,10 @@ from tools.skill_manager_tool import (
 )
 from tools.skill_provenance import (
     BACKGROUND_REVIEW,
+    add_provenance_entry,
+    init_source_chain,
     reset_current_write_origin,
+    reset_source_chain,
     set_current_write_origin,
 )
 
@@ -132,7 +135,12 @@ class TestValidationGateBlocksAdmission:
     def test_background_review_create_valid_skill_admitted(self, tmp_path):
         """A valid auto-created skill IS admitted (marked agent-created)."""
         token = set_current_write_origin(BACKGROUND_REVIEW)
+        chain_token = init_source_chain()
         try:
+            # Simulate a trusted source entry that a real background-review
+            # fork would record (e.g. via read_file / terminal). The
+            # provenance gate (#2288) requires at least one trusted source.
+            add_provenance_entry("read_file", str(tmp_path / "research.md"))
             with _skill_dir(tmp_path):
                 raw = skill_manage("create", "good-auto-skill", content=VALID_SKILL)
                 result = json.loads(raw)
@@ -145,6 +153,7 @@ class TestValidationGateBlocksAdmission:
                 rec = get_record("good-auto-skill")
                 assert rec.get("created_by") is not None
         finally:
+            reset_source_chain(chain_token)
             reset_current_write_origin(token)
 
     def test_background_review_create_short_skill_blocked(self, tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1729,6 +1729,29 @@ def skill_manage(
                                     f"retry."
                                 ),
                             }, ensure_ascii=False)
+                    # === Provenance gate (#2288, PoisonedEvolution) ===
+                    # A background-review skill must carry verifiable source
+                    # attribution before promotion to trusted. Mirrors the
+                    # validate_skill_content gate above: blocking + rollback.
+                    # Reads the LIVE chain (before it's persisted below).
+                    if not _skill_gate_bypass.get():
+                        from tools.skill_provenance import provenance_ok
+                        _ok, _prov_reason = provenance_ok()
+                        if not _ok:
+                            logger.warning(
+                                "Provenance gate BLOCKED promotion of '%s': %s",
+                                name, _prov_reason,
+                            )
+                            _rollback_skill_dir(name)
+                            return json.dumps({
+                                "success": False,
+                                "error": (
+                                    f"Provenance gate rejected skill '{name}': "
+                                    f"{_prov_reason}. The skill was NOT promoted. "
+                                    f"A trusted skill requires verifiable source "
+                                    f"attribution (#2288)."
+                                ),
+                            }, ensure_ascii=False)
                     mark_agent_created(name)
                     # Record the source run ID for provenance tracking (#2190).
                     try:
@@ -1746,6 +1769,12 @@ def skill_manage(
                         if chain:
                             from tools.skill_usage import _mutate
                             _mutate(name, lambda rec: rec.update({"source_chain": chain[:50]}))
+                    except Exception:
+                        pass
+                    # Record promotion audit trail (#2288).
+                    try:
+                        from tools.skill_provenance import record_promotion
+                        record_promotion(name, reason="provenance_ok: trusted sources present")
                     except Exception:
                         pass
             elif action in {"patch", "edit", "write_file", "remove_file"}:

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -14,13 +14,15 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 _write_origin: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "skill_write_origin", default="foreground",
+    "skill_write_origin",
+    default="foreground",
 )
 
 # Source-chain accumulator — list of source entries recorded during the
 # current background-review fork. Each entry: {source_type, source_id, trusted}.
 _source_chain: contextvars.ContextVar[list | None] = contextvars.ContextVar(
-    "skill_source_chain", default=None,
+    "skill_source_chain",
+    default=None,
 )
 
 BACKGROUND_REVIEW = "background_review"
@@ -89,8 +91,59 @@ def get_skill_provenance(skill_name: str) -> List[Dict[str, Any]]:
     """
     try:
         from tools.skill_usage import get_record
+
         rec = get_record(skill_name)
         chain = rec.get("source_chain") or []
         return chain if isinstance(chain, list) else []
     except Exception:
         return []
+
+
+def provenance_ok(
+    chain: list | None = None,
+) -> tuple[bool, str]:
+    """Provenance gate for provisional→trusted skill promotion (#2288).
+
+    PoisonedEvolution (arXiv:2608.05563) shows that trajectory-poisoning
+    attacks embed malicious behaviors via seemingly-ordinary evidence that
+    *looks* causally useful.  The distinctive defense lever is **attribution**:
+    a skill promoted to trusted must carry verifiable source provenance.
+
+    Returns ``(ok, reason)``.  ``ok=False`` blocks promotion.
+
+    A background-review skill must have a recorded source chain whose entries
+    include at least one **trusted** source (terminal, read_file, search_files,
+    execute_code — the SkillJack taxonomy).  An empty chain or one with *zero*
+    trusted sources is rejected — the skill has no verifiable attribution.
+
+    Accepts the *live* chain (from ``get_recorded_chain``) so the gate can run
+    BEFORE the chain is persisted to ``.usage.json``.
+    """
+    entries = chain if chain is not None else get_recorded_chain()
+    if not entries:
+        return False, "no source_chain recorded — skill has no provenance attribution"
+    trusted = [e for e in entries if e.get("trusted")]
+    if not trusted:
+        untrusted_types = sorted({e.get("source_type", "?") for e in entries})
+        return (
+            False,
+            f"source_chain has no trusted sources (all untrusted: {untrusted_types})",
+        )
+    return True, ""
+
+
+def record_promotion(skill_name: str, reason: str = "") -> None:
+    """Stamp the usage record that this skill passed the provenance gate and
+    was promoted to trusted.  Best-effort audit trail (#2288).
+    """
+    try:
+        from datetime import datetime, timezone
+        from tools.skill_usage import _mutate
+
+        def _apply(rec: dict) -> None:
+            rec["promoted_at"] = datetime.now(timezone.utc).isoformat()
+            rec["promotion_reason"] = (reason or "provenance_ok")[:200]
+
+        _mutate(skill_name, _apply)
+    except Exception as exc:
+        logger.warning("record_promotion(%s) failed: %s", skill_name, exc)


### PR DESCRIPTION
Automated evolution PR for issue #2288.

## Summary
Adds a provenance/attribution gate to provisional→trusted skill promotion, implementing the defense recommended by PoisonedEvolution (arXiv:2608.05563). A skill promoted to trusted must carry a source_chain with at least one trusted source (terminal, read_file, search_files, execute_code).

## What changed
- **tools/skill_provenance.py**: `provenance_ok()` gate + `record_promotion()` audit trail
- **tools/skill_manager_tool.py**: gate wired into `skill_manage()` before `mark_agent_created()`
- **tests/tools/test_skill_validation_gate.py**: fixed `test_background_review_create_valid_skill_admitted` — now initializes source_chain with a trusted entry (this was the slice 7/8 CI failure that blocked PR #2367)
- **tests/tools/test_skill_provenance_chain.py**: 6 new tests for provenance_ok + record_promotion

## CI fix context
PR #2367 passed code review but failed CI slice 7/8 because the provenance gate blocked the existing `test_background_review_create_valid_skill_admitted` test (which created a skill without a source_chain). Fixed by making the test reflect real background-review conditions.