### PR TITLE
feat(triage): confidence estimation + abstention gate (Closes #2386)

### DIFF
--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -89,6 +89,37 @@ def _extract_proposals(issues_sidecar: dict) -> list[dict]:
     return filed
 
 
+def estimate_proposal_confidence(proposal: dict, sidecars: dict) -> int:
+    """Cheap reflexive-style P(True) estimate for one proposal (#2386).
+
+    Local triage has no LLM, so confidence is derived from observable
+    evidence in the sidecars — a deliberately conservative heuristic:
+    every known fact nudges the estimate up, unknowns pull it down, and
+    the result is clamped to [5, 95] because a point estimate should
+    never claim certainty (the trajectory-UQ lesson from the source
+    paper: single-turn confidence does not transfer).
+    """
+    conf = 50  # no evidence either way
+    if proposal.get("issue_number"):
+        conf += 10  # filed as a tracked issue
+    if proposal.get("impact_score", 0) > 0 and proposal.get("effort_score", 0) > 0:
+        conf += 10  # both planning scores recorded
+    if len(str(proposal.get("title", ""))) >= 20:
+        conf += 10  # substantive (non-stub) title
+    if "issues" in sidecars and "introspection" in sidecars:
+        conf += 10  # cross-referenced evidence available
+    if proposal.get("effort_score", 0) == 0:
+        conf -= 15  # unknown effort = largest planning uncertainty
+    if proposal.get("priority_score", 0) < 0.8:
+        conf -= 10  # weak signal even before confidence
+    return max(5, min(95, conf))
+
+
+# Minimum confidence to stay in the selection; below this the proposal
+# is deferred for a second research pass instead of implemented (#2386).
+MIN_SELECTION_CONFIDENCE = 40
+
+
 def _read_calibration(evolution_dir: Path) -> dict:
     """Read health and realized-impact sidecars for calibration."""
     cal = {"effort_budget": 3.0, "consolidation_mode": False}
@@ -135,11 +166,24 @@ def run_local_triage(evolution_dir: Path) -> dict:
     # Sort by priority score (descending)
     proposals.sort(key=lambda p: p["priority_score"], reverse=True)
 
-    # Apply effort budget cap
+    # Apply effort budget cap, with confidence estimation + abstention
+    # (#2386): each proposal gets a cheap reflexive-style confidence
+    # estimate; proposals below MIN_SELECTION_CONFIDENCE are deferred
+    # (kept for a second research pass) rather than selected blind.
     max_effort = cal["effort_budget"]
     selected = []
+    deferred_low_confidence = []
     total_effort = 0.0
     for p in proposals:
+        p["confidence"] = estimate_proposal_confidence(p, sidecars)
+        if p["confidence"] < MIN_SELECTION_CONFIDENCE:
+            deferred_low_confidence.append({
+                "issue_number": p["issue_number"],
+                "title": p["title"],
+                "confidence": p["confidence"],
+                "reason": "below-min-confidence — needs a second research pass",
+            })
+            continue
         if total_effort + p["effort_score"] > max_effort:
             continue
         selected.append(p)
@@ -154,6 +198,12 @@ def run_local_triage(evolution_dir: Path) -> dict:
         "consolidation_mode": cal["consolidation_mode"],
         "rejected": [],
         "selected_for_implementation": selected,
+        "confidence_estimation": {
+            "method": "reflexive-evidence-heuristic (#2386)",
+            "min_selection_confidence": MIN_SELECTION_CONFIDENCE,
+            "deferred_count": len(deferred_low_confidence),
+        },
+        "deferred_low_confidence": deferred_low_confidence,
     }
 
     # Emit a StageResult at this boundary (AREX #1338 slice A).
@@ -202,7 +252,9 @@ def run_local_triage(evolution_dir: Path) -> dict:
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Local triage pass (no GitHub API calls)")
+    parser = argparse.ArgumentParser(
+        description="Local triage pass (no GitHub API calls)"
+    )
     parser.add_argument(
         "--evolution-dir",
         default=None,
@@ -214,6 +266,7 @@ def main(argv: list[str] | None = None) -> int:
         evolution_dir = Path(args.evolution_dir)
     else:
         import os
+
         hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
         evolution_dir = Path(hermes_home) / "evolution"
 
@@ -233,14 +286,25 @@ def main(argv: list[str] | None = None) -> int:
         existing = json.loads(output_path.read_text(encoding="utf-8"))
         if not existing.get("local_triage", False):
             # A real analysis exists — don't clobber it with a local-only pass
-            print(f"Skipping: full analysis already exists at {output_path}", file=sys.stderr)
+            print(
+                f"Skipping: full analysis already exists at {output_path}",
+                file=sys.stderr,
+            )
             return 0
 
-    output_path.write_text(json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    output_path.write_text(
+        json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     print(f"Local triage written to {output_path}")
     print(f"  Sidecars read: {', '.join(output['sidecars_read'].keys())}")
     print(f"  Selected: {len(output['selected_for_implementation'])} issues")
     print(f"  Effort budget: {output['effort_budget']}")
+    ce = output.get("confidence_estimation")
+    if ce:
+        print(
+            f"  Confidence gate: min={ce['min_selection_confidence']}, "
+            f"deferred={ce['deferred_count']}"
+        )
     gate = output.get("stage_gate")
     if gate:
         print(

--- a/tests/scripts/test_evolution_local_triage.py
+++ b/tests/scripts/test_evolution_local_triage.py
@@ -150,8 +150,8 @@ def test_latest_file_returns_most_recent(tmp_path):
     d.mkdir()
     old = d / "2026-07-01.json"
     new = d / "2026-07-08.json"
-    old.write_text("{}")
-    new.write_text("{}")
+    old.write_text("{}", encoding="utf-8")
+    new.write_text("{}", encoding="utf-8")
     # Ensure new is modified after old
     import os
 
@@ -163,14 +163,14 @@ def test_latest_file_returns_most_recent(tmp_path):
 
 def test_read_sidecar_json(tmp_path):
     f = tmp_path / "test.json"
-    f.write_text('{"key": "value"}')
+    f.write_text('{"key": "value"}', encoding="utf-8")
     result = _read_sidecar(f)
     assert result["data"]["key"] == "value"
 
 
 def test_read_sidecar_md(tmp_path):
     f = tmp_path / "test.md"
-    f.write_text("# Research report\n\nContent here.")
+    f.write_text("# Research report\n\nContent here.", encoding="utf-8")
     result = _read_sidecar(f)
     assert result["char_count"] > 0
 

--- a/tests/scripts/test_evolution_local_triage.py
+++ b/tests/scripts/test_evolution_local_triage.py
@@ -26,17 +26,37 @@ def evo_dir(tmp_path):
     evo = tmp_path / "evolution"
     issues_dir = evo / "issues"
     issues_dir.mkdir(parents=True)
-    (issues_dir / "2026-07-08.json").write_text(json.dumps({
-        "date": "2026-07-08",
-        "proposals": [
-            {"title": "Alpha", "decision": "filed", "issue": 100,
-             "priority_score": 1.5, "impact": 0.8, "effort": 0.3},
-            {"title": "Beta", "decision": "skipped", "issue": None,
-             "priority_score": 0.5, "impact": 0.2, "effort": 0.1},
-            {"title": "Gamma", "decision": "filed", "issue": 200,
-             "priority_score": 0.9, "impact": 0.5, "effort": 0.8},
-        ]
-    }))
+    (issues_dir / "2026-07-08.json").write_text(
+        json.dumps({
+            "date": "2026-07-08",
+            "proposals": [
+                {
+                    "title": "Alpha",
+                    "decision": "filed",
+                    "issue": 100,
+                    "priority_score": 1.5,
+                    "impact": 0.8,
+                    "effort": 0.3,
+                },
+                {
+                    "title": "Beta",
+                    "decision": "skipped",
+                    "issue": None,
+                    "priority_score": 0.5,
+                    "impact": 0.2,
+                    "effort": 0.1,
+                },
+                {
+                    "title": "Gamma",
+                    "decision": "filed",
+                    "issue": 200,
+                    "priority_score": 0.9,
+                    "impact": 0.5,
+                    "effort": 0.8,
+                },
+            ],
+        })
+    )
     return evo
 
 
@@ -134,6 +154,7 @@ def test_latest_file_returns_most_recent(tmp_path):
     new.write_text("{}")
     # Ensure new is modified after old
     import os
+
     os.utime(old, (1, 1))
     os.utime(new, (2, 2))
     result = _latest_file(d)
@@ -152,6 +173,7 @@ def test_read_sidecar_md(tmp_path):
     f.write_text("# Research report\n\nContent here.")
     result = _read_sidecar(f)
     assert result["char_count"] > 0
+
 
 def test_output_is_json_serializable_with_stage_result(tmp_path):
     """The triage output must survive json.dumps with the StageResult envelope
@@ -173,3 +195,76 @@ def test_output_is_json_serializable_with_stage_result(tmp_path):
     if "stage_result" in output:
         assert "result" not in output["stage_result"]
         assert output["stage_result"]["stage"] == "local_triage"
+
+
+# ---------------------------------------------------------------------------
+# #2386: confidence estimation + abstention in local triage
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_estimate_bounds_and_signals():
+    from evolution_local_triage import estimate_proposal_confidence
+
+    strong = {
+        "issue_number": 42,
+        "title": "A substantive proposal title long enough",
+        "impact_score": 0.8,
+        "effort_score": 0.3,
+        "priority_score": 1.5,
+    }
+    # with cross-referenced sidecars the estimate rises
+    high = estimate_proposal_confidence(strong, {"issues": {}, "introspection": {}})
+    base = estimate_proposal_confidence(strong, {"issues": {}})
+    assert 5 <= high <= 95 and 5 <= base <= 95
+    assert high > base
+
+    weak = {
+        "issue_number": None,
+        "title": "x",
+        "impact_score": 0.0,
+        "effort_score": 0.0,
+        "priority_score": 0.5,
+    }
+    low = estimate_proposal_confidence(weak, {})
+    assert low == max(5, 50 - 15 - 10)  # unknown effort + weak priority
+
+
+def test_low_confidence_proposal_deferred_not_selected(tmp_path):
+    evo = tmp_path / "evolution"
+    issues_dir = evo / "issues"
+    issues_dir.mkdir(parents=True)
+    (issues_dir / "2026-08-14.json").write_text(
+        json.dumps({
+            "date": "2026-08-14",
+            "proposals": [
+                {
+                    "title": "Solid well-evidenced proposal",
+                    "decision": "filed",
+                    "issue": 301,
+                    "priority_score": 1.4,
+                    "impact": 0.8,
+                    "effort": 0.3,
+                },
+                {
+                    "title": "Vague idea",
+                    "decision": "filed",
+                    "issue": 302,
+                    "priority_score": 0.5,
+                    "impact": 0.2,
+                    "effort": 0.0,
+                },
+            ],
+        })
+    )
+    result = run_local_triage(evo)
+    selected_nums = [s["issue_number"] for s in result["selected_for_implementation"]]
+    deferred_nums = [d["issue_number"] for d in result["deferred_low_confidence"]]
+    assert 301 in selected_nums
+    assert 302 not in selected_nums
+    assert 302 in deferred_nums
+    ce = result["confidence_estimation"]
+    assert ce["min_selection_confidence"] == 40
+    assert ce["deferred_count"] == 1
+    # selected proposals carry their confidence estimate
+    sel = result["selected_for_implementation"][0]
+    assert isinstance(sel["confidence"], int)


### PR DESCRIPTION
Automated evolution PR for #2386 — first slice of uncertainty quantification for evolution pipeline decisions.

## What
- `estimate_proposal_confidence()` — cheap reflexive-style P(True) estimate per proposal, derived from observable sidecar evidence (filed issue, recorded impact/effort, substantive title, cross-referenced sidecars), clamped to [5, 95].
- **Abstention gate**: proposals below `MIN_SELECTION_CONFIDENCE` (40) are moved to a new `deferred_low_confidence` block with reason — selected for a **second research pass**, not implemented blind.
- Output now carries `confidence_estimation` metadata (method, threshold, deferred count); every selected proposal carries its `confidence` integer.
- `confidence`-aware print in main().

## Why this shape
Per the source paper (arXiv:2608.11552): single-turn confidence doesn't transfer to trajectories, so the increment deliberately starts with a conservative, evidence-based heuristic at the local-triage boundary — where the pipeline's selection decision is actually made — rather than token probabilities. TER-style multi-trajectory agreement is the natural next slice.

## Verified locally
- ruff check ✓ · ruff format ✓
- pytest `tests/scripts/test_evolution_local_triage.py`: 16/16 ✓ (14 pre-existing + 2 new: bounds/signals + abstention behavior)

## Size
191 changed lines — within the 200-line autonomous merge cap.