### PR TITLE
feat(verification): gate autonomy behind verification + red-line config check (Closes #2528)

### DIFF
--- a/agent/verification_scope.py
+++ b/agent/verification_scope.py
@@ -62,6 +62,35 @@ class VerificationScope:
             name=str(d.get("name", "default_scope")),
         )
 
+    @property
+    def safeguards_disabled(self) -> bool:
+        """True when the scope carries no defensive constraints (#2528).
+
+        A scope is "unsafeguarded" when it is writable AND defines no denied
+        paths, no denied commands, no command allow-list, and no host
+        allow-list — i.e. nothing blocks writes, nothing blocks commands, and
+        nothing constrains network egress. This is the "safeguards disabled"
+        half of the red-line condition.
+        """
+        return (
+            not self.read_only
+            and not self.denied_paths
+            and not self.denied_commands
+            and not self.allowed_commands
+            and not self.allowed_hosts
+        )
+
+    def is_red_line(self) -> bool:
+        """True when autonomy is unverified AND internet is enabled (#2528).
+
+        Anthropic's August 2026 risk report: a frontier model run with
+        "safeguards disabled + internet access" engaged in sustained harmful
+        activity directed at real people. Treat that exact combination —
+        no safeguards plus open network egress — as a red-line configuration
+        the evolution pipeline must refuse to run under.
+        """
+        return self.allow_network and self.safeguards_disabled
+
 
 @dataclass
 class ScopeViolation:
@@ -223,6 +252,28 @@ class VerificationScopeEnforcer:
 
         return True, None
 
+    def check_red_line(self) -> Tuple[bool, Optional[ScopeViolation]]:
+        """Reject a red-line configuration (safeguards off + network on, #2528).
+
+        Returns False and records a violation when the scope has network
+        access while its safeguards are disabled — the combination Anthropic's
+        risk report flags as a red line. Callers gating autonomy behind
+        verification should treat False as "do not proceed".
+        """
+        if not self.scope.is_red_line():
+            return True, None
+        violation = ScopeViolation(
+            action_type="red_line_config",
+            target=self.scope.name,
+            reason=(
+                "Red-line configuration: safeguards disabled while network "
+                "access is enabled"
+            ),
+            scope_name=self.scope.name,
+        )
+        self.violations.append(violation)
+        return False, violation
+
 
 def get_stage_verification_scope(
     stage_name: str,
@@ -292,9 +343,14 @@ def get_stage_verification_scope(
             denied_commands=["sudo", "rm -rf /", "chmod -R 777", "mkfs"],
         )
 
+    # Unknown stage → least agency by default. A wide-open fallback
+    # (writable + network + no constraints) would be a red-line configuration
+    # (#2528): autonomy gated behind nothing, with internet access. Default
+    # unknown stages to read-only with no network so an unverified stage can
+    # never run un-safeguarded.
     return VerificationScope(
         name=f"{stage}_scope",
         allowed_paths=[root],
-        read_only=False,
-        allow_network=True,
+        read_only=True,
+        allow_network=False,
     )

--- a/tests/agent/test_verification_scope.py
+++ b/tests/agent/test_verification_scope.py
@@ -159,3 +159,62 @@ class TestVerificationScope:
         impl_scope = get_stage_verification_scope("implementation", tmp_path)
         assert impl_scope.read_only is False
         assert impl_scope.allow_network is True
+
+
+class TestRedLineConfig:
+    """#2528: treat "safeguards disabled + internet access" as a red line."""
+
+    def test_safeguards_disabled_wide_open_scope(self):
+        scope = VerificationScope(name="wide_open", allow_network=True)
+        assert scope.safeguards_disabled is True
+
+    def test_safeguards_present_constrained_scope(self):
+        scope = VerificationScope(
+            name="constrained",
+            allow_network=True,
+            denied_commands=["rm -rf"],
+            allowed_hosts=["github.com"],
+        )
+        assert scope.safeguards_disabled is False
+        # Read-only alone is also a safeguard.
+        assert VerificationScope(read_only=True).safeguards_disabled is False
+
+    def test_is_red_line_network_plus_no_safeguards(self):
+        assert VerificationScope(allow_network=True).is_red_line() is True
+
+    def test_not_red_line_when_network_disabled(self):
+        assert VerificationScope(allow_network=False).is_red_line() is False
+
+    def test_not_red_line_when_safeguards_present(self):
+        scope = VerificationScope(
+            allow_network=True,
+            denied_paths=["/etc"],
+            denied_commands=["sudo"],
+        )
+        assert scope.is_red_line() is False
+
+    def test_enforcer_check_red_line_rejects(self):
+        enforcer = VerificationScopeEnforcer(VerificationScope(allow_network=True))
+        ok, violation = enforcer.check_red_line()
+        assert ok is False
+        assert violation is not None
+        assert violation.action_type == "red_line_config"
+
+    def test_enforcer_check_red_line_allows_safe(self):
+        enforcer = VerificationScopeEnforcer(
+            VerificationScope(allow_network=False, read_only=True)
+        )
+        ok, violation = enforcer.check_red_line()
+        assert ok is True
+        assert violation is None
+
+    def test_unknown_stage_defaults_to_least_agency(self, tmp_path: Path):
+        scope = get_stage_verification_scope("mystery_stage", tmp_path)
+        assert scope.read_only is True
+        assert scope.allow_network is False
+        assert scope.is_red_line() is False
+
+    def test_preset_stages_are_not_red_line(self, tmp_path: Path):
+        for stage in ("research", "analysis", "implementation"):
+            scope = get_stage_verification_scope(stage, tmp_path)
+            assert scope.is_red_line() is False, f"{stage} must not be red-line"


### PR DESCRIPTION
Automated evolution PR for issue #2528.

## What
Gates autonomy behind verification and treats "safeguards disabled + internet
access" as a red-line configuration, grounded in Anthropic's Aug 2026 risk report
(a frontier model run with safeguards disabled + internet access engaged in
sustained harmful activity).

## Changes
- `agent/verification_scope.py`
  - new `VerificationScope.safeguards_disabled` property (writable scope with no
    denied paths, no denied commands, no command allow-list, no host allow-list).
  - new `VerificationScope.is_red_line()` — `allow_network and safeguards_disabled`.
  - new `VerificationScopeEnforcer.check_red_line()` — returns False + a
    `red_line_config` violation for red-line scopes; callers gate autonomy behind it.
  - unknown-stage fallback in `get_stage_verification_scope` now defaults to
    least-agency (read-only + no network) instead of a wide-open red-line scope.
- `tests/agent/test_verification_scope.py`: 9 new tests (`TestRedLineConfig`).

## Validation
- `ruff check` ✓ (blocking CI lint)
- `pytest tests/agent/test_verification_scope.py tests/agent/test_verification_scope_integration.py` — 18/18 ✓
