### PR TITLE
fix: extract CI failure root causes + surface raw excerpts (Closes #2467)

### DIFF
--- a/scripts/evolution_ci_diagnosis.py
+++ b/scripts/evolution_ci_diagnosis.py
@@ -81,6 +81,8 @@ _TRIVIAL_PATTERNS: List[Tuple[str, str]] = [
     (r"Incompatible return value type", "incompatible-return"),
     (r"Module .* has no attribute", "missing-attribute"),
     (r"mypy.*failed", "mypy"),
+    (r"\b(E[0-9]{3}|W[0-9]{3}|F[0-9]{3}|C[0-9]{3})\b", "lint"),
+    (r"\berror:\s*\[[a-z][a-z0-9-]*\]", "lint"),
 ]
 
 _COMPLEX_PATTERNS: List[Tuple[str, str]] = [
@@ -101,6 +103,17 @@ _COMPLEX_PATTERNS: List[Tuple[str, str]] = [
     (r"ConnectionError:", "connection-error"),
     (r"PermissionError:", "permission-error"),
     (r"subprocess\.CalledProcessError", "subprocess-error"),
+    (r"AssertionError", "assertion-error"),
+    (r"^E\s+assert\b", "assertion-error"),
+    (
+        r"(?:Process completed with|Exited with|Command exited with) exit code \d+",
+        "exit-code",
+    ),
+    (r"exit code \d+", "exit-code"),
+    (r"exit status \d+", "exit-code"),
+    (r"\btimed out\b|Operation timed out|Timeout expired", "timeout"),
+    (r"Permission denied|EACCES|Operation not permitted", "permission-error"),
+    (r"No module named ['\"]?[^'\"]+", "module-not-found"),
 ]
 
 # -----------------------------------------------------------------------------
@@ -401,6 +414,19 @@ def _extract_snippet(
     return "\n".join(lines[start:end])
 
 
+def _raw_tail(text: str, max_lines: int = _SNIPPET_LINES) -> str:
+    """Return the tail of a log/annotation blob as a raw diagnostic excerpt.
+
+    Used when no failure pattern matches, so an unrecognised failure still
+    surfaces actionable context (the actual log lines) in the issue body instead
+    of a bare "Unrecognized failure pattern" with nothing to diagnose (#2467).
+    """
+    if not text:
+        return ""
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:])
+
+
 def _format_annotations(annotations: List[Dict[str, Any]]) -> str:
     parts: List[str] = []
     for ann in annotations:
@@ -434,13 +460,20 @@ def extract_failure(
     if check.annotations:
         annotations_text = _format_annotations(check.annotations)
         error_class, message = _extract_from_text(annotations_text)
+        if error_class == "unknown":
+            snippet = _raw_tail(annotations_text)
+        else:
+            offset = annotations_text.find(message)
+            snippet = (
+                _extract_snippet(annotations_text, offset)
+                if offset >= 0
+                else _raw_tail(annotations_text)
+            )
         return FailureDetails(
             error_class=error_class,
             classification=classify_failure(error_class),
             message=message,
-            snippet=_extract_snippet(
-                annotations_text, annotations_text.find(message) if message else 0
-            ),
+            snippet=snippet,
             source="annotations",
         )
 
@@ -460,11 +493,14 @@ def extract_failure(
 
     error_class, message = _extract_from_text(log_text)
     offset = log_text.find(message) if message else 0
-    snippet = (
-        "\n".join(log_text.splitlines()[:_RUN_LOG_MAX_LINES])
-        if offset == 0
-        else _extract_snippet(log_text, offset)
-    )
+    if offset < 0:
+        snippet = _raw_tail(log_text, max_lines=_RUN_LOG_MAX_LINES)
+    else:
+        snippet = (
+            "\n".join(log_text.splitlines()[:_RUN_LOG_MAX_LINES])
+            if offset == 0
+            else _extract_snippet(log_text, offset)
+        )
     return FailureDetails(
         error_class=error_class,
         classification=classify_failure(error_class),
@@ -529,20 +565,26 @@ def create_child_issue(
 ) -> Optional[str]:
     """Create ONE aggregated issue for all failed checks on a PR.
 
-    Only called when at least one failure is classified (not 'unknown').
-    Skips entirely if all failures are 'unknown' — unrecognised patterns
-    produce noise, not actionable issues.
+    Classified (complex, root-caused) failures get a focused section; failures
+    whose pattern is still unrecognised get their raw log/annotation excerpt
+    surfaced so a human or LLM can diagnose them (rather than being silently
+    dropped). Skips entirely only when nothing is actionable (all trivial).
     """
-    # Only create issues for complex, classifiable failures.
-    # Skip trivial (lint/format) and unknown (unrecognised pattern).
+    # Complex failures with a recognised root cause.
     classified = [
         (check, failure)
         for check, failure in failures
         if failure.classification == "complex" and failure.error_class != "unknown"
     ]
-    if not classified:
+    # Complex failures with no recognised pattern — surface their raw excerpt.
+    unclassified = [
+        (check, failure)
+        for check, failure in failures
+        if failure.error_class == "unknown"
+    ]
+    if not classified and not unclassified:
         print(
-            f"[ci-diagnosis] PR #{pr.number}: all failures are 'unknown' — skipping issue creation"
+            f"[ci-diagnosis] PR #{pr.number}: no classifiable failures (all trivial) — skipping"
         )
         return None
 
@@ -554,6 +596,8 @@ def create_child_issue(
 
     # Aggregate error classes for the title
     error_classes = sorted({f.error_class for _, f in classified})
+    if not error_classes:
+        error_classes = ["unrecognized"]
     title = f"CI failure on PR #{pr.number}: {', '.join(error_classes)}"
 
     # Build body with all failed checks
@@ -563,7 +607,7 @@ def create_child_issue(
         f"**PR**: #{pr.number} — {pr.title}",
         f"**PR URL**: {pr.html_url}",
         f"**Head SHA**: `{pr.head_sha}`",
-        f"**Failed checks**: {len(classified)} (of {len(failures)} total)",
+        f"**Failed checks**: {len(classified) + len(unclassified)} (of {len(failures)} total)",
         "",
     ]
 
@@ -584,13 +628,27 @@ def create_child_issue(
             "",
         ])
 
-    # Note about unclassified failures
-    unknown_count = len(failures) - len(classified)
-    if unknown_count:
+    for check, failure in unclassified:
         body_lines.extend([
-            f"### Unclassified failures ({unknown_count})",
+            f"### {check.name}",
             "",
-            f"{unknown_count} check(s) had unrecognised failure patterns and were omitted.",
+            f"- **Error class**: `{failure.error_class}` (unrecognized pattern)",
+            f"- **Classification**: `{failure.classification}`",
+            f"- **Source**: `{failure.source}`",
+            f"- **Check run URL**: {check.details_url}",
+            "",
+            "**Raw log/annotation excerpt (no pattern matched):**",
+            f"```\n{failure.snippet[:1000] or failure.message}\n```",
+            "",
+        ])
+
+    # Trivial (lint/format) failures are auto-fixable and omitted on purpose.
+    trivial_count = len(failures) - len(classified) - len(unclassified)
+    if trivial_count:
+        body_lines.extend([
+            f"### Trivial failures ({trivial_count})",
+            "",
+            f"{trivial_count} lint/format check(s) were trivial and omitted (auto-fixable).",
             "",
         ])
 

--- a/tests/scripts/test_evolution_ci_diagnosis.py
+++ b/tests/scripts/test_evolution_ci_diagnosis.py
@@ -211,10 +211,7 @@ def test_diagnose_prs_detects_failure_and_creates_child_issue(hermes_home, monke
     # Verify state was recorded.
     assert state_path.is_file()
     recorded = json.loads(state_path.read_text(encoding="utf-8"))
-    assert (
-        recorded["Lexus2016/hermes-agent-evolution#42"]
-        == issue_response["html_url"]
-    )
+    assert recorded["Lexus2016/hermes-agent-evolution#42"] == issue_response["html_url"]
 
 
 def test_diagnose_prs_dry_run_does_not_create_issue(hermes_home, monkeypatch):
@@ -323,3 +320,96 @@ def test_main_cli_runs_with_dry_run(monkeypatch):
     rc = diag.main(["evolution_ci_diagnosis.py", "--dry-run"])
     assert rc == 0
     assert called["dry_run"] is True
+
+
+# --- #2467: root-cause extraction + raw-excerpt fallback ---
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("E   AssertionError: assert 1 == 2", "assertion-error"),
+        ("Process completed with exit code 1.", "exit-code"),
+        ("runner exited with exit code 2", "exit-code"),
+        ("Operation timed out after 120s", "timeout"),
+        ("Permission denied: /nix/store", "permission-error"),
+        ("No module named 'hermes_foo'", "module-not-found"),
+        ("scripts/x.py:42:5: E501 line too long", "lint"),
+    ],
+)
+def test_extract_from_text_new_patterns(text, expected):
+    error_class, _ = diag._extract_from_text(text)
+    assert error_class == expected
+
+
+def test_raw_tail_returns_last_lines():
+    text = "\n".join(f"line {i}" for i in range(50))
+    assert diag._raw_tail(text, max_lines=5).splitlines() == [
+        "line 45",
+        "line 46",
+        "line 47",
+        "line 48",
+        "line 49",
+    ]
+
+
+def test_extract_failure_unknown_surfaces_raw_tail():
+    check = diag.FailedCheck(
+        check_run_id=1,
+        name="tests (slice 3)",
+        conclusion="failure",
+        details_url="https://github.com/runs/1",
+        head_sha="sha1",
+        annotations=[
+            {
+                "path": "tests/x.py",
+                "start_line": 1,
+                "annotation_level": "failure",
+                "message": "some opaque native error without a known shape",
+                "title": "test failed",
+            }
+        ],
+    )
+    failure = diag.extract_failure(check)
+    assert failure.error_class == "unknown"
+    assert failure.classification == "complex"
+    assert "opaque native error" in failure.snippet
+
+
+def test_create_child_issue_surfaces_unclassified_raw_excerpt(hermes_home):
+    pr = diag.PRInfo(
+        number=60,
+        title="feat: opaque failure",
+        head_sha="sha60",
+        head_branch="evolution/x",
+        html_url="https://github.com/Lexus2016/hermes-agent-evolution/pull/60",
+    )
+    check = diag.FailedCheck(
+        check_run_id=7,
+        name="tests (slice 4)",
+        conclusion="failure",
+        details_url="https://github.com/runs/7",
+        head_sha="sha60",
+        annotations=[],
+    )
+    failure = diag.FailureDetails(
+        error_class="unknown",
+        classification="complex",
+        message="Unrecognized failure pattern",
+        snippet="line A\nline B\nopaque detail",
+        source="gh-run-log",
+    )
+    client = FakeClient([
+        (200, {"total_count": 0, "items": []}),
+        (
+            201,
+            {
+                "html_url": "https://github.com/Lexus2016/hermes-agent-evolution/issues/999"
+            },
+        ),
+    ])
+    url = diag.create_child_issue(client, pr, [(check, failure)], dry_run=False)
+    assert url == "https://github.com/Lexus2016/hermes-agent-evolution/issues/999"
+    post_body = json.loads(client.calls[-1][2] or "{}")
+    assert "opaque detail" in post_body["body"]
+    assert "Raw log/annotation excerpt" in post_body["body"]


### PR DESCRIPTION
Automated evolution PR for issue #2467.

## Problem
The CI diagnosis classifier fell through to `unknown` / "Unrecognized failure pattern" for common CI failures (test assertion names, lint rule IDs, exit-code-1 messages), producing no actionable root cause, and silently dropped unrecognised checks — so failing PRs were held for human review with no diagnosis path.

## Change
`scripts/evolution_ci_diagnosis.py`:
- **New failure-class matchers** (complex): assertion errors (incl. pytest `E   assert`), nonzero exit codes (`exit code N` / `exit status N`), timeouts, permission errors, and `No module named` — each maps a real root cause.
- **New lint-code matchers** (trivial): bare flake8/pycodestyle codes (`E501`, `W291`, …) and mypy `error: [code]` — recognised and routed to the auto-fixable path instead of "unknown".
- **Raw-excerpt fallback**: when no pattern matches, the raw tail of the log/annotations is surfaced in the issue body (not just "Unrecognized failure pattern"), so a human or LLM can still diagnose it.
- **Unclassified failures are now surfaced**, not omitted: a PR whose failures are all "unknown" still gets ONE aggregated issue (dedup unchanged) with the raw excerpt.

## Checks
- ruff check ✓, ruff format ✓
- pytest tests/scripts/test_evolution_ci_diagnosis.py: 23 passed
- pre-PR test shard: PASSED
- 10 new tests: parametrized pattern matchers, raw-tail, unknown→excerpt wiring, and end-to-end issue-with-raw-excerpt

Closes #2467