### PR TITLE
feat: anti-conformity pressure — diversity metric + contrarian selection (Closes #2761)

### DIFF
--- a/evolution/lib/tool_batch_evolution.py
+++ b/evolution/lib/tool_batch_evolution.py
@@ -27,6 +27,7 @@ New module, no changes to existing tool loading. Module ≤ 200 lines.
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Sequence
@@ -42,6 +43,8 @@ __all__ = [
     "select_best",
     "transferability_score",
     "accept_best",
+    "variant_distinctness",
+    "select_with_anti_conformity",
 ]
 
 # Deterministic mutation hints cycled across variants; the variant index
@@ -153,3 +156,55 @@ def accept_best(
     if transferability_score(origin_results, held_out_results) < threshold:
         return None
     return best
+
+
+def variant_distinctness(variants: Sequence[SynthesizedTool]) -> float:
+    """Diversity metric over a candidate set (anti-conformity, #2761).
+
+    Returns the fraction of variants whose description is pairwise distinct
+    from every other variant's description. 1.0 = all variants are unique
+    (maximal diversity); 0.0 = every variant is a duplicate of another. A
+    population that has converged on one common description scores 0.0 — the
+    signal that anti-conformity pressure should kick in.
+    """
+    if len(variants) < 2:
+        return 1.0
+    descs = [v.description for v in variants]
+    unique = 0
+    for i, d in enumerate(descs):
+        if all(d != descs[j] for j in range(len(descs)) if j != i):
+            unique += 1
+    return unique / len(descs)
+
+
+def select_with_anti_conformity(
+    results: Sequence[VariantResult],
+    *,
+    min_distinctness: float = 0.5,
+) -> Optional[SynthesizedTool]:
+    """Select the best variant while keeping ≥1 contrarian variant alive.
+
+    Anti-conformity pressure (#2761): once a mediocre variant becomes common
+    in shared state, downstream agents conform to it without any selection
+    pressure forcing that choice (the conformity law). To resist premature
+    convergence, this selection keeps the highest-scoring variant whose
+    description is NOT the most common one — a contrarian — when the
+    population's distinctness falls below *min_distinctness*.
+
+    Returns the best passing variant, or the best contrarian passing variant
+    when the population has converged. None if nothing passes.
+    """
+    passing = [r for r in results if r.passed]
+    if not passing:
+        return None
+    best = max(passing, key=lambda r: r.score)
+    if variant_distinctness([r.variant for r in passing]) >= min_distinctness:
+        return best.variant
+    # Population has converged — keep a contrarian variant alive.
+    descs = [r.variant.description for r in passing]
+    counts = Counter(descs)
+    most_common = counts.most_common(1)[0][0]
+    contrarians = [r for r in passing if r.variant.description != most_common]
+    if not contrarians:
+        return best.variant
+    return max(contrarians, key=lambda r: r.score).variant

--- a/tests/evolution/test_tool_batch_evolution.py
+++ b/tests/evolution/test_tool_batch_evolution.py
@@ -7,7 +7,9 @@ from evolution.lib.tool_batch_evolution import (
     propose_variants,
     run_batch,
     select_best,
+    select_with_anti_conformity,
     transferability_score,
+    variant_distinctness,
 )
 from evolution.lib.tool_synthesis import SynthesizedTool, ToolProposer
 
@@ -104,13 +106,33 @@ class TestSelectBest:
 
 class TestTransferabilityScore:
     def test_equal_pass_rates_score_one(self):
-        origin = _results([("a", True, 1.0), ("b", True, 1.0), ("c", False, 0.0), ("d", False, 0.0)])
-        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", True, 1.0), ("d", False, 0.0)])
+        origin = _results([
+            ("a", True, 1.0),
+            ("b", True, 1.0),
+            ("c", False, 0.0),
+            ("d", False, 0.0),
+        ])
+        held = _results([
+            ("a", True, 1.0),
+            ("b", False, 0.0),
+            ("c", True, 1.0),
+            ("d", False, 0.0),
+        ])
         assert transferability_score(origin, held) == 1.0
 
     def test_partial_transfer_ratio(self):
-        origin = _results([("a", True, 1.0), ("b", True, 1.0), ("c", True, 1.0), ("d", True, 1.0)])
-        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", False, 0.0), ("d", False, 0.0)])
+        origin = _results([
+            ("a", True, 1.0),
+            ("b", True, 1.0),
+            ("c", True, 1.0),
+            ("d", True, 1.0),
+        ])
+        held = _results([
+            ("a", True, 1.0),
+            ("b", False, 0.0),
+            ("c", False, 0.0),
+            ("d", False, 0.0),
+        ])
         assert transferability_score(origin, held) == 0.25
 
     def test_zero_origin_rate_is_zero_even_if_held_out_passes(self):
@@ -130,8 +152,20 @@ class TestAcceptBest:
         assert accept_best(origin, held) is None
 
     def test_accepts_transferable_variant_and_returns_best(self):
-        origin = _results([("a", True, 0.9), ("b", True, 0.6), ("c", True, 0.7), ("d", False, 0.0), ("e", False, 0.0)])
-        held = _results([("a", True, 1.0), ("b", False, 0.0), ("c", True, 1.0), ("d", True, 1.0), ("e", False, 0.0)])
+        origin = _results([
+            ("a", True, 0.9),
+            ("b", True, 0.6),
+            ("c", True, 0.7),
+            ("d", False, 0.0),
+            ("e", False, 0.0),
+        ])
+        held = _results([
+            ("a", True, 1.0),
+            ("b", False, 0.0),
+            ("c", True, 1.0),
+            ("d", True, 1.0),
+            ("e", False, 0.0),
+        ])
         best = accept_best(origin, held)
         assert best is not None
         assert best.name == "a"
@@ -164,3 +198,75 @@ class TestEndToEnd:
         assert best is not None
         assert best.accepted is False
         assert accept_best(results, results) is not None
+
+
+class TestVariantDistinctness:
+    """Diversity metric (anti-conformity, #2761)."""
+
+    def test_all_unique_scores_one(self):
+        variants = [_variant(f"v{i}") for i in range(4)]
+        assert variant_distinctness(variants) == 1.0
+
+    def test_all_duplicates_scores_zero(self):
+        variants = [_variant("v0") for _ in range(4)]
+        assert variant_distinctness(variants) == 0.0
+
+    def test_single_variant_scores_one(self):
+        assert variant_distinctness([_variant("v0")]) == 1.0
+
+    def test_empty_scores_one(self):
+        assert variant_distinctness([]) == 1.0
+
+    def test_partial_duplication(self):
+        # v0 duplicated twice, v1/v2 unique → 2 of 4 are unique.
+        variants = [_variant("v0"), _variant("v0"), _variant("v1"), _variant("v2")]
+        assert variant_distinctness(variants) == 0.5
+
+
+class TestSelectWithAntiConformity:
+    """Anti-conformity pressure keeps a contrarian variant alive (#2761)."""
+
+    def test_diverse_population_keeps_best(self):
+        # All distinct → no pressure → best score wins.
+        results = _results([("a", True, 0.5), ("b", True, 0.9), ("c", True, 0.7)])
+        assert select_with_anti_conformity(results).name == "b"
+
+    def test_converged_population_keeps_contrarian(self):
+        # a and b share a description (converged); c is the contrarian.
+        a = _result("a", True, 0.9)
+        b = _result("b", True, 0.8)
+        c = _result("c", True, 0.6)
+        a.variant.description = "common"
+        b.variant.description = "common"
+        c.variant.description = "contrarian"
+        # Best is a (0.9) but it's the common norm — keep the contrarian c.
+        assert select_with_anti_conformity([a, b, c]).name == "c"
+
+    def test_converged_keeps_highest_scoring_contrarian(self):
+        a = _result("a", True, 0.9)
+        b = _result("b", True, 0.8)
+        c = _result("c", True, 0.7)
+        d = _result("d", True, 0.6)
+        e = _result("e", True, 0.5)
+        a.variant.description = "common"
+        b.variant.description = "common"
+        c.variant.description = "common"
+        d.variant.description = "contrarian-1"
+        e.variant.description = "contrarian-2"
+        # 3 common + 2 contrarian → distinctness = 2/5 = 0.4 < 0.5 (converged).
+        # Contrarians are d (0.6) and e (0.5); keep the higher-scoring one (d).
+        assert select_with_anti_conformity([a, b, c, d, e]).name == "d"
+
+    def test_all_converged_falls_back_to_best(self):
+        # Every variant shares the same description → no contrarian exists.
+        results = _results([("a", True, 0.9), ("b", True, 0.8)])
+        for r in results:
+            r.variant.description = "same"
+        assert select_with_anti_conformity(results).name == "a"
+
+    def test_none_pass_returns_none(self):
+        results = _results([("a", False, 0.0), ("b", False, 0.1)])
+        assert select_with_anti_conformity(results) is None
+
+    def test_empty_returns_none(self):
+        assert select_with_anti_conformity([]) is None


### PR DESCRIPTION
Automated evolution PR for issue #2761 (anti-conformity pressure, research-derived from Science Advances / De Marzo 2026).

## What
Adds an explicit diversity metric to the evolution candidate-selection step and a rule keeping ≥1 contrarian variant alive per cycle:

1. **`variant_distinctness`** — fraction of variants whose description is pairwise distinct. 1.0 = maximal diversity; 0.0 = fully converged.
2. **`select_with_anti_conformity`** — selects the best passing variant, but when the population has converged (distinctness < threshold) keeps the highest-scoring contrarian variant (one whose description is NOT the most common) alive, resisting premature convergence.

## Validation
- Pre-PR targeted shard: PASSED
- `ruff check` + `ruff format --check`: green
- `pytest tests/evolution/test_tool_batch_evolution.py`: 32 passed (11 new tests)
- Diff size: 173 changed lines (within the autonomous merge cap)