### PR TITLE
fix(backup): prune+VACUUM before snapshot to prevent data-loss risk (Closes #2373)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2342,6 +2342,13 @@ def _run_state_db_auto_maintenance(session_db) -> None:
             min_vacuum_interval_days=int(cfg.get("min_vacuum_interval_days", 30)),
             vacuum=bool(cfg.get("vacuum_after_prune", True)),
             sessions_dir=_hermes_home_maint / "sessions",
+            # Issue #2373: force VACUUM when state.db approaches the 1 GiB
+            # backup snapshot limit (768 MiB = 75% of the cap), so the file
+            # is shrunk *before* it grows past the limit and snapshots start
+            # getting silently skipped for 24h+.
+            db_size_vacuum_threshold=int(
+                cfg.get("db_size_vacuum_threshold", 768 * 1024 * 1024)
+            ),
         )
     except Exception as exc:
         logger.debug("state.db auto-maintenance skipped: %s", exc)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6087,6 +6087,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         ),
                         vacuum=bool(_sess_cfg.get("vacuum_after_prune", True)),
                         sessions_dir=self.config.sessions_dir,
+                        # Issue #2373: force VACUUM when state.db approaches the
+                        # 1 GiB backup limit (default 768 MiB = 75% of the cap).
+                        db_size_vacuum_threshold=int(
+                            _sess_cfg.get("db_size_vacuum_threshold", 768 * 1024 * 1024)
+                        ),
                     )
             except Exception as exc:
                 logger.debug("state.db auto-maintenance skipped: %s", exc)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1002,6 +1002,74 @@ _QUICK_STATE_FILES = (
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
 
+# When the state.db exceeds this fraction of max_file_size, we proactively
+# prune+VACUUM before snapshotting so the shrunken DB fits under the cap
+# instead of being silently skipped (issue #2373). 50% leaves headroom for
+# the post-VACUUM file to still be well under the limit.
+_PRUNE_BEFORE_SNAPSHOT_FACTOR = 0.5
+
+
+def _prune_and_vacuum_state_db_before_snapshot(
+    hermes_home: Path,
+    max_file_size: int,
+) -> None:
+    """Run prune+VACUUM on state.db *before* a size-capped snapshot.
+
+    Issue #2373: the state database grows monotonically (~3 MB/hour) even
+    when nothing is prunable, so the existing ``maybe_auto_prune_and_vacuum``
+    (whose VACUUM is gated on ``pruned > 0``) never reclaims space. Once the
+    file crosses ``max_file_size`` the snapshot silently skips it, so no
+    backup is captured for 24h+ — a data-loss risk.
+
+    This opens a short-lived read/write SessionDB connection, runs the prune
+    sweep with a size-based VACUUM threshold set well below ``max_file_size``,
+    and closes it. Never raises — pruning is best-effort and must not block
+    the snapshot.
+    """
+    db_path = hermes_home / "state.db"
+    try:
+        if not db_path.exists():
+            return
+        db_size = db_path.stat().st_size
+        threshold = int(max_file_size * _PRUNE_BEFORE_SNAPSHOT_FACTOR)
+        if db_size <= threshold:
+            return
+
+        from hermes_state import SessionDB
+
+        logger.info(
+            "state.db is %d bytes (>%d threshold) — running prune+VACUUM "
+            "before snapshot (issue #2373)",
+            db_size,
+            threshold,
+        )
+        session_db = SessionDB(db_path=db_path)
+        try:
+            from hermes_constants import get_hermes_home as _get_home
+            from hermes_cli.config import load_config as _load_cfg
+
+            cfg = (_load_cfg() or {}).get("sessions") or {}
+            session_db.maybe_auto_prune_and_vacuum(
+                retention_days=int(cfg.get("retention_days", 90)),
+                min_interval_hours=0,  # force: the snapshot needs it now
+                vacuum=bool(cfg.get("vacuum_after_prune", True)),
+                sessions_dir=_get_home() / "sessions",
+                db_size_vacuum_threshold=threshold,
+            )
+        finally:
+            session_db.close()
+
+        new_size = db_path.stat().st_size if db_path.exists() else 0
+        if new_size < db_size:
+            logger.info(
+                "state.db prune+VACUUM reclaimed %d bytes (%d → %d)",
+                db_size - new_size,
+                db_size,
+                new_size,
+            )
+    except Exception as exc:
+        logger.debug("Pre-snapshot prune+VACUUM skipped: %s", exc)
+
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     home = hermes_home or get_hermes_home()
@@ -1034,6 +1102,12 @@ def create_quick_snapshot(
     """
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
+
+    # Issue #2373: when a size cap is in effect (pre-update / auto snapshot),
+    # proactively prune+VACUUM state.db *before* walking files so the shrunken
+    # DB fits under the cap instead of being silently skipped.
+    if max_file_size is not None:
+        _prune_and_vacuum_state_db_before_snapshot(home, max_file_size)
 
     def _too_large(path: Path, rel_name: str) -> bool:
         """True (and warn) when ``path`` exceeds the max_file_size cap."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9264,6 +9264,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         vacuum: bool = True,
         sessions_dir: Optional[Path] = None,
         min_vacuum_interval_days: int = 30,
+        db_size_vacuum_threshold: int = 0,
     ) -> Dict[str, Any]:
         """Idempotent auto-maintenance: prune inactive sessions + optional VACUUM.
 
@@ -9277,6 +9278,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         When *sessions_dir* is provided, on-disk transcript files
         (``.json`` / ``.jsonl`` / ``request_dump_*``) for pruned sessions
         are removed as part of the same sweep (issue #3015).
+
+        When *db_size_vacuum_threshold* is > 0 and the database file on disk
+        exceeds that many bytes, VACUUM is forced regardless of whether rows
+        were pruned (issue #2373: the DB grows monotonically even with no
+        prunable sessions, so the ``pruned > 0`` gate alone never fires and
+        the file balloons past backup limits).
 
         Never raises. On any failure, logs a warning and returns a dict
         with ``"error"`` set.
@@ -9307,13 +9314,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             result["pruned"] = pruned
 
-            # Only VACUUM if we actually freed rows, and no more often than
-            # once every min_vacuum_interval_days -- a large prune (e.g. the
-            # first one to cross retention_days on a DB with tens of
-            # thousands of rows) can free enough pages that pruned > 0 fires
-            # on every subsequent startup even though a VACUUM already ran
-            # recently. VACUUM on this DB's size (FTS5 shadow tables) is not
-            # cheap -- it holds an exclusive lock for the full rewrite.
+            # VACUUM when either (a) we freed rows this pass, or (b) the DB
+            # file exceeds db_size_vacuum_threshold bytes — issue #2373: the
+            # database grows monotonically even when nothing is prunable, so a
+            # ``pruned > 0``-only gate lets the file balloon past the 1 GiB
+            # backup limit and snapshots get silently skipped for 24h+.
+            # Throttled to once every min_vacuum_interval_days regardless of
+            # which condition triggered it — VACUUM on this DB's size (FTS5
+            # shadow tables) is not cheap; it holds an exclusive lock for the
+            # full rewrite.
             last_vacuum_raw = self.get_meta("last_vacuum")
             vacuum_due = True
             if last_vacuum_raw:
@@ -9321,7 +9330,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     vacuum_due = (now - float(last_vacuum_raw)) >= min_vacuum_interval_days * 86400
                 except (TypeError, ValueError):
                     vacuum_due = True
-            if vacuum and pruned > 0 and vacuum_due:
+
+            db_over_size = False
+            if db_size_vacuum_threshold > 0:
+                try:
+                    db_over_size = (
+                        self.db_path.exists()
+                        and self.db_path.stat().st_size > db_size_vacuum_threshold
+                    )
+                except OSError:
+                    db_over_size = False
+
+            if vacuum and vacuum_due and (pruned > 0 or db_over_size):
                 try:
                     self.vacuum()
                     result["vacuumed"] = True

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5144,6 +5144,46 @@ class TestVacuum:
         assert vacuum_calls == [True, True]
         assert db.get_meta("last_vacuum") is not None
 
+    def test_auto_maintenance_vacuum_on_size_threshold(self, db, monkeypatch):
+        """Issue #2373: VACUUM must fire on DB size alone, even if pruned == 0."""
+        # No sessions pruned (the old gate that prevented VACUUM).
+        monkeypatch.setattr(db, "prune_sessions", lambda **_kwargs: 0)
+        vacuum_calls = []
+        monkeypatch.setattr(db, "vacuum", lambda: vacuum_calls.append(True))
+        # Simulate the DB file exceeding the threshold via a fake path object.
+        fake_path = type("FakePath", (), {
+            "exists": lambda self: True,
+            "stat": lambda self: type("S", (), {"st_size": 2 * 1024 * 1024 * 1024})(),
+        })()
+        monkeypatch.setattr(db, "db_path", fake_path)
+
+        result = db.maybe_auto_prune_and_vacuum(
+            min_interval_hours=0,
+            db_size_vacuum_threshold=1024 * 1024 * 1024,
+        )
+
+        assert result["vacuumed"] is True
+        assert vacuum_calls == [True]
+
+    def test_auto_maintenance_no_size_vacuum_below_threshold(self, db, monkeypatch):
+        """Issue #2373: below the size threshold and no prunes → no VACUUM."""
+        monkeypatch.setattr(db, "prune_sessions", lambda **_kwargs: 0)
+        vacuum_calls = []
+        monkeypatch.setattr(db, "vacuum", lambda: vacuum_calls.append(True))
+        fake_path = type("FakePath", (), {
+            "exists": lambda self: True,
+            "stat": lambda self: type("S", (), {"st_size": 100 * 1024 * 1024})(),
+        })()
+        monkeypatch.setattr(db, "db_path", fake_path)
+
+        result = db.maybe_auto_prune_and_vacuum(
+            min_interval_hours=0,
+            db_size_vacuum_threshold=1024 * 1024 * 1024,
+        )
+
+        assert result["vacuumed"] is False
+        assert vacuum_calls == []
+
 
 class TestOptimizeFts:
     def test_optimize_returns_index_count(self, db):

--- a/tests/test_session_vacuum_config.py
+++ b/tests/test_session_vacuum_config.py
@@ -38,4 +38,5 @@ def test_cli_auto_maintenance_forwards_vacuum_interval(monkeypatch, tmp_path: Pa
         min_vacuum_interval_days=17,
         vacuum=True,
         sessions_dir=tmp_path / "sessions",
+        db_size_vacuum_threshold=768 * 1024 * 1024,
     )


### PR DESCRIPTION
## Summary

Fixes issue #2373: the state database grows monotonically (~3 MB/h) even when nothing is prunable, so the existing `maybe_auto_prune_and_vacuum` (whose VACUUM is gated on `pruned > 0`) never reclaims space. Once `state.db` crosses the 1 GiB backup snapshot cap, snapshots are silently skipped for 24h+ — a data-loss risk.

### Root cause
The `pruned > 0` gate means VACUUM only fires after sessions are deleted. With no sessions past the retention window, VACUUM never runs and the DB file balloons unchecked.

### Changes
- **hermes_state.py**: Add `db_size_vacuum_threshold` kwarg to `maybe_auto_prune_and_vacuum`. When the DB file exceeds this threshold, VACUUM fires regardless of `pruned` count. Throttled to `min_vacuum_interval_days` like the existing condition.
- **cli.py + gateway/run.py**: Wire the new kwarg at both call sites (default 768 MiB = 75% of the 1 GiB cap).
- **hermes_cli/backup.py**: Add `_prune_and_vacuum_state_db_before_snapshot()` — runs prune+VACUUM before a size-capped snapshot so the shrunken DB fits under the cap instead of being silently skipped.
- **tests**: Update `test_session_vacuum_config.py` contract + add 2 new tests for size-threshold VACUUM behavior.

### Rework note
This is a rework of PR #2380 (which was correct but broke `test_session_vacuum_config.py::test_cli_auto_maintenance_forwards_vacuum_interval` by not updating the `assert_called_once_with` mock). This PR updates the test contract.

Closes #2373