### PR TITLE
feat(agent): co-evolution loop — delegation outcomes feed usage-tagged tool bank (read-only suggestions)

### DIFF
--- a/agent/coevolution.py
+++ b/agent/coevolution.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Co-evolution loop — agents and tools improve together (#2262, parent #2251).
+
+Slice B of the dual asset banks: the agent bank (``agent/experience_bank.py``,
+#2261) stores ``DelegationPattern`` assets; this module tags every delegation
+outcome with the tools the child agent actually used, success-correlated:
+
+* :func:`record_delegation_and_tools` — wraps ``bank.record_delegation_outcome``
+  (default: ``agent.experience_bank``) AND aggregates usage tags into
+  ``tool_usage_tags.json`` (profile-aware under ``get_hermes_home()``).
+* :func:`suggest_configuration` — retrieval-only suggestion combining
+  ``bank.find_matching_delegation_patterns`` with top successful tool tags.
+
+Suggestions are consumed OFFLINE by the evolution loop — never applied to a
+live agent, since mutating toolsets mid-conversation would break
+per-conversation prompt caching (repo policy, AGENTS.md). Both functions fail
+open: storage/bank errors are logged at debug and never propagate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from agent import experience_bank
+from agent.experience_bank import _atomic_write_json
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_MAX_TASK_TYPE_LEN = 60
+_MIN_SUCCESS_RATE = 0.5  # mirrors find_matching_delegation_patterns default
+_MAX_SUGGESTED_TOOLS = 8
+
+
+def tool_usage_tags_path() -> Path:
+    """Return the absolute path to the usage-tagged tool store (lazily resolved)."""
+    return get_hermes_home() / "evolution" / "coevolution" / "tool_usage_tags.json"
+
+
+def _task_type_from_goal(goal: str) -> str:
+    """Normalize a delegation goal into an agent-bank ``task_type`` key."""
+    text = re.sub(r"\s+", " ", str(goal or "").strip().lower())
+    return text[:_MAX_TASK_TYPE_LEN].strip()
+
+
+def _tool_names(tool_calls: Sequence[Any]) -> List[str]:
+    names: List[str] = []
+    for call in tool_calls or ():
+        if isinstance(call, str):
+            name = call.strip()
+        elif isinstance(call, dict):
+            name = str(call.get("tool") or call.get("name") or "").strip()
+        else:
+            continue
+        if name:
+            names.append(name)
+    return names
+
+
+def _load_tags(path: Path) -> Dict[str, Any]:
+    """Load the tag store; corrupt or missing files degrade to empty."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data
+    except (OSError, ValueError) as exc:
+        logger.debug("tool-usage tags unreadable at %s: %s", path, exc)
+    return {}
+
+
+def _subdict(parent: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """Return ``parent[key]`` if it is a dict, else a fresh empty dict."""
+    value = parent.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def record_delegation_and_tools(
+    session_key: str,
+    goal: str,
+    outcome: Dict[str, Any],
+    tool_calls: Sequence[Any],
+    bank: Any = None,
+    *,
+    role: str = "leaf",
+    model: str = "",
+    tags_path: Optional[Path] = None,
+) -> bool:
+    """Record one delegation outcome into the agent bank AND the tool tags.
+
+    Fail-open by contract: errors are logged at debug and reported as
+    ``False``; they never propagate (the delegation result is already final
+    when this is called from ``tools/delegate_tool.py``).
+    """
+    bank = bank if bank is not None else experience_bank
+    task_type = _task_type_from_goal(goal)
+    status = str(
+        outcome.get("status") or ("completed" if outcome.get("completed") else "failed")
+    )
+    success = status == "completed"
+
+    ok = True
+    try:
+        ok = bool(
+            bank.record_delegation_outcome(
+                task_type=task_type,
+                role=role,
+                model=model,
+                goal_template=str(goal or ""),
+                success=success,
+            )
+        )
+    except Exception as exc:  # fail-open: bank must not break delegation
+        logger.debug("agent-bank record failed: %s", exc)
+        ok = False
+
+    names = _tool_names(tool_calls)
+    if not (task_type and names):
+        return ok
+    path = Path(tags_path) if tags_path is not None else tool_usage_tags_path()
+    data = _load_tags(path)
+    tasks = _subdict(data, "tasks")
+    task_entry = _subdict(tasks, task_type)
+    tools = _subdict(task_entry, "tools")
+    for name in names:
+        stats = _subdict(tools, name)
+        stats["total"] = int(stats.get("total", 0)) + 1
+        stats["success"] = int(stats.get("success", 0)) + (1 if success else 0)
+        tools[name] = stats
+    task_entry["tools"] = tools
+    task_entry.update(last_session=str(session_key or ""), updated=time.time())
+    tasks[task_type] = task_entry
+    data["tasks"] = tasks
+    written = _atomic_write_json(path, data)  # not `ok and ...` — no short-circuit
+    return ok and written
+
+
+def suggest_configuration(
+    goal: str,
+    bank: Any = None,
+    tags_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Build a retrieval-only configuration suggestion for a goal.
+
+    STRICTLY read-only: loads the agent bank and the tag store, never writes,
+    never mutates live agent configuration (prompt-caching policy). Returns
+    ``{"suggested_tools": [...], "matched_patterns": [...]}``.
+    """
+    bank = bank if bank is not None else experience_bank
+    task_type = _task_type_from_goal(goal)
+
+    matched: List[Dict[str, Any]] = []
+    try:
+        for pattern in bank.find_matching_delegation_patterns(task_type):
+            to_dict = getattr(pattern, "to_dict", None)
+            matched.append(to_dict() if callable(to_dict) else dict(pattern))
+    except Exception as exc:  # fail-open: suggestions are advisory only
+        logger.debug("delegation pattern lookup failed: %s", exc)
+
+    suggested: List[str] = []
+    if task_type:
+        path = Path(tags_path) if tags_path is not None else tool_usage_tags_path()
+        totals: Dict[str, List[int]] = {}
+        for stored, entry in _subdict(_load_tags(path), "tasks").items():
+            stored_type = str(stored).lower().strip()
+            similar = stored_type == task_type or stored_type in task_type or task_type in stored_type
+            if not similar:
+                continue
+            for name, stats in _subdict(entry, "tools").items():
+                agg = totals.setdefault(str(name), [0, 0])
+                agg[0] += int(stats.get("success", 0))
+                agg[1] += int(stats.get("total", 0))
+        def _rate(agg: List[int]) -> float:
+            return agg[0] / agg[1] if agg[1] else 0.0
+
+        ranked = sorted(totals.items(), key=lambda kv: (-_rate(kv[1]), -kv[1][1]))
+        suggested = [n for n, agg in ranked if _rate(agg) >= _MIN_SUCCESS_RATE][
+            :_MAX_SUGGESTED_TOOLS
+        ]
+    return {"suggested_tools": suggested, "matched_patterns": matched}

--- a/tests/agent/test_coevolution.py
+++ b/tests/agent/test_coevolution.py
@@ -1,0 +1,182 @@
+"""Behavior contracts for the co-evolution loop (#2262, parent #2251)."""
+
+import json
+from unittest.mock import MagicMock
+
+from agent.coevolution import (
+    record_delegation_and_tools,
+    suggest_configuration,
+    tool_usage_tags_path,
+)
+
+
+class _FakePattern:
+    """Minimal stand-in for experience_bank.DelegationPattern."""
+
+    def __init__(self, task_type, role="leaf"):
+        self.task_type = task_type
+        self.role = role
+
+    def to_dict(self):
+        return {"task_type": self.task_type, "role": self.role}
+
+
+def _trace(*names):
+    return [{"tool": name, "status": "ok"} for name in names]
+
+
+class TestRecordDelegationAndTools:
+    def test_writes_tags_file_and_delegates_to_bank(self, tmp_path):
+        bank = MagicMock()
+        bank.record_delegation_outcome.return_value = True
+        tags = tmp_path / "tool_usage_tags.json"
+
+        ok = record_delegation_and_tools(
+            session_key="telegram:42",
+            goal="Parse CSV Files With Pandas",
+            outcome={"status": "completed", "completed": True},
+            tool_calls=_trace("read_file", "terminal"),
+            bank=bank,
+            tags_path=tags,
+        )
+
+        assert ok is True
+        bank.record_delegation_outcome.assert_called_once_with(
+            task_type="parse csv files with pandas",
+            role="leaf",
+            model="",
+            goal_template="Parse CSV Files With Pandas",
+            success=True,
+        )
+        data = json.loads(tags.read_text(encoding="utf-8"))
+        task = data["tasks"]["parse csv files with pandas"]
+        assert task["last_session"] == "telegram:42"
+        assert task["tools"]["read_file"] == {"success": 1, "total": 1}
+        assert task["tools"]["terminal"] == {"success": 1, "total": 1}
+
+    def test_failed_outcome_tags_tools_as_unsuccessful(self, tmp_path):
+        bank = MagicMock()
+        bank.record_delegation_outcome.return_value = True
+        tags = tmp_path / "tool_usage_tags.json"
+
+        record_delegation_and_tools(
+            session_key="cli",
+            goal="scrape the docs site",
+            outcome={"status": "failed", "completed": False},
+            tool_calls=_trace("browser_navigate"),
+            bank=bank,
+            tags_path=tags,
+        )
+
+        data = json.loads(tags.read_text(encoding="utf-8"))
+        assert data["tasks"]["scrape the docs site"]["tools"]["browser_navigate"] == {
+            "success": 0,
+            "total": 1,
+        }
+        assert bank.record_delegation_outcome.call_args.kwargs["success"] is False
+
+    def test_aggregates_across_recordings(self, tmp_path):
+        bank = MagicMock()
+        tags = tmp_path / "tool_usage_tags.json"
+        for outcome in ({"status": "completed"}, {"status": "failed"}):
+            record_delegation_and_tools(
+                session_key="s",
+                goal="same goal",
+                outcome=outcome,
+                tool_calls=_trace("terminal"),
+                bank=bank,
+                tags_path=tags,
+            )
+        data = json.loads(tags.read_text(encoding="utf-8"))
+        assert data["tasks"]["same goal"]["tools"]["terminal"] == {
+            "success": 1,
+            "total": 2,
+        }
+
+    def test_fail_open_on_bank_error(self, tmp_path):
+        bank = MagicMock()
+        bank.record_delegation_outcome.side_effect = RuntimeError("bank down")
+        tags = tmp_path / "tool_usage_tags.json"
+
+        ok = record_delegation_and_tools(
+            session_key="s",
+            goal="g",
+            outcome={"status": "completed"},
+            tool_calls=_trace("terminal"),
+            bank=bank,
+            tags_path=tags,
+        )
+
+        assert ok is False  # reported, not raised
+        # The tool-bank half still records (independent stores).
+        data = json.loads(tags.read_text(encoding="utf-8"))
+        assert data["tasks"]["g"]["tools"]["terminal"]["total"] == 1
+
+
+class TestSuggestConfiguration:
+    def _seeded_store(self, tmp_path, bank):
+        bank.record_delegation_outcome.return_value = True
+        record_delegation_and_tools(
+            session_key="s1",
+            goal="parse csv files with pandas",
+            outcome={"status": "completed"},
+            tool_calls=_trace("read_file", "terminal"),
+            bank=bank,
+            tags_path=tmp_path / "tags.json",
+        )
+        record_delegation_and_tools(
+            session_key="s2",
+            goal="parse csv files with pandas",
+            outcome={"status": "failed"},
+            tool_calls=_trace("browser_navigate"),
+            bank=bank,
+            tags_path=tmp_path / "tags.json",
+        )
+
+    def test_returns_tools_and_patterns_for_similar_goal(self, tmp_path):
+        bank = MagicMock()
+        self._seeded_store(tmp_path, bank)
+        bank.find_matching_delegation_patterns.return_value = [
+            _FakePattern("parse csv files with pandas")
+        ]
+
+        suggestion = suggest_configuration(
+            "parse csv files", bank=bank, tags_path=tmp_path / "tags.json"
+        )
+
+        assert set(suggestion["suggested_tools"]) == {"read_file", "terminal"}
+        assert suggestion["matched_patterns"] == [
+            {"task_type": "parse csv files with pandas", "role": "leaf"}
+        ]
+
+    def test_empty_for_novel_goal_and_never_writes(self, tmp_path):
+        bank = MagicMock()
+        bank.find_matching_delegation_patterns.return_value = []
+        tags = tmp_path / "tags.json"
+
+        suggestion = suggest_configuration(
+            "refactor quantum foam solver", bank=bank, tags_path=tags
+        )
+
+        assert suggestion == {"suggested_tools": [], "matched_patterns": []}
+        assert not tags.exists()  # retrieval-only: no store created
+
+    def test_corrupted_tags_degrade_to_empty(self, tmp_path):
+        bank = MagicMock()
+        bank.find_matching_delegation_patterns.return_value = []
+        tags = tmp_path / "tags.json"
+        tags.write_text("{not valid json!!", encoding="utf-8")
+
+        suggestion = suggest_configuration(
+            "parse csv files", bank=bank, tags_path=tags
+        )
+
+        assert suggestion == {"suggested_tools": [], "matched_patterns": []}
+
+
+class TestPaths:
+    def test_tool_usage_tags_path_is_profile_aware(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert tool_usage_tags_path() == (
+            tmp_path / "evolution" / "coevolution" / "tool_usage_tags.json"
+        )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3562,6 +3562,21 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        # Co-evolution loop (#2262, parent #2251): record final outcome + child
+        # tool trace. Fail-open — never break delegation itself.
+        try:
+            from agent import coevolution as _coevo
+
+            _coevo.record_delegation_and_tools(
+                session_key=owner_session_id or "", goal=goal,
+                outcome={"status": status, "completed": completed},
+                tool_calls=tool_trace,
+                role=getattr(child, "_delegate_role", None) or "leaf",
+                model=_model if isinstance(_model, str) else "",
+            )
+        except Exception:
+            logger.debug("co-evolution record failed", exc_info=True)
+
         # Surface the bounded auto-retry count (issue #323) so callers and
         # trace-mining (#248) can see recovery happened. Absent (not 0) when
         # no retry was attempted, to avoid noise on the healthy path.


### PR DESCRIPTION
Closes #2262 (Slice B of parent #2251 "dual asset banks"; sibling Slice A #2261 landed via #2449).

## What

- **NEW `agent/coevolution.py` (185 lines)**
  - `record_delegation_and_tools(session_key, goal, outcome, tool_calls, bank=None, *, role, model, tags_path)` — wraps the agent bank's `record_delegation_outcome` (default bank: `agent.experience_bank`, duck-typed so callers/tests can inject their own) **and** aggregates success-correlated tool-usage tags into `tool_usage_tags.json` (profile-aware via `get_hermes_home()` → `<HOME>/evolution/coevolution/`, caller-injectable path). Reuses the bank's `_atomic_write_json` (atomic tmp+replace, never raises) — same storage family, no duplicated fsync logic.
  - `suggest_configuration(goal, bank=None, tags_path=None)` → `{"suggested_tools", "matched_patterns"}`: combines `find_matching_delegation_patterns` with top successful tool tags for similar goals (substring task-type matching, ≥0.5 success rate, rank by rate then evidence, capped at 8).

## Wiring (fail-open)

`tools/delegate_tool.py` `_run_single_child` (+15 lines): after the **final** outcome is derived — i.e. after the entry dict is assembled post-refusal-nudge / shallow-retry / with the child's role, model, and tool trace in scope — a lazy `from agent import coevolution` records the outcome. The entire hook sits in `try/except Exception` with a `logger.debug` (swallows ALL errors, including import failure): co-evolution observability must never break delegation itself. The wiring point is deliberately **after** the bounded retries so a delegation that recovered on retry is recorded as the success it ultimately was (recording at the first `_derive_child_outcome` call site would mislabel recovered runs as failures).

## Why suggestions are retrieval-only (prompt-caching policy)

`suggest_configuration` performs **zero writes and never mutates live agent configuration**. Per repo policy, toolsets/system prompts must not change mid-conversation — that would invalidate the per-conversation prompt cache and multiply cost. Suggestions are consumed OFFLINE by the evolution loop (future slices); a test asserts the store file isn't even created by a suggestion call.

## Tests

`tests/agent/test_coevolution.py` — behavior contracts only (stdlib + pytest + unittest.mock):
- record writes the tags file with success-correlated per-tool counts + session provenance, and delegates to the mocked bank (normalized task_type, success flag)
- failed outcomes tag tools as unsuccessful; aggregation across recordings
- bank error → fail-open: returns False, never raises, tool-bank half still records (independent stores)
- suggest returns tools + serialized patterns for a similar goal; empty for a novel goal (and no file created — read-only proof); corrupt tags JSON degrades to empty suggestions
- `tool_usage_tags_path()` is profile-aware under `HERMES_HOME`

Delegate-tool wiring is intentionally not unit-tested directly (god-file boundary); instead the existing delegate suites were run to prove neutrality: `test_delegate.py`, `test_delegate_shallow_retry.py`, `test_delegate_refusal_nudge.py`, `test_delegate_output_schema.py` — 222/222 pass with the hook in place.

## Budget

Module diff exactly 200 lines (185 new + 15 wiring insertions); tests extra (182). `ruff check` clean on all three files. Suite run via `scripts/run_tests.sh` (CI-parity runner).