### PR TITLE
feat(evolution): sandbox-escape threat model + regression suite (Closes #2641)

### DIFF
--- a/docs/evolution/sandbox-escape-threat-model.md
+++ b/docs/evolution/sandbox-escape-threat-model.md
@@ -1,0 +1,80 @@
+# Sandbox-Escape Threat Model
+
+Companion to `tests/evolution/test_sandbox_escape_boundary.py` (issue #2641,
+SandboxEscapeBench arXiv:2603.02277). Maps its escape layers (orchestration /
+runtime / kernel) onto Hermes's tool-execution boundary; all refs verified.
+
+## Threat model
+
+- **Escape is cheap.** Tool results and web content are untrusted input: a
+  compromised model, prompt-injected skill/webpage, or malicious subprocess
+  output can drive tool calls. Treat them as already hostile.
+- Every boundary below is **defense-in-depth, NOT an isolation boundary**: the
+  terminal tool runs as the same OS user with shell access, so `cat`/`curl`
+  can bypass any file or network guard.
+- Redaction (`agent/redact.py::redact_sensitive_text`, force-mode at
+  `tools/terminal_tool.py::_redact_terminal_error_text`) is the last line of
+  defense for secrets leaving through logs/errors, not a control on the shell.
+- **Fail closed**: when a guard cannot decide, it denies (`replace.require`,
+  `UnscopedSecretError` below).
+
+## Orchestration layer (agent-level tool policy)
+
+Defended today:
+
+- Write boundary — `agent/file_safety.py`: `build_write_denied_paths()` /
+  `is_write_denied()` hard-deny `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`,
+  `~/.ssh` keys, credential stores under HERMES_HOME; `build_write_denied_prefixes()`
+  covers `.ssh`/`.aws`/`.gnupg`/`.kube`, `/etc/systemd`; approval-gated paths
+  (`build_write_approval_paths`) fail closed for non-interactive callers.
+- Read block (defense-in-depth only) — `get_read_block_error()` blocks `auth.json`, `.env`, `mcp-tokens/`; docstring: NOT a security boundary.
+- Secret scope — `agent/secret_scope.py::get_secret()`: under multiplexing the
+  scope is allowlist + fail-closed; unscoped reads raise `UnscopedSecretError`
+  instead of leaking another profile's env.
+- Verification scope — `agent/verification_scope.py` least-agency checks wired
+  via `file_safety.set_active_verification_scope()`.
+
+Not defended: shell bypass of every file guard; `verification_scope.py`
+documents that disabled safeguards leave open network egress. Coverage:
+`test_filesystem_escape_is_write_denied`,
+`test_secret_scope_never_exposes_foreign_secrets`.
+
+## Runtime layer (process spawn & environment)
+
+Defended today:
+
+- Explicit encoding on the main spawn path — `tools/environments/local.py`,
+  `LocalEnvironment._run_bash()` → `subprocess.Popen(..., text=True,
+  encoding="utf-8", errors="replace")` (Windows-footgun rule); plus
+  process-group teardown (`_kill_process`), safe-cwd recovery.
+- Terminal error envelopes never return raw secrets —
+  `tools/terminal_tool.py::_redact_terminal_error_text` →
+  `agent/redact.py::redact_sensitive_text(force=True)`.
+
+Not defended: spawned processes inherit the process environment; no
+seccomp/landlock, no resource limits; background processes are
+session-tracked, not contained. Coverage:
+`test_process_spawn_passes_explicit_encoding`.
+
+## Kernel layer (network egress & syscalls)
+
+Defended today (remote sandboxes only):
+
+- Egress firewall — `agent/proxy_sources/iron_proxy.py::build_proxy_config()`:
+  default-deny allowlist of provider hosts (anything else is 403'd); SSRF
+  `upstream_deny_cidrs` (loopback, RFC1918, `169.254.0.0/16` cloud
+  metadata/IMDS); fail-closed credential swap (`replace.require: true`). See
+  `docs/security/network-egress-isolation.md`.
+
+Not defended: the `local` terminal backend has no egress control; the proxy is
+opt-in and wired only for docker/modal/ssh backends; TLS-interception trust is
+part of the boundary (compromised proxy CA ⇒ guarantee gone). Coverage:
+`test_network_egress_default_deny`.
+
+## Gap summary
+
+| Layer | Hard boundary today | Primary gap |
+|---|---|---|
+| Orchestration | deny-lists + scopes, fail closed | shell bypass always available |
+| Runtime | encoding + redaction only | no OS-level process isolation |
+| Kernel | opt-in egress proxy (remote) | local backend egress unguarded |

--- a/tests/evolution/test_sandbox_escape_boundary.py
+++ b/tests/evolution/test_sandbox_escape_boundary.py
@@ -1,0 +1,118 @@
+"""Sandbox-escape regression tests for the tool-execution boundary (#2641).
+
+Maps SandboxEscapeBench layers (orchestration / runtime / kernel, arXiv:2603.02277)
+onto real Hermes boundary code — see docs/evolution/sandbox-escape-threat-model.md.
+Each test exercises the actual module; no mock sandbox is invented.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agent import file_safety
+from agent import secret_scope
+from agent.proxy_sources.iron_proxy import TokenMapping
+from agent.proxy_sources.iron_proxy import build_proxy_config
+from tools.environments.local import LocalEnvironment
+
+
+class TestSandboxEscapeBoundary:
+    """Escapes must fail at Hermes's real tool-execution boundary."""
+
+    # ── orchestration layer: filesystem escape ─────────────────────────
+    def test_filesystem_escape_is_write_denied(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """System files and ~/.ssh keys are hard-denied; temp HOME stays writable."""
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+        home = str(Path.home())
+
+        denied = file_safety.build_write_denied_paths(home)
+        assert "/etc/passwd" in denied
+        assert "/etc/shadow" in denied
+
+        for escape in ("/etc/passwd", "/etc/shadow", "/etc/sudoers"):
+            assert file_safety.is_write_denied(escape), escape
+        assert file_safety.is_write_denied(os.path.join(home, ".ssh", "id_rsa"))
+
+        inside = tmp_path / "sandbox" / "notes.txt"
+        assert not file_safety.is_write_denied(str(inside))
+
+    # ── orchestration layer: env / secret exfiltration ─────────────────
+    def test_secret_scope_never_exposes_foreign_secrets(self, monkeypatch) -> None:
+        """Multiplex-mode get_secret is scope-allowlisted and fail-closed."""
+        monkeypatch.setenv("PROFILE_B_API_KEY", "sk-other-profile")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"PROFILE_A_API_KEY": "sk-a"})
+        try:
+            assert secret_scope.get_secret("PROFILE_A_API_KEY") == "sk-a"
+            assert (
+                secret_scope.get_secret("PROFILE_B_API_KEY", default="__missing__")
+                == "__missing__"
+            )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        try:
+            with pytest.raises(secret_scope.UnscopedSecretError):
+                secret_scope.get_secret("PROFILE_B_API_KEY")
+            # allowlisted globals (deployment config) still read os.environ
+            assert secret_scope.get_secret("HERMES_HOME") is not None
+        finally:
+            secret_scope.set_multiplex_active(False)
+
+    # ── runtime layer: process spawn encoding ──────────────────────────
+    def test_process_spawn_passes_explicit_encoding(self, tmp_path: Path) -> None:
+        """Main spawn path (_run_bash) pins utf-8/errors=replace on Popen."""
+        seen: dict = {}
+        real_popen = subprocess.Popen
+
+        def recording_popen(*args, **kwargs):
+            seen.update(kwargs)
+            return real_popen(*args, **kwargs)
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+        try:
+            with mock.patch(
+                "tools.environments.local.subprocess.Popen",
+                side_effect=recording_popen,
+            ):
+                result = env.execute("printf 'escape-probe'")
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert "escape-probe" in result["output"]
+        assert seen.get("encoding") == "utf-8"
+        assert seen.get("errors") == "replace"
+
+    # ── kernel layer: network egress ───────────────────────────────────
+    def test_network_egress_default_deny(self, tmp_path: Path) -> None:
+        """Egress proxy config is default-deny: SSRF list, allowlist, fail-closed."""
+        cfg = build_proxy_config(
+            mappings=[
+                TokenMapping(
+                    proxy_token="proxy-token",
+                    real_env_name="X_API_KEY",
+                    upstream_hosts=("api.x.ai",),
+                )
+            ],
+            ca_cert=tmp_path / "ca.crt",
+            ca_key=tmp_path / "ca.key",
+        )
+
+        deny = cfg["proxy"]["upstream_deny_cidrs"]
+        assert "169.254.0.0/16" in deny  # cloud metadata / IMDS
+        assert "127.0.0.0/8" in deny  # loopback
+
+        allowlist = cfg["transforms"][0]["config"]["domains"]
+        assert "evil.example.com" not in allowlist  # anything else is 403'd
+        assert "api.x.ai" in allowlist  # only mapped upstreams are added
+
+        secret = cfg["transforms"][1]["config"]["secrets"][0]
+        assert secret["replace"]["require"] is True  # no token swap => reject


### PR DESCRIPTION
Automated evolution PR for issue #2641.

Maps SandboxEscapeBench (arXiv:2603.02277) layers onto Hermes's real tool-execution boundary:
- filesystem escape: write-denial via agent/file_safety.py
- env/secret exfiltration: secret-scope allowlist + fail-closed reads
- process spawning: explicit utf-8 encoding on the main spawn path
- network egress: default-deny proxy config (IMDS/loopback denied)

Docs: docs/evolution/sandbox-escape-threat-model.md
Tests: 4/4 pass locally (tests/evolution/test_sandbox_escape_boundary.py), ruff clean.

Closes #2641

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>