### PR TITLE
feat: gated apply-path entry point for harness code-diff proposals (Closes #2615)

### DIFF
--- a/scripts/evolution_harness_gate.py
+++ b/scripts/evolution_harness_gate.py
@@ -1,0 +1,121 @@
+"""Gated apply-path entry point for harness code-diff proposals (#2615, #2525).
+
+Slice C: wire the validated code-diff apply-path (Slice A + B) into the
+evolution loop behind a MANUAL/CRON trigger — never a silent self-modifying
+loop. Reads a Slice-A proposal (code_diff JSON), routes it through the
+sandboxed apply + regression gate (Slice B), prints a machine-readable verdict,
+and ONLY with an explicit ``--apply`` flag AND a green gate writes the
+validated surface to the target file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from evolution_harness_sandbox import (
+    INVALID,
+    REJECTED,
+    VALIDATED,
+    default_gate_runner,
+    validate_code_diff,
+)
+
+EXIT_VALIDATED = 0
+EXIT_REJECTED = 1
+EXIT_INVALID = 2
+EXIT_APPLY_REFUSED = 3
+
+GateRunner = Callable[[Dict[str, Any]], Any]
+
+
+def run_gate(
+    proposal: Dict[str, Any],
+    *,
+    repo_root: Optional[Path] = None,
+    timeout: int = 300,
+    gate_runner: Optional[GateRunner] = None,
+) -> Dict[str, Any]:
+    """Sandboxed apply + regression gate for a proposal; never auto-applies."""
+    if gate_runner is None:
+
+        def _runner(applied: Dict[str, Any]) -> Any:
+            return default_gate_runner(applied, repo_root=repo_root, timeout=timeout)
+
+        gate_runner = _runner
+    return validate_code_diff(proposal, gate_runner=gate_runner)
+
+
+def apply_validated(verdict: Dict[str, Any], out_path: Path) -> bool:
+    """Write the validated surface to *out_path* — ONLY when the gate is green.
+
+    Returns True when written; refuses rejected/invalid proposals outright.
+    """
+    if verdict.get("status") != VALIDATED or not verdict.get("applied"):
+        return False
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(verdict["applied"]["after"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Gated apply-path for harness code-diff proposals (#2615)"
+    )
+    parser.add_argument("proposal", help="path to a Slice-A proposal JSON (code_diff)")
+    parser.add_argument(
+        "--out", help="target path for the validated surface (required with --apply)"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="write the surface ONLY when the regression gate is green",
+    )
+    parser.add_argument("--repo-root", type=Path, default=None)
+    parser.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.proposal, encoding="utf-8") as fh:
+            proposal = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "status": INVALID,
+                    "reason": f"cannot read proposal: {exc}",
+                    "requires_human_review": True,
+                    "auto_apply": False,
+                }
+            )
+        )
+        return EXIT_INVALID
+
+    verdict = run_gate(proposal, repo_root=args.repo_root, timeout=args.timeout)
+    print(json.dumps(verdict, sort_keys=True))
+
+    if verdict.get("status") != VALIDATED:
+        return EXIT_INVALID if verdict.get("status") == INVALID else EXIT_REJECTED
+
+    if not args.apply:
+        return EXIT_VALIDATED  # dry-run: verdict only, nothing written
+
+    if not args.out:
+        print(json.dumps({"status": "refused", "reason": "--apply requires --out"}))
+        return EXIT_APPLY_REFUSED
+
+    if apply_validated(verdict, Path(args.out)):
+        print(json.dumps({"status": "applied", "out": str(Path(args.out))}))
+        return EXIT_VALIDATED
+    print(json.dumps({"status": "refused", "reason": "gate not green; nothing applied"}))
+    return EXIT_APPLY_REFUSED
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/scripts/test_evolution_harness_gate.py
+++ b/tests/scripts/test_evolution_harness_gate.py
@@ -1,0 +1,75 @@
+"""Tests for the Slice-C gated apply-path (scripts/evolution_harness_gate.py)."""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import evolution_harness_gate as gate  # noqa: E402
+from evolution_harness_sandbox import INVALID, REJECTED, VALIDATED  # noqa: E402
+
+PROPOSAL = {
+    "surface": {"retry_count": 3, "backoff": {"base": 1.0}, "guard_conditions": []},
+    "changes": [{"field": "retry_count", "before": 3, "after": 4}],
+}
+
+_GREEN = SimpleNamespace(passed=True, exit_code=0, output="regression ok")
+_RED = SimpleNamespace(passed=False, exit_code=1, output="regression failed")
+
+
+def test_run_gate_validated_applies_in_sandbox():
+    verdict = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _GREEN)
+    assert verdict["status"] == VALIDATED
+    assert verdict["applied"]["after"]["retry_count"] == 4
+    assert verdict["requires_human_review"] is True
+    assert verdict["auto_apply"] is False
+
+
+def test_run_gate_rejected_on_red_gate():
+    verdict = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _RED)
+    assert verdict["status"] == REJECTED
+    assert verdict["gate"]["passed"] is False
+
+
+def test_run_gate_invalid_malformed():
+    verdict = gate.run_gate({"surface": {}}, gate_runner=lambda applied: _GREEN)
+    assert verdict["status"] == INVALID
+
+
+def test_apply_validated_writes_only_when_green(tmp_path):
+    out = tmp_path / "surface.json"
+    green = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _GREEN)
+    assert gate.apply_validated(green, out) is True
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["retry_count"] == 4
+
+    red = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _RED)
+    out2 = tmp_path / "surface-red.json"
+    assert gate.apply_validated(red, out2) is False
+    assert not out2.exists()
+
+
+def test_main_apply_writes_on_green(tmp_path, monkeypatch, capsys):
+    proposal_file = tmp_path / "proposal.json"
+    proposal_file.write_text(json.dumps(PROPOSAL), encoding="utf-8")
+    out = tmp_path / "surface.json"
+    verdict = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _GREEN)
+    monkeypatch.setattr(gate, "run_gate", lambda *a, **k: verdict)
+
+    rc = gate.main([str(proposal_file), "--apply", "--out", str(out)])
+    assert rc == gate.EXIT_VALIDATED
+    assert out.exists()
+    assert '"status": "applied"' in capsys.readouterr().out
+
+
+def test_main_refuses_apply_without_out(tmp_path, monkeypatch):
+    proposal_file = tmp_path / "proposal.json"
+    proposal_file.write_text(json.dumps(PROPOSAL), encoding="utf-8")
+    verdict = gate.run_gate(PROPOSAL, gate_runner=lambda applied: _GREEN)
+    monkeypatch.setattr(gate, "run_gate", lambda *a, **k: verdict)
+
+    rc = gate.main([str(proposal_file), "--apply"])
+    assert rc == gate.EXIT_APPLY_REFUSED


### PR DESCRIPTION
Automated evolution PR for issue #2615 (Harness-R1 Slice C).

- `scripts/evolution_harness_gate.py` (new): the gated entry point that wires the validated code-diff apply-path (Slice A generator + Slice B sandbox/regression gate) into the evolution loop behind a MANUAL/CRON trigger — never a silent self-modifying loop.
  - Reads a Slice-A proposal (code_diff JSON), routes it through `validate_code_diff` (sandboxed apply + regression gate).
  - Prints a machine-readable verdict; dry-run by default.
  - `--apply` writes the validated surface to `--out` ONLY when the gate is green; rejected/invalid proposals are never written.
- `tests/scripts/test_evolution_harness_gate.py` (new, 6 tests): sandbox-apply verdict, red-gate rejection, malformed-proposal invalid, write-only-on-green, CLI apply on green, CLI refuses --apply without --out.

Checks: ruff ✓ pytest 12/12 ✓ (harness gate + sandbox shard) (196 changed lines ≤ 200 cap).