### PR TITLE
feat: wire anti-conformity pressure into the draft winner-pick path (Closes #2761)

### DIFF
--- a/scripts/evolution_draft_selector.py
+++ b/scripts/evolution_draft_selector.py
@@ -20,6 +20,14 @@ DEFAULT_MAX_DRAFTERS = 3
 _OK = frozenset({"completed", "success", "ok"})
 _PAT = r"(?:^|\n)\s*(?:#{1,3}\s|```|[-*]\s|\d+\.\s)"
 
+# ── Anti-conformity pressure (#2761) ─────────────────────────────────────────
+# A draft population has "converged" when the consensus winner has a near-twin
+# (another OK draft whose summary is >= ANTICONFORMITY_SIMILARITY similar).
+# Selection then keeps the highest-scoring CONTRARIAN (distinct) OK draft alive
+# instead of the consensus one, so what the next stage receives still contains
+# candidate diversity (conformity law).
+ANTICONFORMITY_SIMILARITY = 0.8
+
 # ── Cost-aware routing (#798 inc 2) ──────────────────────────────────────────
 # Map complexity bucket -> (tier label, config hint for delegation.model).
 # The hint is a *suggestion*: the orchestrator passes it to delegate_task's
@@ -117,6 +125,45 @@ def _score(text: str) -> float:
     return round(s, 4)
 
 
+def _summary_similarity(a: str, b: str) -> float:
+    """Word-set Jaccard similarity between two summaries (0.0–1.0)."""
+    if not a or not b:
+        return 0.0
+    wa = set(re.findall(r"[a-z0-9]+", a.lower()))
+    wb = set(re.findall(r"[a-z0-9]+", b.lower()))
+    if not wa or not wb:
+        return 0.0
+    return len(wa & wb) / len(wa | wb)
+
+
+def _distinct_variants(drafts: List[Dict[str, Any]]) -> Tuple[int, float]:
+    """Pick the winner with anti-conformity pressure applied (#2761).
+
+    Baseline is the best-scoring OK draft. When the population has converged
+    — the baseline has a near-twin (>= ANTICONFORMITY_SIMILARITY similar) —
+    and a genuinely distinct OK variant exists, the highest-scoring distinct
+    variant wins instead. Every OK draft gets a ``contrarian`` flag (distinct
+    from the consensus) so the orchestrator's output shows which variant the
+    pressure kept alive. Returns (best_index, best_score).
+    """
+    ok = [d for d in drafts if d["ok"]]
+    if not ok:
+        return -1, 0.0
+    best = max(ok, key=lambda d: d["score"])
+    for d in ok:
+        d["contrarian"] = (
+            _summary_similarity(d["summary"], best["summary"])
+            < ANTICONFORMITY_SIMILARITY
+        )
+    if not any(d["index"] != best["index"] and not d["contrarian"] for d in ok):
+        return best["index"], best["score"]
+    contrarians = [d for d in ok if d["contrarian"]]
+    if not contrarians:
+        return best["index"], best["score"]
+    alt = max(contrarians, key=lambda d: d["score"])
+    return alt["index"], alt["score"]
+
+
 def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, Any]]]:
     """Score drafts, pick winner: (best_index, best_score, drafts)."""
     results = (
@@ -142,10 +189,7 @@ def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, 
             "score": _score(sm) if ok else 0.0,
         })
     drafts.sort(key=lambda d: d["index"])
-    bi, bs = -1, 0.0
-    for d in drafts:
-        if d["ok"] and d["score"] > bs:
-            bs, bi = d["score"], d["index"]
+    bi, bs = _distinct_variants(drafts)
     return bi, bs, drafts
 
 

--- a/tests/scripts/test_evolution_draft_selector.py
+++ b/tests/scripts/test_evolution_draft_selector.py
@@ -42,6 +42,47 @@ def test_select():
         assert select_best_draft(bad)[0] == -1
 
 
+# ── Anti-conformity pressure (#2761) ─────────────────────────────────────────
+_CONSENSUS = "## Plan\n\n```python\nx = 1\n```\n\nhttps://a.example.com\n" * 3
+_TWIN = "## Plan\n\n```python\nx = 1\n```\n\nhttps://a.example.com\n" * 3
+_CONTRARIAN = "## Alt\n\n```python\ny = 2\n```\n\nhttps://b.example.com\n" * 3
+
+
+def test_select_keeps_contrarian_when_population_converged():
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": _CONSENSUS},
+        {"task_index": 1, "status": "completed", "summary": _TWIN},
+        {"task_index": 2, "status": "completed", "summary": _CONTRARIAN},
+    ]}  # fmt: skip
+    bi, bs, drafts = select_best_draft(out)
+    # The converged consensus (0/1) does NOT win; the distinct variant does.
+    assert bi == 2 and bs > 0.0
+    flags = {d["index"]: d.get("contrarian", None) for d in drafts}
+    assert flags[0] is False and flags[1] is False and flags[2] is True
+
+
+def test_select_unchanged_when_population_diverse():
+    # No near-twin of the winner → anti-conformity is a no-op (best wins).
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": _CONSENSUS},
+        {"task_index": 2, "status": "completed", "summary": _CONTRARIAN},
+    ]}  # fmt: skip
+    bi, _, drafts = select_best_draft(out)
+    assert bi == 0
+    assert drafts[0]["contrarian"] is False and drafts[1]["contrarian"] is True
+
+
+def test_select_unchanged_when_all_converged():
+    # Every OK draft is a twin of the consensus → nothing distinct to keep.
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": _CONSENSUS},
+        {"task_index": 1, "status": "completed", "summary": _TWIN},
+    ]}  # fmt: skip
+    bi, _, drafts = select_best_draft(out)
+    assert bi == 0
+    assert all(d["contrarian"] is False for d in drafts)
+
+
 def test_cli(capsys, monkeypatch):
     assert main(["x", "build", "--goal", "g", "--drafters", "2"]) == 0
     assert len(json.loads(capsys.readouterr().out)["tasks"]) == 2

--- a/tests/scripts/test_evolution_orchestrator.py
+++ b/tests/scripts/test_evolution_orchestrator.py
@@ -335,6 +335,30 @@ class TestDraftCommands:
         out = json.loads(capsys.readouterr().out)
         assert out["best_index"] == 0
 
+    def test_draft_select_keeps_contrarian_winner(self, capsys, tmp_path):
+        # Anti-conformity pressure (#2761) on the REAL wired path: the
+        # orchestrator's draft-select must hand the next stage the contrarian
+        # variant when the population has converged on one consensus idea.
+        consensus = "## Plan\n\n```python\nx = 1\n```\n\nhttps://a.example.com\n" * 3
+        twin = "## Plan\n\n```python\nx = 1\n```\n\nhttps://a.example.com\n" * 3
+        contrarian = "## Alt\n\n```python\ny = 2\n```\n\nhttps://b.example.com\n" * 3
+        results = tmp_path / "results.json"
+        results.write_text(
+            json.dumps({
+                "results": [
+                    {"task_index": 0, "status": "completed", "summary": consensus},
+                    {"task_index": 1, "status": "completed", "summary": twin},
+                    {"task_index": 2, "status": "completed", "summary": contrarian},
+                ]
+            }),
+            encoding="utf-8",
+        )
+        rc = main(["evolution_orchestrator.py", "draft-select", str(results)])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["best_index"] == 2
+        assert out["drafts"][2]["contrarian"] is True
+
     def test_draft_select_bad_json(self, capsys, monkeypatch):
         monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
         rc = main(["evolution_orchestrator.py", "draft-select"])


### PR DESCRIPTION
Automated evolution PR for issue #2761 (needs-work rework).

**Rework decision: REWORK.** Both prior attempts (#2769/#2770) failed code review for the same root cause — the anti-conformity rule never changed an outcome:
- #2770 added `variant_distinctness`/`select_with_anti_conformity` to `evolution/lib/tool_batch_evolution.py` with zero call sites (and that module has NO production consumer on main at all — only its own tests, verified this session).
- #2769 added a `contrarian` flag to `select_best_draft` but the selection logic stayed `max(score)` — the flag was printed, never consumed.

**What this PR does** — wires the pressure into the REAL winner-pick path, `select_best_draft` → orchestrator `draft-select` (the only wired call site that hands a winner to the next stage):
- `_distinct_variants()` picks the best-scoring OK draft as baseline; if the population has converged (baseline has a near-twin ≥ 0.8 word-set-Jaccard similar) AND a genuinely distinct OK variant exists, the highest-scoring distinct (contrarian) variant wins instead. Every OK draft gets a `contrarian` flag so the orchestrator's JSON output shows which variant the pressure kept alive.
- When the population is diverse or fully converged (no distinct variant to keep), behavior is unchanged — pressure only fires when it would otherwise be crowded out.

**Definition of done (from the owner's rework brief):** a converged candidate population demonstrably keeps ≥1 non-consensus variant ALIVE in what the next stage actually receives — verified via the orchestrator `draft-select` path test (`test_draft_select_keeps_contrarian_winner`), not a standalone-function unit test.

**Checks:** pre-PR targeted shard PASS · ruff check + format clean · pytest affected suites 54/54 ✓ · full scripts suite 1515 passed, 1 pre-existing order-dependent flake (`test_real_escalation_ensures_issue`) reproduced identically on origin/main · diff 117 lines ≤ 200-line cap.