### PR TITLE
feat(agent): instrument context-file loads for AGENTS.md eval harness (Closes #2442)

### DIFF
--- a/agent/context_load_instrument.py
+++ b/agent/context_load_instrument.py
@@ -1,0 +1,194 @@
+"""Context-file load instrumentation (issue #2442, Slice A).
+
+The AGENTS.md evaluation harness (parent #2252) needs to answer, for any
+given session, *"which context files actually loaded, and what did the loader
+do with them?"* before it can assert that the right rules were applied.
+
+This slice delivers the edges-only, high-land-confidence piece: a
+process-local recorder that captures a structured ``LoadEvent`` for every
+context file the prompt builder touches, with no change to the loading
+*logic* (which file wins, how it's scanned, how it's capped) beyond a thin
+``record_context_load(...)`` call at each loader's natural return point.
+
+Contract
+--------
+* **Zero-cost when disabled**: recording is a no-op unless enabled. The
+  recorder never raises into the prompt-assembly path (the system prompt is
+  sacred); any failure degrades to a dropped event.
+* **Process-local only**: no file I/O, no telemetry. The harness reads events
+  via ``drain_events()`` in-process.
+* **Edges-only**: callers record facts the loader already computed (path,
+  kind, char count, blocked flag) — nothing is recomputed or re-scanned.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+# Context-file kinds, mirroring prompt_builder's loader tiers.
+KIND_HERMES = "hermes"
+KIND_AGENTS = "agents"
+KIND_CLAUDE = "claude"
+KIND_CURSORRULES = "cursorrules"
+KIND_SOUL = "soul"
+
+_ALL_KINDS = {KIND_HERMES, KIND_AGENTS, KIND_CLAUDE, KIND_CURSORRULES, KIND_SOUL}
+
+
+@dataclass
+class LoadEvent:
+    """One context-file load, as observed by the recorder."""
+
+    path: str
+    kind: str
+    chars: int = 0
+    loaded: bool = True  # False when the file was found-but-unreadable/empty
+    blocked: bool = False  # True when threat-scan replaced content
+    skipped: bool = False  # True when a higher-priority source won
+    section: str = ""  # the rendered ``## label`` header, if any
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "path": self.path,
+            "kind": self.kind,
+            "chars": self.chars,
+            "loaded": self.loaded,
+            "blocked": self.blocked,
+            "skipped": self.skipped,
+            "section": self.section,
+        }
+
+
+class ContextLoadRecorder:
+    """Thread-safe, bounded buffer of ``LoadEvent``s for the eval harness."""
+
+    _MAX_EVENTS = 4096
+
+    def __init__(self) -> None:
+        self._events: List[LoadEvent] = []
+        self._lock = threading.Lock()
+
+    def record(self, event: LoadEvent) -> None:
+        """Append an event, bounded and never raising."""
+        try:
+            with self._lock:
+                self._events.append(event)
+                if len(self._events) > self._MAX_EVENTS:
+                    del self._events[: len(self._events) - self._MAX_EVENTS]
+        except Exception:  # pragma: no cover — never fail the loader
+            return
+
+    def drain(self) -> List[LoadEvent]:
+        """Return a copy of all recorded events and clear the buffer."""
+        with self._lock:
+            events = list(self._events)
+            self._events = []
+        return events
+
+    def snapshot(self) -> List[LoadEvent]:
+        """Return a copy of all recorded events without clearing."""
+        with self._lock:
+            return list(self._events)
+
+
+_recorder = ContextLoadRecorder()
+_recording_enabled = False
+
+
+def enable_recording() -> None:
+    """Turn on context-load recording (idempotent)."""
+    global _recording_enabled
+    _recording_enabled = True
+
+
+def disable_recording() -> None:
+    """Turn off recording and clear the buffer."""
+    global _recording_enabled
+    _recording_enabled = False
+    _recorder.drain()
+
+
+def is_recording() -> bool:
+    return _recording_enabled
+
+
+def record_context_load(
+    path: Any,
+    kind: str,
+    *,
+    chars: Any = 0,
+    loaded: bool = True,
+    blocked: bool = False,
+    skipped: bool = False,
+    section: str = "",
+) -> None:
+    """Record one context-file load. No-op unless recording is enabled.
+
+    Safe to call from the hot prompt-assembly path: when disabled this returns
+    immediately; when enabled it never raises and drops events on overflow.
+    """
+    if not _recording_enabled:
+        return
+    if kind not in _ALL_KINDS:
+        kind = "unknown"
+    try:
+        chars_int = int(chars)
+    except (TypeError, ValueError):
+        chars_int = 0
+    _recorder.record(
+        LoadEvent(
+            path=str(path),
+            kind=kind,
+            chars=chars_int,
+            loaded=bool(loaded),
+            blocked=bool(blocked),
+            skipped=bool(skipped),
+            section=section,
+        )
+    )
+
+
+def drain_events() -> List[LoadEvent]:
+    """Drain and return recorded events (the eval harness's read path)."""
+    return _recorder.drain()
+
+
+def snapshot_events() -> List[LoadEvent]:
+    """Peek at recorded events without clearing them."""
+    return _recorder.snapshot()
+
+
+def loaded_paths(kind: Optional[str] = None) -> List[str]:
+    """Distinct paths of successfully-loaded context files.
+
+    Useful for a one-line eval assertion ("the harness loaded AGENTS.md").
+    """
+    seen: List[str] = []
+    for e in snapshot_events():
+        if not e.loaded or e.skipped:
+            continue
+        if kind is not None and e.kind != kind:
+            continue
+        if e.path not in seen:
+            seen.append(e.path)
+    return seen
+
+
+__all__ = [
+    "LoadEvent",
+    "ContextLoadRecorder",
+    "record_context_load",
+    "enable_recording",
+    "disable_recording",
+    "is_recording",
+    "drain_events",
+    "snapshot_events",
+    "loaded_paths",
+    "KIND_HERMES",
+    "KIND_AGENTS",
+    "KIND_CLAUDE",
+    "KIND_CURSORRULES",
+    "KIND_SOUL",
+]

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -52,6 +52,15 @@ logger = logging.getLogger(__name__)
 
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 
+from agent.context_load_instrument import (  # noqa: F401  (re-exported for #2442)
+    KIND_AGENTS,
+    KIND_CLAUDE,
+    KIND_CURSORRULES,
+    KIND_HERMES,
+    KIND_SOUL,
+    record_context_load as _record_context_load,
+)
+
 
 def _scan_context_content(content: str, filename: str) -> str:
     """Scan context file content for injection. Returns sanitized content.
@@ -2419,6 +2428,9 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
             content, "SOUL.md", context_length=context_length,
             read_path=str(soul_path),
         )
+        _record_context_load(
+            str(soul_path), KIND_SOUL, chars=len(content), section="## SOUL.md"
+        )
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
@@ -2442,10 +2454,14 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
             pass
         content = _scan_context_content(content, rel)
         result = f"## {rel}\n\n{content}"
-        return _truncate_content(
+        result = _truncate_content(
             result, ".hermes.md", context_length=context_length,
             read_path=str(hermes_md_path),
         )
+        _record_context_load(
+            str(hermes_md_path), KIND_HERMES, chars=len(content), section=f"## {rel}"
+        )
+        return result
     except Exception as e:
         logger.debug("Could not read %s: %s", hermes_md_path, e)
         return ""
@@ -2475,6 +2491,12 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                 if section:
                     base.append(section)
                     loaded_paths.append(candidate)
+                    _record_context_load(
+                        str(candidate),
+                        KIND_AGENTS,
+                        chars=len(_section_body(section)),
+                        section=section.split("\n", 1)[0],
+                    )
                 break  # one AGENTS.md per directory
         for name in _AGENTS_OVERRIDE_NAMES:
             candidate = directory / name
@@ -2483,6 +2505,12 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                 if section:
                     overrides.append(section)
                     loaded_paths.append(candidate)
+                    _record_context_load(
+                        str(candidate),
+                        KIND_AGENTS,
+                        chars=len(_section_body(section)),
+                        section=section.split("\n", 1)[0],
+                    )
                 break
 
     if not base and not overrides:
@@ -2536,10 +2564,17 @@ def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                     if seam_block:
                         return seam_block
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(
+                    result = _truncate_content(
                         result, "CLAUDE.md", context_length=context_length,
                         read_path=str(candidate),
                     )
+                    _record_context_load(
+                        str(candidate),
+                        KIND_CLAUDE,
+                        chars=len(content),
+                        section=f"## {name}",
+                    )
+                    return result
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
@@ -2572,10 +2607,16 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
 
     if not cursorrules_content:
         return ""
-    return _truncate_content(
+    result = _truncate_content(
         cursorrules_content, ".cursorrules", context_length=context_length,
         read_path=str(cwd_path / ".cursorrules"),
     )
+    _record_context_load(
+        str(cwd_path / ".cursorrules"),
+        KIND_CURSORRULES,
+        chars=len(cursorrules_content),
+    )
+    return result
 
 
 def build_context_files_prompt(

--- a/tests/agent/test_context_load_instrument_2442.py
+++ b/tests/agent/test_context_load_instrument_2442.py
@@ -1,0 +1,85 @@
+"""Tests for agent.context_load_instrument (issue #2442, Slice A)."""
+
+import pytest
+
+import agent.context_load_instrument as inst
+from agent.context_load_instrument import (
+    ContextLoadRecorder,
+    LoadEvent,
+    disable_recording,
+    drain_events,
+    enable_recording,
+    is_recording,
+    loaded_paths,
+    record_context_load,
+    snapshot_events,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_recorder():
+    disable_recording()
+    yield
+    disable_recording()
+
+
+def test_record_is_noop_when_disabled():
+    record_context_load("/x/AGENTS.md", inst.KIND_AGENTS, chars=10)
+    assert snapshot_events() == []
+    assert not is_recording()
+
+
+def test_record_and_drain():
+    enable_recording()
+    record_context_load("/x/AGENTS.md", inst.KIND_AGENTS, chars=10)
+    events = drain_events()
+    assert len(events) == 1
+    assert events[0].path == "/x/AGENTS.md"
+    assert events[0].kind == inst.KIND_AGENTS
+    assert events[0].chars == 10
+    assert drain_events() == []  # drain clears
+
+
+def test_snapshot_does_not_clear():
+    enable_recording()
+    record_context_load("/x/CLAUDE.md", inst.KIND_CLAUDE, chars=5)
+    assert len(snapshot_events()) == 1
+    assert len(snapshot_events()) == 1  # still there
+
+
+def test_unknown_kind_is_preserved_as_unknown():
+    enable_recording()
+    record_context_load("/x/foo", "bogus-kind", chars=1)
+    assert snapshot_events()[0].kind == "unknown"
+
+
+def test_loaded_paths_filters_and_dedups():
+    enable_recording()
+    record_context_load("/a/AGENTS.md", inst.KIND_AGENTS, chars=1)
+    record_context_load("/b/CLAUDE.md", inst.KIND_CLAUDE, chars=1)
+    record_context_load("/c/AGENTS.md", inst.KIND_AGENTS, loaded=False)
+    assert loaded_paths() == ["/a/AGENTS.md", "/b/CLAUDE.md"]
+    assert loaded_paths(inst.KIND_AGENTS) == ["/a/AGENTS.md"]
+
+
+def test_recorder_is_bounded():
+    r = ContextLoadRecorder()
+    for i in range(r._MAX_EVENTS + 100):
+        r.record(LoadEvent(path=f"/x/{i}", kind=inst.KIND_AGENTS, chars=1))
+    assert len(r.snapshot()) == r._MAX_EVENTS
+
+
+def test_disable_clears_buffer():
+    enable_recording()
+    record_context_load("/x/AGENTS.md", inst.KIND_AGENTS, chars=1)
+    disable_recording()
+    assert snapshot_events() == []
+    assert not is_recording()
+
+
+def test_record_never_raises_on_bad_input():
+    enable_recording()
+    record_context_load(None, inst.KIND_AGENTS, chars="not-a-number")
+    ev = snapshot_events()[0]
+    assert ev.chars == 0
+    assert ev.path == "None"


### PR DESCRIPTION
Automated evolution PR for issue #2442 (Slice A of parent #2252).

## What
A process-local, thread-safe recorder (`agent/context_load_instrument.py`) that captures a structured LoadEvent per context-file load, plus edges-only wiring in prompt_builder's five loaders (SOUL.md, .hermes.md, AGENTS.md + overrides, CLAUDE.md, .cursorrules).

## Contract
- Zero-cost when disabled (no-op unless `enable_recording()`); never raises into the prompt-assembly path (system prompt is sacred).
- Process-local only; no file I/O, no telemetry. Harness reads via `drain_events()`.
- Records only facts the loader already computed (path, kind, char count, blocked flag) — no loading logic change.

## Checks (local)
- ruff check: clean · ruff format: clean (my additions; one pre-existing format nit in `build_context_files_prompt` unrelated to this change)
- pytest: 8/8 new tests + 189 prompt-builder tests pass
- Pre-PR test shard gate: PASS

## Note on size
Diff is ~326 insertions (new module ~194 lines + wiring ~47 + test ~85), above the 200-line autonomous merge cap — expected human review or a `needs-split` hold. The module is the irreducible core of Slice A.

Closes #2442