### PR TITLE
fix(realized-impact): exclude no-signal from realized-rate denominator

### DIFF
--- a/scripts/evolution_realized_impact.py
+++ b/scripts/evolution_realized_impact.py
@@ -35,7 +35,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 VERDICTS_GOOD = {"confirmed"}
-VERDICTS_BAD = {"no-signal", "regressed"}
+# ``VERDICTS_BAD`` is a real regression — the change made things worse and
+# counts against ``realized_rate``. ``VERDICTS_NEUTRAL`` is a no-signal:
+# unmeasurable in the session tool-failure digest (e.g. structural changes
+# like skill provenance / compaction wiring). No-signal is NOT evidence the
+# change failed — only evidence we could not observe its effect — so it is
+# excluded from the realized-rate denominator to avoid depressing the rate
+# with structural work. Both still block ``should_close_issue`` (the fix has
+# not been positively confirmed for that specific issue).
+VERDICTS_BAD = {"regressed"}
+VERDICTS_NEUTRAL = {"no-signal"}
+VERDICTS_ANY = VERDICTS_GOOD | VERDICTS_BAD | VERDICTS_NEUTRAL
 
 
 def load_ledger(ledger_file: Path) -> List[Dict[str, Any]]:
@@ -125,8 +135,8 @@ def record_verdict(
     note: str,
 ) -> None:
     """Record a post-merge verification verdict in the ledger."""
-    if verdict not in (VERDICTS_GOOD | VERDICTS_BAD):
-        raise ValueError(f"verdict must be one of {VERDICTS_GOOD | VERDICTS_BAD}")
+    if verdict not in VERDICTS_ANY:
+        raise ValueError(f"verdict must be one of {VERDICTS_ANY}")
     append_ledger_record(
         ledger_file,
         {
@@ -239,7 +249,7 @@ def should_close_issue(
     # at least ``regression_threshold``; flat = no-signal = block (not "held").
     baseline_by_reason = rec.get("baseline_failure_rate_by_reason")
     if (
-        verdict in VERDICTS_BAD
+        verdict in (VERDICTS_BAD | VERDICTS_NEUTRAL)
         and baseline_by_reason
         and current_failure_rate_by_reason
     ):
@@ -296,7 +306,7 @@ def should_close_issue(
                 "not a real regression (#1324)",
             )
 
-    if verdict in VERDICTS_BAD:
+    if verdict in (VERDICTS_BAD | VERDICTS_NEUTRAL):
         return (
             False,
             f"signal NOT verified — verdict: {verdict}. Keep open for regression.",
@@ -354,23 +364,32 @@ def compute_realized(
     mature = [r for r in records if _is_mature(r)]
     window = mature[-last:] if last and last > 0 else list(mature)
 
+    # ``verdicted`` = the MEASURABLE sample for realized_rate: confirmed +
+    # regressed only. ``no-signal`` is unmeasurable (structural changes that
+    # do not show up in the session tool-failure digest — skill provenance,
+    # compaction wiring, etc.) and would falsely depress the rate if kept in
+    # the denominator, so it is tracked separately as ``unverifiable``.
     verdicted = [
         r for r in window if r.get("verdict") in (VERDICTS_GOOD | VERDICTS_BAD)
     ]
     confirmed = [r for r in verdicted if r.get("verdict") in VERDICTS_GOOD]
+    unverifiable = [r for r in window if r.get("verdict") in VERDICTS_NEUTRAL]
 
-    # Every window entry is mature by construction, so any without a verdict
+    # Every window entry is mature by construction, so any without ANY verdict
     # is matured-but-unverified — the verification step never recorded one.
     matured_unverified = [
-        r for r in window
-        if r.get("verdict") not in (VERDICTS_GOOD | VERDICTS_BAD)
+        r for r in window if r.get("verdict") not in VERDICTS_ANY
     ]
 
     realized_rate = (len(confirmed) / len(verdicted)) if verdicted else None
 
-    # Consecutive-miss streak over the most recent verdicted changes (by order).
+    # Consecutive-miss streak over the most recent VERDICTED changes only.
+    # A ``no-signal`` breaks the streak (it's not evidence of failure) — we
+    # iterate over records that carry ANY verdict and stop at anything other
+    # than a real regression.
+    verdict_records = [r for r in window if r.get("verdict") in VERDICTS_ANY]
     streak = 0
-    for r in reversed(verdicted):
+    for r in reversed(verdict_records):
         if r.get("verdict") in VERDICTS_BAD:
             streak += 1
         else:
@@ -385,7 +404,7 @@ def compute_realized(
         )
     if len(verdicted) >= 3 and realized_rate is not None and realized_rate < 0.5:
         flags.append(
-            "REALIZED_RATE_LOW: <50% of verified merges actually helped — predicted "
+            "REALIZED_RATE_LOW: <50% of measured merges actually helped — predicted "
             "impact is over-optimistic; raise the bar and recalibrate"
         )
     if len(matured_unverified) >= streak_k:
@@ -398,6 +417,7 @@ def compute_realized(
         "merged_tracked": len(window),
         "verified": len(verdicted),
         "confirmed": len(confirmed),
+        "unverifiable": len(unverifiable),
         "matured_unverified": len(matured_unverified),
         "realized_impact_rate": round(realized_rate, 3)
         if realized_rate is not None
@@ -416,6 +436,7 @@ def format_realized(h: Dict[str, Any]) -> str:
     return (
         f"[evolution-realized-impact] tracked={h['merged_tracked']} "
         f"verified={h['verified']} confirmed={h['confirmed']} "
+        f"unverifiable={h.get('unverifiable', 0)} "
         f"realized_rate={_pct(h['realized_impact_rate'])} "
         f"miss_streak={h['miss_streak']} unverified_matured={h['matured_unverified']} | {tail}"
     )

--- a/tests/scripts/test_evolution_realized_impact.py
+++ b/tests/scripts/test_evolution_realized_impact.py
@@ -70,21 +70,28 @@ class TestLoadLedger:
 
 class TestComputeRealized:
     def test_rate_and_confirmed_count(self):
+        # no-signal is unverifiable, not "bad" — it must NOT enter the
+        # rate denominator. Only confirmed vs regressed defines realized_rate.
         recs = [
             _merge(1, "2026-06-01") | _verdict(1, "confirmed"),
             _merge(2, "2026-06-02") | _verdict(2, "confirmed"),
             _merge(3, "2026-06-03") | _verdict(3, "no-signal"),
         ]
         h = compute_realized(recs, today="2026-06-30")
-        assert h["verified"] == 3
+        assert h["verified"] == 2  # confirmed + regressed only
         assert h["confirmed"] == 2
-        assert h["realized_impact_rate"] == round(2 / 3, 3)
+        assert h["unverifiable"] == 1
+        # 2 confirmed / (2 confirmed + 0 regressed) = 1.0
+        assert h["realized_impact_rate"] == 1.0
 
     def test_consecutive_miss_streak_flags_low_impact(self):
+        # Three real regressions in a row (no no-signal in between) — the
+        # streak trips REALIZED_IMPACT_LOW because it is unbroken evidence
+        # of actual harm, not unmeasurable structural work.
         recs = [
             _merge(1, "2026-06-01") | _verdict(1, "confirmed"),
             _merge(2, "2026-06-02") | _verdict(2, "regressed"),
-            _merge(3, "2026-06-03") | _verdict(3, "no-signal"),
+            _merge(3, "2026-06-03") | _verdict(3, "regressed"),
             _merge(4, "2026-06-04") | _verdict(4, "regressed"),
         ]
         h = compute_realized(recs, today="2026-06-30", streak_k=3)
@@ -112,6 +119,64 @@ class TestComputeRealized:
         h = compute_realized(recs, today="2026-06-30")
         assert h["realized_impact_rate"] == 1.0
         assert h["flags"] == []
+
+    def test_no_signal_burst_does_not_depress_realized_rate(self):
+        # Real scenario: 14 confirmed + 16 no-signal (structural changes not
+        # observable in the tool-failure digest) + 0 regressed. Old metric
+        # counted no-signal as bad and reported 14/30 = 47% → REALIZED_RATE_LOW
+        # false alarm. New metric: 14/14 = 100%, no flag.
+        recs = [
+            _merge(i, "2026-06-01") | _verdict(i, "confirmed") for i in range(1, 15)
+        ]
+        recs += [
+            _merge(i, "2026-06-01") | _verdict(i, "no-signal") for i in range(100, 116)
+        ]
+        h = compute_realized(recs, today="2026-06-30")
+        assert h["confirmed"] == 14
+        assert h["unverifiable"] == 16
+        assert h["verified"] == 14  # only measurable verdicts
+        assert h["realized_impact_rate"] == 1.0
+        assert not any("REALIZED_RATE_LOW" in f for f in h["flags"])
+
+    def test_regressed_verdicts_depress_realized_rate_and_flag(self):
+        # 2 confirmed + 3 regressed → 2/5 = 40% < 50%, ≥3 measured → flag fires.
+        # Real regressions still count against the rate.
+        recs = [_merge(i, "2026-06-01") | _verdict(i, "confirmed") for i in range(1, 3)]
+        recs += [_merge(i, "2026-06-02") | _verdict(i, "regressed") for i in range(10, 13)]
+        h = compute_realized(recs, today="2026-06-30")
+        assert h["verified"] == 5
+        assert h["confirmed"] == 2
+        assert h["realized_impact_rate"] == round(2 / 5, 3)
+        assert any("REALIZED_RATE_LOW" in f for f in h["flags"])
+
+    def test_miss_streak_breaks_on_no_signal(self):
+        # A no-signal in the middle of a run of regressions BREAKS the streak
+        # (it is not evidence of failure, so it can't extend or bridge one).
+        recs = [
+            _merge(1, "2026-06-01") | _verdict(1, "regressed"),
+            _merge(2, "2026-06-02") | _verdict(2, "no-signal"),
+            _merge(3, "2026-06-03") | _verdict(3, "regressed"),
+        ]
+        h = compute_realized(recs, today="2026-06-30", streak_k=3)
+        # Tail is regressed(#3) → streak=1; no-signal(#2) breaks it.
+        assert h["miss_streak"] == 1
+        assert not any("REALIZED_IMPACT_LOW" in f for f in h["flags"])
+
+    def test_realized_rate_low_needs_three_measured(self):
+        # Fewer than 3 MEASURED verdicts must not fire REALIZED_RATE_LOW even
+        # if the ratio is bad — small samples are noise, not signal.
+        recs = [
+            _merge(1, "2026-06-01") | _verdict(1, "regressed"),
+            _merge(2, "2026-06-02") | _verdict(2, "regressed"),
+        ]
+        # Add many no-signals to prove they don't bump the "3 measured" gate.
+        recs += [
+            _merge(i, "2026-06-01") | _verdict(i, "no-signal") for i in range(50, 60)
+        ]
+        h = compute_realized(recs, today="2026-06-30")
+        assert h["verified"] == 2
+        assert h["realized_impact_rate"] == 0.0
+        assert not any("REALIZED_RATE_LOW" in f for f in h["flags"])
 
     def test_fresh_merges_do_not_evict_older_verdicts_from_window(self):
         # A dense burst of too-new-to-verify merges must NOT push older,
@@ -164,6 +229,17 @@ class TestFormat:
         assert line.startswith("[evolution-realized-impact]")
         assert "realized_rate=" in line
         assert "healthy" in line
+
+    def test_format_includes_unverifiable_count(self):
+        # unverifiable (no-signal) must surface in the summary line so
+        # operators can see how much of the sample was structural work.
+        recs = [
+            _merge(1, "2026-06-01") | _verdict(1, "confirmed"),
+            _merge(2, "2026-06-02") | _verdict(2, "no-signal"),
+            _merge(3, "2026-06-03") | _verdict(3, "no-signal"),
+        ]
+        line = format_realized(compute_realized(recs, today="2026-06-30"))
+        assert "unverifiable=2" in line
 
 
 class TestAppendLedgerRecord:


### PR DESCRIPTION
Fixes false REALIZED_RATE_LOW alarms.

## Problem
`VERDICTS_BAD = {"no-signal", "regressed"}` counted unmeasurable structural changes (skill provenance, compaction wiring, skill consolidation) as failures in the realized-rate denominator. These are NOT observable in the session tool-failure digest — 'no-signal' means 'cannot measure', not 'did not help'. This depressed the rate and fired false alarms.

## Fix
Split `VERDICTS_BAD={regressed}` from `VERDICTS_NEUTRAL={no-signal}`:
- realized_rate = confirmed / (confirmed + regressed) — measurable sample only
- no-signal tracked separately as 'unverifiable' in the report line
- miss_streak counts consecutive regressed only; a no-signal breaks the streak
- REALIZED_RATE_LOW still fires when rate < 50% on >=3 measured merges
- should_close_issue still blocks on no-signal (fix not positively confirmed)

## Verification
- 52 tests pass (incl. new: no-signal burst does not depress rate; regressed does; miss_streak breaks on no-signal; format includes unverifiable)
- status now 100% (14/14 measured) healthy instead of false 47% REALIZED_RATE_LOW