### PR TITLE
feat(evolution): add trajectory-adapted uncertainty quantification (Closes #2386)

### DIFF
--- a/evolution/lib/uncertainty_quantification.py
+++ b/evolution/lib/uncertainty_quantification.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Trajectory-adapted uncertainty quantification for evolution decisions (#2386).
+
+Inspired by arXiv:2608.11552 ("Trajectory-Adapted Uncertainty Quantification:
+Single-Turn Confidence Does Not Transfer to Agent Trajectories"):
+- Single-turn confidence metrics (e.g. token logprobs) do not reliably transfer
+  to multi-turn agent trajectories.
+- Uses reflexive P(True) as a low-cost baseline for finding confidence.
+- Uses Trajectory Equivalence Rate (TER) across multiple runs/evaluations for
+  high-stakes pipeline decisions.
+- Maps estimated confidence to clear operational actions:
+  proceed_to_implementation, second_research_pass, or defer.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Sequence
+
+
+@dataclass
+class TrajectoryConfidenceAssessment:
+    """Uncertainty quantification assessment for an evolution pipeline decision."""
+
+    score: int  # 0-100 scale
+    method: str  # "reflexive_p_true", "trajectory_equivalence_rate", "hybrid"
+    p_true: float  # 0.0 - 1.0
+    ter: float | None = None  # 0.0 - 1.0 when multiple trajectories compared
+    verdict: str = (
+        "medium_confidence"  # "high_confidence", "medium_confidence", "low_confidence"
+    )
+    action: str = "second_research_pass"  # "proceed_to_implementation", "second_research_pass", "defer"
+    evidence_count: int = 0
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrajectoryConfidenceAssessment:
+        return cls(
+            score=int(data.get("score", 0)),
+            method=str(data.get("method", "reflexive_p_true")),
+            p_true=float(data.get("p_true", 0.0)),
+            ter=float(data["ter"]) if data.get("ter") is not None else None,
+            verdict=str(data.get("verdict", "medium_confidence")),
+            action=str(data.get("action", "second_research_pass")),
+            evidence_count=int(data.get("evidence_count", 0)),
+            details=dict(data.get("details", {})),
+        )
+
+
+def compute_trajectory_equivalence_rate(
+    outcomes: Sequence[Any],
+) -> float:
+    """Compute the Trajectory Equivalence Rate (TER) across trajectory outcomes.
+
+    TER measures the proportion of trajectory pairs that reached equivalent outcomes
+    (arXiv:2608.11552). Returns a float between 0.0 and 1.0.
+    """
+    if not outcomes:
+        return 0.0
+    if len(outcomes) == 1:
+        return 1.0
+
+    # Canonicalize outcomes to comparable representations
+    canonical: list[str] = []
+    for item in outcomes:
+        if isinstance(item, dict):
+            # Normalize dict key ordering
+            canonical.append(json.dumps(item, sort_keys=True, default=str))
+        elif isinstance(item, (list, set, tuple)):
+            canonical.append(json.dumps(sorted(str(x) for x in item)))
+        else:
+            canonical.append(str(item).strip().lower())
+
+    total_pairs = 0
+    matching_pairs = 0
+    n = len(canonical)
+    for i in range(n):
+        for j in range(i + 1, n):
+            total_pairs += 1
+            if canonical[i] == canonical[j]:
+                matching_pairs += 1
+
+    return matching_pairs / total_pairs if total_pairs > 0 else 0.0
+
+
+def estimate_reflexive_p_true(
+    finding: dict[str, Any],
+) -> float:
+    """Estimate reflexive P(True) for a finding based on evidence and structure.
+
+    Evaluates explicit confidence markers, evidence pointer density,
+    reproducibility indicators, and absence of contradictory signals.
+    """
+    # 1. Base prior from explicit confidence if available
+    raw_conf = finding.get("confidence")
+    if isinstance(raw_conf, (int, float)):
+        base = max(
+            0.0,
+            min(1.0, float(raw_conf) / 100.0 if raw_conf > 1.0 else float(raw_conf)),
+        )
+    else:
+        base = 0.5
+
+    # 2. Evidence density adjustment
+    evidence = finding.get("evidence_pointers", []) or finding.get("evidence", [])
+    ev_count = (
+        len(evidence)
+        if isinstance(evidence, (list, tuple, set))
+        else (1 if evidence else 0)
+    )
+
+    if ev_count >= 3:
+        evidence_bonus = 0.2
+    elif ev_count >= 1:
+        evidence_bonus = 0.1
+    else:
+        evidence_bonus = -0.15
+
+    # 3. Reproducibility & verification flag
+    is_verified = bool(
+        finding.get("verified", False) or finding.get("reproduced", False)
+    )
+    verified_bonus = 0.15 if is_verified else 0.0
+
+    # 4. Uncertainty markers in summary/text
+    text = str(finding.get("summary", "") or finding.get("description", "")).lower()
+    uncertainty_penalty = 0.0
+    if any(
+        w in text
+        for w in (
+            "maybe",
+            "perhaps",
+            "unclear",
+            "unverified",
+            "guess",
+            "likely",
+            "tentative",
+        )
+    ):
+        uncertainty_penalty = -0.1
+
+    p_true = base + evidence_bonus + verified_bonus + uncertainty_penalty
+    return max(0.0, min(1.0, round(p_true, 3)))
+
+
+def assess_finding_confidence(
+    finding: dict[str, Any],
+    trajectories: Sequence[Any] | None = None,
+    *,
+    threshold_high: int = 75,
+    threshold_low: int = 40,
+) -> TrajectoryConfidenceAssessment:
+    """Compute trajectory-adapted uncertainty quantification for an evolution finding.
+
+    - High-confidence (>= threshold_high): proceeds directly to implementation.
+    - Low-confidence (< threshold_low): deferred / abstained.
+    - Medium-confidence: scheduled for a second research pass.
+    """
+    p_true = estimate_reflexive_p_true(finding)
+    evidence = finding.get("evidence_pointers", []) or finding.get("evidence", [])
+    ev_count = (
+        len(evidence)
+        if isinstance(evidence, (list, tuple, set))
+        else (1 if evidence else 0)
+    )
+
+    ter: float | None = None
+    if trajectories and len(trajectories) >= 2:
+        ter = compute_trajectory_equivalence_rate(trajectories)
+        method = "hybrid"
+        # Combine reflexive P(True) and empirical TER
+        combined_score = int(round((0.4 * p_true + 0.6 * ter) * 100))
+    else:
+        method = "reflexive_p_true"
+        combined_score = int(round(p_true * 100))
+
+    score = max(0, min(100, combined_score))
+
+    if score >= threshold_high:
+        verdict = "high_confidence"
+        action = "proceed_to_implementation"
+    elif score < threshold_low:
+        verdict = "low_confidence"
+        action = "defer"
+    else:
+        verdict = "medium_confidence"
+        action = "second_research_pass"
+
+    return TrajectoryConfidenceAssessment(
+        score=score,
+        method=method,
+        p_true=p_true,
+        ter=ter,
+        verdict=verdict,
+        action=action,
+        evidence_count=ev_count,
+        details={
+            "threshold_high": threshold_high,
+            "threshold_low": threshold_low,
+            "has_trajectories": bool(trajectories and len(trajectories) >= 2),
+        },
+    )

--- a/tests/evolution/test_uncertainty_quantification.py
+++ b/tests/evolution/test_uncertainty_quantification.py
@@ -1,0 +1,118 @@
+"""Unit tests for trajectory-adapted uncertainty quantification (#2386)."""
+
+import pytest
+
+from evolution.lib.uncertainty_quantification import (
+    TrajectoryConfidenceAssessment,
+    assess_finding_confidence,
+    compute_trajectory_equivalence_rate,
+    estimate_reflexive_p_true,
+)
+
+
+class TestUncertaintyQuantification:
+    """Test uncertainty estimation routines."""
+
+    def test_ter_computation(self):
+        # Empty and single
+        assert compute_trajectory_equivalence_rate([]) == 0.0
+        assert compute_trajectory_equivalence_rate([{"result": "success"}]) == 1.0
+
+        # All identical
+        outcomes = [{"status": "ok"}, {"status": "ok"}, {"status": "ok"}]
+        assert compute_trajectory_equivalence_rate(outcomes) == 1.0
+
+        # All disjoint
+        disjoint = [{"status": "1"}, {"status": "2"}, {"status": "3"}]
+        assert compute_trajectory_equivalence_rate(disjoint) == 0.0
+
+        # 2 of 3 matching (pairs: (A,A)=1, (A,B)=0, (A,B)=0 -> 1/3)
+        mixed = [{"status": "A"}, {"status": "A"}, {"status": "B"}]
+        assert round(compute_trajectory_equivalence_rate(mixed), 2) == 0.33
+
+    def test_estimate_reflexive_p_true(self):
+        # High evidence + verified
+        solid = {
+            "confidence": 80,
+            "evidence_pointers": ["file1.py", "file2.py", "issue-123"],
+            "verified": True,
+            "summary": "Confirmed bug in file operations",
+        }
+        p_high = estimate_reflexive_p_true(solid)
+        assert p_high >= 0.85
+
+        # Uncertain / speculative
+        shaky = {
+            "confidence": 30,
+            "evidence_pointers": [],
+            "verified": False,
+            "summary": "Maybe this is perhaps related to race condition",
+        }
+        p_low = estimate_reflexive_p_true(shaky)
+        assert p_low <= 0.2
+
+    def test_assess_finding_confidence_actions(self):
+        # 1. High confidence finding -> proceed to implementation
+        high_finding = {
+            "confidence": 85,
+            "evidence_pointers": ["logs.txt", "repro.py", "tests.py"],
+            "verified": True,
+            "summary": "Deterministic failure reproduced with unit test",
+        }
+        res_high = assess_finding_confidence(high_finding)
+        assert res_high.verdict == "high_confidence"
+        assert res_high.action == "proceed_to_implementation"
+        assert res_high.method == "reflexive_p_true"
+
+        # 2. Medium confidence finding -> second research pass
+        med_finding = {
+            "confidence": 50,
+            "evidence_pointers": ["note.md"],
+            "verified": False,
+            "summary": "Suspected latency spike under heavy load",
+        }
+        res_med = assess_finding_confidence(med_finding)
+        assert res_med.verdict == "medium_confidence"
+        assert res_med.action == "second_research_pass"
+
+        # 3. Low confidence finding -> defer
+        low_finding = {
+            "confidence": 20,
+            "evidence_pointers": [],
+            "verified": False,
+            "summary": "Unclear and unverified hypothesis",
+        }
+        res_low = assess_finding_confidence(low_finding)
+        assert res_low.verdict == "low_confidence"
+        assert res_low.action == "defer"
+
+        # 4. Multi-trajectory hybrid assessment
+        trajectories = [
+            {"fix": "add_lock", "status": "pass"},
+            {"fix": "add_lock", "status": "pass"},
+            {"fix": "add_lock", "status": "pass"},
+        ]
+        res_hybrid = assess_finding_confidence(med_finding, trajectories=trajectories)
+        assert res_hybrid.method == "hybrid"
+        assert res_hybrid.ter == 1.0
+        assert res_hybrid.score >= 75
+        assert res_hybrid.action == "proceed_to_implementation"
+
+    def test_assessment_serialization(self):
+        assessment = TrajectoryConfidenceAssessment(
+            score=82,
+            method="hybrid",
+            p_true=0.75,
+            ter=0.90,
+            verdict="high_confidence",
+            action="proceed_to_implementation",
+            evidence_count=3,
+        )
+        d = assessment.to_dict()
+        assert d["score"] == 82
+        assert d["action"] == "proceed_to_implementation"
+
+        loaded = TrajectoryConfidenceAssessment.from_dict(d)
+        assert loaded.score == assessment.score
+        assert loaded.ter == assessment.ter
+        assert loaded.action == assessment.action


### PR DESCRIPTION
Closes #2386.

Implements research findings from arXiv:2608.11552 (*Trajectory-Adapted Uncertainty Quantification: Single-Turn Confidence Does Not Transfer to Agent Trajectories*):

- Implements `estimate_reflexive_p_true` in `evolution/lib/uncertainty_quantification.py` as a lightweight baseline for per-finding confidence estimation.
- Implements `compute_trajectory_equivalence_rate` (TER) for high-stakes decisions across multiple trajectory runs.
- Implements `assess_finding_confidence` which determines confidence tiers and operational actions:
  - `proceed_to_implementation` (score >= 75)
  - `second_research_pass` (40 <= score < 75)
  - `defer` (score < 40)
- Adds full unit tests in `tests/evolution/test_uncertainty_quantification.py`.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>