### PR TITLE
feat(delegation): record child outcomes to the experience bank — #2261 Slice A re-land

### DIFF
--- a/tests/tools/test_delegation_experience_2261.py
+++ b/tests/tools/test_delegation_experience_2261.py
@@ -1,0 +1,110 @@
+"""Delegation-outcome recording into the experience bank (#2261, Slice A).
+
+Finalizing child results must append one ExperienceEntry per child — with
+the delegation configuration (goal, role, model) in ``stats.delegation`` —
+to the EXISTING bank, and must never break finalization on bank failure.
+"""
+
+import json
+
+import pytest
+
+import tools.delegate_tool as dt
+from agent import experience_bank as eb
+
+
+@pytest.fixture()
+def bank_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+class _Parent:
+    session_id = "parent-sess-1"
+    _memory_manager = None
+
+
+def _results():
+    return [
+        {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "did the thing",
+            "model": "glm-4.7",
+            "exit_reason": "completed",
+            "api_calls": 3,
+            "duration_seconds": 12.5,
+            "_child_role": "leaf",
+            "_child_cost_usd": 0.02,
+        },
+        {
+            "task_index": 1,
+            "status": "failed",
+            "summary": "",
+            "model": None,
+            "exit_reason": "max_iterations",
+            "api_calls": 9,
+            "duration_seconds": 30.0,
+            "_child_role": None,
+            "_child_cost_usd": 0.0,
+        },
+    ]
+
+
+def _tasks():
+    return [
+        {"goal": "analyze the repo map"},
+        {"goal": "write the summary"},
+    ]
+
+
+def test_finalize_records_one_entry_per_child(bank_home):
+    dt._finalize_child_results(_results(), _tasks(), [], _Parent())
+    entries = list(eb.iter_entries())
+    assert len(entries) == 2
+    by_platform = {e.platform: e for e in entries}
+    assert set(by_platform) == {"delegation"}
+
+
+def test_entry_carries_delegation_configuration(bank_home):
+    dt._finalize_child_results(_results(), _tasks(), [], _Parent())
+    e = next(e for e in eb.iter_entries() if e.success is True)
+    d = e.stats["delegation"]
+    assert d["goal"] == "analyze the repo map"
+    assert d["role"] == "leaf"
+    assert d["status"] == "completed"
+    assert d["api_calls"] == 3
+    assert d["cost_usd"] == 0.02
+    assert e.model == "glm-4.7"
+    assert e.primary_dimension == "orchestration"
+    assert e.outcome_source == "heuristic:child_status"
+
+
+def test_failed_child_recorded_with_success_false(bank_home):
+    dt._finalize_child_results(_results(), _tasks(), [], _Parent())
+    e = next(e for e in eb.iter_entries() if e.success is False)
+    assert e.stats["delegation"]["status"] == "failed"
+    assert e.terminal_reason == "max_iterations"
+
+
+def test_bank_failure_never_breaks_finalization(bank_home, monkeypatch):
+    # Point the bank at an unwritable HERMES_HOME after import — append must
+    # swallow the error, and finalization must still complete.
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(eb, "append_entry", boom)
+    dt._finalize_child_results(_results(), _tasks(), [], _Parent())  # no raise
+
+
+def test_out_of_range_task_index_skipped(bank_home):
+    results = _results() + [{"task_index": 99, "status": "completed"}]
+    dt._finalize_child_results(results, _tasks(), [], _Parent())
+    assert len(list(eb.iter_entries())) == 2
+
+
+def test_entry_survives_bank_round_trip(bank_home):
+    dt._finalize_child_results(_results(), _tasks(), [], _Parent())
+    raw = json.loads(eb.entries_path().read_text(encoding="utf-8").splitlines()[0])
+    e2 = eb.ExperienceEntry.from_dict(raw)
+    assert e2.stats["delegation"]["goal"] == "analyze the repo map"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3594,6 +3594,60 @@ def _apply_grader_revisions(
                 break
 
 
+def _record_delegation_experience(
+    results: List[Dict[str, Any]],
+    task_list: List[Dict[str, Any]],
+    parent_agent,
+) -> None:
+    """Record each child outcome to the experience bank (#2261, Slice A).
+
+    Delegation configurations (goal, role, model) and their outcomes become
+    retrievable assets by flowing through the EXISTING experience-bank
+    pipeline (entries.jsonl → distiller → system-prompt guidance) — extend,
+    not duplicate. Best-effort: a bank failure must never break finalization.
+    """
+    try:
+        from agent.experience_bank import ExperienceEntry, append_entry
+    except Exception:
+        return
+    for entry in results:
+        try:
+            task_index = entry.get("task_index", -1)
+            if not isinstance(task_index, int) or not (
+                0 <= task_index < len(task_list)
+            ):
+                continue
+            goal = str(task_list[task_index].get("goal", ""))[:200]
+            status = str(entry.get("status", ""))
+            if not goal or not status:
+                continue
+            append_entry(
+                ExperienceEntry(
+                    session_id=str(getattr(parent_agent, "session_id", "") or ""),
+                    platform="delegation",
+                    model=str(entry.get("model") or ""),
+                    success=status == "completed",
+                    outcome_source="heuristic:child_status",
+                    confidence="low",
+                    terminal_reason=str(entry.get("exit_reason", "") or ""),
+                    primary_dimension="orchestration",
+                    analysis=f"delegation status={status}",
+                    stats={
+                        "delegation": {
+                            "goal": goal,
+                            "role": entry.get("_child_role"),
+                            "status": status,
+                            "api_calls": entry.get("api_calls", 0),
+                            "duration_seconds": entry.get("duration_seconds", 0),
+                            "cost_usd": entry.get("_child_cost_usd", 0.0),
+                        }
+                    },
+                )
+            )
+        except Exception:
+            logger.debug("delegation experience record failed", exc_info=True)
+
+
 def _finalize_child_results(
     results: List[Dict[str, Any]],
     task_list: List[Dict[str, Any]],
@@ -3623,6 +3677,10 @@ def _finalize_child_results(
                     )
                 except Exception:
                     pass
+
+        # Slice A of #2261: delegation outcomes → experience bank. Runs
+        # BEFORE the hook loop pops _child_role / _child_cost_usd.
+        _record_delegation_experience(results, task_list, parent_agent)
 
         parent_session_id = getattr(parent_agent, "session_id", None)
         try:


### PR DESCRIPTION
Automated evolution PR for issue #2261 (Slice A of parent #2251). Re-lands the closed-unmerged #2413 as a thin, fully-wired slice that addresses every point of its review.

**How this differs from the closed #2413** (review blockers → fix):
1. *"Dead code / disconnected retrieval"* → wired at `_finalize_child_results`, the single funnel EVERY delegation path (single-task, batch, `_run_child_lifecycle`) already calls. Retrieval needs no new code: entries land in the existing `entries.jsonl → evolution_experience_distill.py → format_patterns_prompt` pipeline that already injects guidance at system-prompt build time.
2. *"Extend, don't duplicate"* → zero new modules; delegation outcomes are plain `ExperienceEntry` records with `platform='delegation'` and the config in `stats.delegation`. `agent/experience_bank.py` is untouched.
3. *"Incorrect telemetry"* → role and cost are read from the very entry dict the runner populated (`_child_role`/`_child_cost_usd`, popped later by the hook loop — recording runs BEFORE the pop), model from the child result dict.
4. *"Data loss on promotion"* → nothing is promoted/overwritten here; the append-only entries log and the existing distiller's harvest-state cursor own that contract.
5. *"Footprint"* → 168 changed lines (was 1006), ≤ 200 merge-gate cap.

**Scope honesty:** this slice delivers tracking + promotion-into-the-existing-bank. `Closes #2261` is intentionally omitted — acceptance criterion "retrieval suggests proven configurations" is satisfied by flowing through the existing distill pipeline, but task-matched suggestion retrieval is the natural Slice B (parent #2251 queue).

**Local validation:** ruff check ✓ · ruff format ✓ · 72/72 tests (6 new + 66 existing experience-bank) ✓ · 168 changed lines ✓. Note: the pre-PR dir-shard `tests/tools` fails to COLLECT on a pre-existing, unrelated module (`test_browser_homebrew_paths.py` imports `AGENT_BROWSER_NPX_SPEC` which is absent from `tools/browser_tool.py` on `origin/main` too — verified by checkout+grep; this diff does not touch either file). Targeted runs are green.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>