### PR TITLE
[SLICE B] Self-refining harness state with versioned rollback (fixes #2497)

### DIFF
--- a/evolution/lib/versioned_harness_state.py
+++ b/evolution/lib/versioned_harness_state.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+"""Self-refining harness state with versioned rollback (Issue #2497, Slice B).
+
+Enables the agent to refine its operating instructions mid-task while keeping
+a structured, versioned history with safe rollback capabilities.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+def get_default_harness_state_dir() -> Path:
+    """Resolve default directory for harness state version storage."""
+    base = os.environ.get("HERMES_HOME")
+    if base:
+        p = Path(base) / "harness_states"
+    else:
+        p = Path.home() / ".hermes" / "harness_states"
+    try:
+        p.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    return p
+
+
+@dataclass
+class HarnessVersion:
+    """A snapshot of operating instructions at a specific version."""
+
+    version: int
+    instructions: str
+    reason: str = ""
+    author: str = "agent"
+    timestamp: float = field(default_factory=time.time)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> HarnessVersion:
+        return cls(
+            version=int(data.get("version", 1)),
+            instructions=str(data.get("instructions", "")),
+            reason=str(data.get("reason", "")),
+            author=str(data.get("author", "agent")),
+            timestamp=float(data.get("timestamp", time.time())),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+class VersionedHarnessState:
+    """Harness state manager tracking version history and enabling rollbacks."""
+
+    def __init__(
+        self,
+        initial_instructions: str = "",
+        session_id: Optional[str] = None,
+        storage_dir: Optional[Union[str, Path]] = None,
+        auto_save: bool = True,
+    ) -> None:
+        self.session_id = session_id or "default"
+        self.storage_dir = (
+            Path(storage_dir) if storage_dir else get_default_harness_state_dir()
+        )
+        self.auto_save = auto_save
+        self._history: List[HarnessVersion] = []
+        if self.storage_file.exists():
+            if not self.load():
+                self._init_first_version(initial_instructions)
+        else:
+            self._init_first_version(initial_instructions)
+
+    def _init_first_version(self, instructions: str) -> None:
+        v1 = HarnessVersion(
+            version=1,
+            instructions=instructions,
+            reason="Initial harness instructions",
+            author="system",
+            timestamp=time.time(),
+        )
+        self._history = [v1]
+        if self.auto_save:
+            self.save()
+
+    @property
+    def storage_file(self) -> Path:
+        """Path to JSON file storing harness history for this session."""
+        safe_id = "".join(
+            c if c.isalnum() or c in ("-", "_") else "_" for c in self.session_id
+        )
+        return self.storage_dir / f"harness_{safe_id}.json"
+
+    @property
+    def current_version(self) -> int:
+        """Current latest version number."""
+        return self._history[-1].version if self._history else 1
+
+    @property
+    def current_instructions(self) -> str:
+        """Current operating instructions."""
+        return self._history[-1].instructions if self._history else ""
+
+    @property
+    def history(self) -> List[HarnessVersion]:
+        """Full list of version snapshots."""
+        return list(self._history)
+
+    def update(
+        self,
+        instructions: str,
+        reason: str = "",
+        author: str = "agent",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> HarnessVersion:
+        """Update instructions and commit a new version to history."""
+        next_v = self.current_version + 1
+        ver = HarnessVersion(
+            version=next_v,
+            instructions=instructions,
+            reason=reason or f"Update to version {next_v}",
+            author=author,
+            timestamp=time.time(),
+            metadata=metadata or {},
+        )
+        self._history.append(ver)
+        if self.auto_save:
+            self.save()
+        return ver
+
+    def rollback(
+        self, target_version: Optional[int] = None, reason: str = ""
+    ) -> HarnessVersion:
+        """Roll back instructions to a previous version."""
+        if len(self._history) <= 1 and (
+            target_version is None or target_version == self.current_version
+        ):
+            raise ValueError("Cannot rollback: no prior versions exist.")
+
+        if target_version is None:
+            target_version = self.current_version - 1
+
+        target_snap = self.get_version(target_version)
+        if target_snap is None:
+            raise ValueError(
+                f"Target version {target_version} does not exist in history."
+            )
+
+        rb_reason = (
+            f"Rollback to v{target_version}: {reason}"
+            if reason
+            else f"Rollback to v{target_version} (was v{self.current_version})"
+        )
+        return self.update(
+            instructions=target_snap.instructions,
+            reason=rb_reason,
+            author="system",
+            metadata={
+                "rollback_from": self.current_version,
+                "rollback_target": target_version,
+            },
+        )
+
+    def get_version(self, version: int) -> Optional[HarnessVersion]:
+        """Retrieve a specific version snapshot."""
+        for v in self._history:
+            if v.version == version:
+                return v
+        return None
+
+    def diff(self, v1: int, v2: int) -> str:
+        """Generate unified diff between two versions."""
+        snap1 = self.get_version(v1)
+        snap2 = self.get_version(v2)
+        if snap1 is None or snap2 is None:
+            return f"Error: one or both versions ({v1}, {v2}) not found."
+        lines1 = snap1.instructions.splitlines(keepends=True)
+        lines2 = snap2.instructions.splitlines(keepends=True)
+        diff_lines = difflib.unified_diff(
+            lines1,
+            lines2,
+            fromfile=f"v{v1} ({snap1.reason})",
+            tofile=f"v{v2} ({snap2.reason})",
+        )
+        return "".join(diff_lines) or "No changes between versions."
+
+    def list_versions(self) -> List[Dict[str, Any]]:
+        """List metadata summary for all versions."""
+        return [
+            {
+                "version": v.version,
+                "reason": v.reason,
+                "author": v.author,
+                "length": len(v.instructions),
+                "timestamp": v.timestamp,
+            }
+            for v in self._history
+        ]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize state and history to dictionary."""
+        return {
+            "session_id": self.session_id,
+            "history": [v.to_dict() for v in self._history],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> VersionedHarnessState:
+        """Construct state from dictionary."""
+        state = cls(session_id=data.get("session_id", "default"), auto_save=False)
+        hist_data = data.get("history", [])
+        if isinstance(hist_data, list) and hist_data:
+            state._history = [
+                HarnessVersion.from_dict(v) for v in hist_data if isinstance(v, dict)
+            ]
+        return state
+
+    def save(self, path: Optional[Union[str, Path]] = None) -> Path:
+        """Save history to disk."""
+        target = Path(path) if path else self.storage_file
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        except OSError as e:
+            logger.warning("Failed to save harness state history: %s", e)
+        return target
+
+    def load(self, path: Optional[Union[str, Path]] = None) -> bool:
+        """Load history from disk."""
+        target = Path(path) if path else self.storage_file
+        if not target.exists():
+            return False
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+            hist_data = data.get("history", [])
+            if isinstance(hist_data, list) and hist_data:
+                self._history = [
+                    HarnessVersion.from_dict(v)
+                    for v in hist_data
+                    if isinstance(v, dict)
+                ]
+                return True
+        except (OSError, ValueError) as e:
+            logger.warning("Failed to load harness state history: %s", e)
+        return False
+
+    def execute_command(self, action: str, *args: str) -> str:
+        """Execute a harness management CLI action."""
+        act = (action or "").strip().lower()
+        if act == "update" and args:
+            instr = args[0]
+            reason = args[1] if len(args) > 1 else ""
+            ver = self.update(instr, reason=reason)
+            return f"Updated harness to v{ver.version}: {ver.reason}"
+        elif act in ("rollback", "revert"):
+            target = int(args[0]) if args and args[0].isdigit() else None
+            reason = args[1] if len(args) > 1 else ""
+            try:
+                ver = self.rollback(target_version=target, reason=reason)
+                return f"Rolled back harness to v{ver.version}: {ver.reason}"
+            except ValueError as e:
+                return f"Rollback failed: {e}"
+        elif act in ("list", "history"):
+            return json.dumps(self.list_versions(), indent=2)
+        elif act == "current":
+            return self.current_instructions
+        elif (
+            act == "diff" and len(args) >= 2 and args[0].isdigit() and args[1].isdigit()
+        ):
+            return self.diff(int(args[0]), int(args[1]))
+        elif act == "show" and args and args[0].isdigit():
+            snap = self.get_version(int(args[0]))
+            return snap.instructions if snap else f"Version {args[0]} not found."
+        else:
+            return "Usage: harness {update|rollback|list|current|diff|show} [args...]"

--- a/run_agent.py
+++ b/run_agent.py
@@ -4929,6 +4929,46 @@ class AIAgent:
             return store.list_vars()
         return []
 
+    @property
+    def harness_state(self) -> Optional[Any]:
+        """Access the attached VersionedHarnessState instance."""
+        if not hasattr(self, "_harness_state") or self._harness_state is None:
+            try:
+                from evolution.lib.versioned_harness_state import VersionedHarnessState
+
+                init_prompt = getattr(self, "system_prompt", "") or ""
+                self._harness_state = VersionedHarnessState(
+                    initial_instructions=init_prompt, session_id=self.session_id
+                )
+            except Exception:
+                self._harness_state = None
+        return self._harness_state
+
+    def update_harness_instructions(
+        self, instructions: str, reason: str = ""
+    ) -> Optional[Any]:
+        """Update operating instructions with a new version."""
+        hs = self.harness_state
+        if hs:
+            return hs.update(instructions, reason=reason)
+        return None
+
+    def rollback_harness_instructions(
+        self, target_version: Optional[int] = None, reason: str = ""
+    ) -> Optional[Any]:
+        """Rollback operating instructions to a previous version."""
+        hs = self.harness_state
+        if hs:
+            return hs.rollback(target_version=target_version, reason=reason)
+        return None
+
+    def get_harness_instructions(self) -> str:
+        """Get current versioned harness instructions."""
+        hs = self.harness_state
+        if hs:
+            return hs.current_instructions
+        return getattr(self, "system_prompt", "") or ""
+
     def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
         """Forwarder — see ``agent.system_prompt.build_system_prompt_parts``."""
         from agent.system_prompt import build_system_prompt_parts

--- a/tests/evolution/test_versioned_harness_state.py
+++ b/tests/evolution/test_versioned_harness_state.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""Tests for self-refining harness state with versioned rollback (Issue #2497, Slice B)."""
+
+from __future__ import annotations
+
+import pytest
+
+from evolution.lib.versioned_harness_state import (
+    HarnessVersion,
+    VersionedHarnessState,
+    get_default_harness_state_dir,
+)
+from run_agent import AIAgent
+
+
+class TestVersionedHarnessState:
+    def test_init_initial_version(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="You are a helpful coding assistant.",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        assert state.current_version == 1
+        assert state.current_instructions == "You are a helpful coding assistant."
+        assert len(state.history) == 1
+        assert state.history[0].version == 1
+
+    def test_update_version(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="Base prompt",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        v2 = state.update("Revised prompt: be concise", reason="User requested brevity")
+        assert v2.version == 2
+        assert state.current_version == 2
+        assert state.current_instructions == "Revised prompt: be concise"
+        assert len(state.history) == 2
+
+    def test_rollback_to_previous_version(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="V1 Instructions",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        state.update("V2 Broken Instructions", reason="Flawed edit")
+        assert state.current_version == 2
+
+        # Rollback to previous version (V1)
+        v3 = state.rollback(reason="Revert broken instructions")
+        assert v3.version == 3
+        assert state.current_version == 3
+        assert state.current_instructions == "V1 Instructions"
+        assert "Rollback to v1" in v3.reason
+
+    def test_rollback_to_specific_version(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="Base v1",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        state.update("Edit v2", reason="step 2")
+        state.update("Edit v3", reason="step 3")
+        state.update("Edit v4", reason="step 4")
+
+        # Rollback specifically to v2
+        v5 = state.rollback(target_version=2, reason="Jump back to v2")
+        assert v5.version == 5
+        assert state.current_instructions == "Edit v2"
+
+    def test_rollback_invalid_raises(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="V1",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        with pytest.raises(ValueError, match="Cannot rollback"):
+            state.rollback()
+
+        state.update("V2")
+        with pytest.raises(ValueError, match="Target version 99 does not exist"):
+            state.rollback(target_version=99)
+
+    def test_diff_between_versions(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="Line 1\nLine 2\n",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        state.update("Line 1\nLine 2 modified\nLine 3\n", reason="Add line 3")
+        diff_text = state.diff(1, 2)
+        assert "-Line 2" in diff_text
+        assert "+Line 2 modified" in diff_text
+        assert "+Line 3" in diff_text
+
+    def test_list_versions_and_metadata(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="Init",
+            session_id="test_harness_sess",
+            storage_dir=tmp_path,
+        )
+        state.update("Second", reason="second version")
+        summary = state.list_versions()
+        assert len(summary) == 2
+        assert summary[0]["version"] == 1
+        assert summary[1]["version"] == 2
+        assert summary[1]["reason"] == "second version"
+
+    def test_persistence_and_reload(self, tmp_path):
+        state1 = VersionedHarnessState(
+            initial_instructions="Saved instructions",
+            session_id="persist_harness_sess",
+            storage_dir=tmp_path,
+        )
+        state1.update("Updated instructions", reason="Persist check")
+
+        # Reload from disk in a new instance
+        state2 = VersionedHarnessState(
+            initial_instructions="Different default",
+            session_id="persist_harness_sess",
+            storage_dir=tmp_path,
+        )
+        assert state2.current_version == 2
+        assert state2.current_instructions == "Updated instructions"
+
+    def test_execute_command(self, tmp_path):
+        state = VersionedHarnessState(
+            initial_instructions="CLI init",
+            session_id="cli_harness_sess",
+            storage_dir=tmp_path,
+        )
+        up_msg = state.execute_command("update", "CLI updated instructions", "CLI edit")
+        assert "Updated harness to v2" in up_msg
+        assert state.execute_command("current") == "CLI updated instructions"
+
+        rb_msg = state.execute_command("rollback", "1")
+        assert "Rolled back harness to v3" in rb_msg
+        assert state.execute_command("current") == "CLI init"
+
+        hist_json = state.execute_command("list")
+        assert '"version": 1' in hist_json
+
+
+class TestAIAgentHarnessIntegration:
+    def test_agent_harness_update_and_rollback(self, tmp_path):
+        agent = AIAgent(
+            api_key="mock-key",
+            base_url="http://localhost:8080/v1",
+            model="test-model",
+            quiet_mode=True,
+            session_id="agent_harness_sess",
+        )
+        init_instr = agent.get_harness_instructions()
+
+        # Update instructions mid-task
+        v2 = agent.update_harness_instructions(
+            "New operating rules: write Python 3.11 typed code only",
+            reason="Adopt strict typing",
+        )
+        assert v2 is not None
+        assert v2.version == 2
+        assert (
+            agent.get_harness_instructions()
+            == "New operating rules: write Python 3.11 typed code only"
+        )
+
+        # Rollback bad instruction edit
+        v3 = agent.rollback_harness_instructions(
+            reason="Revert strict typing for legacy project"
+        )
+        assert v3 is not None
+        assert v3.version == 3
+        assert agent.get_harness_instructions() == init_instr


### PR DESCRIPTION
## Summary
Implements Slice B of self-refining harness state with versioned rollback (parent #2478, closes #2497).

## Changes
- **VersionedHarnessState**: Implemented `VersionedHarnessState` and `HarnessVersion` in `evolution/lib/versioned_harness_state.py` supporting versioned instruction evolution, mid-task rollback to previous or specific versions, diff inspection, and persistence.
- **AIAgent Integration**: Added `harness_state`, `update_harness_instructions`, `rollback_harness_instructions`, and `get_harness_instructions` in `run_agent.py`.
- **Tests**: Added full unit and integration tests in `tests/evolution/test_versioned_harness_state.py`.

Fixes #2497