### PR TITLE
feat(compaction): preserve temporal info in context-compaction prompts (Closes #2381)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3847,6 +3847,13 @@ Describe agent/tool work only as completed actions, state, or historical work.]"
                 f'proposal email to John on {_today_str}." Never leave a finished '
                 "action worded as if it still needs doing, and never invent a date "
                 "for work that has not happened yet.\n"
+                "PRESERVE TEMPORAL INFORMATION: When summarising the source turns, "
+                "retain all timestamps, dates, durations, deadlines, and sequence "
+                "ordering mentioned in the conversation — do not strip temporal "
+                "expressions just because they are not task-critical. If a turn "
+                'says "ran the test at 14:30 UTC on 2026-03-15 and it failed", '
+                'keep the time, not just "the test failed". Events that happened '
+                "in a specific order must stay ordered in the summary.\n"
             )
         else:
             _temporal_anchoring_rule = ""

--- a/tests/agent/test_context_compressor_temporal_anchoring.py
+++ b/tests/agent/test_context_compressor_temporal_anchoring.py
@@ -84,3 +84,21 @@ def test_anchoring_rule_uses_date_from_hermes_time_now():
 
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
     assert "2025-12-31" in prompt
+
+
+def test_anchoring_rule_preserves_temporal_information_directive():
+    """Issue #2381: the compaction prompt must instruct the summariser to
+    preserve timestamps, dates, durations, and sequence ordering from the
+    source turns — not just anchor the current date. This is the fix from
+    the Sleeping Agent paper (arXiv:2608.11775): gist compression silently
+    destroys temporal info, which a one-sentence prompt directive recovers."""
+    compressor = _compressor()
+    with patch.object(hermes_time, "now", _fixed_now), patch(
+        "agent.context_compressor.call_llm", return_value=_response("summary")
+    ) as mock_call:
+        compressor._generate_summary(_turns())
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PRESERVE TEMPORAL INFORMATION" in prompt
+    assert "timestamps" in prompt.lower()
+    assert "sequence" in prompt.lower()


### PR DESCRIPTION
## Summary

Fixes issue #2381: research finding from arXiv:2608.11775 (*The Sleeping Agent: Gist Compression Silently Destroys Temporal Information*).

### Problem
Gist compression discards timestamps, dates, and sequence ordering from source conversation turns. The existing `_temporal_anchoring_rule` anchors the **current** date (rewriting relative references like "email John" into dated past-tense facts like "Sent email to John on 2026-08-14"), but does NOT instruct the summariser to **preserve temporal expressions from the source turns**.

### Fix
Added a `PRESERVE TEMPORAL INFORMATION` directive to the existing `_temporal_anchoring_rule` block. This is the paper's one-sentence prompt fix that raises temporal-expression preservation ~20× (3.05% → 62.39%) while barely changing named-entity/event preservation.

The directive instructs the summariser to retain all timestamps, dates, durations, deadlines, and sequence ordering from the conversation — and gives a concrete before/after example.

### Coverage
The directive flows through both compaction paths since they reuse `_generate_summary`:
- Auto-compress (`compress_context`)
- Delegate `collapsed_summary` handoff mode

### Test
Added `test_anchoring_rule_preserves_temporal_information_directive` to the existing temporal-anchoring test suite.

Closes #2381