### PR TITLE
fix(merge-gate): sync PRs must land as true merge commits, never squash (Closes #2783)

### DIFF
--- a/scripts/evolution_merge_gate.py
+++ b/scripts/evolution_merge_gate.py
@@ -101,6 +101,30 @@ def _norm(path: Any) -> str:
     return p.lower()
 
 
+def check_merge_method_policy(
+    head_branch: Optional[str], method: str
+) -> List[str]:
+    """Enforce the merge METHOD per PR class (#2783).
+
+    Upstream release-sync PRs (``sync/*`` branches) must land as TRUE MERGE
+    commits (``merge_method=merge``). A squash/rebase fold makes the upstream
+    release SHA unreachable from ``main``'s ancestry, so the next sync's
+    ``git rev-list --count main..<release>`` re-counts every integrated commit
+    (~979 at v2026.8.16) and multi-release catch-ups with 90+ conflicts keep
+    recurring. Everything else keeps the squash default (one commit per
+    evolution PR — the readable-mainline policy).
+    """
+    branch = (head_branch or "").strip()
+    if branch.startswith("sync/") and method != "merge":
+        return [
+            f"MERGE_METHOD: sync PR branch '{branch}' must merge with "
+            f"'--method merge' (true merge commit), not '{method}' — squash "
+            "breaks upstream-release ancestry and re-surfaces integrated "
+            "commits in every later sync (#2783)"
+        ]
+    return []
+
+
 def check_merge_policy(
     files: Sequence[Dict[str, Any]],
     max_lines: int = DEFAULT_MAX_LINES,
@@ -418,13 +442,14 @@ def _pr_snapshot(
     first, head later) leave open — a push landing between them would otherwise
     be merged with a SHA whose diff was never reviewed.
 
-    Returns ``(files, head)``. Fails CLOSED — ``(None, None)`` on a gh error, non-
-    JSON output, or a response that does not carry a proper ``files`` LIST. A
+    Returns ``(files, head, head_branch)``. Fails CLOSED — all-``None`` on a gh
+    error, non-JSON output, or a response that does not carry a proper ``files``
+    LIST. A
     missing ``files`` key is an unreadable PR, NOT "an empty, therefore safe,
     diff": the caller refuses to merge. ``head`` is ``None`` only when the files
     were readable but the SHA was absent.
     """
-    cmd = ["gh", "pr", "view", str(pr), "--json", "files,headRefOid"]
+    cmd = ["gh", "pr", "view", str(pr), "--json", "files,headRefOid,headRefName"]
     if repo:
         cmd += ["--repo", repo]
     code, out, _ = runner(cmd)
@@ -435,12 +460,13 @@ def _pr_snapshot(
     except ValueError:
         return None, None
     if not isinstance(data, dict) or not isinstance(data.get("files"), list):
-        return None, None
+        return None, None, None
     files = data["files"]
     head = data.get("headRefOid")
+    branch = data.get("headRefName") or ""
     if not isinstance(head, str) or not head:
-        return files, None
-    return files, head
+        return files, None, branch
+    return files, head, branch
 
 
 def _looks_like_test(path: str) -> bool:
@@ -557,7 +583,7 @@ def main(argv: List[str]) -> int:
     runner = _run
     # One snapshot: the files we review and the SHA we merge come from the SAME
     # gh read, so the policy is checked against exactly the commit that lands.
-    files, head = _pr_snapshot(pr, repo, runner)
+    files, head, head_branch = _pr_snapshot(pr, repo, runner)
     if files is None:
         print(
             f"[merge-gate] could not read PR #{pr} files (gh error / malformed response) — refusing to merge"
@@ -578,6 +604,7 @@ def main(argv: List[str]) -> int:
         floor_scores=floor_scores,
         pr_metrics=pr_metrics,
     )
+    violations += check_merge_method_policy(head_branch, method)
     if violations:
         print(f"[merge-gate] PR #{pr} BLOCKED from autonomous self-merge:")
         for v in violations:

--- a/skills/evolution/evolution-integration/SKILL.md
+++ b/skills/evolution/evolution-integration/SKILL.md
@@ -213,6 +213,12 @@ gh pr list --repo "$REPO" --state open --limit 50 \
 ```bash
 python3 scripts/evolution_merge_gate.py --pr <N> --repo "$REPO" --merge --method squash
 ```
+   **Exception — upstream sync PRs (#2783):** a PR whose head branch is `sync/*`
+   MUST merge with `--method merge` (a TRUE merge commit), never squash/rebase —
+   squash makes the upstream release SHA unreachable from `main`'s ancestry, so
+   every later sync re-counts integrated commits and multi-release catch-ups
+   with 90+ conflicts recur. The gate enforces this: `--method squash` on a
+   `sync/*` branch is a BLOCKED verdict (`MERGE_METHOD`).
    Non-zero exit = BLOCKED (policy violation, or the head moved since review). Do
    NOT merge blind. If the head moved, re-run the 2a code review + dead-code grep
    against the FULL current diff and retry; if the policy blocked it (oversized /

--- a/tests/scripts/test_evolution_merge_gate.py
+++ b/tests/scripts/test_evolution_merge_gate.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_merge_gate import (  # noqa: E402
     check_flip_gate,
+    check_merge_method_policy,
     check_merge_policy,
     check_merge_policy_with_quality,
     _pr_snapshot,
@@ -151,32 +152,35 @@ class TestPrSnapshot:
         runner = self._runner(
             0, {"files": [_f("a.py", 1, 0)], "headRefOid": "deadbeef01"}
         )
-        files, head = _pr_snapshot(7, "O/r", runner)
+        files, head, branch = _pr_snapshot(7, "O/r", runner)
         assert head == "deadbeef01"
         assert files == [_f("a.py", 1, 0)]
-        # Exactly ONE gh read, requesting BOTH fields together (the atomic snapshot).
+        assert branch == ""  # absent headRefName degrades to "" (not an error)
+        # Exactly ONE gh read, requesting ALL fields together (the atomic snapshot).
         assert len(runner.calls) == 1  # type: ignore[attr-defined]
-        assert "files,headRefOid" in runner.calls[0]  # type: ignore[attr-defined]
+        assert any(
+            "files,headRefOid" in a for a in runner.calls[0]  # type: ignore[attr-defined]
+        )
 
     def test_missing_files_key_fails_closed(self):
         # exit 0 but no "files" key — the original fail-open bug (`.get() or []`
         # treated this as an empty, safe diff). Must now refuse.
         runner = self._runner(0, {"headRefOid": "abc"})
-        assert _pr_snapshot(7, None, runner) == (None, None)
+        assert _pr_snapshot(7, None, runner)[:2] == (None, None)
 
     def test_files_not_a_list_fails_closed(self):
         runner = self._runner(0, {"files": "oops", "headRefOid": "abc"})
-        assert _pr_snapshot(7, None, runner) == (None, None)
+        assert _pr_snapshot(7, None, runner)[:2] == (None, None)
 
     def test_gh_error_fails_closed(self):
-        assert _pr_snapshot(7, None, self._runner(1, "")) == (None, None)
+        assert _pr_snapshot(7, None, self._runner(1, ""))[:2] == (None, None)
 
     def test_non_json_fails_closed(self):
-        assert _pr_snapshot(7, None, self._runner(0, "not json")) == (None, None)
+        assert _pr_snapshot(7, None, self._runner(0, "not json"))[:2] == (None, None)
 
     def test_files_readable_but_head_absent(self):
         runner = self._runner(0, {"files": []})
-        files, head = _pr_snapshot(7, None, runner)
+        files, head, _branch = _pr_snapshot(7, None, runner)
         assert files == [] and head is None
 
 
@@ -257,7 +261,7 @@ class TestMainWiring:
         # clean, mergeable diff (files present, head resolved) — post-#1244 the
         # gh IO is _pr_snapshot (files + head in one call), not _pr_files.
         monkeypatch.setattr(
-            emg, "_pr_snapshot", lambda pr, repo, runner: ([], "deadbeef")
+            emg, "_pr_snapshot", lambda pr, repo, runner: ([], "deadbeef", "evolution/issue-x")
         )
         monkeypatch.setattr(emg, "_run", lambda cmd: (0, "[]", ""))
 
@@ -469,3 +473,26 @@ class TestReachabilityIntegration:
             source_contents=source_contents,
         )
         assert violations == []
+
+
+class TestCheckMergeMethodPolicy:
+    """#2783: sync/* PRs must land as true merge commits, never squash."""
+
+    def test_sync_branch_squash_blocked(self):
+        v = check_merge_method_policy("sync/upstream-v2026.8.16.2", "squash")
+        assert v and "MERGE_METHOD" in v[0] and "merge" in v[0]
+
+    def test_sync_branch_rebase_blocked(self):
+        assert check_merge_method_policy("sync/upstream-release-x", "rebase")
+
+    def test_sync_branch_true_merge_allowed(self):
+        assert check_merge_method_policy("sync/upstream-release-x", "merge") == []
+
+    def test_evolution_branch_keeps_squash_default(self):
+        assert check_merge_method_policy("evolution/issue-1-foo", "squash") == []
+
+    def test_missing_branch_is_not_sync(self):
+        # headRefName absent (degraded snapshot) — never matches sync/, so the
+        # method policy opts out rather than blocking on missing data.
+        assert check_merge_method_policy(None, "squash") == []
+        assert check_merge_method_policy("", "squash") == []


### PR DESCRIPTION
Implements #2783 (root-cause fix from the #2776 escalation).

## Root cause
A squash-folded sync PR (like #2719) makes the upstream release tag unreachable from `main`'s ancestry. Every subsequent sync's `git rev-list --count main..<release>` then re-counts the ~979 already-integrated commits, inflating BEHIND and driving the recurring multi-release catch-ups with 90+ conflicts.

## What this adds
- **`check_merge_method_policy(head_branch, method)`** — a `sync/*` head branch accepts ONLY `merge_method=merge`; squash/rebase returns a blocking `MERGE_METHOD` verdict naming the reason. All other branches keep the squash default (one commit per evolution PR — the readable-mainline policy).
- **`_pr_snapshot()`** now also returns `headRefName` from the SAME single atomic `gh` read (no extra request, no new TOCTOU window).
- **Integration SKILL.md** — documents the exception at the merge command so a future integration stage that picks up a sync PR uses `--method merge`.
- **Tests**: 5 new policy tests (sync+squash blocked, sync+rebase blocked, sync+merge allowed, evolution branch keeps squash, missing branch opts out) + snapshot-arity updates.

## Verification
`pytest tests/scripts/test_evolution_merge_gate.py tests/scripts/test_evolution_skill_integrity.py` → 71 passed. ruff clean.

Note: this PR touches the merge-gate machinery itself (a high-risk path the gate refuses to self-merge) — merging under owner direction per the issue's DoD.