### PR TITLE
feat(evolution): structured code-diff proposal for the retry-policy surface (Closes #2613)

### DIFF
--- a/scripts/evolution_harness_code_diff.py
+++ b/scripts/evolution_harness_code_diff.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Self-Harness code-diff proposal generator for the retry-policy surface (#2613, parent #2525).
+
+Companion to ``evolution_harness_proposer.py``: turns a weakness record into a
+structured CODE DIFF against the retry-policy surface (``retry_count`` /
+``backoff`` / ``guard_conditions``), where the proposer only emits prose.
+
+Emitted diff shape (the proposal schema): ``surface``, ``changes`` (list of
+``{field, before, after, reason}`` knob edits), ``unified_diff``, ``evidence``,
+plus ``source`` / ``status`` / ``requires_human_review`` / ``auto_apply``.
+Human-gated, never auto-applied; nothing here writes a file or config.
+"""
+from __future__ import annotations
+
+import difflib
+from typing import Any, Dict, List, Optional
+
+DIFFABLE_KINDS = ("retry_spiral", "provider_error")
+RETRY_SPIRAL_CAP = 3
+
+
+def _normalize_surface(surface: Any) -> Dict[str, Any]:
+    s = surface if isinstance(surface, dict) else {}
+    b = s.get("backoff") if isinstance(s.get("backoff"), dict) else {}
+    guards = s.get("guard_conditions") if isinstance(s.get("guard_conditions"), list) else []
+    return {
+        "retry_count": int(s.get("retry_count", 3)),
+        "backoff": {"base_delay_sec": float(b.get("base_delay_sec", 1.0)),
+                    "multiplier": float(b.get("multiplier", 2.0)),
+                    "max_delay_sec": float(b.get("max_delay_sec", 60.0))},
+        "guard_conditions": [str(g) for g in guards],
+    }
+
+
+def _evidence_of(weakness: Dict[str, Any]) -> Dict[str, Any]:
+    allowed = ("kind", "tool", "signature", "occurrences", "severity",
+               "label", "max_consecutive", "sessions")
+    return {k: weakness[k] for k in allowed if k in weakness}
+
+
+def _render_diff(surface: Dict[str, Any], changes: List[Dict[str, Any]]) -> str:
+    after = {"retry_count": surface["retry_count"], "backoff": dict(surface["backoff"]),
+             "guard_conditions": list(surface["guard_conditions"])}
+    for c in changes:
+        after[c["field"]] = c["after"]
+    return "".join(difflib.unified_diff(
+        [f"{k}: {v}" for k, v in surface.items()], [f"{k}: {v}" for k, v in after.items()],
+        fromfile="retry_policy (current)", tofile="retry_policy (proposed)", lineterm="\n"))
+
+
+def build_retry_policy_diff(
+    weakness: Dict[str, Any], surface: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
+    """Return a structured retry-policy code diff for one weakness, or ``None``.
+
+    Deterministic and inert: the returned dict follows the schema documented in
+    the module docstring and carries the human-gating fields.
+    """
+    if not isinstance(weakness, dict) or weakness.get("kind") not in DIFFABLE_KINDS:
+        return None
+    s = _normalize_surface(surface)
+    kind = weakness["kind"]
+    changes: List[Dict[str, Any]] = []
+    guards = list(s["guard_conditions"])
+
+    if kind == "retry_spiral":
+        if s["retry_count"] > RETRY_SPIRAL_CAP:
+            changes.append({
+                "field": "retry_count", "before": s["retry_count"],
+                "after": RETRY_SPIRAL_CAP,
+                "reason": "cap consecutive retries after a spiral "
+                          "(observed %s consecutive)" % weakness.get("max_consecutive"),
+            })
+        guard = "non-retryable after %d consecutive attempts" % RETRY_SPIRAL_CAP
+        if weakness.get("tool"):
+            guard += f" for `{weakness['tool']}`"
+        if guard not in guards:
+            changes.append({"field": "guard_conditions", "before": list(guards),
+                            "after": guards + [guard], "reason": "stop retrying past the cap"})
+    else:  # provider_error
+        b = s["backoff"]
+        sig = weakness.get("signature")
+        changes.append({
+            "field": "backoff", "before": b,
+            "after": {"base_delay_sec": b["base_delay_sec"] * 2.0,
+                      "multiplier": b["multiplier"], "max_delay_sec": b["max_delay_sec"] * 2.0},
+            "reason": f"widen backoff for recurring provider error `{sig}`",
+        })
+        guard = f"non-retryable error class: {sig}"
+        if sig and guard not in guards:
+            changes.append({"field": "guard_conditions", "before": list(guards),
+                            "after": guards + [guard],
+                            "reason": "mark recurring provider error class non-retryable"})
+
+    if not changes:
+        return None
+    return {
+        "surface": s,
+        "changes": changes,
+        "unified_diff": _render_diff(s, changes),
+        "evidence": _evidence_of(weakness),
+        "source": "self-harness",
+        "status": "proposed",
+        "requires_human_review": True,
+        "auto_apply": False,
+    }

--- a/scripts/evolution_harness_proposer.py
+++ b/scripts/evolution_harness_proposer.py
@@ -59,6 +59,8 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from evolution_harness_code_diff import build_retry_policy_diff
+
 # A weakness ``kind`` (from the trace miner) maps to exactly one harness
 # proposal ``type``. This is the constrained vocabulary the issues stage relies
 # on — anything outside it is dropped rather than passed through as free-form.
@@ -137,6 +139,7 @@ def build_proposal(
     weakness: Dict[str, Any],
     *,
     llm: Optional[LLMFn] = None,
+    surface: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Turn ONE weakness record into ONE structured harness proposal.
 
@@ -148,7 +151,9 @@ def build_proposal(
     (``title``, ``delta``, ``rationale``). When absent the proposal is a
     deterministic ENVELOPE: correct type + evidence + a templated body, with
     ``llm_authored=False`` so a reviewer can see it needs fleshing out. Either
-    way the proposal carries the hard human-gating fields.
+    way the proposal carries the hard human-gating fields. ``surface`` (optional)
+    is the current retry-policy surface; when provided, ``retry_policy_change``
+    proposals also carry a structured ``code_diff``.
     """
     if not isinstance(weakness, dict):
         return None
@@ -191,6 +196,12 @@ def build_proposal(
         proposal["rationale"] = _coerce_str(weakness.get("label"))
         proposal["llm_authored"] = False
 
+    # Attach a structured code diff for the retry-policy surface (#2613).
+    if ptype == "retry_policy_change" and surface is not None:
+        diff = build_retry_policy_diff(weakness, surface)
+        if diff is not None:
+            proposal["code_diff"] = diff
+
     return proposal
 
 
@@ -198,6 +209,7 @@ def generate_proposals(
     weaknesses: List[Dict[str, Any]],
     *,
     llm: Optional[LLMFn] = None,
+    surface: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Map a list of weakness records to harness proposals (best-first).
 
@@ -207,7 +219,7 @@ def generate_proposals(
     proposal. Pure aside from the injected ``llm`` seam."""
     proposals: List[Dict[str, Any]] = []
     for w in weaknesses:
-        p = build_proposal(w, llm=llm)
+        p = build_proposal(w, llm=llm, surface=surface)
         if p is not None:
             proposals.append(p)
     return proposals

--- a/tests/scripts/test_evolution_harness_code_diff.py
+++ b/tests/scripts/test_evolution_harness_code_diff.py
@@ -1,0 +1,64 @@
+"""Tests for scripts/evolution_harness_code_diff.py (#2613, parent #2525)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_harness_code_diff import RETRY_SPIRAL_CAP, build_retry_policy_diff  # noqa: E402
+
+SURFACE = {"retry_count": 10,
+           "backoff": {"base_delay_sec": 1.0, "multiplier": 2.0, "max_delay_sec": 60.0},
+           "guard_conditions": []}
+
+
+def _spiral(n=15):
+    return {"kind": "retry_spiral", "tool": "browser_navigate",
+            "max_consecutive": n, "occurrences": n, "severity": n}
+
+
+def _provider_error():
+    return {"kind": "provider_error", "signature": "429:rate_limit",
+            "occurrences": 60, "severity": 60}
+
+
+def test_spiral_caps_and_guards():
+    d = build_retry_policy_diff(_spiral(), SURFACE)
+    fields = {c["field"]: c for c in d["changes"]}
+    assert fields["retry_count"]["before"] == 10
+    assert fields["retry_count"]["after"] == RETRY_SPIRAL_CAP
+    assert "browser_navigate" in fields["guard_conditions"]["after"][0]
+
+
+def test_provider_error_widens_backoff():
+    d = build_retry_policy_diff(_provider_error(), SURFACE)
+    fields = {c["field"]: c for c in d["changes"]}
+    assert fields["backoff"]["after"]["base_delay_sec"] == 2.0
+    assert "non-retryable error class: 429:rate_limit" in fields["guard_conditions"]["after"]
+
+
+def test_diff_schema_and_human_gating():
+    w = _spiral()
+    w["raw_trace"] = "secret"
+    d = build_retry_policy_diff(w, SURFACE)
+    for key in ("surface", "changes", "unified_diff", "evidence", "source",
+                "status", "requires_human_review", "auto_apply"):
+        assert key in d
+    assert d["unified_diff"].startswith("--- retry_policy (current)")
+    assert "-retry_count: 10" in d["unified_diff"]
+    assert d["status"] == "proposed" and d["requires_human_review"] is True
+    assert d["auto_apply"] is False
+    assert "raw_trace" not in d["evidence"] and "raw_trace" not in json.dumps(d)
+
+
+def test_dropped_noop_and_default_surface():
+    assert build_retry_policy_diff({"kind": "tool_failure"}) is None
+    assert build_retry_policy_diff("nope") is None
+    s = {"retry_count": RETRY_SPIRAL_CAP,
+         "backoff": {"base_delay_sec": 1.0, "multiplier": 2.0, "max_delay_sec": 60.0},
+         "guard_conditions": ["non-retryable after 3 consecutive attempts "
+                              "for `browser_navigate`"]}
+    assert build_retry_policy_diff(_spiral(), s) is None
+    d = build_retry_policy_diff(_provider_error())
+    assert d["surface"]["retry_count"] == 3 and d["surface"]["backoff"]["multiplier"] == 2.0

--- a/tests/scripts/test_evolution_harness_proposer.py
+++ b/tests/scripts/test_evolution_harness_proposer.py
@@ -276,3 +276,14 @@ class TestMainCLI:
         rc = main(["evolution_harness_proposer.py", str(p)])
         out = json.loads(capsys.readouterr().out)
         assert rc == 0 and out["count"] == 0 and out["proposals"] == []
+
+
+# --- retry-policy code-diff attachment (#2613) -----------------------------
+
+def test_retry_policy_attaches_code_diff():
+    p = build_proposal(_retry_spiral(), surface={"retry_count": 10})
+    assert p["type"] == "retry_policy_change"
+    assert p["code_diff"]["auto_apply"] is False
+    assert any(c["field"] == "retry_count" for c in p["code_diff"]["changes"])
+    assert "code_diff" not in build_proposal(_retry_spiral())
+    assert "code_diff" not in build_proposal(_tool_failure(), surface={"retry_count": 10})


### PR DESCRIPTION
Slice A of #2525 (Harness-R1) — the code-diff proposal path for the retry-policy harness surface.

## What
- New `scripts/evolution_harness_code_diff.py`: `build_retry_policy_diff(weakness, surface=None)` turns a trace-miner weakness record (`retry_spiral` / `provider_error`) into a structured, human-gated CODE DIFF against the retry-policy surface (`retry_count` / `backoff` / `guard_conditions`) — concrete `{field, before, after, reason}` edits + a rendered unified diff, instead of the proposer's free-form prose `delta`.
- Wired into `evolution_harness_proposer.py`: `build_proposal(..., surface=...)` now attaches `code_diff` to `retry_policy_change` proposals when a surface is supplied (real call site — not dead code).

## Safety
Human-gated invariant preserved: `status="proposed"`, `requires_human_review=True`, `auto_apply=False`. Nothing here writes a file or config. Evidence is whitelisted (no raw traces).

## Checks
- ruff check ✓ · pre-PR shard (2 exact) ✓ · targeted pytest 32/32 ✓
- Diff: 195 insertions / 2 deletions (under the 200-line self-merge cap)

## Deferred (next increment)
- #2614 (Slice B): sandbox apply + validate code-diff proposals via regression gate.
- #2615 (Slice C): wire the code-diff apply-path into the evolution loop.