### PR TITLE
feat: anti-conformity pressure — contrarian variant in draft selection (Closes #2761)

### DIFF
--- a/scripts/evolution_draft_selector.py
+++ b/scripts/evolution_draft_selector.py
@@ -117,6 +117,41 @@ def _score(text: str) -> float:
     return round(s, 4)
 
 
+def _tokens(text: str) -> set:
+    """Lowercased word tokens for distinctness comparison (anti-conformity)."""
+    return set(re.findall(r"[a-z0-9_]{3,}", (text or "").lower()))
+
+
+def _distinctness(a: str, b: str) -> float:
+    """1 - Jaccard similarity of two summaries' tokens. 1.0 = fully distinct."""
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta or not tb:
+        return 1.0
+    return 1.0 - len(ta & tb) / len(ta | tb)
+
+
+def _contrarian_index(drafts: List[Dict[str, Any]]) -> int:
+    """Index of the most distinct (least similar) OK draft — the contrarian
+    kept alive against spontaneous consensus (conformity law, #2761).
+
+    Pairs every draft against the highest-scoring draft (the would-be norm):
+    the one with the largest distinctness is the contrarian. Returns -1 when
+    there is nothing to compare.
+    """
+    ok = [d for d in drafts if d.get("ok")]
+    if len(ok) < 2:
+        return -1
+    best = max(ok, key=lambda d: d.get("score", 0.0))
+    # Tie-break on index so the LAST most-distinct draft wins — max() would
+    # otherwise return the first draft on equal distinctness.
+    contrarian = max(
+        ok, key=lambda d: (_distinctness(d["summary"], best["summary"]), d["index"])
+    )
+    if contrarian is best:
+        return -1
+    return contrarian["index"]
+
+
 def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, Any]]]:
     """Score drafts, pick winner: (best_index, best_score, drafts)."""
     results = (
@@ -142,6 +177,11 @@ def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, 
             "score": _score(sm) if ok else 0.0,
         })
     drafts.sort(key=lambda d: d["index"])
+    # Anti-conformity pressure (#2761): mark the most distinct OK draft as the
+    # contrarian so callers can keep >=1 non-consensus variant alive per cycle.
+    ci = _contrarian_index(drafts)
+    for d in drafts:
+        d["contrarian"] = d["ok"] and d["index"] == ci
     bi, bs = -1, 0.0
     for d in drafts:
         if d["ok"] and d["score"] > bs:

--- a/tests/scripts/test_evolution_draft_selector.py
+++ b/tests/scripts/test_evolution_draft_selector.py
@@ -10,6 +10,7 @@ from evolution_draft_selector import (  # noqa: E402  # fmt: skip
     DEFAULT_MAX_DRAFTERS,
     _CMAP,
     _TIERS,
+    _distinctness,
     build_draft_tasks,
     route_cost_tier,
     select_best_draft,
@@ -129,3 +130,48 @@ def test_route_cli_positional(capsys):
 
 def test_route_cli_missing_complexity(capsys):
     assert main(["x", "route"]) == 2
+
+
+# ── Anti-conformity pressure tests (#2761) ───────────────────────────────────
+
+
+def test_contrarian_kept_alive_when_draft_differs():
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "## A\n\nUse hash map for the cache lookup in the main loop with a retry."},
+        {"task_index": 1, "status": "completed", "summary": "## B\n\nUse hash map for the cache lookup in the main loop with a retry."},
+        {"task_index": 2, "status": "completed", "summary": "## C\n\nZebra rocket noodles teleport quietly through the quantum garden."},
+    ]}  # fmt: skip
+    _, _, drafts = select_best_draft(out)
+    # The near-identical pair is the norm; the most distinct draft (later
+    # index wins the tie) is the contrarian kept alive against consensus.
+    assert drafts[0]["contrarian"] is False
+    assert drafts[1]["contrarian"] is True
+    assert drafts[2]["contrarian"] is False
+
+
+def test_no_contrarian_when_single_ok_draft():
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "## A\n\nSolo draft with a summary and a link https://x.com"},
+        {"task_index": 1, "status": "timeout", "summary": ""},
+    ]}  # fmt: skip
+    _, _, drafts = select_best_draft(out)
+    assert drafts[0]["contrarian"] is False
+
+
+def test_distinctness_symmetric_and_bounded():
+    assert _distinctness("same same same", "same same same") == 0.0
+    assert _distinctness("aaa bbb ccc", "xxx yyy zzz") == 1.0
+    # 3 of 5 tokens shared → Jaccard 0.6 → distinctness 0.4.
+    assert _distinctness("alpha beta gamma", "alpha beta gamma delta epsilon") == 0.4
+
+
+def test_contrarian_surfaces_in_cli(capsys, monkeypatch):
+    payload = json.dumps({"results": [
+        {"task_index": 0, "status": "completed", "summary": "Use cache for the lookup loop"},
+        {"task_index": 1, "status": "completed", "summary": "Use cache for the lookup loop"},
+        {"task_index": 2, "status": "completed", "summary": "Zebra rockets teleport quantum noodles"},
+    ]})  # fmt: skip
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert main(["x", "select"]) == 0
+    drafts = json.loads(capsys.readouterr().out)["drafts"]
+    assert [d["contrarian"] for d in drafts] == [False, True, False]


### PR DESCRIPTION
Automated evolution PR for issue #2761 (conformity law, Science Advances 2026 study).

## What
`scripts/evolution_draft_selector.py` gains anti-conformity pressure:

- `_tokens` / `_distinctness` — variant distinctness metric (1 − Jaccard token similarity between summaries).
- `_contrarian_index` — finds the most distinct OK draft relative to the highest-scoring draft (the would-be norm); tie-breaks to the later index.
- `select_best_draft` now marks each draft with `contrarian: bool` (≥1 non-consensus variant kept alive per cycle, surfaced via the `select` CLI output).

Callers (orchestrator) can now prefer/keep the contrarian variant instead of letting commonness alone drive selection.

## Validation
- `pytest tests/scripts/test_evolution_draft_selector.py`: 19 passed (4 new: contrarian kept alive, no-contrarian single-draft, distinctness bounds, CLI surface)
- `ruff check` + `ruff format --check`: green
- Pre-PR shard: PASSED (`20260818T073426.log`)
- Diff: 86 changed lines

## Deferred (next increment)
- Skill-usage-frequency audit in the introspection stage (flag skills adopted by commonness rather than measured quality).