### PR TITLE
feat: pre-compaction snapshot as re-readable virtual file (Closes #2471)

### DIFF
--- a/evolution/lib/parallel_compaction.py
+++ b/evolution/lib/parallel_compaction.py
@@ -13,8 +13,11 @@ context is swapped in safely at turn boundaries without mid-turn truncation.
 from __future__ import annotations
 
 import concurrent.futures
+import json
+import time
 from dataclasses import asdict, dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -74,6 +77,33 @@ class CompactionSnapshot:
     token_count_at_trigger: int
 
 
+def _default_snapshot_dir() -> Path:
+    return Path.home() / ".hermes" / "compaction" / "snapshots"
+
+
+def write_precompaction_snapshot(
+    messages: List[Dict[str, Any]], snapshot_dir: Optional[str] = None
+) -> str:
+    """Write a pre-compaction snapshot to a re-readable JSON file (#2471).
+
+    Returns the absolute path so the agent can later re-read dropped context via
+    :func:`read_precompaction_snapshot` instead of re-running the original tool
+    calls.
+    """
+    directory = Path(snapshot_dir) if snapshot_dir else _default_snapshot_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"snapshot-{int(time.time() * 1000)}.json"
+    payload = {"messages": messages, "captured_at_unix_ms": int(time.time() * 1000)}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return str(path)
+
+
+def read_precompaction_snapshot(path: str) -> List[Dict[str, Any]]:
+    """Re-read a snapshot written by :func:`write_precompaction_snapshot`."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return data["messages"]
+
+
 class ParallelCompactor:
     """Orchestrates early-triggered background context compaction and safe turn swaps."""
 
@@ -81,15 +111,22 @@ class ParallelCompactor:
         self,
         config: Optional[ParallelCompactionConfig] = None,
         executor: Optional[concurrent.futures.Executor] = None,
+        snapshot_dir: Optional[str] = None,
     ) -> None:
         self.config = config or ParallelCompactionConfig()
         self._executor = executor
+        self._snapshot_dir = snapshot_dir
+        self._snapshot_path: Optional[str] = None
         self._state = CompactionState.IDLE
         self._future: Optional[concurrent.futures.Future[List[Dict[str, Any]]]] = None
         self._snapshot: Optional[CompactionSnapshot] = None
         self._compacted_prefix: Optional[List[Dict[str, Any]]] = None
         self._last_error: Optional[str] = None
         self._swap_count: int = 0
+
+    @property
+    def snapshot_path(self) -> Optional[str]:
+        return self._snapshot_path
 
     @property
     def state(self) -> CompactionState:
@@ -124,6 +161,13 @@ class ParallelCompactor:
             return False
 
         snapshot_messages = [dict(m) for m in messages]
+        try:
+            self._snapshot_path = write_precompaction_snapshot(
+                snapshot_messages, self._snapshot_dir
+            )
+        except OSError:
+            # Best-effort recovery aid: never block compaction on a snapshot write.
+            self._snapshot_path = None
         self._snapshot = CompactionSnapshot(
             trigger_index=len(snapshot_messages),
             message_count=len(snapshot_messages),
@@ -208,10 +252,23 @@ class ParallelCompactor:
         self._swap_count += 1
         return new_messages
 
+    def read_snapshot(
+        self, path: Optional[str] = None
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Re-read the pre-compaction snapshot for this pass (or an explicit path).
+
+        Returns None when no snapshot was captured this pass and no path was given.
+        """
+        target = path or self._snapshot_path
+        if target is None:
+            return None
+        return read_precompaction_snapshot(target)
+
     def reset(self) -> None:
         """Reset state for next cycle."""
         self._state = CompactionState.IDLE
         self._future = None
         self._snapshot = None
+        self._snapshot_path = None
         self._compacted_prefix = None
         self._last_error = None

--- a/tests/evolution/test_parallel_compaction_snapshot.py
+++ b/tests/evolution/test_parallel_compaction_snapshot.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Tests for the pre-compaction snapshot (Issue #2471)."""
+
+from __future__ import annotations
+
+from evolution.lib.parallel_compaction import (
+    ParallelCompactor,
+    read_precompaction_snapshot,
+    write_precompaction_snapshot,
+)
+
+
+def test_write_and_read_snapshot_roundtrip(tmp_path):
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    path = write_precompaction_snapshot(messages, snapshot_dir=str(tmp_path))
+    assert path.startswith(str(tmp_path))
+
+    recovered = read_precompaction_snapshot(path)
+    assert recovered == messages
+
+
+def test_compactor_writes_snapshot_on_compaction(tmp_path):
+    compactor = ParallelCompactor(snapshot_dir=str(tmp_path))
+
+    def summarizer(msgs):
+        return [{"role": "system", "content": "summary"}]
+
+    msgs = [{"role": "user", "content": "hi"}]
+    assert compactor.start_async_compaction(msgs, 90000, summarizer)
+
+    assert compactor.snapshot_path is not None
+    assert compactor.snapshot_path.startswith(str(tmp_path))
+
+    # The agent can re-read the dropped context later.
+    recovered = compactor.read_snapshot()
+    assert recovered == msgs
+
+
+def test_read_snapshot_none_when_not_captured():
+    compactor = ParallelCompactor()
+    assert compactor.read_snapshot() is None
+
+
+def test_reset_clears_snapshot_path(tmp_path):
+    compactor = ParallelCompactor(snapshot_dir=str(tmp_path))
+
+    def summarizer(msgs):
+        return [{"role": "system", "content": "summary"}]
+
+    compactor.start_async_compaction(
+        [{"role": "user", "content": "x"}], 90000, summarizer
+    )
+    assert compactor.snapshot_path is not None
+
+    compactor.reset()
+    assert compactor.snapshot_path is None
+    assert compactor.read_snapshot() is None


### PR DESCRIPTION
Automated evolution PR for issue #2471 (parent #2186, Slice C).

## What
Stores a pre-compaction snapshot of the message context in a re-readable JSON file before background summarization runs, so context dropped during compaction can be recovered by reading the snapshot instead of re-running the original tool calls. Adds to `evolution/lib/parallel_compaction.py`:

- `write_precompaction_snapshot(messages, snapshot_dir)` / `read_precompaction_snapshot(path)` — JSON round-trip helpers.
- `ParallelCompactor(snapshot_dir=...)` writes the snapshot at `start_async_compaction` (best-effort; a write failure never blocks compaction) and exposes it via `snapshot_path`.
- `ParallelCompactor.read_snapshot()` re-reads the captured snapshot; `reset()` clears it.

## Checks
- `ruff check` ✓
- `ruff format --check` ✓
- targeted tests `tests/evolution/test_parallel_compaction_snapshot.py` + `test_parallel_compaction.py` ✓ (9 passed)

## Diff
117 insertions (well under the 200-line autonomous self-merge cap).