### PR TITLE
fix(evolution): hydra gate ledger compares content hashes, not mtimes (Closes #2425)

### DIFF
--- a/scripts/evolution_hydra_gate.py
+++ b/scripts/evolution_hydra_gate.py
@@ -15,14 +15,16 @@ on a broken pipeline (#770).
 
 A per-edge dispatch ledger (#1305) suppresses false-positive wake-ups: once the
 gate has dispatched for an edge on a given day, subsequent ticks on the same day
-do NOT re-fire unless the upstream stage produced NEW output (a strictly newer
-mtime) since the last dispatch. Without this ledger the raw-mtime check re-fires
-on every tick — observed at 20+ wasted orchestrator wake-ups/day on the
-integration→upstream-sync edge alone (#1305).
+do NOT re-fire unless the upstream stage produced NEW content since the last
+dispatch. Newness is judged by a content hash of the upstream output (#2425) —
+mtime alone is clobberable by parallel writers rewriting identical bytes, which
+caused 4/9 zero-dispatch orchestrator wakes in a single day. Ledger entries
+written before #2425 (mtime-only) keep the old mtime semantics until refreshed.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -72,6 +74,23 @@ def _latest_output(evo_dir: Path, stage: str) -> float:
     return max(_mtime(json_path), _mtime(md_path))
 
 
+def _stage_content_hash(evo_dir: Path, stage: str) -> str:
+    """Stable content fingerprint of today's stage output (#2425).
+
+    Parallel writers can rewrite a file with byte-identical content, bumping
+    its mtime without any substantive change — such a rewrite must NOT count
+    as new material. Hashing the bytes makes the dispatch ledger immune to
+    that; only a real content change re-fires the edge.
+    """
+    h = hashlib.sha256()
+    for path in sorted(_today_paths(evo_dir, stage)):
+        try:
+            h.update(path.read_bytes())
+        except OSError:
+            h.update(b"<missing>")
+    return h.hexdigest()
+
+
 # ---------------------------------------------------------------------------
 # Dispatch ledger (#1305) — stop false-positive re-wake-ups on the same day
 # ---------------------------------------------------------------------------
@@ -118,13 +137,19 @@ def _write_ledger(evo_dir: Path, ledger: Dict[str, dict]) -> None:
         print(f"[hydra-gate] ledger write failed ({exc}) — continuing", file=sys.stderr)
 
 
-def _already_dispatched_today(evo_dir: Path, edge: str, upstream_mtime: float) -> bool:
+def _already_dispatched_today(
+    evo_dir: Path,
+    edge: str,
+    upstream_mtime: float,
+    upstream_hash: Optional[str] = None,
+) -> bool:
     """Return True if this edge was already dispatched today AND the upstream
-    stage has NOT produced newer output since that dispatch.
+    stage has NOT produced new content since that dispatch.
 
-    A NEW upstream mtime (strictly greater than the one recorded at dispatch
-    time) means genuinely fresh material arrived → re-fire. The same or older
-    mtime means the edge is a repeat of an already-adjudicated state → suppress.
+    #2425: newness is judged by content hash first — a rewritten-but-identical
+    upstream file (same hash, newer mtime) is NOT new material and stays
+    suppressed. Entries recorded before #2425 carry no hash and fall back to
+    the legacy mtime comparison until the next dispatch refreshes them.
     """
     entry = _read_ledger(evo_dir).get(edge)
     if not isinstance(entry, dict):
@@ -132,24 +157,33 @@ def _already_dispatched_today(evo_dir: Path, edge: str, upstream_mtime: float) -
     if entry.get("date") != _today():
         # Stale entry from a prior day — that day's verdict doesn't carry over.
         return False
+    recorded_hash = entry.get("upstream_hash")
+    if isinstance(recorded_hash, str) and upstream_hash is not None:
+        return recorded_hash == upstream_hash
     recorded_mtime = entry.get("upstream_mtime")
     if not isinstance(recorded_mtime, (int, float)):
         return False
-    # Suppress only when upstream has not advanced since the last dispatch.
-    # A strict-newer mtime is genuine new material and must re-fire.
+    # Legacy entry (no hash): suppress only when upstream has not advanced.
     return upstream_mtime <= float(recorded_mtime)
 
 
-def _record_dispatch(evo_dir: Path, edge: str, upstream_mtime: float) -> None:
-    """Record that the gate dispatched for ``edge`` at ``upstream_mtime`` today.
+def _record_dispatch(
+    evo_dir: Path,
+    edge: str,
+    upstream_mtime: float,
+    upstream_hash: Optional[str] = None,
+) -> None:
+    """Record that the gate dispatched for ``edge`` at ``upstream_mtime`` (and
+    content hash, #2425) today. Opportunistically prunes old entries.
 
-    Also opportunistically prunes entries older than ``_LEDGER_PRUNE_DAYS`` so
-    the file stays small over time.
+    ``upstream_hash`` makes the entry immune to same-content rewrites: the
+    next tick compares content, not the clobberable mtime.
     """
     ledger = _read_ledger(evo_dir)
     ledger[edge] = {
         "date": _today(),
         "upstream_mtime": upstream_mtime,
+        "upstream_hash": upstream_hash,
         "verdict": None,
     }
     # Prune stale entries (older than the prune window). Keep today's + the
@@ -302,7 +336,8 @@ def _has_work(evo_dir: Path) -> Tuple[bool, str]:
             fresh_pairs.append(pair)
             continue
         up_mtime = _latest_output(evo_dir, up_stage)
-        if _already_dispatched_today(evo_dir, pair, up_mtime):
+        up_hash = _stage_content_hash(evo_dir, up_stage)
+        if _already_dispatched_today(evo_dir, pair, up_mtime, up_hash):
             # Already dispatched today for this exact upstream state — suppress.
             suppressed.append(pair)
         else:
@@ -313,7 +348,12 @@ def _has_work(evo_dir: Path) -> Tuple[bool, str]:
         # no upstream advancement is suppressed next time.
         for pair in fresh_pairs:
             up_stage = edge_upstream[pair]
-            _record_dispatch(evo_dir, pair, _latest_output(evo_dir, up_stage))
+            _record_dispatch(
+                evo_dir,
+                pair,
+                _latest_output(evo_dir, up_stage),
+                _stage_content_hash(evo_dir, up_stage),
+            )
         return True, f"fresh material: {', '.join(fresh_pairs)}"
 
     # Time-based triggers: root stages that should run periodically even when

--- a/tests/scripts/test_evolution_hydra_gate.py
+++ b/tests/scripts/test_evolution_hydra_gate.py
@@ -183,25 +183,54 @@ class TestDispatchLedger:
     def test_newer_upstream_after_dispatch_re_fires(
         self, tmp_path, capsys, monkeypatch
     ):
-        """Genuine new material (newer upstream mtime) must re-wake even after a
-        same-day dispatch — the ledger must not suppress a real state change."""
+        """Genuine new material (new upstream CONTENT, #2425) must re-wake even
+        after a same-day dispatch — the ledger must not suppress a real state
+        change. A pure mtime bump with identical bytes stays suppressed."""
         monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
-        self._make_edge_fresh(tmp_path, "integration→upstream-sync")
+        # Give EVERY stage a today-output so no time trigger / safety wake can
+        # fire — isolating the ledger's verdict on this single edge.
+        for stage in (
+            "research",
+            "issues",
+            "introspection",
+            "analysis",
+            "implementation",
+            "integration",
+            "upstream-sync",
+        ):
+            d = tmp_path / stage
+            d.mkdir(parents=True, exist_ok=True)
+            (d / f"{hydra._today()}.json").write_text("{}", encoding="utf-8")
+        # Make ONLY integration newer than its downstream → the single fresh edge.
+        up_file = tmp_path / "integration" / f"{hydra._today()}.json"
+        up_file.write_text('{"merges": ["#2400"]}', encoding="utf-8")
+        # Same-tick writes share an mtime (fs granularity) — back-date the
+        # downstream file so the edge is strictly fresh.
+        old_ts = time.time() - 3600
+        ds_file = tmp_path / "upstream-sync" / f"{hydra._today()}.json"
+        os.utime(ds_file, (old_ts, old_ts))
         with patch.object(
             hydra, "_check_github_write_access", return_value=(True, "ok")
         ):
-            hydra.main()  # tick 1 — records dispatch at mtime T1
+            hydra.main()  # tick 1 — records dispatch (mtime + content hash)
             capsys.readouterr()
 
-            # Simulate the upstream stage producing NEW output (newer mtime).
-            up_file = tmp_path / "integration" / f"{hydra._today()}.json"
+            # Same-content rewrite (mtime-only bump) must NOT re-fire (#2425).
             new_time = time.time()
             os.utime(up_file, (new_time, new_time))
-
-            hydra.main()  # tick 2 — newer upstream → must wake
+            hydra.main()  # tick 2 — identical bytes → suppressed
             out2 = capsys.readouterr().out
-        assert "fresh material" in out2
-        assert json.loads(out2.strip().splitlines()[-1]) == {"wakeAgent": True}
+            assert json.loads(out2.strip().splitlines()[-1]) == {"wakeAgent": False}
+
+            # Real new material (content change) must re-wake.
+            up_file.write_text(
+                up_file.read_text(encoding="utf-8") + "\n# new merge landed",
+                encoding="utf-8",
+            )
+            hydra.main()  # tick 3 — content changed → wake
+            out3 = capsys.readouterr().out
+        assert "fresh material" in out3
+        assert json.loads(out3.strip().splitlines()[-1]) == {"wakeAgent": True}
 
     def test_ledger_prunes_old_entries(self, tmp_path):
         """_record_dispatch prunes entries older than the prune window so the

--- a/tests/scripts/test_evolution_hydra_gate_hash_2425.py
+++ b/tests/scripts/test_evolution_hydra_gate_hash_2425.py
@@ -1,0 +1,75 @@
+"""Content-hash dispatch-ledger tests for the Hydra gate (#2425).
+
+A rewritten-but-identical upstream file (newer mtime, same bytes) must NOT
+re-fire an edge already dispatched today; only a real content change may.
+Legacy mtime-only ledger entries keep the old semantics until refreshed.
+"""
+
+from pathlib import Path
+
+from scripts import evolution_hydra_gate as hydra
+
+EDGE = "analysis→implementation"
+
+
+def _write_stage(evo_dir: Path, stage: str, content: str) -> None:
+    d = evo_dir / stage
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{hydra._today()}.md").write_text(content, encoding="utf-8")
+
+
+def _record(tmp_path: Path) -> None:
+    """Record a dispatch for EDGE at analysis' current mtime + content hash."""
+    hydra._record_dispatch(
+        tmp_path,
+        EDGE,
+        hydra._latest_output(tmp_path, "analysis"),
+        hydra._stage_content_hash(tmp_path, "analysis"),
+    )
+
+
+def _dispatched(tmp_path: Path) -> bool:
+    return hydra._already_dispatched_today(
+        tmp_path,
+        EDGE,
+        hydra._latest_output(tmp_path, "analysis"),
+        hydra._stage_content_hash(tmp_path, "analysis"),
+    )
+
+
+class TestContentHashLedger:
+    def test_same_content_rewrite_stays_suppressed(self, tmp_path):
+        _write_stage(tmp_path, "analysis", "selection v1")
+        _record(tmp_path)
+        _write_stage(tmp_path, "analysis", "selection v1")  # identical bytes
+        assert _dispatched(tmp_path) is True
+
+    def test_real_content_change_re_fires(self, tmp_path):
+        _write_stage(tmp_path, "analysis", "selection v1")
+        _record(tmp_path)
+        _write_stage(tmp_path, "analysis", "selection v2 — NEW picks")
+        assert _dispatched(tmp_path) is False
+
+    def test_hash_stable_across_identical_rewrites(self, tmp_path):
+        _write_stage(tmp_path, "issues", "issue list")
+        h1 = hydra._stage_content_hash(tmp_path, "issues")
+        _write_stage(tmp_path, "issues", "issue list")
+        assert hydra._stage_content_hash(tmp_path, "issues") == h1
+
+    def test_hash_changes_on_content_change(self, tmp_path):
+        _write_stage(tmp_path, "issues", "issue list A")
+        h1 = hydra._stage_content_hash(tmp_path, "issues")
+        _write_stage(tmp_path, "issues", "issue list B")
+        assert hydra._stage_content_hash(tmp_path, "issues") != h1
+
+    def test_missing_stage_hash_is_defined(self, tmp_path):
+        # No output at all — hash over "<missing>" markers, never an exception.
+        assert isinstance(hydra._stage_content_hash(tmp_path, "research"), str)
+
+    def test_legacy_mtime_entry_still_suppresses_without_hash(self, tmp_path):
+        # Pre-#2425 ledger entry (no upstream_hash) → legacy mtime comparison.
+        ledger = hydra._read_ledger(tmp_path)
+        ledger[EDGE] = {"date": hydra._today(), "upstream_mtime": 100.0}
+        hydra._write_ledger(tmp_path, ledger)
+        assert hydra._already_dispatched_today(tmp_path, EDGE, 90.0, None) is True
+        assert hydra._already_dispatched_today(tmp_path, EDGE, 200.0, None) is False


### PR DESCRIPTION
Automated evolution PR for issue #2425.

**Problem.** The orchestrator wake-gate's dispatch ledger judged upstream newness by mtime alone. Parallel writers rewrite canonical stage files with byte-identical content (clobbering the mtime), so the ledger misread identical bytes as fresh material and re-fired the orchestrator — 4 of ~9 ticks on 2026-08-14 woke and dispatched zero work, burning cron slots and model budget.

**Fix** (`scripts/evolution_hydra_gate.py`):
- New `_stage_content_hash()`: SHA-256 over today's stage output files — stable across identical rewrites, changes only on real content change.
- `_record_dispatch()` now stores `upstream_hash` alongside the mtime.
- `_already_dispatched_today()` compares content hash first: same hash + newer mtime → still suppressed (the #2425 bug class); different hash → re-fire.
- Legacy pre-#2425 entries (mtime-only, no hash) keep the old mtime semantics until the next dispatch refreshes them — no migration needed.
- Time-triggers and safety-wake logic untouched.

**Tests.** 6 new tests in `tests/scripts/test_evolution_hydra_gate_hash_2425.py`: identical-rewrite suppression, real-content-change re-fire, hash stability/change, missing-output definedness, legacy-entry fallback. Existing `test_evolution_hydra_gate.py` re-fire test updated to the new contract: mtime-only bump stays asleep, content change wakes (and isolates the ledger verdict from time-triggers by giving every stage a today-output + back-dating the downstream file past fs mtime granularity).

**Local validation:** ruff check ✓ · ruff format ✓ · 20/20 tests (existing + new) ✓ · pre-PR shard runner PASS ✓ · 200 changed lines (≤ 200 merge-gate cap) ✓

Closes #2425

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>