### PR TITLE
feat(skills): typed skill contract extractor — SkillZip Slice A (Closes #2414)

### DIFF
--- a/agent/skill_contract.py
+++ b/agent/skill_contract.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""Skill contract extraction — read-only Slice A of SkillZip (#2382, #2414).
+
+``extract_contract`` parses an existing SKILL.md and returns a typed
+structural contract — interface, workflow, tool protocol, scoped rules —
+as a standalone JSON-serializable object. Read-only by design: no
+compression or rewriting happens here (that is Slice B, #2415, which
+gates on this contract existing first).
+
+Style mirrors ``agent/experience_bank.py``: pure functions + dataclasses,
+standard library only, defensive everywhere — a malformed skill yields a
+contract with empty fields, never an exception. PyYAML is used when
+importable (it always is in-repo); a tolerant line parser is the
+fallback so the module never hard-depends on it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+__version__ = "1.0.0"
+__all__ = ["SkillContract", "extract_contract"]
+
+_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\n(.*?)\n---[ \t]*(?:\n|\Z)", re.DOTALL)
+_SECTION_RE = re.compile(
+    r"^##+[ \t]*(?P<title>[^\n]+)\n(?P<body>.*?)(?=^##+[ \t]*|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+_LIST_ITEM_RE = re.compile(
+    r"^[ \t]*(?:\d+\.|[-*])[ \t]+(?P<text>.+?)[ \t]*$", re.MULTILINE
+)
+_TOOL_TOKEN_RE = re.compile(r"`([a-z][a-z0-9_]{1,63})`")
+_SKILL_NAME_RE = re.compile(r"\A[a-z0-9][a-z0-9_-]{0,63}\Z")
+_WORKFLOW_TITLE_RE = re.compile(
+    r"workflow|procedure|process|phases|steps", re.IGNORECASE
+)
+_RULE_TITLE_RE = re.compile(
+    r"when to use|pitfall|checklist|iron law|red flag|constraint", re.IGNORECASE
+)
+
+
+def _parse_frontmatter(text: str) -> Dict[str, str]:
+    """Return flat scalar frontmatter keys (``name``, ``description``, ...).
+
+    Nested blocks (``metadata:``) are ignored by both paths so the return
+    type stays ``Dict[str, str]``. Never raises on malformed input.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        return {}
+    raw = match.group(1)
+    try:  # Prefer real YAML when importable.
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw)
+        if isinstance(data, dict):
+            return {
+                str(k): v
+                for k, v in data.items()
+                if isinstance(v, (str, int, float)) and not isinstance(v, bool)
+            }
+    except Exception:
+        pass  # Fall through to the tolerant line parser below.
+    parsed: Dict[str, str] = {}
+    for line in raw.splitlines():
+        if not line or line[0] in " \t#" or ":" not in line:
+            continue  # Top-level scalar keys only; skip nesting/comments.
+        key, _, value = line.partition(":")
+        parsed[key.strip()] = value.strip().strip("'\"")
+    return parsed
+
+
+def _strip_markup(text: str) -> str:
+    """Drop checkbox markers, bold, and backticks from one list item."""
+    cleaned = re.sub(r"^\[[ xX]\][ \t]*", "", text.strip())
+    return cleaned.replace("**", "").replace("`", "").strip()
+
+
+def _dedupe(items: List[str]) -> List[str]:
+    """Order-preserving dedupe."""
+    seen: set = set()
+    out: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+@dataclass
+class SkillContract:
+    """Typed structural contract extracted from one SKILL.md.
+
+    Slice B (#2415) will use this as its coverage gate: a compressed
+    skill must still satisfy its own contract.
+    """
+
+    skill_name: str = ""
+    description: str = ""
+    version: str = ""
+    license: str = ""
+    workflow: List[str] = field(default_factory=list)
+    tools: List[str] = field(default_factory=list)
+    scoped_rules: List[str] = field(default_factory=list)
+    section_titles: List[str] = field(default_factory=list)
+    source_chars: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "skill_name": self.skill_name,
+            "description": self.description,
+            "version": self.version,
+            "license": self.license,
+            "workflow": list(self.workflow),
+            "tools": list(self.tools),
+            "scoped_rules": list(self.scoped_rules),
+            "section_titles": list(self.section_titles),
+            "source_chars": self.source_chars,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SkillContract":
+        """Tolerant deserialization — malformed fields coerce to defaults."""
+
+        def _s(key: str) -> str:
+            return str(d.get(key, "") or "")
+
+        def _l(key: str) -> List[str]:
+            raw = d.get(key)
+            return [str(x) for x in raw] if isinstance(raw, list) else []
+
+        try:
+            chars = int(d.get("source_chars", 0) or 0)
+        except (TypeError, ValueError):
+            chars = 0
+        return cls(
+            skill_name=_s("skill_name"),
+            description=_s("description"),
+            version=_s("version"),
+            license=_s("license"),
+            workflow=_l("workflow"),
+            tools=_l("tools"),
+            scoped_rules=_l("scoped_rules"),
+            section_titles=_l("section_titles"),
+            source_chars=chars,
+        )
+
+
+def extract_contract(skill_markdown: str) -> SkillContract:
+    """Parse one SKILL.md (read-only) into its structural contract.
+
+    Never raises: missing frontmatter or absent sections simply produce
+    empty fields, so callers can extract defensively at scale. The
+    ``skill_name`` keeps the repo's lowercase-hyphen convention — values
+    that violate it (e.g. from corrupt frontmatter) degrade to ``""``.
+    """
+    text = skill_markdown if isinstance(skill_markdown, str) else ""
+    front = _parse_frontmatter(text)
+    sections = list(_SECTION_RE.finditer(text))
+    titles = [m.group("title").strip() for m in sections]
+    bodies = {m.group("title").strip().lower(): m.group("body") for m in sections}
+
+    def _items(body: str) -> List[str]:
+        return [_strip_markup(m.group("text")) for m in _LIST_ITEM_RE.finditer(body)]
+
+    workflow: List[str] = []
+    scoped: List[str] = []
+    for title, body in bodies.items():
+        if _WORKFLOW_TITLE_RE.search(title):
+            workflow.extend(_items(body))
+        elif _RULE_TITLE_RE.search(title):
+            scoped.extend(_items(body))
+    raw_name = str(front.get("name", "") or "")
+    return SkillContract(
+        skill_name=raw_name if _SKILL_NAME_RE.match(raw_name) else "",
+        description=str(front.get("description", "") or ""),
+        version=str(front.get("version", "") or ""),
+        license=str(front.get("license", "") or ""),
+        workflow=workflow,
+        tools=_dedupe(_TOOL_TOKEN_RE.findall(text)),
+        scoped_rules=_dedupe(scoped),
+        section_titles=titles,
+        source_chars=len(text),
+    )

--- a/tests/agent/test_skill_contract.py
+++ b/tests/agent/test_skill_contract.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent/skill_contract.py — Slice A of SkillZip (#2414).
+
+Covers the issue's acceptance criteria:
+- extractor returns a typed contract object from skill markdown
+- contract covers interface, workflow, tool protocol, scoped rules
+- unit tests over 3 sample skills (minimal, full-featured, malformed)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.skill_contract import SkillContract, extract_contract
+
+# ---------------------------------------------------------------------------
+# Sample skills
+# ---------------------------------------------------------------------------
+
+MINIMAL_SKILL = """---
+name: minimal-skill
+description: "Use when doing a minimal thing."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [minimal]
+---
+# Minimal Skill
+## Overview
+One paragraph of what and why.
+
+## When to Use
+- User asks for a minimal thing
+- Don't use for: anything complex
+"""
+
+FULL_SKILL = """---
+name: deploy-service
+description: "Use when deploying a service to production."
+version: 2.1.0
+author: Hermes Agent
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [deploy, ops]
+    related_skills: [plan]
+---
+# Deploy Service
+## Overview
+Deploys a service end to end.
+
+## When to Use
+- User asks to deploy a service
+- A release is approved
+- Don't use for: local dev setups
+
+## Workflow
+1. Run the preflight checks with `terminal`
+2. Review the release notes with `read_file`
+3. Tag the release via `git`
+4. Verify with the monitoring dashboard
+
+## Common Pitfalls
+1. Skipping preflight checks — deploy fails at the gate
+2. Forgetting the `--no-cache` flag — stale image ships
+
+## Verification Checklist
+- [ ] Preflight passed
+- [ ] Dashboard shows the new version
+"""
+
+MALFORMED_SKILL = """---
+name: [broken
+description: - item
+  nested: [unclosed
+version: 1..2
+license:
+---
+## Workflow
+1. only step
+
+not a list, no heading above this
+"""
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: typed contract object from skill markdown
+# ---------------------------------------------------------------------------
+
+
+class TestTypedContract:
+    def test_returns_skill_contract_instance(self):
+        assert isinstance(extract_contract(MINIMAL_SKILL), SkillContract)
+
+    def test_interface_fields_from_frontmatter(self):
+        c = extract_contract(FULL_SKILL)
+        assert c.skill_name == "deploy-service"
+        assert "deploying a service" in c.description
+        assert c.version == "2.1.0"
+        assert c.license == "Apache-2.0"
+
+    def test_interface_fields_empty_when_frontmatter_missing(self):
+        c = extract_contract("# Just a title\n## Overview\nbody\n")
+        assert c.skill_name == ""
+        assert c.description == ""
+
+    def test_roundtrip_via_json(self):
+        c = extract_contract(FULL_SKILL)
+        restored = SkillContract.from_dict(json.loads(json.dumps(c.to_dict())))
+        assert restored == c
+
+    def test_from_dict_tolerates_malformed_fields(self):
+        restored = SkillContract.from_dict({
+            "skill_name": None,
+            "workflow": "not-a-list",
+            "source_chars": "x",
+        })
+        assert restored.skill_name == ""
+        assert restored.workflow == []
+        assert restored.source_chars == 0
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: contract covers the four contract areas
+# ---------------------------------------------------------------------------
+
+
+class TestContractCoverage:
+    def test_workflow_steps_extracted(self):
+        c = extract_contract(FULL_SKILL)
+        assert any("preflight" in step.lower() for step in c.workflow)
+        assert len(c.workflow) == 4
+
+    def test_workflow_empty_when_no_workflow_section(self):
+        assert extract_contract(MINIMAL_SKILL).workflow == []
+
+    def test_tools_extracted_and_deduped(self):
+        c = extract_contract(FULL_SKILL)
+        assert "terminal" in c.tools
+        assert "read_file" in c.tools
+        assert len(c.tools) == len(set(c.tools))
+
+    def test_scoped_rules_from_pitfalls_checklist_when_to_use(self):
+        c = extract_contract(FULL_SKILL)
+        rules_text = " ".join(c.scoped_rules).lower()
+        assert "skipping preflight" in rules_text
+        assert "release is approved" in rules_text
+        assert "preflight passed" in rules_text
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: three sample skills, including malformed input
+# ---------------------------------------------------------------------------
+
+
+class TestThreeSampleSkills:
+    @pytest.mark.parametrize(
+        "sample",
+        [MINIMAL_SKILL, FULL_SKILL, MALFORMED_SKILL],
+        ids=["minimal", "full", "malformed"],
+    )
+    def test_never_raises_on_any_sample(self, sample):
+        extract_contract(sample)
+
+    def test_minimal_skill_contract(self):
+        c = extract_contract(MINIMAL_SKILL)
+        assert c.skill_name == "minimal-skill"
+        assert c.description.startswith("Use when")
+        assert c.section_titles == ["Overview", "When to Use"]
+        assert "User asks for a minimal thing" in c.scoped_rules
+
+    def test_full_skill_contract(self):
+        c = extract_contract(FULL_SKILL)
+        assert c.skill_name == "deploy-service"
+        assert len(c.workflow) == 4
+        assert set(c.tools) >= {"terminal", "read_file", "git"}
+        assert c.source_chars == len(FULL_SKILL)
+
+    def test_malformed_skill_never_raises_and_degrades(self):
+        c = extract_contract(MALFORMED_SKILL)
+        assert c.skill_name == ""  # unparseable frontmatter → empty interface
+        assert len(c.workflow) == 1
+        assert c.source_chars == len(MALFORMED_SKILL)
+
+    def test_empty_input(self):
+        assert extract_contract("") == SkillContract()


### PR DESCRIPTION
Automated evolution PR for #2414 (parent #2382).

## What
- `agent/skill_contract.py` — read-only extractor: SKILL.md → typed `SkillContract` (interface ← frontmatter, workflow ← Workflow/Steps, tool protocol ← backticked tokens, scoped rules ← When-to-Use/Pitfalls/Checklist). JSON round-trip via `to_dict`/`from_dict`; degrades to empty fields on malformed input, never raises.
- `tests/agent/test_skill_contract.py` — 16 tests: typed contract, 4 contract areas, 3 sample skills (minimal / full / malformed).

## Checks (local, pre-PR)
- ruff check ✓ · ruff format ✓ · targeted pytest: 16/16 ✓

## Merge-gate note (honest scope)
Diff is 376 lines — ABOVE the 200-line autonomous self-merge cap, so the merge gate will hold this for human review. Deliberately not thinned further: tests over 3 sample skills are an explicit acceptance criterion of #2414, and the module alone (187 lines) would land untested code.

## Not speculative infrastructure
Unlike the closed GEPA PR #2330, this extractor has a declared, issue-tracked consumer: Slice B (#2415 — MDL compression gated on this contract) with its own acceptance criteria, per the decomposition of parent #2382.