### PR TITLE
[SLICE A] Deterministic claim-extraction in rubric-judge output schema (fixes #2513)

### DIFF
--- a/scripts/evolution_rubric_judge.py
+++ b/scripts/evolution_rubric_judge.py
@@ -640,6 +640,11 @@ class StrictRubricJudgeGrader:
             "total_max": total_max,
             "overall_percentage": pct,
             "flags": flags,
+            "claims": extract_claims(
+                ("research", research_md),
+                ("implementation", implementation_md),
+                ("integration", json.dumps(integration_json)),
+            ),
         }
 
 
@@ -729,6 +734,121 @@ class AgentJudgeGrader:
         scorecard["grader"] = "agent"
         scorecard["narratives"] = narratives
         return scorecard
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Claim extraction — machine-readable, deterministic (#2482 Slice A)
+# ──────────────────────────────────────────────────────────────────────
+
+# Outcome signals marking a sentence as a claim (an asserted achievement /
+# enablement / measured result) rather than neutral prose. Kept to strong,
+# measurable words so extraction is stable and doesn't over-fire.
+_CLAIM_SIGNALS = (
+    "improve",
+    "reduced",
+    "reduce",
+    "increase",
+    "faster",
+    "speedup",
+    "latency",
+    "enables",
+    "enabled",
+    "achiev",
+    "fixes",
+    "fixed",
+    "resolves",
+    "merged",
+    "%",
+    "percent",
+    "seconds",
+    "tokens",
+    "cost",
+)
+
+_CLAIM_URL_RE = re.compile(r"https?://\S+")
+
+
+def _markdown_sections(text: str) -> List[Tuple[str, str]]:
+    """Split markdown into ``(section_header, body)`` blocks in order;
+    text before the first ``#`` header is an unnamed preamble block."""
+    blocks: List[Tuple[str, str]] = []
+    current: List[str] = []
+    current_header = ""
+    for line in text.splitlines():
+        if line.startswith("#") and line.strip("# "):
+            if current:
+                blocks.append((current_header, "\n".join(current)))
+            current_header = line.strip("# ").strip()
+            current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append((current_header, "\n".join(current)))
+    return [(h.strip(), b) for h, b in blocks if b.strip()]
+
+
+def _split_sentences(block: str) -> List[str]:
+    """Deterministic per-line sentence splitter for markdown prose."""
+    sentences: List[str] = []
+    for raw in block.splitlines():
+        raw = raw.strip().lstrip("-* \t")
+        if not raw:
+            continue
+        for p in re.split(r"(?<=[.!?])\s+(?=[A-Z\"#(])", raw):
+            p = p.strip().rstrip(".").strip()
+            if len(p) >= 20:
+                sentences.append(p)
+    return sentences
+
+
+def _is_claim_sentence(sentence: str) -> bool:
+    low = sentence.lower()
+    return any(sig in low for sig in _CLAIM_SIGNALS)
+
+
+def extract_claims(
+    *artifacts: Tuple[str, Optional[str]],
+    max_per_source: int = 12,
+) -> List[Dict[str, Any]]:
+    """Deterministically extract discrete claims from judged artifacts.
+
+    A claim is a sentence asserting an outcome (improvement, reduction,
+    enablement, a merged/fixed issue, a measured result), tagged with its
+    source stage + section and any supporting URL. Returns a machine-readable
+    list of ``{"claim", "source", "evidence_url"}`` dicts, deduplicated and
+    sorted so identical input always yields identical output (Slice A
+    determinism). ``artifacts`` are ``(stage, markdown_text)`` pairs.
+    """
+    out: List[Dict[str, Any]] = []
+    seen: set = set()
+    for stage, text in artifacts:
+        if not text:
+            continue
+        per_source = 0
+        for header, block in _markdown_sections(text):
+            for sentence in _split_sentences(block):
+                if per_source >= max_per_source:
+                    break
+                if not _is_claim_sentence(sentence):
+                    continue
+                urls = _CLAIM_URL_RE.findall(sentence)
+                key = (stage, header, sentence)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(
+                    {
+                        "claim": sentence,
+                        "source": {
+                            "stage": stage,
+                            "section": header or "preamble",
+                        },
+                        "evidence_url": urls[0] if urls else None,
+                    }
+                )
+                per_source += 1
+    out.sort(key=lambda c: (c["source"]["stage"], c["source"]["section"], c["claim"]))
+    return out
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/scripts/test_evolution_rubric_judge.py
+++ b/tests/scripts/test_evolution_rubric_judge.py
@@ -1,0 +1,65 @@
+"""Tests for deterministic claim extraction (#2482 Slice A / #2513).
+
+Slice A requires that the rubric-judge output includes a structured list of
+extracted claims (not only an aggregate score) and that extraction is
+deterministic / reproducible for identical input.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_rubric_judge import _markdown_sections, extract_claims  # noqa: E402
+
+SAMPLE = """\
+# Finding 1
+Adopting the parallel compactor improved merge latency by 52% across the
+benchmark suite. Source: https://example.com/bench.
+
+# Finding 2
+The tokenizer change reduced prompt tokens by 64%, cutting cost per run.
+Some neutral background prose with no measurable outcome here.
+"""
+
+
+def test_markdown_sections_keeps_order_and_preamble() -> None:
+    assert [h for h, _ in _markdown_sections(SAMPLE)] == ["Finding 1", "Finding 2"]
+    blocks = _markdown_sections("lead-in prose\n\n# Head\nbody text")
+    assert blocks[0][0] == "" and blocks[1][0] == "Head"
+
+
+def test_extract_claims_emits_structured_list() -> None:
+    claims = extract_claims(("research", SAMPLE))
+    assert claims and {"claim", "source", "evidence_url"} <= set(claims[0])
+    assert claims[0]["source"]["stage"] == "research"
+
+
+def test_extract_claims_picks_outcome_sentences() -> None:
+    texts = [c["claim"] for c in extract_claims(("research", SAMPLE))]
+    assert any("improved merge latency" in t for t in texts)
+    assert any("reduced prompt tokens" in t for t in texts)
+    assert not any("neutral background prose" in t for t in texts)
+
+
+def test_extract_claims_deterministic_for_identical_input() -> None:
+    a = extract_claims(("r", SAMPLE), ("i", "# X\nFixed issue #7."))
+    b = extract_claims(("r", SAMPLE), ("i", "# X\nFixed issue #7."))
+    assert a == b
+
+
+def test_extract_claims_dedupes_and_sorts() -> None:
+    text = (
+        "## A\nSwitching the index improved lookup speed by 30% overall.\n\n"
+        "## B\nSwitching the index improved lookup speed by 30% overall."
+    )
+    claims = extract_claims(("research", text))
+    assert [c["source"]["section"] for c in claims] == ["A", "B"]
+
+
+def test_extract_claims_ignores_none_and_empty() -> None:
+    assert extract_claims(("research", None), ("implementation", "")) == []


### PR DESCRIPTION
## Summary
Slice A of #2482. The evolution rubric-judge now emits a structured, machine-readable `claims` list alongside the aggregate score. Each claim is a sentence asserting an outcome (improvement, reduction, enablement, a fixed/merged issue, a measured result), tagged with its source stage + section and any supporting URL.

## Scope (matches #2513)
- Extend `evolution_rubric_judge.py` output schema — did not rewrite the judge.
- Claims derived deterministically from research, implementation, and integration artifacts.
- Backward-compatible: all prior scorecard keys (`cycle_date`, `grader`, `dimensions`, `total_score`, `total_max`, `overall_percentage`, `flags`) unchanged; `claims` added.

## Acceptance criteria
- [x] Rubric-judge output includes a structured list of extracted claims, not only one aggregate score.
- [x] Claim extraction is deterministic / reproducible for identical input (dedup + sort by source/claim; verified by test).

## Constraints honored
- Diff ≤ 200 lines (187 added).
- Narrow-waist: extended the existing `evolution_rubric_judge.py` output schema only.
- No new `*_gate.py`; only touches the rubric judge + its test.

## Tests
- `tests/scripts/test_evolution_rubric_judge.py` — 6 tests (structure, outcome filtering, determinism, dedup/sort, empty handling, markdown sections). All pass; `ruff check` clean.

Fixes #2513 (part of #2482).