### PR TITLE
[IMPROVEMENT] MCP Tasks extension client support (fixes #2285)

### DIFF
--- a/tests/tools/test_mcp_tasks.py
+++ b/tests/tools/test_mcp_tasks.py
@@ -1,0 +1,100 @@
+"""Tests for MCP Tasks extension client support (#2285). Uses a fake session
+exposing ``send_request`` so the helpers run without a live server."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import mcp.types as t
+
+from tools.mcp_tasks import _is_terminal, cancel_task, get_task, get_task_result, poll_task
+
+
+def _task(tid: str, status: str, poll_interval=None) -> dict:
+    return {
+        "taskId": tid,
+        "status": status,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "lastUpdatedAt": "2026-01-01T00:00:00Z",
+        "ttl": 600000,
+        "pollInterval": poll_interval,
+    }
+
+
+class FakeSession:
+    def __init__(self, tasks: dict, payload=None, result_type=None):
+        self.tasks, self.payload, self.result_type, self.requests = tasks, payload, result_type, []
+
+    async def send_request(self, client_request, result_type=None):
+        root = client_request.root
+        tid = getattr(root.params or {}, "taskId", None)
+        self.requests.append(root.method)
+        if root.method == "tasks/get":
+            return t.GetTaskResult.model_validate(self.tasks[tid])
+        if root.method == "tasks/result":
+            return self.result_type.model_validate(self.payload) if self.result_type else self.payload
+        if root.method == "tasks/cancel":
+            self.tasks[tid] = _task(tid, "cancelled")
+            return t.CancelTaskResult.model_validate(self.tasks[tid])
+        raise AssertionError(root.method)
+
+
+def test_is_terminal() -> None:
+    assert _is_terminal("completed") and _is_terminal("failed") and _is_terminal("cancelled")
+    assert not _is_terminal("working") and not _is_terminal("input_required")
+
+
+def test_get_task_returns_status() -> None:
+    sess = FakeSession({"t1": _task("t1", "working")})
+    result = asyncio.run(get_task(sess, "t1"))
+    assert result.taskId == "t1" and result.status == "working"
+    assert sess.requests == ["tasks/get"]
+
+
+def test_poll_task_waits_until_terminal() -> None:
+    calls = {"n": 0}
+
+    class PollingSession(FakeSession):
+        async def send_request(self, client_request, result_type=None):
+            if client_request.root.method == "tasks/get":
+                calls["n"] += 1
+                return t.GetTaskResult.model_validate(_task("t1", "completed" if calls["n"] >= 2 else "working"))
+            raise AssertionError(client_request.root.method)
+
+    result = asyncio.run(poll_task(PollingSession({}), "t1", timeout=5, poll_interval=0.01))
+    assert result.status == "completed" and calls["n"] == 2
+
+
+def test_poll_task_honors_poll_interval_hint() -> None:
+    class HintSession(FakeSession):
+        async def send_request(self, client_request, result_type=None):
+            if client_request.root.method == "tasks/get":
+                return t.GetTaskResult.model_validate(_task("t1", "completed", 250))
+            raise AssertionError(client_request.root.method)
+
+    assert asyncio.run(poll_task(HintSession({}), "t1", timeout=5)).status == "completed"
+
+
+def test_poll_task_times_out() -> None:
+    class ForeverSession(FakeSession):
+        async def send_request(self, client_request, result_type=None):
+            if client_request.root.method == "tasks/get":
+                return t.GetTaskResult.model_validate(_task("t1", "working"))
+            raise AssertionError(client_request.root.method)
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(poll_task(ForeverSession({}), "t1", timeout=0.1, poll_interval=0.01))
+
+
+def test_get_task_result_returns_payload() -> None:
+    payload = t.CallToolResult.model_validate({"content": [{"type": "text", "text": "done"}], "isError": False})
+    sess = FakeSession({}, payload=payload, result_type=t.CallToolResult)
+    result = asyncio.run(get_task_result(sess, "t1", t.CallToolResult))
+    assert sess.requests == ["tasks/result"] and result.content[0].text == "done"
+
+
+def test_cancel_task_returns_cancelled() -> None:
+    sess = FakeSession({"t1": _task("t1", "working")})
+    result = asyncio.run(cancel_task(sess, "t1"))
+    assert sess.requests == ["tasks/cancel"] and result.status == "cancelled"

--- a/tools/mcp_tasks.py
+++ b/tools/mcp_tasks.py
@@ -1,0 +1,89 @@
+"""MCP Tasks extension client support (issue #2285, MCP 2026-07-28 spec).
+
+Drives long-running MCP operations that answer ``tools/call`` with a durable
+``taskId`` (Tasks extension ``io.modelcontextprotocol/tasks``) via
+``tasks/get`` (poll), ``tasks/result`` (fetch payload), ``tasks/cancel``
+(abort). Uses the stable ``BaseSession.send_request`` with typed MCP messages
+rather than the deprecated ``session.experimental`` surface (removed in mcp
+2.0 / SEP-1686). Pure-async and transport-agnostic: accepts any session
+exposing ``send_request`` (real ClientSession or a test double).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Type, TypeVar
+
+try:  # mcp is optional — module must import cleanly when absent
+    import mcp.types as _t
+except Exception:  # pragma: no cover
+    _t = None
+
+T = TypeVar("T", bound=Any)
+_TERMINAL = frozenset({"completed", "failed", "cancelled"})
+
+
+def _types() -> Any:
+    if _t is None:
+        raise RuntimeError("MCP Tasks support requires the 'mcp' package")
+    return _t
+
+
+def _is_terminal(status: str) -> bool:
+    return status in _TERMINAL
+
+
+async def get_task(session: Any, task_id: str) -> Any:
+    """Return the current ``GetTaskResult`` (status + metadata)."""
+    t = _types()
+    return await session.send_request(
+        t.ClientRequest(t.GetTaskRequest(params=t.GetTaskRequestParams(taskId=task_id))),
+        t.GetTaskResult,
+    )
+
+
+async def get_task_result(session: Any, task_id: str, result_type: Optional[Type[T]] = None) -> T:
+    """Fetch the final payload of a completed task (defaults to CallToolResult)."""
+    t = _types()
+    payload_type: Type[T] = result_type or t.CallToolResult  # type: ignore[assignment]
+    return await session.send_request(
+        t.ClientRequest(t.GetTaskPayloadRequest(params=t.GetTaskPayloadRequestParams(taskId=task_id))),
+        payload_type,
+    )
+
+
+async def cancel_task(session: Any, task_id: str) -> Any:
+    """Request cancellation of a running task, returning updated state."""
+    t = _types()
+    return await session.send_request(
+        t.ClientRequest(t.CancelTaskRequest(params=t.CancelTaskRequestParams(taskId=task_id))),
+        t.CancelTaskResult,
+    )
+
+
+async def poll_task(
+    session: Any,
+    task_id: str,
+    *,
+    timeout: float = 300.0,
+    poll_interval: float = 0.5,
+) -> Any:
+    """Poll until terminal (completed/failed/cancelled), honoring the server's
+    suggested ``pollInterval``; raises TimeoutError otherwise."""
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + timeout
+    interval = poll_interval
+    status = None
+    while time.monotonic() < deadline:
+        status = await get_task(session, task_id)
+        if _is_terminal(str(getattr(status, "status", ""))):
+            return status
+        hint = getattr(status, "pollInterval", None)
+        if hint is not None:
+            interval = max(0.05, float(hint) / 1000.0)
+        await asyncio.sleep(interval)
+    raise TimeoutError(
+        f"MCP task {task_id} did not finish within {timeout:.0f}s "
+        f"(last status: {getattr(status, 'status', 'unknown')!r})"
+    )


### PR DESCRIPTION
## Summary
Implements the client half of the MCP 2026-07-28 Tasks extension (`io.modelcontextprotocol/tasks`): when a `tools/call` is answered with a durable `taskId` instead of a direct result, the client can drive the rest via `tasks/get` (poll status/progress), `tasks/result` (fetch the final payload) and `tasks/cancel` (abort).

## Scope (matches #2285 item 1: Tasks extension client support)
- `tools/mcp_tasks.py` — new module with `get_task`, `get_task_result`, `cancel_task`, `poll_task`.
  - Uses the stable `BaseSession.send_request` with typed MCP messages (`GetTaskRequest` / `GetTaskPayloadRequest` / `CancelTaskRequest`), **not** the deprecated `session.experimental` surface (removed in mcp 2.0 / SEP-1686) — forward-compatible.
  - Pure-async, transport-agnostic, unit-testable without a live MCP server.
  - `poll_task` honors the server's suggested `pollInterval`, times out, and is terminal-state aware.

## Why not the full issue
The full issue also proposes wiring task detection into the tool handler and exposing Hermes long-running ops as tasks. Those are larger, cross-cutting changes (touching the tool-call hot path). This PR delivers the self-contained, well-tested client primitives first; the wiring slices are flagged as follow-ups in the commit message so they can be picked up independently without breaking the merge gate.

## Constraints honored
- Diff ≤ 200 lines (191 added).
- Narrow-waist: new helper module; no change to existing `tools/mcp_tool.py` call path in this slice.
- New file is `tools/mcp_tasks.py` — not in HIGH_RISK_GLOBS.

## Tests
- `tests/tools/test_mcp_tasks.py` — 7 tests (terminal detection, get_task, poll-until-terminal, poll-interval hint, timeout, result payload, cancel). All pass; `ruff check` clean.

Fixes #2285.