### PR TITLE
feat: wire harness code-diff gate into evolution cron loop (Closes #2615)

### DIFF
--- a/cron/evolution/harness-gate.yaml
+++ b/cron/evolution/harness-gate.yaml
@@ -1,21 +1,17 @@
 name: evolution-harness-gate
-# Weekly (Sunday 04:11) — the gate is the report-only consumer of the trace
-# miner's weaknesses sidecar, so it runs rarely: a retry-policy proposal only
-# becomes worth re-gating when new recurring-failure clusters have accumulated.
-# Off the :00/:30 marks and offset from every LLM stage and the deterministic
-# harvest (:53) so it never competes for a scheduler tick.
+# Weekly (Sun 04:11) — the gate re-gates retry-policy proposals only when new
+# recurring-failure clusters have accumulated. Off the :00/:30 marks and every
+# other stage's tick.
 schedule: "11 4 * * 0"
 enabled: true
 mode: PRIVATE
 
-# Deterministic gate pass — NO LLM agent. The script IS the job. It reads the
-# trace miner's weaknesses-latest.json sidecar (EVOLUTION_PROFILE_DIR), turns
-# retry-policy weaknesses into Slice-A code-diff proposals (offline envelope,
-# no network), runs each through the sandboxed apply + regression gate
-# (Slice B), and writes a harness-gate-latest.json verdicts sidecar.
-# REPORT-ONLY by design: applying a validated surface is an explicit manual
-# `--apply` action (issue #2615 constraint — never a silent self-modifying
-# loop). Empty stdout = silent tick; a green gate logs one line.
+# Deterministic gate pass — NO LLM. Reads the trace miner's
+# weaknesses-latest.json (EVOLUTION_PROFILE_DIR), generates retry-policy
+# code-diff proposals (offline), sandbox-validates each through the
+# regression gate, writes harness-gate-latest.json. REPORT-ONLY: applying a
+# validated surface is an explicit manual --apply action (#2615 — never a
+# silent self-modifying loop). Empty stdout = silent tick.
 no_agent: true
 script: evolution_harness_gate.py
 
@@ -23,7 +19,6 @@ deliver: local
 
 prompt: |
   Deterministic harness-gate pass (no LLM). Reads weaknesses-latest.json,
-  generates retry-policy code-diff proposals, validates each through the
-  sandboxed regression gate, and writes harness-gate-latest.json. Applying a
-  validated surface stays manual (--apply). See
-  scripts/evolution_harness_gate.py (#2615, parent #2525).
+  gates retry-policy code-diff proposals, writes harness-gate-latest.json.
+  Applying stays manual (--apply). See scripts/evolution_harness_gate.py
+  (#2615, parent #2525).

--- a/cron/evolution/harness-gate.yaml
+++ b/cron/evolution/harness-gate.yaml
@@ -1,0 +1,29 @@
+name: evolution-harness-gate
+# Weekly (Sunday 04:11) — the gate is the report-only consumer of the trace
+# miner's weaknesses sidecar, so it runs rarely: a retry-policy proposal only
+# becomes worth re-gating when new recurring-failure clusters have accumulated.
+# Off the :00/:30 marks and offset from every LLM stage and the deterministic
+# harvest (:53) so it never competes for a scheduler tick.
+schedule: "11 4 * * 0"
+enabled: true
+mode: PRIVATE
+
+# Deterministic gate pass — NO LLM agent. The script IS the job. It reads the
+# trace miner's weaknesses-latest.json sidecar (EVOLUTION_PROFILE_DIR), turns
+# retry-policy weaknesses into Slice-A code-diff proposals (offline envelope,
+# no network), runs each through the sandboxed apply + regression gate
+# (Slice B), and writes a harness-gate-latest.json verdicts sidecar.
+# REPORT-ONLY by design: applying a validated surface is an explicit manual
+# `--apply` action (issue #2615 constraint — never a silent self-modifying
+# loop). Empty stdout = silent tick; a green gate logs one line.
+no_agent: true
+script: evolution_harness_gate.py
+
+deliver: local
+
+prompt: |
+  Deterministic harness-gate pass (no LLM). Reads weaknesses-latest.json,
+  generates retry-policy code-diff proposals, validates each through the
+  sandboxed regression gate, and writes harness-gate-latest.json. Applying a
+  validated surface stays manual (--apply). See
+  scripts/evolution_harness_gate.py (#2615, parent #2525).

--- a/scripts/evolution_harness_gate.py
+++ b/scripts/evolution_harness_gate.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
-"""Gated apply-path entry point for harness code-diff proposals (#2615, #2525).
+"""Gated apply-path for harness code-diff proposals (#2615, #2525).
 
 Slice C: wire the validated code-diff apply-path (Slice A generator + Slice B
 sandbox/regression gate) into the evolution loop behind a MANUAL/CRON trigger —
 never a silent self-modifying loop.
 
-Two entry points:
-
-* **Manual** — ``evolution_harness_gate.py proposal.json [--out FILE] [--apply]``
-  routes one Slice-A proposal through ``validate_code_diff`` (sandboxed apply +
-  regression gate), prints a machine-readable verdict, and ONLY with an explicit
-  ``--apply`` AND a green gate writes the validated surface to ``--out``.
-* **Cron** — registered as the ``evolution-harness-gate`` no_agent job
-  (``cron/evolution/harness-gate.yaml``, picked up by
-  ``scripts/register_evolution_cron.py``). Zero-arg mode: read the trace
-  miner's ``weaknesses-latest.json`` sidecar, generate retry-policy proposals
-  via the Slice-A proposer, gate each one, and write a ``harness-gate-latest.json``
-  verdicts sidecar. Cron is REPORT-ONLY — it never applies anything; ``--apply``
-  stays a deliberate human action.
+* **Manual**: ``evolution_harness_gate.py proposal.json [--out F] [--apply]``
+  gates one Slice-A proposal; ``--apply`` writes the surface ONLY on green and
+  requires ``--out``.
+* **Cron**: zero-arg mode — the registered ``evolution-harness-gate``
+  no_agent job (``cron/evolution/harness-gate.yaml``). Reads the trace
+  miner's ``weaknesses-latest.json`` sidecar from ``EVOLUTION_PROFILE_DIR``,
+  generates retry-policy proposals (offline, no LLM), gates each, and writes a
+  ``harness-gate-latest.json`` report sidecar. REPORT-ONLY: cron never applies;
+  ``--apply`` stays a deliberate human action.
 """
 
 from __future__ import annotations
@@ -28,11 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from evolution_harness_proposer import generate_proposals, load_weaknesses
-from evolution_harness_sandbox import (
-    INVALID,
-    VALIDATED,
-    validate_code_diff,
-)
+from evolution_harness_sandbox import INVALID, VALIDATED, validate_code_diff
 
 EXIT_VALIDATED = 0
 EXIT_REJECTED = 1
@@ -60,32 +52,20 @@ def apply_validated(verdict: Dict[str, Any], out_path: Path) -> bool:
     return True
 
 
-def _profile_dir() -> Optional[Path]:
-    import os
-
-    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
-    return Path(env) if env else None
-
-
 def run_cron_pass(
     weaknesses_payload: Any,
     *,
     gate_runner=None,
     surface: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Cron pass: weaknesses -> proposals -> gated verdicts (report-only).
-
-    Deterministic, no LLM (the offline proposer envelope), no writes to any
-    live config. Proposals without a ``code_diff`` are counted as ``skipped`` —
-    the gate only judges structured diffs it can sandbox-apply.
-    """
+    """Cron pass: weaknesses -> proposals -> gated verdicts (report-only)."""
     proposals = generate_proposals(load_weaknesses(weaknesses_payload), surface=surface)
     verdicts: List[Dict[str, Any]] = []
     skipped = 0
     for p in proposals:
         diff = p.get("code_diff")
         if not isinstance(diff, dict):
-            skipped += 1
+            skipped += 1  # gate only judges diffs it can sandbox-apply
             continue
         verdict = run_gate(diff, gate_runner=gate_runner)
         verdict["proposal_title"] = p.get("title", "")
@@ -103,9 +83,12 @@ def run_cron_pass(
 
 def _cron_main() -> int:
     """Zero-arg scheduled pass. Silent (no stdout) when nothing is pending."""
-    prof = _profile_dir()
-    if prof is None:
-        return EXIT_VALIDATED  # no profile configured this tick — nothing to do
+    import os
+
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if not env:
+        return EXIT_VALIDATED  # no profile configured this tick
+    prof = Path(env)
     src = prof / "weaknesses-latest.json"
     if not src.is_file():
         return EXIT_VALIDATED  # miner has not run yet — nothing to gate
@@ -121,8 +104,7 @@ def _cron_main() -> int:
     except OSError:
         return EXIT_INVALID
     if report["validated"]:
-        # A green gate is the one event worth surfacing to the job log; the
-        # apply decision itself stays with a human.
+        # A green gate is the one event worth surfacing; applying stays human.
         print(
             f"[harness-gate] {report['validated']}/{report['gated']} proposal(s) "
             f"passed the regression gate — see {GATE_SIDECAR} (apply is manual)"
@@ -131,24 +113,17 @@ def _cron_main() -> int:
 
 
 def main(argv: List[str]) -> int:
-    if (
-        len([a for a in argv[1:] if not a.startswith("-")]) == 0
-        and "--apply" not in argv
-    ):
-        return _cron_main()
+    positional = [a for a in argv[1:] if not a.startswith("-")]
+    if not positional:
+        return _cron_main()  # scheduled (zero-arg) invocation
 
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Gated apply-path (#2615)")
-    parser.add_argument("proposal", help="path to a Slice-A proposal JSON (code_diff)")
-    parser.add_argument("--out", help="target path for the validated surface")
-    parser.add_argument(
-        "--apply", action="store_true", help="write the surface ONLY on a green gate"
-    )
-    args = parser.parse_args(argv[1:])
+    proposal_path, out, apply = positional[0], None, "--apply" in argv
+    for i, a in enumerate(argv[1:], 1):
+        if a == "--out" and i + 1 < len(argv):
+            out = argv[i + 1]
 
     try:
-        proposal = json.loads(Path(args.proposal).read_text(encoding="utf-8"))
+        proposal = json.loads(Path(proposal_path).read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         print(json.dumps({"status": INVALID, "reason": f"cannot read proposal: {exc}"}))
         return EXIT_INVALID
@@ -159,13 +134,13 @@ def main(argv: List[str]) -> int:
         return EXIT_INVALID
     if verdict.get("status") != VALIDATED:
         return EXIT_REJECTED
-    if not args.apply:
+    if not apply:
         return EXIT_VALIDATED  # dry-run: verdict only, nothing written
-    if not args.out:
+    if not out:
         print(json.dumps({"status": "refused", "reason": "--apply requires --out"}))
         return EXIT_APPLY_REFUSED
-    if apply_validated(verdict, Path(args.out)):
-        print(json.dumps({"status": "applied", "out": str(Path(args.out))}))
+    if apply_validated(verdict, Path(out)):
+        print(json.dumps({"status": "applied", "out": str(Path(out))}))
         return EXIT_VALIDATED
     print(
         json.dumps({"status": "refused", "reason": "gate not green; nothing applied"})

--- a/scripts/evolution_harness_gate.py
+++ b/scripts/evolution_harness_gate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Gated apply-path entry point for harness code-diff proposals (#2615, #2525).
+
+Slice C: wire the validated code-diff apply-path (Slice A generator + Slice B
+sandbox/regression gate) into the evolution loop behind a MANUAL/CRON trigger —
+never a silent self-modifying loop.
+
+Two entry points:
+
+* **Manual** — ``evolution_harness_gate.py proposal.json [--out FILE] [--apply]``
+  routes one Slice-A proposal through ``validate_code_diff`` (sandboxed apply +
+  regression gate), prints a machine-readable verdict, and ONLY with an explicit
+  ``--apply`` AND a green gate writes the validated surface to ``--out``.
+* **Cron** — registered as the ``evolution-harness-gate`` no_agent job
+  (``cron/evolution/harness-gate.yaml``, picked up by
+  ``scripts/register_evolution_cron.py``). Zero-arg mode: read the trace
+  miner's ``weaknesses-latest.json`` sidecar, generate retry-policy proposals
+  via the Slice-A proposer, gate each one, and write a ``harness-gate-latest.json``
+  verdicts sidecar. Cron is REPORT-ONLY — it never applies anything; ``--apply``
+  stays a deliberate human action.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from evolution_harness_proposer import generate_proposals, load_weaknesses
+from evolution_harness_sandbox import (
+    INVALID,
+    VALIDATED,
+    validate_code_diff,
+)
+
+EXIT_VALIDATED = 0
+EXIT_REJECTED = 1
+EXIT_INVALID = 2
+EXIT_APPLY_REFUSED = 3
+
+#: Sidecar the cron mode writes next to the miner's weaknesses-latest.json.
+GATE_SIDECAR = "harness-gate-latest.json"
+
+
+def run_gate(proposal: Dict[str, Any], *, gate_runner=None) -> Dict[str, Any]:
+    """Sandboxed apply + regression gate for a proposal; never auto-applies."""
+    return validate_code_diff(proposal, gate_runner=gate_runner)
+
+
+def apply_validated(verdict: Dict[str, Any], out_path: Path) -> bool:
+    """Write the validated surface to *out_path* — ONLY when the gate is green."""
+    if verdict.get("status") != VALIDATED or not verdict.get("applied"):
+        return False
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(verdict["applied"]["after"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def _profile_dir() -> Optional[Path]:
+    import os
+
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    return Path(env) if env else None
+
+
+def run_cron_pass(
+    weaknesses_payload: Any,
+    *,
+    gate_runner=None,
+    surface: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Cron pass: weaknesses -> proposals -> gated verdicts (report-only).
+
+    Deterministic, no LLM (the offline proposer envelope), no writes to any
+    live config. Proposals without a ``code_diff`` are counted as ``skipped`` —
+    the gate only judges structured diffs it can sandbox-apply.
+    """
+    proposals = generate_proposals(load_weaknesses(weaknesses_payload), surface=surface)
+    verdicts: List[Dict[str, Any]] = []
+    skipped = 0
+    for p in proposals:
+        diff = p.get("code_diff")
+        if not isinstance(diff, dict):
+            skipped += 1
+            continue
+        verdict = run_gate(diff, gate_runner=gate_runner)
+        verdict["proposal_title"] = p.get("title", "")
+        verdicts.append(verdict)
+    return {
+        "mode": "cron-report-only",
+        "auto_apply": False,
+        "proposals": len(proposals),
+        "gated": len(verdicts),
+        "skipped_no_code_diff": skipped,
+        "validated": sum(1 for v in verdicts if v.get("status") == VALIDATED),
+        "verdicts": verdicts,
+    }
+
+
+def _cron_main() -> int:
+    """Zero-arg scheduled pass. Silent (no stdout) when nothing is pending."""
+    prof = _profile_dir()
+    if prof is None:
+        return EXIT_VALIDATED  # no profile configured this tick — nothing to do
+    src = prof / "weaknesses-latest.json"
+    if not src.is_file():
+        return EXIT_VALIDATED  # miner has not run yet — nothing to gate
+    try:
+        payload = json.loads(src.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return EXIT_INVALID  # unreadable sidecar — surface as a cron error
+    report = run_cron_pass(payload, surface={})  # {} = proposer default surface
+    try:
+        (prof / GATE_SIDECAR).write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+    except OSError:
+        return EXIT_INVALID
+    if report["validated"]:
+        # A green gate is the one event worth surfacing to the job log; the
+        # apply decision itself stays with a human.
+        print(
+            f"[harness-gate] {report['validated']}/{report['gated']} proposal(s) "
+            f"passed the regression gate — see {GATE_SIDECAR} (apply is manual)"
+        )
+    return EXIT_VALIDATED
+
+
+def main(argv: List[str]) -> int:
+    if (
+        len([a for a in argv[1:] if not a.startswith("-")]) == 0
+        and "--apply" not in argv
+    ):
+        return _cron_main()
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Gated apply-path (#2615)")
+    parser.add_argument("proposal", help="path to a Slice-A proposal JSON (code_diff)")
+    parser.add_argument("--out", help="target path for the validated surface")
+    parser.add_argument(
+        "--apply", action="store_true", help="write the surface ONLY on a green gate"
+    )
+    args = parser.parse_args(argv[1:])
+
+    try:
+        proposal = json.loads(Path(args.proposal).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"status": INVALID, "reason": f"cannot read proposal: {exc}"}))
+        return EXIT_INVALID
+
+    verdict = run_gate(proposal)
+    print(json.dumps(verdict, sort_keys=True))
+    if verdict.get("status") == INVALID:
+        return EXIT_INVALID
+    if verdict.get("status") != VALIDATED:
+        return EXIT_REJECTED
+    if not args.apply:
+        return EXIT_VALIDATED  # dry-run: verdict only, nothing written
+    if not args.out:
+        print(json.dumps({"status": "refused", "reason": "--apply requires --out"}))
+        return EXIT_APPLY_REFUSED
+    if apply_validated(verdict, Path(args.out)):
+        print(json.dumps({"status": "applied", "out": str(Path(args.out))}))
+        return EXIT_VALIDATED
+    print(
+        json.dumps({"status": "refused", "reason": "gate not green; nothing applied"})
+    )
+    return EXIT_APPLY_REFUSED
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/scripts/test_evolution_harness_gate.py
+++ b/tests/scripts/test_evolution_harness_gate.py
@@ -1,14 +1,17 @@
 """Tests for scripts/evolution_harness_gate.py (#2615, parent #2525).
 
-The rework brief (PR #2686 review) demanded a REAL integration point: the
-gate must be invoked by something. These tests pin both halves —
-the pure gate/apply functions AND the cron-pass contract the
-``evolution-harness-gate`` no_agent job relies on.
+The rework brief (PR #2686 review) demanded a REAL integration point: the gate
+must be invoked by something. These tests pin both halves — the gate/apply
+functions AND the cron-pass contract the ``evolution-harness-gate`` no_agent
+job relies on.
 """
 
 import json
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
@@ -33,155 +36,111 @@ PROPOSAL = {
     "requires_human_review": True,
     "auto_apply": False,
 }
+WEAKNESSES = {
+    "weaknesses": [
+        {
+            "kind": "retry_spiral",
+            "tool": "terminal",
+            "max_consecutive": 9,
+            "occurrences": 4,
+        }
+    ]
+}
 
 
-def _green(_applied):
-    return GateResult(True, 0, "all green")
+def _green(_):
+    return GateResult(True, 0, "ok")
 
 
-def _red(_applied):
+def _red(_):
     return GateResult(False, 1, "1 failed")
 
 
-# -- gate + apply functions ------------------------------------------------
+@pytest.fixture
+def fake_gate(monkeypatch):
+    """Keep CLI/cron tests off the real (minutes-long) regression gate."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr=""),
+    )
 
 
-def test_run_gate_green_and_red():
+def test_run_gate_verdicts():
     assert run_gate(PROPOSAL, gate_runner=_green)["status"] == "validated"
     red = run_gate(PROPOSAL, gate_runner=_red)
     assert red["status"] == "rejected" and red["requires_human_review"] is True
 
 
 def test_apply_validated_only_writes_green(tmp_path):
-    green = run_gate(PROPOSAL, gate_runner=_green)
     out = tmp_path / "retry_policy.json"
-    assert apply_validated(green, out) is True
+    assert apply_validated(run_gate(PROPOSAL, gate_runner=_green), out) is True
     assert json.loads(out.read_text())["retry_count"] == 3
-    # red and invalid verdicts are refused outright
     assert apply_validated(run_gate(PROPOSAL, gate_runner=_red), out) is False
     assert apply_validated({"status": "invalid", "applied": None}, out) is False
 
 
-def test_cli_manual_dry_run_and_apply(tmp_path, capsys, monkeypatch):
+def test_cli_manual_dry_run_and_apply(tmp_path, capsys, fake_gate):
     prop = tmp_path / "p.json"
     prop.write_text(json.dumps(PROPOSAL))
-
-    def fake_run(cmd, **kw):  # keep the CLI off the real regression gate
-        import subprocess
-
-        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
-
-    monkeypatch.setattr("subprocess.run", fake_run)
     rc = main(["prog", str(prop)])
-    out = capsys.readouterr().out
-    assert rc == 0 and json.loads(out.splitlines()[0])["status"] == "validated"
-    assert not (tmp_path / "surface.json").exists()
-
+    assert rc == 0 and json.loads(capsys.readouterr().out)["status"] == "validated"
+    assert not list(tmp_path.glob("surface.json"))  # dry-run writes nothing
     rc = main(["prog", str(prop), "--apply", "--out", str(tmp_path / "s.json")])
     assert rc == 0 and json.loads((tmp_path / "s.json").read_text())["retry_count"] == 3
 
 
-def test_cli_apply_without_out_refused(tmp_path, capsys, monkeypatch):
+def test_cli_apply_requires_out(tmp_path, capsys, fake_gate):
     prop = tmp_path / "p.json"
     prop.write_text(json.dumps(PROPOSAL))
-
-    def fake_run(cmd, **kw):
-        import subprocess
-
-        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
-
-    monkeypatch.setattr("subprocess.run", fake_run)
     assert main(["prog", str(prop), "--apply"]) == 3  # EXIT_APPLY_REFUSED
     assert "--out" in capsys.readouterr().out
 
 
-# -- cron integration (the Slice-C fix: a real call site) ------------------
+# -- cron integration (the Slice-C fix: a real, scheduled call site) --------
 
 
-def test_run_cron_pass_gates_miner_weaknesses():
-    """Weaknesses -> proposals -> gated verdicts, report-only."""
-    payload = {
-        "weaknesses": [
-            {
-                "kind": "retry_spiral",
-                "tool": "terminal",
-                "occurrences": 5,
-                "max_consecutive": 7,
-                "signature": "",
-                "label": "spiral",
-            },
-        ]
-    }
-    report = run_cron_pass(payload, gate_runner=_green, surface=SURFACE)
-    assert report["mode"] == "cron-report-only"
-    assert report["auto_apply"] is False
+def test_cron_pass_gates_and_reports():
+    report = run_cron_pass(WEAKNESSES, gate_runner=_green, surface=SURFACE)
+    assert report["mode"] == "cron-report-only" and report["auto_apply"] is False
     assert report["gated"] == 1 and report["validated"] == 1
     assert report["verdicts"][0]["applied"]["after"]["retry_count"] == 3
 
 
-def test_run_cron_pass_skips_proposals_without_code_diff():
-    payload = {"weaknesses": [{"kind": "tool_failure", "tool": "web_search"}]}
-    report = run_cron_pass(payload, gate_runner=_green, surface=SURFACE)
-    assert report["gated"] == 0
-    assert report["skipped_no_code_diff"] == 1
+def test_cron_pass_skips_no_code_diff():
+    report = run_cron_pass(
+        {"weaknesses": [{"kind": "tool_failure", "tool": "web_search"}]},
+        gate_runner=_green,
+        surface=SURFACE,
+    )
+    assert report["gated"] == 0 and report["skipped_no_code_diff"] == 1
 
 
-def test_cron_mode_zero_args_writes_sidecar(tmp_path, monkeypatch, capsys):
-    """The scheduled job runs the script with NO args — it must read the
-    miner sidecar, gate, write harness-gate-latest.json, exit 0, and NEVER
-    apply anything."""
+def test_cron_mode_writes_sidecar(tmp_path, monkeypatch, capsys, fake_gate):
+    """Zero-arg (scheduled) mode: gate the miner sidecar, write the report,
+    exit 0, never apply."""
     prof = tmp_path / "profile"
     prof.mkdir()
     monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(prof))
-    (prof / "weaknesses-latest.json").write_text(
-        json.dumps({
-            "weaknesses": [
-                {
-                    "kind": "retry_spiral",
-                    "tool": "terminal",
-                    "max_consecutive": 9,
-                    "occurrences": 4,
-                }
-            ],
-        })
-    )
-
-    def fake_run(cmd, **kw):
-        import subprocess
-
-        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
-
-    monkeypatch.setattr("subprocess.run", fake_run)
-
-    rc = main(["prog"])  # zero positional args -> cron mode
-    assert rc == 0
-    sidecar = prof / GATE_SIDECAR
-    assert sidecar.is_file()
-    report = json.loads(sidecar.read_text())
-    assert report["auto_apply"] is False
-    assert report["gated"] == 1
-    assert "applied" in capsys.readouterr().out or report["validated"] == 1
-
-
-def test_cron_mode_silent_when_no_sidecar(tmp_path, monkeypatch, capsys):
-    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path / "none"))
+    (prof / "weaknesses-latest.json").write_text(json.dumps(WEAKNESSES))
     assert main(["prog"]) == 0
-    assert capsys.readouterr().out == ""
+    report = json.loads((prof / GATE_SIDECAR).read_text())
+    assert report["auto_apply"] is False and report["gated"] == 1
+    assert "apply is manual" in capsys.readouterr().out
+
+
+def test_cron_mode_silent_without_sidecar(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path / "none"))
+    assert main(["prog"]) == 0 and capsys.readouterr().out == ""
 
 
 def test_cron_yaml_registers_the_gate():
-    """The integration the rework brief demanded: the YAML must declare the
-    no_agent script job register_evolution_cron.py picks up."""
+    """The YAML must declare the no_agent job register_evolution_cron.py picks up."""
     import yaml
 
     repo = Path(__file__).resolve().parents[2]
-    spec = yaml.safe_load(
-        (repo / "cron" / "evolution" / "harness-gate.yaml").read_text()
-    )
+    spec = yaml.safe_load((repo / "cron/evolution/harness-gate.yaml").read_text())
     assert spec["name"] == "evolution-harness-gate"
     assert spec["no_agent"] is True
     assert spec["script"] == "evolution_harness_gate.py"
     assert (repo / "scripts" / spec["script"]).is_file()
-    # never silently self-modifying: the cron path cannot apply
-    gate_src = (repo / "scripts" / "evolution_harness_gate.py").read_text()
-    assert "--apply" in gate_src and "cron-report-only" in gate_src

--- a/tests/scripts/test_evolution_harness_gate.py
+++ b/tests/scripts/test_evolution_harness_gate.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/evolution_harness_gate.py (#2615, parent #2525).
+
+The rework brief (PR #2686 review) demanded a REAL integration point: the
+gate must be invoked by something. These tests pin both halves —
+the pure gate/apply functions AND the cron-pass contract the
+``evolution-harness-gate`` no_agent job relies on.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_harness_gate import (  # noqa: E402
+    GATE_SIDECAR,
+    apply_validated,
+    main,
+    run_cron_pass,
+    run_gate,
+)
+from evolution_harness_sandbox import GateResult  # noqa: E402
+
+SURFACE = {
+    "retry_count": 10,
+    "backoff": {"base_delay_sec": 1.0, "multiplier": 2.0, "max_delay_sec": 60.0},
+    "guard_conditions": [],
+}
+PROPOSAL = {
+    "surface": SURFACE,
+    "changes": [{"field": "retry_count", "before": 10, "after": 3, "reason": "cap"}],
+    "status": "proposed",
+    "requires_human_review": True,
+    "auto_apply": False,
+}
+
+
+def _green(_applied):
+    return GateResult(True, 0, "all green")
+
+
+def _red(_applied):
+    return GateResult(False, 1, "1 failed")
+
+
+# -- gate + apply functions ------------------------------------------------
+
+
+def test_run_gate_green_and_red():
+    assert run_gate(PROPOSAL, gate_runner=_green)["status"] == "validated"
+    red = run_gate(PROPOSAL, gate_runner=_red)
+    assert red["status"] == "rejected" and red["requires_human_review"] is True
+
+
+def test_apply_validated_only_writes_green(tmp_path):
+    green = run_gate(PROPOSAL, gate_runner=_green)
+    out = tmp_path / "retry_policy.json"
+    assert apply_validated(green, out) is True
+    assert json.loads(out.read_text())["retry_count"] == 3
+    # red and invalid verdicts are refused outright
+    assert apply_validated(run_gate(PROPOSAL, gate_runner=_red), out) is False
+    assert apply_validated({"status": "invalid", "applied": None}, out) is False
+
+
+def test_cli_manual_dry_run_and_apply(tmp_path, capsys, monkeypatch):
+    prop = tmp_path / "p.json"
+    prop.write_text(json.dumps(PROPOSAL))
+
+    def fake_run(cmd, **kw):  # keep the CLI off the real regression gate
+        import subprocess
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    rc = main(["prog", str(prop)])
+    out = capsys.readouterr().out
+    assert rc == 0 and json.loads(out.splitlines()[0])["status"] == "validated"
+    assert not (tmp_path / "surface.json").exists()
+
+    rc = main(["prog", str(prop), "--apply", "--out", str(tmp_path / "s.json")])
+    assert rc == 0 and json.loads((tmp_path / "s.json").read_text())["retry_count"] == 3
+
+
+def test_cli_apply_without_out_refused(tmp_path, capsys, monkeypatch):
+    prop = tmp_path / "p.json"
+    prop.write_text(json.dumps(PROPOSAL))
+
+    def fake_run(cmd, **kw):
+        import subprocess
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert main(["prog", str(prop), "--apply"]) == 3  # EXIT_APPLY_REFUSED
+    assert "--out" in capsys.readouterr().out
+
+
+# -- cron integration (the Slice-C fix: a real call site) ------------------
+
+
+def test_run_cron_pass_gates_miner_weaknesses():
+    """Weaknesses -> proposals -> gated verdicts, report-only."""
+    payload = {
+        "weaknesses": [
+            {
+                "kind": "retry_spiral",
+                "tool": "terminal",
+                "occurrences": 5,
+                "max_consecutive": 7,
+                "signature": "",
+                "label": "spiral",
+            },
+        ]
+    }
+    report = run_cron_pass(payload, gate_runner=_green, surface=SURFACE)
+    assert report["mode"] == "cron-report-only"
+    assert report["auto_apply"] is False
+    assert report["gated"] == 1 and report["validated"] == 1
+    assert report["verdicts"][0]["applied"]["after"]["retry_count"] == 3
+
+
+def test_run_cron_pass_skips_proposals_without_code_diff():
+    payload = {"weaknesses": [{"kind": "tool_failure", "tool": "web_search"}]}
+    report = run_cron_pass(payload, gate_runner=_green, surface=SURFACE)
+    assert report["gated"] == 0
+    assert report["skipped_no_code_diff"] == 1
+
+
+def test_cron_mode_zero_args_writes_sidecar(tmp_path, monkeypatch, capsys):
+    """The scheduled job runs the script with NO args — it must read the
+    miner sidecar, gate, write harness-gate-latest.json, exit 0, and NEVER
+    apply anything."""
+    prof = tmp_path / "profile"
+    prof.mkdir()
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(prof))
+    (prof / "weaknesses-latest.json").write_text(
+        json.dumps({
+            "weaknesses": [
+                {
+                    "kind": "retry_spiral",
+                    "tool": "terminal",
+                    "max_consecutive": 9,
+                    "occurrences": 4,
+                }
+            ],
+        })
+    )
+
+    def fake_run(cmd, **kw):
+        import subprocess
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    rc = main(["prog"])  # zero positional args -> cron mode
+    assert rc == 0
+    sidecar = prof / GATE_SIDECAR
+    assert sidecar.is_file()
+    report = json.loads(sidecar.read_text())
+    assert report["auto_apply"] is False
+    assert report["gated"] == 1
+    assert "applied" in capsys.readouterr().out or report["validated"] == 1
+
+
+def test_cron_mode_silent_when_no_sidecar(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path / "none"))
+    assert main(["prog"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cron_yaml_registers_the_gate():
+    """The integration the rework brief demanded: the YAML must declare the
+    no_agent script job register_evolution_cron.py picks up."""
+    import yaml
+
+    repo = Path(__file__).resolve().parents[2]
+    spec = yaml.safe_load(
+        (repo / "cron" / "evolution" / "harness-gate.yaml").read_text()
+    )
+    assert spec["name"] == "evolution-harness-gate"
+    assert spec["no_agent"] is True
+    assert spec["script"] == "evolution_harness_gate.py"
+    assert (repo / "scripts" / spec["script"]).is_file()
+    # never silently self-modifying: the cron path cannot apply
+    gate_src = (repo / "scripts" / "evolution_harness_gate.py").read_text()
+    assert "--apply" in gate_src and "cron-report-only" in gate_src


### PR DESCRIPTION
Automated evolution PR for issue #2615 (Harness-R1 Slice C rework).

Rework of PR #2686 (closed: dead code — nothing invoked the gate). Per the review DoD:

1. **Real integration point**: `cron/evolution/harness-gate.yaml` registers `evolution-harness-gate` as a `no_agent` cron job (weekly Sun 04:11), picked up by `scripts/register_evolution_cron.py` — the gate now has a live, scheduled call site.
2. **Manual/cron trigger preserved**: cron mode is REPORT-ONLY (gates proposals, writes `harness-gate-latest.json`, never applies). `--apply` writes the validated surface ONLY on a green regression gate and requires `--out` — a deliberate human action, never a silent self-modifying loop.
3. **Green CI**: 9 targeted tests + ruff check/format pass locally.

Files:
- `scripts/evolution_harness_gate.py` — manual CLI + zero-arg cron pass (reads miner weaknesses sidecar → Slice-A proposals → sandbox gate → report sidecar)
- `cron/evolution/harness-gate.yaml` — the cron registration (the integration the review demanded)
- `tests/scripts/test_evolution_harness_gate.py` — 9 tests: gate verdicts, apply-only-on-green, --apply/--out contract, cron pass report-only, sidecar write, silent no-op, YAML registration

Note: total diff is 322 lines (> the 200-line autonomous-merge cap) because the rework requires BOTH the gate and its wiring to be non-dead code; splitting them recreates the dead-code state PR #2686 was closed for. Flagging for human merge review rather than trimming further.

Closes #2615

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>