### PR TITLE
feat(evolution): instruction provenance — structured rationale + decay check (Closes #2629)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -345,13 +345,28 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
 
     cron_referenced = _cron_referenced_skills()
 
-    counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0, "seeded": 0}
+    counts = {
+        "marked_stale": 0,
+        "archived": 0,
+        "reactivated": 0,
+        "checked": 0,
+        "seeded": 0,
+        "rationale_decayed": 0,
+    }
 
     for row in _u.curated_report():
         counts["checked"] += 1
         name = row["name"]
         if row.get("pinned"):
             continue
+        # Instruction provenance (#2629): flag skills whose rationale is
+        # missing or has decayed (patched since the rationale was captured).
+        # Non-destructive — flags for review rather than auto-pruning, so
+        # the evolution loop can consolidate/prune with the *why* in hand
+        # instead of guessing at intent (the paper's divergence guard
+        # against unbounded prompt growth).
+        if _u.rationale_decayed(row):
+            counts["rationale_decayed"] += 1
 
         # A skill referenced by any cron job (incl. paused/disabled) is in
         # use by definition — resuming or the next fire must find it. The
@@ -1589,6 +1604,10 @@ def run_curator_review(
         auto_summary_parts.append(f"{counts['archived']} archived")
     if counts["reactivated"]:
         auto_summary_parts.append(f"{counts['reactivated']} reactivated")
+    if counts.get("rationale_decayed"):
+        auto_summary_parts.append(
+            f"{counts['rationale_decayed']} rationale-decayed (review needed)"
+        )
     auto_summary = ", ".join(auto_summary_parts) if auto_summary_parts else "no changes"
 
     # Persist state before the LLM pass so a crash mid-review still records

--- a/tests/tools/test_skill_rationale_provenance.py
+++ b/tests/tools/test_skill_rationale_provenance.py
@@ -1,0 +1,80 @@
+"""Tests for instruction provenance (rationale blocks) — issue #2629."""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def usage_mod(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME + freshly-relocated skill_usage module."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    mod = importlib.import_module("tools.skill_usage")
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return mod
+
+
+def test_empty_record_rationale_fields(usage_mod):
+    rec = usage_mod._empty_record()
+    assert rec["rationale"] is None
+    assert rec["rationale_generation"] == 0
+
+
+def test_rationale_decayed_missing_or_advanced(usage_mod):
+    # Missing rationale => decayed by definition.
+    assert usage_mod.rationale_decayed({}) is True
+    assert (
+        usage_mod.rationale_decayed({"patch_generation": 3, "rationale": None}) is True
+    )
+    # Rationale captured at gen 2, skill now at gen 3 => decayed.
+    assert (
+        usage_mod.rationale_decayed({
+            "patch_generation": 3,
+            "rationale_generation": 2,
+            "rationale": {"why": "x"},
+        })
+        is True
+    )
+    # Up to date => not decayed.
+    assert (
+        usage_mod.rationale_decayed({
+            "patch_generation": 3,
+            "rationale_generation": 3,
+            "rationale": {"why": "x"},
+        })
+        is False
+    )
+    # Custom gap threshold.
+    assert (
+        usage_mod.rationale_decayed(
+            {
+                "patch_generation": 4,
+                "rationale_generation": 3,
+                "rationale": {"why": "x"},
+            },
+            generations_gap=2,
+        )
+        is False
+    )
+
+
+def test_set_rationale_persists_and_records_generation(usage_mod):
+    rec = {"patch_generation": 2}
+    usage_mod._mutate("demo", lambda r: r.update(rec))
+    usage_mod.set_rationale(
+        "demo",
+        "freeform why text",
+        failure="cmd failed on fresh env",
+        hypothesis="needs explicit PATH",
+        outcome="solved",
+    )
+    stored = usage_mod.get_record("demo")
+    assert stored["rationale"]["failure"] == "cmd failed on fresh env"
+    assert stored["rationale"]["hypothesis"] == "needs explicit PATH"
+    assert stored["rationale"]["outcome"] == "solved"
+    assert stored["rationale"]["why"] == "freeform why text"
+    assert stored["rationale_generation"] == 2
+    assert usage_mod.rationale_decayed(stored) is False

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1683,6 +1683,7 @@ def skill_manage(
     new_string: str = None,
     replace_all: bool = False,
     absorbed_into: str = None,
+    rationale: str = None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
@@ -1812,6 +1813,15 @@ def skill_manage(
                         run_id = _os.environ.get("HERMES_SESSION_ID", "") or ""
                         if run_id:
                             set_source_run_id(name, run_id)
+                    except Exception:
+                        pass
+                    # Instruction provenance (#2629): a skill must carry its
+                    # rationale (failure/hypothesis/outcome) or it decays into
+                    # prompt noise. Best-effort; never breaks the create.
+                    try:
+                        from tools.skill_usage import set_rationale
+                        if rationale:
+                            set_rationale(name, rationale)
                     except Exception:
                         pass
                     # Store the source chain accumulated during the
@@ -1973,6 +1983,18 @@ SKILL_MANAGE_SCHEMA = {
                     "rewriting) will have to guess at intent."
                 )
             },
+            "rationale": {
+                "type": "string",
+                "description": (
+                    "Optional but STRONGLY RECOMMENDED for 'create': the *why* "
+                    "behind this skill (the failure that triggered it, the "
+                    "hypothesis it encodes, and the observed outcome). Storing "
+                    "the rationale prevents catastrophic remembering — a "
+                    "rationale-less instruction decays into prompt noise and "
+                    "cannot be pruned later. The curator flags skills whose "
+                    "rationale is missing or has decayed."
+                )
+            },
         },
         "required": ["action", "name"],
     },
@@ -1996,6 +2018,7 @@ registry.register(
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False),
-        absorbed_into=args.get("absorbed_into")),
+        absorbed_into=args.get("absorbed_into"),
+        rationale=args.get("rationale")),
     emoji="📝",
 )

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -664,7 +664,65 @@ def _empty_record() -> Dict[str, Any]:
         # Provisional→trusted lifecycle (#2256)
         "trust_state": "provisional",
         "consecutive_successes": 0,
+        # Instruction provenance — structured rationale (#2629).
+        # A skill must carry the *why* behind its creation (failure that
+        # triggered it, hypothesis, observed outcome) so the curator can
+        # flag it when the rationale has decayed after the skill evolved.
+        # ``rationale_generation`` is the patch_generation at which the
+        # rationale was last (re)captured; decay = patch_generation has
+        # advanced beyond it without a rationale refresh.
+        "rationale": None,
+        "rationale_generation": 0,
     }
+
+
+def set_rationale(
+    skill_name: str,
+    rationale: str,
+    *,
+    failure: str = "",
+    hypothesis: str = "",
+    outcome: str = "",
+) -> None:
+    """Persist a structured rationale block for a skill (#2629).
+
+    The block records the *why* behind a skill/instruction so it can be
+    evaluated for decay later. ``rationale`` is the freeform narrative;
+    the structured ``failure``/``hypothesis``/``outcome`` fields let callers
+    encode the paper's three-part model explicitly. Called from the
+    skill_manage create path. Best-effort: never breaks the tool call.
+    """
+    narrative = (rationale or "").strip()[:1000]
+    block = {
+        "failure": (failure or "").strip()[:1000],
+        "hypothesis": (hypothesis or "").strip()[:1000],
+        "outcome": (outcome or "").strip()[:1000],
+        "why": narrative,
+    }
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["rationale"] = block
+        rec["rationale_generation"] = _non_negative_int(rec.get("patch_generation"))
+
+    _mutate(skill_name, _apply)
+
+
+def rationale_decayed(record: Dict[str, Any], *, generations_gap: int = 1) -> bool:
+    """Whether a skill's rationale is missing or has decayed (#2629).
+
+    Decay model (arXiv:2608.11095 "catastrophic remembering"): a rationale
+    captured at generation G is *stale* once the skill has been patched
+    ``generations_gap`` or more times since. A missing rationale is decayed
+    by definition — an instruction with no recorded *why* is the failure mode
+    the paper identifies as the source of unbounded prompt growth.
+    """
+    if not isinstance(record, dict):
+        return True
+    if not record.get("rationale"):
+        return True
+    patch_gen = _non_negative_int(record.get("patch_generation"))
+    rationale_gen = _non_negative_int(record.get("rationale_generation"))
+    return (patch_gen - rationale_gen) >= generations_gap
 
 
 def load_usage() -> Dict[str, Dict[str, Any]]:


### PR DESCRIPTION
Implements #2629: instruction provenance — store the *why* behind each skill/instruction to prevent catastrophic remembering (arXiv:2608.11095).

## What
- **`tools/skill_usage.py`**: `set_rationale()` persists a structured `failure`/`hypothesis`/`outcome`/`why` block per skill; `rationale_decayed()` encodes the divergence model — a rationale captured at generation G is stale once the skill has been patched `generations_gap`+ times since (missing rationale = decayed by definition).
- **`tools/skill_manager_tool.py`**: `skill_manage` `create` accepts an optional `rationale` arg, wired into `set_rationale` (best-effort, never breaks the create).
- **`agent/curator.py`**: `apply_automatic_transitions` counts `rationale_decayed` skills and the review summary reports them — a non-destructive review signal, not auto-pruning, so the loop consolidates/prunes with the *why* in hand.
- **`tests/tools/test_skill_rationale_provenance.py`**: 3 tests.

## Safety
Non-destructive (flags for review, never auto-prunes). Rationale is stored in the existing usage sidecar, not user-authored SKILL.md content.

## Checks
- ruff check ✓ (baseline format noncompliance on the touched files is pre-existing on origin/main, not introduced here)
- pytest (this module): 3 passed ✓
- Diff: 184 lines (under the 200-line self-merge cap)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>