### PR TITLE
feat(retry): raise cron-context 429 retry ceiling + add jitter (Closes #2376)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1948,6 +1948,16 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Issue #2376: cron/unattended contexts get a higher retry ceiling so
+    # transient 429/overload spikes don't kill the pipeline stage.
+    try:
+        _raw_cron_retries = _agent_section.get("cron_api_max_retries", 15)
+        _cron_retries = int(_raw_cron_retries)
+        _cron_retries = max(_cron_retries, 1)
+    except (TypeError, ValueError):
+        _cron_retries = 15
+    agent._cron_api_max_retries = _cron_retries
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2688,6 +2688,20 @@ def _run_conversation_impl(
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
+        # Issue #2376: raise the retry ceiling for cron/unattended contexts
+        # where no human is waiting — transient 429/overload spikes should
+        # not kill the pipeline stage. Cron gets a higher ceiling (default
+        # 15 vs 3) and wider jitter (±40% vs ±25%) so retries are decorrelated
+        # and ride out brief provider spikes.
+        _is_cron_context = getattr(agent, "platform", None) == "cron"
+        if _is_cron_context:
+            _cron_max = getattr(agent, "_cron_api_max_retries", 15)
+            if _cron_max > max_retries:
+                max_retries = _cron_max
+                logger.info(
+                    "%sCron-context extended retry active: max_retries=%d (default %d)",
+                    agent.log_prefix, max_retries, agent._api_max_retries,
+                )
         _retry = TurnRetryState()
 
         finish_reason = "stop"
@@ -3332,8 +3346,15 @@ def _run_conversation_impl(
                             "failed": True,  # Mark as failure for filtering
                         }
 
-                    # Backoff before retry — jittered exponential: 5s base, 120s cap
-                    wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                    # Backoff before retry — jittered exponential: 5s base, 120s cap.
+                    # Issue #2376: in cron context, widen jitter to ±40% (jitter_ratio=0.8)
+                    # so concurrent cron retries are decorrelated and don't thunder-herd
+                    # the same overloaded provider simultaneously.
+                    _backoff_jitter = 0.8 if _is_cron_context else 0.5
+                    wait_time = jittered_backoff(
+                        retry_count, base_delay=5.0, max_delay=120.0,
+                        jitter_ratio=_backoff_jitter,
+                    )
                     agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
                     logger.warning("Invalid API response (retry %d/%d): %s | Provider: %s", retry_count, max_retries, ', '.join(error_details), provider_name)
                     # Sleep in small increments to stay responsive to interrupts

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -69,6 +69,11 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Issue #2376: in cron/unattended contexts there is no human waiting,
+        # so transient 429/overload spikes should tolerate more retries before
+        # giving up. This raises the ceiling for platform=="cron" only;
+        # interactive sessions keep the standard api_max_retries.
+        "cron_api_max_retries": 15,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/tests/run_agent/test_cron_api_max_retries_config.py
+++ b/tests/run_agent/test_cron_api_max_retries_config.py
@@ -1,0 +1,54 @@
+"""Tests for cron-context extended retry ceiling (issue #2376).
+
+Slice A of #2374: raise the 429 retry ceiling for cron/unattended contexts
+and widen jitter so brief provider spikes don't kill the pipeline stage.
+"""
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(api_max_retries=None, cron_api_max_retries=None, platform="cli"):
+    """Build an AIAgent with a mocked config tree."""
+    cfg = {"agent": {}}
+    if api_max_retries is not None:
+        cfg["agent"]["api_max_retries"] = api_max_retries
+    if cron_api_max_retries is not None:
+        cfg["agent"]["cron_api_max_retries"] = cron_api_max_retries
+
+    with patch("run_agent.OpenAI"), \
+         patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform=platform,
+        )
+
+
+def test_default_cron_api_max_retries_is_fifteen():
+    """No config override → cron ceiling defaults to 15."""
+    agent = _make_agent()
+    assert agent._cron_api_max_retries == 15
+
+
+def test_cron_api_max_retries_honors_config_override():
+    """Setting agent.cron_api_max_retries in config propagates."""
+    agent = _make_agent(cron_api_max_retries=20)
+    assert agent._cron_api_max_retries == 20
+
+    agent2 = _make_agent(cron_api_max_retries=1)
+    assert agent2._cron_api_max_retries == 1
+
+
+def test_cron_ceiling_does_not_lower_interactive_ceiling():
+    """A cron ceiling below the interactive one must not reduce max_retries."""
+    agent = _make_agent(api_max_retries=5, cron_api_max_retries=2)
+    # The cron ceiling is only *raised* above the interactive default, never
+    # lowered — interactive sessions keep their own api_max_retries.
+    assert agent._cron_api_max_retries == 2
+    assert agent._api_max_retries == 5


### PR DESCRIPTION
Automated evolution PR for issue #2376 (Slice A of #2374).

## Problem
The existing circuit breaker fails after 2 consecutive overloaded responses, but cron jobs retry up to 8 times then die. For cron/unattended contexts (no human waiting), raise the retry ceiling and widen jitter so brief provider spikes don't kill the pipeline stage.

## Changes (92 insertions, 2 deletions across 4 files)
1. **`hermes_cli/config_defaults.py`** — Add `agent.cron_api_max_retries` (default 15).
2. **`agent/agent_init.py`** — Read `cron_api_max_retries` and set `agent._cron_api_max_retries`.
3. **`agent/conversation_loop.py`** — When `platform == 'cron'`, raise `max_retries` to the cron ceiling (never below the interactive default) and widen backoff jitter to ±40% (`jitter_ratio=0.8`) so concurrent cron retries are decorrelated. Log when cron-context extended retry is active.
4. **`tests/run_agent/test_cron_api_max_retries_config.py`** — 3 new tests for the cron retry ceiling config surface.

## Validation
- Targeted tests: 16 passed (cron retry config + api_max_retries + retry_utils)
- `ruff check`: All checks passed
- Pre-PR shard: 2 environmental failures (test_runtime_zai, test_hub_index_cache_blocked) both pass in isolation on clean main AND with this change — test-ordering artifacts unrelated to this change.

Closes #2376