### PR TITLE
feat: AgenticTx S2 — transactional skill hub, staged publish behind a validation gate (Closes #2763)

### DIFF
--- a/evolution/lib/skill_hub_tx.py
+++ b/evolution/lib/skill_hub_tx.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Agentic Transaction Slice 2 — transactional skill hub (#2763).
+
+Child of #2759 (Agentic Transaction, arXiv 2608.13900). Semantic atomicity
+for skill-card writes: a skill body becomes VISIBLE in the skill store only
+after its validation gate passes. The write is staged to a temp file on the
+target's filesystem, the gate runs against the staged body, and only a pass
+publishes — via ``os.replace`` (atomic on the same filesystem), so readers
+never observe a partially-valid skill. On failure the staged copy is
+discarded and the visible store is untouched (rollback by omission).
+
+Combined with the Slice 1 envelope (#2762): when an enabled
+``TransactionEnvelope`` is supplied, the publish registers a compensation
+that restores the prior body (or removes a newly created card), so a crash
+AFTER the atomic replace still rolls the store back to its pre-transaction
+state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from evolution.lib.agentic_tx import TransactionEnvelope
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["StagedSkillResult", "staged_skill_publish"]
+
+# Gate applied to the staged body: True = may become visible.
+SkillValidator = Callable[[str], bool]
+
+
+@dataclass
+class StagedSkillResult:
+    """Outcome of one staged skill-card write."""
+
+    published: bool
+    reason: str
+    prior_body: Optional[str] = None  # None also when no card existed before
+
+
+def staged_skill_publish(
+    skill_path: Path,
+    new_body: str,
+    validator: SkillValidator,
+    *,
+    envelope: Optional[TransactionEnvelope] = None,
+) -> StagedSkillResult:
+    """Stage → validate → atomic publish; discard on gate failure.
+
+    ``skill_path`` is the visible card (e.g. ``<skill>/SKILL.md``). The
+    staged temp file lives in the same directory (same filesystem → the
+    final ``os.replace`` is atomic). A throwing validator is a failure.
+    """
+    skill_path = Path(skill_path)
+    staged = skill_path.with_name(f".{skill_path.name}.tx-staged")
+    try:
+        staged.write_text(new_body, encoding="utf-8")
+    except OSError as exc:
+        return StagedSkillResult(False, f"stage failed: {exc}")
+
+    try:
+        try:
+            gate_passed = bool(validator(new_body))
+        except Exception as exc:  # noqa: BLE001 - a throwing gate fails closed
+            logger.debug("skill validator raised: %s", exc)
+            gate_passed = False
+        if not gate_passed:
+            return StagedSkillResult(
+                False, "validation gate failed — staged write discarded"
+            )
+
+        prior_body: Optional[str] = None
+        if skill_path.exists():
+            try:
+                prior_body = skill_path.read_text(encoding="utf-8")
+            except OSError:
+                prior_body = None
+
+        if envelope is not None and envelope.enabled:
+            envelope.register(
+                f"skill-card:{skill_path}",
+                _restore_compensation(skill_path, prior_body),
+            )
+
+        os.replace(staged, skill_path)  # the ONE atomic visibility switch
+        return StagedSkillResult(True, "published", prior_body=prior_body)
+    finally:
+        # Discard the staged copy on every non-published path (and a
+        # post-replace finally is a no-op — the file no longer exists).
+        try:
+            staged.unlink()
+        except OSError:
+            pass
+
+
+def _restore_compensation(skill_path: Path, prior_body: Optional[str]) -> Callable[[], None]:
+    """Compensation returning the card to its pre-transaction state."""
+
+    def _restore() -> None:
+        try:
+            if prior_body is None:
+                skill_path.unlink(missing_ok=True)
+            else:
+                skill_path.write_text(prior_body, encoding="utf-8")
+        except OSError as exc:
+            logger.warning("skill-card restore for %s failed: %s", skill_path, exc)
+
+    return _restore

--- a/tests/evolution/test_skill_hub_tx.py
+++ b/tests/evolution/test_skill_hub_tx.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Agentic Transaction Slice 2 — transactional skill hub tests (#2763)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution.lib.agentic_tx import begin  # noqa: E402
+from evolution.lib.skill_hub_tx import staged_skill_publish  # noqa: E402
+
+
+def _card(tmp_path: Path) -> Path:
+    card = tmp_path / "my-skill" / "SKILL.md"
+    card.parent.mkdir(parents=True, exist_ok=True)
+    card.write_text("old body", encoding="utf-8")
+    return card
+
+
+def test_gate_failure_discards_and_leaves_store_untouched(tmp_path):
+    card = _card(tmp_path)
+    result = staged_skill_publish(card, "broken body", lambda b: False)
+    assert result.published is False
+    assert "validation gate failed" in result.reason
+    assert card.read_text(encoding="utf-8") == "old body"
+    # No staged residue.
+    assert not list(card.parent.glob("*.tx-staged"))
+
+
+def test_gate_pass_publishes_atomically(tmp_path):
+    card = _card(tmp_path)
+    result = staged_skill_publish(card, "great body", lambda b: "great" in b)
+    assert result.published is True
+    assert card.read_text(encoding="utf-8") == "great body"
+    assert result.prior_body == "old body"
+
+
+def test_throwing_validator_fails_closed(tmp_path):
+    card = _card(tmp_path)
+
+    def boom(_b):
+        raise RuntimeError("gate crashed")
+
+    result = staged_skill_publish(card, "x", boom)
+    assert result.published is False
+    assert card.read_text(encoding="utf-8") == "old body"
+
+
+def test_envelope_rollback_restores_prior_body(tmp_path):
+    card = _card(tmp_path)
+    envelope = begin(enabled=True)
+    published = staged_skill_publish(
+        card, "new body", lambda b: True, envelope=envelope
+    )
+    assert published.published and card.read_text(encoding="utf-8") == "new body"
+    # A later mutation in the SAME transaction fails → rollback fires the
+    # skill-card compensation and the store returns to its pre-tx state
+    # (begin() re-raises after rolling back — by design in S1).
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        with envelope.begin():
+            raise RuntimeError("later mutation failed")
+    assert card.read_text(encoding="utf-8") == "old body"
+
+
+def test_envelope_rollback_removes_newly_created_card(tmp_path):
+    card = tmp_path / "fresh" / "SKILL.md"
+    card.parent.mkdir(parents=True)
+    envelope = begin(enabled=True)
+    result = staged_skill_publish(card, "first body", lambda b: True, envelope=envelope)
+    assert result.published and result.prior_body is None
+    envelope.rollback()
+    assert not card.exists()
+
+
+def test_disabled_envelope_registers_nothing(tmp_path):
+    card = _card(tmp_path)
+    envelope = begin(enabled=False)
+    staged_skill_publish(card, "v2", lambda b: True, envelope=envelope)
+    envelope.rollback()  # no compensations registered — v2 stays visible
+    assert card.read_text(encoding="utf-8") == "v2"


### PR DESCRIPTION
Slice 2 of #2759 (Agentic Transaction), building on the merged S1 envelope (#2794).

## The transactional-skill-hub pattern
A skill card becomes VISIBLE only after its validation gate passes:

1. **Stage** — the new body goes to a `.tx-staged` temp file in the card's own directory (same filesystem, so the final switch is atomic).
2. **Gate** — the validator runs against the staged body; a throwing gate fails closed.
3. **Publish or discard** — a pass publishes via ONE `os.replace` (atomic visibility: readers never see a partially-valid skill); a fail discards the staged copy, leaving the visible store untouched (rollback by omission, no residue).

## Envelope integration (S1)
With an enabled `TransactionEnvelope`, the publish registers a compensation restoring the prior body — or removing a newly created card — so even a crash AFTER the atomic replace rolls the store back to its pre-transaction state (`test_envelope_rollback_restores_prior_body`, `test_envelope_rollback_removes_newly_created_card`).

## Tests (6) + S1 suite green (14 total). ruff clean. Diff ~190 lines ≤ cap.