### PR TITLE
feat: tag CI failures with the MAST 14-mode taxonomy (Closes #2523)

### DIFF
--- a/scripts/evolution_ci_diagnosis.py
+++ b/scripts/evolution_ci_diagnosis.py
@@ -117,6 +117,94 @@ _COMPLEX_PATTERNS: List[Tuple[str, str]] = [
 ]
 
 # -----------------------------------------------------------------------------
+# MAST failure taxonomy (arXiv:2503.13657) — adopted as the tagging rubric (#2523)
+# -----------------------------------------------------------------------------
+# 14 failure modes in 3 categories. Each diagnosed failure is tagged with one
+# mode (in addition to its free-form narrative) so recurrence is measurable by
+# mode ("incorrect-verification dropped N%") instead of by narrative.
+
+MAST_CATEGORIES: Dict[str, str] = {
+    "1": "system-design",
+    "2": "inter-agent-misalignment",
+    "3": "task-verification",
+}
+
+MAST_FAILURE_MODES: Dict[str, str] = {
+    "1.1": "Disobey Task Specification",
+    "1.2": "Disobey Role Specification",
+    "1.3": "Step Repetition",
+    "1.4": "Loss of Conversation History",
+    "1.5": "Unaware of Termination",
+    "2.1": "Conversation Reset",
+    "2.2": "Fail to Ask for Clarification",
+    "2.3": "Task Derailment",
+    "2.4": "Information Withholding",
+    "2.5": "Ignored Other Agent's Input",
+    "2.6": "Reasoning-Action Mismatch",
+    "3.1": "Premature Termination",
+    "3.2": "No or Incomplete Verification",
+    "3.3": "Incorrect Verification",
+}
+
+# Deterministic error_class -> MAST mode. The error_class names a failure
+# family the existing patterns already classify; this maps each to its most
+# likely mode.
+_ERROR_CLASS_TO_MAST: Dict[str, str] = {
+    "assertion-error": "3.3",
+    "test-failure": "3.3",
+    "test-error": "3.3",
+    "pytest-error": "3.3",
+    "timeout": "3.1",
+    "exit-code": "3.1",
+    "recursion-error": "1.3",
+    "syntax-error": "2.6",
+    "indentation-error": "2.6",
+    "type-error": "2.6",
+    "value-error": "2.6",
+    "key-error": "2.6",
+    "index-error": "2.6",
+    "attribute-error": "2.6",
+    "subprocess-error": "2.6",
+    "import-error": "1.1",
+    "module-not-found": "1.1",
+    "permission-error": "1.1",
+    "connection-error": "1.4",
+}
+
+# High-signal message keywords that override the coarse error_class map.
+_MAST_MESSAGE_HINTS: Tuple[Tuple[str, str], ...] = (
+    ("timeout", "3.1"),
+    ("terminat", "3.1"),
+    ("premature", "3.1"),
+    ("assert", "3.3"),
+    ("verif", "3.3"),
+    ("repetit", "1.3"),
+    ("conversation history", "1.4"),
+    ("no module named", "1.1"),
+)
+
+
+def mast_mode_label(mode: str) -> str:
+    """Return a MAST mode as ``id Name`` (e.g. ``1.1 Disobey Task Specification``)."""
+    name = MAST_FAILURE_MODES.get(mode)
+    return f"{mode} {name}" if name else mode
+
+
+def classify_mast_mode(error_class: str, message: str = "") -> str:
+    """Map a diagnosed failure to a MAST mode id, deterministically.
+
+    Message keywords win over the error_class map (they are more specific);
+    unknown error classes fall back to 2.6 (reasoning-action mismatch), the
+    most common failure family. Always returns one of the 14 mode ids.
+    """
+    text = (message or "").lower()
+    for keyword, mode in _MAST_MESSAGE_HINTS:
+        if keyword in text:
+            return mode
+    return _ERROR_CLASS_TO_MAST.get(error_class, "2.6")
+
+
+# -----------------------------------------------------------------------------
 # Types
 # -----------------------------------------------------------------------------
 
@@ -147,6 +235,7 @@ class FailureDetails:
     message: str
     snippet: str
     source: str  # "annotations" or "gh-run-log"
+    mast_mode: str = ""  # MAST failure-mode id (e.g. "3.3") — #2523
 
 
 Client = Callable[
@@ -475,6 +564,7 @@ def extract_failure(
             message=message,
             snippet=snippet,
             source="annotations",
+            mast_mode=classify_mast_mode(error_class, message),
         )
 
     # 2. Fallback to gh run view --log-failed.
@@ -489,6 +579,7 @@ def extract_failure(
             message="Could not retrieve failure details (no annotations and no gh log).",
             snippet="",
             source="none",
+            mast_mode=classify_mast_mode("unknown", ""),
         )
 
     error_class, message = _extract_from_text(log_text)
@@ -507,6 +598,7 @@ def extract_failure(
         message=message,
         snippet=snippet,
         source="gh-run-log",
+        mast_mode=classify_mast_mode(error_class, message),
     )
 
 
@@ -617,6 +709,7 @@ def create_child_issue(
             "",
             f"- **Error class**: `{failure.error_class}`",
             f"- **Classification**: `{failure.classification}`",
+            f"- **MAST mode**: `{mast_mode_label(failure.mast_mode)}`",
             f"- **Source**: `{failure.source}`",
             f"- **Check run URL**: {check.details_url}",
             "",
@@ -814,6 +907,7 @@ def diagnose_prs(
                 "conclusion": "failure",
                 "classification": failure.classification,
                 "error_class": failure.error_class,
+                "mast_mode": failure.mast_mode,
                 "message": failure.message,
                 "child_issue_url": child_issue_url,
             })

--- a/tests/scripts/test_evolution_ci_diagnosis.py
+++ b/tests/scripts/test_evolution_ci_diagnosis.py
@@ -413,3 +413,56 @@ def test_create_child_issue_surfaces_unclassified_raw_excerpt(hermes_home):
     post_body = json.loads(client.calls[-1][2] or "{}")
     assert "opaque detail" in post_body["body"]
     assert "Raw log/annotation excerpt" in post_body["body"]
+
+
+# --- #2523: MAST failure-mode tagging ---
+
+
+def test_mast_failure_modes_complete():
+    assert len(diag.MAST_FAILURE_MODES) == 14
+    assert set(diag.MAST_CATEGORIES) == {"1", "2", "3"}
+
+
+def test_classify_mast_mode_by_error_class():
+    assert diag.classify_mast_mode("test-failure") == "3.3"
+    assert diag.classify_mast_mode("assertion-error") == "3.3"
+    assert diag.classify_mast_mode("timeout") == "3.1"
+    assert diag.classify_mast_mode("module-not-found") == "1.1"
+    assert diag.classify_mast_mode("syntax-error") == "2.6"
+
+
+def test_classify_mast_mode_message_hint_overrides():
+    # a "timeout" keyword in the message wins over a non-timeout error class
+    assert diag.classify_mast_mode("exit-code", "Operation timed out after 120s") == "3.1"
+    assert diag.classify_mast_mode("key-error", "assert x == y failed") == "3.3"
+
+
+def test_classify_mast_mode_unknown_defaults():
+    assert diag.classify_mast_mode("unknown", "") == "2.6"
+    assert diag.classify_mast_mode("some-future-class") == "2.6"
+
+
+def test_mast_mode_label():
+    assert diag.mast_mode_label("3.3") == "3.3 Incorrect Verification"
+    assert diag.mast_mode_label("") == ""
+
+
+def test_extract_failure_tags_mast_mode():
+    check = diag.FailedCheck(
+        check_run_id=1,
+        name="tests",
+        conclusion="failure",
+        details_url="https://github.com/runs/1",
+        head_sha="sha1",
+        annotations=[
+            {
+                "path": "tests/x.py",
+                "start_line": 1,
+                "annotation_level": "failure",
+                "message": "KeyError: 'missing'",
+                "title": "test failed",
+            }
+        ],
+    )
+    failure = diag.extract_failure(check)
+    assert failure.mast_mode == "2.6"  # key-error -> reasoning-action mismatch


### PR DESCRIPTION
Automated evolution PR for issue #2523.

## What
Adopts MAST (Berkeley Sky, NeurIPS 2025, arXiv:2503.13657) as the tagging rubric for `scripts/evolution_ci_diagnosis.py`:

- Encodes the 14 failure modes across 3 categories (`MAST_FAILURE_MODES` / `MAST_CATEGORIES`).
- Adds a deterministic `classify_mast_mode(error_class, message)` that tags each diagnosed failure with a mode (message keywords → error-class map → a conservative default).
- `FailureDetails` gains a `mast_mode` field, populated at every `extract_failure` return site.
- The mode is surfaced in the child-issue body (`MAST mode: `3.3 Incorrect Verification``) and in the diagnosis report's `results` records.

## Why
Makes failure recurrence measurable *by mode* ("incorrect-verification dropped N%") instead of by free-form narrative, and gives the causal-topology-pruning work a principled "which edges cause which modes" signal.

## Validation (local)
- `ruff check` on changed files — passes (the CI blocking lint).
- `python -m pytest tests/scripts/test_evolution_ci_diagnosis.py` — 29/29 pass (6 new MAST tests).
- Diff: 147 insertions / 0 deletions (under the 200-line self-merge cap).

Closes #2523