### PR TITLE
feat(retry): raise cron-context 429 retry ceiling (Closes #2376)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2688,6 +2688,23 @@ def _run_conversation_impl(
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
+
+        # Issue #2376 (SLICE A): For cron/non-interactive contexts (no user
+        # waiting), raise the retry ceiling so brief provider 429/overload
+        # spikes don't kill the pipeline stage. The default interactive
+        # ceiling (3) is designed for responsiveness; cron jobs benefit from
+        # more persistence since nobody is watching the spinner.
+        _is_cron_context = env_var_enabled("HERMES_CRON_SESSION")
+        if _is_cron_context:
+            _cron_retries = int(os.environ.get("HERMES_CRON_MAX_RETRIES", "15"))
+            if _cron_retries > max_retries:
+                logger.info(
+                    "cron-context API retry ceiling raised %d → %d "
+                    "(HERMES_CRON_SESSION active, issue #2376)",
+                    max_retries,
+                    _cron_retries,
+                )
+                max_retries = _cron_retries
         _retry = TurnRetryState()
 
         finish_reason = "stop"

--- a/tests/run_agent/test_cron_retry_ceiling.py
+++ b/tests/run_agent/test_cron_retry_ceiling.py
@@ -1,0 +1,74 @@
+"""Tests for cron-context API retry ceiling (issue #2376, SLICE A).
+
+When HERMES_CRON_SESSION is set, the retry ceiling is raised from the
+default interactive ceiling (agent._api_max_retries, typically 3) to a
+higher value (default 15) so brief provider 429/overload spikes don't
+kill a cron pipeline stage.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _mock_agent(max_retries: int = 3):
+    """Create a minimal mock agent with _api_max_retries set."""
+    agent = MagicMock()
+    agent._api_max_retries = max_retries
+    agent.quiet_mode = True
+    agent.log_prefix = "[test] "
+    agent.provider = "test"
+    agent.model = "test/model"
+    return agent
+
+
+def test_cron_context_raises_retry_ceiling(monkeypatch):
+    """When HERMES_CRON_SESSION is set, max_retries should be raised to 15."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_CRON_MAX_RETRIES", raising=False)
+
+    # Import the module fresh so the env var is read at call time.
+    from agent import conversation_loop as cl
+
+    agent = _mock_agent(max_retries=3)
+
+    # The retry-ceiling logic is inline in process_conversation_turn.
+    # We verify the env-var detection + ceiling computation directly.
+    is_cron = cl.env_var_enabled("HERMES_CRON_SESSION")
+    assert is_cron, "HERMES_CRON_SESSION should be detected"
+
+    cron_retries = int(os.environ.get("HERMES_CRON_MAX_RETRIES", "15"))
+    assert cron_retries == 15
+    assert cron_retries > agent._api_max_retries
+
+
+def test_non_cron_context_keeps_default_ceiling(monkeypatch):
+    """Without HERMES_CRON_SESSION, the ceiling stays at agent default."""
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    from agent import conversation_loop as cl
+
+    is_cron = cl.env_var_enabled("HERMES_CRON_SESSION")
+    assert not is_cron, "HERMES_CRON_SESSION should not be detected"
+
+
+def test_cron_max_retries_env_override(monkeypatch):
+    """HERMES_CRON_MAX_RETRIES env var overrides the default 15."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_CRON_MAX_RETRIES", "20")
+
+    cron_retries = int(os.environ.get("HERMES_CRON_MAX_RETRIES", "15"))
+    assert cron_retries == 20
+
+
+def test_cron_ceiling_never_lowers_below_default(monkeypatch):
+    """If HERMES_CRON_MAX_RETRIES < agent default, keep the agent default."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_CRON_MAX_RETRIES", "2")
+
+    agent = _mock_agent(max_retries=5)
+    cron_retries = int(os.environ.get("HERMES_CRON_MAX_RETRIES", "15"))
+
+    # The code uses `if _cron_retries > max_retries` — it never lowers.
+    assert cron_retries <= agent._api_max_retries


### PR DESCRIPTION
## Summary

SLICE A of parent #2374 (HTTP 429 provider overload kills cron jobs).

### Problem
Cron/non-interactive jobs share the interactive retry ceiling (default 3, set via `agent._api_max_retries`). A brief provider 429/overload spike kills the entire cron pipeline stage after just 3 attempts, even though nobody is waiting for a response.

### Fix
When `HERMES_CRON_SESSION` is set (the standard cron-context signal already used throughout the codebase), raise the retry ceiling to 15 (configurable via `HERMES_CRON_MAX_RETRIES` env var). The existing `jittered_backoff` function already provides ±50% jitter (exceeding the ±30% target from the issue), so only the ceiling needs adjustment.

### Scope
- Detects cron context via `HERMES_CRON_SESSION` env var (already established convention)
- Raises ceiling from `agent._api_max_retries` (default 3) to 15 (env-overridable)
- Never lowers below the configured default (guards against misconfigured env)
- Logs when cron-context extended retry is active

### What's NOT in this slice (deferred to SLICE B / #2377)
Cross-provider failover for cron-driven runs. SLICE A only raises the ceiling for the current provider.

Closes #2376