### PR TITLE
feat(tools): credential masking for terminal/tool execution output (#2435)

### DIFF
--- a/tests/tools/test_credential_masking.py
+++ b/tests/tools/test_credential_masking.py
@@ -1,0 +1,66 @@
+"""Tests for credential masking of terminal/tool output (#2435)."""
+
+from __future__ import annotations
+
+from tools import credential_masking
+
+
+def test_masking_disabled_by_default_passthrough():
+    credential_masking.reset_cache()
+    # The config gate is cache-backed; forcing it off verifies passthrough.
+    credential_masking._config_cache["enabled"] = False
+    original = "sk-abc123 no change here"
+    assert credential_masking.mask_tool_output(original) == original
+    credential_masking.reset_cache()
+
+
+def test_mask_credentials_redacts_known_prefix():
+    credential_masking._config_cache["enabled"] = True
+    out = credential_masking.mask_credentials("my key is sk-S4v4g3K3y0123456789")
+    assert "sk-S4v4g3K3y0123456789" not in out
+    credential_masking.reset_cache()
+
+
+def test_mask_credentials_no_secret_unchanged():
+    credential_masking._config_cache["enabled"] = True
+    text = "just some normal output with nothing secret"
+    assert credential_masking.mask_credentials(text) == text
+    credential_masking.reset_cache()
+
+
+def test_mask_tool_output_string_passthrough_when_off():
+    credential_masking._config_cache["enabled"] = False
+    value = "sk-letthispassthrough0000000"
+    assert credential_masking.mask_tool_output(value) == value
+    credential_masking.reset_cache()
+
+
+def test_mask_tool_output_dict_recurses():
+    credential_masking._config_cache["enabled"] = True
+    value = {"ok": "fine", "leak": "token ghp_ShouldBeMasked00000000"}
+    out = credential_masking.mask_tool_output(value)
+    assert isinstance(out, dict)
+    assert out["ok"] == "fine"
+    assert "ghp_ShouldBeMasked00000000" not in out["leak"]
+    credential_masking.reset_cache()
+
+
+def test_mask_tool_output_non_text_passthrough():
+    credential_masking._config_cache["enabled"] = True
+    assert credential_masking.mask_tool_output(42) == 42
+    assert credential_masking.mask_tool_output(None) is None
+    credential_masking.reset_cache()
+
+
+def test_mask_credentials_never_raises_on_garbage():
+    credential_masking._config_cache["enabled"] = True
+    # mask_credentials is a total function: non-string inputs return as-is
+    # (mask_tool_output is the Any-typed entry point; mask_credentials guards
+    # non-str defensively too).
+    from typing import Any
+
+    fake: Any = 123
+    assert credential_masking.mask_credentials(fake) == 123
+    fake_none: Any = None
+    assert credential_masking.mask_credentials(fake_none) is None
+    credential_masking.reset_cache()

--- a/tools/credential_masking.py
+++ b/tools/credential_masking.py
@@ -1,0 +1,108 @@
+"""Credential masking for terminal / tool execution output (#2435).
+
+Wires the existing ``agent.redact`` machinery to the tool-result choke point
+so that *every* string a tool returns (terminal output, file reads, search
+results, error messages) is redacted before it enters the model's context.
+
+The heavy lifting lives in ``agent.redact`` — this module is a thin,
+config-gated adapter that keeps the gateway/CLI surfaces consistent:
+
+- ``masking_enabled()`` reads ``security.credential_masking`` from config.yaml
+  (NOT a new ``HERMES_*`` env var — AGENTS.md: ``.env`` is for secrets only).
+- ``mask_credentials(text)`` applies ``agent.redact.redact_sensitive_text``.
+- ``mask_tool_output(value)`` is the single entry point the registry choke
+  point calls for string results; it is a total function (never raises) and,
+  when masking is disabled, a byte-identical passthrough.
+
+Default is **off** so every existing test fixture remains byte-identical.
+Masking must never break a tool result: any failure degrades to the unmasked
+string rather than surfacing an error into the model context.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Cache the config gate so we don't re-read + re-parse config on every tool
+# result (a hot path: one call per tool dispatch). Reset via reset_cache().
+_config_cache: dict = {"enabled": None}
+
+
+def _read_masking_enabled() -> bool:
+    """Read ``security.credential_masking`` from config.yaml.
+
+    Returns False on any failure (unreadable config, missing key, wrong type):
+    masking is an opt-in safety net, so fail-open rather than fail-closed on
+    config errors — but *never* fail into masking-off silently at runtime;
+    a mismatch is logged once.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        security = cfg.get("security", {}) or {}
+        value = security.get("credential_masking", False)
+        return bool(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("credential masking config read failed: %s", exc)
+        return False
+
+
+def masking_enabled() -> bool:
+    """Return whether credential masking is currently enabled."""
+    if _config_cache["enabled"] is None:
+        _config_cache["enabled"] = _read_masking_enabled()
+    return _config_cache["enabled"]
+
+
+def reset_cache() -> None:
+    """Force the config gate to be re-read on the next ``masking_enabled()``.
+
+    Intended for tests and for config-reload boundaries.
+    """
+    _config_cache["enabled"] = None
+
+
+def mask_credentials(text: str) -> str:
+    """Redact credentials from ``text`` using the core redaction engines.
+
+    A thin wrapper over ``agent.redact.redact_sensitive_text``. Returns the
+    input unchanged (never raises) when redaction is unavailable or fails.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(text)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("credential masking redaction failed: %s", exc)
+        return text
+
+
+def mask_tool_output(value: Any) -> Any:
+    """Mask credentials in a tool result value.
+
+    - When masking is disabled → byte-identical passthrough.
+    - Strings → ``mask_credentials``.
+    - Dicts / lists → ``mask_credentials`` applied to every ``str`` leaf
+      (preserves structure; only text can carry a token-shaped secret).
+    - Anything else → passthrough.
+
+    Never raises: masking must not break a tool result.
+    """
+    if not masking_enabled():
+        return value
+    try:
+        if isinstance(value, str):
+            return mask_credentials(value)
+        if isinstance(value, dict):
+            return {k: mask_tool_output(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [mask_tool_output(v) for v in value]
+        return value
+    except Exception:  # pragma: no cover - defensive
+        return value

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1078,12 +1078,40 @@ class ToolRegistry:
         persistence from receiving values they cannot safely slice or size.
         """
         if isinstance(result, str):
+            # Credential masking (issue #2435): when
+            # ``security.credential_masking`` is enabled in config.yaml,
+            # run every string tool result through the redaction filter
+            # before it enters the model's context (terminal output, file
+            # reads, search results, errors). Gate-off (the default) is a
+            # byte-identical passthrough. Masking must never break a tool
+            # result, so any failure degrades to the unmasked string.
+            try:
+                from tools.credential_masking import mask_tool_output
+
+                result = mask_tool_output(result)
+            except Exception:
+                pass
             return _bound_json_error_result(result)
         if (
             isinstance(result, dict)
             and result.get("_multimodal") is True
             and isinstance(result.get("content"), list)
         ):
+            # Mask the text parts of the multimodal envelope too (images
+            # and other binary parts cannot carry token-shaped text).
+            try:
+                from tools.credential_masking import mask_credentials, masking_enabled
+
+                if masking_enabled():
+                    for _part in result.get("content", []):
+                        if (
+                            isinstance(_part, dict)
+                            and _part.get("type") == "text"
+                            and isinstance(_part.get("text"), str)
+                        ):
+                            _part["text"] = mask_credentials(_part["text"])
+            except Exception:
+                pass
             return result
 
         result_type = type(result).__name__


### PR DESCRIPTION
Closes #2435.

Adds `tools/credential_masking.py` — a config-gated adapter over the existing `agent.redact` engine — and wires it into `ToolRegistry._normalize_handler_result`, the single choke point every tool result flows through.

- `security.credential_masking: true` in `config.yaml` enables it; default-off is a byte-identical passthrough.
- Masks secrets from terminal output, file reads, search results, and errors before they enter the model context.
- Wrapped in `try/except` so masking can never break a tool result; non-string values pass through.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>