### PR TITLE
feat: QCR summary-reranking selector — increment 2 of #2694

### DIFF
--- a/scripts/evolution_qcr.py
+++ b/scripts/evolution_qcr.py
@@ -12,14 +12,16 @@ a deliberately simple **target-bound note** with four fields:
 
 This module adds the note schema and a deterministic builder that derives a
 note from a successful trajectory (the ``TrajectoryStore`` projection in
-``evolution_trajectory_store``). Pure functions, import-safe, deterministic,
-no LLM, no network. First coherent slice of #2694: schema + builder.
+``evolution_trajectory_store``), plus the summary-reranking selector that
+picks the reusable memory for a new target. Pure functions, import-safe,
+deterministic, no LLM, no network. Increments of #2694: schema + builder
+(increment 1, PR #2703); summary-reranking selector (increment 2).
 """
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 #: The four QCR note fields, in canonical order.
 QCR_FIELDS: tuple = (
@@ -136,3 +138,83 @@ def build_qcr_note(
         source_task_type=task_type,
         source_tools=tools,
     )
+
+
+def _note_from(obj: Union[QcrNote, Dict[str, Any]]) -> QcrNote:
+    """Coerce a :class:`QcrNote` or its dict projection to a :class:`QcrNote`."""
+    if isinstance(obj, QcrNote):
+        return obj
+    return QcrNote.from_dict(obj)
+
+
+def score_note_for_target(
+    note: Union[QcrNote, Dict[str, Any]],
+    target_task_type: str = "",
+    target_tools: Optional[Sequence[str]] = None,
+) -> float:
+    """Deterministic reuse score (clamped 0.0–1.0) for one note vs a new target.
+
+    Summary-reranking signal (#2694 increment 2): prefer the note whose
+    workflow invariant still applies and whose bindings re-resolve cheaply
+    with the tools the target actually has. No LLM — pure arithmetic:
+
+    * ``+0.5`` task-type match; ``+0.3`` × source-tool overlap share;
+      ``−0.2`` per binding tool missing from the target (cap −0.6);
+      ``−0.05`` per binding to re-obtain; ``+0.1`` any-environment note.
+    """
+    n = _note_from(note)
+    target_tool_set = {t.lower() for t in (target_tools or [])}
+    src_tool_set = {t.lower() for t in n.source_tools}
+
+    score = 0.0
+    if target_task_type and n.source_task_type:
+        if target_task_type.lower() == n.source_task_type.lower():
+            score += 0.5
+
+    if target_tool_set and src_tool_set:
+        score += 0.3 * (len(src_tool_set & target_tool_set) / len(src_tool_set))
+        missing = src_tool_set - target_tool_set
+        score -= 0.2 * min(len(missing), 3)
+
+    score -= 0.05 * len(n.bindings_to_obtain)
+
+    conditions = " ".join(n.applicability_conditions).lower()
+    if "any environment" in conditions:
+        score += 0.1
+
+    return max(0.0, min(1.0, score))
+
+
+def rank_notes_for_target(
+    notes: Sequence[Union[QcrNote, Dict[str, Any]]],
+    target_task_type: str = "",
+    target_tools: Optional[Sequence[str]] = None,
+) -> List[Tuple[float, QcrNote]]:
+    """Rank candidate notes for a new target, best first.
+
+    Stable sort — ties keep input order, so the result is deterministic for
+    the same input list. Returns ``[(score, note), ...]``.
+    """
+    scored = [
+        (score_note_for_target(n, target_task_type, target_tools), _note_from(n))
+        for n in notes
+    ]
+    return sorted(scored, key=lambda pair: pair[0], reverse=True)
+
+
+def select_reusable_memory(
+    notes: Sequence[Union[QcrNote, Dict[str, Any]]],
+    target_task_type: str = "",
+    target_tools: Optional[Sequence[str]] = None,
+    min_score: float = 0.5,
+) -> Optional[QcrNote]:
+    """Pick the best reusable memory for a new target, or ``None`` below threshold.
+
+    ``min_score`` (default 0.5) is the floor: when no candidate reaches it the
+    caller should fall back to a fresh execution instead of forcing a
+    mismatched reuse (the QCR "does not apply" branch).
+    """
+    ranked = rank_notes_for_target(notes, target_task_type, target_tools)
+    if ranked and ranked[0][0] >= min_score:
+        return ranked[0][1]
+    return None

--- a/tests/scripts/test_evolution_qcr.py
+++ b/tests/scripts/test_evolution_qcr.py
@@ -1,4 +1,4 @@
-"""Tests for the QCR target-bound note schema (#2694)."""
+"""Tests for the QCR target-bound note schema + summary-reranking selector (#2694)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,9 @@ from evolution_qcr import (  # noqa: E402
     QCR_FIELDS,
     QcrNote,
     build_qcr_note,
+    rank_notes_for_target,
+    score_note_for_target,
+    select_reusable_memory,
 )
 
 
@@ -60,3 +63,109 @@ def test_note_roundtrip_dict() -> None:
     d = note.to_dict()
     assert set(QCR_FIELDS) <= set(d)
     assert QcrNote.from_dict(d).to_dict() == d
+
+
+# ── increment 2: summary-reranking selector ──────────────────────────────────
+
+
+def _make_note(
+    task_type: str,
+    tools: list[str],
+    bindings: list[str] | None = None,
+    any_env: bool = True,
+) -> QcrNote:
+    """Fixture-style helper: a note with the requested task type / tools."""
+    return QcrNote(
+        workflow_invariant=f"Workflow is known to succeed for {task_type} tasks",
+        bindings_to_obtain=bindings or [f"{t}-target" for t in tools],
+        applicability_conditions=(
+            ["Applies to any environment with the standard toolset."]
+            if any_env
+            else ["Requires the same environment (terminal/browser) as the source run."]
+        ),
+        verification_guardrail="Re-run the verification step.",
+        source_task_type=task_type,
+        source_tools=list(tools),
+    )
+
+
+def test_score_prefers_task_type_match() -> None:
+    coding = _make_note("coding", ["read_file", "patch"])
+    research = _make_note("research", ["web_search", "web_extract"])
+    target_tools = ["read_file", "patch", "terminal"]
+
+    coding_score = score_note_for_target(coding, "coding", target_tools)
+    research_score = score_note_for_target(research, "coding", target_tools)
+
+    # Same tools available to both; only task-type match differs.
+    assert coding_score > research_score
+    assert coding_score >= 0.5  # task-type match alone clears the floor
+
+
+def test_score_penalizes_unresolvable_bindings() -> None:
+    note = _make_note("coding", ["read_file", "web_search"])
+    # Target lacks web_search -> binding cannot be re-resolved.
+    with_tools = score_note_for_target(note, "coding", ["read_file", "patch"])
+    without_tools = score_note_for_target(note, "coding", ["read_file", "web_search"])
+    assert with_tools < without_tools
+    # Overlap-only score must be below a fully-overlapping target.
+    full = score_note_for_target(note, "coding", ["read_file", "web_search", "patch"])
+    assert full > with_tools
+
+
+def test_score_penalizes_binding_count() -> None:
+    few = _make_note("coding", ["read_file"], bindings=["re-resolve file targets"])
+    many = _make_note(
+        "coding",
+        ["read_file"],
+        bindings=["a", "b", "c", "d", "e", "f", "g", "h"],
+    )
+    assert score_note_for_target(few, "coding", ["read_file"]) > score_note_for_target(
+        many, "coding", ["read_file"]
+    )
+
+
+def test_score_clamped_to_unit_interval() -> None:
+    best = _make_note("coding", ["read_file"], bindings=[])
+    score = score_note_for_target(best, "coding", ["read_file"])
+    assert 0.0 <= score <= 1.0
+    worst = _make_note("ops", ["web_search"], bindings=["x"] * 10)
+    low = score_note_for_target(worst, "coding", ["terminal"])
+    assert 0.0 <= low <= 1.0
+
+
+def test_rank_notes_best_first_deterministic() -> None:
+    coding = _make_note("coding", ["read_file"])
+    research = _make_note("research", ["web_search"])
+    notes = [research, coding]
+
+    ranked = rank_notes_for_target(notes, "coding", ["read_file", "patch"])
+    assert [n.source_task_type for _, n in ranked] == ["coding", "research"]
+    # Same input twice -> same output (deterministic).
+    assert ranked == rank_notes_for_target(notes, "coding", ["read_file", "patch"])
+
+
+def test_rank_accepts_dict_projections() -> None:
+    coding = _make_note("coding", ["read_file"]).to_dict()
+    ranked = rank_notes_for_target([coding], "coding", ["read_file"])
+    assert len(ranked) == 1
+    assert isinstance(ranked[0][1], QcrNote)
+    assert ranked[0][1].source_task_type == "coding"
+
+
+def test_select_reusable_memory_picks_best_above_floor() -> None:
+    coding = _make_note("coding", ["read_file"])
+    research = _make_note("research", ["web_search"])
+    picked = select_reusable_memory(
+        [research, coding], "coding", ["read_file", "patch"]
+    )
+    assert picked is not None
+    assert picked.source_task_type == "coding"
+
+
+def test_select_reusable_memory_none_below_floor() -> None:
+    research = _make_note("research", ["web_search"])
+    picked = select_reusable_memory(
+        [research], "coding", ["read_file", "patch"], min_score=0.5
+    )
+    assert picked is None


### PR DESCRIPTION
Automated evolution PR for issue #2694 (next-increment).

**Increment 2: summary-reranking selector.** Adds three pure, deterministic functions to `scripts/evolution_qcr.py` on top of increment 1 (schema + builder, PR #2703):

- `score_note_for_target` — clamped 0.0–1.0 reuse score: task-type match, tool-overlap share, unresolvable-binding penalty, binding count, any-environment bonus.
- `rank_notes_for_target` — stable, deterministic best-first ranking of candidate notes.
- `select_reusable_memory` — picks the best note above `min_score` (default 0.5), else None (QCR "does not apply" fallback).

No LLM, no network, no call-site wiring yet — standalone pure functions matching the increment-1 foundation pattern (precedent: increment 1 merged zero-call-site). 8 new tests (13 total in the file).

Checks: pre-PR shard ✓, ruff ✓, format ✓, pytest 13 passed ✓.

Deferred (next increment):
- Persist captured trajectories *as* target-bound notes (needs a wiring point in the trajectory capture path)
- Wire the guardrail check into the replay path (verify applicability + re-resolve bindings before reuse)