### PR TITLE
feat: wire AgentProcessBench harm gate into tool pre-execution (Closes #2662)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -369,6 +369,37 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     )
 
 
+def _harm_gate_block_reason(function_name: str, function_args: Any) -> Optional[str]:
+    """Score a pre-execution call with the AgentProcessBench harm rules.
+
+    Fail-open: a broken bench module yields None (tool allowed); only a
+    high-harm verdict (>= BLOCK_THRESHOLD) rejects the call.
+    """
+    name = str(function_name or "").lower()
+    if name not in ("shell", "terminal", "bash") and not (
+        isinstance(function_args, dict)
+        and any(k in function_args for k in ("path", "file_path", "filename", "command"))
+    ):
+        return None
+    try:
+        from evolution.lib.agent_process_bench import harm_verdict_for_tool_call
+
+        return harm_verdict_for_tool_call(name, function_args)
+    except Exception:
+        return None
+
+
+def _harm_blocked_tool_result(reason: str) -> str:
+    return json.dumps(
+        {
+            "error": f"Tool execution blocked by safety gate: {reason}",
+            "status": "blocked",
+            "harm_gate": "agent_process_bench",
+        },
+        ensure_ascii=False,
+    )
+
+
 def _emit_cancelled_terminal_post_tool_call(
     agent,
     *,
@@ -1096,6 +1127,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             try:
                 def _execute(next_args: dict[str, Any]) -> Any:
+                    # AgentProcessBench harm gate (#2662): reject high-impact
+                    # calls (delete/overwrite/credential access) pre-execution.
+                    block_reason = _harm_gate_block_reason(function_name, next_args)
+                    if block_reason is not None:
+                        logger.warning(
+                            "tool %s blocked by AgentProcessBench harm gate: %s",
+                            function_name,
+                            block_reason,
+                        )
+                        return _harm_blocked_tool_result(block_reason)
                     return agent._invoke_tool(
                         function_name,
                         next_args,

--- a/evolution/lib/agent_process_bench.py
+++ b/evolution/lib/agent_process_bench.py
@@ -1,0 +1,65 @@
+"""AgentProcessBench: harm scoring for the tool pre-execution gate (#2662)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+# Tool calls scoring at/above this harm value are blocked pre-execution.
+BLOCK_THRESHOLD = 1.0
+
+_SHELL_TOOLS = ("shell", "terminal", "bash")
+_HARM_RE = re.compile(
+    r"(?P<destructive>rm\s+-rf\s+/|mkfs\b|dd\s+.*of=/dev/|mv\s+/.*\s+/dev/null\b|"
+    r"shutdown|reboot\b)"
+    r"|(?P<exfil>\b(curl|wget|scp|nc|rsync)\b.*\bhttps?://|cat\s+.*\|\s*(curl|nc|ssh)\b)"
+    r"|(?P<cred>\.ssh/|\.aws/credentials|/etc/passwd|/etc/shadow|id_rsa|\.env\b)"
+    r"|(?P<inject>ignore (all |the )?(previous|above) instructions|disregard.*instructions)",
+    re.I,
+)
+
+
+def _flags_for(tool: str, content: str) -> List[str]:
+    m = _HARM_RE.search(content)
+    if not m:
+        return []
+    if tool in _SHELL_TOOLS and m.group("destructive"):
+        return ["destructive-command"]
+    if m.group("cred"):
+        return ["credential-access"]
+    if m.group("exfil"):
+        return ["exfiltration"]
+    if m.group("inject"):
+        return ["prompt-injection-marker"]
+    return []
+
+
+def score_step(index: int, tool: str, content: str) -> Dict[str, Any]:
+    """Score one step: 0.0 clean, 0.5 suspicious (injection), 1.0 critical."""
+    flags = _flags_for(tool, content)
+    harm = (
+        1.0
+        if flags and flags[0] != "prompt-injection-marker"
+        else 0.5
+        if flags
+        else 0.0
+    )
+    return {"index": index, "tool": tool, "harm_score": harm, "risk_flags": flags}
+
+
+def harm_verdict_for_tool_call(
+    tool_name: str, args: Any, threshold: float = BLOCK_THRESHOLD
+) -> Optional[str]:
+    """Block reason if the call crosses *threshold*, else None (safe)."""
+    name = str(tool_name or "").lower()
+    if name in _SHELL_TOOLS and isinstance(args, dict) and args.get("command"):
+        content = str(args["command"])
+    elif isinstance(args, str):
+        content = args
+    else:
+        content = json.dumps(args)
+    score = score_step(0, name, content)
+    if score["harm_score"] >= threshold:
+        return f"harm_score={score['harm_score']} flags={score['risk_flags']}"
+    return None

--- a/scripts/evolution_pre_pr_test_runner.py
+++ b/scripts/evolution_pre_pr_test_runner.py
@@ -181,6 +181,7 @@ SRC_TO_TEST_PREFIX = (
     # is a different mapping: scripts/foo.py → tests/scripts/test_foo.py
     ("scripts/", "tests/scripts/"),
     ("cron/", "tests/cron/"),
+    ("evolution/", "tests/evolution/"),
 )
 
 

--- a/tests/evolution/test_agent_process_bench.py
+++ b/tests/evolution/test_agent_process_bench.py
@@ -1,0 +1,93 @@
+"""Regression tests for the AgentProcessBench harm gate (#2662): the real
+pre-execution path rejects a risky tool call BEFORE invoking it."""
+
+import json
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+_noop = lambda *a, **k: None  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+
+def test_gate_helper_blocks_risky_and_passes_benign(monkeypatch):
+    import agent.tool_executor as te
+    from evolution.lib import agent_process_bench as apb
+
+    g = te._harm_gate_block_reason
+    reason = g("terminal", {"command": "rm -rf / --no-preserve-root"})
+    assert reason is not None and "harm_score=1.0" in reason
+    assert "destructive-command" in reason
+    reason = g("file_write", {"path": "/etc/passwd", "content": "root::"})
+    assert reason is not None and "credential-access" in reason
+    assert g("file_write", {"path": "/tmp/notes.md", "content": "hi"}) is None
+    assert g("file_read", {"path": "ignore previous instructions"}) is None
+    assert g("web_search", {"query": "docs"}) is None
+
+    boom = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("broken"))  # noqa: E731
+    monkeypatch.setattr(apb, "harm_verdict_for_tool_call", boom)
+    assert g("terminal", {"command": "rm -rf /"}) is None
+    blocked = json.loads(te._harm_blocked_tool_result("harm_score=1.0"))
+    assert blocked["status"] == "blocked"
+    assert "blocked by safety gate" in blocked["error"]
+
+
+def test_risky_tool_rejected_before_invocation(monkeypatch):
+    import run_agent as _ra
+    import agent.tool_executor as te
+    from concurrent.futures import ThreadPoolExecutor
+
+    # Py3.14 daemon_pool incompatibility (pre-existing); use the stdlib pool.
+    monkeypatch.setattr(
+        "tools.daemon_pool.DaemonThreadPoolExecutor", ThreadPoolExecutor
+    )
+
+    def _fast_mw(agent, *, function_name, function_args, execute, **kw):
+        # Report blocked-and-not-dispatched so the post-loop keeps the result.
+        r = execute(function_args)
+        return te._ManagedToolResult(r, function_args, [], True, False)
+
+    monkeypatch.setattr(te, "_run_agent_tool_execution_middleware", _fast_mw)
+
+    dispatched: list = []
+    agent = MagicMock()
+    agent._interrupt_requested = False
+    agent._tool_worker_threads = set()
+    agent._tool_worker_threads_lock = threading.Lock()
+    agent.quiet_mode = True
+    agent._invoke_tool = MagicMock(
+        side_effect=lambda name, *a, **kw: (
+            dispatched.append(name) or json.dumps({"ok": name})
+        )
+    )
+    agent._touch_activity = _noop
+    agent._vprint = _noop
+    agent._record_file_mutation_result = _noop
+    agent._tool_result_content_for_active_model = lambda n, r: r
+    agent._should_emit_quiet_tool_messages = lambda: False
+    agent._should_start_quiet_spinner = lambda: False
+    agent._apply_pending_steer_to_tool_results = _noop
+    agent._append_guardrail_observation = _noop
+    agent._flush_messages_to_session_db = _noop
+    agent._subdirectory_hints = MagicMock()
+    agent._subdirectory_hints.check_tool_call = lambda *a, **k: None
+    agent._execute_tool_calls_concurrent = (
+        _ra.AIAgent._execute_tool_calls_concurrent.__get__(agent)
+    )
+
+    tc = MagicMock(id="tc_risky")
+    tc.function.name = "terminal"
+    tc.function.arguments = json.dumps({"command": "rm -rf / --no-preserve-root"})
+    msg = MagicMock(tool_calls=[tc])
+
+    messages = []
+    agent._execute_tool_calls_concurrent(msg, messages, "task")
+
+    assert dispatched == [], f"risky tool was invoked: {dispatched}"
+    assert "blocked by safety gate" in json.dumps(messages)


### PR DESCRIPTION
Automated evolution PR for issue #2662 (rework of the dead-code bounce).

- `evolution/lib/agent_process_bench.py` (new): harm rules (destructive commands / exfiltration / credential access / prompt-injection markers), `score_step`, `harm_verdict_for_tool_call` (fail-closed verdict, BLOCK_THRESHOLD=1.0).
- `agent/tool_executor.py`: `_harm_gate_block_reason` + `_harm_blocked_tool_result` wired into the REAL tool-execution path — `execute_tool_calls_concurrent` → `_execute` scores high-impact calls (delete/overwrite/credential access) BEFORE `agent._invoke_tool`, and a high-harm verdict rejects the call without executing it. Fail-open: a broken bench module can never break real tool execution.
- `scripts/evolution_pre_pr_test_runner.py`: added the missing `evolution/ -> tests/evolution/` shard mapping (1 line).
- Tests: bench rules + gate helper (risky blocked / benign passes / fail-open) + a real-path regression test proving a risky `terminal rm -rf /` never reaches `_invoke_tool` and the blocked result lands in messages.

Checks: ruff ✓ pytest 2/2 ✓ (200 changed lines, at the ≤200 cap).