### PR TITLE
feat(monitoring): emit OTel MCP tracing spans on execute_tool (Closes #2634)

### DIFF
--- a/agent/monitoring/events.py
+++ b/agent/monitoring/events.py
@@ -79,8 +79,31 @@ class CronExecutionEvent:
         return {"event": "cron_execution", **asdict(self)}
 
 
+@dataclass(slots=True)
+class ExecuteToolEvent:
+    """Content-free MCP tool-execution span projection.
+
+    Carries only the low-cardinality OTel MCP identifiers (method name, session
+    id, protocol version) plus lifecycle metadata — never tool args/results.
+    """
+
+    name: str
+    tool_name: Optional[str] = None
+    mcp_method_name: Optional[str] = None
+    mcp_session_id: Optional[str] = None
+    mcp_protocol_version: Optional[str] = None
+    status: str = "completed"
+    duration_ms: Optional[int] = None
+    error_class: Optional[str] = None
+    ts_ns: int = field(default_factory=_now_ns)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"event": "execute_tool", **asdict(self)}
+
+
 __all__ = [
     "GatewayHealthEvent",
     "GatewayDiagnosticEvent",
     "CronExecutionEvent",
+    "ExecuteToolEvent",
 ]

--- a/agent/monitoring/mcp_tracing.py
+++ b/agent/monitoring/mcp_tracing.py
@@ -1,0 +1,52 @@
+"""OTel MCP tracing enrichment for tool-execution spans.
+
+OpenTelemetry's MCP semantic conventions (added in v1.39) standardize
+tool-layer observability on the ``mcp.method.name``, ``mcp.session.id`` and
+``mcp.protocol.version`` span attributes. This module is the single seam that
+maps a Hermes tool-execution monitoring event onto those attributes so
+``execute_tool`` spans are queryable by any standard OTel backend.
+
+It is additive and content-free: it never raises and never carries anything
+beyond the low-cardinality MCP identifiers, so the monitoring plane's
+hot-path invariant (``emit()`` must never block or raise) is preserved.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# OTel MCP semantic-convention attribute keys (GenAI semconv, v1.39+).
+MCP_METHOD_NAME = "mcp.method.name"
+MCP_SESSION_ID = "mcp.session.id"
+MCP_PROTOCOL_VERSION = "mcp.protocol.version"
+
+# Map event fields (underscored, matching the monitoring event style) to the
+# standard OTel MCP attribute keys.
+_FIELD_TO_ATTR = {
+    MCP_METHOD_NAME: "mcp_method_name",
+    MCP_SESSION_ID: "mcp_session_id",
+    MCP_PROTOCOL_VERSION: "mcp_protocol_version",
+}
+
+
+def mcp_span_attrs(ev: Dict[str, Any]) -> Dict[str, Any]:
+    """Return MCP span attributes for a tool-execution event.
+
+    Only present fields are returned; an event with no MCP metadata yields
+    an empty dict (so ordinary tool events are unaffected). Values are
+    coerced to strings and never contain user/session content.
+    """
+    attrs: Dict[str, Any] = {}
+    for attr_key, field in _FIELD_TO_ATTR.items():
+        val = ev.get(field)
+        if val:
+            attrs[attr_key] = str(val)
+    return attrs
+
+
+__all__ = [
+    "MCP_METHOD_NAME",
+    "MCP_SESSION_ID",
+    "MCP_PROTOCOL_VERSION",
+    "mcp_span_attrs",
+]

--- a/agent/monitoring/otlp_exporter.py
+++ b/agent/monitoring/otlp_exporter.py
@@ -160,6 +160,15 @@ def _span_attrs(ev: Dict[str, Any]) -> Dict[str, Any]:
                 except Exception:
                     v = "[redaction-unavailable]"
             attrs[f"hermes.{col}"] = v
+    if kind == "execute_tool":
+        # OTel MCP semantic conventions: mcp.method.name, mcp.session.id,
+        # mcp.protocol.version on execute_tool spans. Fail-closed on the hot path.
+        try:
+            from agent.monitoring.mcp_tracing import mcp_span_attrs
+
+            attrs.update(mcp_span_attrs(ev))
+        except Exception:
+            pass
     return attrs
 
 

--- a/tests/monitoring/test_otel_mcp.py
+++ b/tests/monitoring/test_otel_mcp.py
@@ -1,0 +1,77 @@
+"""OTel MCP tracing: execute_tool spans carry MCP semantic-convention attrs.
+
+Uses the in-memory OTel span exporter (no network). Skipped when the optional
+otlp extra is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+otel = pytest.importorskip("opentelemetry.sdk.trace", reason="otlp extra not installed")
+
+import agent.monitoring.otlp_exporter as OE
+from agent.monitoring.events import ExecuteToolEvent
+from agent.monitoring.mcp_tracing import (
+    MCP_METHOD_NAME,
+    MCP_PROTOCOL_VERSION,
+    MCP_SESSION_ID,
+    mcp_span_attrs,
+)
+
+
+def _mem_provider():
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def test_mcp_attrs_on_execute_tool_span():
+    provider, mem = _mem_provider()
+    ev = ExecuteToolEvent(
+        name="mcp_tqmemory_recent_context",
+        mcp_method_name="tools/call",
+        mcp_session_id="sess-abc123",
+        mcp_protocol_version="2025-06-18",
+        status="completed",
+        duration_ms=42,
+    )
+    n = OE.export_batch(provider, [ev.to_dict()])
+    assert n == 1
+    span = mem.get_finished_spans()[0]
+    assert span.name == "hermes.execute_tool"
+    attrs = dict(span.attributes or {})
+    assert attrs[MCP_METHOD_NAME] == "tools/call"
+    assert attrs[MCP_SESSION_ID] == "sess-abc123"
+    assert attrs[MCP_PROTOCOL_VERSION] == "2025-06-18"
+
+
+def test_mcp_attrs_absent_without_mcp_fields():
+    # An execute_tool event with no MCP metadata must not pick up fake attrs.
+    attrs = mcp_span_attrs({"event": "execute_tool", "name": "ls", "status": "ok"})
+    assert attrs == {}
+
+
+def test_emit_never_raises_for_malformed_execute_tool_event():
+    from agent.monitoring.emitter import MonitoringEmitter
+
+    provider, mem = _mem_provider()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(OE, "_make_provider", lambda cfg: (provider, None))
+    streamer = OE.OTLPStreamer({}, event_filter=lambda ev: True)
+
+    em = MonitoringEmitter()
+    em.subscribe(streamer)
+    # Missing required field + non-dict payloads must never raise on emit.
+    em.emit({"event": "execute_tool"})
+    em.emit(object())
+    em.flush()
+    em.close()
+    monkeypatch.undo()


### PR DESCRIPTION
## Summary

Emits OpenTelemetry MCP tracing spans on `execute_tool` events so tool-layer observability is standardized and queryable. OpenTelemetry v1.39 added the MCP semantic conventions (`mcp.method.name`, `mcp.session.id`, `mcp.protocol.version`); this wires them onto the monitoring exporter.

## Changes

- **`agent/monitoring/mcp_tracing.py`** (new): single seam mapping tool-execution events onto the standard OTel MCP attribute keys. Additive and content-free — never raises.
- **`agent/monitoring/events.py`**: adds a content-free `ExecuteToolEvent` typed event carrying the low-cardinality MCP identifiers plus lifecycle metadata (never tool args/results).
- **`agent/monitoring/otlp_exporter.py`**: `_span_attrs()` enriches `execute_tool` spans with the MCP attributes via `mcp_span_attrs()`, fail-closed so the hot-path invariant (emit must never block/raise) holds.
- **`tests/monitoring/test_otel_mcp.py`** (new): verifies `mcp.method.name`/`mcp.session.id`/`mcp.protocol.version` appear on `execute_tool` spans (in-memory span exporter, no network), that absent MCP metadata yields no attrs, and that emit never raises on malformed events.

Diff is small and additive (161 lines, all additions).

Closes #2634