### PR TITLE
fix(curator): auto-preload skill content before write in background-review (Closes #2375)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -881,3 +881,73 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# Background-review SKILL.md auto-preload (#2375)
+# ---------------------------------------------------------------------------
+
+
+class TestCuratorSkillMdAutoPreload:
+    """The read-before-write guard must NOT trap the curator in an infinite
+    loop when it tries to edit/patch SKILL.md without a prior skill_view.
+
+    Reproduces #2375: the background skill-curation agent oscillates —
+    skill_manage(edit) is refused ("content has not been loaded"), the agent
+    falls back to read_file (denied — not whitelisted in background-review
+    mode), then loops back to the write. Auto-preloading SKILL.md (the write
+    paths re-read it from disk before mutating) breaks the cycle while
+    preserving the blind-overwrite protection for supporting files.
+    """
+
+    def test_edit_skill_md_succeeds_without_prior_skill_view(self, tmp_path, monkeypatch):
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("looped", _skill_content("looped"))
+
+            # No skill_view("looped") first — the exact oscillation trigger.
+            new_content = _skill_content("looped").replace(
+                "Step 1: Do the thing.", "Step 1: Do the better thing."
+            )
+            result = _edit_skill("looped", new_content)
+        assert result["success"] is True, result
+        _reset_background_review_read_marks()
+
+    def test_patch_skill_md_succeeds_without_prior_skill_view(self, tmp_path, monkeypatch):
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("looped", _skill_content("looped"))
+
+            result = _patch_skill(
+                "looped",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the patched thing.",
+            )
+        assert result["success"] is True, result
+        _reset_background_review_read_marks()
+
+    def test_support_file_still_requires_explicit_read(self, tmp_path, monkeypatch):
+        """Auto-preload applies to SKILL.md only; linked files keep the strict
+        refuse path (blind-overwrite protection must stay intact)."""
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("looped", _skill_content("looped"))
+            ref = tmp_path / ".hermes" / "skills" / "looped" / "references"
+            ref.mkdir()
+            (ref / "workflow.md").write_text("old workflow\n", encoding="utf-8")
+
+            blocked = json.loads(skill_manage(
+                action="write_file",
+                name="looped",
+                file_path="references/workflow.md",
+                file_content="new workflow\n",
+            ))
+        assert blocked["success"] is False
+        assert blocked.get("_read_before_write_required") is True
+        _reset_background_review_read_marks()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -536,7 +536,24 @@ def _background_review_read_before_write_guard(
     action: str,
     file_label: str,
 ) -> Optional[Dict[str, Any]]:
-    """Require review forks to load the exact target before mutating it."""
+    """Require review forks to load the exact target before mutating it.
+
+    SKILL.md auto-preload (#2375): the background skill-curation agent enters
+    an infinite oscillation when it attempts to edit/patch SKILL.md without
+    first calling skill_view — the guard refuses the write, the agent then
+    tries read_file (not whitelisted in background-review mode), that is
+    denied, and it loops back to the write. ``read_file`` is intentionally
+    NOT whitelisted (only memory/skill tools are), so the precondition the
+    refusal demands can never be satisfied through the agent's reflexive
+    recovery path. ``skill_view`` IS whitelisted, but the LLM often does not
+    reach for it. SKILL.md writes (edit/patch) re-read the actual on-disk
+    content in ``_edit_skill`` / ``_patch_skill`` before mutating, so the
+    guard's "content basis" guarantee is preserved by auto-marking SKILL.md
+    as read here. Supporting files (references/, templates/, scripts/) keep
+    the strict refuse path — the agent can satisfy those via
+    skill_view(name, file_path=...) which IS whitelisted, and the blind-
+    overwrite protection for linked files must stay intact (#2375 test).
+    """
     try:
         from tools.skill_provenance import is_background_review
         if not is_background_review():
@@ -545,6 +562,19 @@ def _background_review_read_before_write_guard(
         return None
 
     if _background_review_has_read(target):
+        return None
+
+    # Auto-preload the skill's main SKILL.md: this is the file the curator
+    # most often edits, and the write paths below re-read it from disk before
+    # applying changes, so marking it read is safe and breaks the loop.
+    if _is_skill_md_target(name, target):
+        try:
+            mark_background_review_skill_read(target)
+        except Exception:
+            logger.debug(
+                "auto-preload of SKILL.md for skill '%s' failed", name,
+                exc_info=True,
+            )
         return None
 
     return {
@@ -558,6 +588,29 @@ def _background_review_read_before_write_guard(
         ),
         "_read_before_write_required": True,
     }
+
+
+def _is_skill_md_target(name: str, target: Path) -> bool:
+    """True if ``target`` is the main SKILL.md of skill ``name``.
+
+    Used by the read-before-write guard to decide auto-preload eligibility:
+    only the skill's primary SKILL.md is auto-loaded (the write paths re-read
+    it from disk), never its supporting files.
+    """
+    if target.name != "SKILL.md":
+        return False
+    try:
+        resolved = str(target.resolve())
+    except Exception:
+        resolved = str(target)
+    found = _find_skill(name)
+    if not found:
+        return False
+    try:
+        skill_md = str((found["path"] / "SKILL.md").resolve())
+    except Exception:
+        skill_md = str(found["path"] / "SKILL.md")
+    return resolved == skill_md
 
 
 def _background_review_preflight(action: str, name: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
Automated evolution PR for issue #2375.

## Summary
Auto-preload the skill's main SKILL.md in the background-review read-before-write guard so the curator no longer enters an infinite oscillation. Added `_is_skill_md_target()` helper that identifies the primary SKILL.md; when the guard fires for it, the file is marked as read (auto-preloaded) instead of refused. Supporting files (references/, templates/, scripts/) keep the strict refuse path.

## Root cause
The background skill-curation agent enters an infinite loop because skill_manage refuses writes when the content has not been loaded, but read_file is not whitelisted in background-review mode. The agent reflexively tries read_file → denied → loops back to the write. `skill_view` IS whitelisted but the LLM often does not reach for it. The write paths (`_edit_skill` / `_patch_skill`) re-read the actual on-disk SKILL.md content before mutating, so auto-marking SKILL.md as read is safe and breaks the loop. Supporting files keep blind-overwrite protection (the agent can satisfy those via `skill_view(name, file_path=...)` which IS whitelisted).

## Tests
- `test_edit_skill_md_succeeds_without_prior_skill_view` — edit no longer blocked without skill_view
- `test_patch_skill_md_succeeds_without_prior_skill_view` — patch no longer blocked without skill_view
- `test_support_file_still_requires_explicit_read` — linked-file protection preserved
- All 61 tests in the targeted suite pass; diff is 124 insertions, 1 deletion.