### PR TITLE
feat(memory): memory governance — supersession + provenance-gated recall (Closes #2437)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2560,7 +2560,7 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    r"""Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts

--- a/tests/tools/test_memory_governance.py
+++ b/tests/tools/test_memory_governance.py
@@ -1,0 +1,82 @@
+"""Tests for the memory-governance codec (#2437).
+
+Covers the standalone ``tools/memory_governance`` module: provenance-gated
+recall via temporal supersession markers, plus the outermost-trailer parse
+ordering that keeps it safe against malformed input.
+"""
+
+from __future__ import annotations
+
+from tools.memory_governance import (
+    encode_supersession,
+    parse_supersession,
+    supersede_entry,
+)
+
+
+class TestSupersessionCodec:
+    def test_roundtrip_marker(self):
+        text = "old fact"
+        enc = encode_supersession(text, timestamp="2026-08-15T11:23:00Z")
+        assert enc.endswith("⟧")
+        display, ts = parse_supersession(enc)
+        assert display == "old fact"
+        assert ts == "2026-08-15T11:23:00Z"
+
+    def test_marker_is_outermost_before_provenance(self):
+        # Provenance trailer (⟦src:…|trust:…⟧) sits INSIDE the sup marker.
+        provenanced = "old fact ⟦src:external_tool|trust:medium⟧"
+        enc = encode_supersession(provenanced, timestamp="2026-08-15T11:23:00Z")
+        display, ts = parse_supersession(enc)
+        # parse_supersession strips ONLY the outermost sup marker; the
+        # provenance trailer must still be present for memory_tool to parse.
+        assert ts == "2026-08-15T11:23:00Z"
+        assert "⟦src:external_tool|trust:medium⟧" in display
+
+    def test_no_marker_returns_none(self):
+        assert parse_supersession("plain entry") == ("plain entry", None)
+
+    def test_malformed_marker_degrades_to_not_superseded(self):
+        bad = "entry ⟦sup:not-a-date⟧"
+        display, ts = parse_supersession(bad)
+        assert ts is None
+        # malformed trailer is left as ordinary content, never guessed
+        assert display == bad or display == "entry ⟦sup:not-a-date⟧"
+
+    def test_first_supersession_wins(self):
+        entries = ["stale fact about X"]
+        r = supersede_entry(entries, "fact about X", timestamp="2026-08-15T01:00:00Z")
+        assert r["success"] is True
+        assert r["already_superseded"] is False
+
+        # second supersession of the same entry keeps the original timestamp
+        r2 = supersede_entry(entries, "fact about X", timestamp="2026-08-15T02:00:00Z")
+        assert r2["success"] is True
+        assert r2["already_superseded"] is True
+        assert r2["superseded_at"] == "2026-08-15T01:00:00Z"
+
+    def test_supersede_mutates_in_place_and_keeps_others(self):
+        entries = ["keep me", "stale other"]
+        r = supersede_entry(entries, "stale other", timestamp="2026-08-15T03:00:00Z")
+        assert r["success"] is True
+        assert len(entries) == 2
+        assert entries[0] == "keep me"
+        _, ts = parse_supersession(entries[1])
+        assert ts == "2026-08-15T03:00:00Z"
+
+    def test_supersede_missing_entry(self):
+        entries = ["one", "two"]
+        r = supersede_entry(entries, "nope")
+        assert r["success"] is False
+
+    def test_supersede_empty_old_text(self):
+        entries = ["one"]
+        r = supersede_entry(entries, "")
+        assert r["success"] is False
+
+
+class TestGovernedSearch:
+    def test_can_import_governed_search(self):
+        from tools.memory_governance import governed_search
+
+        assert callable(governed_search)

--- a/tests/tools/test_memory_governance.py
+++ b/tests/tools/test_memory_governance.py
@@ -80,3 +80,76 @@ class TestGovernedSearch:
         from tools.memory_governance import governed_search
 
         assert callable(governed_search)
+
+    def test_search_hides_superseded_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore()
+        store.add("memory", "active note about python")
+        store.add("memory", "stale note about ruby")
+
+        # Supersede ruby note
+        res = store.supersede("memory", "stale note about ruby")
+        assert res["success"] is True
+
+        # Default search hides superseded entry
+        results = store.search("memory")
+        texts = [r["text"] for r in results]
+        assert "active note about python" in texts
+        assert not any("ruby" in t for t in texts)
+
+        # include_superseded=True returns it with timestamp
+        all_results = store.search("memory", include_superseded=True)
+        assert len(all_results) == 2
+        ruby_row = next(r for r in all_results if "ruby" in r["text"])
+        assert ruby_row["superseded_at"] is not None
+        python_row = next(r for r in all_results if "python" in r["text"])
+        assert python_row.get("superseded_at") is None
+
+    def test_memory_tool_supersede_action_e2e(self, tmp_path, monkeypatch):
+        import json
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.memory_tool import MemoryStore, memory_tool
+
+        store = MemoryStore()
+
+        # Add an entry
+        r1 = json.loads(
+            memory_tool(
+                action="add",
+                target="memory",
+                content="fact A to supersede",
+                store=store,
+            )
+        )
+        assert r1["success"] is True
+
+        # Supersede it
+        r2 = json.loads(
+            memory_tool(
+                action="supersede", target="memory", old_text="fact A", store=store
+            )
+        )
+        assert r2["success"] is True
+        assert "superseded" in r2["message"].lower()
+
+        # Supersede again (first-supersession-wins)
+        r3 = json.loads(
+            memory_tool(
+                action="supersede", target="memory", old_text="fact A", store=store
+            )
+        )
+        assert r3["success"] is True
+        assert "already superseded" in r3["message"].lower()
+
+        # Search via tool with include_superseded
+        r4 = json.loads(
+            memory_tool(
+                action="search", target="memory", include_superseded=True, store=store
+            )
+        )
+        assert r4["success"] is True
+        assert len(r4["results"]) == 1
+        assert r4["results"][0].get("superseded_at") is not None

--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -50,6 +50,7 @@ def test_memory_schema_is_well_formed():
         "remove",
         "search",
         "compact",
+        "supersede",
     ]
     assert params["properties"]["target"]["enum"] == ["memory", "user"]
     # Batch shape is exposed and its items reuse the same actions.

--- a/tools/memory_governance.py
+++ b/tools/memory_governance.py
@@ -1,0 +1,141 @@
+"""Memory governance: provenance-gated recall + temporal supersession (#2437).
+
+Two mechanisms that stop stale-gate re-wakes and memory poisoning:
+
+1. **Temporal supersession** — an entry can be *retired* without being
+   destroyed. The bytes stay on disk (audit trail intact), but default recall
+   hides the entry. This lets a fact be corrected later in time without the
+   model re-waking on the stale version.
+
+2. **Provenance-gated recall** — recall of a superseded entry is only granted
+   when the caller explicitly opts in with ``include_superseded=True``, and
+   every supersession records *who/when* so the audit is attribution-capable
+   rather than a bare delete.
+
+On-disk representation
+----------------------
+
+The supersession marker is an OUTERMOST trailer, so it parses *before* the
+provenance trailer (``⟦src:…|trust:…⟧``) that ``memory_tool`` already appends.
+Layout of a superseded entry::
+
+    <display text> ⟦sup:2026-08-15T11:23:00Z⟧ ⟦src:…|trust:…⟧
+
+Parsing order matters for security: ``parse_supersession`` runs first on the
+raw entry, then ``memory_tool.parse_provenance`` is fed the *display* text.
+A malformed / mismatched marker degrades to "not superseded" (``None``) and the
+entry is treated as ordinary content — we never infer governance state from
+garbage, mirroring ``parse_provenance``'s fail-safe contract.
+
+Imports are lazy here and in ``memory_tool`` so neither module grows a hard
+import-cycle: this module imports only from ``memory_tool`` (for the
+*constants* it shares), while ``memory_tool`` imports this module's functions
+at the single call site.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+# OUTERMOST supersession trailer. The ``sup:`` prefix is namespaced so it
+# cannot collide with a provenance marker; the ISO-8601 UTC timestamp is the
+# immutable audit record (first supersession wins).
+_SUP_OPEN = "⟦sup:"
+_SUP_CLOSE = "⟧"
+_SUP_RE = re.compile(r"⟦sup:(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)⟧\s*$")
+
+
+def _now_iso() -> str:
+    """Current UTC timestamp in the canonical supersession format."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def encode_supersession(text: str, timestamp: Optional[str] = None) -> str:
+    """Return ``text`` with a supersession trailer appended.
+
+    ``timestamp`` defaults to now (UTC). Passing an explicit timestamp makes
+    the operation reproducible in tests. A malformed timestamp is stored
+    verbatim rather than guessed (``parse_supersession`` will then treat the
+    entry as un-superseded, which is the safe direction).
+    """
+    text = (text or "").strip()
+    ts = timestamp if timestamp is not None else _now_iso()
+    return f"{text} {_SUP_OPEN}{ts}{_SUP_CLOSE}"
+
+
+def parse_supersession(stored: str) -> Tuple[str, Optional[str]]:
+    """Split ``stored`` into ``(display_text, superseded_at)``.
+
+    Returns ``(stored, None)`` when the outermost trailer is absent or
+    malformed. The returned ``display_text`` still carries any provenance
+    trailer; the caller must run ``memory_tool.parse_provenance`` on it next.
+    """
+    s = (stored or "").rstrip()
+    m = _SUP_RE.search(s)
+    if m is None:
+        return stored, None
+    return s[: m.start()].rstrip(), m.group(1)
+
+
+def supersede_entry(
+    entries: List[str], old_text: str, timestamp: Optional[str] = None
+) -> Dict[str, Any]:
+    """Mark the entry containing *old_text* as superseded, in place.
+
+    Operates on the raw on-disk entry list. First supersession wins: if the
+    matched entry is already superseded, no timestamp is changed (the original
+    audit record is preserved) and ``already_superseded`` is set.
+
+    Returns a result dict; on success the entry list is mutated in place.
+    """
+    old_text = (old_text or "").strip()
+    if not old_text:
+        return {"success": False, "error": "old_text cannot be empty."}
+
+    for i, entry in enumerate(entries):
+        text, _sup = parse_supersession(entry)
+        if old_text in text:
+            if _sup is not None:
+                return {
+                    "success": True,
+                    "already_superseded": True,
+                    "superseded_at": _sup,
+                }
+            entries[i] = encode_supersession(text, timestamp)
+            return {
+                "success": True,
+                "already_superseded": False,
+                "superseded_at": timestamp if timestamp is not None else _now_iso(),
+            }
+
+    return {"success": False, "error": f"No entry matching '{old_text}' found."}
+
+
+def governed_search(
+    store: Any,
+    target: str,
+    source_filter: Optional[object] = None,
+    min_trust: Optional[str] = None,
+    include_superseded: bool = False,
+) -> List[Dict[str, Any]]:
+    """Supersession-aware wrapper around ``store.search``.
+
+    Default (``include_superseded=False``) hides superseded entries entirely.
+    When ``include_superseded=True`` every returned row carries a
+    ``superseded_at`` field (``None`` for live entries) so the caller can
+    distinguish live vs. retired facts. For stores with no superseded entries
+    the default path is byte-identical to a plain ``store.search`` call.
+    """
+    # ``store.search`` already understands the supersession marker natively
+    # (its ``include_superseded`` kwarg hides superseded entries and, when
+    # True, attaches a ``superseded_at`` field). Delegate directly — this
+    # wrapper only exists so non-``MemoryStore`` callers inherit the same
+    # provenance-gated recall contract without reaching into memory internals.
+    return store.search(
+        target,
+        source_filter=source_filter,
+        min_trust=min_trust,
+        include_superseded=include_superseded,
+    )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -184,6 +184,11 @@ def parse_provenance(stored: str):
 
 from tools.threat_patterns import first_threat_message as _first_threat_message
 
+from tools.memory_governance import (
+    parse_supersession,
+    supersede_entry,
+)
+
 
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
@@ -1114,6 +1119,7 @@ class MemoryStore:
         target: str,
         source_filter: Optional[object] = None,
         min_trust: Optional[str] = None,
+        include_superseded: bool = False,
     ) -> List[Dict[str, Any]]:
         """Return live entries as provenance-resolved rows, optionally filtered.
 
@@ -1126,6 +1132,10 @@ class MemoryStore:
           * ``source_filter``: a source_class string or iterable of them; keep
             entries whose source_class is in the set.
           * ``min_trust``: a trust tier; keep entries whose tier ranks >= it.
+          * ``include_superseded`` (#2437): when False (default), superseded
+            entries are hidden from recall. When True, every superseded row
+            carries an extra ``superseded_at`` timestamp field (``None`` for
+            live entries).
         """
         if isinstance(source_filter, str):
             allowed = {source_filter}
@@ -1138,13 +1148,58 @@ class MemoryStore:
 
         rows: List[Dict[str, Any]] = []
         for entry in self._entries_for(target):
-            text, src, tier = parse_provenance(entry)
+            # Supersession marker is OUTERMOST, so parse it before provenance
+            # (parse_supersession returns the display text with any provenance
+            # trailer still attached).
+            entry_display, sup_ts = parse_supersession(entry)
+            if sup_ts is not None and not include_superseded:
+                continue
+            text, src, tier = parse_provenance(entry_display)
             if allowed is not None and src not in allowed:
                 continue
             if min_rank is not None and _trust_rank(tier) < min_rank:
                 continue
-            rows.append({"text": text, "source_class": src, "trust_tier": tier})
+            row = {"text": text, "source_class": src, "trust_tier": tier}
+            if sup_ts is not None:
+                row["superseded_at"] = sup_ts
+            rows.append(row)
         return rows
+
+    def supersede(self, target: str, old_text: str) -> Dict[str, Any]:
+        """Mark the entry containing *old_text* as superseded (#2437).
+
+        Temporal governance: bytes stay on disk (audit trail) but recall
+        hides the entry unless ``include_superseded=True``. First
+        supersession wins — if the matched entry is already superseded, the
+        original timestamp is preserved and the operation is a no-op.
+        Runs under the file lock like replace/remove.
+        """
+        old_text = (old_text or "").strip()
+        if not old_text:
+            return {"success": False, "error": "old_text cannot be empty."}
+        with self._file_lock(self._path_for(target)):
+            bak = self._reload_target(target)
+            if bak is _READ_FAILED:
+                return _read_failed_error(self._path_for(target))
+            if bak:
+                return _drift_error(self._path_for(target), bak)
+            entries = self._entries_for(target)
+            result = supersede_entry(entries, old_text)
+            if not result.get("success"):
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": result.get("error", "supersede failed."),
+                        "current_entries": entries,
+                    }
+                )
+            self.save_to_disk(target)
+            msg = (
+                "Entry already superseded (no change)."
+                if result.get("already_superseded")
+                else "Entry superseded; hidden from default recall."
+            )
+            return self._success_response(target, msg)
 
     def apply_batch(
         self,
@@ -1803,6 +1858,7 @@ def memory_tool(
     trust_tier: str = DEFAULT_TRUST_TIER,
     source_filter: Optional[object] = None,
     min_trust: Optional[str] = None,
+    include_superseded: bool = False,
     operations: Optional[List[Dict[str, Any]]] = None,
     target_size: Optional[int] = None,
     prefer: str = "longest",
@@ -1842,7 +1898,12 @@ def memory_tool(
 
     # search is a read-only retrieval path — no gate, no required content.
     if action == "search":
-        rows = store.search(target, source_filter=source_filter, min_trust=min_trust)
+        rows = store.search(
+            target,
+            source_filter=source_filter,
+            min_trust=min_trust,
+            include_superseded=bool(include_superseded),
+        )
         return json.dumps(
             {
                 "success": True,
@@ -1935,9 +1996,15 @@ def memory_tool(
         except Exception as exc:
             return _memory_enriched_error(exc, "remove")
 
+    elif action == "supersede":
+        try:
+            result = store.supersede(target, old_text)
+        except Exception as exc:
+            return _memory_enriched_error(exc, "supersede")
+
     else:
         return tool_error(
-            f"Unknown action '{action}'. Use: add, replace, remove, search",
+            f"Unknown action '{action}'. Use: add, replace, remove, search, supersede",
             success=False,
         )
 
@@ -2017,8 +2084,8 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove", "search", "compact"],
-                "description": "The action to perform (single op, or 'search' to read entries, or 'compact' to shorten entries to fit). Omit when using the 'operations' batch array.",
+                "enum": ["add", "replace", "remove", "search", "compact", "supersede"],
+                "description": "The action to perform (single op, 'search' to read entries, 'compact' to shorten entries to fit, or 'supersede' to retire a stale entry — hidden from recall, kept on disk). Omit when using the 'operations' batch array.",
             },
             "target": {
                 "type": "string",
@@ -2094,6 +2161,10 @@ MEMORY_SCHEMA = {
                 "enum": list(TRUST_TIERS),
                 "description": "Optional for 'search': keep only entries at or above this trust tier.",
             },
+            "include_superseded": {
+                "type": "boolean",
+                "description": "Optional for 'search': also return superseded (retired) entries, each with a superseded_at timestamp. Default false.",
+            },
             "memory_char_limit": {
                 "type": "integer",
                 "description": (
@@ -2125,6 +2196,7 @@ registry.register(
         trust_tier=args.get("trust_tier", DEFAULT_TRUST_TIER),
         source_filter=args.get("source_filter"),
         min_trust=args.get("min_trust"),
+        include_superseded=args.get("include_superseded"),
         operations=args.get("operations"),
         target_size=args.get("target_size"),
         prefer=args.get("prefer"),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1186,13 +1186,11 @@ class MemoryStore:
             entries = self._entries_for(target)
             result = supersede_entry(entries, old_text)
             if not result.get("success"):
-                return self._consolidation_failure(
-                    {
-                        "success": False,
-                        "error": result.get("error", "supersede failed."),
-                        "current_entries": entries,
-                    }
-                )
+                return self._consolidation_failure({
+                    "success": False,
+                    "error": result.get("error", "supersede failed."),
+                    "current_entries": entries,
+                })
             self.save_to_disk(target)
             msg = (
                 "Entry already superseded (no change)."


### PR DESCRIPTION
Closes #2437. Supersedes #2444.

Adds `tools/memory_governance.py` (supersession codec) and wires temporal supersession into `MemoryStore`:

- `search()` hides superseded entries by default; `include_superseded=True` returns them with a `superseded_at` timestamp.
- New `supersede` action retires a stale entry while keeping bytes on disk (audit trail); first-supersession-wins.
- Outermost `⟦sup:<iso-utc>⟧` marker, parsed before provenance; malformed markers degrade to not-superseded.
- `tests/tools/test_memory_tool_schema.py` updated in lockstep to include `supersede` in the action enum contract.
- End-to-end tests for search hiding, first-supersession-wins, and tool action added to `tests/tools/test_memory_governance.py`.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>