### PR TITLE
feat: claim-extraction in rubric-judge output schema (Closes #2513)

### DIFF
--- a/scripts/evolution_rubric_judge.py
+++ b/scripts/evolution_rubric_judge.py
@@ -28,6 +28,7 @@ Scorecard schema (both graders produce the same shape):
     "total_max": 52,
     "overall_percentage": float,
     "flags": [str],
+    "claims": [{"statement": str, "source": str, "location": str}],
   }
 """
 
@@ -220,6 +221,71 @@ def _safe_int(v: Any, default: int = 0) -> int:
         return int(v) if v is not None else default
     except (TypeError, ValueError):
         return default
+
+
+# Claim extraction (#2482 Slice A): pull discrete, verifiable assertions out of
+# the stage outputs so a downstream triage stage can classify each one against
+# ground truth instead of trusting a self-assigned aggregate score.
+
+_CLAIM_BULLET_RE = re.compile(
+    r"^[ \t]*(?:[-*+]|[0-9]+[.)])[ \t]+(?P<stmt>\S.*)$", re.MULTILINE
+)
+_CLAIM_HEADING_RE = re.compile(
+    r"^[ \t]*(?:#{1,4})[ \t]+(?P<stmt>\S.*)$", re.MULTILINE
+)
+
+
+def _claim(source: str, location: str, statement: str) -> Dict[str, str]:
+    return {"statement": statement, "source": source, "location": location}
+
+
+def _claims_from_text(source: str, text: str) -> List[Dict[str, str]]:
+    """Bullet/list items and headings become claims, keyed by source + line."""
+    claims: List[Dict[str, str]] = []
+    seen: set[str] = set()
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        m = _CLAIM_BULLET_RE.match(line) or _CLAIM_HEADING_RE.match(line)
+        if not m:
+            continue
+        statement = m.group("stmt").strip()
+        if statement and statement not in seen:
+            seen.add(statement)
+            claims.append(_claim(source, f"line {lineno}", statement))
+    return claims
+
+
+def _claims_from_json(source: str, data: Any) -> List[Dict[str, str]]:
+    """Issue titles / merged count / proposed issues become claims."""
+    d = _as_dict(data) if data is not None else {}
+    claims: List[Dict[str, str]] = []
+    for idx, issue in enumerate(d.get("issues") or []):
+        if isinstance(issue, dict) and issue.get("title"):
+            title = str(issue["title"]).strip()
+            score = issue.get("priority_score")
+            stmt = title if score is None else f"{title} (priority {score})"
+            claims.append(_claim(source, f"issues[{idx}]", stmt))
+    if "merged_count" in d:
+        stmt = f"merged {_safe_int(d.get('merged_count'))} PR(s)"
+        claims.append(_claim(source, "merged_count", stmt))
+    for idx, prop in enumerate(d.get("new_issues_proposed") or []):
+        if isinstance(prop, dict):
+            stmt = str(prop.get("title") or "").strip()
+        else:
+            stmt = str(prop).strip()
+        if stmt:
+            claims.append(_claim(source, f"new_issues_proposed[{idx}]", stmt))
+    return claims
+
+
+def extract_claims(outputs: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Deterministic claim list across all stage outputs (pure regex/JSON)."""
+    claims: List[Dict[str, str]] = []
+    for source, content in outputs.items():
+        if isinstance(content, str):
+            claims.extend(_claims_from_text(source, content))
+        elif isinstance(content, dict):
+            claims.extend(_claims_from_json(source, content))
+    return claims
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -632,6 +698,19 @@ class StrictRubricJudgeGrader:
                     f"({dim_pct:.0f}%) — stage nearly absent or very poor"
                 )
 
+        # Extract discrete claims from the same raw outputs (#2482 Slice A):
+        # a machine-readable claim list downstream triage can verify against
+        # ground truth, instead of trusting the aggregate score alone.
+        claims = extract_claims(
+            {
+                "research": research_md,
+                "issues": issues_json,
+                "introspection": introspection_data,
+                "implementation": implementation_md,
+                "integration": integration_json,
+            }
+        )
+
         return {
             "cycle_date": date,
             "grader": "strict",
@@ -640,6 +719,7 @@ class StrictRubricJudgeGrader:
             "total_max": total_max,
             "overall_percentage": pct,
             "flags": flags,
+            "claims": claims,
         }
 
 

--- a/tests/scripts/test_evolution_rubric_judge.py
+++ b/tests/scripts/test_evolution_rubric_judge.py
@@ -1,0 +1,106 @@
+"""Tests for claim-extraction in evolution_rubric_judge.py (#2482 Slice A / #2513).
+
+Covers: extract_claims (markdown + JSON + determinism) and the ``claims`` key
+now emitted by StrictRubricJudgeGrader.score().
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_rubric_judge import (  # noqa: E402
+    StrictRubricJudgeGrader,
+    extract_claims,
+)
+
+
+class TestExtractClaimsFromText:
+    def test_bullets_and_headings_are_claims(self):
+        md = "## Findings\n\n- Added a memory gate\n- Fixed stale analysis\n\n1. Merged two PRs\n"
+        claims = extract_claims({"implementation": md})
+        statements = [c["statement"] for c in claims]
+        assert "Added a memory gate" in statements
+        assert "Fixed stale analysis" in statements
+        assert "Merged two PRs" in statements
+
+    def test_source_and_location_are_recorded(self):
+        md = "- Wired the gate into run_agent.py\n"
+        claims = extract_claims({"implementation": md})
+        assert claims == [
+            {
+                "statement": "Wired the gate into run_agent.py",
+                "source": "implementation",
+                "location": "line 1",
+            }
+        ]
+
+    def test_duplicate_statements_deduplicated(self):
+        md = "- Same claim\n- Same claim\n"
+        claims = extract_claims({"implementation": md})
+        assert len(claims) == 1
+
+    def test_plain_paragraphs_are_not_claims(self):
+        md = "This is a plain narrative paragraph.\n"
+        assert extract_claims({"implementation": md}) == []
+
+
+class TestExtractClaimsFromJson:
+    def test_issue_titles_are_claims(self):
+        data = {
+            "issues": [
+                {"title": "Add a dead-code gate", "priority_score": 1.78},
+                {"title": "Fix the stale gate"},
+            ]
+        }
+        claims = extract_claims({"issues": data})
+        statements = {c["statement"] for c in claims}
+        assert "Add a dead-code gate (priority 1.78)" in statements
+        assert "Fix the stale gate" in statements
+
+    def test_merged_count_is_a_claim(self):
+        claims = extract_claims({"integration": {"merged_count": 3}})
+        assert any("merged 3 PR(s)" in c["statement"] for c in claims)
+
+    def test_none_input_yields_no_claims(self):
+        assert extract_claims({"issues": None}) == []
+
+
+class TestExtractClaimsDeterminism:
+    def test_identical_input_yields_identical_output(self):
+        outputs = {
+            "research": "## Ideas\n\n- Proposal A\n- Proposal B\n",
+            "issues": {"issues": [{"title": "Issue one"}]},
+        }
+        assert extract_claims(outputs) == extract_claims(outputs)
+
+
+class TestScorecardIncludesClaims:
+    def _write_stage(self, root: Path, subdir: str, date: str, name: str, text: str) -> None:
+        d = root / subdir
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{date}.{name}").write_text(text, encoding="utf-8")
+
+    def test_score_emits_claims_key(self, tmp_path):
+        date = "2026-08-16"
+        self._write_stage(
+            tmp_path, "implementation", date, "md",
+            "# Report\n\n- Implemented the gate\n- Closes #123\n",
+        )
+        self._write_stage(tmp_path, "research", date, "md", "## Findings\n\n- Proposal A\n")
+        (tmp_path / "issues").mkdir(exist_ok=True)
+        (tmp_path / "issues" / f"{date}.json").write_text(
+            json.dumps({"issues": [{"title": "Issue one", "priority_score": 1.5}]}),
+            encoding="utf-8",
+        )
+
+        scorecard = StrictRubricJudgeGrader().score(date, tmp_path)
+
+        assert "claims" in scorecard
+        statements = {c["statement"] for c in scorecard["claims"]}
+        assert "Implemented the gate" in statements
+        assert "Proposal A" in statements
+        assert "Issue one (priority 1.5)" in statements


### PR DESCRIPTION
Automated evolution PR for issue #2513 (Slice A of #2482).

## What
`StrictRubricJudgeGrader.score()` now emits a deterministic, machine-readable `claims` list alongside the aggregate score — each claim is a discrete assertion the pipeline made, as `{statement, source, location}`:

- **Markdown stages** (research/implementation): bullet/list items and headings become claims, located by `line N`.
- **JSON stages** (issues/integration/introspection): issue titles, `merged_count`, and `new_issues_proposed` become claims, located by JSON path.

Pure regex + JSON traversal — no LLM — so extraction is reproducible for identical input.

## Why
Answers the REALIZED_RATE_LOW over-optimism signal: a self-assigned aggregate score can't be verified, but discrete claims can be triaged downstream (Slice B: verified / falsified / toy-scale / no-evidence) against ground truth.

## Validation (local)
- `ruff check` on changed files — passes (the CI blocking lint).
- `python -m pytest tests/scripts/test_evolution_rubric_judge.py` — 9/9 pass.
- Diff: 186 insertions / 0 deletions (under the 200-line self-merge cap).

Closes #2513