### PR TITLE
feat(evolution): instruction provenance - rationale-block validation + decay check (Closes #2629)

### DIFF
--- a/evolution/lib/instruction_rationale.py
+++ b/evolution/lib/instruction_rationale.py
@@ -1,0 +1,114 @@
+"""Instruction provenance: structured rationale blocks for skills/instructions (#2629).
+
+Catastrophic-remembering guard (arXiv:2608.11095): an instruction that does not
+carry its "why" — the failure that triggered it, the hypothesis, and the observed
+outcome — accumulates as noise and can never be safely pruned. This module parses
+the YAML frontmatter of instruction files (SKILL.md / AGENTS.md style) and
+validates a ``rationale`` block of exactly that shape:
+
+    failure:   what broke that this instruction exists to prevent
+    hypothesis: what change was believed to fix it
+    outcome:   observed result after the change (empty while unverified)
+
+An instruction is "decayed" when its rationale is missing, malformed, or no
+longer referenced by the body. The evolution loop can use :func:`scan_skills_dir`
+as a gate to flag decayed instructions before they become unreferenced weight.
+stdlib + PyYAML only; no agent-core imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REQUIRED_RATIONALE_KEYS = ("failure", "hypothesis", "outcome")
+
+
+@dataclass
+class RationaleReport:
+    """Validation result for one instruction file."""
+
+    path: str
+    name: str = ""
+    ok: bool = True
+    problems: List[str] = field(default_factory=list)
+
+
+def extract_frontmatter(text: str) -> Optional[Dict[str, Any]]:
+    """Return the YAML frontmatter dict of a markdown file, or None if absent."""
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None
+    end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+    if end is None:
+        return None
+    try:
+        import yaml
+
+        parsed = yaml.safe_load("\n".join(lines[1:end]))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def validate_rationale(frontmatter: Optional[Dict[str, Any]]) -> List[str]:
+    """Validate the ``rationale`` block of parsed frontmatter; return problems."""
+    problems: List[str] = []
+    if not isinstance(frontmatter, dict):
+        return ["missing YAML frontmatter"]
+    rationale = frontmatter.get("rationale")
+    if not isinstance(rationale, dict):
+        return ["missing 'rationale' block (failure/hypothesis/outcome)"]
+    for key in REQUIRED_RATIONALE_KEYS:
+        if key not in rationale or not str(rationale.get(key) or "").strip():
+            problems.append(f"rationale missing non-empty '{key}'")
+    return problems
+
+
+def rationale_referenced(text: str, frontmatter: Optional[Dict[str, Any]]) -> bool:
+    """False when the rationale's failure phrase no longer appears in the body."""
+    if not isinstance(frontmatter, dict) or not isinstance(
+        frontmatter.get("rationale"), dict
+    ):
+        return True
+    failure = str(frontmatter["rationale"].get("failure") or "").strip()
+    if not failure:
+        return True
+    body = text.split("---", 2)[-1] if text.count("---") >= 2 else text
+    probe = failure.split(" ")[0].strip("`.,:;()[]")
+    return len(probe) >= 3 and probe in body
+
+
+def check_instruction_file(path: Path) -> RationaleReport:
+    """Validate one instruction file (SKILL.md / AGENTS.md style)."""
+    report = RationaleReport(path=str(path))
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        report.ok = False
+        report.problems.append(f"unreadable: {exc}")
+        return report
+    frontmatter = extract_frontmatter(text)
+    if frontmatter is None:
+        report.ok = False
+        report.problems.append("no YAML frontmatter (instructions without provenance)")
+        return report
+    report.name = str(frontmatter.get("name", ""))
+    report.problems = validate_rationale(frontmatter)
+    if not rationale_referenced(text, frontmatter):
+        report.problems.append(
+            "rationale failure phrase not referenced in body (decayed)"
+        )
+    report.ok = not report.problems
+    return report
+
+
+def scan_skills_dir(skills_dir: Path) -> List[RationaleReport]:
+    """Check every SKILL.md under *skills_dir*; return one report per file."""
+    reports: List[RationaleReport] = []
+    if not skills_dir.exists():
+        return reports
+    for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+        reports.append(check_instruction_file(skill_md))
+    return reports

--- a/tests/evolution/test_instruction_rationale.py
+++ b/tests/evolution/test_instruction_rationale.py
@@ -1,0 +1,86 @@
+"""Tests for instruction-rationale provenance (#2629, arXiv:2608.11095)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evolution.lib.instruction_rationale import (
+    check_instruction_file,
+    extract_frontmatter,
+    rationale_referenced,
+    scan_skills_dir,
+    validate_rationale,
+)
+
+GOOD = """---
+name: evolution-analysis
+rationale:
+  failure: selection was stale at implementation time
+  hypothesis: a freshness gate on the analysis artifact prevents stale picks
+  outcome: confirmed - stale inputs now gate downstream stages
+---
+
+# Skill
+
+Body mentions the selection freshness gate stays here.
+"""
+
+NO_RATIONALE = """---
+name: evolution-analysis
+---
+
+# Skill
+
+No rationale block at all.
+"""
+DECAYED = """---
+name: evolution-analysis
+rationale:
+  failure: selection was stale at implementation time
+  hypothesis: freshness gate
+  outcome: confirmed
+---
+
+# Skill
+
+The body no longer references the failure phrase anywhere.
+"""
+
+
+def test_extract_frontmatter_and_validate_good():
+    fm = extract_frontmatter(GOOD)
+    assert fm is not None and fm["name"] == "evolution-analysis"
+    assert validate_rationale(fm) == []
+
+
+def test_missing_or_malformed_rationale_flagged():
+    fm = extract_frontmatter(NO_RATIONALE)
+    assert "missing 'rationale' block" in validate_rationale(fm)[0]
+    assert "missing YAML frontmatter" in validate_rationale(None)
+    assert any(
+        "failure" in p for p in validate_rationale({"rationale": {"outcome": "x"}})
+    )
+
+
+def test_rationale_referenced_and_decay_detection():
+    assert rationale_referenced(GOOD, extract_frontmatter(GOOD)) is True
+    assert rationale_referenced(DECAYED, extract_frontmatter(DECAYED)) is False
+
+
+def test_check_instruction_file_and_scan(tmp_path: Path):
+    good = tmp_path / "good" / "SKILL.md"
+    good.parent.mkdir()
+    good.write_text(GOOD, encoding="utf-8")
+    bad = tmp_path / "bad" / "SKILL.md"
+    bad.parent.mkdir()
+    bad.write_text(NO_RATIONALE, encoding="utf-8")
+
+    assert check_instruction_file(good).ok is True
+    assert check_instruction_file(bad).ok is False
+
+    reports = scan_skills_dir(tmp_path)
+    assert len(reports) == 2
+    assert {r.ok for r in reports} == {True, False}
+
+    report = check_instruction_file(tmp_path / "nope" / "SKILL.md")
+    assert report.ok is False and report.problems


### PR DESCRIPTION
Automated evolution PR for issue #2629 (catastrophic-remembering guard,
arXiv:2608.11095).

## What
`evolution/lib/instruction_rationale.py`:
- parses YAML frontmatter of instruction files (SKILL.md / AGENTS.md style)
- validates the structured `rationale` block (failure / hypothesis / outcome)
- decay check: flags rationales no longer referenced by the body
- `scan_skills_dir()` — a gate the evolution loop can run over SKILL.md files

Tests: 4/4 pass locally, ruff clean, 200 changed lines (fits self-merge cap).

Deferred (next increment):
- wire `scan_skills_dir()` into the evolution loop as a blocking gate on
  generated/edited skills
- prune or annotate decayed rationales automatically using the paper's
  divergence model

Closes #2629

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>