### PR TITLE
feat(gepa): held-out validation + promotion ledger (#2232, Slice C re-land)

### DIFF
--- a/scripts/evolution_gepa_optimize.py
+++ b/scripts/evolution_gepa_optimize.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Live runtime caller for run_gepa_generation (issue #2232, Slice B)."""
+"""Live runtime caller for GEPA generation + held-out validation (#2232, Slice B+C)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from tools.gepa_evolution import EvolutionTree, run_gepa_generation  # noqa: E402
 from tools.gepa_reflector import VariantResult  # noqa: E402
+from tools.gepa_validator import promote_if_valid, validate_held_out  # noqa: E402
 
 SEED_TEXT = (
     "Read the task prompt carefully. Use the available tools to gather the "
@@ -20,18 +21,33 @@ SEED_TEXT = (
 
 
 def build_seed_results() -> List[VariantResult]:
-    """Construct deterministic evaluation results for the seed candidate."""
+    """Deterministic *training* evaluation results for the seed candidate."""
     return [
-        VariantResult(variant="seed", task="t1", passed=True),
-        VariantResult(variant="seed", task="t2", passed=False),
+        VariantResult(variant="seed", task="train-1", passed=True),
+        VariantResult(variant="seed", task="train-2", passed=False),
+    ]
+
+
+def build_held_out_results(variant: str = "child") -> List[VariantResult]:
+    """Deterministic *held-out* evaluation results (Slice C)."""
+    return [
+        VariantResult(variant=variant, task="holdout-1", passed=True),
+        VariantResult(variant=variant, task="holdout-2", passed=True),
+        VariantResult(variant=variant, task="holdout-3", passed=False),
     ]
 
 
 def run(argv: List[str]) -> int:
-    """Run one GEPA generation and print a JSON summary."""
+    """Run one GEPA generation + held-out validation and print a JSON summary."""
     tree = EvolutionTree()
     seed = tree.add_seed(SEED_TEXT)
-    child = run_gepa_generation(tree, seed, build_seed_results())
+    train = build_seed_results()
+    child = run_gepa_generation(tree, seed, train)
+
+    held_out = build_held_out_results(variant=child.id)
+    result = validate_held_out(child, train, held_out, threshold=0.6)
+    promoted = promote_if_valid(child, result)
+
     print(
         json.dumps(
             {
@@ -42,6 +58,14 @@ def run(argv: List[str]) -> int:
                 "origin": child.origin,
                 "critique_summary": child.critique_summary,
                 "tree_size": len(tree),
+                "held_out_validation": {
+                    "passed": result.passed,
+                    "pass_rate": round(result.pass_rate, 4),
+                    "threshold": result.threshold,
+                    "n_held_out": result.n_held_out,
+                    "n_passed": result.n_passed,
+                },
+                "promoted": promoted,
             },
             sort_keys=True,
         )

--- a/scripts/evolution_gepa_optimize.py
+++ b/scripts/evolution_gepa_optimize.py
@@ -12,7 +12,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from tools.gepa_evolution import EvolutionTree, run_gepa_generation  # noqa: E402
 from tools.gepa_reflector import VariantResult  # noqa: E402
-from tools.gepa_validator import promote_if_valid, validate_held_out  # noqa: E402
+from tools.gepa_validator import (  # noqa: E402
+    default_ledger_path,
+    promote_if_valid,
+    validate_held_out,
+)
 
 SEED_TEXT = (
     "Read the task prompt carefully. Use the available tools to gather the "
@@ -66,6 +70,7 @@ def run(argv: List[str]) -> int:
                     "n_passed": result.n_passed,
                 },
                 "promoted": promoted,
+                "ledger_path": default_ledger_path(),
             },
             sort_keys=True,
         )

--- a/tests/scripts/test_evolution_gepa_optimize.py
+++ b/tests/scripts/test_evolution_gepa_optimize.py
@@ -1,5 +1,10 @@
-"""Tests for scripts/evolution_gepa_optimize.py — live GEPA caller (#2232)."""
+"""Tests for scripts/evolution_gepa_optimize.py — live GEPA caller (#2232).
 
+Covers Slice B (mutation + tree accumulation) and Slice C (held-out
+validation gate before promotion).
+"""
+
+import json
 import sys
 from pathlib import Path
 
@@ -22,3 +27,22 @@ def test_run_gepa_generation_adds_child():
 
 def test_main_returns_zero():
     assert main(["evolution_gepa_optimize.py"]) == 0
+
+
+def test_main_outputs_held_out_validation():
+    """Slice C: runtime output must include the held-out validation block."""
+    import io
+    import contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = main(["evolution_gepa_optimize.py"])
+    assert rc == 0
+    out = json.loads(buf.getvalue())
+    assert "held_out_validation" in out
+    hov = out["held_out_validation"]
+    assert "passed" in hov
+    assert "pass_rate" in hov
+    assert "threshold" in hov
+    assert "n_held_out" in hov
+    assert "promoted" in out

--- a/tests/tools/test_gepa_validator.py
+++ b/tests/tools/test_gepa_validator.py
@@ -1,0 +1,70 @@
+"""Tests for gepa_validator held-out validation (issue #2232, Slice C)."""
+
+from tools.gepa_evolution import EvolutionTree, run_gepa_generation
+from tools.gepa_reflector import VariantResult
+from tools.gepa_validator import HeldOutResult, promote_if_valid, validate_held_out
+
+
+def _candidate():
+    return EvolutionTree().add_seed("baseline text")
+
+
+def _results(flags):
+    return [
+        VariantResult(variant="v", task=f"t{i}", passed=p) for i, p in enumerate(flags)
+    ]
+
+
+def test_validate_passed_when_above_threshold():
+    res = validate_held_out(
+        _candidate(), _results([True, False]), _results([True, True, False])
+    )
+    assert isinstance(res, HeldOutResult)
+    assert res.passed is True
+    assert res.n_passed == 2
+    assert res.n_held_out == 3
+
+
+def test_validate_failed_when_below_threshold():
+    res = validate_held_out(
+        _candidate(), _results([True]), _results([True, False, False, False])
+    )
+    assert res.passed is False
+    assert res.pass_rate == 0.25
+
+
+def test_validate_empty_held_out_fails():
+    res = validate_held_out(_candidate(), _results([True]), [])
+    assert res.passed is False
+    assert res.n_held_out == 0
+
+
+def test_promote_marks_selected_on_pass():
+    cand = _candidate()
+    res = validate_held_out(cand, _results([True]), _results([True, True]))
+    assert promote_if_valid(cand, res) is True
+    assert cand.selected is True
+    assert cand.pruned is False
+    assert "held_out_validation" in cand.metadata
+
+
+def test_promote_marks_pruned_on_fail():
+    cand = _candidate()
+    res = validate_held_out(cand, _results([True]), _results([False, False]))
+    assert promote_if_valid(cand, res) is False
+    assert cand.selected is False
+    assert cand.pruned is True
+
+
+def test_held_out_gate_after_gepa_generation():
+    """End-to-end: generate → validate → promote."""
+    tree = EvolutionTree()
+    seed = tree.add_seed("seed text")
+    train = _results([True, False])
+    child = run_gepa_generation(tree, seed, train)
+    held_out = _results([True, True, True])
+    res = validate_held_out(child, train, held_out, threshold=0.6)
+    promote_if_valid(child, res)
+    assert res.passed is True
+    assert child.selected is True
+    assert child.metadata["held_out_validation"]["n_held_out"] == 3

--- a/tests/tools/test_gepa_validator.py
+++ b/tests/tools/test_gepa_validator.py
@@ -68,3 +68,37 @@ def test_held_out_gate_after_gepa_generation():
     assert res.passed is True
     assert child.selected is True
     assert child.metadata["held_out_validation"]["n_held_out"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Slice C persistence: promoted candidates survive to a JSONL ledger
+# ---------------------------------------------------------------------------
+
+
+def test_promoted_candidate_persisted_to_ledger(tmp_path, monkeypatch):
+    """A PASSING candidate must be appended to the promotions ledger."""
+    ledger = tmp_path / "promotions.jsonl"
+    monkeypatch.setenv("GEPA_LEDGER_PATH", str(ledger))
+    cand = _candidate()
+    res = validate_held_out(cand, _results([True]), _results([True, True]))
+    promote_if_valid(cand, res)
+    assert ledger.exists()
+    import json as _json
+
+    lines = ledger.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = _json.loads(lines[0])
+    assert rec["candidate_id"] == cand.id
+    assert rec["held_out_validation"]["n_passed"] == 2
+    assert rec["promoted_at"]
+
+
+def test_failed_candidate_not_persisted(tmp_path, monkeypatch):
+    """A FAILING candidate must NOT be written to the ledger."""
+    ledger = tmp_path / "promotions.jsonl"
+    monkeypatch.setenv("GEPA_LEDGER_PATH", str(ledger))
+    cand = _candidate()
+    res = validate_held_out(cand, _results([True]), _results([False, False]))
+    promote_if_valid(cand, res)
+    assert not ledger.exists()
+    assert cand.metadata["ledger_path"] if "ledger_path" in cand.metadata else True

--- a/tools/gepa_validator.py
+++ b/tools/gepa_validator.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""GEPA held-out validation gate (issue #2232, Slice C).
+
+Validates mutated candidates against an unseen held-out task set before
+promotion, preventing overfit to training-set critiques.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from tools.gepa_evolution import Candidate
+from tools.gepa_reflector import VariantResult
+
+
+@dataclass
+class HeldOutResult:
+    """Outcome of held-out validation for one candidate."""
+
+    candidate_id: str
+    passed: bool
+    pass_rate: float
+    threshold: float
+    train_pass_rate: float
+    n_held_out: int
+    n_passed: int
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _pass_rate(results: List[VariantResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.passed) / len(results)
+
+
+def validate_held_out(
+    candidate: Candidate,
+    train_results: List[VariantResult],
+    held_out_results: List[VariantResult],
+    *,
+    threshold: float = 0.6,
+) -> HeldOutResult:
+    """Validate *candidate* against a held-out task set.
+
+    ``passed`` is ``True`` only when held-out pass-rate ≥ *threshold*.
+    """
+    train_rate = _pass_rate(train_results)
+    held_rate = _pass_rate(held_out_results)
+    n_passed = sum(1 for r in held_out_results if r.passed)
+    return HeldOutResult(
+        candidate_id=candidate.id,
+        passed=held_rate >= threshold,
+        pass_rate=held_rate,
+        threshold=threshold,
+        train_pass_rate=train_rate,
+        n_held_out=len(held_out_results),
+        n_passed=n_passed,
+    )
+
+
+def promote_if_valid(candidate: Candidate, result: HeldOutResult) -> bool:
+    """Mark *candidate* selected (pass) or pruned (fail); record audit metadata."""
+    if result.passed:
+        candidate.selected = True
+    else:
+        candidate.pruned = True
+    candidate.metadata["held_out_validation"] = {
+        "passed": result.passed,
+        "pass_rate": round(result.pass_rate, 4),
+        "threshold": result.threshold,
+        "train_pass_rate": round(result.train_pass_rate, 4),
+        "n_held_out": result.n_held_out,
+        "n_passed": result.n_passed,
+    }
+    return result.passed

--- a/tools/gepa_validator.py
+++ b/tools/gepa_validator.py
@@ -2,16 +2,34 @@
 """GEPA held-out validation gate (issue #2232, Slice C).
 
 Validates mutated candidates against an unseen held-out task set before
-promotion, preventing overfit to training-set critiques.
+promotion, preventing overfit to training-set critiques. Promoted
+candidates are persisted to a JSONL ledger so downstream consumers
+(Slice D skill-system wiring) can read them — nothing stays in memory.
 """
 
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from tools.gepa_evolution import Candidate
 from tools.gepa_reflector import VariantResult
+
+
+def default_ledger_path() -> str:
+    """Ledger location under HERMES_HOME (override: GEPA_LEDGER_PATH)."""
+    override = os.environ.get("GEPA_LEDGER_PATH")
+    if override:
+        return override
+    return os.path.join(
+        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
+        "evolution",
+        "gepa",
+        "promotions.jsonl",
+    )
 
 
 @dataclass
@@ -59,6 +77,42 @@ def validate_held_out(
     )
 
 
+def persist_promotion(candidate: Candidate, result: HeldOutResult) -> str | None:
+    """Append a promotion record to the JSONL ledger; return the path.
+
+    Only promoted (passed) candidates are persisted — the ledger is the
+    hand-off point to Slice D consumers. IO errors return ``None``
+    rather than raising: validation must never fail because the ledger
+    is unwritable.
+    """
+    if not result.passed:
+        return None
+    record = {
+        "candidate_id": candidate.id,
+        "parent_id": candidate.parent_id,
+        "generation": candidate.generation,
+        "origin": candidate.origin,
+        "text": candidate.text,
+        "critique_summary": candidate.critique_summary,
+        "held_out_validation": {
+            "pass_rate": round(result.pass_rate, 4),
+            "threshold": result.threshold,
+            "train_pass_rate": round(result.train_pass_rate, 4),
+            "n_held_out": result.n_held_out,
+            "n_passed": result.n_passed,
+        },
+        "promoted_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path = default_ledger_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError:
+        return None
+    return path
+
+
 def promote_if_valid(candidate: Candidate, result: HeldOutResult) -> bool:
     """Mark *candidate* selected (pass) or pruned (fail); record audit metadata."""
     if result.passed:
@@ -73,4 +127,6 @@ def promote_if_valid(candidate: Candidate, result: HeldOutResult) -> bool:
         "n_held_out": result.n_held_out,
         "n_passed": result.n_passed,
     }
+    if result.passed:
+        candidate.metadata["ledger_path"] = persist_promotion(candidate, result)
     return result.passed


### PR DESCRIPTION
Automated evolution PR for #2232 (Slice C re-land of closed PR #2330).

## What
- `tools/gepa_validator.py` — `validate_held_out` (pass-rate gate vs threshold) + `promote_if_valid` (selected/pruned + audit metadata) + `persist_promotion` (**JSONL ledger** — the persistence consumer whose absence closed #2330).
- `scripts/evolution_gepa_optimize.py` — live caller now runs generate → validate → promote → persist and reports `held_out_validation` + `ledger_path` in its JSON output.
- Tests: 11 across validator + caller, incl. ledger round-trip (promoted written, failed not written).

## Review-blocker fix (why #2330 closed)
The reviewer's exact ask: *"wire at least one real consumer (a cron job, curator hook, or CLI command that **persists promoted candidates to disk** and feeds them into the skill system)"*. This PR delivers the persist-to-disk half: every promoted candidate is appended to `~/.hermes/evolution/gepa/promotions.jsonl` (env-overridable `GEPA_LEDGER_PATH`), verified working end-to-end in the live caller run above.

## Verified locally
- ruff check ✓ · ruff format ✓ · pytest validator+caller: 11/11 ✓
- Live run: `python scripts/evolution_gepa_optimize.py` → JSON out with `promoted: true` + ledger record on disk ✓

## Honest scope / merge-gate note
Diff is 296 lines — above the 200-line self-merge cap → held for human review (same as #2330, deliberately not thinned: validator + wiring + tests form one coherent shippable slice).

Deferred (next increment — Slice D):
- Feed ledger promotions into the skill system (curator hook reading `promotions.jsonl`)
- Multi-generation loop over the tree
- Wire real (non-deterministic) task evaluation