### PR TITLE
feat: QCR target-bound note schema — increment 1 of #2694

### DIFF
--- a/scripts/evolution_qcr.py
+++ b/scripts/evolution_qcr.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Query-conditioned trajectory reuse (QCR) — target-bound note schema (#2694).
+
+arXiv:2608.12847 isolates the post-retrieval reuse step as the bottleneck for
+long-horizon trajectory memory. Instead of injecting a raw trace, QCR delivers
+a deliberately simple **target-bound note** with four fields:
+
+1. ``workflow_invariant`` — what must stay true for the approach to apply,
+2. ``bindings_to_obtain`` — values that must be re-resolved against the target,
+3. ``applicability_conditions`` — when the memory applies / when it does not,
+4. ``verification_guardrail`` — what must be checked before trusting the outcome.
+
+This module adds the note schema and a deterministic builder that derives a
+note from a successful trajectory (the ``TrajectoryStore`` projection in
+``evolution_trajectory_store``). Pure functions, import-safe, deterministic,
+no LLM, no network. First coherent slice of #2694: schema + builder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List
+
+#: The four QCR note fields, in canonical order.
+QCR_FIELDS: tuple = (
+    "workflow_invariant",
+    "bindings_to_obtain",
+    "applicability_conditions",
+    "verification_guardrail",
+)
+
+#: Tools that read/search external state whose targets must be re-resolved
+#: against a new target (bindings).
+_BINDING_TOOLS = frozenset({
+    "read_file",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "browser_navigate",
+})
+
+#: Tools that mutate/execute and therefore require a verification step.
+_VERIFY_TOOLS = frozenset({
+    "terminal",
+    "execute_code",
+    "patch",
+    "write_file",
+    "browser_navigate",
+})
+
+#: Tools that imply the workflow is environment-specific.
+_ENV_TOOLS = frozenset({"terminal", "browser_navigate", "docker", "ssh"})
+
+
+@dataclass
+class QcrNote:
+    """A target-bound note distilled from a successful trajectory."""
+
+    workflow_invariant: str = ""
+    bindings_to_obtain: List[str] = field(default_factory=list)
+    applicability_conditions: List[str] = field(default_factory=list)
+    verification_guardrail: str = ""
+    source_task_type: str = ""
+    source_tools: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "QcrNote":
+        return cls(
+            workflow_invariant=str(d.get("workflow_invariant", "")),
+            bindings_to_obtain=list(d.get("bindings_to_obtain", []) or []),
+            applicability_conditions=list(d.get("applicability_conditions", []) or []),
+            verification_guardrail=str(d.get("verification_guardrail", "")),
+            source_task_type=str(d.get("source_task_type", "")),
+            source_tools=list(d.get("source_tools", []) or []),
+        )
+
+
+def _tool_names(record: Dict[str, Any]) -> List[str]:
+    tools = record.get("tools") or []
+    if isinstance(tools, (list, tuple, set, frozenset)):
+        return [str(t) for t in tools]
+    return []
+
+
+def build_qcr_note(
+    record: Dict[str, Any],
+    task_type: str = "",
+) -> QcrNote:
+    """Derive a target-bound note from a successful trajectory record.
+
+    ``record`` is a ``TrajectoryStore`` projection (``{"tools": [...], ...}``).
+    Deterministic: the same record always yields the same note. The four
+    fields are derived from the tool set: the task type becomes the workflow
+    invariant; read/search tools become bindings to re-resolve; env-dependent
+    tools make applicability conditional; mutating/executing tools require a
+    verification guardrail.
+    """
+    tools = _tool_names(record)
+    tool_set = {t.lower() for t in tools}
+
+    invariant = (
+        f"Workflow is known to succeed for {task_type or 'general'} tasks; "
+        "reuse only when the new target is of the same task type."
+    )
+
+    bindings = sorted(t for t in tools if t.lower() in _BINDING_TOOLS)
+    if not bindings:
+        bindings = ["re-resolve any file/URL/entity targets against the current task"]
+
+    conditions: List[str] = []
+    if tool_set & _ENV_TOOLS:
+        conditions.append(
+            "Requires the same environment (terminal/browser) as the source run."
+        )
+    if not conditions:
+        conditions.append("Applies to any environment with the standard toolset.")
+
+    guardrail = (
+        "Before trusting the outcome, verify the final artifact exists and "
+        "matches the task's success criteria."
+    )
+    if tool_set & _VERIFY_TOOLS:
+        guardrail += (
+            " Re-run the verification step (tests/exit code) since the workflow "
+            "mutates or executes."
+        )
+
+    return QcrNote(
+        workflow_invariant=invariant,
+        bindings_to_obtain=bindings,
+        applicability_conditions=conditions,
+        verification_guardrail=guardrail,
+        source_task_type=task_type,
+        source_tools=tools,
+    )

--- a/tests/scripts/test_evolution_qcr.py
+++ b/tests/scripts/test_evolution_qcr.py
@@ -1,0 +1,62 @@
+"""Tests for the QCR target-bound note schema (#2694)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_qcr import (  # noqa: E402
+    QCR_FIELDS,
+    QcrNote,
+    build_qcr_note,
+)
+
+
+def test_qcr_fields_are_the_four_canonical_fields() -> None:
+    assert QCR_FIELDS == (
+        "workflow_invariant",
+        "bindings_to_obtain",
+        "applicability_conditions",
+        "verification_guardrail",
+    )
+
+
+def test_build_note_from_coding_record() -> None:
+    record = {"tools": ["read_file", "patch", "terminal", "write_file"]}
+    note = build_qcr_note(record, task_type="coding")
+    assert note.source_task_type == "coding"
+    assert "coding" in note.workflow_invariant
+    # read_file is a binding tool -> re-resolve targets.
+    assert any("read_file" in b for b in note.bindings_to_obtain)
+    # terminal is an env tool -> applicability is conditional.
+    assert any("environment" in c for c in note.applicability_conditions)
+    # patch/terminal/write_file are verify tools -> guardrail mentions re-run.
+    assert "Re-run the verification step" in note.verification_guardrail
+
+
+def test_build_note_from_research_record() -> None:
+    record = {"tools": ["web_search", "web_extract"]}
+    note = build_qcr_note(record, task_type="research")
+    assert note.source_task_type == "research"
+    assert any("web_search" in b for b in note.bindings_to_obtain)
+    # No env/mutating tools -> guardrail is the generic one.
+    assert "Re-run the verification step" not in note.verification_guardrail
+
+
+def test_build_note_empty_record() -> None:
+    note = build_qcr_note({}, task_type="")
+    assert note.source_task_type == ""
+    assert note.workflow_invariant
+    assert note.bindings_to_obtain  # falls back to a generic re-resolve binding
+    assert note.applicability_conditions
+
+
+def test_note_roundtrip_dict() -> None:
+    note = build_qcr_note({"tools": ["read_file", "terminal"]}, task_type="ops")
+    d = note.to_dict()
+    assert set(QCR_FIELDS) <= set(d)
+    assert QcrNote.from_dict(d).to_dict() == d


### PR DESCRIPTION
First coherent slice of #2694 (arXiv:2608.12847 — Query-Conditioned Reuse of Long-Horizon Agent Trajectories).

## What
Adds the 4-field target-bound note schema (`workflow_invariant`, `bindings_to_obtain`, `applicability_conditions`, `verification_guardrail`) and a deterministic builder that derives a note from a successful trajectory record (the `TrajectoryStore` projection in `evolution_trajectory_store`). Pure functions, import-safe, deterministic, no LLM, no network.

## Validation
- `tests/scripts/test_evolution_qcr.py`: 5 passed
- `ruff check` + `ruff format --check`: green
- Diff size: 200 lines ≤ 200 auto-merge cap

## Deferred (next increment)
- Persist captured trajectories *as* target-bound notes (instead of alongside raw traces)
- Add the summary-reranking selector that picks the reusable memory for a new target
- Wire the guardrail check into the replay path (verify applicability + re-resolve bindings before reuse)