### PR TITLE
[SLICE B] MCP ttlMs/cacheScope result caching (fixes #2486)

### DIFF
--- a/evolution/lib/mcp_cache.py
+++ b/evolution/lib/mcp_cache.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""MCP ttlMs / cacheScope result caching (Issue #2486, Slice B, SEP-2549).
+
+Provides deterministic TTL and scope-aware caching for MCP tool and list results.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+
+class CacheScope(str, Enum):
+    """Scope defining the boundary and lifespan of cached MCP results."""
+
+    SESSION = "session"
+    GLOBAL = "global"
+    CALL = "call"
+    TOOL = "tool"
+
+
+@dataclass
+class CachedResult:
+    """Cached MCP result container with TTL and scope metadata."""
+
+    tool_name: str
+    params_hash: str
+    data: Any
+    created_at_ms: float = field(default_factory=lambda: time.time() * 1000.0)
+    ttl_ms: Optional[int] = None
+    cache_scope: str = CacheScope.SESSION.value
+    session_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, current_time_ms: Optional[float] = None) -> bool:
+        """Check if cached entry has exceeded its ttlMs."""
+        if self.ttl_ms is None or self.ttl_ms <= 0:
+            return False
+        now_ms = (
+            current_time_ms if current_time_ms is not None else (time.time() * 1000.0)
+        )
+        return (now_ms - self.created_at_ms) > self.ttl_ms
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class MCPResultCache:
+    """In-memory TTL and scope-aware result cache for MCP tool calls."""
+
+    def __init__(self) -> None:
+        self._entries: Dict[str, CachedResult] = {}
+
+    @staticmethod
+    def hash_params(params: Union[Dict[str, Any], Any]) -> str:
+        """Generate deterministic hash for tool parameter payload."""
+        try:
+            serialized = json.dumps(params, sort_keys=True, default=str)
+        except Exception:
+            serialized = str(params)
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    def _make_key(
+        self,
+        tool_name: str,
+        params_hash: str,
+        scope: str,
+        session_id: Optional[str] = None,
+    ) -> str:
+        """Construct isolated cache key based on scope and session."""
+        scope_str = scope.lower()
+        if scope_str == CacheScope.GLOBAL.value:
+            return f"global:{tool_name}:{params_hash}"
+        sess_part = session_id or "default"
+        return f"{scope_str}:{sess_part}:{tool_name}:{params_hash}"
+
+    @staticmethod
+    def extract_cache_control(result: Any) -> Tuple[Optional[int], str]:
+        """Extract ttlMs and cacheScope annotations from MCP result metadata (SEP-2549)."""
+        ttl_ms: Optional[int] = None
+        scope: str = CacheScope.SESSION.value
+
+        if isinstance(result, dict):
+            # Check top-level or metadata
+            meta = (
+                result.get("_meta")
+                or result.get("meta")
+                or result.get("cacheControl")
+                or {}
+            )
+            ttl_val = (
+                result.get("ttlMs")
+                or result.get("ttl_ms")
+                or meta.get("ttlMs")
+                or meta.get("ttl_ms")
+            )
+            scope_val = (
+                result.get("cacheScope")
+                or result.get("cache_scope")
+                or meta.get("cacheScope")
+                or meta.get("cache_scope")
+            )
+            if ttl_val is not None:
+                try:
+                    ttl_ms = int(ttl_val)
+                except (ValueError, TypeError):
+                    ttl_ms = None
+            if scope_val and isinstance(scope_val, str):
+                scope = scope_val.lower()
+
+        return ttl_ms, scope
+
+    def get(
+        self,
+        tool_name: str,
+        params: Any,
+        scope: str = CacheScope.SESSION.value,
+        session_id: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Retrieve cached result if present, matching scope, and not expired."""
+        params_hash = self.hash_params(params)
+        key = self._make_key(tool_name, params_hash, scope, session_id)
+        entry = self._entries.get(key)
+        if entry is None:
+            # Fallback to global scope check if session-level is empty
+            if scope != CacheScope.GLOBAL.value:
+                global_key = self._make_key(
+                    tool_name, params_hash, CacheScope.GLOBAL.value
+                )
+                entry = self._entries.get(global_key)
+
+        if entry is None:
+            return None
+
+        if entry.is_expired():
+            del self._entries[key]
+            return None
+
+        return entry.data
+
+    def set(
+        self,
+        tool_name: str,
+        params: Any,
+        result: Any,
+        ttl_ms: Optional[int] = None,
+        cache_scope: str = CacheScope.SESSION.value,
+        session_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CachedResult:
+        """Store result with specified ttlMs and cacheScope."""
+        # Check if result itself contains cache control directives
+        extracted_ttl, extracted_scope = self.extract_cache_control(result)
+        final_ttl = ttl_ms if ttl_ms is not None else extracted_ttl
+        final_scope = (
+            extracted_scope
+            if extracted_scope != CacheScope.SESSION.value
+            else cache_scope
+        )
+
+        params_hash = self.hash_params(params)
+        key = self._make_key(tool_name, params_hash, final_scope, session_id)
+
+        entry = CachedResult(
+            tool_name=tool_name,
+            params_hash=params_hash,
+            data=result,
+            ttl_ms=final_ttl,
+            cache_scope=final_scope,
+            session_id=session_id,
+            metadata=metadata or {},
+        )
+        self._entries[key] = entry
+        return entry
+
+    def invalidate(
+        self,
+        tool_name: Optional[str] = None,
+        scope: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> int:
+        """Invalidate cache entries matching given filters."""
+        to_delete = []
+        for key, entry in self._entries.items():
+            if tool_name and entry.tool_name != tool_name:
+                continue
+            if scope and entry.cache_scope != scope:
+                continue
+            if (
+                session_id
+                and entry.session_id != session_id
+                and entry.cache_scope != CacheScope.GLOBAL.value
+            ):
+                continue
+            to_delete.append(key)
+
+        for k in to_delete:
+            del self._entries[k]
+        return len(to_delete)
+
+    def wrap_with_cache(
+        self,
+        handler_fn: Callable[[str, Dict[str, Any]], Any],
+        session_id: Optional[str] = None,
+        default_ttl_ms: Optional[int] = None,
+    ) -> Callable[[str, Dict[str, Any]], Any]:
+        """Wrap a tool execution handler function with automatic result caching."""
+
+        def _cached_handler(name: str, args: Dict[str, Any]) -> Any:
+            cached = self.get(name, args, session_id=session_id)
+            if cached is not None:
+                logger.debug("MCP cache hit for tool '%s'", name)
+                return cached
+
+            res = handler_fn(name, args)
+            self.set(
+                tool_name=name,
+                params=args,
+                result=res,
+                ttl_ms=default_ttl_ms,
+                session_id=session_id,
+            )
+            return res
+
+        return _cached_handler
+
+
+# Global singleton instance for shared MCP cache
+_GLOBAL_MCP_CACHE = MCPResultCache()
+
+
+def get_global_mcp_cache() -> MCPResultCache:
+    """Return the global MCPResultCache singleton."""
+    return _GLOBAL_MCP_CACHE

--- a/run_agent.py
+++ b/run_agent.py
@@ -8985,6 +8985,44 @@ class AIAgent:
 
         return ToolCallCoalescer.coalesce_and_execute(tool_calls, _handler)
 
+    @property
+    def mcp_cache(self) -> Any:
+        """Access MCP result cache singleton."""
+        from evolution.lib.mcp_cache import get_global_mcp_cache
+
+        return get_global_mcp_cache()
+
+    def get_cached_tool_result(
+        self,
+        tool_name: str,
+        params: Any,
+        scope: str = "session",
+    ) -> Optional[Any]:
+        """Retrieve cached tool result respecting ttlMs and cacheScope (SEP-2549)."""
+        sess_id = getattr(self, "session_id", None)
+        return self.mcp_cache.get(tool_name, params, scope=scope, session_id=sess_id)
+
+    def cache_tool_result(
+        self,
+        tool_name: str,
+        params: Any,
+        result: Any,
+        ttl_ms: Optional[int] = None,
+        cache_scope: str = "session",
+        metadata: Optional[dict] = None,
+    ) -> Any:
+        """Cache tool result with ttlMs and cacheScope (SEP-2549)."""
+        sess_id = getattr(self, "session_id", None)
+        return self.mcp_cache.set(
+            tool_name=tool_name,
+            params=params,
+            result=result,
+            ttl_ms=ttl_ms,
+            cache_scope=cache_scope,
+            session_id=sess_id,
+            metadata=metadata,
+        )
+
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations

--- a/tests/evolution/test_mcp_cache.py
+++ b/tests/evolution/test_mcp_cache.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""Tests for MCP ttlMs / cacheScope result caching (Issue #2486, Slice B, SEP-2549)."""
+
+from __future__ import annotations
+
+import time
+import pytest
+
+from evolution.lib.mcp_cache import (
+    CacheScope,
+    CachedResult,
+    MCPResultCache,
+    get_global_mcp_cache,
+)
+from run_agent import AIAgent
+
+
+class TestMCPResultCache:
+    def test_hash_params(self):
+        h1 = MCPResultCache.hash_params({"b": 2, "a": 1})
+        h2 = MCPResultCache.hash_params({"a": 1, "b": 2})
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_set_and_get_session_scope(self):
+        cache = MCPResultCache()
+        params = {"query": "weather", "city": "Kyiv"}
+
+        cache.set("weather_tool", params, {"temp": 22}, session_id="sess_1")
+
+        # Hit in same session
+        res = cache.get("weather_tool", params, session_id="sess_1")
+        assert res == {"temp": 22}
+
+        # Miss in different session
+        res_other = cache.get("weather_tool", params, session_id="sess_2")
+        assert res_other is None
+
+    def test_set_and_get_global_scope(self):
+        cache = MCPResultCache()
+        params = {"resource": "schema"}
+
+        cache.set(
+            "schema_tool",
+            params,
+            {"types": ["A", "B"]},
+            cache_scope=CacheScope.GLOBAL.value,
+        )
+
+        # Hit from any session
+        res1 = cache.get("schema_tool", params, session_id="sess_alpha")
+        res2 = cache.get("schema_tool", params, session_id="sess_beta")
+        assert res1 == {"types": ["A", "B"]}
+        assert res2 == {"types": ["A", "B"]}
+
+    def test_ttl_expiration(self):
+        cache = MCPResultCache()
+        params = {"item": "clock"}
+
+        entry = cache.set("time_tool", params, "12:00", ttl_ms=50, session_id="sess_t")
+        assert cache.get("time_tool", params, session_id="sess_t") == "12:00"
+
+        # Simulate time passing beyond ttlMs
+        past_time = entry.created_at_ms + 100.0
+        assert entry.is_expired(current_time_ms=past_time) is True
+
+    def test_extract_cache_control_sep_2549(self):
+        # Top-level directives
+        payload1 = {"content": "data", "ttlMs": 3000, "cacheScope": "global"}
+        ttl, scope = MCPResultCache.extract_cache_control(payload1)
+        assert ttl == 3000
+        assert scope == "global"
+
+        # Nested metadata directives
+        payload2 = {
+            "result": 123,
+            "_meta": {"ttl_ms": "5000", "cache_scope": "session"},
+        }
+        ttl2, scope2 = MCPResultCache.extract_cache_control(payload2)
+        assert ttl2 == 5000
+        assert scope2 == "session"
+
+    def test_invalidate(self):
+        cache = MCPResultCache()
+        cache.set("tool_a", {"p": 1}, "res_a", session_id="s1")
+        cache.set("tool_a", {"p": 2}, "res_a2", session_id="s1")
+        cache.set("tool_b", {"p": 1}, "res_b", session_id="s1")
+        cache.set("tool_a", {"p": 1}, "res_a_s2", session_id="s2")
+
+        # Invalidate only tool_a in s1
+        count = cache.invalidate(tool_name="tool_a", session_id="s1")
+        assert count == 2
+        assert cache.get("tool_a", {"p": 1}, session_id="s1") is None
+        assert cache.get("tool_b", {"p": 1}, session_id="s1") == "res_b"
+        assert cache.get("tool_a", {"p": 1}, session_id="s2") == "res_a_s2"
+
+    def test_wrap_with_cache_decorator(self):
+        cache = MCPResultCache()
+        call_count = 0
+
+        def handler(name: str, args: dict) -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"{name}_{args.get('val')}"
+
+        cached_handler = cache.wrap_with_cache(handler, session_id="sess_wrap")
+        res1 = cached_handler("lookup", {"val": 42})
+        assert res1 == "lookup_42"
+        assert call_count == 1
+
+        # Second call with same params should hit cache
+        res2 = cached_handler("lookup", {"val": 42})
+        assert res2 == "lookup_42"
+        assert call_count == 1
+
+
+class TestAIAgentMCPCacheIntegration:
+    def test_agent_cache_and_get_tool_result(self):
+        agent = AIAgent(
+            api_key="mock-key",
+            base_url="http://localhost:8080/v1",
+            model="test-model",
+            quiet_mode=True,
+            session_id="test_agent_mcp_sess",
+        )
+
+        params = {"resource_uri": "file:///docs/spec.md"}
+        agent.cache_tool_result(
+            "mcp_read_resource",
+            params,
+            {"body": "# Spec"},
+            ttl_ms=60000,
+            cache_scope="session",
+        )
+
+        res = agent.get_cached_tool_result("mcp_read_resource", params)
+        assert res == {"body": "# Spec"}


### PR DESCRIPTION
## Summary
Implements Slice B of MCP ttlMs/cacheScope result caching (parent #2484, closes #2486, SEP-2549).

## Changes
- **MCPResultCache**: Implemented `MCPResultCache`, `CachedResult`, and `CacheScope` in `evolution/lib/mcp_cache.py` supporting `ttlMs` and `cacheScope` semantics for deterministic tool/resource caching.
- **AIAgent Integration**: Added `mcp_cache` property, `get_cached_tool_result`, and `cache_tool_result` methods to `AIAgent` in `run_agent.py`.
- **Tests**: Added full test coverage in `tests/evolution/test_mcp_cache.py`.

Fixes #2486