### PR TITLE
feat: anti-conformity draft selection on the real wired path (Closes #2761)

### DIFF
--- a/scripts/evolution_draft_selector.py
+++ b/scripts/evolution_draft_selector.py
@@ -117,8 +117,63 @@ def _score(text: str) -> float:
     return round(s, 4)
 
 
-def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, Any]]]:
-    """Score drafts, pick winner: (best_index, best_score, drafts)."""
+def _text_similarity(a: str, b: str) -> float:
+    """Jaccard similarity over word sets, 0..1 (0 = disjoint, 1 = identical)."""
+    wa, wb = set(a.lower().split()), set(b.lower().split())
+    if not wa or not wb:
+        return 0.0
+    return len(wa & wb) / len(wa | wb)
+
+
+def _consensus_similarity(drafts: List[Dict[str, Any]]) -> float:
+    """Top-2 similarity among OK drafts; 1.0 = the two best agree completely.
+
+    Convergence is measured by whether the *top contenders* (highest-scoring
+    OK drafts) are near-identical — not by the mean of all pairs, which is
+    diluted by the contrarian outlier itself (#2761).
+    """
+    ok = sorted([d for d in drafts if d["ok"]], key=lambda d: d["score"], reverse=True)
+    if len(ok) < 2:
+        return 0.0
+    return _text_similarity(ok[0]["summary"], ok[1]["summary"])
+
+
+def _contrarian_index(drafts: List[Dict[str, Any]]) -> int:
+    """Index of the OK draft least similar to the best-scoring draft.
+
+    The contrarian is the OK draft whose summary is farthest (lowest Jaccard)
+    from the consensus winner — the one that would be lost if we only kept
+    the best-scoring common draft.  Returns -1 when there are no OK drafts.
+    """
+    ok = sorted([d for d in drafts if d["ok"]], key=lambda d: d["score"], reverse=True)
+    if not ok:
+        return -1
+    best_summary = ok[0]["summary"]
+    if not best_summary:
+        return -1
+    worst, worst_sim = ok[0]["index"], 1.0
+    for d in ok:
+        sim = _text_similarity(d["summary"], best_summary)
+        if sim < worst_sim:
+            worst_sim, worst = sim, d["index"]
+    return worst
+
+
+def select_best_draft(
+    delegate_output: Any,
+    anti_conformity: bool = False,
+    distinctness_threshold: float = 0.2,
+) -> Tuple[int, float, List[Dict[str, Any]]]:
+    """Score drafts, pick winner: (best_index, best_score, drafts).
+
+    With ``anti_conformity=True``, a *converged* population (mean pairwise
+    similarity ≥ 1 - distinctness_threshold, i.e. distinctness below the
+    threshold) keeps the contrarian (non-consensus) OK draft alive instead of
+    the best-scoring common one — so a converged candidate population does not
+    collapse onto a single norm (anti-conformity, #2761).  When the population
+    is NOT converged, or anti_conformity is off, the highest-scoring OK draft
+    wins exactly as before.
+    """
     results = (
         delegate_output.get("results", [])
         if isinstance(delegate_output, dict)
@@ -143,9 +198,17 @@ def select_best_draft(delegate_output: Any) -> Tuple[int, float, List[Dict[str, 
         })
     drafts.sort(key=lambda d: d["index"])
     bi, bs = -1, 0.0
-    for d in drafts:
-        if d["ok"] and d["score"] > bs:
-            bs, bi = d["score"], d["index"]
+    if (
+        anti_conformity
+        and _consensus_similarity(drafts) >= 1.0 - distinctness_threshold
+    ):
+        bi = _contrarian_index(drafts)
+        if bi >= 0:
+            bs = next(d["score"] for d in drafts if d["index"] == bi)
+    if bi < 0:
+        for d in drafts:
+            if d["ok"] and d["score"] > bs:
+                bs, bi = d["score"], d["index"]
     return bi, bs, drafts
 
 

--- a/scripts/evolution_orchestrator.py
+++ b/scripts/evolution_orchestrator.py
@@ -456,22 +456,30 @@ def _cmd_draft_select(argv: List[str]) -> int:
     """Select the best draft from parallel draft results (#798).
 
     Real call site for ``select_best_draft``.  Reads delegate_task's JSON
-    output (from stdin or a file path) and prints the winner.
+    output (from stdin or a file path) and prints the winner.  With
+    ``--anti-conformity``, a converged population keeps the contrarian
+    (non-consensus) OK draft alive instead of the best-scoring common one
+    (#2761).
     """
     path: Optional[str] = None
+    anti_conformity = False
     i = 0
     while i < len(argv):
         arg = argv[i]
-        if arg.startswith("-"):
+        if arg == "--anti-conformity":
+            anti_conformity = True
+            i += 1
+        elif arg.startswith("-"):
             print(f"[evolution-orchestrator] unknown flag: {arg}", file=sys.stderr)
             return 2
-        path = arg
-        i += 1
+        else:
+            path = arg
+            i += 1
     data, err = _load_json(path)
     if err:
         print(f"[evolution-orchestrator] {err}", file=sys.stderr)
         return 2
-    bi, bs, drafts = select_best_draft(data)
+    bi, bs, drafts = select_best_draft(data, anti_conformity=anti_conformity)
     print(
         json.dumps(
             {"best_index": bi, "best_score": bs, "drafts": drafts}, ensure_ascii=False
@@ -521,7 +529,7 @@ def main(argv: List[str]) -> int:
             '  build         --subtask S --angle A [--angle A ...] [--max-workers N] [--toolsets a,b] [--complexity "task desc"]\n'
             "  collect       [results.json] [--angles angles.json]   (reads stdin if no path)\n"
             "  draft         --goal G [--drafters N] [--context C] [--toolsets a,b]\n"
-            "  draft-select  [results.json]   (reads stdin if no path)\n"
+            "  draft-select  [results.json] [--anti-conformity]   (reads stdin if no path)\n"
             '  route         --complexity "task desc"',
             file=sys.stderr,
         )

--- a/tests/scripts/test_evolution_draft_selector.py
+++ b/tests/scripts/test_evolution_draft_selector.py
@@ -129,3 +129,57 @@ def test_route_cli_positional(capsys):
 
 def test_route_cli_missing_complexity(capsys):
     assert main(["x", "route"]) == 2
+
+
+# ── anti-conformity tests (#2761) ────────────────────────────────────────────
+
+
+def test_converged_population_keeps_contrarian_with_flag():
+    """When drafts are near-identical (converged), anti-conformity picks
+    the contrarian outlier instead of the best-scoring common draft."""
+    # All OK; drafts 0-1 are near-identical, draft 2 is the contrarian.
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+        {"task_index": 1, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+        {"task_index": 2, "status": "completed", "summary": "## X\n\nhttps://y.com\n" * 3},
+    ]}  # fmt: skip
+    bi, bs, drafts = select_best_draft(out, anti_conformity=True)
+    # Draft 0 and 1 are identical -> consensus sim = 1.0 -> converged.
+    # Contrarian is the one least similar to the consensus -> draft 2.
+    assert bi == 2
+
+
+def test_diverse_population_ignores_flag():
+    """When drafts are diverse (not converged), anti-conformity falls back
+    to the normal best-scoring winner — the flag does not distort a healthy
+    population."""
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "## H\n\nhttps://a.com\n" * 3},
+        {"task_index": 1, "status": "completed", "summary": "## Q\n\nhttps://b.com\n" * 3},
+        {"task_index": 2, "status": "completed", "summary": "## Z\n\nhttps://c.com\n" * 3},
+    ]}  # fmt: skip
+    bi, bs, drafts = select_best_draft(out, anti_conformity=True)
+    # All three are disjoint -> consensus sim = 0.0 -> not converged -> best score wins.
+    bi_no_flag, _, _ = select_best_draft(out)
+    assert bi == bi_no_flag
+
+
+def test_flag_off_picks_best_score():
+    """Without the flag, converged populations pick best score (status quo)."""
+    out = {"results": [
+        {"task_index": 0, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+        {"task_index": 1, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+        {"task_index": 2, "status": "completed", "summary": "## X\n\nhttps://y.com\n" * 3},
+    ]}  # fmt: skip
+    bi, _, _ = select_best_draft(out, anti_conformity=False)
+    # Draft 0 and 1 have the same score; the first one with score > bs wins.
+    assert bi == 0
+
+
+def test_no_ok_drafts_returns_none_with_flag():
+    out = {"results": [
+        {"task_index": 0, "status": "timeout", "summary": ""},
+        {"task_index": 1, "status": "timeout", "summary": ""},
+    ]}  # fmt: skip
+    bi, bs, _ = select_best_draft(out, anti_conformity=True)
+    assert bi == -1 and bs == 0.0

--- a/tests/scripts/test_evolution_orchestrator.py
+++ b/tests/scripts/test_evolution_orchestrator.py
@@ -340,6 +340,38 @@ class TestDraftCommands:
         rc = main(["evolution_orchestrator.py", "draft-select"])
         assert rc == 2
 
+    def test_draft_select_anti_conformity_keeps_contrarian(self, capsys, monkeypatch):
+        """The real wired path (draft-select --anti-conformity) keeps the
+        contrarian OK draft alive in a converged population (#2761)."""
+        payload = json.dumps({
+            "results": [
+                {"task_index": 0, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+                {"task_index": 1, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+                {"task_index": 2, "status": "completed", "summary": "## X\n\nhttps://y.com\n" * 3},
+            ]
+        })  # fmt: skip
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+        rc = main(["evolution_orchestrator.py", "draft-select", "--anti-conformity"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        # Converged population -> contrarian (draft 2) wins, not best-score draft 0.
+        assert out["best_index"] == 2
+
+    def test_draft_select_anti_conformity_off_picks_best(self, capsys, monkeypatch):
+        """Without the flag, the same converged population picks best score."""
+        payload = json.dumps({
+            "results": [
+                {"task_index": 0, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+                {"task_index": 1, "status": "completed", "summary": "## H\n\nhttps://e.com\n" * 3},
+                {"task_index": 2, "status": "completed", "summary": "## X\n\nhttps://y.com\n" * 3},
+            ]
+        })  # fmt: skip
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+        rc = main(["evolution_orchestrator.py", "draft-select"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["best_index"] == 0
+
     def test_route_maps_complexity(self, capsys):
         rc = main(["evolution_orchestrator.py", "route", "--complexity", "fix typo"])
         assert rc == 0


### PR DESCRIPTION
Automated evolution PR for issue #2761 (rework).

**Rework of the rejected #2770 / #2769:** the prior attempts added anti-conformity as dead code (no call site) or as a no-effect flag. This rework wires it into the REAL selection call site — `select_best_draft` in `scripts/evolution_draft_selector.py`, invoked via `evolution_orchestrator.py draft-select --anti-conformity` (line 474).

**Behavior:** when a candidate population is converged (top-2 OK drafts near-identical, distinctness below threshold), the contrarian (non-consensus) OK draft is kept alive instead of the best-scoring common norm. Off by default — no behavior change unless the flag is set.

**Tests:** unit tests on `select_best_draft` + CLI tests on the real orchestrator path (converged population keeps contrarian; diverse population falls back to best score; flag off = status quo).

Closes #2761