### PR TITLE
feat(evolution): parallel batch tool evolution + cross-domain transfer gate

### DIFF
--- a/evolution/lib/tool_batch_evolution.py
+++ b/evolution/lib/tool_batch_evolution.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Parallel batch tool evolution + cross-domain transfer gate (#2260).
+
+Slice B of the In-Situ Self-Evolving paradigm (parent #2248; Slice A is
+the tool synthesis harness in ``tool_synthesis.py``, #2259): evolve a
+tool by proposing mutation variants, validating the whole batch in
+parallel, keeping the best variant, and accepting it only if it
+transfers to held-out domains — not just the origin domain.
+
+Components:
+
+1. **Variant proposer** — generate N mutation variants of a base tool.
+   The default is a deterministic string-level mutation of the tool's
+   description; an LLM/subagent-backed proposer can be injected without
+   changing the harness contract.
+2. **Batch runner** — validate all variants in parallel via a thread
+   pool; the validator is injectable (production: ``SandboxValidator``).
+3. **Selection** — the highest-scoring passing variant wins.
+4. **Transferability gate** — an accepted tool must pass on held-out
+   domains at ≥ threshold of its origin pass-rate, preventing
+   task-specific overfitting (mirrors the validation-overfitting guard
+   philosophy from #2480).
+
+New module, no changes to existing tool loading. Module ≤ 200 lines.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+from evolution.lib.tool_synthesis import SynthesizedTool
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "VariantResult",
+    "propose_variants",
+    "run_batch",
+    "select_best",
+    "transferability_score",
+    "accept_best",
+]
+
+# Deterministic mutation hints cycled across variants; the variant index
+# is embedded in each description so variants stay pairwise distinct.
+_MUTATION_HINTS = (
+    "handle edge cases explicitly",
+    "return structured typed results",
+    "fail fast on invalid input",
+    "keep outputs deterministic",
+)
+
+
+@dataclass
+class VariantResult:
+    """Outcome of validating one variant."""
+
+    variant: SynthesizedTool
+    passed: bool
+    score: float
+
+
+def _mutate_description(base: SynthesizedTool, index: int) -> SynthesizedTool:
+    """Default deterministic mutation: rewrite the description field."""
+    hint = _MUTATION_HINTS[index % len(_MUTATION_HINTS)]
+    description = f"{base.description} [variant {index}: {hint}]"
+    code = (
+        base.code.replace(base.description, description)
+        if base.description and base.description in base.code
+        else base.code
+    )
+    return SynthesizedTool(name=base.name, description=description, code=code)
+
+
+def propose_variants(
+    base_tool: SynthesizedTool,
+    n_variants: int,
+    proposer: Optional[Callable[[SynthesizedTool, int], SynthesizedTool]] = None,
+) -> List[SynthesizedTool]:
+    """Propose *n_variants* mutation variants of *base_tool*.
+
+    *proposer* is a callable ``(base_tool, index) -> SynthesizedTool``;
+    the default is a deterministic description-level mutation.
+    """
+    mutate = proposer or _mutate_description
+    return [mutate(base_tool, i) for i in range(n_variants)]
+
+
+def run_batch(
+    variants: Sequence[SynthesizedTool],
+    validator: Callable[[SynthesizedTool], float],
+    max_workers: int = 4,
+) -> List[VariantResult]:
+    """Validate *variants* in parallel; collect pass/fail + score each.
+
+    *validator* returns a score; bool validators score 1.0/0.0. A
+    variant passes when its score is > 0.
+    """
+
+    def evaluate(variant: SynthesizedTool) -> VariantResult:
+        score = float(validator(variant))
+        return VariantResult(variant=variant, passed=score > 0.0, score=score)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        return list(pool.map(evaluate, variants))
+
+
+def _pass_rate(results: Sequence[VariantResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.passed) / len(results)
+
+
+def select_best(results: Sequence[VariantResult]) -> Optional[SynthesizedTool]:
+    """Return the highest-scoring passing variant, or None if none pass."""
+    passing = [r for r in results if r.passed]
+    if not passing:
+        return None
+    return max(passing, key=lambda r: r.score).variant
+
+
+def transferability_score(
+    origin_results: Sequence[VariantResult],
+    held_out_results: Sequence[VariantResult],
+) -> float:
+    """Held-out pass-rate ÷ origin pass-rate (cross-domain transfer).
+
+    1.0 means perfect transfer; below 1.0 degrades on held-out domains.
+    Returns 0.0 when the origin pass-rate is 0 (nothing to transfer).
+    """
+    origin_rate = _pass_rate(origin_results)
+    if origin_rate == 0.0:
+        return 0.0
+    return _pass_rate(held_out_results) / origin_rate
+
+
+def accept_best(
+    origin_results: Sequence[VariantResult],
+    held_out_results: Sequence[VariantResult],
+    threshold: float = 0.5,
+) -> Optional[SynthesizedTool]:
+    """Accept the best variant only if it passes origin AND transfers.
+
+    Gate: transferability ≥ *threshold* and the best origin variant
+    passed. Prevents overfitting to the origin domain (cf. #2480).
+    """
+    best = select_best(origin_results)
+    if best is None:
+        return None
+    if transferability_score(origin_results, held_out_results) < threshold:
+        return None
+    return best

--- a/tests/evolution/test_tool_batch_evolution.py
+++ b/tests/evolution/test_tool_batch_evolution.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for parallel batch tool evolution + transfer gate (#2260)."""
+
+from evolution.lib.tool_batch_evolution import (
+    VariantResult,
+    accept_best,
+    propose_variants,
+    run_batch,
+    select_best,
+    transferability_score,
+)
+from evolution.lib.tool_synthesis import SynthesizedTool, ToolProposer
+
+
+def _base_tool() -> SynthesizedTool:
+    return ToolProposer.propose("parse a CSV file", "csv_parser")
+
+
+def _variant(name: str) -> SynthesizedTool:
+    return SynthesizedTool(name=name, description=f"desc {name}", code="def f(): pass")
+
+
+def _result(name: str, passed: bool, score: float) -> VariantResult:
+    return VariantResult(variant=_variant(name), passed=passed, score=score)
+
+
+def _results(specs) -> list:
+    """Build results from (name, passed, score) tuples."""
+    return [_result(n, p, s) for n, p, s in specs]
+
+
+class TestProposeVariants:
+    def test_produces_n_distinct_variants(self):
+        variants = propose_variants(_base_tool(), 5)
+        assert len(variants) == 5
+        assert len({v.description for v in variants}) == 5
+
+    def test_more_variants_than_hints_stay_distinct(self):
+        variants = propose_variants(_base_tool(), 10)
+        assert len({v.description for v in variants}) == 10
+
+    def test_variants_preserve_base_identity(self):
+        base = _base_tool()
+        variants = propose_variants(base, 3)
+        assert all(v.name == base.name for v in variants)
+        assert all(v.accepted is False for v in variants)
+
+    def test_default_mutation_keeps_code_consistent_with_description(self):
+        variants = propose_variants(_base_tool(), 1)
+        assert variants[0].description in variants[0].code
+
+    def test_injected_proposer_is_used(self):
+        def proposer(base: SynthesizedTool, i: int) -> SynthesizedTool:
+            return SynthesizedTool(name=f"v{i}", description="d", code="c")
+
+        variants = propose_variants(_base_tool(), 3, proposer=proposer)
+        assert [v.name for v in variants] == ["v0", "v1", "v2"]
+
+
+class TestRunBatch:
+    def test_collects_all_outcomes(self):
+        variants = [_variant(f"v{i}") for i in range(4)]
+        scores = {"v0": 1.0, "v1": 0.0, "v2": 0.75, "v3": False}
+        results = run_batch(variants, validator=lambda t: scores[t.name], max_workers=2)
+        by_name = {r.variant.name: r for r in results}
+        assert len(results) == 4
+        assert by_name["v0"].passed is True and by_name["v0"].score == 1.0
+        assert by_name["v1"].passed is False
+        assert by_name["v2"].passed is True and by_name["v2"].score == 0.75
+        assert by_name["v3"].passed is False and by_name["v3"].score == 0.0
+
+    def test_validator_sees_every_variant_exactly_once(self):
+        variants = [_variant(f"v{i}") for i in range(3)]
+        seen: list = []
+
+        def validator(t: SynthesizedTool) -> float:
+            seen.append(t.name)
+            return 1.0
+
+        results = run_batch(variants, validator=validator, max_workers=3)
+        assert sorted(seen) == ["v0", "v1", "v2"]
+        assert len(results) == 3
+
+    def test_empty_batch_returns_empty(self):
+        assert run_batch([], validator=lambda t: 1.0) == []
+
+
+class TestSelectBest:
+    def test_picks_max_score_passer(self):
+        results = _results([("a", True, 0.5), ("b", True, 0.9), ("c", True, 0.7)])
+        assert select_best(results).name == "b"
+
+    def test_ignores_failing_even_if_higher_score(self):
+        results = _results([("a", True, 0.5), ("b", False, 0.99)])
+        assert select_best(results).name == "a"
+
+    def test_returns_none_when_nothing_passes(self):
+        results = _results([("a", False, 0.0), ("b", False, 0.1)])
+        assert select_best(results) is None
+
+    def test_empty_results_return_none(self):
+        assert select_best([]) is None
+
+
+class TestTransferabilityScore:
+    def test_equal_pass_rates_score_one(self):
+        origin = _results([("a", True, 1.0), ("b", True, 1.0), ("c", False, 0.0), ("d", False, 0.0)])
+        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", True, 1.0), ("d", False, 0.0)])
+        assert transferability_score(origin, held) == 1.0
+
+    def test_partial_transfer_ratio(self):
+        origin = _results([("a", True, 1.0), ("b", True, 1.0), ("c", True, 1.0), ("d", True, 1.0)])
+        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", False, 0.0), ("d", False, 0.0)])
+        assert transferability_score(origin, held) == 0.25
+
+    def test_zero_origin_rate_is_zero_even_if_held_out_passes(self):
+        origin = _results([("a", False, 0.0), ("b", False, 0.0)])
+        held = _results([("a", True, 1.0), ("b", True, 1.0)])
+        assert transferability_score(origin, held) == 0.0
+
+    def test_empty_held_out_is_zero(self):
+        origin = _results([("a", True, 1.0)])
+        assert transferability_score(origin, []) == 0.0
+
+
+class TestAcceptBest:
+    def test_rejects_overfit_variant(self):
+        origin = _results([("a", True, 1.0), ("b", True, 0.8)])
+        held = _results([(f"h{i}", i < 3, 1.0 if i < 3 else 0.0) for i in range(10)])
+        assert accept_best(origin, held) is None
+
+    def test_accepts_transferable_variant_and_returns_best(self):
+        origin = _results([("a", True, 0.9), ("b", True, 0.6), ("c", True, 0.7), ("d", False, 0.0), ("e", False, 0.0)])
+        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", True, 1.0), ("d", True, 1.0), ("e", False, 0.0)])
+        best = accept_best(origin, held)
+        assert best is not None
+        assert best.name == "a"
+
+    def test_rejects_when_no_origin_variant_passes(self):
+        origin = _results([("a", False, 0.0), ("b", False, 0.0)])
+        held = _results([("a", True, 1.0), ("b", True, 1.0)])
+        assert accept_best(origin, held) is None
+
+    def test_threshold_boundary_is_inclusive(self):
+        origin = _results([("a", True, 1.0), ("b", True, 1.0)])
+        held = _results([("a", True, 1.0), ("b", False, 0.0)])
+        # transferability == 0.5 exactly
+        assert accept_best(origin, held, threshold=0.5) is not None
+        assert accept_best(origin, held, threshold=0.6) is None
+
+
+class TestEndToEnd:
+    def test_propose_run_select_gate_pipeline(self):
+        variants = propose_variants(_base_tool(), 4)
+
+        call_count = {"n": 0}
+
+        def validator(t: SynthesizedTool) -> float:
+            call_count["n"] += 1
+            return [1.0, 0.5, 0.0, 0.75][call_count["n"] - 1]
+
+        results = run_batch(variants, validator=validator, max_workers=4)
+        best = select_best(results)
+        assert best is not None
+        assert best.accepted is False
+        assert accept_best(results, results) is not None


### PR DESCRIPTION
Closes #2260

## Summary

Slice B of the In-Situ Self-Evolving paradigm (parent #2248), building on Slice A (#2259, `evolution/lib/tool_synthesis.py`):

- **`propose_variants(base_tool, n_variants, proposer=None)`** — generate N mutation variants of a base tool. Default is a deterministic string-level mutation of the description (ToolProposer synthesizes from scratch, so it doesn't fit mutation-of-existing); an LLM/subagent-backed proposer is injectable without changing the contract.
- **`run_batch(variants, validator, max_workers)`** — validate the batch in parallel via `ThreadPoolExecutor`; validator is injectable (production: `SandboxValidator`; tests: stubs). Collects pass/fail + score per variant.
- **`select_best(results)`** — highest-scoring passing variant, `None` when nothing passes.
- **`transferability_score(origin_results, held_out_results)`** — held-out pass-rate ÷ origin pass-rate (cross-domain transfer metric, pure function).
- **`accept_best(origin_results, held_out_results, threshold=0.5)`** — gate: accept only if transferability ≥ threshold AND the best variant passed origin — prevents overfitting to the origin domain (mirrors the validation-overfitting guard philosophy from #2480).

## Test plan

- [x] `scripts/run_tests.sh tests/evolution/test_tool_batch_evolution.py` — 21 tests passed (behavior contracts only; stub validators/proposers, no subprocess, no network)
- [x] `ruff check` on both files — All checks passed
- [x] Module ≤ 200 lines (155)