### PR TITLE
[SLICE B] Verified/falsified/toy-scale/no-evidence claim triage taxonomy (fixes #2514)

### DIFF
--- a/scripts/evolution_rubric_judge.py
+++ b/scripts/evolution_rubric_judge.py
@@ -188,6 +188,7 @@ def _hot_path(evolution_dir: Path) -> Path:
 # Helpers — safe JSON/MD loading
 # ──────────────────────────────────────────────────────────────────────
 
+
 def _load_json(path: Path) -> Any | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -225,6 +226,7 @@ def _safe_int(v: Any, default: int = 0) -> int:
 # ──────────────────────────────────────────────────────────────────────
 # StrictRubricJudgeGrader — deterministic, rule-based, no LLM
 # ──────────────────────────────────────────────────────────────────────
+
 
 class StrictRubricJudgeGrader:
     """Score each dimension by parsing the structured outputs with explicit rules.
@@ -282,9 +284,7 @@ class StrictRubricJudgeGrader:
         meta = _as_dict(data.get("meta"))
 
         # priority_distribution: all issues have priority_score > 0
-        scored = sum(
-            1 for i in issues if _safe_int(i.get("priority_score", 0)) > 0
-        )
+        scored = sum(1 for i in issues if _safe_int(i.get("priority_score", 0)) > 0)
         if not issues:
             priority_distribution = 0.0
         elif scored == len(issues):
@@ -357,14 +357,16 @@ class StrictRubricJudgeGrader:
         # signal_quality: distinct signals with rich observations
         signals = _as_dict(d.get("signals"))
         good_signals = sum(
-            1 for s in signals.values()
+            1
+            for s in signals.values()
             if isinstance(s, dict) and len(str(s.get("observation", ""))) > 80
         )
         signal_quality = min(3.0, good_signals)
 
         # cross_referencing: signals refer to tracked issues
         ref_count = sum(
-            1 for s in signals.values()
+            1
+            for s in signals.values()
             if isinstance(s, dict) and _safe_int(s.get("tracked_in_issue"))
         )
         total_signals = len(signals)
@@ -378,7 +380,8 @@ class StrictRubricJudgeGrader:
         # action_proposals: new_issues_proposed with impact/effort
         proposals = d.get("new_issues_proposed") or []
         scored_props = sum(
-            1 for p in proposals
+            1
+            for p in proposals
             if isinstance(p, dict) and p.get("priority_score") is not None
         )
         action_proposals = min(3.0, scored_props)
@@ -402,16 +405,18 @@ class StrictRubricJudgeGrader:
         scope_discipline = min(3.0, issue_refs)
 
         # test_presence: mentions tests
-        test_mentions = _count_matches(
-            tx, r"(?i)\b(?:test|tests|testing|pytest)\b"
+        test_mentions = _count_matches(tx, r"(?i)\b(?:test|tests|testing|pytest)\b")
+        test_presence = (
+            2.0 if test_mentions >= 2 else (1.0 if test_mentions >= 1 else 0.0)
         )
-        test_presence = 2.0 if test_mentions >= 2 else (1.0 if test_mentions >= 1 else 0.0)
 
         # documentation: mentions documentation
         doc_mentions = _count_matches(
             tx, r"(?i)\b(?:doc|docs|documentation|documented)\b"
         )
-        documentation = 2.0 if doc_mentions >= 2 else (1.0 if doc_mentions >= 1 else 0.0)
+        documentation = (
+            2.0 if doc_mentions >= 2 else (1.0 if doc_mentions >= 1 else 0.0)
+        )
 
         # diff_quality: diff size is clean and reported
         diff_mentions = _count_matches(
@@ -448,9 +453,7 @@ class StrictRubricJudgeGrader:
 
         # merge_discipline: merges limited, evolution/* pattern
         branch_pattern = _count_matches(tx, r"(?i)evolution/")
-        limit_mentions = _count_matches(
-            tx, r"(?i)\b(?:max|limit)\s+\d+\s+(?:merge|pr)"
-        )
+        limit_mentions = _count_matches(tx, r"(?i)\b(?:max|limit)\s+\d+\s+(?:merge|pr)")
         score = 0
         if branch_pattern >= 1:
             score += 1
@@ -543,8 +546,10 @@ class StrictRubricJudgeGrader:
             freshness = 0.0
 
         # failure_awareness: any output mentions failure rates
-        combined = research_md + json.dumps(issues_json or {}) + json.dumps(
-            introspection_json or {}
+        combined = (
+            research_md
+            + json.dumps(issues_json or {})
+            + json.dumps(introspection_json or {})
         )
         failure_mentions = _count_matches(
             combined,
@@ -566,15 +571,11 @@ class StrictRubricJudgeGrader:
 
         # Load all stage outputs (gracefully — missing = empty)
         research_md = _load_md(evolution_dir / "research" / f"{date}.md")
-        issues_json = _as_dict(
-            _load_json(evolution_dir / "issues" / f"{date}.json")
-        )
+        issues_json = _as_dict(_load_json(evolution_dir / "issues" / f"{date}.json"))
         introspection_data = _load_json(
             evolution_dir / "introspection" / f"{date}.json"
         )
-        implementation_md = _load_md(
-            evolution_dir / "implementation" / f"{date}.md"
-        )
+        implementation_md = _load_md(evolution_dir / "implementation" / f"{date}.md")
         integration_json = _as_dict(
             _load_json(evolution_dir / "integration" / f"{date}.json")
         )
@@ -588,9 +589,7 @@ class StrictRubricJudgeGrader:
         health_scores = self._score_pipeline_health(date, evolution_dir)
 
         # Build dimension records
-        def _build_dimension(
-            dim_name: str, scores: Dict[str, float]
-        ) -> Dict[str, Any]:
+        def _build_dimension(dim_name: str, scores: Dict[str, float]) -> Dict[str, Any]:
             dim_def = RUBRIC_DIMENSIONS[dim_name]
             total = sum(scores.values())
             return {
@@ -612,6 +611,19 @@ class StrictRubricJudgeGrader:
         total_max = sum(d["max"] for d in dimensions.values())
         pct = round((total_score / total_max) * 100, 1) if total_max > 0 else 0.0
 
+        raw_claims = extract_claims(
+            ("research", research_md),
+            ("implementation", implementation_md),
+            ("integration", json.dumps(integration_json)),
+        )
+        claims = triage_claims(raw_claims)
+        claim_stats = compute_claim_score(claims, total_max)
+
+        # Derive aggregate score from claim verdicts when claims are present
+        if claims:
+            total_score = claim_stats["score"]
+            pct = claim_stats["overall_percentage"]
+
         # Generate flags for concerning signals
         flags: List[str] = []
         if pct < 30:
@@ -632,6 +644,16 @@ class StrictRubricJudgeGrader:
                     f"({dim_pct:.0f}%) — stage nearly absent or very poor"
                 )
 
+        if claims:
+            if claim_stats["verdict_counts"]["falsified"] > 0:
+                flags.append(
+                    f"FALSIFIED_CLAIMS: {claim_stats['verdict_counts']['falsified']} claim(s) refuted by evidence"
+                )
+            if claim_stats["verdict_counts"]["no-evidence"] > len(claims) * 0.5:
+                flags.append(
+                    f"UNVERIFIED_CLAIMS: {claim_stats['verdict_counts']['no-evidence']}/{len(claims)} claims lack evidence"
+                )
+
         return {
             "cycle_date": date,
             "grader": "strict",
@@ -640,17 +662,15 @@ class StrictRubricJudgeGrader:
             "total_max": total_max,
             "overall_percentage": pct,
             "flags": flags,
-            "claims": extract_claims(
-                ("research", research_md),
-                ("implementation", implementation_md),
-                ("integration", json.dumps(integration_json)),
-            ),
+            "claims": claims,
+            "claim_verdicts": claim_stats["verdict_counts"] if claims else {},
         }
 
 
 # ──────────────────────────────────────────────────────────────────────
 # AgentJudgeGrader — LLM-based qualitative assessment
 # ──────────────────────────────────────────────────────────────────────
+
 
 class AgentJudgeGrader:
     """LLM-backed grader that loads the strict scores, reads the raw outputs,
@@ -700,9 +720,7 @@ class AgentJudgeGrader:
         LLM to adjust."""
         return self.strict_grader.score(self.cycle_date, self.evolution_dir)
 
-    def narrative_assessment(
-        self, outputs: Dict[str, Any]
-    ) -> Dict[str, str]:
+    def narrative_assessment(self, outputs: Dict[str, Any]) -> Dict[str, str]:
         """Template for LLM output: per-dimension narrative commentary.
 
         The LLM should fill this dict by reading each stage's output and
@@ -836,24 +854,131 @@ def extract_claims(
                 if key in seen:
                     continue
                 seen.add(key)
-                out.append(
-                    {
-                        "claim": sentence,
-                        "source": {
-                            "stage": stage,
-                            "section": header or "preamble",
-                        },
-                        "evidence_url": urls[0] if urls else None,
-                    }
-                )
+                out.append({
+                    "claim": sentence,
+                    "source": {
+                        "stage": stage,
+                        "section": header or "preamble",
+                    },
+                    "evidence_url": urls[0] if urls else None,
+                })
                 per_source += 1
     out.sort(key=lambda c: (c["source"]["stage"], c["source"]["section"], c["claim"]))
     return out
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Claim triage taxonomy — Slice B (#2482 / #2514)
+# ──────────────────────────────────────────────────────────────────────
+
+CLAIM_VERDICTS: Tuple[str, ...] = ("verified", "falsified", "toy-scale", "no-evidence")
+
+CLAIM_VERDICT_WEIGHTS: Dict[str, float] = {
+    "verified": 1.0,
+    "toy-scale": 0.3,
+    "no-evidence": 0.0,
+    "falsified": 0.0,
+}
+
+_FALSIFIED_RE = re.compile(
+    r"\b(failed|falsified|broken|regression|reverted|0\s*passed|error|conflict|timeout|crash|fails)\b",
+    re.IGNORECASE,
+)
+_TOY_SCALE_RE = re.compile(
+    r"\b(toy|mock|stub|synthetic|dummy|trivial|placeholder|sample\s*only|minimal\s*test|toy-scale)\b",
+    re.IGNORECASE,
+)
+_VERIFIED_METRIC_RE = re.compile(
+    r"(\d+(?:\.\d+)?%|\d+\s*ms|\d+\s*s\b|\d+\s*seconds|\d+\s*tokens?|\d+\s*lines?|\d+x\b|issue\s*#\d+|pr\s*#\d+|#\d+|\bmerged\b|\bfixed\b|\bresolves\b)",
+    re.IGNORECASE,
+)
+
+
+def triage_claim(claim_item: Dict[str, Any]) -> Dict[str, Any]:
+    """Classify an extracted claim into the 4-verdict triage taxonomy (#2514).
+
+    Verdicts:
+      - ``falsified``: claim asserts a failure, regression, conflict, or refuted outcome.
+      - ``toy-scale``: claim relies on synthetic, mock, or toy-scale demonstration without production proof.
+      - ``verified``: claim is supported by an evidence URL, tracked PR/issue, or concrete measured metrics.
+      - ``no-evidence``: assertive outcome statement without backing URL, commit, or numerical evidence.
+
+    Returns a shallow copy of ``claim_item`` with ``verdict`` and ``justification`` fields.
+    """
+    out = dict(claim_item)
+    text = out.get("claim", "")
+    url = out.get("evidence_url")
+
+    if _FALSIFIED_RE.search(text):
+        verdict = "falsified"
+        justification = (
+            "Claim asserts a failure, regression, conflict, or refuted outcome."
+        )
+    elif _TOY_SCALE_RE.search(text):
+        verdict = "toy-scale"
+        justification = "Claim relies on synthetic, mock, or toy-scale demonstration without production-scale evidence."
+    elif url or _VERIFIED_METRIC_RE.search(text):
+        verdict = "verified"
+        justification = "Claim is backed by external evidence URL, tracked PR/issue, or concrete measured metrics."
+    else:
+        verdict = "no-evidence"
+        justification = "Claim asserts an outcome without concrete numerical metrics, commit/PR links, or external evidence."
+
+    out["verdict"] = verdict
+    out["justification"] = justification
+    return out
+
+
+def triage_claims(claims: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Triage a list of extracted claims, classifying each into the 4-verdict taxonomy."""
+    return [triage_claim(c) for c in claims]
+
+
+def compute_claim_score(
+    claims: List[Dict[str, Any]],
+    dimension_max: float = 52.0,
+) -> Dict[str, Any]:
+    """Compute aggregate quality score and statistics from triaged claim verdicts."""
+    counts = {
+        "verified": 0,
+        "falsified": 0,
+        "toy-scale": 0,
+        "no-evidence": 0,
+    }
+    for c in claims:
+        v = c.get("verdict", "no-evidence")
+        if v in counts:
+            counts[v] += 1
+        else:
+            counts["no-evidence"] += 1
+
+    total_claims = len(claims)
+    if total_claims == 0:
+        return {
+            "score": 0.0,
+            "max": dimension_max,
+            "overall_percentage": 0.0,
+            "verdict_counts": counts,
+        }
+
+    raw_points = sum(
+        CLAIM_VERDICT_WEIGHTS.get(c.get("verdict", ""), 0.0) for c in claims
+    )
+    percentage = round((raw_points / total_claims) * 100, 1)
+    derived_score = round((percentage / 100.0) * dimension_max, 1)
+
+    return {
+        "score": derived_score,
+        "max": dimension_max,
+        "overall_percentage": percentage,
+        "verdict_counts": counts,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Persistence — read / append rubric scorecards (like metrics.jsonl)
 # ──────────────────────────────────────────────────────────────────────
+
 
 def load_scorecards(scorecard_file: Path) -> List[Dict[str, Any]]:
     """Read all rubric scorecards, oldest-first, skipping malformed lines."""
@@ -905,7 +1030,11 @@ def summarize_scorecards(
     strict_records = [r for r in records if r.get("grader") == "strict"]
     recent = strict_records[-last:] if last and last > 0 else list(strict_records)
 
-    pcts = [r.get("overall_percentage", 0) for r in recent if r.get("overall_percentage") is not None]
+    pcts = [
+        r.get("overall_percentage", 0)
+        for r in recent
+        if r.get("overall_percentage") is not None
+    ]
     avg_pct = sum(pcts) / len(pcts) if pcts else 0.0
 
     # Trend: improving / flat / declining
@@ -938,7 +1067,11 @@ def summarize_scorecards(
 
 def format_summary(summary: Dict[str, Any]) -> str:
     """One-line rendering for no_agent cron output."""
-    tail = " | ".join(summary["persistent_flags"][:3]) if summary["persistent_flags"] else "no flags"
+    tail = (
+        " | ".join(summary["persistent_flags"][:3])
+        if summary["persistent_flags"]
+        else "no flags"
+    )
     return (
         f"[rubric-judge] last {summary['cycles']} cycles: "
         f"avg={summary['avg_overall_pct']}% min={summary['min_pct']}% "
@@ -949,6 +1082,7 @@ def format_summary(summary: Dict[str, Any]) -> str:
 # ──────────────────────────────────────────────────────────────────────
 # CLI
 # ──────────────────────────────────────────────────────────────────────
+
 
 def cycle_date(now: datetime | None = None) -> str:
     """Same logic as evolution_funnel.cycle_date: before 08:00, use yesterday."""

--- a/tests/scripts/test_evolution_rubric_judge.py
+++ b/tests/scripts/test_evolution_rubric_judge.py
@@ -14,7 +14,15 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from evolution_rubric_judge import _markdown_sections, extract_claims  # noqa: E402
+from evolution_rubric_judge import (  # noqa: E402
+    CLAIM_VERDICTS,
+    StrictRubricJudgeGrader,
+    _markdown_sections,
+    compute_claim_score,
+    extract_claims,
+    triage_claim,
+    triage_claims,
+)
 
 SAMPLE = """\
 # Finding 1
@@ -63,3 +71,83 @@ def test_extract_claims_dedupes_and_sorts() -> None:
 
 def test_extract_claims_ignores_none_and_empty() -> None:
     assert extract_claims(("research", None), ("implementation", "")) == []
+
+
+def test_triage_claim_verdicts_taxonomy() -> None:
+    # 1. Verified via URL or metric
+    c_url = triage_claim({
+        "claim": "Improved speed significantly.",
+        "evidence_url": "https://example.com/speed",
+    })
+    assert c_url["verdict"] == "verified"
+    assert "justification" in c_url
+
+    c_metric = triage_claim({
+        "claim": "Fixed issue #42 and reduced latency by 35%.",
+        "evidence_url": None,
+    })
+    assert c_metric["verdict"] == "verified"
+
+    # 2. Falsified via contradiction/failure
+    c_falsified = triage_claim({
+        "claim": "The integration tests failed with 0 passed.",
+        "evidence_url": "https://example.com",
+    })
+    assert c_falsified["verdict"] == "falsified"
+
+    # 3. Toy-scale
+    c_toy = triage_claim({
+        "claim": "Demonstrated improved performance on a toy mock stub.",
+        "evidence_url": None,
+    })
+    assert c_toy["verdict"] == "toy-scale"
+
+    # 4. No-evidence
+    c_no_ev = triage_claim({
+        "claim": "This approach enables generalized improvements everywhere.",
+        "evidence_url": None,
+    })
+    assert c_no_ev["verdict"] == "no-evidence"
+
+
+def test_triage_claims_all_have_verdict_and_justification() -> None:
+    raw_claims = extract_claims(("research", SAMPLE))
+    triaged = triage_claims(raw_claims)
+    assert len(triaged) == len(raw_claims)
+    for c in triaged:
+        assert c["verdict"] in CLAIM_VERDICTS
+        assert len(c["justification"]) > 5
+
+
+def test_compute_claim_score_calculation() -> None:
+    claims = [
+        {"claim": "A", "verdict": "verified"},  # 1.0
+        {"claim": "B", "verdict": "toy-scale"},  # 0.3
+        {"claim": "C", "verdict": "no-evidence"},  # 0.0
+        {"claim": "D", "verdict": "falsified"},  # 0.0
+    ]
+    res = compute_claim_score(claims, dimension_max=50.0)
+    # (1.0 + 0.3 + 0.0 + 0.0) / 4 = 1.3 / 4 = 32.5%
+    assert res["overall_percentage"] == 32.5
+    # 32.5% of 50.0 = 16.25 -> 16.2 or 16.3
+    assert res["score"] == 16.2 or res["score"] == 16.3
+    assert res["verdict_counts"] == {
+        "verified": 1,
+        "toy-scale": 1,
+        "no-evidence": 1,
+        "falsified": 1,
+    }
+
+
+def test_strict_grader_scores_from_claim_verdicts(tmp_path: Path) -> None:
+    res_dir = tmp_path / "research"
+    res_dir.mkdir(parents=True, exist_ok=True)
+    res_file = res_dir / "2026-06-23.md"
+    res_file.write_text(SAMPLE, encoding="utf-8")
+    grader = StrictRubricJudgeGrader()
+    scorecard = grader.score("2026-06-23", tmp_path)
+    assert "claims" in scorecard
+    assert "claim_verdicts" in scorecard
+    assert scorecard["claim_verdicts"]["verified"] >= 1
+    # Check that total_score was derived from claim verdicts, not self-assigned
+    assert scorecard["overall_percentage"] > 0


### PR DESCRIPTION
## Summary
Implements Slice B of claim triage taxonomy and verdict-derived aggregate scoring (parent #2482, closes #2514).

## Changes
- **Claim Triage Taxonomy**: Defined `CLAIM_VERDICTS` (`verified`, `falsified`, `toy-scale`, `no-evidence`), `CLAIM_VERDICT_WEIGHTS`, `triage_claim`, and `triage_claims` in `scripts/evolution_rubric_judge.py`.
- **Verdict-Derived Aggregate Scoring**: Implemented `compute_claim_score` and updated `StrictRubricJudgeGrader.score` so that whenever claims are present, the aggregate quality score and percentage are computed directly from claim verdicts with explicit justification, with safety flags for falsified or unverified claims.
- **Tests**: Added tests in `tests/scripts/test_evolution_rubric_judge.py` testing all 4 taxonomy verdicts, full triage output guarantees, and rubric-judge integration.

Fixes #2514