### PR TITLE
fix(agent): circuit breaker half-open probe state recovers within a session (#2439)

### DIFF
--- a/agent/tool_error_recovery.py
+++ b/agent/tool_error_recovery.py
@@ -22,6 +22,7 @@ import enum
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -504,7 +505,7 @@ def recovery_hint(failure: ToolFailure) -> str:
 
 @dataclass
 class CircuitBreaker:
-    """Simple per-tool circuit breaker.
+    """Simple per-tool circuit breaker with a half-open probe state.
 
     Tracks consecutive failures for a single tool. After ``threshold``
     consecutive failures, the circuit opens and ``should_trip()`` returns
@@ -521,11 +522,22 @@ class CircuitBreaker:
     threshold: int = 5
     _consecutive_failures: int = 0
     _is_open: bool = False
+    # #2439 — half-open probe state. When the breaker opens, it records the
+    # wall-clock time it opened. After ``cooldown_seconds`` elapse, the next
+    # ``should_trip()`` call returns False (allowing a single probe call).
+    # A successful probe closes the breaker; a failed probe re-opens it and
+    # restarts the cooldown. This lets a transient infrastructure failure
+    # recover within a session instead of wedging the tool permanently.
+    cooldown_seconds: float = 30.0
+    _opened_at: Optional[float] = None
+    _probe_armed: bool = False
 
     def record_failure(self) -> None:
         self._consecutive_failures += 1
         if self._consecutive_failures >= self.threshold:
             self._is_open = True
+            self._opened_at = time.monotonic()
+            self._probe_armed = False
             logger.warning(
                 "circuit breaker opened for tool after %d consecutive failures",
                 self._consecutive_failures,
@@ -534,9 +546,36 @@ class CircuitBreaker:
     def record_success(self) -> None:
         self._consecutive_failures = 0
         self._is_open = False
+        self._opened_at = None
+        self._probe_armed = False
 
     def should_trip(self) -> bool:
-        return self._is_open
+        """Return True when the breaker is open and no probe is due.
+
+        When the breaker is open but the cooldown has elapsed, this returns
+        False exactly once (arming a single probe). The probe is consumed by
+        ``record_failure`` (re-opens) or ``record_success`` (closes). This
+        gives a transient failure a chance to recover within a session
+        (#2439).
+        """
+        if not self._is_open:
+            return False
+        if self._probe_armed:
+            # A probe is already armed and awaiting its outcome — keep the
+            # gate closed until the probe resolves.
+            return True
+        if self._opened_at is not None:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self.cooldown_seconds:
+                # Cooldown elapsed — arm a single probe and let it through.
+                self._probe_armed = True
+                logger.info(
+                    "circuit breaker half-open probe armed for tool after "
+                    "%.1fs cooldown",
+                    elapsed,
+                )
+                return False
+        return True
 
 
 # ── Per-tool breaker registry (process-global) ───────────────────────────

--- a/model_tools.py
+++ b/model_tools.py
@@ -1767,7 +1767,10 @@ def handle_function_call(
                     f"{function_name} and use an alternative tool "
                     f"(read_file, search_files, write_file) or report the "
                     f"blocker. Repeatedly calling {function_name} will keep "
-                    f"failing."
+                    f"failing. The breaker will allow a single probe call "
+                    f"after a ~{int(_breaker.cooldown_seconds)}s cooldown — "
+                    f"wait, then retry once; if it succeeds the breaker "
+                    f"closes and normal use resumes."
                 )
                 result = json.dumps({"error": _breaker_msg}, ensure_ascii=False)
                 _emit_post_tool_call_hook(

--- a/tests/agent/test_tool_circuit_breaker_gate.py
+++ b/tests/agent/test_tool_circuit_breaker_gate.py
@@ -159,3 +159,100 @@ def test_terminal_failure_accumulates_breaker():
             )
         )
     assert get_breaker("terminal").should_trip()
+
+
+# ── Half-open probe state (#2439) ────────────────────────────────────────
+
+
+class _FakeClock:
+    """Controllable monotonic clock for deterministic cooldown tests."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _open_breaker(threshold: int = 3, cooldown: float = 30.0) -> CircuitBreaker:
+    breaker = CircuitBreaker(threshold=threshold, cooldown_seconds=cooldown)
+    for _ in range(threshold):
+        breaker.record_failure()
+    assert breaker.should_trip()
+    return breaker
+
+
+def test_breaker_stays_open_until_cooldown_elapses(monkeypatch):
+    """An open breaker keeps tripping until the cooldown elapses."""
+    clock = _FakeClock()
+    monkeypatch.setattr("agent.tool_error_recovery.time.monotonic", clock)
+    breaker = _open_breaker()
+    # Even after more failures, still open.
+    breaker.record_failure()
+    assert breaker.should_trip()
+    # Cooldown has not elapsed — still tripping.
+    clock.advance(10.0)
+    assert breaker.should_trip()
+
+
+def test_breaker_half_open_probes_after_cooldown(monkeypatch):
+    """After the cooldown elapses, should_trip() returns False once (probe)."""
+    clock = _FakeClock()
+    monkeypatch.setattr("agent.tool_error_recovery.time.monotonic", clock)
+    breaker = _open_breaker()
+    assert breaker.should_trip()
+
+    # Simulate the cooldown elapsing.
+    clock.advance(31.0)
+    # First call after cooldown: probe armed, gate opens.
+    assert not breaker.should_trip()
+    # Probe is armed and awaiting outcome — gate stays closed.
+    assert breaker.should_trip()
+
+
+def test_breaker_half_open_probe_closes_on_success(monkeypatch):
+    """A successful probe closes the breaker and resets the failure count."""
+    clock = _FakeClock()
+    monkeypatch.setattr("agent.tool_error_recovery.time.monotonic", clock)
+    breaker = _open_breaker()
+
+    clock.advance(31.0)
+    assert not breaker.should_trip()  # probe allowed through
+    breaker.record_success()  # probe succeeded
+    assert not breaker.should_trip()
+    assert breaker._consecutive_failures == 0
+    assert breaker._is_open is False
+
+
+def test_breaker_half_open_probe_reopens_on_failure(monkeypatch):
+    """A failed probe re-opens the breaker and restarts the cooldown."""
+    clock = _FakeClock()
+    monkeypatch.setattr("agent.tool_error_recovery.time.monotonic", clock)
+    breaker = _open_breaker()
+
+    clock.advance(31.0)
+    assert not breaker.should_trip()  # probe allowed through
+    breaker.record_failure()  # probe failed — re-opens, restarts cooldown
+    assert breaker.should_trip()
+    # Cooldown restarted — still tripping immediately after.
+    assert breaker.should_trip()
+    # After the restarted cooldown elapses, a new probe is allowed.
+    clock.advance(31.0)
+    assert not breaker.should_trip()
+
+
+def test_breaker_half_open_probe_requires_cooldown(monkeypatch):
+    """A probe is only allowed after the cooldown has fully elapsed."""
+    clock = _FakeClock()
+    monkeypatch.setattr("agent.tool_error_recovery.time.monotonic", clock)
+    breaker = _open_breaker()
+
+    # Only 10s elapsed — still tripping.
+    clock.advance(10.0)
+    assert breaker.should_trip()
+    # Exactly at the boundary (30s) — probe allowed.
+    clock.advance(20.0)
+    assert not breaker.should_trip()


### PR DESCRIPTION
## Problem

Tool circuit breakers (terminal, patch, read_file, search_files) open after 5 consecutive failures and **never half-open probe** within a session. Once open, the breaker stays open for the entire session, forcing agents to route around the tool (e.g. full-file `write_file` instead of `patch`, `mcp__scrapling__get` on `file://` URLs instead of `read_file`).

Observed across 2026-08-13/14/15 in both the orchestrator and subagent contexts:
- `patch`: "Circuit breaker open: patch has failed 5 consecutive times..." — permanently open, blocks the 223KB `stage_gate.jsonl` append.
- `terminal`: "Circuit breaker open: terminal has failed 5 consecutive times..." — blocks the entire write path (git/gh/pytest/ruff).
- `read_file`/`search_files`: opened in the orchestrator context on 08-14 (7 and 5 consecutive failures), worked around via scrapling `file://` reads.

## Root cause

The circuit breaker has no half-open recovery state. It transitions open→closed only on a fresh session, not on a cooldown timer. A transient infrastructure failure (e.g. a large-file read timing out, a one-off terminal regression) permanently disables the tool for the rest of the session even after the underlying cause clears.

## Fix

Add a half-open probe state with a ~30s cooldown to `CircuitBreaker` in `agent/tool_error_recovery.py`:

- `record_failure()` stamps `_opened_at` (monotonic) when the breaker trips.
- `should_trip()` returns `False` exactly once after the cooldown elapses, arming a single probe call.
- A successful probe (`record_success`) closes the breaker and resets the failure count; a failed probe (`record_failure`) re-opens it and restarts the cooldown.
- The gate message in `model_tools.py` now tells the model the breaker will allow a single probe after the cooldown, so it can wait and retry instead of routing around the tool permanently.

## Tests

Regression tests in `tests/agent/test_tool_circuit_breaker_gate.py` assert:
- An open breaker keeps tripping until the cooldown elapses.
- A probe is allowed exactly once after the cooldown.
- A successful probe closes the breaker and resets the failure count.
- A failed probe re-opens the breaker and restarts the cooldown.
- A probe requires the full cooldown to have elapsed.

All 66 tests in the affected modules pass.

Closes #2439