### PR TITLE
feat: govern memory->skill promotion with an explicit evidence bar (Closes #2746)

### DIFF
--- a/evolution/lib/skill_crystallizer.py
+++ b/evolution/lib/skill_crystallizer.py
@@ -25,6 +25,15 @@ __all__ = [
 
 MAX_SKILL_SIZE_BYTES = 15 * 1024  # 15 KB strict gate
 
+# Evidence bar for promoting a memory/trace into a reusable skill (#2746).
+# A candidate must clear ALL of these to be promoted — the explicit guardrail
+# governing the memory->skill distillation path, so a single lucky trace does
+# not silently become a persistent skill that compounds its errors.
+MIN_REUSABILITY_SCORE = 0.6  # reusability heuristic must clear this
+MIN_DISTINCT_TOOLS = 2  # must exercise more than one tool (real workflow)
+MIN_ACTIONS = 3  # must be a non-trivial multi-step workflow
+REQUIRE_VERIFIED = True  # trace must be a verified success, not just "ok"
+
 
 @dataclass
 class CrystallizedSkillCandidate:
@@ -69,6 +78,48 @@ class SkillCrystallizer:
         clean = re.sub(r"[^a-zA-Z0-9_-]", "-", name.strip().lower())
         clean = re.sub(r"-+", "-", clean).strip("-")
         return clean or "crystallized-skill"
+
+    @classmethod
+    def meets_evidence_bar(
+        cls,
+        candidate: CrystallizedSkillCandidate,
+        *,
+        distinct_tools: int = 0,
+        action_count: int = 0,
+        verified: bool = True,
+    ) -> Tuple[bool, str]:
+        """Check a candidate against the memory->skill evidence bar (#2746).
+
+        The explicit guardrail governing which memories/traces may be promoted
+        to persistent skills. A candidate must clear ALL of:
+          - reusability score >= MIN_REUSABILITY_SCORE
+          - exercised >= MIN_DISTINCT_TOOLS distinct tools
+          - >= MIN_ACTIONS total actions (non-trivial workflow)
+          - verified success (REQUIRE_VERIFIED)
+
+        Returns (passes, reason). A candidate that fails is NOT promoted —
+        it stays a provisional memory rather than becoming a persistent skill
+        that could compound its errors.
+        """
+        if candidate.reusability_score < MIN_REUSABILITY_SCORE:
+            return (
+                False,
+                f"reusability {candidate.reusability_score:.2f} < "
+                f"{MIN_REUSABILITY_SCORE}",
+            )
+        if distinct_tools < MIN_DISTINCT_TOOLS:
+            return (
+                False,
+                f"only {distinct_tools} distinct tool(s), need >= {MIN_DISTINCT_TOOLS}",
+            )
+        if action_count < MIN_ACTIONS:
+            return (
+                False,
+                f"only {action_count} action(s), need >= {MIN_ACTIONS}",
+            )
+        if REQUIRE_VERIFIED and not verified:
+            return False, "trace not verified as a success"
+        return True, "meets evidence bar"
 
     @classmethod
     def reflect_on_trace(
@@ -148,7 +199,20 @@ tags:
         )
 
         ok, _ = cls.validate_candidate(candidate)
-        return candidate if ok else None
+        if not ok:
+            return None
+
+        # Evidence bar (#2746): only promote traces that clear the explicit
+        # memory->skill guardrail. A trace that is too thin, too single-tool,
+        # or not verified stays a provisional memory, not a persistent skill.
+        verified = status in {"success", "completed"}
+        bar_ok, _ = cls.meets_evidence_bar(
+            candidate,
+            distinct_tools=len(tools_used),
+            action_count=total_actions,
+            verified=verified,
+        )
+        return candidate if bar_ok else None
 
     @classmethod
     def validate_candidate(

--- a/tests/evolution/test_skill_crystallizer.py
+++ b/tests/evolution/test_skill_crystallizer.py
@@ -79,3 +79,79 @@ class TestSkillCrystallizer:
         assert saved_path.name == "SKILL.md"
         assert saved_path.parent.name == "test-workflow"
         assert saved_path.read_text(encoding="utf-8") == candidate.skill_markdown
+
+
+class TestEvidenceBar:
+    """Memory->skill evidence bar (#2746)."""
+
+    def _candidate(self, reusability: float = 0.8) -> CrystallizedSkillCandidate:
+        return CrystallizedSkillCandidate(
+            name="test",
+            description="test",
+            skill_markdown="---\nname: test\ndescription: test\n---\n# Body",
+            reusability_score=reusability,
+        )
+
+    def test_meets_bar_when_all_clear(self):
+        ok, reason = SkillCrystallizer.meets_evidence_bar(
+            self._candidate(), distinct_tools=3, action_count=5, verified=True
+        )
+        assert ok is True
+        assert "meets" in reason
+
+    def test_fails_low_reusability(self):
+        ok, reason = SkillCrystallizer.meets_evidence_bar(
+            self._candidate(reusability=0.3), distinct_tools=3, action_count=5
+        )
+        assert ok is False
+        assert "reusability" in reason
+
+    def test_fails_single_tool(self):
+        ok, reason = SkillCrystallizer.meets_evidence_bar(
+            self._candidate(), distinct_tools=1, action_count=5
+        )
+        assert ok is False
+        assert "distinct tool" in reason
+
+    def test_fails_too_few_actions(self):
+        ok, reason = SkillCrystallizer.meets_evidence_bar(
+            self._candidate(), distinct_tools=3, action_count=2
+        )
+        assert ok is False
+        assert "action" in reason
+
+    def test_fails_unverified(self):
+        ok, reason = SkillCrystallizer.meets_evidence_bar(
+            self._candidate(), distinct_tools=3, action_count=5, verified=False
+        )
+        assert ok is False
+        assert "verified" in reason
+
+    def test_reflect_rejects_single_tool_trace(self):
+        """A trace using only one tool must NOT be promoted to a skill."""
+        trace = {
+            "status": "success",
+            "session_id": "sess_single",
+            "goal": "Run a single command",
+            "tool_calls": [
+                {"name": "terminal", "arguments": '{"command": "ls"}'},
+                {"name": "terminal", "arguments": '{"command": "pwd"}'},
+                {"name": "terminal", "arguments": '{"command": "whoami"}'},
+            ],
+        }
+        assert SkillCrystallizer.reflect_on_trace(trace) is None
+
+    def test_reflect_rejects_unverified_status(self):
+        """A trace with status 'ok' (not verified success) must NOT promote."""
+        trace = {
+            "status": "ok",
+            "session_id": "sess_ok",
+            "goal": "Multi-tool workflow",
+            "tool_calls": [
+                {"name": "file_read", "arguments": '{"path": "a"}'},
+                {"name": "terminal", "arguments": '{"command": "x"}'},
+                {"name": "web_search", "arguments": "{}"},
+                {"name": "terminal", "arguments": '{"command": "y"}'},
+            ],
+        }
+        assert SkillCrystallizer.reflect_on_trace(trace) is None


### PR DESCRIPTION
Automated evolution PR for issue #2746 (memory->skill evidence bar, research-derived from arXiv 2607.16621).

## What
Adds an explicit evidence bar to the skill crystallization path (the pipeline's own memory->skill distillation move):

- **`meets_evidence_bar`** — a candidate must clear a reusability floor (>= 0.6), exercise >= 2 distinct tools, be a non-trivial multi-step workflow (>= 3 actions), and be a verified success before it is promoted to a persistent skill.
- Wired into `reflect_on_trace`: a thin, single-tool, or unverified trace stays a provisional memory instead of becoming a skill that could compound its errors.

## Validation
- Pre-PR targeted shard: PASSED
- `ruff check` + `ruff format --check`: green
- `pytest tests/evolution/test_skill_crystallizer.py`: 11 passed (7 new tests)
- Diff size: 142 changed lines (within the autonomous merge cap)