### PR TITLE
feat: SkillProx S1 — re-execution verify primitive (Closes #2777)

### DIFF
--- a/evolution/lib/skill_prox.py
+++ b/evolution/lib/skill_prox.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""SkillProx Slice 1 — re-execution verify primitive for proposed skill edits (#2777).
+
+Child of #2744 (SkillProx validation gate).  A proposed skill edit is
+trustworthy only if re-running it on the *same* batch reproduces the same
+outcome — a proximal check that catches edits which pass once by luck but
+fail on re-execution (non-determinism, hidden state, order dependence).
+
+Components:
+
+1. **Re-execution verifier** — a pure function that applies a proposed edit
+   to a skill body, runs the edited skill against the same batch of inputs,
+   and returns a pass/fail verdict plus the per-input outcomes.
+2. **Verdict** — ``True`` when the edited skill passes every input in the
+   batch; ``False`` otherwise.  The verdict is *verified* because it is
+   derived from an actual re-run, not from the edit's author's claim.
+
+New module, no changes to existing skill loading.  Diff ≤ 200 lines.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ReExecutionVerdict",
+    "verify_skill_edit",
+]
+
+# A skill edit is a callable that transforms a skill body (str) into a new
+# body (str).  The verifier re-runs the *edited* body against the batch.
+SkillEdit = Callable[[str], str]
+# A runner executes a skill body against one input and returns a bool outcome.
+SkillRunner = Callable[[str, Any], bool]
+
+
+@dataclass
+class ReExecutionVerdict:
+    """Outcome of re-running a proposed skill edit on the same batch."""
+
+    passed: bool
+    per_input: Dict[str, bool] = field(default_factory=dict)
+    edited_body: str = ""
+    error: Optional[str] = None
+
+
+def verify_skill_edit(
+    original_body: str,
+    edit: SkillEdit,
+    batch: Sequence[Any],
+    runner: SkillRunner,
+    *,
+    input_keys: Optional[Sequence[str]] = None,
+) -> ReExecutionVerdict:
+    """Re-run a proposed skill edit on the same batch and return a verdict.
+
+    ``edit`` transforms ``original_body`` into the proposed new body.  The
+    edited body is then executed against every input in ``batch`` via
+    ``runner``; the verdict passes only when *all* inputs succeed.
+
+    ``input_keys`` optionally names each input (for the per-input map);
+    otherwise inputs are keyed by position.  A runner exception is treated
+    as a per-input failure (never a crash of the verifier itself).
+    """
+    try:
+        edited_body = edit(original_body)
+    except Exception as exc:  # noqa: BLE001 - an edit that throws is a failure
+        return ReExecutionVerdict(
+            passed=False,
+            edited_body=original_body,
+            error=f"edit raised: {exc}",
+        )
+
+    per_input: Dict[str, bool] = {}
+    for pos, inp in enumerate(batch):
+        key = input_keys[pos] if input_keys and pos < len(input_keys) else str(pos)
+        try:
+            per_input[key] = bool(runner(edited_body, inp))
+        except Exception as exc:  # noqa: BLE001 - a runner that throws is a failure
+            per_input[key] = False
+            logger.debug("skill_edit re-execution failed on %r: %s", key, exc)
+
+    return ReExecutionVerdict(
+        passed=all(per_input.values()) if per_input else False,
+        per_input=per_input,
+        edited_body=edited_body,
+    )

--- a/tests/evolution/test_skill_prox.py
+++ b/tests/evolution/test_skill_prox.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for SkillProx Slice 1 — re-execution verify primitive (#2777)."""
+
+from evolution.lib.skill_prox import ReExecutionVerdict, verify_skill_edit
+
+
+def _runner(body: str, inp: int) -> bool:
+    """A runner that passes when the body contains the input as a digit."""
+    return str(inp) in body
+
+
+def test_passes_when_edit_reruns_clean_on_all_inputs():
+    body = "handle 1"
+    edit = lambda b: b + " and 2"  # noqa: E731
+    verdict = verify_skill_edit(body, edit, [1, 2], _runner)
+    assert verdict.passed is True
+    assert verdict.per_input == {"0": True, "1": True}
+    assert "and 2" in verdict.edited_body
+
+
+def test_fails_when_any_input_fails_on_rerun():
+    body = "handle 1"
+    edit = lambda b: b + " and 2"  # noqa: E731
+    verdict = verify_skill_edit(body, edit, [1, 2, 3], _runner)
+    assert verdict.passed is False
+    assert verdict.per_input["2"] is False  # input 3 not handled
+
+
+def test_edit_that_raises_is_a_failure_not_a_crash():
+    def bad_edit(b: str) -> str:
+        raise RuntimeError("boom")
+
+    verdict = verify_skill_edit("x", bad_edit, [1], _runner)
+    assert verdict.passed is False
+    assert "boom" in (verdict.error or "")
+
+
+def test_runner_that_raises_is_a_per_input_failure():
+    def flaky_runner(body: str, inp: int) -> bool:
+        if inp == 2:
+            raise ValueError("nope")
+        return True
+
+    verdict = verify_skill_edit("x", lambda b: b, [1, 2], flaky_runner)
+    assert verdict.passed is False
+    assert verdict.per_input == {"0": True, "1": False}
+
+
+def test_empty_batch_is_not_a_pass():
+    verdict = verify_skill_edit("x", lambda b: b, [], _runner)
+    assert verdict.passed is False
+
+
+def test_input_keys_are_used_when_provided():
+    verdict = verify_skill_edit("1", lambda b: b, [1], _runner, input_keys=["a"])
+    assert verdict.per_input == {"a": True}
+
+
+def test_verdict_is_a_dataclass():
+    v = ReExecutionVerdict(passed=True)
+    assert v.per_input == {} and v.edited_body == "" and v.error is None


### PR DESCRIPTION
Automated evolution PR for issue #2777 (SkillProx Slice 1, child of #2744).

**Deliverable:** a pure function that re-runs a proposed skill edit on the same batch and returns a verified pass/fail verdict. An edit that throws, or a runner that throws on any input, is a failure — never a crash. Empty batch is not a pass.

**Tests:** 7 unit tests covering pass/fail, edit-throws, runner-throws, empty batch, and input keys. Ruff clean.

Closes #2777