### PR TITLE
feat(security): wire verification scope into execution path (Closes #2458)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -11,6 +11,7 @@ def _hermes_home_path() -> Path:
     """Resolve the active HERMES_HOME (profile-aware) without circular imports."""
     try:
         from hermes_constants import get_hermes_home  # local import to avoid cycles
+
         return get_hermes_home()
     except Exception:
         return Path(os.path.expanduser("~/.hermes"))
@@ -19,10 +20,27 @@ def _hermes_home_path() -> Path:
 def _hermes_root_path() -> Path:
     """Resolve the Hermes root dir (always the parent of any profile, never per-profile)."""
     try:
-        from hermes_constants import get_default_hermes_root  # local import to avoid cycles
+        from hermes_constants import (
+            get_default_hermes_root,
+        )  # local import to avoid cycles
+
         return get_default_hermes_root()
     except Exception:
         return Path(os.path.expanduser("~/.hermes"))
+
+
+_ACTIVE_VERIFICATION_SCOPE: Any = None
+
+
+def set_active_verification_scope(scope: Any) -> None:
+    """Set the active VerificationScope for least-agency boundary enforcement."""
+    global _ACTIVE_VERIFICATION_SCOPE
+    _ACTIVE_VERIFICATION_SCOPE = scope
+
+
+def get_active_verification_scope() -> Any:
+    """Return the currently active VerificationScope, or None if unbounded."""
+    return _ACTIVE_VERIFICATION_SCOPE
 
 
 def build_write_denied_paths(home: str) -> set[str]:
@@ -194,6 +212,17 @@ def _classify_write_denial(path: str) -> Optional[str]:
         if not allowed:
             return "safe_root"
 
+    if _ACTIVE_VERIFICATION_SCOPE is not None:
+        try:
+            from agent.verification_scope import VerificationScopeEnforcer
+
+            enforcer = VerificationScopeEnforcer(_ACTIVE_VERIFICATION_SCOPE)
+            ok, _ = enforcer.check_file_access(resolved, mode="write")
+            if not ok:
+                return "verification_scope"
+        except Exception:
+            pass
+
     return None
 
 
@@ -207,6 +236,9 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
     denial = _classify_write_denial(path)
     if denial is None:
         return None
+    if denial == "verification_scope":
+        scope_name = getattr(_ACTIVE_VERIFICATION_SCOPE, "name", "active_scope")
+        return f"{verb} denied: '{path}' violates active verification scope ({scope_name})."
     if denial == "safe_root":
         roots_display = os.pathsep.join(sorted(get_safe_write_roots()))
         return (
@@ -387,6 +419,18 @@ def get_read_block_error(path: str) -> Optional[str]:
             "(Defense-in-depth — not a security boundary; the terminal tool can still bypass.)"
         )
 
+    if _ACTIVE_VERIFICATION_SCOPE is not None:
+        try:
+            from agent.verification_scope import VerificationScopeEnforcer
+
+            enforcer = VerificationScopeEnforcer(_ACTIVE_VERIFICATION_SCOPE)
+            ok, _ = enforcer.check_file_access(resolved, mode="read")
+            if not ok:
+                scope_name = getattr(_ACTIVE_VERIFICATION_SCOPE, "name", "active_scope")
+                return f"Access denied: '{path}' violates active verification scope ({scope_name})."
+        except Exception:
+            pass
+
     return None
 
 
@@ -507,9 +551,7 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
         target_profile = "default"
         area = parts[0]
     elif (
-        parts[0] == "profiles"
-        and len(parts) >= 3
-        and parts[2] in PROFILE_SCOPED_AREAS
+        parts[0] == "profiles" and len(parts) >= 3 and parts[2] in PROFILE_SCOPED_AREAS
     ):
         # ``<root>/profiles/<name>/<area>/...`` → named profile.
         target_profile = parts[1]
@@ -628,7 +670,9 @@ def classify_sandbox_mirror_target(path: str) -> Optional[dict]:
         return None
 
     mirror_root = str(Path(*parts[: inner_idx + 1]))
-    inner_path = str(Path(*parts[inner_idx + 1 :])) if inner_idx + 1 < len(parts) else ""
+    inner_path = (
+        str(Path(*parts[inner_idx + 1 :])) if inner_idx + 1 < len(parts) else ""
+    )
 
     return {
         "target_path": str(target),

--- a/scripts/evolution_orchestrator.py
+++ b/scripts/evolution_orchestrator.py
@@ -62,6 +62,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # (via build_draft_tasks) and a ``select`` command that picks the best draft
 # (via select_best_draft) — closing the dead-code gap flagged in #798.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from agent.verification_scope import get_stage_verification_scope
 from evolution_draft_selector import (  # noqa: E402  # fmt: skip
     build_draft_tasks,
     route_cost_tier,
@@ -95,6 +96,8 @@ def build_worker_task(
     *,
     toolsets: Optional[List[str]] = None,
     complexity: Optional[str] = None,
+    stage: str = "research",
+    workspace_root: str = ".",
 ) -> Dict[str, Any]:
     """Build ONE leaf-worker task dict for ``delegate_task``'s batch array.
 
@@ -106,6 +109,9 @@ def build_worker_task(
     When ``complexity`` is provided, ``route_cost_tier`` is called to determine
     the model tier for this worker, and the result is attached as ``model_hint``
     so the skill can pass it to ``delegate_task``'s model override (#798 inc 3).
+
+    Also attaches the least-agency ``verification_scope`` for the target stage
+    (#2436 / #2458).
     """
     subtask = _clean_str(subtask)
     angle = _clean_str(angle)
@@ -127,6 +133,9 @@ def build_worker_task(
         if toolsets is not None
         else list(DEFAULT_WORKER_TOOLSETS),
         "role": "leaf",
+        "verification_scope": get_stage_verification_scope(
+            stage, workspace_root=workspace_root
+        ).to_dict(),
     }
     # Cost-aware routing (#798 inc 3): attach model tier hint when complexity
     # is provided so the skill can route workers to cheaper models for simple
@@ -321,7 +330,10 @@ def _cmd_build(argv: List[str]) -> int:
         )
         return 2
     tasks, dropped = build_worker_tasks(
-        subtask, angles, max_workers=max_workers, toolsets=toolsets,
+        subtask,
+        angles,
+        max_workers=max_workers,
+        toolsets=toolsets,
         complexity=complexity,
     )
     print(json.dumps({"tasks": tasks, "dropped": dropped}, ensure_ascii=False))
@@ -506,7 +518,7 @@ def main(argv: List[str]) -> int:
     if len(argv) < 2 or argv[1] in ("-h", "--help"):
         print(
             "usage: evolution_orchestrator.py {build,collect,draft,draft-select,route} ...\n"
-            "  build         --subtask S --angle A [--angle A ...] [--max-workers N] [--toolsets a,b] [--complexity \"task desc\"]\n"
+            '  build         --subtask S --angle A [--angle A ...] [--max-workers N] [--toolsets a,b] [--complexity "task desc"]\n'
             "  collect       [results.json] [--angles angles.json]   (reads stdin if no path)\n"
             "  draft         --goal G [--drafters N] [--context C] [--toolsets a,b]\n"
             "  draft-select  [results.json]   (reads stdin if no path)\n"

--- a/tests/agent/test_verification_scope_integration.py
+++ b/tests/agent/test_verification_scope_integration.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Integration tests proving verification scope enforcement in real execution path (#2458)."""
+
+import json
+from pathlib import Path
+import pytest
+
+from agent.file_safety import (
+    get_active_verification_scope,
+    get_read_block_error,
+    get_write_denied_error,
+    is_write_denied,
+    set_active_verification_scope,
+)
+from agent.verification_scope import (
+    VerificationScope,
+    get_stage_verification_scope,
+)
+from scripts.evolution_orchestrator import build_worker_task
+from tools.terminal_tool import terminal_tool
+
+
+class TestVerificationScopeIntegration:
+    """Integration test suite ensuring real call sites enforce verification scope."""
+
+    def teardown_method(self):
+        # Reset active verification scope after every test
+        set_active_verification_scope(None)
+
+    def test_terminal_tool_blocks_denied_command(self):
+        # Without scope: command runs / is evaluated normally
+        assert get_active_verification_scope() is None
+
+        # With active scope denying rm commands
+        scope = VerificationScope(
+            name="guarded_scope",
+            denied_commands=["*rm -rf*", "sudo *"],
+        )
+        set_active_verification_scope(scope)
+
+        res_json = terminal_tool(command="rm -rf /tmp/test_dir")
+        res = json.loads(res_json)
+        assert res["status"] == "error"
+        assert res["exit_code"] == -1
+        assert "blocked by active verification scope (guarded_scope)" in res["error"]
+
+    def test_file_safety_enforces_read_only_and_path_bounds(self, tmp_path: Path):
+        allowed_dir = tmp_path / "workspace"
+        allowed_dir.mkdir()
+        outside_file = tmp_path / "secret.txt"
+        outside_file.write_text("secret", encoding="utf-8")
+        inside_file = allowed_dir / "code.py"
+        inside_file.write_text("print(1)", encoding="utf-8")
+
+        scope = VerificationScope(
+            name="research_env",
+            allowed_paths=[str(allowed_dir)],
+            read_only=True,
+        )
+        set_active_verification_scope(scope)
+
+        # Inside file read: allowed
+        assert get_read_block_error(str(inside_file)) is None
+
+        # Inside file write: denied due to read_only
+        assert is_write_denied(str(inside_file)) is True
+        write_err = get_write_denied_error(str(inside_file))
+        assert write_err is not None
+        assert "violates active verification scope (research_env)" in write_err
+
+        # Outside file read: denied because outside allowed_paths
+        read_err = get_read_block_error(str(outside_file))
+        assert read_err is not None
+        assert "violates active verification scope (research_env)" in read_err
+
+    def test_orchestrator_attaches_stage_verification_scope(self, tmp_path: Path):
+        task = build_worker_task(
+            subtask="Analyze memory leaks",
+            angle="core loop",
+            stage="research",
+            workspace_root=str(tmp_path),
+        )
+        assert "verification_scope" in task
+        scope_data = task["verification_scope"]
+        assert scope_data["name"] == "research_stage"
+        assert scope_data["read_only"] is True
+        assert "arxiv.org" in scope_data["allowed_hosts"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -221,6 +221,7 @@ def _check_disk_usage_warning():
     harmless.
     """
     import time as _time_mod
+
     now = _time_mod.monotonic()
     if now - _disk_usage_cache["timestamp"] < _DISK_USAGE_CACHE_TTL:
         return _disk_usage_cache["result"]
@@ -238,12 +239,15 @@ def _check_disk_usage_warning():
                         total_bytes += f.stat().st_size
                     except OSError as e:
                         logger.debug("Could not stat file %s: %s", f, e)
-        total_gb = total_bytes / (1024 ** 3)
+        total_gb = total_bytes / (1024**3)
 
         exceeded = total_gb > DISK_USAGE_WARNING_THRESHOLD_GB
         if exceeded:
-            logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
-                           total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
+            logger.warning(
+                "Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
+                total_gb,
+                DISK_USAGE_WARNING_THRESHOLD_GB,
+            )
         _disk_usage_cache["timestamp"] = _time_mod.monotonic()
         _disk_usage_cache["result"] = exceeded
         return exceeded
@@ -405,7 +409,7 @@ def _check_all_guards(
 # paths while preserving the injection boundary around command execution
 # (the cwd is additionally shlex-quoted before it reaches the shell; this
 # allowlist is defense-in-depth).
-_WORKDIR_SAFE_ASCII_CHARS = frozenset('/\\:_-.~ +@=,')
+_WORKDIR_SAFE_ASCII_CHARS = frozenset("/\\:_-.~ +@=,")
 
 
 def _is_safe_workdir_char(ch: str) -> bool:
@@ -1065,9 +1069,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         _configured_password = os.environ.get("SUDO_PASSWORD")
     has_configured_password = _configured_password is not None
     sudo_password = (
-        _configured_password
-        if has_configured_password
-        else _get_cached_sudo_password()
+        _configured_password if has_configured_password else _get_cached_sudo_password()
     )
 
     # Local hosts with sudoers NOPASSWD should not be forced through the
@@ -1415,7 +1417,9 @@ def _docker_session_isolation_enabled() -> bool:
     if os.getenv("TERMINAL_ENV", "local") != "docker":
         return False
     return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {
-        "true", "1", "yes",
+        "true",
+        "1",
+        "yes",
     }
 
 
@@ -1424,10 +1428,16 @@ def _has_isolation_overrides(task_id: Optional[str]) -> bool:
     if not task_id:
         return False
     overrides = _task_env_overrides.get(task_id) or {}
-    return bool(set(overrides.keys()) & {
-        "docker_image", "modal_image", "singularity_image",
-        "daytona_image", "env_type",
-    })
+    return bool(
+        set(overrides.keys())
+        & {
+            "docker_image",
+            "modal_image",
+            "singularity_image",
+            "daytona_image",
+            "env_type",
+        }
+    )
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1631,7 +1641,9 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
-def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
+def _resolve_task_host_cwd(
+    config: Dict[str, Any], task_id: Optional[str]
+) -> Optional[str]:
     """Host directory to bind-mount at ``/workspace`` for *task_id*'s container.
 
     The single owner of the cwd-mount policy, shared by every environment
@@ -1762,10 +1774,18 @@ def _get_env_config() -> Dict[str, Any]:
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
+        docker_forward_env = _parse_env_var(
+            "TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"
+        )
+        docker_volumes = _parse_env_var(
+            "TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"
+        )
+        docker_env = _parse_env_var(
+            "TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"
+        )
+        docker_extra_args = _parse_env_var(
+            "TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"
+        )
         docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
@@ -1973,7 +1993,8 @@ def _create_environment(
             network=docker_network,
             extra_args=docker_extra_args,
             persist_across_processes=(
-                False if session_scoped
+                False
+                if session_scoped
                 else cc.get("docker_persist_across_processes", True)
             ),
             shm_size=cc.get("docker_shm_size", "1g"),
@@ -2290,7 +2311,9 @@ def ensure_task_env(task_id: Optional[str] = None):
                     ),
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_env": config.get("docker_env", {}),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                    "docker_run_as_host_user": config.get(
+                        "docker_run_as_host_user", False
+                    ),
                     "docker_extra_args": config.get("docker_extra_args", []),
                     "docker_shm_size": config.get("docker_shm_size", "1g"),
                     "docker_network": config.get("docker_network", True),
@@ -2325,7 +2348,9 @@ def ensure_task_env(task_id: Optional[str] = None):
         except Exception as exc:  # noqa: BLE001 — best-effort bring-up
             logger.warning(
                 "Lazy %s environment init failed for task %s: %s",
-                env_type, effective_task_id[:8], exc,
+                env_type,
+                effective_task_id[:8],
+                exc,
             )
             return None
 
@@ -2334,7 +2359,8 @@ def ensure_task_env(task_id: Optional[str] = None):
             _last_activity[effective_task_id] = time.time()
         logger.info(
             "%s environment lazily initialized for task %s",
-            env_type, effective_task_id[:8],
+            env_type,
+            effective_task_id[:8],
         )
         return new_env
 
@@ -2704,7 +2730,7 @@ def _foreground_background_guidance(command: str) -> str | None:
     if _SHELL_LEVEL_BACKGROUND_RE.search(unquoted):
         return (
             "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
-            "Re-send WITHOUT the wrapper as terminal(command=\"<cmd>\", background=true, "
+            'Re-send WITHOUT the wrapper as terminal(command="<cmd>", background=true, '
             "notify_on_complete=true) so Hermes tracks the process, then run readiness "
             "checks and tests in separate commands."
         )
@@ -2714,7 +2740,7 @@ def _foreground_background_guidance(command: str) -> str | None:
     ):
         return (
             "Foreground command uses '&' backgrounding. Re-send WITHOUT the '&' as "
-            "terminal(command=\"<cmd>\", background=true) — add notify_on_complete=true "
+            'terminal(command="<cmd>", background=true) — add notify_on_complete=true '
             "for bounded jobs — then run health checks and tests in follow-up terminal calls."
         )
 
@@ -2790,7 +2816,9 @@ def _resolve_command_cwd(
         logger.info(
             "Ignoring recorded session cwd %r for %s backend "
             "(host/relative path won't work in sandbox). Using %r instead.",
-            recorded, env_type, default_cwd,
+            recorded,
+            env_type,
+            default_cwd,
         )
         return default_cwd
     return recorded or default_cwd
@@ -2812,7 +2840,8 @@ def _attach_spill_metadata(
             raw_spill = _sp.read_text(encoding="utf-8", errors="replace")
             _sp.write_text(
                 redact_terminal_output(strip_ansi(raw_spill), command),
-                encoding="utf-8", errors="replace",
+                encoding="utf-8",
+                errors="replace",
             )
             result_dict["output_total_chars"] = spill_total_chars
             result_dict["full_output_path"] = spill_file_path
@@ -2888,6 +2917,26 @@ def terminal_tool(
                 },
                 ensure_ascii=False,
             )
+
+        # Check active verification scope (issue #2458 / #2436)
+        from agent.file_safety import get_active_verification_scope
+
+        active_scope = get_active_verification_scope()
+        if active_scope is not None:
+            from agent.verification_scope import VerificationScopeEnforcer
+
+            enforcer = VerificationScopeEnforcer(active_scope)
+            ok, violation = enforcer.check_command_execution(command)
+            if not ok and violation:
+                return json.dumps(
+                    {
+                        "output": "",
+                        "exit_code": -1,
+                        "error": f"Command blocked by active verification scope ({active_scope.name}): {violation.reason}",
+                        "status": "error",
+                    },
+                    ensure_ascii=False,
+                )
 
         # Get configuration
         config = _get_env_config()
@@ -3094,8 +3143,12 @@ def terminal_tool(
                                     "docker_forward_env", []
                                 ),
                                 "docker_env": config.get("docker_env", {}),
-                                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                                "docker_extra_args": config.get("docker_extra_args", []),
+                                "docker_run_as_host_user": config.get(
+                                    "docker_run_as_host_user", False
+                                ),
+                                "docker_extra_args": config.get(
+                                    "docker_extra_args", []
+                                ),
                                 "docker_shm_size": config.get("docker_shm_size", "1g"),
                                 "docker_network": config.get("docker_network", True),
                                 "docker_persist_across_processes": config.get(
@@ -3168,18 +3221,22 @@ def terminal_tool(
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
             )
+
             if contains_launchctl_submit_command(command):
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": (
-                        "Blocked: launchctl submit/bootstrap registers a persistent "
-                        "KeepAlive job and is unsafe from inside the gateway process. "
-                        "Use Hermes cron for one-shot delayed work, or install an "
-                        "explicit LaunchAgent from a separate shell."
-                    ),
-                    "status": "error",
-                }, ensure_ascii=False)
+                return json.dumps(
+                    {
+                        "output": "",
+                        "exit_code": 1,
+                        "error": (
+                            "Blocked: launchctl submit/bootstrap registers a persistent "
+                            "KeepAlive job and is unsafe from inside the gateway process. "
+                            "Use Hermes cron for one-shot delayed work, or install an "
+                            "explicit LaunchAgent from a separate shell."
+                        ),
+                        "status": "error",
+                    },
+                    ensure_ascii=False,
+                )
             guard_cwd_base = get_session_cwd(session_key)
             if guard_cwd_base is None:
                 guard_cwd_base = getattr(env, "cwd", None) or cwd
@@ -3205,7 +3262,10 @@ def terminal_tool(
                         local_path = Path(guard_cwd) / local_path
                     if local_path.is_file():
                         metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
+                        if (
+                            stat.S_ISREG(metadata.st_mode)
+                            and metadata.st_size <= 1024 * 1024
+                        ):
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
                                 return data.decode("utf-8", errors="replace")
@@ -3225,18 +3285,21 @@ def terminal_tool(
                 cwd=guard_cwd,
                 read_remote_script=_read_script_in_env,
             ):
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": (
-                        "Blocked: command or referenced script cannot restart or stop "
-                        "the gateway from inside the gateway process. The gateway would "
-                        "kill this command before it could complete (SIGTERM propagates "
-                        "to child processes). Run `hermes gateway restart` from a "
-                        "separate shell outside the running gateway."
-                    ),
-                    "status": "error",
-                }, ensure_ascii=False)
+                return json.dumps(
+                    {
+                        "output": "",
+                        "exit_code": 1,
+                        "error": (
+                            "Blocked: command or referenced script cannot restart or stop "
+                            "the gateway from inside the gateway process. The gateway would "
+                            "kill this command before it could complete (SIGTERM propagates "
+                            "to child processes). Run `hermes gateway restart` from a "
+                            "separate shell outside the running gateway."
+                        ),
+                        "status": "error",
+                    },
+                    ensure_ascii=False,
+                )
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
@@ -3408,12 +3471,15 @@ def terminal_tool(
                     "Blocked self-repo git mutation (command: %s)",
                     _safe_command_preview(command),
                 )
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": _self_repo_msg,
-                    "status": "blocked",
-                }, ensure_ascii=False)
+                return json.dumps(
+                    {
+                        "output": "",
+                        "exit_code": 1,
+                        "error": _self_repo_msg,
+                        "status": "blocked",
+                    },
+                    ensure_ascii=False,
+                )
 
         # Prepare command for execution
         pty_disabled_reason = None
@@ -4069,6 +4135,7 @@ def terminal_tool(
                 _min_error += " Review the output above for details."
                 try:
                     from tools.terminal_hints import annotate_failure
+
                     failure_hint = annotate_failure(command, returncode, output)
                 except Exception:
                     failure_hint = None
@@ -4086,7 +4153,12 @@ def terminal_tool(
             # borrowed from crush's <cwd> injection).
             try:
                 post_cwd = getattr(env, "cwd", None)
-                if post_cwd and command_cwd and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd)):
+                if (
+                    post_cwd
+                    and command_cwd
+                    and os.path.realpath(str(post_cwd))
+                    != os.path.realpath(str(command_cwd))
+                ):
                     result_dict["cwd"] = str(post_cwd)
             except Exception:
                 pass
@@ -4096,7 +4168,9 @@ def terminal_tool(
             # of re-running the command. The spill was written raw by the
             # collector; redact it here with the same pass as the visible
             # output so no secret persists unmasked on disk.
-            _attach_spill_metadata(result_dict, spill_file_path, spill_total_chars, command)
+            _attach_spill_metadata(
+                result_dict, spill_file_path, spill_total_chars, command
+            )
             try:
                 from agent.verification_evidence import record_terminal_result
 
@@ -4153,17 +4227,23 @@ def terminal_tool(
         degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
         if degraded_mode == "fail":
             import traceback
+
             tb_str = traceback.format_exc()
             logger.error("terminal_tool exception:\n%s", tb_str)
             # Exception text can embed the failing command line (and any
             # secrets inline in it) — redact before returning to the model.
-            return json.dumps({
-                "output": "",
-                "exit_code": -1,
-                "error": _redact_terminal_error_text(f"Failed to execute command: {e}"),
-                "traceback": _redact_terminal_error_text(tb_str),
-                "status": "error"
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "output": "",
+                    "exit_code": -1,
+                    "error": _redact_terminal_error_text(
+                        f"Failed to execute command: {e}"
+                    ),
+                    "traceback": _redact_terminal_error_text(tb_str),
+                    "status": "error",
+                },
+                ensure_ascii=False,
+            )
 
         logger.warning("terminal backend degraded: %s", e.reason)
         # Never keep a possibly-broken backend cached: evict it so the next
@@ -4175,14 +4255,17 @@ def terminal_tool(
                 _last_activity.pop(task_id, None)
         except Exception:
             logger.debug("degraded-env eviction failed", exc_info=True)
-        return json.dumps({
-            "output": "",
-            "exit_code": -1,
-            "status": "degraded",
-            "reason": e.reason,
-            "retry_hint": e.retry_hint,
-            "error": f"Terminal backend degraded: {e.reason}",
-        }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "output": "",
+                "exit_code": -1,
+                "status": "degraded",
+                "reason": e.reason,
+                "retry_hint": e.retry_hint,
+                "error": f"Terminal backend degraded: {e.reason}",
+            },
+            ensure_ascii=False,
+        )
 
     except Exception as e:
         import traceback
@@ -4319,6 +4402,7 @@ def check_terminal_requirements() -> bool:
             from daytona import Daytona  # noqa: F401 — SDK presence check
 
             from agent.secret_scope import get_secret
+
             return get_secret("DAYTONA_API_KEY") is not None
 
         else:
@@ -4407,7 +4491,7 @@ TERMINAL_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": "Run in the background, returning a session_id. Pair with notify_on_complete=true for anything with a defined end (tests, builds, deploys) — without it the process runs silently. Only servers/watchers/daemons that never exit should stay silent. Short commands: prefer foreground with a generous timeout.",
-                "default": False
+                "default": False,
             },
             "timeout": {
                 "type": "integer",
@@ -4426,13 +4510,13 @@ TERMINAL_SCHEMA = {
             "notify_on_complete": {
                 "type": "boolean",
                 "description": "With background=true: get exactly one notification when the process exits. The right choice for nearly every bounded long task — set it and keep working. MUTUALLY EXCLUSIVE with watch_patterns (watch_patterns is dropped when both are set).",
-                "default": False
+                "default": False,
             },
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
-            }
+                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete.",
+            },
         },
         "required": ["command"],
     },


### PR DESCRIPTION
Closes #2458.

Wires `agent/verification_scope.py` into the real execution path:
- Integrated active verification scope checking into `agent/file_safety.py` (`_classify_write_denial`, `get_write_denied_error`, `get_read_block_error`).
- Wired command execution scope check into `tools/terminal_tool.py` before running shell commands.
- Wired `get_stage_verification_scope` into `scripts/evolution_orchestrator.py` (`build_worker_task`).
- Added integration test suite in `tests/agent/test_verification_scope_integration.py`.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>