### PR TITLE
fix(process): decompose 'other' error bucket into reason subclasses with recovery hints (Closes #2621)

### DIFF
--- a/tests/tools/test_process_error_decomposition.py
+++ b/tests/tools/test_process_error_decomposition.py
@@ -1,0 +1,97 @@
+"""Tests for process tool error decomposition (#2621).
+
+The ``process`` tool's ``other`` error bucket was the largest undecomposed
+failure mode — opaque errors with no reason subclass and no recovery hint
+drove deep retry spirals. ``_classify_process_error`` maps each error text to
+a concrete category + recovery hint so the agent can act instead of
+blind-retrying, mirroring the decomposition done for ``tool_call``/``memory``/
+``tool_describe``.
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from tools.process_registry import _classify_process_error, _handle_process
+
+
+class TestClassifyProcessError:
+    """Unit tests for the error classifier."""
+
+    def test_session_not_found(self):
+        cls = _classify_process_error("No process with ID 'abc123'")
+        assert cls["error_category"] == "session-not-found"
+        assert "action='list'" in cls["recovery_hint"]
+
+    def test_session_not_found_no_processes(self):
+        cls = _classify_process_error(
+            "No process with ID 'abc123'. No processes are currently registered."
+        )
+        assert cls["error_category"] == "session-not-found"
+
+    def test_invalid_action(self):
+        cls = _classify_process_error("Unknown process action: 'status'")
+        assert cls["error_category"] == "invalid-action"
+        assert "list" in cls["recovery_hint"]
+
+    def test_session_id_required(self):
+        cls = _classify_process_error("session_id is required for poll")
+        assert cls["error_category"] == "session-id-required"
+
+    def test_process_exited(self):
+        cls = _classify_process_error("Process has already finished")
+        assert cls["error_category"] == "process-exited"
+        assert "action='log'" in cls["recovery_hint"]
+
+    def test_poll_timeout(self):
+        cls = _classify_process_error("Wait window of 30s elapsed — timed out")
+        assert cls["error_category"] == "poll-timeout"
+
+    def test_other_fallback(self):
+        cls = _classify_process_error("Some unexpected opaque error")
+        assert cls["error_category"] == "other"
+        assert "action='list'" in cls["recovery_hint"]
+
+    def test_empty_message_falls_back_to_other(self):
+        cls = _classify_process_error("")
+        assert cls["error_category"] == "other"
+
+
+class TestHandleProcessErrorClassification:
+    """The handler's error returns carry the classification fields."""
+
+    def test_invalid_action_error_includes_category(self):
+        result = _handle_process({"action": "status"}, task_id="test")
+        data = json.loads(result)
+        assert data["error_category"] == "invalid-action"
+        assert "recovery_hint" in data
+
+    def test_session_id_required_includes_category(self):
+        with (
+            patch("tools.process_registry.process_registry") as mock_reg,
+            patch("tools.approval.get_current_session_key") as mock_key,
+        ):
+            mock_reg.list_sessions.return_value = []
+            mock_key.return_value = ""
+            result = _handle_process({"action": "poll"}, task_id="test")
+            data = json.loads(result)
+            assert data["error_category"] == "session-id-required"
+            assert "recovery_hint" in data
+
+    def test_stale_session_id_includes_category(self):
+        with (
+            patch("tools.process_registry.process_registry") as mock_reg,
+            patch("tools.approval.get_current_session_key") as mock_key,
+        ):
+            mock_reg.get.return_value = None
+            mock_reg.list_sessions.return_value = [
+                {"session_id": "proc_a", "status": "running"}
+            ]
+            mock_key.return_value = ""
+            result = _handle_process(
+                {"action": "poll", "session_id": "stale_id"},
+                task_id="test",
+            )
+            data = json.loads(result)
+            assert data["error_category"] == "session-not-found"
+            assert "recovery_hint" in data

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -3007,6 +3007,74 @@ def _redact_process_result(result: dict) -> dict:
     return result
 
 
+def _classify_process_error(message: str) -> dict:
+    """Decompose a ``process`` tool error into a reason subclass + recovery hint.
+
+    Issue #2621: the ``process`` tool's ``other`` bucket was the largest
+    undecomposed failure mode — opaque errors with no reason subclass and no
+    recovery hint drove 18-deep retry spirals. This mirrors the decomposition
+    already done for ``tool_call``/``memory``/``tool_describe``: map the error
+    text to a concrete category the agent can act on instead of blind-retrying.
+
+    Returns a dict with ``error_category`` and ``recovery_hint``. The category
+    is one of: ``session-not-found``, ``invalid-action``, ``session-id-required``,
+    ``process-exited``, ``poll-timeout``, or ``other`` (fallback).
+    """
+    low = (message or "").lower()
+    if "no process with id" in low or "no processes are currently registered" in low:
+        return {
+            "error_category": "session-not-found",
+            "recovery_hint": (
+                "The session_id does not match any registered process. Use "
+                "action='list' to see the current processes, then retry with a "
+                "valid session_id. Do NOT retry the same stale ID."
+            ),
+        }
+    if "unknown process action" in low:
+        return {
+            "error_category": "invalid-action",
+            "recovery_hint": (
+                "The action name is not valid. Use one of the listed valid "
+                "actions (list, poll, log, wait, kill, write, submit, close). "
+                "Do NOT retry the same invalid action."
+            ),
+        }
+    if "session_id is required" in low:
+        return {
+            "error_category": "session-id-required",
+            "recovery_hint": (
+                "session_id is required for this action. Use action='list' to "
+                "find the process, then retry with its session_id."
+            ),
+        }
+    if "process has already finished" in low or "already exited" in low:
+        return {
+            "error_category": "process-exited",
+            "recovery_hint": (
+                "The process has already finished. Use action='log' to read its "
+                "final output, or action='list' to see current processes. Do NOT "
+                "retry write/submit/close on a finished process."
+            ),
+        }
+    if "timed out" in low or "timeout" in low:
+        return {
+            "error_category": "poll-timeout",
+            "recovery_hint": (
+                "The wait/poll timed out. The process may still be running — "
+                "poll again later, or use terminal(background=true, "
+                "notify_on_complete=true) for automatic notification."
+            ),
+        }
+    return {
+        "error_category": "other",
+        "recovery_hint": (
+            "The process tool returned an unclassified error. Inspect the "
+            "message, use action='list' to check process state, and adjust "
+            "before retrying."
+        ),
+    }
+
+
 def _handle_process(args, **kw):
     task_id = kw.get("task_id")
     action = args.get("action", "")
@@ -3058,7 +3126,10 @@ def _handle_process(args, **kw):
                     hint = f" {len(active_procs)} processes are running. Specify one of: {ids}"
                 elif len(all_procs) > 1:
                     hint = f" {len(all_procs)} processes exist. Use action='list' to see all."
-                return tool_error(f"session_id is required for {action}.{hint}")
+                return tool_error(
+                    f"session_id is required for {action}.{hint}",
+                    **_classify_process_error(f"session_id is required for {action}"),
+                )
         if session_id:
             _existing = process_registry.get(session_id)
             if _existing is None:
@@ -3079,12 +3150,14 @@ def _handle_process(args, **kw):
                     return tool_error(
                         f"No process with ID '{session_id}'. "
                         f"Available: {', '.join(_avail_ids[:5])}. "
-                        f"Use action='list' to see all processes."
+                        f"Use action='list' to see all processes.",
+                        **_classify_process_error(f"No process with ID '{session_id}'"),
                     )
                 return tool_error(
                     f"No process with ID '{session_id}'. "
                     "No processes are currently registered. "
-                    "Use action='list' to verify."
+                    "Use action='list' to verify.",
+                    **_classify_process_error(f"No process with ID '{session_id}'"),
                 )
         if action == "poll":
             return json.dumps(_redact_process_result(process_registry.poll(session_id)), ensure_ascii=False)
@@ -3110,10 +3183,12 @@ def _handle_process(args, **kw):
         if suggestion:
             return tool_error(
                 f"Unknown process action: {action!r}. Did you mean '{suggestion}'? "
-                f"Valid actions: {valid_list}"
+                f"Valid actions: {valid_list}",
+                **_classify_process_error(f"Unknown process action: {action!r}"),
             )
         return tool_error(
-            f"Unknown process action: {action!r}. Valid actions: {valid_list}"
+            f"Unknown process action: {action!r}. Valid actions: {valid_list}",
+            **_classify_process_error(f"Unknown process action: {action!r}"),
         )
 
 


### PR DESCRIPTION
Automated evolution PR for issue #2621.

Decomposes the process tool's opaque 'other' error bucket into reason subclasses (session-not-found, invalid-action, session-id-required, process-exited, poll-timeout, other) with a targeted recovery hint per subclass, mirroring the decomposition already done for tool_call/memory/tool_describe. Wires the subclass into the tool_error returns so a dead session stops being blind-retried.

Closes #2621