### PR TITLE
feat(evolution): C-A-F loop — sandbox verifier, execution-grounded experience, regret-based routing updates

### DIFF
--- a/evolution/lib/caf_loop.py
+++ b/evolution/lib/caf_loop.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""C-A-F loop — Context-Action-Feedback (Issue #2258, Slice B, parent #2247).
+
+Sandbox-test candidates against a verifier, accumulate execution-grounded
+experience, update the #2257 RoutingTable from sandbox feedback; cumulative
+regret (pass-rate gap to the per-dimension best model) is the quality metric.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+Verifier = Union[Callable[[str, str], bool], str, Path]
+
+
+def _default_base_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return Path.home() / ".hermes"
+
+
+def default_experience_path() -> Path:
+    return _default_base_dir() / "evolution" / "caf" / "experience.jsonl"
+
+
+def default_routing_table_path() -> Path:
+    return _default_base_dir() / "evolution" / "routing" / "table.json"
+
+
+@dataclass
+class CafRecord:
+    """One execution-grounded observation: did *model* pass on *task_dim*?"""
+
+    task_dim: str
+    model: str
+    passed: bool
+    timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "CafRecord":
+        return cls(
+            str(d.get("task_dim", "")), str(d.get("model", "")),
+            bool(d.get("passed", False)), str(d.get("timestamp", "")),
+        )
+
+
+class CafSandboxVerifier:
+    """Run an answer against a verifier; binary verdict (B1). ``verifier`` is
+    a callable ``(task, answer) -> bool`` or a script path reading
+    ``{"task", "answer"}`` JSON on stdin, exit 0 = pass (mirrors
+    ``SandboxValidator`` in ``tool_synthesis.py``, kept simpler)."""
+
+    timeout_seconds: float = 30.0
+
+    def verify(self, task: str, answer: str, verifier: Verifier) -> bool:
+        if callable(verifier):
+            try:
+                return bool(verifier(task, answer))
+            except Exception as exc:
+                logger.warning("C-A-F verifier callable failed: %s", exc)
+                return False
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(verifier)],
+                input=json.dumps({"task": task, "answer": answer}),
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+            return proc.returncode == 0
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("C-A-F verifier script failed: %s", exc)
+            return False
+
+
+class CafExperience:
+    """Append-only JSONL store of pass/fail records (B3), fail-open on read."""
+
+    def __init__(self, path: Optional[Union[str, Path]] = None) -> None:
+        self.path = Path(path) if path is not None else default_experience_path()
+
+    def record(self, task_dim: str, model: str, passed: bool) -> CafRecord:
+        rec = CafRecord(task_dim=task_dim, model=model, passed=passed)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(asdict(rec), ensure_ascii=False) + "\n")
+        return rec
+
+    def load(self) -> List[CafRecord]:
+        """Load records; corrupt/blank lines are skipped, never fatal."""
+        if not self.path.exists():
+            return []
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return []
+        records: List[CafRecord] = []
+        for line in lines:
+            try:
+                records.append(CafRecord.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, ValueError):
+                continue
+        return records
+
+
+def cumulative_regret(records: List[CafRecord], model: str) -> float:
+    """Regret of *model* vs the per-dimension best model (B2, pure function):
+    trial-weighted average of ``p_best - p_model`` per dimension — 0.0 for
+    the best model (or no/unknown records)."""
+
+    by_dim: Dict[str, Dict[str, List[bool]]] = {}
+    for r in records:
+        by_dim.setdefault(r.task_dim, {}).setdefault(r.model, []).append(r.passed)
+    total_trials = 0
+    regret_sum = 0.0
+    for models in by_dim.values():
+        trials = models.get(model)
+        if not trials:
+            continue
+        p_model = sum(trials) / len(trials)
+        p_best = max(sum(t) / len(t) for t in models.values())
+        regret_sum += (p_best - p_model) * len(trials)
+        total_trials += len(trials)
+    if total_trials == 0:
+        return 0.0
+    return regret_sum / total_trials
+
+
+def run_caf_cycle(
+    task_dim: str,
+    task: str,
+    candidates: Dict[str, str],
+    verifier: Verifier,
+    table: Any,
+    experience: Optional[CafExperience] = None,
+) -> Dict[str, Any]:
+    """Sandbox-test each candidate (model → answer); record outcomes in the
+    experience store AND ``table.record_outcome``. Returns
+    ``{"task_dim", "results", "best_model", "regret"}``."""
+
+    exp = experience if experience is not None else CafExperience()
+    sandbox = CafSandboxVerifier()
+    results: List[Dict[str, Any]] = []
+    for model, answer in candidates.items():
+        passed = sandbox.verify(task, answer, verifier)
+        exp.record(task_dim=task_dim, model=model, passed=passed)
+        table.record_outcome(model=model, dimension=task_dim, success=passed)
+        results.append({"model": model, "passed": passed})
+    all_records = exp.load()
+    return {
+        "task_dim": task_dim,
+        "results": results,
+        "best_model": table.best_model(task_dim),
+        "regret": {m: cumulative_regret(all_records, m) for m in candidates},
+    }
+
+
+def save_routing_table(table: Any, path: Optional[Union[str, Path]] = None) -> Path:
+    """Persist a RoutingTable as JSON at *path* (default: profile-aware)."""
+    p = Path(path) if path is not None else default_routing_table_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(table.to_json(), encoding="utf-8")
+    return p
+
+
+def load_routing_table(path: Optional[Union[str, Path]] = None) -> Any:
+    """Load a RoutingTable from *path*; fail-open to an empty table."""
+    from tools.model_routing_table import RoutingTable
+    p = Path(path) if path is not None else default_routing_table_path()
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return RoutingTable.from_dict(data)
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        logger.debug("C-A-F routing table load failed (using empty table): %s", exc)
+        return RoutingTable(models=[])

--- a/tests/evolution/test_caf_loop.py
+++ b/tests/evolution/test_caf_loop.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""Tests for the C-A-F loop (Issue #2258, Slice B, parent #2247).
+
+Behavior contracts: verifier pass/fail → experience records; regret math on
+hand-built records; run_caf_cycle updates a real RoutingTable via
+record_outcome; save/load round-trip; corrupt table → fail-open empty table.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evolution.lib.caf_loop import (
+    CafExperience,
+    CafRecord,
+    CafSandboxVerifier,
+    cumulative_regret,
+    load_routing_table,
+    run_caf_cycle,
+    save_routing_table,
+)
+from tools.model_routing_table import RoutingTable
+
+
+def _verifier_strict(task: str, answer: str) -> bool:
+    return answer == "right"
+
+
+class TestCafSandboxVerifier:
+    def test_callable_verifier_pass_and_fail(self):
+        v = CafSandboxVerifier()
+        assert v.verify("t", "right", _verifier_strict) is True
+        assert v.verify("t", "wrong", _verifier_strict) is False
+
+    def test_callable_verifier_exception_is_fail(self):
+        def boom(task: str, answer: str) -> bool:
+            raise RuntimeError("boom")
+
+        assert CafSandboxVerifier().verify("t", "x", boom) is False
+
+    def test_script_verifier_exit_code_verdict(self, tmp_path):
+        script = tmp_path / "verifier.py"
+        script.write_text(
+            "import json, sys\n"
+            "payload = json.load(sys.stdin)\n"
+            "sys.exit(0 if payload['answer'] == 'right' else 1)\n",
+            encoding="utf-8",
+        )
+        v = CafSandboxVerifier()
+        assert v.verify("t", "right", str(script)) is True
+        assert v.verify("t", "wrong", str(script)) is False
+
+    def test_script_verifier_missing_or_crashing_is_fail(self, tmp_path):
+        v = CafSandboxVerifier()
+        assert v.verify("t", "x", str(tmp_path / "missing.py")) is False
+        crash = tmp_path / "crash.py"
+        crash.write_text("raise SystemExit(2)\n", encoding="utf-8")
+        assert v.verify("t", "x", str(crash)) is False
+
+
+class TestCafExperience:
+    def test_record_appends_and_loads_in_order(self, tmp_path):
+        exp = CafExperience(tmp_path / "experience.jsonl")
+        exp.record("coding", "model-a", True)
+        exp.record("coding", "model-b", False)
+        records = exp.load()
+        assert [(r.task_dim, r.model, r.passed) for r in records] == [
+            ("coding", "model-a", True),
+            ("coding", "model-b", False),
+        ]
+        assert all(r.timestamp for r in records)
+
+    def test_load_skips_corrupt_lines_and_missing_file(self, tmp_path):
+        path = tmp_path / "experience.jsonl"
+        path.write_text(
+            '{"task_dim": "coding", "model": "m", "passed": true}\n'
+            "not-json\n"
+            "\n",
+            encoding="utf-8",
+        )
+        records = CafExperience(path).load()
+        assert len(records) == 1 and records[0].model == "m"
+        assert CafExperience(tmp_path / "absent.jsonl").load() == []
+
+
+class TestCumulativeRegret:
+    def test_zero_for_best_model_and_unknown_model(self):
+        records = [
+            CafRecord("coding", "best", True, "t1"),
+            CafRecord("coding", "best", False, "t2"),
+            CafRecord("coding", "worse", False, "t3"),
+        ]
+        assert cumulative_regret(records, "best") == 0.0
+        assert cumulative_regret(records, "stranger") == 0.0
+        assert cumulative_regret([], "anyone") == 0.0
+
+    def test_gap_to_per_dimension_best_model(self):
+        records = [
+            CafRecord("coding", "best", True, "t1"),
+            CafRecord("coding", "best", False, "t2"),
+            CafRecord("coding", "worse", False, "t3"),
+            CafRecord("coding", "worse", False, "t4"),
+        ]
+        # best pass rate 0.5 vs worse 0.0 → regret 0.5
+        assert cumulative_regret(records, "worse") == pytest.approx(0.5)
+
+    def test_trial_weighted_across_dimensions(self):
+        records = [
+            # coding: model 2/2 (best), other 0/2 → gap 0.0 over 2 trials
+            CafRecord("coding", "model", True, "1"),
+            CafRecord("coding", "model", True, "2"),
+            CafRecord("coding", "other", False, "3"),
+            CafRecord("coding", "other", False, "4"),
+            # reasoning: model 0/1, other 1/1 (best) → gap 1.0 over 1 trial
+            CafRecord("reasoning", "model", False, "5"),
+            CafRecord("reasoning", "other", True, "6"),
+        ]
+        assert cumulative_regret(records, "model") == pytest.approx(1 / 3)
+
+
+class TestRunCafCycle:
+    def test_records_experience_and_updates_routing_table(self, tmp_path):
+        table = RoutingTable(models=["good", "bad"])
+        exp = CafExperience(tmp_path / "experience.jsonl")
+
+        report = run_caf_cycle(
+            task_dim="coding",
+            task="write a function",
+            candidates={"good": "right", "bad": "wrong"},
+            verifier=_verifier_strict,
+            table=table,
+            experience=exp,
+        )
+
+        # Experience store got the correct pass/fail records.
+        by_model = {r.model: r.passed for r in exp.load()}
+        assert by_model == {"good": True, "bad": False}
+        assert all(r.task_dim == "coding" for r in exp.load())
+
+        # RoutingTable was updated via record_outcome.
+        recs = {r["model"]: r for r in table.to_dict()["records"]}
+        assert recs["good"]["attempts"] == 1 and recs["good"]["successes"] == 1
+        assert recs["bad"]["attempts"] == 1 and recs["bad"]["successes"] == 0
+        assert table.best_model("coding") == "good"
+
+        # Cycle report contract.
+        assert report["task_dim"] == "coding"
+        assert {r["model"]: r["passed"] for r in report["results"]} == {
+            "good": True,
+            "bad": False,
+        }
+        assert report["best_model"] == "good"
+        assert report["regret"]["good"] == 0.0
+        assert report["regret"]["bad"] == pytest.approx(1.0)
+
+    def test_script_verifier_end_to_end(self, tmp_path):
+        script = tmp_path / "verifier.py"
+        script.write_text(
+            "import json, sys\n"
+            "payload = json.load(sys.stdin)\n"
+            "sys.exit(0 if 'def ' in payload['answer'] else 1)\n",
+            encoding="utf-8",
+        )
+        table = RoutingTable(models=["m1", "m2"])
+        report = run_caf_cycle(
+            task_dim="coding",
+            task="t",
+            candidates={"m1": "def f(): pass", "m2": "no code"},
+            verifier=str(script),
+            table=table,
+            experience=CafExperience(tmp_path / "experience.jsonl"),
+        )
+        assert report["best_model"] == "m1"
+        assert table.best_model("coding") == "m1"
+
+
+class TestRoutingTablePersistence:
+    def test_save_load_roundtrip(self, tmp_path):
+        table = RoutingTable(models=["a", "b"], epsilon=0.25)
+        table.record_outcome("a", "coding", True)
+        table.record_outcome("b", "coding", False)
+        path = tmp_path / "routing" / "table.json"
+        assert save_routing_table(table, path) == path
+
+        loaded = load_routing_table(path)
+        assert isinstance(loaded, RoutingTable)
+        assert loaded.models == ["a", "b"]
+        assert loaded.epsilon == 0.25
+        assert loaded.best_model("coding") == "a"
+
+    def test_load_missing_file_returns_empty_table(self, tmp_path):
+        loaded = load_routing_table(tmp_path / "absent.json")
+        assert isinstance(loaded, RoutingTable)
+        assert loaded.models == []
+
+    def test_load_corrupt_file_returns_empty_table(self, tmp_path):
+        path = tmp_path / "corrupt.json"
+        path.write_text("{not json", encoding="utf-8")
+        loaded = load_routing_table(path)
+        assert isinstance(loaded, RoutingTable)
+        assert loaded.models == []
+
+    def test_load_structurally_invalid_returns_empty_table(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps({"models": ["a"], "records": [{"nope": 1}]}),
+            encoding="utf-8",
+        )
+        loaded = load_routing_table(path)
+        assert loaded.models == []

--- a/tests/tools/test_delegate_model_routing.py
+++ b/tests/tools/test_delegate_model_routing.py
@@ -10,6 +10,7 @@ routing error must never break delegation.
 import pytest
 
 from tools.delegate_tool import _route_subagent_model
+from tools.model_routing_table import RoutingTable
 
 
 class TestRouteSubagentModel:
@@ -46,3 +47,34 @@ class TestRouteSubagentModel:
     def test_fail_open_on_missing_routing_key(self, monkeypatch):
         monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
         assert _route_subagent_model("write a poem", None, 0) is None
+
+
+class TestRouteSubagentModelPersistedTable:
+    """C-A-F persistence hook (issue #2258): a persisted routing table with
+    execution-grounded records is preferred over the ephemeral one."""
+
+    def _enable_routing(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.delegate_tool._load_config",
+            lambda: {"routing": {"enabled": True, "models": ["cfg-a", "cfg-b"]}},
+        )
+
+    def test_persisted_records_drive_routing(self, monkeypatch):
+        self._enable_routing(monkeypatch)
+        saved = RoutingTable(models=["persistent-best"], epsilon=0.0)
+        saved.record_outcome("persistent-best", "coding", True)
+        monkeypatch.setattr(
+            "evolution.lib.caf_loop.load_routing_table", lambda path=None: saved
+        )
+        routed = _route_subagent_model("write python code", None, 0)
+        assert routed == "persistent-best"
+
+    def test_loader_failure_falls_back_to_ephemeral(self, monkeypatch):
+        self._enable_routing(monkeypatch)
+
+        def boom(path=None):
+            raise RuntimeError("corrupt table")
+
+        monkeypatch.setattr("evolution.lib.caf_loop.load_routing_table", boom)
+        routed = _route_subagent_model("write a poem", None, 0)
+        assert routed in {"cfg-a", "cfg-b"}

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5266,6 +5266,15 @@ def _route_subagent_model(
             return None
         _task = {"type": goal, "tags": [context or ""]}
         _routing_table = RoutingTable(models=list(_routing_models))
+        try:  # fail-open: prefer persisted C-A-F experience if present (#2258)
+            from evolution.lib.caf_loop import default_routing_table_path, load_routing_table
+
+            _saved = load_routing_table(default_routing_table_path())
+            if _saved.models:
+                _saved.models = list(dict.fromkeys(_routing_models + _saved.models))
+                _routing_table = _saved
+        except Exception:
+            pass
         _routed = _routing_table.select_model(_task)
         if _routed:
             logger.info(


### PR DESCRIPTION
Closes #2258 (Slice B of parent #2247; builds on Slice A #2257 landed via #2268 — `tools/model_routing_table.py`).

Delivers the deferred B1/B2/B3 split from the #2258 deferral comment as one small module — the three pieces are coupled and small together.

## What lands

**`evolution/lib/caf_loop.py` (191 lines):**
- **B1 `CafSandboxVerifier`** — runs a model's answer against a verifier in an isolated subprocess; binary pass/fail. Verifier is a callable `(task, answer) -> bool` or a script path reading `{"task", "answer"}` JSON on stdin (exit 0 = pass; crash/timeout = fail). Mirrors `SandboxValidator` from `evolution/lib/tool_synthesis.py`, kept simpler.
- **B3 `CafExperience`** — append-only JSONL store of execution-grounded records `(task_dim, model, passed, timestamp)` under `<HERMES_HOME>/evolution/caf/experience.jsonl` via `get_hermes_home()` (profile-aware, never hardcoded); path injectable for tests; corrupt lines skipped on read.
- **B2 `cumulative_regret(records, model)`** — pure streaming quality metric: trial-weighted average of the pass-rate gap to the per-task-dimension best model; 0.0 for the best model / unknown model.
- **`run_caf_cycle(...)`** — sandbox-tests each candidate (model → answer), records outcomes in BOTH the experience store and `RoutingTable.record_outcome()`, returns a cycle report `{task_dim, results, best_model, regret}` — routing improves with every execution.
- **`save_routing_table` / `load_routing_table`** — JSON persistence under `<HERMES_HOME>/evolution/routing/table.json` (path injectable).

## delegate_tool fail-open wiring (+9 lines)

`_route_subagent_model` previously built an **ephemeral** RoutingTable on every call — no memory between calls. Now, at function start, it tries `load_routing_table(default_routing_table_path())` and uses the persisted table's records when present (candidate list = config `delegation.routing.models` + persisted models, order-preserving dedupe). Wrapped in try/except: on **ANY** error — import failure, corrupt/missing file, IO — it falls back to exactly the current ephemeral behavior. When the file is absent or empty, behavior is byte-identical to main.

## Tests

`tests/evolution/test_caf_loop.py` (15 tests, behavior contracts only, stdlib + pytest + unittest.mock patterns):
- verifier pass/fail (callable + script + exception/missing/crash → fail)
- experience append/load ordering, corrupt-line skipping, missing file
- regret math on hand-built records (0.0 for best, gap 0.5, trial-weighted 1/3 across dimensions)
- `run_caf_cycle` updates a real RoutingTable via `record_outcome` + experience records + report contract
- save/load round-trip via `tmp_path`; missing/corrupt/structurally-invalid file → fail-open empty table

`tests/tools/test_delegate_model_routing.py` (+2 wiring tests at the module boundary — mock `evolution.lib.caf_loop.load_routing_table`, the god-file itself is only touched via its existing wiring-test file): persisted records drive routing; loader failure falls back to ephemeral.

**Result: 22/22 pass** via `scripts/run_tests.sh`; `ruff check` clean on all touched files. Module diff exactly 200 lines (191 + 9).