### PR TITLE
feat: AgentOpt Slice 1 — opt-in LLM-call telemetry hook (Closes #2741)

### DIFF
--- a/agent/agentopt_telemetry.py
+++ b/agent/agentopt_telemetry.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 1 — opt-in LLM-call telemetry (#2741).
+
+Child of #2695. Opt-in via ``config.yaml -> agentopt.telemetry.enabled`` ONLY
+(no env vars), disabled by default. When on, each auxiliary LLM call appends
+one content-free JSONL record (model, tool, step, cost, latency_ms, outcome);
+off = byte-identical. Fail-closed, content-free (payloads never captured).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_FNAME = "agentopt-llm-calls.jsonl"
+
+
+def _store_path() -> Path:
+    override = os.environ.get("AGENTOPT_TELEMETRY_STORE", "").strip()
+    if override:
+        return Path(override)
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / _FNAME
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / _FNAME
+        if hh
+        else Path.home() / ".hermes" / "evolution" / _FNAME
+    )
+
+
+def agentopt_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Opt-in flag from config.yaml; default False; fail-closed. Injectable."""
+    if config is not None:
+        section = config.get("agentopt")
+        tel = section.get("telemetry") if isinstance(section, dict) else None
+        return bool(isinstance(tel, dict) and tel.get("enabled", False))
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return agentopt_enabled(load_config_readonly())
+    except Exception:
+        return False
+
+
+def estimate_cost(usage: Any) -> Optional[float]:
+    """Token-based USD estimate; None when usage absent (no fabricated cost)."""
+    if hasattr(usage, "prompt_tokens"):
+        prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
+        completion = int(getattr(usage, "completion_tokens", 0) or 0)
+    elif isinstance(usage, dict):
+        prompt = int(usage.get("prompt_tokens") or 0)
+        completion = int(usage.get("completion_tokens") or 0)
+    else:
+        return None
+    return round((prompt + completion) * 0.002 / 1000.0, 6)
+
+
+def append_record(record: Dict[str, Any], store: Optional[Path] = None) -> bool:
+    """Append one JSONL line. Best-effort; never raises."""
+    if not isinstance(record.get("model"), str) or not record.get("model"):
+        return False
+    record.setdefault("ts", time.time())
+    record.setdefault("latency_ms", 0.0)
+    record.setdefault("outcome", "unknown")
+    path = store or _store_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def record_llm_call(
+    *,
+    model: str,
+    tool: str,
+    step: str,
+    latency_ms: float,
+    outcome: str,
+    usage: Any = None,
+    store: Optional[Path] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Record one LLM call when telemetry is enabled; no-op otherwise."""
+    if not agentopt_enabled(config):
+        return False
+    rec: Dict[str, Any] = {
+        "model": model,
+        "tool": tool,
+        "step": step,
+        "latency_ms": round(float(latency_ms), 3),
+        "outcome": outcome,
+    }
+    if usage is not None:
+        est = estimate_cost(usage)
+        if est is not None:
+            rec["cost"] = est
+    return append_record(rec, store=store)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9153,6 +9153,9 @@ def call_llm(
     if semaphore is not None:
         semaphore.acquire()
     try:
+        from agent.agentopt_telemetry import record_llm_call
+
+        _t0 = time.time()
         response = _call_llm_impl(
             task=task,
             provider=provider,
@@ -9177,6 +9180,18 @@ def call_llm(
             stream_semaphore = semaphore
             semaphore = None
             return _release_sync_semaphore_after_stream(response, stream_semaphore)
+        try:
+            usage = getattr(response, "usage", None)
+        except Exception:
+            usage = None
+        record_llm_call(
+            model=model or task or "aux",
+            tool=task or "aux",
+            step="llm",
+            latency_ms=(time.time() - _t0) * 1000.0,
+            outcome="ok",
+            usage=usage,
+        )
         return response
     finally:
         if semaphore is not None:

--- a/tests/agent/test_agentopt_telemetry.py
+++ b/tests/agent/test_agentopt_telemetry.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Tests for AgentOpt Slice 1 telemetry hook (#2741)."""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent.agentopt_telemetry import (  # noqa: E402
+    agentopt_enabled,
+    append_record,
+    estimate_cost,
+    record_llm_call,
+)
+
+ON = {"agentopt": {"telemetry": {"enabled": True}}}
+
+
+class TestAgentoptEnabled:
+    def test_disabled_by_default(self):
+        assert agentopt_enabled({}) is False
+
+    def test_enabled_when_flag_set(self):
+        assert agentopt_enabled(ON) is True
+
+    def test_false_on_malformed(self):
+        assert agentopt_enabled({"agentopt": "oops"}) is False
+        assert agentopt_enabled(None) is False
+
+
+class TestEstimateCost:
+    def test_dict_usage(self):
+        assert estimate_cost({"prompt_tokens": 500, "completion_tokens": 500}) == 0.002
+
+    def test_object_usage(self):
+        assert (
+            estimate_cost(SimpleNamespace(prompt_tokens=1000, completion_tokens=0))
+            == 0.002
+        )
+
+
+class TestAppendRecord:
+    def test_writes_jsonl(self, tmp_path):
+        store = tmp_path / "calls.jsonl"
+        assert append_record({"model": "m", "tool": "t", "step": "s"}, store=store)
+        rec = json.loads(store.read_text().splitlines()[0])
+        assert rec["model"] == "m" and rec["outcome"] == "unknown"
+
+
+class TestRecordLlmCall:
+    def test_noop_when_disabled(self, tmp_path):
+        store = tmp_path / "c.jsonl"
+        assert not record_llm_call(
+            model="m",
+            tool="t",
+            step="s",
+            latency_ms=1.0,
+            outcome="ok",
+            config={},
+            store=store,
+        )
+        assert not store.exists()
+
+    def test_records_when_enabled(self, tmp_path):
+        store = tmp_path / "c.jsonl"
+        ok = record_llm_call(
+            model="m",
+            tool="t",
+            step="s",
+            latency_ms=12.3,
+            outcome="ok",
+            usage={"prompt_tokens": 1000, "completion_tokens": 0},
+            config=ON,
+            store=store,
+        )
+        assert ok is True
+        rec = json.loads(store.read_text())
+        assert rec["model"] == "m" and rec["cost"] == 0.002 and rec["outcome"] == "ok"


### PR DESCRIPTION
Automated evolution PR for issue #2741.

Opt-in via `config.yaml -> agentopt.telemetry.enabled` ONLY (no env vars), disabled by default. When on, each auxiliary LLM call through `call_llm` appends one content-free JSONL record (model, tool, step, cost, latency_ms, outcome) to a local store; off = byte-identical. Fail-closed, payloads never captured.

Wired at the `call_llm` seam (real, non-dead call site). Diff: 200 lines — within the self-merge cap. Lint ✓, format ✓, targeted tests ✓.