### PR TITLE
fix(agent): decompose process tool 'other' error bucket + non-retryable fast-path (Closes #2621)

### DIFF
--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -136,6 +136,15 @@ _NON_RETRYABLE_BY_TOOL: dict[str, frozenset[str]] = {
     # non-retryable for search_files bounds the spiral at 2 instead of the
     # generic idempotent fail threshold of 4.
     "search_files": frozenset({"parse_error"}),
+    # #2621 — process "other" bucket. A dead session (session_not_found), a wrong
+    # action name (invalid_action), and a write/submit/close against a finished
+    # process (process_exited) are all deterministic: the same call reproduces the
+    # same failure. Marking them non-retryable makes the loop_guard fire at the
+    # 2-call threshold instead of the generic mutating fail threshold, bounding the
+    # 18-deep blind-retry spirals observed on background-process tasks. (A `wait`
+    # timeout — status="timeout", the process still running — is already caught by
+    # the global _NON_RETRYABLE set, so it is not duplicated here.)
+    "process": frozenset({"session_not_found", "invalid_action", "process_exited"}),
 }
 
 
@@ -239,6 +248,13 @@ _DIVERSION_HINT = {
     "tool_describe": (
         " Verify the tool name first (`skills_list` or the available-tools "
         "list); if an MCP server is unavailable, pick a native alternative."
+    ),
+    "process": (
+        " If the session is gone (session_not_found), use action='list' to find "
+        "the live session id or re-spawn the process with terminal(background=true). "
+        "If the process already finished, read its output with action='log' instead "
+        "of writing/submitting to it. If an action name was rejected, use a valid "
+        "one: list / poll / log / wait / kill / write / submit / close."
     ),
     "browser_navigate": (
         " Stop navigating: extract what you need from the CURRENT page "

--- a/agent/tool_diagnostics.py
+++ b/agent/tool_diagnostics.py
@@ -230,6 +230,50 @@ _RULES: tuple[tuple[re.Pattern, str, str], ...] = (
         "the same command will fail identically. Fix the command/arguments, do NOT retry "
         "it unchanged.",
     ),
+    # #2621 — process tool "other" bucket decomposition. The process tool's
+    # failures were opaque: "No process with ID ..." (dead session), "Unknown
+    # process action" (bad action name), and "Process has already finished"
+    # (write/submit/close to an exited process) all fell through to the generic
+    # ``runtime_error`` ``error:`` catch-all below — retryable, with no
+    # process-specific recovery hint — leaving the agent to blind-retry (observed
+    # 18-deep spirals). These rules decompose that bucket into reason subclasses
+    # with targeted hints; loop_guard marks session_not_found / invalid_action /
+    # process_exited non-retryable (a dead session won't reappear, a wrong action
+    # name won't become valid, and writing to a finished process fails
+    # identically). Must run BEFORE the runtime_error catch-all (which matches the
+    # JSON ``error:`` key present in every tool_error envelope).
+    (
+        re.compile(
+            r"no process with id|no processes are currently registered|"
+            r"session_id is required",
+            re.I,
+        ),
+        "session_not_found",
+        "The background-process session no longer exists (never spawned, already "
+        "pruned, or belongs to a different gateway session). A dead session will "
+        "NOT reappear on retry. Use action='list' to see live sessions, or re-spawn "
+        "with terminal(background=true). Do NOT retry the same session_id.",
+    ),
+    (
+        re.compile(
+            r"unknown process action",
+            re.I,
+        ),
+        "invalid_action",
+        "That action name is not a valid process action. Use one of: list / poll / "
+        "log / wait / kill / write / submit / close. A wrong action name will never "
+        "become valid — do NOT retry it unchanged.",
+    ),
+    (
+        re.compile(
+            r"process has already finished|already_exited",
+            re.I,
+        ),
+        "process_exited",
+        "The process has already finished — you cannot write/submit/close to a "
+        "completed process. Read its final output with action='log', or spawn a new "
+        "process. Do NOT retry the write against the finished session.",
+    ),
     (
         re.compile(
             r"traceback \(most recent call|exit code[:\s]+[1-9]|exit status [1-9]|non-zero exit|error:|exception|failed",

--- a/tests/agent/test_loop_guard_per_tool_nonretryable.py
+++ b/tests/agent/test_loop_guard_per_tool_nonretryable.py
@@ -153,3 +153,40 @@ class TestGlobalClassesStillApplyToPerToolTools:
     def test_patch_timeout_trips_non_retryable(self):
         n = maybe_nudge(_fail_run("patch", 2, "failure-class=timeout — timed out"))
         assert n is not None and "non-retryable" in n and "timeout" in n
+
+
+class TestProcessNonRetryable:
+    """#2621 — process "other" bucket: a dead session, a bad action name, and a
+    write to a finished process are deterministic and must stop being retried."""
+
+    def test_session_not_found_is_non_retryable(self):
+        assert _is_non_retryable("process", "session_not_found")
+
+    def test_invalid_action_is_non_retryable(self):
+        assert _is_non_retryable("process", "invalid_action")
+
+    def test_process_exited_is_non_retryable(self):
+        assert _is_non_retryable("process", "process_exited")
+
+    def test_two_session_not_found_trips_hard_stop(self):
+        n = maybe_nudge(
+            _fail_run("process", 2, '{"status": "not_found", "error": "No process with ID proc_x"}')
+        )
+        assert n is not None and "non-retryable" in n and "session_not_found" in n
+
+    def test_two_session_not_found_warrants_cron_hard_stop(self):
+        assert run_warrants_cron_hard_stop(
+            _fail_run("process", 2, '{"status": "not_found", "error": "No process with ID proc_x"}')
+        )
+
+    def test_single_session_not_found_is_quiet(self):
+        assert (
+            maybe_nudge(_fail_run("process", 1, '{"status": "not_found", "error": "No process with ID proc_x"}'))
+            is None
+        )
+
+    def test_two_invalid_action_trips_hard_stop(self):
+        n = maybe_nudge(
+            _fail_run("process", 2, '{"error": "Unknown process action: \'create\'. Valid actions: list, poll"}')
+        )
+        assert n is not None and "non-retryable" in n and "invalid_action" in n

--- a/tests/agent/test_tool_diagnostics.py
+++ b/tests/agent/test_tool_diagnostics.py
@@ -94,6 +94,68 @@ class TestClassify:
         assert "deterministic" in hint.lower()
 
 
+class TestProcessBucketDecomposition:
+    """#2621 — process tool "other" bucket decomposed into reason subclasses.
+
+    Before the fix, every process failure envelope (``{"error": ...}``) fell
+    through to the generic ``runtime_error`` via the JSON ``error:`` key —
+    retryable and carrying no process-specific recovery hint — so a dead session
+    or a typo'd action name was blindly retried (18-deep spirals observed).
+    """
+
+    def test_session_not_found(self):
+        cat, hint = classify(
+            '{"status": "not_found", "error": "No process with ID proc_abc123"}'
+        )
+        assert cat == "session_not_found"
+        assert "list" in hint
+
+    def test_session_not_found_handler_form(self):
+        cat, _ = classify(
+            '{"error": "No process with ID \'proc_x\'. Available: proc_y. '
+            "Use action='list' to see all processes.\"}"
+        )
+        assert cat == "session_not_found"
+
+    def test_no_processes_registered(self):
+        cat, _ = classify(
+            '{"error": "No process with ID \'proc_x\'. No processes are currently '
+            "registered. Use action='list' to verify.\"}"
+        )
+        assert cat == "session_not_found"
+
+    def test_session_id_required(self):
+        cat, _ = classify(
+            '{"error": "session_id is required for poll. 3 processes are running. '
+            "Specify one of: proc_a, proc_b, proc_c\"}"
+        )
+        assert cat == "session_not_found"
+
+    def test_invalid_action(self):
+        cat, hint = classify(
+            '{"error": "Unknown process action: \'create\'. Did you mean \'list\'? '
+            "Valid actions: list, poll, log, wait, kill, write, submit, close\"}"
+        )
+        assert cat == "invalid_action"
+        assert "list" in hint
+
+    def test_process_exited(self):
+        cat, hint = classify(
+            '{"status": "already_exited", "error": "Process has already finished"}'
+        )
+        assert cat == "process_exited"
+        assert "log" in hint
+
+    def test_not_runtime_error(self):
+        # Regression guard: these used to be classified as retryable runtime_error.
+        for content in (
+            '{"status": "not_found", "error": "No process with ID proc_x"}',
+            '{"error": "Unknown process action: \'create\'."}',
+            '{"status": "already_exited", "error": "Process has already finished"}',
+        ):
+            assert classify(content)[0] != "runtime_error"
+
+
 class TestInlineDiagnosticsEnabled:
     def test_default_off_with_empty_config(self, monkeypatch):
         monkeypatch.delenv("HERMES_DIAGNOSTICS_INLINE", raising=False)


### PR DESCRIPTION
Automated evolution PR for issue #2621.

## What
Decompose the `process` tool's opaque `other` failure bucket into reason subclasses with targeted recovery hints, and wire the deterministic ones into the loop-guard non-retryable fast-path.

## Why
The `process` tool's failures were opaque: `No process with ID ...` (dead session), `Unknown process action` (bad action name), and `Process has already finished` (write/submit/close to an exited process) all fell through to the generic retryable `runtime_error` (via the JSON `error:` key) or to no classification at all. The agent then blind-retried (18-deep spirals, 90 failures/7d across 20 sessions).

## Changes
- `agent/tool_diagnostics.py`: add `session_not_found` / `invalid_action` / `process_exited` rules (run before the `runtime_error` catch-all), each with a process-specific recovery hint.
- `agent/loop_guard.py`: mark those three classes non-retryable for `process` (`_NON_RETRYABLE_BY_TOOL`), plus a `process` diversion hint.
- Tests: classification + non-retryable wiring (`test_tool_diagnostics.py`, `test_loop_guard_per_tool_nonretryable.py`).

## Checks
- ruff check ✓
- pytest (targeted, 86 passed) ✓
- Diff: ~159 lines (under the 200-line self-merge cap)