### PR TITLE
feat: verify already_implemented claims against the worktree (Closes #2468)

### DIFF
--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -38,6 +38,14 @@ _CITED_PATH_RE = re.compile(
     r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+\.[A-Za-z][A-Za-z0-9]{0,5})"
 )
 
+# A prose marker that the analysis agent believes a capability already exists on
+# the tree — "already_implemented", "already implemented", "already-implemented",
+# or "implemented locally". These are the #2468 claims that must be re-verified
+# against the live worktree before being trusted.
+_ALREADY_IMPL_RE = re.compile(
+    r"already[_ -]?implemented|implemented locally", re.IGNORECASE
+)
+
 
 def _num(x: Any) -> Optional[float]:
     """Coerce to float, but reject bool (True/False are ints in Python)."""
@@ -128,6 +136,62 @@ def audit_rejections(report: Dict[str, Any], repo_root: Optional[Path]) -> List[
     return out
 
 
+def audit_already_implemented(
+    report: Dict[str, Any], repo_root: Optional[Path]
+) -> List[str]:
+    """Catch UNVERIFIED ``already_implemented`` claims — the #2468 class.
+
+    The analysis agent sometimes marks an issue as already-implemented (or
+    "implemented locally on <date>") based on a stale prior-report reading, and
+    cites a code artifact that does not actually exist in the current worktree.
+    Unlike the #83 fabrication (which closes an issue), this defect rides the
+    note/deprioritize path: a wrong already-implemented note mis-ranks the issue
+    and wastes an implementation slot re-doing phantom work. This is the same
+    defect class, guarded on the other path.
+
+    Mirrors ``audit_rejections``: flags ONLY when a claim cites one or more
+    concrete repo paths and NONE of them exist (a single missing path among
+    existing ones is a typo / secondary reference). Needs the repo to verify;
+    silent without it, with no such claims, or when a claim cites no concrete
+    path (a bare word is not proof of fabrication).
+    """
+    if not isinstance(report, dict) or repo_root is None:
+        return []
+    repo = Path(repo_root)
+    try:
+        if not repo.is_dir():
+            return []
+    except OSError:
+        return []
+    out: List[str] = []
+    # A claim can live in a selection note, a deferred note, or any per-issue
+    # entry the report carries; scan every dict-valued top-level list.
+    for value in report.values():
+        if not isinstance(value, list):
+            continue
+        for entry in value:
+            if not isinstance(entry, dict):
+                continue
+            blob = " ".join(
+                str(v) for v in entry.values() if isinstance(v, (str, int, float))
+            )
+            if not _ALREADY_IMPL_RE.search(blob):
+                continue
+            cited = _CITED_PATH_RE.findall(blob)
+            if cited and not any((repo / p).exists() for p in cited):
+                issue = (
+                    entry.get("issue_number")
+                    or entry.get("id")
+                    or entry.get("parent_issue")
+                )
+                out.append(
+                    f"UNVERIFIED_ALREADY_IMPLEMENTED: issue #{issue} marked "
+                    f"already-implemented citing {', '.join(cited[:3])} — none "
+                    f"exist in the repo"
+                )
+    return out
+
+
 def _record_meta_skill_trace(report: Dict[str, Any], evolution_dir: Path) -> None:
     """Wire #1876: append a per-cycle meta-skill trace record.
 
@@ -188,7 +252,11 @@ def audit_latest(evolution_dir: Path, repo_root: Optional[Path] = None) -> List[
         report = json.loads(latest.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return []
-    violations = audit_analysis(report) + audit_rejections(report, repo_root)
+    violations = (
+        audit_analysis(report)
+        + audit_rejections(report, repo_root)
+        + audit_already_implemented(report, repo_root)
+    )
 
     # Wire #1876: record a meta-skill trace per analysis cycle (fire-and-forget).
     _record_meta_skill_trace(report, evolution_dir)

--- a/tests/scripts/test_evolution_analysis_audit.py
+++ b/tests/scripts/test_evolution_analysis_audit.py
@@ -8,6 +8,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_analysis_audit import (  # noqa: E402
+    audit_already_implemented,
     audit_analysis,
     audit_latest,
     audit_rejections,
@@ -102,7 +103,9 @@ class TestAuditLatest:
 
     def test_unreadable_json_is_silent(self, tmp_path):
         (tmp_path / "analysis").mkdir(parents=True)
-        (tmp_path / "analysis" / "2026-06-24.json").write_text("{not json", encoding="utf-8")
+        (tmp_path / "analysis" / "2026-06-24.json").write_text(
+            "{not json", encoding="utf-8"
+        )
         assert audit_latest(tmp_path) == []
 
     def test_audit_latest_runs_rejection_check_with_repo(self, tmp_path):
@@ -232,3 +235,104 @@ class TestAuditRejections:
         assert audit_rejections({"rejected": []}, tmp_path) == []
         assert audit_rejections({}, tmp_path) == []
 
+
+class TestAuditAlreadyImplemented:
+    def _rep(self, selected=None, deferred=None):
+        report = {"date": "2026-08-15"}
+        if selected is not None:
+            report["selected_for_implementation"] = selected
+        if deferred is not None:
+            report["deferred_not_selected"] = deferred
+        return report
+
+    def test_verified_path_is_clean(self, tmp_path):
+        (tmp_path / "agent").mkdir()
+        (tmp_path / "agent" / "cache.py").write_text("x")
+        selected = [
+            {
+                "issue_number": 21,
+                "note": "already implemented locally in agent/cache.py",
+            }
+        ]
+        assert audit_already_implemented(self._rep(selected=selected), tmp_path) == []
+
+    def test_unverified_path_flagged(self, tmp_path):
+        selected = [
+            {
+                "issue_number": 22,
+                "note": "already_implemented: see tools/ghost_cache.py (line 42)",
+            }
+        ]
+        v = audit_already_implemented(self._rep(selected=selected), tmp_path)
+        assert any("UNVERIFIED_ALREADY_IMPLEMENTED" in x and "#22" in x for x in v)
+        assert any("tools/ghost_cache.py" in x for x in v)
+
+    def test_both_marker_variants_detected(self, tmp_path):
+        # "already implemented" (spaces) and "implemented locally" are both markers.
+        selected = [
+            {"issue_number": 23, "note": "already implemented in tools/nope.py"}
+        ]
+        deferred = [{"id": 24, "reason": "implemented locally in agent/also_nope.py"}]
+        v = audit_already_implemented(
+            self._rep(selected=selected, deferred=deferred), tmp_path
+        )
+        assert any("#23" in x for x in v)
+        assert any("#24" in x for x in v)
+
+    def test_mixed_real_and_missing_is_clean(self, tmp_path):
+        (tmp_path / "agent").mkdir()
+        (tmp_path / "agent" / "real.py").write_text("x")
+        selected = [
+            {
+                "issue_number": 25,
+                "note": "already implemented in agent/real.py and agent/missing.py",
+            }
+        ]
+        assert audit_already_implemented(self._rep(selected=selected), tmp_path) == []
+
+    def test_no_concrete_path_is_not_flagged(self, tmp_path):
+        # A bare word ("cache") is not verifiable; do not false-alarm.
+        selected = [
+            {
+                "issue_number": 26,
+                "note": "already_implemented: the cache capability exists",
+            }
+        ]
+        assert audit_already_implemented(self._rep(selected=selected), tmp_path) == []
+
+    def test_non_claim_entries_ignored(self, tmp_path):
+        selected = [
+            {
+                "issue_number": 27,
+                "note": "unblocks slice B; no already-implemented claim",
+            }
+        ]
+        assert audit_already_implemented(self._rep(selected=selected), tmp_path) == []
+
+    def test_no_repo_root_is_silent(self):
+        selected = [{"issue_number": 1, "note": "already implemented in x/y.py"}]
+        assert audit_already_implemented(self._rep(selected=selected), None) == []
+
+    def test_empty_report_clean(self, tmp_path):
+        assert audit_already_implemented({}, tmp_path) == []
+        assert (
+            audit_already_implemented({"selected_for_implementation": []}, tmp_path)
+            == []
+        )
+
+    def test_audit_latest_runs_already_implemented_check(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (tmp_path / "analysis").mkdir(parents=True)
+        report = {
+            "scoring_model": {"selection_constraints": {"max_total_effort": 3.0}},
+            "total_effort_selected": 2.0,
+            "selected_for_implementation": [
+                {"issue_number": 28, "note": "already implemented in tools/phantom.py"}
+            ],
+        }
+        (tmp_path / "analysis" / "2026-08-15.json").write_text(
+            json.dumps(report), encoding="utf-8"
+        )
+        out = audit_latest(tmp_path, repo)
+        assert any("UNVERIFIED_ALREADY_IMPLEMENTED" in x and "#28" in x for x in out)


### PR DESCRIPTION
Automated evolution PR for issue #2468.

## What
The analysis stage marks issues `already_implemented` (or "implemented locally") based on stale prior-report readings, without grep-verifying the claimed code artifact actually exists in the worktree. A wrong claim mis-ranks the issue and wastes an implementation slot re-doing phantom work — the same defect class as the #83 fabricated rejection, but on the note/deprioritize path instead of the close path.

## Change
Extends `scripts/evolution_analysis_audit.py` (the deterministic audit behind the prompt-level evidence rule) with `audit_already_implemented(report, repo_root)`:
- Scans the analysis report for `already_implemented` / `already implemented` / `implemented locally` prose markers.
- Extracts cited repo-relative paths and flags `UNVERIFIED_ALREADY_IMPLEMENTED` when NONE of them exist in the worktree.
- Mirrors the existing `audit_rejections` threshold (a single missing path among existing ones is a typo, not fabrication; a bare word is unverifiable and not flagged).
- Wired into `audit_latest` so it runs every cycle alongside the budget and fabricated-rejection checks.

## Checks
- ruff check ✓, ruff format ✓
- pytest tests/scripts/test_evolution_analysis_audit.py: 35 passed
- pre-PR test shard: PASSED
- 9 new tests covering verified/missing/mixed/no-path/no-repo/end-to-end cases

Closes #2468