### PR TITLE
fix: wire claim-verification into the analysis run path (Closes #2494)

### DIFF
--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -39,6 +39,16 @@ _CITED_PATH_RE = re.compile(
 )
 
 
+# Candidate/issue collection keys the analysis report may carry (#2468/#2494).
+_CANDIDATE_KEYS: Tuple[str, ...] = (
+    "candidates",
+    "proposals",
+    "evaluated_issues",
+    "selected_for_implementation",
+    "issues",
+)
+
+
 def _num(x: Any) -> Optional[float]:
     """Coerce to float, but reject bool (True/False are ints in Python)."""
     if isinstance(x, bool):
@@ -161,13 +171,7 @@ def audit_implemented_claims(
     out: List[str] = []
     # Inspect all possible candidate/issue collection keys
     items_to_check: List[Dict[str, Any]] = []
-    for key in (
-        "candidates",
-        "proposals",
-        "evaluated_issues",
-        "selected_for_implementation",
-        "issues",
-    ):
+    for key in _CANDIDATE_KEYS:
         val = report.get(key)
         if isinstance(val, list):
             for entry in val:
@@ -232,6 +236,73 @@ def reconcile_implemented_candidates(
                 item["already_implemented_unverified"] = True
         reconciled.append(item)
     return reconciled
+
+
+def reconcile_report(
+    report: Dict[str, Any], repo_root: Optional[Path]
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Clear unverified ``already_implemented`` flags across candidate collections (#2494).
+
+    Returns ``(report, notes)``; ``notes`` lists each cleared claim for audit.
+    """
+    if not isinstance(report, dict):
+        return report, []
+    notes: List[str] = []
+    for key in _CANDIDATE_KEYS:
+        val = report.get(key)
+        if not isinstance(val, list):
+            continue
+        reconciled = reconcile_implemented_candidates(val, repo_root)
+        report[key] = reconciled
+        for item in reconciled:
+            if isinstance(item, dict) and item.get("already_implemented_unverified"):
+                issue = (
+                    item.get("issue_number")
+                    or item.get("issue")
+                    or item.get("id")
+                    or "unknown"
+                )
+                notes.append(
+                    f"CLEARED_IMPLEMENTED_CLAIM: issue #{issue} marked "
+                    f"already_implemented but cited artifact does not exist — "
+                    f"flag cleared so it is re-ranked"
+                )
+    return report, notes
+
+
+def _is_dated_report_name(name: str) -> bool:
+    """True for the cycle-report filename ``YYYY-MM-DD.json`` (same set as ``audit_latest``)."""
+    if not name.endswith(".json") or len(name) != 15:
+        return False
+    return name[4] == "-" and name[7] == "-"
+
+
+def reconcile_latest(evolution_dir: Path, repo_root: Optional[Path]) -> List[str]:
+    """Reconcile the latest dated analysis report and write it back atomically (#2494)."""
+    if repo_root is None:
+        return []
+    analysis_dir = evolution_dir / "analysis"
+    try:
+        files = list(analysis_dir.glob("*.json"))
+    except OSError:
+        return []
+    dated = sorted(f for f in files if _is_dated_report_name(f.name))
+    if not dated:
+        return []
+    latest = dated[-1]
+    try:
+        report = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    report, notes = reconcile_report(report, repo_root)
+    if not notes:
+        return []
+    import os
+
+    tmp = latest.with_name(latest.name + ".reconcile-tmp")
+    tmp.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, latest)
+    return notes
 
 
 def audit_rejections(report: Dict[str, Any], repo_root: Optional[Path]) -> List[str]:

--- a/scripts/evolution_watchdog.py
+++ b/scripts/evolution_watchdog.py
@@ -809,13 +809,20 @@ def check_analysis_integrity(evolution_dir: Path) -> List[str]:
     scheduler installs evolution_*.py alongside this script, so the sibling import
     resolves at runtime; the guard keeps unit imports safe)."""
     try:
-        from evolution_analysis_audit import audit_latest
+        from evolution_analysis_audit import audit_latest, reconcile_latest
     except ImportError:
         return []
-    return [
-        f"analysis selection integrity: {v}"
-        for v in audit_latest(evolution_dir, _resolve_repo_dir())
+    repo = _resolve_repo_dir()
+    out = [
+        f"analysis selection integrity: {v}" for v in audit_latest(evolution_dir, repo)
     ]
+    # Reconcile AFTER auditing: audit flags the original fabricated claim, then
+    # reconciliation clears it so implementation re-ranks it (#2494 live call site).
+    out += [
+        f"analysis claim reconciliation: {n}"
+        for n in reconcile_latest(evolution_dir, repo)
+    ]
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_evolution_analysis_audit.py
+++ b/tests/scripts/test_evolution_analysis_audit.py
@@ -14,6 +14,8 @@ from evolution_analysis_audit import (  # noqa: E402
     audit_rejections,
     extract_cited_paths,
     reconcile_implemented_candidates,
+    reconcile_latest,
+    reconcile_report,
     verify_implementation_claim,
 )
 
@@ -330,3 +332,97 @@ class TestReconcileImplementedCandidates:
         reconciled = reconcile_implemented_candidates(candidates, tmp_path)
         assert len(reconciled) == 1
         assert reconciled[0]["already_implemented"] is True
+
+
+class TestReconcileReport:
+    def test_clears_unverified_claim_across_candidate_keys(self, tmp_path):
+        report = {
+            "date": "2026-08-16",
+            "candidates": [
+                {
+                    "issue_number": 400,
+                    "already_implemented": True,
+                    "reason": "implemented in tools/ghost.py",
+                    "priority_score": 0.9,
+                }
+            ],
+            "selected_for_implementation": [
+                {
+                    "issue_number": 401,
+                    "already_implemented": True,
+                    "reason": "implemented in scripts/phantom.py",
+                }
+            ],
+        }
+        report, notes = reconcile_report(report, tmp_path)
+        assert report["candidates"][0]["already_implemented"] is False
+        assert report["candidates"][0]["already_implemented_unverified"] is True
+        assert report["selected_for_implementation"][0]["already_implemented"] is False
+        assert len(notes) == 2
+        assert all("CLEARED_IMPLEMENTED_CLAIM" in n for n in notes)
+
+    def test_preserves_valid_claim(self, tmp_path):
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "real.py").write_text("x")
+        report = {
+            "candidates": [
+                {
+                    "issue_number": 402,
+                    "already_implemented": True,
+                    "reason": "implemented in tools/real.py",
+                }
+            ]
+        }
+        report, notes = reconcile_report(report, tmp_path)
+        assert report["candidates"][0]["already_implemented"] is True
+        assert notes == []
+
+    def test_non_dict_report_is_safe(self, tmp_path):
+        report, notes = reconcile_report([], tmp_path)  # type: ignore[arg-type]
+        assert report == []
+        assert notes == []
+
+
+class TestReconcileLatest:
+    def _write(self, d, name, report):
+        (d / "analysis").mkdir(parents=True, exist_ok=True)
+        (d / "analysis" / name).write_text(json.dumps(report), encoding="utf-8")
+
+    def test_reconciles_and_writes_back_latest_dated_report(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write(
+            tmp_path,
+            "2026-08-16.json",
+            {
+                "date": "2026-08-16",
+                "candidates": [
+                    {
+                        "issue_number": 500,
+                        "already_implemented": True,
+                        "reason": "implemented in tools/ghost.py",
+                    }
+                ],
+            },
+        )
+        notes = reconcile_latest(tmp_path, repo)
+        assert any("#500" in n for n in notes)
+        # Written back: flag cleared, marker set.
+        saved = json.loads((tmp_path / "analysis" / "2026-08-16.json").read_text())
+        assert saved["candidates"][0]["already_implemented"] is False
+        assert saved["candidates"][0]["already_implemented_unverified"] is True
+
+    def test_no_repo_is_silent(self, tmp_path):
+        self._write(
+            tmp_path,
+            "2026-08-16.json",
+            {"candidates": [{"issue_number": 1, "already_implemented": True}]},
+        )
+        assert reconcile_latest(tmp_path, None) == []
+
+    def test_ignores_non_dated_snapshots(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write(tmp_path, "issues_2026-08-16.json", {"junk": True})
+        self._write(tmp_path, "prs_2026-08-16.json", [])
+        assert reconcile_latest(tmp_path, repo) == []


### PR DESCRIPTION
Automated evolution PR for issue #2494.

Wires `reconcile_implemented_candidates` / `audit_implemented_claims` (the #2468 verification helpers, dead code since PR #2474 merged) into the live analysis gate. Adds `reconcile_report` + `reconcile_latest` and calls them from the watchdog's analysis-integrity check, so a fabricated `already_implemented` claim is both flagged AND cleared — the issue gets re-ranked instead of silently skipped.

- lint ✓, format ✓, targeted tests ✓ (121 passed)