### PR TITLE
fix(read_file): auto-retry-with-correction on confident path typo (Closes #2411)

### DIFF
--- a/tests/tools/test_read_file_auto_retry.py
+++ b/tests/tools/test_read_file_auto_retry.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for read_file auto-retry-with-correction (#2411).
+
+Covers the ``confident_nearby_match`` gate (sole >=90 candidate, regular
+file, ambiguous veto) and the read_file_tool wiring: a confident typo is
+retried with the corrected path; ambiguous or failing retries fall back
+to the existing hint-only error contract.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.file_tools import read_file_tool
+from tools.path_validation import confident_nearby_match
+
+
+class _TmpDir(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="test_autoretry_")
+        self.config = os.path.join(self._tmp, "config.yaml")
+        with open(self.config, "w") as f:
+            f.write("key: value\n")
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+class TestConfidentNearbyMatch(_TmpDir):
+    def test_none_for_existing_path(self):
+        self.assertIsNone(confident_nearby_match(self.config))
+
+    def test_same_stem_typo_corrected(self):
+        self.assertEqual(
+            confident_nearby_match(os.path.join(self._tmp, "config.yam")),
+            self.config,
+        )
+
+    def test_ambiguous_twin_returns_none(self):
+        with open(os.path.join(self._tmp, "config.yml"), "w") as f:
+            f.write("other\n")
+        self.assertIsNone(
+            confident_nearby_match(os.path.join(self._tmp, "config.yam"))
+        )
+
+    def test_weak_match_returns_none(self):
+        self.assertIsNone(
+            confident_nearby_match(os.path.join(self._tmp, "zebra.py"))
+        )
+
+
+class TestReadFileAutoRetry(_TmpDir):
+    """read_file_tool must retry once on a confident correction (#2411)."""
+
+    @staticmethod
+    def _fail(path):
+        result = MagicMock()
+        result.to_dict.return_value = {"error": f"File not found: {path}"}
+        return result
+
+    def test_confident_typo_retried_automatically(self):
+        missing = os.path.join(self._tmp, "config.yam")
+        ok = MagicMock()
+        ok.to_dict.return_value = {"content": "key: value\n", "path": self.config}
+        ops = MagicMock()
+        ops.read_file.side_effect = [self._fail(missing), ok]
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = json.loads(read_file_tool(missing, task_id="test_retry_ok"))
+        self.assertNotIn("error", result)
+        self.assertEqual(result["content"], "key: value\n")
+        self.assertEqual(result["auto_corrected"]["requested"], missing)
+        self.assertEqual(result["auto_corrected"]["read"], self.config)
+
+    def test_ambiguous_twin_keeps_hint_only_error(self):
+        with open(os.path.join(self._tmp, "config.yml"), "w") as f:
+            f.write("other\n")
+        missing = os.path.join(self._tmp, "config.yam")
+        ops = MagicMock()
+        ops.read_file.return_value = self._fail(missing)
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = json.loads(read_file_tool(missing, task_id="test_retry_amb"))
+        err = result.get("error") or ""
+        self.assertIn("Did you mean", err)
+        self.assertNotIn("auto_corrected", result)
+
+    def test_failed_retry_falls_back_to_hint(self):
+        missing = os.path.join(self._tmp, "config.yam")
+        ops = MagicMock()
+        ops.read_file.side_effect = [
+            self._fail(missing),
+            self._fail(self.config),  # retry attempt also fails
+        ]
+        with (
+            patch("tools.file_tools._get_file_ops", return_value=ops),
+            patch.dict(os.environ, {"TERMINAL_CWD": self._tmp}),
+        ):
+            result = json.loads(read_file_tool(missing, task_id="test_retry_fb"))
+        err = result.get("error") or ""
+        self.assertIn("File not found", err)
+        self.assertIn("Did you mean", err)
+        self.assertNotIn("auto_corrected", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -20,7 +20,11 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
-from tools.path_validation import format_nearby_hint, suggest_nearby_paths
+from tools.path_validation import (
+    confident_nearby_match,
+    format_nearby_hint,
+    suggest_nearby_paths,
+)
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -1667,6 +1671,24 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 _hint = format_nearby_hint(str(_resolved), _nearby)
                 if _hint:
                     result_dict["error"] = _err + "\n\n" + _hint
+                # #2411 — auto-retry-with-correction: with ONE unambiguous
+                # high-confidence candidate (score >= 90: exact-case or
+                # same-stem), retry once with the corrected path instead of
+                # only hinting. Hints drove the rate 10.6% -> 5.8%
+                # (#1377/#1587/#2293) then plateaued — the residual cohort
+                # re-issues the same wrong path. A corrected retry collapses
+                # that failure turn; on retry failure fall through to the
+                # negative cache + hint exactly as before.
+                _fixed = confident_nearby_match(str(_resolved))
+                if _fixed:
+                    _retry = file_ops.read_file(_fixed, offset, limit)
+                    _retry_dict = _retry.to_dict()
+                    if not (_retry_dict.get("error") or _retry_dict.get("error_class")):
+                        _retry_dict["auto_corrected"] = {
+                            "requested": resolved_str_for_neg,
+                            "read": _fixed,
+                        }
+                        return json.dumps(_retry_dict, ensure_ascii=False)
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
             _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 

--- a/tools/path_validation.py
+++ b/tools/path_validation.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import List, Optional
 
 
-def suggest_nearby_paths(path: str, max_results: int = 5) -> List[str]:
+def _scored_nearby(path: str) -> List[tuple]:
     """Return up to *max_results* paths near *path* the caller likely meant.
 
     Pure-Python existence check + similarity scoring (no shell). Returns
@@ -61,7 +61,29 @@ def suggest_nearby_paths(path: str, max_results: int = 5) -> List[str]:
             scored.append((score, os.path.join(target, f)))
 
     scored.sort(key=lambda x: -x[0])
-    return [fp for _, fp in scored[:max_results]]
+    return scored
+
+
+def suggest_nearby_paths(path: str, max_results: int = 5) -> List[str]:
+    """Return up to *max_results* paths near *path* the caller likely meant."""
+    return [fp for _, fp in _scored_nearby(path)[:max_results]]
+
+
+def confident_nearby_match(path: str, min_score: int = 90) -> Optional[str]:
+    """Return the single unambiguous high-confidence correction for *path*.
+
+    #2411 auto-retry gate: a candidate qualifies only when it is the sole
+    entry at or above *min_score* (exact-case-insensitive or same-stem
+    match) and is a regular file. Ambiguous or weak matches return None —
+    callers fall back to the hint-only contract.
+    """
+    scored = _scored_nearby(path)
+    if not scored or scored[0][0] < min_score:
+        return None
+    if len(scored) > 1 and scored[1][0] >= min_score:
+        return None  # two equally-plausible candidates — don't guess
+    best = scored[0][1]
+    return best if os.path.isfile(best) else None
 
 
 def format_nearby_hint(path: str, nearby: List[str]) -> Optional[str]:


### PR DESCRIPTION
Automated evolution PR for #2411.

Second-generation intervention for the plateaued read_file file-not-found rate (5.8%, 212 failures / 3655 sessions, flat 3 cycles after hint-only fixes #1377/#1587/#2293):

- tools/path_validation.py: refactor suggest_nearby_paths into _scored_nearby + new confident_nearby_match(path, min_score=90) — returns the corrected path ONLY when it is the single unambiguous high-score candidate (case-exact or same-stem) and a regular file; ambiguous twins and weak matches return None (keep hint-only contract).
- tools/file_tools.py: in the read_file FNF block, when the correction is confident, retry once via the same file_ops and return the successful result tagged auto_corrected={requested, read}. Failed retry falls through to the unchanged negative-cache + hint path — side-effect order preserved.
- tests/tools/test_read_file_auto_retry.py: 7 tests — confident typo auto-corrected end-to-end (mocked ops), ambiguous twin vetoed, weak match ignored, failed retry falls back to hint, plus gate unit tests.

Validation: pytest on test_read_file_auto_retry + test_path_validation + test_file_tools = 75 passed; ruff check/format clean. Pre-PR shard runner could not execute locally (pytest-timeout not importable in this env — pip installs blocked by sandbox guard; plugin is pinned in dev extras and present in CI); the identical shard file set was run manually without --timeout, all green.

Total diff 164 lines (merge-gate cap 200).