### PR TITLE
feat: emit OTel MCP execute_tool spans from tool-execution path (Closes #2634)

### DIFF
--- a/agent/monitoring/events.py
+++ b/agent/monitoring/events.py
@@ -79,8 +79,31 @@ class CronExecutionEvent:
         return {"event": "cron_execution", **asdict(self)}
 
 
+@dataclass(slots=True)
+class ExecuteToolEvent:
+    """Content-free tool-execution span projection for OTel MCP tracing.
+
+    Carries only the low-cardinality OTel MCP identifiers — never tool
+    args/results.
+    """
+
+    name: str
+    tool_name: Optional[str] = None
+    mcp_method_name: Optional[str] = None
+    mcp_session_id: Optional[str] = None
+    mcp_protocol_version: Optional[str] = None
+    status: str = "completed"
+    duration_ms: Optional[int] = None
+    error_class: Optional[str] = None
+    ts_ns: int = field(default_factory=_now_ns)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"event": "execute_tool", **asdict(self)}
+
+
 __all__ = [
     "GatewayHealthEvent",
     "GatewayDiagnosticEvent",
     "CronExecutionEvent",
+    "ExecuteToolEvent",
 ]

--- a/agent/monitoring/mcp_tracing.py
+++ b/agent/monitoring/mcp_tracing.py
@@ -1,0 +1,47 @@
+"""OTel MCP tracing enrichment for tool-execution spans.
+
+Maps a Hermes ``execute_tool`` monitoring event onto the OTel MCP semantic
+convention span attributes (``mcp.method.name``, ``mcp.session.id``,
+``mcp.protocol.version``). Additive and content-free: never raises, never
+carries anything beyond the low-cardinality MCP identifiers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# OTel MCP semantic-convention attribute keys (GenAI semconv, v1.39+).
+MCP_METHOD_NAME = "mcp.method.name"
+MCP_SESSION_ID = "mcp.session.id"
+MCP_PROTOCOL_VERSION = "mcp.protocol.version"
+
+# Map event fields (underscored, matching the monitoring event style) to the
+# standard OTel MCP attribute keys.
+_FIELD_TO_ATTR = {
+    MCP_METHOD_NAME: "mcp_method_name",
+    MCP_SESSION_ID: "mcp_session_id",
+    MCP_PROTOCOL_VERSION: "mcp_protocol_version",
+}
+
+
+def mcp_span_attrs(ev: Dict[str, Any]) -> Dict[str, Any]:
+    """Return MCP span attributes for a tool-execution event.
+
+    Only present fields are returned; an event with no MCP metadata yields an
+    empty dict (so ordinary tool events are unaffected). Values are coerced to
+    strings and never contain user/session content.
+    """
+    attrs: Dict[str, Any] = {}
+    for attr_key, field in _FIELD_TO_ATTR.items():
+        val = ev.get(field)
+        if val:
+            attrs[attr_key] = str(val)
+    return attrs
+
+
+__all__ = [
+    "MCP_METHOD_NAME",
+    "MCP_SESSION_ID",
+    "MCP_PROTOCOL_VERSION",
+    "mcp_span_attrs",
+]

--- a/agent/monitoring/otlp_exporter.py
+++ b/agent/monitoring/otlp_exporter.py
@@ -189,6 +189,16 @@ def _span_attrs(ev: Dict[str, Any]) -> Dict[str, Any]:
         attrs.update(reuse_attributes(audit_experience_reuse(ev)))
     except Exception:
         pass
+    if kind == "execute_tool":
+        # OTel MCP semantic conventions: mcp.method.name, mcp.session.id,
+        # mcp.protocol.version on execute_tool spans. Fail-closed on the
+        # hot path like every other attribute enrichment.
+        try:
+            from agent.monitoring.mcp_tracing import mcp_span_attrs
+
+            attrs.update(mcp_span_attrs(ev))
+        except Exception:
+            pass
     return attrs
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -359,6 +359,31 @@ def _emit_terminal_post_tool_call(
         pass
 
 
+def _emit_execute_tool_event(agent, function_name: str) -> None:
+    """Emit a content-free ExecuteToolEvent for the live tool-execution path.
+
+    Carries only the OTel MCP identifiers — never tool args/results.
+    Fail-closed on the hot path: a monitoring fault must never affect tool
+    execution.
+    """
+    try:
+        from agent.monitoring.events import ExecuteToolEvent
+        from agent.monitoring.emitter import get_emitter
+
+        session_id = str(getattr(agent, "session_id", "") or "")
+        get_emitter().emit(
+            ExecuteToolEvent(
+                name=function_name,
+                tool_name=function_name,
+                mcp_method_name=function_name,
+                mcp_session_id=session_id or None,
+                mcp_protocol_version="2025-06-18",
+            )
+        )
+    except Exception:
+        pass
+
+
 def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     return json.dumps(
         {
@@ -1096,6 +1121,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             try:
                 def _execute(next_args: dict[str, Any]) -> Any:
+                    _emit_execute_tool_event(agent, function_name)
                     return agent._invoke_tool(
                         function_name,
                         next_args,

--- a/tests/monitoring/test_otel_mcp.py
+++ b/tests/monitoring/test_otel_mcp.py
@@ -1,0 +1,87 @@
+"""OTel MCP tracing: a real tool call emits an execute_tool event whose
+mcp_method_name maps to the OTel MCP attribute mcp.method.name."""
+
+from __future__ import annotations
+
+import threading
+import types
+from unittest.mock import MagicMock
+
+from agent.monitoring import emitter as emitter_mod
+from agent.monitoring.mcp_tracing import MCP_METHOD_NAME, mcp_span_attrs
+
+
+def _patch_daemon_pool(monkeypatch):
+    """Py3.14 workaround: daemon_pool mirrors pre-3.14 ThreadPoolExecutor
+    internals; substitute a daemonized stdlib pool so the real concurrent
+    tool-execution path runs unchanged."""
+    import concurrent.futures
+
+    import tools.daemon_pool as daemon_pool
+
+    class _DaemonPool(concurrent.futures.ThreadPoolExecutor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            for t in list(getattr(self, "_threads", ())):
+                t.daemon = True
+
+    monkeypatch.setattr(daemon_pool, "DaemonThreadPoolExecutor", _DaemonPool)
+
+
+def test_live_tool_call_emits_execute_tool_event_with_mcp_method_name(monkeypatch):
+    """A real concurrent tool call emits an ExecuteToolEvent with
+    mcp_method_name mapped to mcp.method.name."""
+    from run_agent import AIAgent
+
+    _patch_daemon_pool(monkeypatch)
+
+    em = emitter_mod.MonitoringEmitter()
+    emitter_mod.reset_emitter_for_tests(em)
+    received: list = []
+    em.subscribe(lambda batch: received.extend(batch))
+    try:
+        agent = MagicMock()
+        agent.session_id = "sess-e2e-0001"
+        agent._interrupt_requested = False
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+        agent._invoke_tool = MagicMock(return_value="ok")
+        agent._append_guardrail_observation = lambda name, args, result, failed: result
+        agent._tool_result_content_for_active_model = lambda name, result: result
+        agent._subdirectory_hints = MagicMock()
+        agent._subdirectory_hints.check_tool_call.return_value = []
+        agent.quiet_mode = True
+        agent._should_emit_quiet_tool_messages = lambda: False
+        agent._should_start_quiet_spinner = lambda: False
+        agent._execute_tool_calls_concurrent = types.MethodType(
+            AIAgent._execute_tool_calls_concurrent, agent
+        )
+
+        tc = MagicMock()
+        tc.id = "call_e2e_1"
+        tc.function.name = "read_file"
+        tc.function.arguments = "{}"
+        assistant_msg = MagicMock()
+        assistant_msg.tool_calls = [tc]
+
+        agent._execute_tool_calls_concurrent(assistant_msg, [], "task-e2e")
+        em.flush()
+
+        tool_events = [ev for ev in received if ev.get("event") == "execute_tool"]
+        assert tool_events, f"no execute_tool event in {received!r}"
+        ev = tool_events[0]
+        assert ev["mcp_method_name"] == "read_file"
+        assert ev["mcp_session_id"] == "sess-e2e-0001"
+        assert ev["mcp_protocol_version"] == "2025-06-18"
+        # The exporter seam: event field -> OTel MCP semconv attribute.
+        assert mcp_span_attrs(ev)[MCP_METHOD_NAME] == "read_file"
+        agent._invoke_tool.assert_called_once()
+    finally:
+        em.close()
+        emitter_mod.reset_emitter_for_tests(None)
+
+
+def test_mcp_attrs_absent_without_mcp_fields():
+    # An execute_tool event with no MCP metadata must not pick up fake attrs.
+    attrs = mcp_span_attrs({"event": "execute_tool", "name": "ls"})
+    assert attrs == {}


### PR DESCRIPTION
Automated evolution PR for issue #2634 (rework of the dead-code bounce).

- Adds `ExecuteToolEvent` (agent/monitoring/events.py): content-free, carries only mcp_method_name/mcp_session_id/mcp_protocol_version.
- `agent/monitoring/mcp_tracing.py`: maps event fields to OTel MCP semconv attrs (mcp.method.name, mcp.session.id, mcp.protocol.version).
- `agent/tool_executor.py`: `_emit_execute_tool_event` fires from the REAL tool-execution path (`execute_tool_calls_concurrent` → `_execute`, right before `agent._invoke_tool`). Fail-closed on the hot path — a monitoring fault never affects tool execution.
- `agent/monitoring/otlp_exporter.py`: execute_tool spans pick up the MCP attrs.
- Test: real concurrent tool call (AIAgent._execute_tool_calls_concurrent) emits the event through the process-wide emitter; subscriber sees mcp_method_name; mcp_span_attrs maps it to mcp.method.name.

Checks: ruff ✓ pytest tests/monitoring/test_otel_mcp.py 2/2 ✓ (193 changed lines ≤ 200 cap). Note: `ruff format --check` shows pre-existing whole-file drift on tool_executor.py/otlp_exporter.py at HEAD under local ruff — not introduced by this change.