### PR TITLE
[SLICE C] Pre-compaction snapshot as re-readable virtual file (fixes #2471)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -19,11 +19,12 @@ Improvements over v2:
 import hashlib
 import json
 import logging
-import sqlite3
+from pathlib import Path
 import re
+import sqlite3
 import time
+from typing import Any, Dict, List, Optional, Union
 import uuid
-from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import (
     AuxiliaryExplicitCancellation,
@@ -3019,6 +3020,9 @@ class ContextCompressor(ContextEngine):
         pc = getattr(self, "_parallel_compactor", None)
         if not pc:
             return False
+        sid = getattr(self, "_session_id", None)
+        if sid:
+            pc.session_id = sid
         return pc.start_async_compaction(
             messages=messages,
             current_tokens=current_tokens,
@@ -3035,6 +3039,32 @@ class ContextCompressor(ContextEngine):
         if not pc:
             return None
         return pc.try_apply_swap(messages)
+
+    @property
+    def snapshot_path(self) -> Optional[Any]:
+        """Path to the latest pre-compaction snapshot if available."""
+        pc = getattr(self, "_parallel_compactor", None)
+        if pc:
+            return pc.snapshot_path
+        return None
+
+    def read_precompaction_snapshot(
+        self, snapshot_path: Optional[Union[str, Path]] = None
+    ) -> Optional[Any]:
+        """Read pre-compaction snapshot via attached ParallelCompactor."""
+        pc = getattr(self, "_parallel_compactor", None)
+        if pc:
+            return pc.read_snapshot(snapshot_path)
+        return None
+
+    def read_precompaction_snapshot_text(
+        self, snapshot_path: Optional[Union[str, Path]] = None
+    ) -> Optional[str]:
+        """Read pre-compaction snapshot text via attached ParallelCompactor."""
+        pc = getattr(self, "_parallel_compactor", None)
+        if pc:
+            return pc.read_snapshot_text(snapshot_path)
+        return None
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""

--- a/evolution/lib/parallel_compaction.py
+++ b/evolution/lib/parallel_compaction.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 import concurrent.futures
 from dataclasses import asdict, dataclass, field
 from enum import Enum
+import json
+from pathlib import Path
 import re
-from typing import Any, Callable, Dict, List, Optional
+import time
+from typing import Any, Callable, Dict, List, Optional, Union
+import uuid
 
 
 class CompactionState(Enum):
@@ -121,6 +125,8 @@ class ParallelCompactionConfig:
         explicit_headroom_tokens: Optional explicit token count for headroom override.
         preserve_recent_count: Number of recent messages to exclude from compression.
         summary_constraint: Optional hard structural constraint on summary volume.
+        save_snapshot: Whether to persist pre-compaction snapshot to disk.
+        snapshot_dir: Optional explicit directory for snapshot storage.
     """
 
     enabled: bool = True
@@ -129,6 +135,8 @@ class ParallelCompactionConfig:
     explicit_headroom_tokens: Optional[int] = None
     preserve_recent_count: int = 4
     summary_constraint: Optional[SummaryVolumeConstraint] = None
+    save_snapshot: bool = True
+    snapshot_dir: Optional[str] = None
 
     @property
     def headroom_tokens(self) -> int:
@@ -161,6 +169,96 @@ class CompactionSnapshot:
     message_count: int
     messages: List[Dict[str, Any]]
     token_count_at_trigger: int
+    snapshot_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "timestamp": self.timestamp,
+            "trigger_index": self.trigger_index,
+            "message_count": self.message_count,
+            "token_count_at_trigger": self.token_count_at_trigger,
+            "messages": self.messages,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "CompactionSnapshot":
+        return cls(
+            trigger_index=d.get("trigger_index", len(d.get("messages", []))),
+            message_count=d.get("message_count", len(d.get("messages", []))),
+            messages=d.get("messages", []),
+            token_count_at_trigger=d.get("token_count_at_trigger", 0),
+            snapshot_id=d.get("snapshot_id", uuid.uuid4().hex[:12]),
+            timestamp=d.get("timestamp", time.time()),
+        )
+
+    def to_readable_text(self) -> str:
+        """Format messages into clean markdown transcript representation."""
+        lines = [
+            f"# Pre-Compaction Snapshot [{self.snapshot_id}]",
+            f"- Trigger index: {self.trigger_index}",
+            f"- Message count: {self.message_count}",
+            f"- Token count at trigger: {self.token_count_at_trigger}",
+            "",
+            "## Transcript",
+            "",
+        ]
+        for i, msg in enumerate(self.messages, start=1):
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            lines.append(f"### Turn {i} ({role})")
+            if content:
+                lines.append(str(content).strip())
+            if msg.get("tool_calls"):
+                for tc in msg["tool_calls"]:
+                    fn = tc.get("function", {})
+                    fn_name = fn.get("name", "tool")
+                    fn_args = fn.get("arguments", "")
+                    lines.append(f"```tool_call:{fn_name}\n{fn_args}\n```")
+            lines.append("")
+        return "\n".join(lines).strip()
+
+
+def get_default_snapshot_dir() -> Path:
+    """Resolve default directory for pre-compaction snapshots."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        base = get_hermes_home()
+    except Exception:
+        base = Path.home() / ".hermes"
+    d = base / "snapshots"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def write_precompaction_snapshot(
+    snapshot: CompactionSnapshot,
+    snapshot_dir: Optional[Union[str, Path]] = None,
+    session_id: Optional[str] = None,
+) -> Path:
+    """Persist pre-compaction snapshot to disk as a re-readable virtual file."""
+    target_dir = Path(snapshot_dir) if snapshot_dir else get_default_snapshot_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"{session_id}_" if session_id else ""
+    file_name = f"{prefix}snapshot_{snapshot.snapshot_id}.json"
+    snapshot_path = target_dir / file_name
+    snapshot_path.write_text(json.dumps(snapshot.to_dict(), indent=2), encoding="utf-8")
+    return snapshot_path
+
+
+def read_precompaction_snapshot(snapshot_path: Union[str, Path]) -> CompactionSnapshot:
+    """Read a pre-compaction snapshot from disk."""
+    p = Path(snapshot_path)
+    data = json.loads(p.read_text(encoding="utf-8"))
+    return CompactionSnapshot.from_dict(data)
+
+
+def read_precompaction_snapshot_text(snapshot_path: Union[str, Path]) -> str:
+    """Read pre-compaction snapshot as human/agent-readable transcript."""
+    snap = read_precompaction_snapshot(snapshot_path)
+    return snap.to_readable_text()
 
 
 class ParallelCompactor:
@@ -170,15 +268,26 @@ class ParallelCompactor:
         self,
         config: Optional[ParallelCompactionConfig] = None,
         executor: Optional[concurrent.futures.Executor] = None,
+        session_id: Optional[str] = None,
     ) -> None:
         self.config = config or ParallelCompactionConfig()
         self._executor = executor
+        self._session_id = session_id
         self._state = CompactionState.IDLE
         self._future: Optional[concurrent.futures.Future[List[Dict[str, Any]]]] = None
         self._snapshot: Optional[CompactionSnapshot] = None
+        self._snapshot_path: Optional[Path] = None
         self._compacted_prefix: Optional[List[Dict[str, Any]]] = None
         self._last_error: Optional[str] = None
         self._swap_count: int = 0
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self._session_id
+
+    @session_id.setter
+    def session_id(self, val: Optional[str]) -> None:
+        self._session_id = val
 
     @property
     def state(self) -> CompactionState:
@@ -191,6 +300,14 @@ class ParallelCompactor:
     @property
     def swap_count(self) -> int:
         return self._swap_count
+
+    @property
+    def snapshot(self) -> Optional[CompactionSnapshot]:
+        return self._snapshot
+
+    @property
+    def snapshot_path(self) -> Optional[Path]:
+        return self._snapshot_path
 
     def should_trigger(self, current_tokens: int) -> bool:
         """Check whether current token usage crossed early trigger threshold."""
@@ -219,6 +336,18 @@ class ParallelCompactor:
             messages=snapshot_messages,
             token_count_at_trigger=current_tokens,
         )
+        if self.config.save_snapshot:
+            try:
+                self._snapshot_path = write_precompaction_snapshot(
+                    self._snapshot,
+                    snapshot_dir=self.config.snapshot_dir,
+                    session_id=self._session_id,
+                )
+            except Exception as exc:
+                self._snapshot_path = None
+        else:
+            self._snapshot_path = None
+
         self._state = CompactionState.COMPACTING
         self._last_error = None
         self._compacted_prefix = None
@@ -297,6 +426,29 @@ class ParallelCompactor:
         self._swap_count += 1
         return new_messages
 
+    def read_snapshot(
+        self, snapshot_path: Optional[Union[str, Path]] = None
+    ) -> Optional[CompactionSnapshot]:
+        """Read a pre-compaction snapshot from disk or memory."""
+        if snapshot_path is not None:
+            return read_precompaction_snapshot(snapshot_path)
+        if self._snapshot is not None:
+            return self._snapshot
+        if self._snapshot_path is not None and self._snapshot_path.exists():
+            return read_precompaction_snapshot(self._snapshot_path)
+        return None
+
+    def read_snapshot_text(
+        self, snapshot_path: Optional[Union[str, Path]] = None
+    ) -> Optional[str]:
+        """Read snapshot as formatted text transcript."""
+        if snapshot_path is not None:
+            return read_precompaction_snapshot_text(snapshot_path)
+        snap = self.read_snapshot()
+        if snap is not None:
+            return snap.to_readable_text()
+        return None
+
     def build_summary_instruction(self) -> str:
         """Structural summarization instruction; empty when unconfigured."""
         constraint = self.config.summary_constraint
@@ -329,5 +481,6 @@ class ParallelCompactor:
         self._state = CompactionState.IDLE
         self._future = None
         self._snapshot = None
+        self._snapshot_path = None
         self._compacted_prefix = None
         self._last_error = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -4857,6 +4857,32 @@ class AIAgent:
             getattr(self, "context_compressor", None), "parallel_compactor", None
         )
 
+    @property
+    def precompaction_snapshot_path(self) -> Optional[Any]:
+        """Path to the latest pre-compaction snapshot if available."""
+        compressor = getattr(self, "context_compressor", None)
+        if compressor:
+            return getattr(compressor, "snapshot_path", None)
+        return None
+
+    def read_precompaction_snapshot(
+        self, snapshot_path: Optional[Any] = None
+    ) -> Optional[Any]:
+        """Read pre-compaction snapshot if available."""
+        compressor = getattr(self, "context_compressor", None)
+        if compressor and hasattr(compressor, "read_precompaction_snapshot"):
+            return compressor.read_precompaction_snapshot(snapshot_path)
+        return None
+
+    def read_precompaction_snapshot_text(
+        self, snapshot_path: Optional[Any] = None
+    ) -> Optional[str]:
+        """Read pre-compaction snapshot formatted text if available."""
+        compressor = getattr(self, "context_compressor", None)
+        if compressor and hasattr(compressor, "read_precompaction_snapshot_text"):
+            return compressor.read_precompaction_snapshot_text(snapshot_path)
+        return None
+
     def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
         """Forwarder — see ``agent.system_prompt.build_system_prompt_parts``."""
         from agent.system_prompt import build_system_prompt_parts

--- a/tests/evolution/test_parallel_compaction_snapshot.py
+++ b/tests/evolution/test_parallel_compaction_snapshot.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Tests for pre-compaction snapshot virtual file storage and recovery (Issue #2471)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from evolution.lib.parallel_compaction import (
+    CompactionSnapshot,
+    ParallelCompactionConfig,
+    ParallelCompactor,
+    read_precompaction_snapshot,
+    read_precompaction_snapshot_text,
+    write_precompaction_snapshot,
+)
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def sample_messages():
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Run tests and examine logs"},
+        {
+            "role": "assistant",
+            "content": "Running command",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command": "pytest"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "All 10 tests passed"},
+        {"role": "assistant", "content": "Tests passed successfully."},
+    ]
+
+
+def test_compaction_snapshot_to_from_dict(sample_messages):
+    snap = CompactionSnapshot(
+        trigger_index=len(sample_messages),
+        message_count=len(sample_messages),
+        messages=sample_messages,
+        token_count_at_trigger=1500,
+    )
+    d = snap.to_dict()
+    assert d["trigger_index"] == 5
+    assert d["message_count"] == 5
+    assert d["token_count_at_trigger"] == 1500
+    assert len(d["messages"]) == 5
+    assert "snapshot_id" in d
+    assert "timestamp" in d
+
+    restored = CompactionSnapshot.from_dict(d)
+    assert restored.snapshot_id == snap.snapshot_id
+    assert restored.trigger_index == snap.trigger_index
+    assert restored.message_count == snap.message_count
+    assert restored.token_count_at_trigger == snap.token_count_at_trigger
+    assert restored.messages == snap.messages
+
+
+def test_compaction_snapshot_to_readable_text(sample_messages):
+    snap = CompactionSnapshot(
+        trigger_index=len(sample_messages),
+        message_count=len(sample_messages),
+        messages=sample_messages,
+        token_count_at_trigger=1500,
+        snapshot_id="testsnap123",
+    )
+    text = snap.to_readable_text()
+    assert "# Pre-Compaction Snapshot [testsnap123]" in text
+    assert "### Turn 1 (system)" in text
+    assert "You are Hermes." in text
+    assert "### Turn 2 (user)" in text
+    assert "Run tests and examine logs" in text
+    assert "```tool_call:terminal" in text
+    assert "All 10 tests passed" in text
+
+
+def test_write_and_read_precompaction_snapshot(sample_messages, tmp_path):
+    snap = CompactionSnapshot(
+        trigger_index=len(sample_messages),
+        message_count=len(sample_messages),
+        messages=sample_messages,
+        token_count_at_trigger=1500,
+    )
+    path = write_precompaction_snapshot(
+        snap, snapshot_dir=tmp_path, session_id="session_abc"
+    )
+    assert path.exists()
+    assert "session_abc" in path.name
+    assert path.name.endswith(".json")
+
+    loaded = read_precompaction_snapshot(path)
+    assert loaded.snapshot_id == snap.snapshot_id
+    assert loaded.messages == snap.messages
+    assert loaded.trigger_index == snap.trigger_index
+
+    text = read_precompaction_snapshot_text(path)
+    assert f"Pre-Compaction Snapshot [{snap.snapshot_id}]" in text
+    assert "All 10 tests passed" in text
+
+
+def test_parallel_compactor_writes_snapshot_on_async_trigger(sample_messages, tmp_path):
+    config = ParallelCompactionConfig(
+        enabled=True,
+        hard_token_limit=1000,
+        headroom_ratio=0.2,
+        snapshot_dir=str(tmp_path),
+    )
+    compactor = ParallelCompactor(config=config, session_id="sess_123")
+
+    def mock_summarize(msgs):
+        return [{"role": "system", "content": "Summary"}]
+
+    ok = compactor.start_async_compaction(
+        messages=sample_messages,
+        current_tokens=900,
+        summarize_fn=mock_summarize,
+    )
+    assert ok is True
+    assert compactor.snapshot is not None
+    assert compactor.snapshot_path is not None
+    assert compactor.snapshot_path.exists()
+
+    # Read back through compactor methods
+    snap_read = compactor.read_snapshot()
+    assert snap_read is not None
+    assert snap_read.snapshot_id == compactor.snapshot.snapshot_id
+
+    text_read = compactor.read_snapshot_text()
+    assert text_read is not None
+    assert "All 10 tests passed" in text_read
+
+
+def test_parallel_compactor_save_snapshot_disabled(sample_messages, tmp_path):
+    config = ParallelCompactionConfig(
+        enabled=True,
+        hard_token_limit=1000,
+        headroom_ratio=0.2,
+        save_snapshot=False,
+        snapshot_dir=str(tmp_path),
+    )
+    compactor = ParallelCompactor(config=config)
+
+    def mock_summarize(msgs):
+        return [{"role": "system", "content": "Summary"}]
+
+    ok = compactor.start_async_compaction(
+        messages=sample_messages,
+        current_tokens=900,
+        summarize_fn=mock_summarize,
+    )
+    assert ok is True
+    assert compactor.snapshot is not None
+    assert compactor.snapshot_path is None
+
+
+def test_context_compressor_snapshot_integration(sample_messages, tmp_path):
+    compressor = ContextCompressor(model="test-model")
+    pc = compressor.parallel_compactor
+    assert pc is not None
+    pc.config.snapshot_dir = str(tmp_path)
+    compressor.bind_session_state(session_id="session_xyz")
+
+    compressor.compress = MagicMock(
+        return_value=[{"role": "system", "content": "Summary"}]
+    )
+
+    started = compressor.start_parallel_compaction(
+        messages=sample_messages,
+        current_tokens=90000,
+    )
+    assert started is True
+    assert compressor.snapshot_path is not None
+    assert compressor.snapshot_path.exists()
+
+    recovered = compressor.read_precompaction_snapshot()
+    assert recovered is not None
+    assert len(recovered.messages) == len(sample_messages)
+
+    recovered_text = compressor.read_precompaction_snapshot_text()
+    assert "All 10 tests passed" in recovered_text
+
+
+def test_ai_agent_precompaction_snapshot_access(sample_messages, tmp_path):
+    agent = AIAgent(
+        api_key="mock-key",
+        base_url="http://localhost:8080/v1",
+        model="test-model",
+        quiet_mode=True,
+    )
+    if agent.context_compressor and agent.parallel_compactor:
+        agent.parallel_compactor.config.snapshot_dir = str(tmp_path)
+        agent.context_compressor.compress = MagicMock(
+            return_value=[{"role": "system", "content": "Summary"}]
+        )
+        agent.context_compressor.start_parallel_compaction(
+            messages=sample_messages,
+            current_tokens=90000,
+        )
+        assert agent.precompaction_snapshot_path is not None
+        assert agent.precompaction_snapshot_path.exists()
+
+        snap = agent.read_precompaction_snapshot()
+        assert snap is not None
+        assert len(snap.messages) == len(sample_messages)
+
+        text = agent.read_precompaction_snapshot_text()
+        assert "All 10 tests passed" in text


### PR DESCRIPTION
## Summary
Implements Slice C of asynchronous parallel context compaction (parent #2186, closes #2471).

## Changes
- **Snapshot Persistence**: Implemented `write_precompaction_snapshot`, `read_precompaction_snapshot`, `read_precompaction_snapshot_text`, and added `snapshot_id`, `timestamp`, and `to_readable_text()` to `CompactionSnapshot` in `evolution/lib/parallel_compaction.py`.
- **ParallelCompactor Integration**: Automatically persists pre-compaction snapshots to disk on `start_async_compaction` and provides `read_snapshot()` and `read_snapshot_text()` recovery methods.
- **ContextCompressor & AIAgent Wiring**: Wired snapshot access properties (`snapshot_path`, `precompaction_snapshot_path`) and recovery functions (`read_precompaction_snapshot`, `read_precompaction_snapshot_text`) into `ContextCompressor` and `AIAgent`.
- **Tests**: Added comprehensive unit and integration tests in `tests/evolution/test_parallel_compaction_snapshot.py`.

Fixes #2471