### PR TITLE
feat(evolution): long-horizon 50+ turn stress bucket in validation split (opt-in)

### DIFF
--- a/scripts/eval_baseline.py
+++ b/scripts/eval_baseline.py
@@ -16,6 +16,7 @@ Usage::
     python3 scripts/eval_baseline.py                       # null baseline
     python3 scripts/eval_baseline.py --agent real          # real agent run
     python3 scripts/eval_baseline.py -o /tmp/scores.jsonl
+    python3 scripts/eval_baseline.py --with-long-horizon   # + opt-in stress bucket
 
 Writes ``scores.jsonl`` (one JSON object per task) plus a summary line.
 """
@@ -37,7 +38,11 @@ from eval_runner import (  # noqa: E402
     run_task_set,
     write_trajectories,
 )
-from eval_tasks import latest_version, load_task_set  # noqa: E402
+from eval_tasks import (  # noqa: E402
+    latest_version,
+    load_long_horizon_tasks,
+    load_task_set,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +164,31 @@ def summarize(scores: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def _run_bucket(
+    tasks: List[Any],
+    *,
+    agent: str,
+    scores_path: Optional[str] = None,
+    trajectories_path: Optional[str] = None,
+    agent_config: Optional[Dict[str, Any]] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Run + score one bucket through the real code path (shared wiring)."""
+    if agent == "null":
+        trajectories = run_task_set(
+            tasks,
+            agent_factory=_null_agent_factory,
+            conversation_fn=_null_run_conversation,
+        )
+    else:
+        trajectories = run_task_set(tasks, agent_config=agent_config)
+    scores = score_all(trajectories, tasks)
+    if scores_path:
+        write_scores(scores, scores_path)
+    if trajectories_path:
+        write_trajectories(trajectories, trajectories_path)
+    return scores, summarize(scores)
+
+
 def run_null_agent_baseline(
     version: Optional[str] = None,
     scores_path: str = ".evolution/eval/scores-null.jsonl",
@@ -166,21 +196,12 @@ def run_null_agent_baseline(
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Run the null agent over the task set and write its floor scores."""
     tasks = load_task_set(version or latest_version())
-
-    # Only the conversation driver is swapped. Everything else — recorder
-    # wiring, trajectory assembly, error capture, scoring — is the same code a
-    # real run goes through, so the floor is measured on the real path.
-    trajectories = run_task_set(
+    return _run_bucket(
         tasks,
-        agent_factory=_null_agent_factory,
-        conversation_fn=_null_run_conversation,
+        agent="null",
+        scores_path=scores_path,
+        trajectories_path=trajectories_path,
     )
-
-    scores = score_all(trajectories, tasks)
-    write_scores(scores, scores_path)
-    if trajectories_path:
-        write_trajectories(trajectories, trajectories_path)
-    return scores, summarize(scores)
 
 
 def run_real_agent_baseline(
@@ -191,12 +212,32 @@ def run_real_agent_baseline(
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Run the real agent over the task set and write its scores."""
     tasks = load_task_set(version or latest_version())
-    trajectories = run_task_set(tasks, agent_config=agent_config)
-    scores = score_all(trajectories, tasks)
-    write_scores(scores, scores_path)
-    if trajectories_path:
-        write_trajectories(trajectories, trajectories_path)
-    return scores, summarize(scores)
+    return _run_bucket(
+        tasks,
+        agent="real",
+        scores_path=scores_path,
+        trajectories_path=trajectories_path,
+        agent_config=agent_config,
+    )
+
+
+def run_long_horizon_stress(
+    agent: str = "null",
+    scores_path: Optional[str] = None,
+    trajectories_path: Optional[str] = None,
+    agent_config: Optional[Dict[str, Any]] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Run the opt-in long-horizon stress bucket — 50+ turn tasks (#2530).
+    Too expensive to block CI on; a too-fast finish is marked ``shortcut``."""
+    if scores_path is None:
+        scores_path = f".evolution/eval/scores-long-horizon-{agent}.jsonl"
+    return _run_bucket(
+        load_long_horizon_tasks(),
+        agent=agent,
+        scores_path=scores_path,
+        trajectories_path=trajectories_path,
+        agent_config=agent_config,
+    )
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -210,6 +251,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--version", default=None, help="task-set version")
     ap.add_argument("-o", "--output", default=None, help="scores.jsonl path")
     ap.add_argument("--trajectories", default=None, help="trajectories.jsonl path")
+    ap.add_argument(
+        "--with-long-horizon",
+        action="store_true",
+        help="also run the opt-in long-horizon stress bucket (#2530)",
+    )
     args = ap.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -228,6 +274,20 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
 
     print(json.dumps({"agent": args.agent, **summary}, indent=2))
+
+    if args.with_long_horizon:
+        base_out = args.output or f".evolution/eval/scores-{args.agent}.jsonl"
+        _, stress_summary = run_long_horizon_stress(
+            agent=args.agent,
+            scores_path=base_out.replace(".jsonl", "-long-horizon.jsonl"),
+        )
+        # Separate section: the stress bucket never folds into the default mean.
+        print(
+            json.dumps(
+                {"agent": args.agent, "bucket": "long-horizon-stress", **stress_summary},
+                indent=2,
+            )
+        )
 
     if args.agent == "null" and summary["mean_total"] > 0.25:
         print(

--- a/scripts/eval_runner.py
+++ b/scripts/eval_runner.py
@@ -14,7 +14,9 @@ reflects what the agent actually did rather than a reconstruction.
 Anything that goes wrong while running a task is captured into
 ``EvalTrajectory.error`` instead of raising: one task blowing up must not
 abort a whole baseline run, and "this task errored" is itself a result worth
-scoring.
+scoring. Long-horizon tasks (``min_turns > 0``, #2530) additionally fail via
+that same error gate when they finish in fewer turns than the chain requires
+— a "shortcut" solution skipped the work and scores zero.
 """
 
 from __future__ import annotations
@@ -35,6 +37,23 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = os.environ.get("HERMES_EVAL_MODEL", "")
 DEFAULT_TOOLSETS = ["files"]
 DEFAULT_MAX_ITERATIONS = 8
+
+# Name of the opt-in long-horizon stress bucket (#2530): tasks flagged with
+# ``min_turns > 0`` in the task schema. 50+ turn runs are too expensive for
+# the default (CI-blocking) split, so these route into a separate bucket.
+LONG_HORIZON_BUCKET = "long-horizon-stress"
+
+
+def horizon_bucket(task: Any) -> Optional[str]:
+    """Stress-bucket name for a ``min_turns > 0`` task, else None."""
+    return LONG_HORIZON_BUCKET if int(getattr(task, "min_turns", 0) or 0) > 0 else None
+
+
+def split_by_horizon(tasks: List[Any]) -> Tuple[List[Any], List[Any]]:
+    """Partition tasks into ``(default, long_horizon_stress)`` buckets."""
+    stress = [t for t in tasks if horizon_bucket(t) is not None]
+    default = [t for t in tasks if horizon_bucket(t) is None]
+    return default, stress
 
 
 @dataclass
@@ -160,6 +179,12 @@ def run_eval_task(
     pinned = build_pinned_config(agent_config)
     task_id = getattr(task, "id", str(task))
     prompt = getattr(task, "prompt", str(task))
+    min_turns = int(getattr(task, "min_turns", 0) or 0)
+    if min_turns > 0 and pinned["max_iterations"] < min_turns:
+        # A long-horizon task must be runnable at its own horizon: the default
+        # cap of 8 iterations would truncate the chain before it completes.
+        # The raised cap lands in traj.agent_config, so runs stay comparable.
+        pinned["max_iterations"] = min_turns
 
     traj = EvalTrajectory(task_id=task_id, agent_config=pinned)
     tool_calls, on_start, on_complete = _make_recorder()
@@ -203,6 +228,15 @@ def run_eval_task(
     if not traj.model_turns and traj.final_answer:
         # Providers that don't return a history still completed a turn.
         traj.model_turns = 1
+    if min_turns > 0 and not traj.error and traj.model_turns < min_turns:
+        # Long-horizon shortcut rule (#2530): completing a 50+ turn chain in a
+        # handful of turns means the agent skipped the chain. Recorded through
+        # the existing error gate so scoring floors it at zero like any other
+        # failed run, instead of rewarding a too-cheap "solution".
+        traj.error = (
+            f"shortcut: finished in {traj.model_turns} turns, "
+            f"long-horizon task requires >= {min_turns}"
+        )
     return traj
 
 

--- a/scripts/eval_tasks.py
+++ b/scripts/eval_tasks.py
@@ -30,6 +30,7 @@ class EvalTask:
     expected_result_pattern: Optional[str] = None
     category: str = "reasoning"
     difficulty: str = "easy"
+    min_turns: int = 0  # >0 flags a long-horizon task (#2530); 0 = no floor
 
 
 # Canonical v1.0 task set — small, real pieces of evolution work, covering
@@ -80,6 +81,69 @@ _TASKS_V1: List[EvalTask] = [
 
 def _by_version(version: str) -> Dict[str, List[EvalTask]]:
     return {"1.0": _TASKS_V1, "1": _TASKS_V1}  # "1" = major-version alias
+
+
+# Long-horizon stress bucket (#2530, LongHorizon-Harness): benchmarks rarely
+# test behavior after the 50th tool turn, yet long-running work is where
+# reliability collapses. Each task is an iterative survey/verify chain over
+# the real evolution scripts — each loop iteration structurally needs its own
+# tool turns, so an honest solution cannot compress the chain. NOT part of
+# ``_TASKS_V1``/``load_task_set``: 50+ turn runs are too expensive for CI.
+LONG_HORIZON_MIN_TURNS = 50
+
+_TASKS_LONG_HORIZON: List[EvalTask] = [
+    EvalTask(
+        id="lh-extract-helpers-loop",
+        prompt=(
+            "Run an iterative refactor survey over every scripts/evolution_*.py "
+            "module: read each fully, list functions longer than 20 lines, then "
+            "per function re-read the module, identify one extractable helper, "
+            "search the repo for call sites, verify each, and record the plan. "
+            "Report per-module planned-extraction counts and the total."
+        ),
+        expected_tools=["search_files", "read_file"],
+        expected_result_pattern="extraction",
+        category="long-horizon",
+        difficulty="hard",
+        min_turns=60,
+    ),
+    EvalTask(
+        id="lh-import-graph-audit",
+        prompt=(
+            "Audit imports of every scripts/evolution_*.py module: read each, "
+            "list repo-local imports, then per import search the repo to locate "
+            "the target file and read it to confirm the symbol exists; re-check "
+            "failures with an alternate search pattern. Report per-module "
+            "import counts and the unresolved list."
+        ),
+        expected_tools=["search_files", "read_file"],
+        expected_result_pattern="unresolved",
+        category="long-horizon",
+        difficulty="hard",
+        min_turns=50,
+    ),
+    EvalTask(
+        id="lh-config-drift-sweep",
+        prompt=(
+            "Sweep every scripts/evolution_*.py module for config drift: read "
+            "each, extract config keys/defaults/thresholds, then per key search "
+            "for other users, read each user, and check values agree. Flag "
+            "disagreements. Report a per-module drift table and total count."
+        ),
+        expected_tools=["search_files", "read_file"],
+        expected_result_pattern="drift",
+        category="long-horizon",
+        difficulty="hard",
+        min_turns=50,
+    ),
+]
+
+
+def load_long_horizon_tasks() -> List[EvalTask]:
+    """Load the opt-in long-horizon stress bucket (#2530) — deliberately kept
+    out of ``load_task_set`` so the default split is unchanged; enter via
+    ``eval_baseline --with-long-horizon`` (manual/cron only)."""
+    return list(_TASKS_LONG_HORIZON)
 
 
 def latest_version() -> str:

--- a/tests/scripts/test_long_horizon_stress.py
+++ b/tests/scripts/test_long_horizon_stress.py
@@ -1,0 +1,202 @@
+"""Tests for the long-horizon stress bucket (#2530, LongHorizon-Harness).
+
+Behavior contracts, not snapshots:
+  * task defs parse, carry the horizon marker (min_turns >= 50), and stay out
+    of the default split;
+  * the runner routes flagged tasks into the stress bucket and floors the
+    iteration cap at the task's own horizon;
+  * a run that finishes a 50+ turn chain too fast is marked ``shortcut`` and
+    scores zero, while a run that walks the chain is not penalized;
+  * the bucket is opt-in (``--with-long-horizon``), reported as its own
+    section, and absent from the default run.
+
+Pure stdlib + pytest; the agent and conversation driver are stubbed at the
+seams ``run_eval_task`` exposes — no network, no LLM calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from eval_baseline import main as baseline_main  # noqa: E402
+from eval_baseline import run_long_horizon_stress, run_null_agent_baseline  # noqa: E402
+from eval_runner import (  # noqa: E402
+    DEFAULT_MAX_ITERATIONS,
+    LONG_HORIZON_BUCKET,
+    horizon_bucket,
+    run_eval_task,
+    split_by_horizon,
+)
+from eval_tasks import (  # noqa: E402
+    LONG_HORIZON_MIN_TURNS,
+    EvalTask,
+    load_long_horizon_tasks,
+    load_task_set,
+)
+
+
+def _task(**kw) -> EvalTask:
+    base = {
+        "id": "t1",
+        "prompt": "do the thing",
+        "expected_tools": ["search_files"],
+        "expected_result_pattern": "found-it",
+        "category": "search",
+        "difficulty": "easy",
+    }
+    base.update(kw)
+    return EvalTask(**base)
+
+
+def _fake_agent_factory(_pinned, on_start, on_complete):
+    return SimpleNamespace(on_start=on_start, on_complete=on_complete)
+
+
+def _driver(turns=1, answer="found-it"):
+    """A conversation driver that reports ``turns`` assistant messages."""
+
+    def drive(_agent, _prompt, **_kw):
+        return {
+            "response": answer,
+            "conversation_history": [
+                {"role": "assistant", "content": answer} for _ in range(turns)
+            ],
+            "failed": False,
+        }
+
+    return drive
+
+
+class TestTaskDefs:
+    def test_defs_parse_and_carry_the_horizon_marker(self):
+        tasks = load_long_horizon_tasks()
+        assert 2 <= len(tasks) <= 3
+        assert all(isinstance(t, EvalTask) for t in tasks)
+        for t in tasks:
+            assert t.min_turns >= LONG_HORIZON_MIN_TURNS  # the 50+ marker
+            assert t.id.startswith("lh-")
+            assert t.prompt and t.expected_tools
+
+    def test_loader_returns_a_fresh_copy(self):
+        assert load_long_horizon_tasks() is not load_long_horizon_tasks()
+
+    def test_ids_unique_and_disjoint_from_default_split(self):
+        stress_ids = {t.id for t in load_long_horizon_tasks()}
+        default_ids = {t.id for t in load_task_set()}
+        assert len(stress_ids) == len(load_long_horizon_tasks())
+        assert stress_ids & default_ids == set()
+
+    def test_default_split_carries_no_horizon_marker(self):
+        assert all(t.min_turns == 0 for t in load_task_set())
+
+
+class TestRunnerBucketing:
+    def test_horizon_bucket_classifies_by_min_turns(self):
+        assert horizon_bucket(_task(min_turns=50)) == LONG_HORIZON_BUCKET
+        assert horizon_bucket(_task()) is None
+        assert horizon_bucket(_task(min_turns=0)) is None
+
+    def test_split_by_horizon_partitions_all_tasks(self):
+        mixed = load_task_set() + load_long_horizon_tasks()
+        default, stress = split_by_horizon(mixed)
+        assert default == load_task_set()
+        assert stress == load_long_horizon_tasks()
+        assert len(default) + len(stress) == len(mixed)
+
+    def test_iteration_cap_floored_at_task_horizon(self):
+        traj = run_eval_task(
+            _task(min_turns=50), None, _fake_agent_factory, _driver(turns=50)
+        )
+        assert traj.agent_config["max_iterations"] >= 50
+
+    def test_default_tasks_keep_the_pinned_cap(self):
+        traj = run_eval_task(
+            _task(), None, _fake_agent_factory, _driver(turns=1)
+        )
+        assert traj.agent_config["max_iterations"] == DEFAULT_MAX_ITERATIONS
+
+
+class TestShortcutRule:
+    def test_finished_too_fast_is_marked_shortcut(self):
+        traj = run_eval_task(
+            _task(min_turns=50), None, _fake_agent_factory, _driver(turns=3)
+        )
+        assert traj.error is not None
+        assert traj.error.startswith("shortcut:")
+
+    def test_shortcut_scores_zero_through_the_error_gate(self):
+        from eval_baseline import score_trajectory
+
+        traj = run_eval_task(
+            _task(min_turns=50), None, _fake_agent_factory, _driver(turns=3)
+        )
+        assert score_trajectory(traj, _task(min_turns=50))["total"] == 0.0
+
+    def test_a_run_that_walks_the_chain_is_not_penalized(self):
+        # exactly at the horizon boundary is still an honest completion
+        traj = run_eval_task(
+            _task(min_turns=50), None, _fake_agent_factory, _driver(turns=50)
+        )
+        assert traj.error is None
+        assert traj.model_turns == 50
+
+    def test_default_task_1_turn_completion_stays_clean(self):
+        """Regression guard: the shortcut rule must not leak to normal tasks."""
+        traj = run_eval_task(_task(), None, _fake_agent_factory, _driver(turns=1))
+        assert traj.error is None
+
+
+def _parse_reports(out: str):
+    """Parse consecutive (pretty-printed) JSON objects printed to stdout."""
+    decoder = json.JSONDecoder()
+    reports, idx = [], 0
+    while idx < len(out):
+        if out[idx] == "{":
+            obj, end = decoder.raw_decode(out, idx)
+            reports.append(obj)
+            idx = end
+        else:
+            idx += 1
+    return reports
+
+
+class TestBaselineIntegration:
+    def test_null_agent_floor_is_zero_on_the_stress_bucket(self, tmp_path, capsys):
+        scores, summary = run_long_horizon_stress(
+            agent="null", scores_path=str(tmp_path / "s-lh.jsonl")
+        )
+        assert summary["tasks"] == len(load_long_horizon_tasks())
+        assert summary["mean_total"] == 0.0
+        # the null agent refuses in 1 turn -> every task is a shortcut
+        assert scores and all(s["error"] and s["error"].startswith("shortcut:") for s in scores)
+        assert (tmp_path / "s-lh.jsonl").exists()
+
+    def test_default_run_excludes_the_stress_bucket(self, tmp_path):
+        _, summary = run_null_agent_baseline(scores_path=str(tmp_path / "s.jsonl"))
+        assert summary["tasks"] == len(load_task_set())
+
+    def test_cli_flag_adds_the_stress_section(self, tmp_path, capsys):
+        rc = baseline_main(
+            ["-o", str(tmp_path / "s.jsonl"), "--with-long-horizon"]
+        )
+        assert rc == 0
+        reports = _parse_reports(capsys.readouterr().out)
+        # default split section (no bucket key) + separate stress section
+        assert any(
+            r.get("bucket") is None and r.get("tasks") == len(load_task_set())
+            for r in reports
+        )
+        assert any(r.get("bucket") == LONG_HORIZON_BUCKET for r in reports)
+        assert (tmp_path / "s-long-horizon.jsonl").exists()
+
+    def test_cli_without_flag_has_no_stress_section(self, tmp_path, capsys):
+        rc = baseline_main(["-o", str(tmp_path / "s.jsonl")])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "long-horizon-stress" not in out
+        assert not (tmp_path / "s-long-horizon.jsonl").exists()


### PR DESCRIPTION
Closes #2530

Adds a long-horizon (50+ turn) stress bucket to the eval harness, per the LongHorizon-Harness durability gap: standard benchmarks rarely test how an agent behaves after its 50th tool call, yet long-running work is where reliability collapses.

## What lands

- **`scripts/eval_tasks.py`** — 3 long-horizon task definitions (`lh-extract-helpers-loop` min_turns=60, `lh-import-graph-audit` min_turns=50, `lh-config-drift-sweep` min_turns=50): realistic iterative refactor/verify chains over the real `scripts/evolution_*.py` modules where each loop iteration structurally needs its own tool turns. New `min_turns` field on `EvalTask` is the horizon marker; new `load_long_horizon_tasks()` loads the bucket.
- **`scripts/eval_runner.py`** — `horizon_bucket()` / `split_by_horizon()` classify flagged tasks into the `long-horizon-stress` bucket; the pinned iteration cap is floored at the task's own `min_turns` (a 50+ turn chain must be runnable; the raised cap is recorded on the trajectory); **shortcut rule**: a long-horizon task completed without error in fewer than `min_turns` turns is marked `shortcut` via the existing error gate and scores zero — an agent that skips the chain gets no credit.
- **`scripts/eval_baseline.py`** — `run_long_horizon_stress()` + `--with-long-horizon` CLI flag; the bucket prints as its **own report section** and never folds into the default mean.
- **`tests/scripts/test_long_horizon_stress.py`** — 16 behavior-contract tests (defs carry the marker, runner bucketing, shortcut-fail rule incl. exact-boundary + regression guard for default tasks, opt-in exclusion, CLI flag section presence/absence). stdlib + pytest only; agent/driver stubbed at the seams `run_eval_task` exposes; no network, no LLM.

## Why opt-in, not CI-blocking

50+ turn agent runs are expensive (each is 50+ real model calls). The bucket is therefore **excluded from the default split** — `load_task_set()` and `TASK_SET_VERSION` are untouched, so historical default-split scores stay comparable — and enters only via the explicit `--with-long-horizon` flag (manual or cron invocation, e.g. `python3 scripts/eval_baseline.py --with-long-horizon [--agent real]`).

## Integration points: existed vs assumed (deviations)

- Research assumed the validation split lives in `evolution_bilevel_eval.py` / `evolution_adaptive_validation.py`. In reality **neither executes tasks**: bilevel is a pure decision module over already-computed per-case scores, adaptive_validation is about LLM-generated test specs. The runnable task split is `eval_baseline.py`, so that is where the opt-in bucket is wired.
- No env-var trigger was added: repo policy forbids new `HERMES_*` env vars for non-secret config, so the trigger is the CLI flag only (cron can pass args).
- `TASK_SET_VERSION` deliberately NOT bumped: the default task set is unchanged.

## Tests

- `scripts/run_tests.sh tests/scripts/test_long_horizon_stress.py` — 16 passed
- `scripts/run_tests.sh tests/scripts/ -k eval` — 78 passed (no regression)
- `scripts/run_tests.sh tests/test_eval_runner.py` — 27 passed (no regression)
- `ruff check` on all changed files — clean
- Non-test diff: 200 changed lines (158 net)