### PR TITLE
feat: SkillProx S2 — accept/reject memory for proposed skill edits (Closes #2778)

### DIFF
--- a/evolution/lib/skill_prox.py
+++ b/evolution/lib/skill_prox.py
@@ -20,15 +20,21 @@ New module, no changes to existing skill loading.  Diff ≤ 200 lines.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "ReExecutionVerdict",
     "verify_skill_edit",
+    "verify_skill_edit_with_memory",
+    "record_verdict",
+    "is_rejected",
+    "edit_key",
 ]
 
 # A skill edit is a callable that transforms a skill body (str) into a new
@@ -89,3 +95,121 @@ def verify_skill_edit(
         per_input=per_input,
         edited_body=edited_body,
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 2 — accept/reject memory (#2778): persist verdicts so a rejected
+# edit is never re-proposed. The edit's identity is the content hash of
+# (skill name, edited body): a byte-identical re-proposal is recognized
+# across runs without any proposer cooperation.
+# ──────────────────────────────────────────────────────────────────────
+
+_DEFAULT_STORE = ("skill-prox", "verdicts.jsonl")
+
+
+def _default_store_path() -> Path:
+    """Canonical store: $EVOLUTION_PROFILE_DIR or ~/.hermes/evolution."""
+    import os
+    from pathlib import Path as _P
+
+    base = os.environ.get("EVOLUTION_PROFILE_DIR") or str(_P.home() / ".hermes" / "evolution")
+    return _P(base).joinpath(*_DEFAULT_STORE)
+
+
+def edit_key(skill_name: str, edited_body: str) -> str:
+    """Stable identity of a proposed edit (sha256 of skill + body)."""
+    import hashlib
+
+    return hashlib.sha256(
+        f"{(skill_name or '').strip()}\n{edited_body or ''}".encode("utf-8")
+    ).hexdigest()
+
+
+def _load_verdicts(store_path: Path) -> Dict[str, bool]:
+    verdicts: Dict[str, bool] = {}
+    try:
+        for line in store_path.read_text(encoding="utf-8").splitlines():
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and isinstance(rec.get("key"), str):
+                verdicts[rec["key"]] = bool(rec.get("passed"))
+    except OSError:
+        pass
+    return verdicts
+
+
+def record_verdict(
+    skill_name: str,
+    edited_body: str,
+    passed: bool,
+    *,
+    store_path: Optional[Path] = None,
+) -> None:
+    """Append one verdict record (best-effort; never raises)."""
+    import time as _time
+
+    path = store_path or _default_store_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rec = {
+            "key": edit_key(skill_name, edited_body),
+            "skill": (skill_name or "")[:200],
+            "passed": bool(passed),
+            "recorded_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.debug("skill-prox verdict record failed: %s", exc)
+
+
+def is_rejected(skill_name: str, edited_body: str, *, store_path: Optional[Path] = None) -> bool:
+    """True when this EXACT edit already failed verification once.
+
+    Latest verdict wins (a later accept supersedes an earlier reject for the
+    same key — e.g. a fixed environment re-verification), and a rejected edit
+    must not be re-proposed while its reject stands.
+    """
+    verdicts = _load_verdicts(store_path or _default_store_path())
+    return verdicts.get(edit_key(skill_name, edited_body)) is False
+
+
+def verify_skill_edit_with_memory(
+    skill_name: str,
+    original_body: str,
+    edit: SkillEdit,
+    batch: Sequence[Any],
+    runner: SkillRunner,
+    *,
+    input_keys: Optional[Sequence[str]] = None,
+    store_path: Optional[Path] = None,
+) -> ReExecutionVerdict:
+    """Verify an edit ONCE: a previously-rejected identical edit is skipped.
+
+    The gate the skill-evolution loop calls (#2744): a rejected edit returns
+    its recorded verdict without re-running the batch; a fresh edit is
+    verified and its verdict persisted, so the decision survives restarts.
+    """
+    # Cheap pre-check on the edited body (runs the edit; an edit that throws
+    # is a failed verdict, identical to verify_skill_edit).
+    try:
+        candidate_body = edit(original_body)
+    except Exception as exc:  # noqa: BLE001
+        verdict = ReExecutionVerdict(
+            passed=False, edited_body=original_body, error=f"edit raised: {exc}"
+        )
+        record_verdict(skill_name, original_body, False, store_path=store_path)
+        return verdict
+    if is_rejected(skill_name, candidate_body, store_path=store_path):
+        return ReExecutionVerdict(
+            passed=False,
+            edited_body=candidate_body,
+            error="previously rejected edit (skill-prox memory) — not re-verified",
+        )
+    verdict = verify_skill_edit(
+        original_body, edit, batch, runner, input_keys=input_keys
+    )
+    record_verdict(skill_name, verdict.edited_body, verdict.passed, store_path=store_path)
+    return verdict

--- a/tests/evolution/test_skill_prox.py
+++ b/tests/evolution/test_skill_prox.py
@@ -59,3 +59,57 @@ def test_input_keys_are_used_when_provided():
 def test_verdict_is_a_dataclass():
     v = ReExecutionVerdict(passed=True)
     assert v.per_input == {} and v.edited_body == "" and v.error is None
+
+
+# ── Slice 2: accept/reject memory (#2778) ──────────────────────────────
+
+from evolution.lib.skill_prox import (  # noqa: E402
+    edit_key,
+    is_rejected,
+    record_verdict,
+    verify_skill_edit_with_memory,
+)
+
+
+def test_rejected_edit_is_recorded_and_not_reproposed(tmp_path):
+    store = tmp_path / "verdicts.jsonl"
+    calls = []
+
+    def runner(body: str, inp) -> bool:
+        calls.append(inp)
+        return False  # always fails → rejected
+
+    v1 = verify_skill_edit_with_memory(
+        "my-skill", "body", lambda b: b + "!", [1], runner, store_path=store
+    )
+    assert v1.passed is False and calls == [1]
+    assert is_rejected("my-skill", "body!", store_path=store)
+
+    # Identical re-proposal: NOT re-verified (the batch never re-runs).
+    v2 = verify_skill_edit_with_memory(
+        "my-skill", "body", lambda b: b + "!", [1], runner, store_path=store
+    )
+    assert v2.passed is False
+    assert "previously rejected" in (v2.error or "")
+    assert calls == [1]  # runner never re-ran
+
+
+def test_later_accept_supersedes_earlier_reject(tmp_path):
+    store = tmp_path / "verdicts.jsonl"
+    body = "edited"
+    record_verdict("s", body, False, store_path=store)
+    record_verdict("s", body, True, store_path=store)
+    assert is_rejected("s", body, store_path=store) is False
+
+
+def test_distinct_edits_are_independent(tmp_path):
+    store = tmp_path / "verdicts.jsonl"
+    record_verdict("s", "edit-A", False, store_path=store)
+    assert is_rejected("s", "edit-A", store_path=store)
+    assert is_rejected("s", "edit-B", store_path=store) is False
+
+
+def test_edit_key_is_stable_and_content_addressed():
+    assert edit_key("s", "b") == edit_key("s", "b")
+    assert edit_key("s", "b") != edit_key("s2", "b")
+    assert edit_key("s", "b") != edit_key("s", "b2")


### PR DESCRIPTION
Slice 2 of #2744 (SkillProx validation gate), building on the merged S1 re-execution verifier (#2792).

## What
- **`edit_key(skill, edited_body)`** — content-addressed edit identity (sha256): a re-proposal is recognized across runs/processes with zero proposer cooperation.
- **`record_verdict` / `is_rejected`** — append-only JSONL store at `$EVOLUTION_PROFILE_DIR/skill-prox/verdicts.jsonl`; latest verdict wins per key (a later accept supersedes an earlier reject, e.g. after an environment fix).
- **`verify_skill_edit_with_memory(...)`** — the gate the skill-evolution loop calls: a previously-rejected identical edit is skipped with its recorded verdict (the batch never re-runs — pinned by test), a fresh edit is verified via the S1 primitive and its verdict persisted, so decisions survive restarts.

## Tests (5)
not-re-proposed contract (runner never re-runs) · later-accept supersedes · distinct edits independent · key stability · plus the S1 suite still green (11 passed total). ruff clean. Diff ~160 lines ≤ cap.