### PR TITLE
feat: reject tampered metrics.jsonl records in the live funnel loader (Closes #2673)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -29,6 +29,13 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+try:
+    from evolution.lib.telemetry_guard import validate_metrics_record
+
+    _HAS_TELEMETRY_GUARD = True
+except ImportError:  # pragma: no cover - standalone copy without the guard
+    _HAS_TELEMETRY_GUARD = False
+
 
 def _load_json(path: Path) -> Any | None:
     try:
@@ -200,7 +207,9 @@ def append_funnel(metrics_file: Path, record: Dict[str, Any]) -> None:
 
 def load_records(metrics_file: Path) -> list[Dict[str, Any]]:
     """Read all funnel records (one JSON object per line), oldest-first,
-    skipping blank/malformed lines."""
+    skipping blank/malformed lines. Tampered records (#2673) that fail the
+    telemetry integrity check are REJECTED, never silently consumed — they
+    must not steer selection."""
     out: list[Dict[str, Any]] = []
     if not metrics_file.exists():
         return out
@@ -212,8 +221,12 @@ def load_records(metrics_file: Path) -> list[Dict[str, Any]]:
             obj = json.loads(ln)
         except ValueError:
             continue
-        if isinstance(obj, dict):
-            out.append(obj)
+        if not isinstance(obj, dict):
+            continue
+        if _HAS_TELEMETRY_GUARD and not validate_metrics_record(obj).safe:
+            logger.warning("funnel rejecting tampered metrics record: %s", obj.get("date"))
+            continue
+        out.append(obj)
     return out
 
 

--- a/tests/scripts/test_evolution_funnel.py
+++ b/tests/scripts/test_evolution_funnel.py
@@ -243,6 +243,20 @@ class TestSummary:
     def test_load_records_missing_file(self, tmp_path):
         assert load_records(tmp_path / "nope.jsonl") == []
 
+    def test_load_records_rejects_tampered_records(self, tmp_path):
+        """#2673: a tampered metrics.jsonl line (e.g. negative count) is
+        rejected by the live loader, not silently consumed."""
+        f = tmp_path / "metrics.jsonl"
+        good = {"date": "2026-08-16", "issues_created": 2, "selected": 1,
+                "rejected": 1, "merged": 1, "skipped": 0}
+        tampered = dict(good, date="2026-08-17", selected=-1)
+        f.write_text(
+            json.dumps(good) + "\n" + json.dumps(tampered) + "\n",
+            encoding="utf-8",
+        )
+        recs = load_records(f)
+        assert [r["date"] for r in recs] == ["2026-08-16"]
+
     def test_reject_rate_and_window(self):
         recs = [self._rec(f"d{i}", selected=1, rejected=9, merged=1) for i in range(10)]
         s = summarize(recs, last=7)
@@ -283,9 +297,11 @@ class TestSummarySidecar:
         (tmp_path / "metrics.jsonl").write_text(
             json.dumps({
                 "date": "2026-06-10",
+                "issues_created": 2,
                 "selected": 1,
                 "rejected": 9,
                 "merged": 0,
+                "skipped": 0,
             })
             + "\n",
             encoding="utf-8",


### PR DESCRIPTION
Automated evolution PR for issue #2673.

- `scripts/evolution_funnel.py` `load_records()` now validates every parsed record with `validate_metrics_record` (the dormant half of the merged #2637 telemetry-integrity work): tampered records (negative counts, missing required keys, NaN/Inf) are REJECTED — logged and excluded — so they can never silently steer selection. Guarded import keeps standalone-copy mode working.
- Regression test: a tampered line (selected=-1) is dropped by the live loader while the valid record passes.
- Updated one sidecar-test fixture to the production record shape (all 6 required keys — what `append_funnel` actually writes).

Checks: ruff ✓ pytest tests/scripts/test_evolution_funnel.py 32/32 ✓ (35 changed lines ≤ 200 cap).