### PR TITLE
feat(evolution): hard structural summary-volume constraint for compaction (Closes #2470)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6065,10 +6065,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # ``[CONTEXT COMPACTION — REFERENCE ONLY]`` block (fixes #29824).
         # Each anchor only walks ``cut_idx`` backward, so chaining them is
         # monotonic — the tail can only grow, never shrink.
-        # fmt: skip
-        cut_idx = self._ensure_last_assistant_message_in_tail(
-            messages, cut_idx, head_end
-        )
+        cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)  # fmt: skip
 
         # Extend to the last N actionable user messages when configured
         # (compression.min_tail_user_messages > 1).  This prevents the

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -48,6 +48,7 @@ try:
         CompactionState,
         ParallelCompactionConfig,
         ParallelCompactor,
+        SummaryVolumeConstraint,
     )
 
     _HAS_PARALLEL_COMPACTOR = True
@@ -4512,6 +4513,14 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
 
+        if (
+            self._parallel_compactor
+            and self._parallel_compactor.config.summary_constraint
+        ):
+            _vol_inst = self._parallel_compactor.build_summary_instruction()
+            if _vol_inst:
+                _template_sections += f"\n\nSTRUCTURAL CONSTRAINT:\n{_vol_inst}"
+
         if self._previous_summary:
             # Iterative update: preserve existing info, add new progress.
             # Bound the previous-summary block with the same aggregate cap as
@@ -4667,6 +4676,16 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
             self._validate_summary_user_provenance(summary, has_user_turn)
+            if (
+                self._parallel_compactor
+                and self._parallel_compactor.config.summary_constraint
+            ):
+                _val_res = self._parallel_compactor.validate_summary(summary)
+                if not _val_res.ok:
+                    logger.warning(
+                        "Compaction summary violated volume constraints (%s)",
+                        "; ".join(_val_res.violations),
+                    )
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()
@@ -6049,7 +6068,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Each anchor only walks ``cut_idx`` backward, so chaining them is
         # monotonic — the tail can only grow, never shrink.
         # fmt: skip
-        cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+        cut_idx = self._ensure_last_assistant_message_in_tail(
+            messages, cut_idx, head_end
+        )
 
         # Extend to the last N actionable user messages when configured
         # (compression.min_tail_user_messages > 1).  This prevents the

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3007,7 +3007,7 @@ class ContextCompressor(ContextEngine):
     @property
     def parallel_compactor(self) -> Optional[Any]:
         """Access the attached ParallelCompactor instance."""
-        return self._parallel_compactor
+        return getattr(self, "_parallel_compactor", None)
 
     def start_parallel_compaction(
         self,
@@ -3016,9 +3016,10 @@ class ContextCompressor(ContextEngine):
         focus_topic: Optional[str] = None,
     ) -> bool:
         """Launch background summarization via ParallelCompactor if enabled."""
-        if not self._parallel_compactor:
+        pc = getattr(self, "_parallel_compactor", None)
+        if not pc:
             return False
-        return self._parallel_compactor.start_async_compaction(
+        return pc.start_async_compaction(
             messages=messages,
             current_tokens=current_tokens,
             summarize_fn=lambda msgs: self.compress(
@@ -3030,9 +3031,10 @@ class ContextCompressor(ContextEngine):
         self, messages: List[Dict[str, Any]]
     ) -> Optional[List[Dict[str, Any]]]:
         """Check if parallel compaction completed and can be safely swapped in."""
-        if not self._parallel_compactor:
+        pc = getattr(self, "_parallel_compactor", None)
+        if not pc:
             return None
-        return self._parallel_compactor.try_apply_swap(messages)
+        return pc.try_apply_swap(messages)
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -4513,11 +4515,9 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
 
-        if (
-            self._parallel_compactor
-            and self._parallel_compactor.config.summary_constraint
-        ):
-            _vol_inst = self._parallel_compactor.build_summary_instruction()
+        _pc = getattr(self, "_parallel_compactor", None)
+        if _pc and _pc.config.summary_constraint:
+            _vol_inst = _pc.build_summary_instruction()
             if _vol_inst:
                 _template_sections += f"\n\nSTRUCTURAL CONSTRAINT:\n{_vol_inst}"
 
@@ -4676,11 +4676,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
             self._validate_summary_user_provenance(summary, has_user_turn)
-            if (
-                self._parallel_compactor
-                and self._parallel_compactor.config.summary_constraint
-            ):
-                _val_res = self._parallel_compactor.validate_summary(summary)
+            _pc = getattr(self, "_parallel_compactor", None)
+            if _pc and _pc.config.summary_constraint:
+                _val_res = _pc.validate_summary(summary)
                 if not _val_res.ok:
                     logger.warning(
                         "Compaction summary violated volume constraints (%s)",

--- a/evolution/lib/parallel_compaction.py
+++ b/evolution/lib/parallel_compaction.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import concurrent.futures
 from dataclasses import asdict, dataclass, field
 from enum import Enum
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -29,6 +30,87 @@ class CompactionState(Enum):
 
 
 @dataclass
+class SummaryVolumeConstraint:
+    """Hard structural volume constraint for context summarization."""
+
+    section_count: int = 6
+    per_section_token_cap: int = 250
+    enabled: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SummaryVolumeConstraint":
+        return cls(**{k: d[k] for k in d if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class SummaryValidationResult:
+    """Outcome of post-validating a summary against a volume constraint."""
+
+    ok: bool
+    detected_sections: int
+    expected_sections: int
+    overlong_sections: List[int]
+    violations: List[str]
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token); 0 for empty input."""
+    if not text:
+        return 0
+    return max(1, (len(text) + 3) // 4)
+
+
+_SECTION_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
+
+
+def split_sections(summary: str) -> List[str]:
+    """Split a summary into sections on markdown headings (``## ...``)."""
+    sections: List[str] = []
+    current: List[str] = []
+    for line in summary.splitlines():
+        if _SECTION_HEADING_RE.match(line.strip()):
+            if current:
+                sections.append("\n".join(current).rstrip())
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        sections.append("\n".join(current).rstrip())
+    return [s for s in sections if s.strip()]
+
+
+def validate_summary_volume(
+    summary: str,
+    constraint: SummaryVolumeConstraint,
+) -> SummaryValidationResult:
+    """Post-validate a summary against the volume constraint; disabled always ok."""
+    if not constraint.enabled:
+        return SummaryValidationResult(True, 0, constraint.section_count, [], [])
+
+    sections = split_sections(summary)
+    detected = len(sections)
+    violations: List[str] = []
+    overlong: List[int] = []
+    if detected != constraint.section_count:
+        violations.append(
+            f"expected {constraint.section_count} sections, got {detected}"
+        )
+    for i, section in enumerate(sections, start=1):
+        if estimate_tokens(section) > constraint.per_section_token_cap:
+            overlong.append(i)
+            violations.append(
+                f"section {i} exceeds {constraint.per_section_token_cap} tokens"
+            )
+
+    return SummaryValidationResult(
+        not violations, detected, constraint.section_count, overlong, violations
+    )
+
+
+@dataclass
 class ParallelCompactionConfig:
     """Configuration for parallel context compaction.
 
@@ -38,6 +120,7 @@ class ParallelCompactionConfig:
         headroom_ratio: Fraction of hard limit to reserve as early-trigger headroom.
         explicit_headroom_tokens: Optional explicit token count for headroom override.
         preserve_recent_count: Number of recent messages to exclude from compression.
+        summary_constraint: Optional hard structural constraint on summary volume.
     """
 
     enabled: bool = True
@@ -45,6 +128,7 @@ class ParallelCompactionConfig:
     headroom_ratio: float = 0.15
     explicit_headroom_tokens: Optional[int] = None
     preserve_recent_count: int = 4
+    summary_constraint: Optional[SummaryVolumeConstraint] = None
 
     @property
     def headroom_tokens(self) -> int:
@@ -61,7 +145,12 @@ class ParallelCompactionConfig:
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "ParallelCompactionConfig":
-        return cls(**{k: d[k] for k in d if k in cls.__dataclass_fields__})
+        kwargs = {k: d[k] for k in d if k in cls.__dataclass_fields__}
+        if isinstance(kwargs.get("summary_constraint"), dict):
+            kwargs["summary_constraint"] = SummaryVolumeConstraint.from_dict(
+                kwargs["summary_constraint"]
+            )
+        return cls(**kwargs)
 
 
 @dataclass
@@ -207,6 +296,33 @@ class ParallelCompactor:
         self._state = CompactionState.SWAPPED
         self._swap_count += 1
         return new_messages
+
+    def build_summary_instruction(self) -> str:
+        """Structural summarization instruction; empty when unconfigured."""
+        constraint = self.config.summary_constraint
+        if constraint is None or not constraint.enabled:
+            return ""
+        return (
+            f"Produce a summary with EXACTLY {constraint.section_count} '##' sections, "
+            f"each at most {constraint.per_section_token_cap} tokens; no extra content."
+        )
+
+    def validate_summary(self, summary: str) -> SummaryValidationResult:
+        """Post-validate a produced summary; unconfigured always validates."""
+        constraint = self.config.summary_constraint
+        if constraint is None:
+            return SummaryValidationResult(True, 0, 0, [], [])
+        return validate_summary_volume(summary, constraint)
+
+    def build_reprompt_instruction(self, result: SummaryValidationResult) -> str:
+        """Corrective re-prompt for a violating summary; empty when valid."""
+        if result.ok:
+            return ""
+        return (
+            "Summary violated structural constraints:\n- "
+            + "\n- ".join(result.violations)
+            + "\nRewrite the summary to comply exactly."
+        )
 
     def reset(self) -> None:
         """Reset state for next cycle."""

--- a/tests/evolution/test_parallel_compaction_volume.py
+++ b/tests/evolution/test_parallel_compaction_volume.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Tests for the hard structural summary-volume constraint (Issue #2470)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from evolution.lib.parallel_compaction import (
+    ParallelCompactionConfig,
+    ParallelCompactor,
+    SummaryVolumeConstraint,
+    estimate_tokens,
+    split_sections,
+    validate_summary_volume,
+)
+from agent.context_compressor import ContextCompressor
+
+
+def _summary(sections):
+    return "\n\n".join(f"## Section {i + 1}\n{body}" for i, body in enumerate(sections))
+
+
+def test_estimate_tokens_and_split_sections():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("fives") == 2
+    sections = split_sections("## One\nbody one\n\n## Two\nbody two")
+    assert [s.splitlines()[0] for s in sections] == ["## One", "## Two"]
+
+
+def test_validate_compliant_and_violations():
+    c = SummaryVolumeConstraint(section_count=3, per_section_token_cap=200)
+    assert validate_summary_volume(_summary(["a", "b", "c"]), c).ok is True
+
+    # Wrong section count.
+    result = validate_summary_volume(_summary(["a", "b"]), c)
+    assert result.ok is False
+    assert any("expected 3 sections" in v for v in result.violations)
+
+    # Overlong section.
+    tight = SummaryVolumeConstraint(section_count=2, per_section_token_cap=5)
+    over = validate_summary_volume(_summary(["x" * 200, "ok"]), tight)
+    assert over.ok is False
+    assert over.overlong_sections == [1]
+
+    # Disabled constraint always validates.
+    assert validate_summary_volume(
+        "anything", SummaryVolumeConstraint(enabled=False)
+    ).ok
+
+
+def test_config_nested_roundtrip():
+    config = ParallelCompactionConfig(
+        summary_constraint=SummaryVolumeConstraint(
+            section_count=4, per_section_token_cap=60
+        )
+    )
+    restored = ParallelCompactionConfig.from_dict(config.to_dict())
+    assert restored.summary_constraint is not None
+    assert restored.summary_constraint.section_count == 4
+    assert restored.summary_constraint.per_section_token_cap == 60
+
+
+def test_instruction_and_reprompt():
+    compactor = ParallelCompactor(
+        config=ParallelCompactionConfig(
+            summary_constraint=SummaryVolumeConstraint(
+                section_count=2, per_section_token_cap=5
+            )
+        )
+    )
+    instruction = compactor.build_summary_instruction()
+    assert "EXACTLY 2" in instruction
+    assert "5 tokens" in instruction
+    assert ParallelCompactor().build_summary_instruction() == ""
+
+    bad = _summary(["x" * 200, "ok"])
+    result = compactor.validate_summary(bad)
+    assert result.ok is False
+    assert "section 1 exceeds" in compactor.build_reprompt_instruction(result)
+
+    good = _summary(["a", "b"])
+    assert compactor.validate_summary(good).ok is True
+    assert compactor.build_reprompt_instruction(compactor.validate_summary(good)) == ""
+
+
+def test_context_compressor_uses_summary_volume_constraint():
+    """Verify ContextCompressor wires SummaryVolumeConstraint into prompt and validation."""
+    constraint = SummaryVolumeConstraint(section_count=6, per_section_token_cap=250)
+    config = ParallelCompactionConfig(summary_constraint=constraint)
+    compressor = ContextCompressor(
+        model="mock-model",
+        api_key="mock-key",
+        base_url="http://mock",
+    )
+    compressor._parallel_compactor = ParallelCompactor(config)
+
+    # Verify prompt includes structural constraint instruction
+    with patch("agent.context_compressor.call_llm") as mock_llm:
+        mock_resp = MagicMock()
+        mock_resp.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content="## Section 1\nContent 1\n\n## Section 2\nContent 2"
+                )
+            )
+        ]
+        mock_llm.return_value = mock_resp
+
+        sample_turns = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = compressor._generate_summary(sample_turns)
+        assert result is not None
+
+        # Verify call_llm was passed the prompt containing the structural constraint
+        called_prompt = mock_llm.call_args[1]["messages"][0]["content"]
+        assert "STRUCTURAL CONSTRAINT:" in called_prompt
+        assert "EXACTLY 6" in called_prompt


### PR DESCRIPTION
Closes #2470.

Rework of Slice B after #2495 runtime wiring:

- Adds `SummaryVolumeConstraint` and structural validation helpers (`estimate_tokens`, `split_sections`, `validate_summary_volume`) to `evolution/lib/parallel_compaction.py`.
- Adds `build_summary_instruction`, `validate_summary`, and `build_reprompt_instruction` to `ParallelCompactor`.
- Wires `SummaryVolumeConstraint` into `ContextCompressor` prompt building and post-generation validation.
- Adds comprehensive unit and integration tests in `tests/evolution/test_parallel_compaction_volume.py`.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>