### PR TITLE
fix(tools): circuit breaker half-open recovery — unstick the read/patch path (Closes #2423)

### DIFF
--- a/agent/tool_error_recovery.py
+++ b/agent/tool_error_recovery.py
@@ -22,6 +22,7 @@ import enum
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -499,44 +500,97 @@ def recovery_hint(failure: ToolFailure) -> str:
     return f" [{failure.recovery_action.value}: {failure.hint}]"
 
 
-# ── Circuit breaker (lightweight, per-tool) ──────────────────────────────
+# ── Circuit breaker (per-tool, with half-open recovery) ──────────────────
+
+# How long an admitted-but-unrecorded probe (cancelled call, crash) pins
+# the breaker in half-open before should_trip() re-arms a fresh probe.
+_BREAKER_PROBE_STALE_SECONDS = 300.0
 
 
 @dataclass
 class CircuitBreaker:
-    """Simple per-tool circuit breaker.
+    """Per-tool circuit breaker with half-open recovery (#2423).
 
-    Tracks consecutive failures for a single tool. After ``threshold``
-    consecutive failures, the circuit opens and ``should_trip()`` returns
-    True — callers can use this to fail-fast instead of retrying.
-
-    The breaker resets on any success. It does not auto-transition to
-    half-open; a success call manually resets it.
-
-    This is intentionally minimal — no timeout-based half-open, no rolling
-    window. Just consecutive-count → trip. Enough to prevent infinite
-    retry loops on a permanently broken tool without adding complexity.
+    ``threshold`` consecutive failures open the circuit (fail-fast, #942).
+    Previously it then stayed open forever — the fail-fast gate suppressed
+    the very success that would have reset it, so a run of recoverable
+    mistakes removed a whole tool for the rest of the process (#2423).
+    Now after ``cooldown_seconds`` the breaker half-opens and admits
+    exactly ONE probe: success closes it, failure re-opens with a fresh
+    cooldown. Inside the cooldown every call still trips (#942 unchanged).
     """
 
     threshold: int = 5
+    cooldown_seconds: float = 60.0
     _consecutive_failures: int = 0
     _is_open: bool = False
+    _opened_at: float = 0.0
+    _half_open: bool = False
+    _probe_in_flight: bool = False
+    _probe_started_at: float = 0.0
+
+    def _open(self, now: float) -> None:
+        self._is_open = True
+        self._half_open = False
+        self._probe_in_flight = False
+        self._opened_at = now
+        logger.warning(
+            "circuit breaker opened for tool after %d consecutive "
+            "failures; half-open probe in %.0fs",
+            self._consecutive_failures,
+            self.cooldown_seconds,
+        )
 
     def record_failure(self) -> None:
         self._consecutive_failures += 1
-        if self._consecutive_failures >= self.threshold:
-            self._is_open = True
-            logger.warning(
-                "circuit breaker opened for tool after %d consecutive failures",
-                self._consecutive_failures,
-            )
+        now = time.monotonic()
+        if self._half_open:
+            # The recovery probe failed — re-open with a fresh cooldown.
+            self._open(now)
+        elif self._consecutive_failures >= self.threshold:
+            self._open(now)
 
     def record_success(self) -> None:
         self._consecutive_failures = 0
         self._is_open = False
+        self._half_open = False
+        self._probe_in_flight = False
+
+    def _cooldown_elapsed(self, now: float) -> bool:
+        return (now - self._opened_at) >= self.cooldown_seconds
+
+    def _probe_is_stale(self, now: float) -> bool:
+        return (now - self._probe_started_at) >= _BREAKER_PROBE_STALE_SECONDS
 
     def should_trip(self) -> bool:
-        return self._is_open
+        """Trip while cooling down; admit exactly one probe after cooldown."""
+        if not self._is_open:
+            return False
+        now = time.monotonic()
+        if self._half_open:
+            if self._probe_in_flight and not self._probe_is_stale(now):
+                return True  # a probe is still pending
+            # No live probe (or the admitted one went stale) — admit one.
+            self._probe_in_flight = True
+            self._probe_started_at = now
+            return False
+        if self._cooldown_elapsed(now):
+            self._half_open = True
+            self._probe_in_flight = True
+            self._probe_started_at = now
+            return False
+        return True
+
+    def is_half_open(self) -> bool:
+        """True while the breaker is admitting (or running) a recovery probe."""
+        return self._is_open and self._half_open
+
+    def seconds_until_retry(self) -> float:
+        """Seconds until the next recovery probe is admitted (0.0 if now)."""
+        if not self._is_open or self._half_open:
+            return 0.0
+        remaining = self.cooldown_seconds - (time.monotonic() - self._opened_at)
+        return max(0.0, remaining)
 
 
 # ── Per-tool breaker registry (process-global) ───────────────────────────

--- a/model_tools.py
+++ b/model_tools.py
@@ -1769,6 +1769,13 @@ def handle_function_call(
                     f"blocker. Repeatedly calling {function_name} will keep "
                     f"failing."
                 )
+                # #2423 — the breaker auto-recovers: after its cooldown it admits
+                # one probe; success closes it. Say so — "wait Ns", not tool death.
+                _breaker_msg += (
+                    f" One recovery probe is admitted automatically in "
+                    f"{_breaker.seconds_until_retry():.0f}s; if it succeeds, "
+                    f"the breaker closes."
+                )
                 result = json.dumps({"error": _breaker_msg}, ensure_ascii=False)
                 _emit_post_tool_call_hook(
                     function_name=function_name,

--- a/tests/agent/test_circuit_breaker_half_open_2423.py
+++ b/tests/agent/test_circuit_breaker_half_open_2423.py
@@ -1,0 +1,99 @@
+"""Half-open recovery tests for the per-tool circuit breaker (#2423).
+
+Cooldown expiry is forced by back-dating ``_opened_at``, never sleeping.
+"""
+
+import pytest
+
+from agent.tool_error_recovery import CircuitBreaker, get_breaker, record_tool_outcome
+
+requires_half_open = pytest.mark.skipif(
+    not hasattr(CircuitBreaker, "seconds_until_retry"),
+    reason="circuit breaker half-open recovery (#2423) not on this tree",
+)
+
+
+@requires_half_open
+class TestHalfOpenLifecycle:
+    def test_trips_repeatedly_during_cooldown(self):
+        cb = CircuitBreaker(threshold=2, cooldown_seconds=3600.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.should_trip()
+        assert cb.should_trip()  # still cooling down: no probe admitted
+        assert not cb.is_half_open()
+
+    def test_admits_exactly_one_probe_after_cooldown(self):
+        cb = CircuitBreaker(threshold=2, cooldown_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.should_trip()  # opened; still cooling down → trips
+        cb._opened_at -= 61.0  # force cooldown expiry without sleeping
+        assert cb.should_trip() is False  # the one admitted probe
+        assert cb.is_half_open()
+        assert cb.should_trip()  # further calls trip until the outcome lands
+
+    def test_successful_probe_closes_breaker(self):
+        cb = CircuitBreaker(threshold=2, cooldown_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        cb._opened_at -= 61.0
+        assert cb.should_trip() is False  # probe admitted
+        cb.record_success()
+        assert not cb.should_trip()
+        assert not cb.is_half_open()
+        assert cb._consecutive_failures == 0
+
+    def test_failed_probe_reopens_with_fresh_cooldown(self):
+        cb = CircuitBreaker(threshold=2, cooldown_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        cb._opened_at -= 61.0
+        assert cb.should_trip() is False  # probe admitted
+        cb.record_failure()  # probe failed → re-open, fresh cooldown
+        assert cb.should_trip()
+        assert not cb.is_half_open()
+        cb._opened_at -= 61.0
+        assert cb.should_trip() is False  # new probe after fresh cooldown
+
+    def test_stale_probe_is_rearmed(self):
+        cb = CircuitBreaker(threshold=2, cooldown_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        cb._opened_at -= 61.0
+        assert cb.should_trip() is False  # probe admitted but never recorded
+        cb._probe_started_at -= 400.0  # outcome lost (cancelled call) → stale
+        assert cb.should_trip() is False  # re-armed, not tripping forever
+
+    def test_seconds_until_retry_counts_down(self):
+        cb = CircuitBreaker(threshold=1, cooldown_seconds=60.0)
+        cb.record_failure()
+        assert 0.0 < cb.seconds_until_retry() <= 60.0
+        cb._opened_at -= 60.0
+        assert cb.seconds_until_retry() == 0.0
+
+
+@requires_half_open
+class TestHalfOpenRegistry:
+    def test_record_outcome_success_closes_half_open(self):
+        name = "test_tool_halfopen_2423_a"
+        breaker = get_breaker(name, threshold=2)
+        breaker.cooldown_seconds = 60.0
+        record_tool_outcome(name, success=False)
+        record_tool_outcome(name, success=False)
+        breaker._opened_at -= 61.0
+        assert breaker.should_trip() is False  # probe admitted
+        record_tool_outcome(name, success=True)
+        assert not breaker.should_trip()
+
+    def test_record_outcome_failure_during_probe_reopens(self):
+        name = "test_tool_halfopen_2423_b"
+        breaker = get_breaker(name, threshold=2)
+        breaker.cooldown_seconds = 60.0
+        record_tool_outcome(name, success=False)
+        record_tool_outcome(name, success=False)
+        breaker._opened_at -= 61.0
+        assert breaker.should_trip() is False  # probe admitted
+        record_tool_outcome(name, success=False)  # probe failed → re-open
+        assert breaker.should_trip()  # fresh 60s cooldown → trips
+        assert breaker._consecutive_failures == 3


### PR DESCRIPTION
Automated evolution PR for issue #2423.

**Problem.** The per-tool circuit breaker opened after N consecutive failures and stayed open for the rest of the process: the fail-fast gate in `handle_function_call` suppressed the very success that would have reset it. A run of cd8e2305fd ... [snip for brevity in command] ...