### PR TITLE
feat(evolution): early-trigger parallel compaction and safe turn swap (Closes #2469)

### DIFF
--- a/evolution/lib/parallel_compaction.py
+++ b/evolution/lib/parallel_compaction.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Asynchronous early-trigger parallel context compaction.
+
+Issue #2469 (parent #2186) — arXiv:2605.23296.
+
+Decouples compaction from the hard context limit by triggering summarization
+in the background slightly before the hard limit is reached (using a
+configurable headroom). The agent continues executing in parallel with
+the summarization worker. When summarization completes, the compacted
+context is swapped in safely at turn boundaries without mid-turn truncation.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+
+class CompactionState(Enum):
+    """Lifecycle state of an asynchronous compaction pass."""
+
+    IDLE = "idle"
+    COMPACTING = "compacting"
+    READY_TO_SWAP = "ready_to_swap"
+    SWAPPED = "swapped"
+    FAILED = "failed"
+
+
+@dataclass
+class ParallelCompactionConfig:
+    """Configuration for parallel context compaction.
+
+    Attributes:
+        enabled: Master toggle for early-trigger parallel compaction.
+        hard_token_limit: Upper bound context capacity for the model.
+        headroom_ratio: Fraction of hard limit to reserve as early-trigger headroom.
+        explicit_headroom_tokens: Optional explicit token count for headroom override.
+        preserve_recent_count: Number of recent messages to exclude from compression.
+    """
+
+    enabled: bool = True
+    hard_token_limit: int = 100000
+    headroom_ratio: float = 0.15
+    explicit_headroom_tokens: Optional[int] = None
+    preserve_recent_count: int = 4
+
+    @property
+    def headroom_tokens(self) -> int:
+        if self.explicit_headroom_tokens is not None:
+            return max(0, self.explicit_headroom_tokens)
+        return max(1, int(self.hard_token_limit * self.headroom_ratio))
+
+    @property
+    def early_trigger_threshold(self) -> int:
+        return max(0, self.hard_token_limit - self.headroom_tokens)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ParallelCompactionConfig":
+        return cls(**{k: d[k] for k in d if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class CompactionSnapshot:
+    """Snapshot captured when background compaction was triggered."""
+
+    trigger_index: int
+    message_count: int
+    messages: List[Dict[str, Any]]
+    token_count_at_trigger: int
+
+
+class ParallelCompactor:
+    """Orchestrates early-triggered background context compaction and safe turn swaps."""
+
+    def __init__(
+        self,
+        config: Optional[ParallelCompactionConfig] = None,
+        executor: Optional[concurrent.futures.Executor] = None,
+    ) -> None:
+        self.config = config or ParallelCompactionConfig()
+        self._executor = executor
+        self._state = CompactionState.IDLE
+        self._future: Optional[concurrent.futures.Future[List[Dict[str, Any]]]] = None
+        self._snapshot: Optional[CompactionSnapshot] = None
+        self._compacted_prefix: Optional[List[Dict[str, Any]]] = None
+        self._last_error: Optional[str] = None
+        self._swap_count: int = 0
+
+    @property
+    def state(self) -> CompactionState:
+        return self._state
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._last_error
+
+    @property
+    def swap_count(self) -> int:
+        return self._swap_count
+
+    def should_trigger(self, current_tokens: int) -> bool:
+        """Check whether current token usage crossed early trigger threshold."""
+        if not self.config.enabled:
+            return False
+        if self._state not in (CompactionState.IDLE, CompactionState.SWAPPED):
+            return False
+        return current_tokens >= self.config.early_trigger_threshold
+
+    def start_async_compaction(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int,
+        summarize_fn: Callable[[List[Dict[str, Any]]], List[Dict[str, Any]]],
+    ) -> bool:
+        """Launch background summarization on a snapshot of messages."""
+        if not self.config.enabled:
+            return False
+        if self._state == CompactionState.COMPACTING:
+            return False
+
+        snapshot_messages = [dict(m) for m in messages]
+        self._snapshot = CompactionSnapshot(
+            trigger_index=len(snapshot_messages),
+            message_count=len(snapshot_messages),
+            messages=snapshot_messages,
+            token_count_at_trigger=current_tokens,
+        )
+        self._state = CompactionState.COMPACTING
+        self._last_error = None
+        self._compacted_prefix = None
+
+        if self._executor is not None:
+            self._future = self._executor.submit(summarize_fn, snapshot_messages)
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                # Synchronous fallback if no executor provided
+                try:
+                    res = summarize_fn(snapshot_messages)
+                    self._compacted_prefix = res
+                    self._state = CompactionState.READY_TO_SWAP
+                    return True
+                except Exception as exc:
+                    self._last_error = str(exc)
+                    self._state = CompactionState.FAILED
+                    return False
+
+        return True
+
+    def poll_status(self) -> CompactionState:
+        """Update and return the compaction status."""
+        if self._state == CompactionState.COMPACTING and self._future is not None:
+            if self._future.done():
+                try:
+                    self._compacted_prefix = self._future.result()
+                    self._state = CompactionState.READY_TO_SWAP
+                except Exception as exc:
+                    self._last_error = str(exc)
+                    self._state = CompactionState.FAILED
+        return self._state
+
+    def is_safe_swap_boundary(self, current_messages: List[Dict[str, Any]]) -> bool:
+        """Verify context is at a safe turn boundary before swapping.
+
+        Safe boundary rules:
+        - No un-responded tool calls (last message cannot be tool_calls without tool response).
+        - Must have at least 1 message.
+        """
+        if not current_messages:
+            return False
+
+        last_msg = current_messages[-1]
+        role = last_msg.get("role")
+
+        # Incomplete tool execution turn is not safe
+        if role == "assistant" and last_msg.get("tool_calls"):
+            return False
+        if role == "tool":
+            # Mid-tool execution sequence; check if more tool calls are pending
+            return False
+
+        return True
+
+    def try_apply_swap(
+        self, current_messages: List[Dict[str, Any]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Swap in compacted prefix with new messages appended if ready and safe."""
+        self.poll_status()
+        if self._state != CompactionState.READY_TO_SWAP:
+            return None
+        if not self.is_safe_swap_boundary(current_messages):
+            return None
+        if self._snapshot is None or self._compacted_prefix is None:
+            return None
+
+        # Messages added while background compaction was running
+        trigger_index = self._snapshot.trigger_index
+        delta_messages = current_messages[trigger_index:]
+
+        # Merge compacted prefix with newly arrived delta messages
+        new_messages = list(self._compacted_prefix) + [dict(m) for m in delta_messages]
+
+        self._state = CompactionState.SWAPPED
+        self._swap_count += 1
+        return new_messages
+
+    def reset(self) -> None:
+        """Reset state for next cycle."""
+        self._state = CompactionState.IDLE
+        self._future = None
+        self._snapshot = None
+        self._compacted_prefix = None
+        self._last_error = None

--- a/tests/evolution/test_parallel_compaction.py
+++ b/tests/evolution/test_parallel_compaction.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for early-trigger parallel compaction (Issue #2469)."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import time
+from typing import Any, Dict, List
+
+import pytest
+
+from evolution.lib.parallel_compaction import (
+    CompactionSnapshot,
+    CompactionState,
+    ParallelCompactionConfig,
+    ParallelCompactor,
+)
+
+
+def test_config_headroom_and_early_trigger():
+    config = ParallelCompactionConfig(
+        hard_token_limit=100000,
+        headroom_ratio=0.15,
+    )
+    assert config.headroom_tokens == 15000
+    assert config.early_trigger_threshold == 85000
+
+    config_explicit = ParallelCompactionConfig(
+        hard_token_limit=100000,
+        explicit_headroom_tokens=20000,
+    )
+    assert config_explicit.headroom_tokens == 20000
+    assert config_explicit.early_trigger_threshold == 80000
+
+    d = config.to_dict()
+    restored = ParallelCompactionConfig.from_dict(d)
+    assert restored.hard_token_limit == 100000
+
+
+def test_should_trigger_evaluation():
+    config = ParallelCompactionConfig(hard_token_limit=10000, headroom_ratio=0.2)
+    compactor = ParallelCompactor(config=config)
+
+    # 10000 * 0.8 = 8000
+    assert not compactor.should_trigger(7999)
+    assert compactor.should_trigger(8000)
+    assert compactor.should_trigger(9500)
+
+    config_disabled = ParallelCompactionConfig(enabled=False)
+    compactor_disabled = ParallelCompactor(config=config_disabled)
+    assert not compactor_disabled.should_trigger(90000)
+
+
+def test_async_compaction_and_safe_swap():
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    compactor = ParallelCompactor(executor=executor)
+
+    def slow_summarizer(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        time.sleep(0.05)
+        return [{"role": "system", "content": "Summary of prior turns"}]
+
+    initial_messages = [
+        {"role": "user", "content": "Hello step 1"},
+        {"role": "assistant", "content": "Response step 1"},
+    ]
+
+    # Start background compaction
+    assert compactor.start_async_compaction(
+        initial_messages, current_tokens=86000, summarize_fn=slow_summarizer
+    )
+    assert compactor.state == CompactionState.COMPACTING
+
+    # Agent executes more turns in parallel
+    live_messages = list(initial_messages)
+    live_messages.append({"role": "user", "content": "Step 2 in parallel"})
+    live_messages.append({
+        "role": "assistant",
+        "content": "Response step 2 in parallel",
+    })
+
+    # Wait for future to finish
+    time.sleep(0.1)
+    status = compactor.poll_status()
+    assert status == CompactionState.READY_TO_SWAP
+
+    # Apply swap at safe boundary
+    swapped = compactor.try_apply_swap(live_messages)
+    assert swapped is not None
+    assert compactor.state == CompactionState.SWAPPED
+    assert compactor.swap_count == 1
+
+    # Should contain summarized prefix + delta messages (step 2)
+    assert len(swapped) == 3
+    assert swapped[0] == {"role": "system", "content": "Summary of prior turns"}
+    assert swapped[1] == {"role": "user", "content": "Step 2 in parallel"}
+    assert swapped[2] == {"role": "assistant", "content": "Response step 2 in parallel"}
+
+    executor.shutdown(wait=True)
+
+
+def test_unsafe_swap_boundary_rejected():
+    compactor = ParallelCompactor()
+
+    def dummy_summarizer(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return [{"role": "system", "content": "summary"}]
+
+    msgs = [{"role": "user", "content": "hi"}]
+    compactor.start_async_compaction(msgs, 90000, dummy_summarizer)
+    assert compactor.state == CompactionState.READY_TO_SWAP
+
+    # Unsafe boundary: assistant with pending tool call
+    unsafe_messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None, "tool_calls": [{"name": "read_file"}]},
+    ]
+    assert not compactor.is_safe_swap_boundary(unsafe_messages)
+    assert compactor.try_apply_swap(unsafe_messages) is None
+
+    # Unsafe boundary: tool response without final assistant turn
+    unsafe_tool_msg = [
+        {"role": "tool", "content": "file contents"},
+    ]
+    assert not compactor.is_safe_swap_boundary(unsafe_tool_msg)
+    assert compactor.try_apply_swap(unsafe_tool_msg) is None
+
+
+def test_failed_compaction_handling():
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    compactor = ParallelCompactor(executor=executor)
+
+    def failing_summarizer(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        raise RuntimeError("Summarization LLM quota exceeded")
+
+    msgs = [{"role": "user", "content": "test"}]
+    compactor.start_async_compaction(msgs, 90000, failing_summarizer)
+
+    time.sleep(0.05)
+    assert compactor.poll_status() == CompactionState.FAILED
+    assert compactor.last_error is not None
+    assert "quota exceeded" in compactor.last_error
+
+    compactor.reset()
+    assert compactor.state == CompactionState.IDLE
+    assert compactor.last_error is None
+
+    executor.shutdown(wait=True)


### PR DESCRIPTION
Closes #2469.

Implements [SLICE A] Early-trigger parallel compaction (parent #2186, arXiv:2605.23296):

- Implements `ParallelCompactor` and `ParallelCompactionConfig` in `evolution/lib/parallel_compaction.py`.
- Triggers context compaction before hard limit using configurable token headroom.
- Runs summarization asynchronously in the background while agent continues inference.
- Reconciles delta messages generated during background execution and swaps at safe turn boundaries without mid-turn truncation.
- Adds comprehensive unit tests in `tests/evolution/test_parallel_compaction.py`.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>