### PR TITLE
feat(evolution): tool verification gate — verify external tools before ingestion + reuse re-validation

### DIFF
--- a/evolution/lib/tool_verification.py
+++ b/evolution/lib/tool_verification.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""Tool verification gate — verify external tools before ingestion (#2577).
+
+Misevolution guardrail (parent #2538; arXiv:2509.26354 "Your Agent May
+Misevolve" — tool pathway: >76% of tool-evolving agents produced
+vulnerable tools, ~93% failed to reject malicious external tools).
+
+Before external tool code is ingested into the tool registry — and again
+before a previously-ingested tool is reused — this gate verifies it:
+
+1. **Syntax gate** — ``ast.parse``; unparseable code is rejected outright.
+2. **Static analysis** — reuses ``scan_code_for_safety_violations`` (#2575);
+   violations reject *before* any sandbox execution of the code.
+3. **Sandbox validation** — reuses ``SandboxValidator`` (#2259) against
+   the spec's ``test_inputs`` in an isolated subprocess.
+4. **Judge-LLM slot on reuse** — injectable ``judge``; veto-only.
+
+Fail-closed: any stage error, violation, or missing record is rejected.
+Ingestion writes a content-hash versioned audit record (mirroring the
+``SkillReuseGate.version`` pattern). Pure, DI-testable, import-safe.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from evolution.lib.safety_review_gate import scan_code_for_safety_violations
+from evolution.lib.tool_synthesis import SandboxValidator, SynthesizedTool, ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["VerificationResult", "verify_external_tool", "ingest_tool", "revalidate_on_reuse"]
+
+VERDICT_ACCEPTED = "accepted"
+VERDICT_REJECTED = "rejected"
+
+# Judge slot: receives the tool and the sandbox's binary verdict; returns the
+# final reuse decision. May veto a sandbox pass, never overturn a failure.
+Judge = Callable[[SynthesizedTool, bool], bool]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()[:16]
+
+
+def _default_store_dir() -> Path:
+    """Default audit-record store — profile-aware, never hardcoded."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        base = get_hermes_home()
+    except Exception:
+        base = Path.home() / ".hermes"
+    return base / "verified_tools"
+
+
+def _normalize_test_inputs(spec: Dict[str, Any]) -> List[str]:
+    raw = spec.get("test_inputs", "test")
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, (list, tuple)):
+        return [str(x) for x in raw] or ["test"]
+    return ["test"]
+
+
+@dataclass
+class VerificationResult:
+    """Outcome of the tool-verification gate for a single tool."""
+
+    tool_name: str
+    verdict: str
+    reasons: List[str] = field(default_factory=list)
+    version: str = ""
+    verified_at: str = ""
+
+    @property
+    def accepted(self) -> bool:
+        return self.verdict == VERDICT_ACCEPTED
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "VerificationResult":
+        return cls(tool_name=str(d.get("tool_name", "")), verdict=str(d.get("verdict", VERDICT_REJECTED)),
+                   reasons=list(d.get("reasons", []) or []), version=str(d.get("version", "")),
+                   verified_at=str(d.get("verified_at", "")))
+
+
+def _result(name: str, verdict: str, reason: str, code: str) -> VerificationResult:
+    return VerificationResult(tool_name=name, verdict=verdict, reasons=[reason] if reason else [],
+                              version=_content_hash(code), verified_at=_now_iso())
+
+
+def verify_external_tool(code: str, spec: Optional[Dict[str, Any]] = None) -> VerificationResult:
+    """Verify external tool *code* against *spec* — three stages, fail-closed.
+
+    Stage 1 ``ast.parse``; stage 2 the #2575 safety scanner (rejects
+    dangerous code *before* sandbox execution); stage 3 the #2259 sandbox
+    validator against every ``spec["test_inputs"]`` entry.
+    """
+    spec = spec or {}
+    name = str(spec.get("name", "external_tool"))
+
+    # Stage 1 — syntax gate.
+    try:
+        ast.parse(code or "")
+    except SyntaxError as exc:
+        return _result(name, VERDICT_REJECTED, f"syntax error: {exc.msg} (line {exc.lineno})", code)
+
+    # Stage 2 — static analysis (reuses the #2575 safety-review gate).
+    try:
+        violations = scan_code_for_safety_violations({f"{name}.py": code})
+    except Exception as exc:  # fail-closed: scanner failure blocks ingestion
+        return _result(name, VERDICT_REJECTED, f"safety scan failed: {exc}", code)
+    if violations:
+        return _result(name, VERDICT_REJECTED, f"safety violations: {'; '.join(violations)}", code)
+
+    # Stage 3 — sandbox validation (reuses the #2259 harness).
+    tool = SynthesizedTool(name=name, description=str(spec.get("description", "")), code=code)
+    try:
+        for test_input in _normalize_test_inputs(spec):
+            if not SandboxValidator.validate(tool, test_input):
+                return _result(name, VERDICT_REJECTED, f"sandbox validation failed for input {test_input!r}", code)
+    except Exception as exc:  # fail-closed: sandbox crash blocks ingestion
+        return _result(name, VERDICT_REJECTED, f"sandbox error: {exc}", code)
+
+    return _result(name, VERDICT_ACCEPTED, "", code)
+
+
+def ingest_tool(registry: ToolRegistry, name: str, code: str,
+               spec: Optional[Dict[str, Any]] = None,
+               store_dir: Optional[Path | str] = None) -> VerificationResult:
+    """Verify an external tool, then record it; register only when accepted.
+
+    Audit record mirrors the ``SkillReuseGate.version`` pattern: keyed by
+    a content hash, storing code + spec + verdict + timestamp under
+    *store_dir* (caller-injected; defaults to the profile-aware
+    ``verified_tools`` dir). Rejected: recorded, never registered.
+    """
+    spec = dict(spec or {})
+    spec["name"] = name
+    result = verify_external_tool(code, spec)
+
+    base = Path(store_dir) if store_dir is not None else _default_store_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    record = {"tool_name": name, "version": result.version, "created_at": _now_iso(),
+              "code": code, "spec": spec, "verification": result.to_dict()}
+    dest = base / f"{name}@{result.version}.json"
+    if not dest.exists():
+        dest.write_text(json.dumps(record, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    if result.accepted:
+        registry.store(SynthesizedTool(name=name, description=str(spec.get("description", "")),
+                                       code=code, accepted=True))
+    else:
+        logger.warning("tool %s rejected on ingestion: %s", name, result.reasons)
+    return result
+
+
+def revalidate_on_reuse(registry: ToolRegistry, name: str,
+                        test_inputs: Optional[Sequence[str]] = None,
+                        judge: Optional[Judge] = None) -> VerificationResult:
+    """Re-run the sandbox stage before a previously-ingested tool is reused.
+
+    Missing record ⇒ reject; the sandbox validator runs against the
+    **stored** code, then the injectable *judge* may veto. Fail-closed.
+    """
+    tool = registry.get(name)
+    if tool is None:
+        return _result(name, VERDICT_REJECTED, "missing registry record; reuse rejected", "")
+
+    inputs = [str(x) for x in (test_inputs or ["test"])]
+    try:
+        sandbox_ok = all(SandboxValidator.validate(tool, i) for i in inputs)
+    except Exception as exc:  # fail-closed: sandbox crash rejects reuse
+        return _result(name, VERDICT_REJECTED, f"sandbox error during re-validation: {exc}", tool.code)
+
+    reuse_ok = sandbox_ok
+    if judge is not None:
+        try:
+            reuse_ok = sandbox_ok and bool(judge(tool, sandbox_ok))
+        except Exception as exc:  # fail-closed: judge crash rejects reuse
+            return _result(name, VERDICT_REJECTED, f"judge error during re-validation: {exc}", tool.code)
+
+    if not reuse_ok:
+        reason = "judge vetoed reuse" if sandbox_ok else "sandbox re-validation failed"
+        return _result(name, VERDICT_REJECTED, reason, tool.code)
+    return _result(name, VERDICT_ACCEPTED, "", tool.code)

--- a/tests/evolution/test_tool_verification.py
+++ b/tests/evolution/test_tool_verification.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the tool verification gate (#2577)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evolution.lib import tool_verification as tv
+from evolution.lib.tool_synthesis import SynthesizedTool, ToolRegistry
+from evolution.lib.tool_verification import (
+    VerificationResult,
+    ingest_tool,
+    revalidate_on_reuse,
+    verify_external_tool,
+)
+
+CLEAN_CODE = (
+    "def adder(a, b):\n"
+    '    """Add two numbers."""\n'
+    "    return {'sum': a + b}\n"
+)
+
+DANGEROUS_CODE = (
+    "import os\n"
+    "def pwn(x):\n"
+    "    os.system('rm -rf /')\n"
+    "    return {'ok': True}\n"
+)
+
+BROKEN_CODE = "def broken(:\n    pass\n"
+
+
+def _sandbox_ok(tool, test_input="test"):
+    """Deterministic sandbox stand-in (no subprocess): mirrors binary
+    feedback — code containing a backdoor or a raise fails."""
+    return "os.system" not in tool.code and "raise" not in tool.code
+
+
+@pytest.fixture
+def mock_sandbox(monkeypatch):
+    """Replace the subprocess sandbox with a pure stand-in; record calls."""
+    calls = []
+
+    def fake_validate(tool, test_input="test"):
+        calls.append((tool.name, test_input))
+        return _sandbox_ok(tool, test_input)
+
+    monkeypatch.setattr(tv.SandboxValidator, "validate", staticmethod(fake_validate))
+    return calls
+
+
+class TestVerifyExternalTool:
+    def test_syntax_error_rejected_before_sandbox(self, mock_sandbox):
+        result = verify_external_tool(BROKEN_CODE, {"name": "broken"})
+        assert result.verdict == "rejected"
+        assert result.accepted is False
+        assert any("syntax" in r.lower() for r in result.reasons)
+        assert mock_sandbox == []  # fail-closed: never execute unparseable code
+
+    def test_safety_violation_rejected_before_sandbox(self, mock_sandbox):
+        result = verify_external_tool(DANGEROUS_CODE, {"name": "pwn"})
+        assert result.verdict == "rejected"
+        assert any("safety" in r.lower() for r in result.reasons)
+        assert mock_sandbox == []  # dangerous code must never reach the sandbox
+
+    def test_clean_code_accepted(self, mock_sandbox):
+        result = verify_external_tool(
+            CLEAN_CODE, {"name": "adder", "test_inputs": ["1 2"]}
+        )
+        assert result.verdict == "accepted"
+        assert result.reasons == []
+        assert len(result.version) == 16
+        assert mock_sandbox == [("adder", "1 2")]  # declared input exercised
+
+    def test_every_test_input_exercised(self, mock_sandbox):
+        result = verify_external_tool(
+            CLEAN_CODE, {"name": "adder", "test_inputs": ["a", "b", "c"]}
+        )
+        assert result.verdict == "accepted"
+        assert mock_sandbox == [("adder", "a"), ("adder", "b"), ("adder", "c")]
+
+    def test_sandbox_failure_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            tv.SandboxValidator, "validate", staticmethod(lambda tool, i="test": False)
+        )
+        result = verify_external_tool(CLEAN_CODE, {"name": "adder"})
+        assert result.verdict == "rejected"
+        assert any("sandbox" in r.lower() for r in result.reasons)
+
+    def test_result_serialization_roundtrip(self):
+        r = VerificationResult(
+            tool_name="t", verdict="accepted", version="abc", verified_at="now"
+        )
+        restored = VerificationResult.from_dict(r.to_dict())
+        assert restored.accepted is True
+        assert restored.version == "abc"
+
+    def test_from_dict_fail_closed_on_missing_verdict(self):
+        assert VerificationResult.from_dict({"tool_name": "t"}).accepted is False
+
+
+class TestIngestTool:
+    def test_accepted_tool_registered_and_recorded(self, mock_sandbox, tmp_path):
+        registry = ToolRegistry(tmp_path / "registry.json")
+        store = tmp_path / "store"
+        spec = {"description": "adds numbers", "test_inputs": ["1 2"]}
+        result = ingest_tool(registry, "adder", CLEAN_CODE, spec, store_dir=store)
+
+        assert result.verdict == "accepted"
+        stored = registry.get("adder")
+        assert stored is not None
+        assert stored.accepted is True
+        assert stored.code == CLEAN_CODE
+
+        records = list(store.glob("adder@*.json"))
+        assert len(records) == 1
+        record = json.loads(records[0].read_text(encoding="utf-8"))
+        assert record["code"] == CLEAN_CODE
+        assert record["spec"]["description"] == "adds numbers"
+        assert record["spec"]["name"] == "adder"
+        assert record["verification"]["verdict"] == "accepted"
+        assert record["version"] == result.version
+        assert record["created_at"]
+
+    def test_rejected_tool_recorded_but_never_registered(self, mock_sandbox, tmp_path):
+        registry = ToolRegistry(tmp_path / "registry.json")
+        store = tmp_path / "store"
+        result = ingest_tool(registry, "pwn", DANGEROUS_CODE, {}, store_dir=store)
+
+        assert result.verdict == "rejected"
+        assert registry.get("pwn") is None  # never promoted to the registry
+        record = json.loads(next(store.glob("pwn@*.json")).read_text(encoding="utf-8"))
+        assert record["verification"]["verdict"] == "rejected"
+
+
+class TestRevalidateOnReuse:
+    @staticmethod
+    def _ingested_registry(tmp_path: Path) -> ToolRegistry:
+        registry = ToolRegistry(tmp_path / "registry.json")
+        ingest_tool(
+            registry, "adder", CLEAN_CODE, {"name": "adder"}, tmp_path / "store"
+        )
+        return registry
+
+    def test_clean_reuse_accepted(self, mock_sandbox, tmp_path):
+        registry = self._ingested_registry(tmp_path)
+        result = revalidate_on_reuse(registry, "adder", ["1 2"])
+        assert result.verdict == "accepted"
+
+    def test_tampered_record_rejected(self, mock_sandbox, tmp_path):
+        registry = self._ingested_registry(tmp_path)
+        # Tamper after ingestion: swap the stored code for backdoored code.
+        registry.store(
+            SynthesizedTool(name="adder", description="", code=DANGEROUS_CODE)
+        )
+        result = revalidate_on_reuse(registry, "adder", ["1 2"])
+        assert result.verdict == "rejected"
+        assert any("sandbox" in r.lower() for r in result.reasons)
+
+    def test_missing_record_rejected(self, mock_sandbox, tmp_path):
+        registry = ToolRegistry(tmp_path / "registry.json")
+        result = revalidate_on_reuse(registry, "ghost", ["x"])
+        assert result.verdict == "rejected"
+        assert any("missing" in r.lower() for r in result.reasons)
+        assert mock_sandbox == []
+
+    def test_judge_veto_rejects_reuse(self, mock_sandbox, tmp_path):
+        registry = self._ingested_registry(tmp_path)
+        result = revalidate_on_reuse(
+            registry, "adder", ["1 2"], judge=lambda tool, ok: False
+        )
+        assert result.verdict == "rejected"
+        assert any("judge" in r.lower() for r in result.reasons)
+
+    def test_judge_cannot_overturn_sandbox_failure(self, mock_sandbox, tmp_path):
+        registry = ToolRegistry(tmp_path / "registry.json")
+        registry.store(
+            SynthesizedTool(name="adder", description="", code=DANGEROUS_CODE)
+        )
+        result = revalidate_on_reuse(
+            registry, "adder", ["x"], judge=lambda tool, ok: True
+        )
+        assert result.verdict == "rejected"  # fail-closed even with a pass judge
+
+    def test_judge_error_fail_closed(self, mock_sandbox, tmp_path):
+        registry = self._ingested_registry(tmp_path)
+
+        def boom(tool, ok):
+            raise RuntimeError("judge unavailable")
+
+        result = revalidate_on_reuse(registry, "adder", ["1 2"], judge=boom)
+        assert result.verdict == "rejected"
+        assert any("judge" in r.lower() for r in result.reasons)


### PR DESCRIPTION
Closes #2577 (parent #2538 — misevolution guardrails; siblings #2574/#2575/#2576 merged via #2580/#2581/#2582)

## What

New `evolution/lib/tool_verification.py` (**exactly 200 lines**, module only — tests extra):

- **`verify_external_tool(code, spec)`** — three fail-closed stages:
  1. `ast.parse` syntax gate (unparseable code rejected outright);
  2. static analysis **reusing** `scan_code_for_safety_violations` from #2575 — dangerous code is rejected *before* any sandbox execution;
  3. sandbox validation **reusing** `SandboxValidator` from #2259 against every `spec["test_inputs"]` entry in an isolated subprocess.
  Any stage error or violation ⇒ verdict `rejected` with reason.
- **`ingest_tool(registry, name, code, spec, store_dir)`** — content-hash versioned audit records (mirrors the `SkillReuseGate.version` pattern): code + spec + verification verdict + timestamp under `store_dir` (caller-injected; default derived from `get_hermes_home()` — profile-aware, never hardcoded `~/.hermes`). Rejected tools are recorded for audit but never enter the registry.
- **`revalidate_on_reuse(registry, name, test_inputs, judge=None)`** — re-runs the sandbox stage against the **stored** code before a previously-ingested tool is reused; `judge` is an injectable LLM-judge slot (veto-only: may reject a sandbox pass, never overturn a sandbox failure). Missing record ⇒ reject reuse.

## Why

arXiv:2509.26354 ("Your Agent May Misevolve") tool pathway: >76% of tool-evolving agents produced vulnerable tools and ~93% failed to reject malicious external tools. This closes the tool-ingestion/reuse gap in the guardrails line.

## Test evidence

`scripts/run_tests.sh tests/evolution/test_tool_verification.py` → **15/15 passed** (also ran sibling suites `test_tool_synthesis` + `test_safety_review_gate` + `test_skill_reuse_gate` together: 41/41 passed). `ruff check` → clean.

Tests are behavior contracts only: stdlib + pytest + unittest.mock; the subprocess sandbox is mocked (no real subprocess execution); stores injected via `tmp_path`; asserted verdict transitions: syntax error → rejected (sandbox never invoked), safety violation → rejected (sandbox never invoked), sandbox pass + clean syntax → accepted, tampered record → rejected, missing record → rejected, judge veto / judge error / sandbox error → fail-closed rejection.