### PR TITLE
feat(evolution): cost-reduced validation via task-selection subset (Closes #2638)

### DIFF
--- a/scripts/evolution_validation_subset.py
+++ b/scripts/evolution_validation_subset.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Cost-reduce the validation stage via task-selection benchmark reduction (#2638).
+
+Task-selection / benchmark-reduction (arXiv:2603.23749): pick a deterministic,
+ranking-faithful SUBSET of benchmark tasks so regression checks run on fewer
+tasks without distorting the difficulty mix; track validation cost per cycle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+__all__ = ["select_subset", "estimate_cost", "track_validation_cost", "main"]
+
+DIFFICULTY_BANDS = ("easy", "medium", "hard")
+
+
+def _band(task: Dict[str, Any]) -> str:
+    difficulty = str(task.get("difficulty", "medium")).lower()
+    return difficulty if difficulty in DIFFICULTY_BANDS else "medium"
+
+
+def select_subset(
+    tasks: Sequence[Dict[str, Any]], budget_ratio: float = 0.5, seed: int = 7
+) -> Dict[str, Any]:
+    """Deterministic stratified subset that preserves the difficulty mix."""
+    rng = random.Random(seed)
+    tasks = list(tasks)
+    total = len(tasks)
+    if not 0 < budget_ratio <= 1:
+        raise ValueError("budget_ratio must be in (0, 1]")
+    budget = max(1, round(total * budget_ratio))
+    chosen: List[Dict[str, Any]] = []
+    for band in DIFFICULTY_BANDS:
+        items = [t for t in tasks if _band(t) == band]
+        if items:
+            take = max(1, round(len(items) * budget_ratio))
+            chosen.extend(rng.sample(items, min(take, len(items))))
+    if len(chosen) > budget:
+        chosen = rng.sample(chosen, budget)
+    return {
+        "tasks": chosen,
+        "stats": {
+            "total": total,
+            "subset": len(chosen),
+            "budget_ratio": budget_ratio,
+            "savings_ratio": round(1 - (len(chosen) / total if total else 0.0), 3),
+        },
+    }
+
+
+def estimate_cost(
+    tasks: Sequence[Dict[str, Any]], cost_per_step: float = 1.0
+) -> Dict[str, Any]:
+    """Estimate validation cost of a task set (steps * per-step cost)."""
+    steps = sum(int(t.get("steps", 1) or 1) for t in tasks)
+    return {
+        "tasks": len(tasks),
+        "steps": steps,
+        "estimated_cost": round(steps * cost_per_step, 3),
+    }
+
+
+def track_validation_cost(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate per-cycle validation cost from prior validation records."""
+    cycles: Dict[str, int] = {}
+    total = 0
+    for record in records:
+        cycle = str(record.get("cycle", "unknown"))
+        cost = int(record.get("validation_cost", 0) or 0)
+        cycles[cycle] = cycles.get(cycle, 0) + cost
+        total += cost
+    return {"cycles": cycles, "total_cost": total, "record_count": len(records)}
+
+
+def main(argv: List[str]) -> int:
+    """CLI: reduce a benchmark task list to a ranking-faithful subset."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--tasks-json", type=Path, required=True)
+    parser.add_argument("--budget-ratio", type=float, default=0.5)
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args(argv[1:])
+    tasks = json.loads(args.tasks_json.read_text(encoding="utf-8"))
+    if not isinstance(tasks, list):
+        print(
+            "[evolution-validation-subset] tasks JSON must be a list", file=sys.stderr
+        )
+        return 2
+    result = select_subset(tasks, budget_ratio=args.budget_ratio, seed=args.seed)
+    result["cost"] = estimate_cost(result["tasks"])
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_validation_subset.py
+++ b/tests/scripts/test_evolution_validation_subset.py
@@ -1,0 +1,90 @@
+"""Tests for scripts/evolution_validation_subset.py (#2638)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_validation_subset import (  # noqa: E402
+    estimate_cost,
+    main,
+    select_subset,
+    track_validation_cost,
+)
+
+TASKS = [
+    {"id": i, "difficulty": b, "steps": 2}
+    for i, b in enumerate(["easy"] * 4 + ["medium"] * 4 + ["hard"] * 4)
+]
+
+
+def test_subset_respects_budget_and_difficulty_mix():
+    result = select_subset(TASKS, budget_ratio=0.5)
+    stats = result["stats"]
+    assert stats["subset"] <= stats["total"]
+    assert stats["subset"] == 6
+    # Every band keeps a proportional share (ranking fidelity proxy).
+    assert {t["difficulty"] for t in result["tasks"]} == {"easy", "medium", "hard"}
+
+
+def test_subset_is_deterministic():
+    a = select_subset(TASKS, budget_ratio=0.5, seed=7)
+    b = select_subset(TASKS, budget_ratio=0.5, seed=7)
+    assert [t["id"] for t in a["tasks"]] == [t["id"] for t in b["tasks"]]
+
+
+def test_subset_under_ratio_keeps_all_when_small():
+    result = select_subset(
+        [{"id": 1, "difficulty": "easy", "steps": 1}], budget_ratio=0.5
+    )
+    assert result["stats"]["subset"] == 1
+    assert result["tasks"][0]["id"] == 1
+
+
+def test_subset_empty():
+    result = select_subset([], budget_ratio=0.5)
+    assert result["tasks"] == []
+    assert result["stats"]["total"] == 0
+
+
+def test_subset_invalid_ratio_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        select_subset(TASKS, budget_ratio=0.0)
+
+
+def test_estimate_cost_counts_steps():
+    cost = estimate_cost(TASKS, cost_per_step=0.5)
+    assert cost["tasks"] == 12
+    assert cost["steps"] == 24
+    assert cost["estimated_cost"] == 12.0
+
+
+def test_track_validation_cost_aggregates_cycles():
+    records = [
+        {"cycle": "2026-08-15", "validation_cost": 10},
+        {"cycle": "2026-08-15", "validation_cost": 5},
+        {"cycle": "2026-08-16", "validation_cost": 7},
+    ]
+    report = track_validation_cost(records)
+    assert report["cycles"]["2026-08-15"] == 15
+    assert report["total_cost"] == 22
+    assert report["record_count"] == 3
+
+
+def test_cli_reduces_task_list(tmp_path, capsys):
+    p = tmp_path / "tasks.json"
+    p.write_text(json.dumps(TASKS), encoding="utf-8")
+    rc = main([
+        "evolution_validation_subset.py",
+        "--tasks-json",
+        str(p),
+        "--budget-ratio",
+        "0.5",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["stats"]["subset"] == 6
+    assert out["cost"]["tasks"] == 6


### PR DESCRIPTION
Automated evolution PR for issue #2638.

## What
Cost-reduce the validation stage: task-selection / benchmark-reduction (arXiv:2603.23749) applied so regression checks run on a cost-reduced, ranking-faithful subset of benchmark tasks, with validation cost tracked per cycle.

## Changes
- `scripts/evolution_validation_subset.py` (new): `select_subset` (deterministic, seedable stratified subset by difficulty band that preserves the mix — the ranking-fidelity proxy), `estimate_cost` (steps * per-step cost), `track_validation_cost` (aggregate per-cycle validation cost from prior records), plus a CLI (`--tasks-json`, `--budget-ratio`, `--seed`).
- `tests/scripts/test_evolution_validation_subset.py` (new, 8 tests): budget + difficulty-mix preservation, determinism, small/empty inputs, invalid ratio, cost estimation, per-cycle cost aggregation, CLI end-to-end.

## Scope note (first increment)
Wiring the subset selector into the running validation pipeline (evolution_bilevel_eval / evolution_adaptive_validation) is the next increment — this lands the deterministic selection primitive + cost tracking as a standalone, tested module the stage can call.

## Checks
- ruff check ✓ · ruff format ✓ · pytest 8/8 ✓
- Pre-PR targeted shard: PASSED ✓
- Diff: 191 changed lines (≤ 200 cap)