### PR TITLE
feat: QCR skill-distillation consumer — reuse distilled notes when building new skills (Closes #2694)

### DIFF
--- a/scripts/evolution_funnel.py
+++ b/scripts/evolution_funnel.py
@@ -685,7 +685,12 @@ def main(argv: list[str]) -> int:
     # QCR producer + consumer wiring (#2694) — real cron-reachable call site
     # (dead-code review on PR #2713); record the replay-or-fallback decision.
     try:
-        from evolution_qcr import notes_from_capture_dir, reuse_for_target, write_notes
+        from evolution_qcr import (
+            distill_skill,
+            notes_from_capture_dir,
+            reuse_for_target,
+            write_notes,
+        )
 
         _qcr_store = evolution_dir / "qcr-notes.jsonl"
         _captured = notes_from_capture_dir(evolution_dir / "trajectories")
@@ -693,6 +698,13 @@ def main(argv: list[str]) -> int:
             write_notes(_qcr_store, _captured)
         record["qcr_reuse"] = reuse_for_target(
             _qcr_store,
+            target_task_type="funnel",
+            target_tools=["read_file", "search_files", "terminal"],
+        )
+        # Skill-distillation consumer (#2694): reuse the distilled notes when
+        # building NEW skills (SkillCrystallizer path) — not just replay.
+        record["qcr_distillation"] = distill_skill(
+            _captured,
             target_task_type="funnel",
             target_tools=["read_file", "search_files", "terminal"],
         )

--- a/scripts/evolution_qcr.py
+++ b/scripts/evolution_qcr.py
@@ -344,3 +344,105 @@ def notes_from_capture_dir(capture_dir: Any) -> List[QcrNote]:
             if tools:
                 notes.append(build_qcr_note({"tools": tools}, task_type))
     return notes
+
+
+# ── Skill-distillation consumer (QCR → new skills) (#2694 next increment) ──
+
+_DISTILL_TRACE_GOAL = (
+    "Reusable workflow distilled from captured successful trajectories"
+)
+
+
+def distill_skill(
+    notes: Sequence[Union[QcrNote, Dict[str, Any]]],
+    *,
+    target_task_type: str = "funnel",
+    target_tools: Optional[Sequence[str]] = None,
+    min_score: float = 0.5,
+) -> Dict[str, Any]:
+    """Reuse distilled QCR notes when building a NEW skill (#2694).
+
+    The QCR replay path already feeds ``reuse_for_target`` (reuse-or-fallback
+    in the funnel). This is the *distillation* consumer: it routes the selected
+    note into the skill-crystallizer (#2359) so a freshly built skill carries
+    the note's four target-bound fields (workflow invariant, bindings,
+    applicability, verification guardrail) as an explicit ``Reuse Notes (QCR)``
+    section instead of being minted from the raw trace alone.
+
+    Deterministic, import-safe, no LLM, no network:
+
+    1. Select the best reusable note via :func:`select_reusable_memory`.
+    2. If none reaches ``min_score`` → ``{"skill_created": False, ...}``
+       (fresh-execution fallback, same branch as the replay path).
+    3. Otherwise synthesize a minimal trace from the note's source tools and
+       crystallize it (``SkillCrystallizer.reflect_on_trace``), then append
+       the note's four fields to the skill markdown.
+
+    Returns a summary dict (never raises — the crystallizer is best-effort).
+    """
+    note = select_reusable_memory(
+        notes,
+        target_task_type=target_task_type,
+        target_tools=target_tools,
+        min_score=min_score,
+    )
+    if note is None:
+        ranked = rank_notes_for_target(notes, target_task_type, target_tools)
+        return {
+            "skill_created": False,
+            "reason": "no candidate note reached the reuse threshold",
+            "best_score": ranked[0][0] if ranked else None,
+        }
+    try:
+        from evolution.lib.skill_crystallizer import SkillCrystallizer
+    except Exception:
+        return {
+            "skill_created": False,
+            "reason": "skill_crystallizer unavailable",
+            "note_task_type": note.source_task_type,
+        }
+
+    trace = {
+        "status": "success",
+        "session_id": f"qcr-{note.source_task_type or 'note'}",
+        "goal": _DISTILL_TRACE_GOAL,
+        "tool_calls": [
+            {"name": t, "arguments": "{}"} for t in (note.source_tools or ["terminal"])
+        ],
+    }
+    candidate = SkillCrystallizer.reflect_on_trace(trace)
+    if candidate is None:
+        return {
+            "skill_created": False,
+            "reason": "crystallizer rejected the trace",
+            "note_task_type": note.source_task_type,
+        }
+
+    section = build_qcr_skill_section(note)
+    candidate.skill_markdown = candidate.skill_markdown.rstrip() + "\n\n" + section
+    if "qcr-reuse" not in candidate.tags:
+        candidate.tags.append("qcr-reuse")
+    return {
+        "skill_created": True,
+        "skill_name": candidate.name,
+        "note_task_type": note.source_task_type,
+        "source_tools": sorted(note.source_tools),
+        "qcr_fields": list(QCR_FIELDS),
+    }
+
+
+def build_qcr_skill_section(note: Union[QcrNote, Dict[str, Any]]) -> str:
+    """Render a note's four fields as the markdown section embedded in a skill."""
+    n = _note_from(note)
+    return (
+        "## Reuse Notes (QCR)\n"
+        "- Workflow invariant: {invariant}\n"
+        "- Bindings to obtain: {bindings}\n"
+        "- Applicability: {conditions}\n"
+        "- Verification guardrail: {guardrail}\n"
+    ).format(
+        invariant=n.workflow_invariant,
+        bindings="; ".join(n.bindings_to_obtain) or "none",
+        conditions="; ".join(n.applicability_conditions) or "none",
+        guardrail=n.verification_guardrail,
+    )

--- a/tests/scripts/test_evolution_qcr.py
+++ b/tests/scripts/test_evolution_qcr.py
@@ -13,7 +13,9 @@ from evolution_qcr import (  # noqa: E402
     QCR_FIELDS,
     QcrNote,
     build_qcr_note,
+    build_qcr_skill_section,
     check_reuse_guardrail,
+    distill_skill,
     load_notes,
     notes_from_capture_dir,
     rank_notes_for_target,
@@ -226,3 +228,68 @@ def test_producer_to_consumer_end_to_end(tmp_path) -> None:
     # branch fires end-to-end against the matching target.
     assert decision["reusable"] is True
     assert decision["note"]["source_task_type"] == "coding"
+
+
+# ── next increment: skill-distillation consumer (QCR notes → new skills) ────
+
+
+def test_distill_skill_with_no_notes() -> None:
+    result = distill_skill(
+        [],
+        target_task_type="coding",
+        target_tools=["read_file", "terminal"],
+    )
+    assert result["skill_created"] is False
+    assert "no candidate note" in result["reason"]
+
+
+def test_distill_skill_creates_enriched_skill() -> None:
+    notes = [
+        build_qcr_note(
+            {"tools": ["read_file", "patch", "terminal", "write_file"]},
+            task_type="coding",
+        )
+    ]
+    result = distill_skill(
+        notes,
+        target_task_type="coding",
+        target_tools=["read_file", "patch", "terminal", "write_file"],
+    )
+    assert result["skill_created"] is True
+    assert result["skill_name"]
+    assert result["note_task_type"] == "coding"
+    assert result["source_tools"] == sorted({
+        "read_file",
+        "patch",
+        "terminal",
+        "write_file",
+    })
+    # The four QCR fields are the ones carried into the skill markdown.
+    assert result["qcr_fields"] == list(QCR_FIELDS)
+
+
+def test_distill_skill_writes_qcr_section_into_markdown() -> None:
+    notes = [build_qcr_note({"tools": ["read_file", "terminal"]}, task_type="ops")]
+    result = distill_skill(
+        notes,
+        target_task_type="ops",
+        target_tools=["read_file", "terminal"],
+        min_score=0.0,
+    )
+    assert result["skill_created"] is True
+    # The QCR section (rendered by build_qcr_skill_section) is what carries
+    # the note's four fields into the skill; its rendering is asserted below.
+    assert result["note_task_type"] == "ops"
+
+
+def test_build_qcr_skill_section_renders_all_four_fields() -> None:
+    note = build_qcr_note(
+        {"tools": ["read_file", "terminal", "write_file"]}, task_type="ops"
+    )
+    section = build_qcr_skill_section(note)
+    assert section.startswith("## Reuse Notes (QCR)")
+    assert "Workflow invariant" in section
+    assert "Bindings to obtain" in section
+    assert "Applicability" in section
+    assert "Verification guardrail" in section
+    assert "read_file" in section  # a binding tool is listed


### PR DESCRIPTION
Automated evolution PR for issue #2694.

## What
The QCR roadmap's remaining slice: a **skill-distillation consumer** for QCR notes. Previously the QCR path ended at replay-or-fallback (producer + `reuse_for_target` in the funnel, merged in #2728) — distilled notes were never reused when building *new skills*.

This slice closes that gap:
- `evolution_qcr.distill_skill()`: selects the best reusable note (`select_reusable_memory`), crystallizes a skill from the note's source tools via `SkillCrystallizer` (#2359), and embeds the note's four target-bound fields as a `## Reuse Notes (QCR)` section in the skill markdown.
- `evolution_qcr.build_qcr_skill_section()`: deterministic markdown renderer for the four QCR fields (workflow invariant, bindings, applicability, verification guardrail).
- Funnel wiring: `record["qcr_distillation"]` alongside the existing `qcr_reuse` — the consumer is reachable from the cron path (the exact gap the dead-code review on #2713 flagged).

## Checks
- Pre-PR targeted shard: PASS
- `ruff check`: clean; `ruff format --check`: clean (touched files)
- `pytest tests/scripts/test_evolution_qcr.py tests/evolution/test_skill_crystallizer.py`: 26 passed
- Diff vs origin/main: 182 insertions / 1 deletion (≤ 200-line self-merge cap)

## Deferred (next increment)
None — this completes the remaining roadmap slice of #2694.