### PR TITLE
fix(cli): utf-8 encoding in os.fdopen — unblock Windows footguns gate

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10235,7 +10235,7 @@ def _read_ssh_session_token_file(path: str) -> str:
         if hasattr(os, "getuid") and (file_stat.st_mode & 0o777) & ~0o600:
             raise SystemExit("--ssh-session-token-file has unsafe permissions")
 
-        with os.fdopen(file_fd, "r") as token_stream:
+        with os.fdopen(file_fd, "r", encoding="utf-8") as token_stream:
             file_fd = -1
             token = token_stream.read(65)
 


### PR DESCRIPTION
Unblock-the-funnel fix: `lint.yml` runs `check-windows-footguns.py --all`, and a bare text-mode `os.fdopen` introduced by upstream sync (#2418) at `hermes_cli/main.py:10238` fails the gate on **every open PR**, not just this file's owner.

## What
- One line: `os.fdopen(file_fd, "r")` → `os.fdopen(file_fd, "r", encoding="utf-8")`. Token file is read as hex chars (regex `[0-9a-f]{64}`), so utf-8 is behaviour-identical on POSIX and fixes cp1252/mbcs mojibake class on Windows.

## Verified locally
- `python scripts/check-windows-footguns.py --all` → ✓ 0 footguns (was 1)
- ruff check + format ✓
- 1 changed line — well under the merge cap.

## Remaining main redness (NOT this PR)
Test import errors from #2418 fallout (`_acquire_sync_aux_semaphore`, `_PRUNE_MIN_CHARS`) and the nix `agent-browser` attribute error are tracked in #2410 — those need the upstream-sync owner, not a drive-by fix.