### PR TITLE
feat: AgentOpt S2 — per-combo aggregation + Pareto frontier view (Closes #2742)

### DIFF
--- a/scripts/evolution_agentopt_report.py
+++ b/scripts/evolution_agentopt_report.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 2 — per-combo aggregation + Pareto frontier (#2742).
+
+Child of #2695. Deterministic aggregation over the Slice-1 telemetry JSONL
+(``agentopt_telemetry.record_llm_call``): per model-combination cost /
+latency / accuracy stats per task class, and the Pareto frontier of
+non-dominated combinations — the measured baseline Slice 3 feeds into the
+router.
+
+Grouping (deterministic; absent fields degrade, never crash):
+- ``combo``    — record["combo"] if present, else the single model name.
+- ``task``     — record["task_class"] or record["tool"] or "default".
+
+CLI: read the default Slice-1 store and print the aggregate as JSON.
+Exit 0 always — an empty/missing store reports empty stats, not an error.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.agentopt_telemetry import _store_path  # noqa: E402
+
+ComboKey = str  # "model-a+model-b" — sorted, deduplicated, "+"-joined
+
+
+def combo_key(record: Dict[str, Any]) -> ComboKey:
+    """Identity of the model combination that served one call."""
+    raw = record.get("combo")
+    models = (
+        [str(m) for m in raw if str(m)]
+        if isinstance(raw, (list, tuple))
+        else ([str(raw)] if raw else [str(record.get("model") or "unknown")])
+    )
+    return "+".join(sorted(set(models)))
+
+
+def task_class(record: Dict[str, Any]) -> str:
+    """Task class of one call — combo stats are reported per class."""
+    for field in ("task_class", "task", "tool"):
+        value = record.get(field)
+        if isinstance(value, str) and value:
+            return value
+    return "default"
+
+
+def load_records(store: Path) -> List[Dict[str, Any]]:
+    """Parse the Slice-1 JSONL; malformed lines are skipped, never fatal."""
+    try:
+        lines = store.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    out: List[Dict[str, Any]] = []
+    for line in lines:
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(rec, dict):
+            out.append(rec)
+    return out
+
+
+def aggregate(records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[ComboKey, Dict[str, Any]]]:
+    """Per task class × combo: calls, cost, mean latency, success rate."""
+    acc: Dict[str, Dict[ComboKey, Dict[str, Any]]] = {}
+    for rec in records:
+        cls, combo = task_class(rec), combo_key(rec)
+        bucket = acc.setdefault(cls, {}).setdefault(
+            combo, {"calls": 0, "cost": 0.0, "latency_sum": 0.0, "ok": 0}
+        )
+        bucket["calls"] += 1
+        try:
+            bucket["cost"] += float(rec.get("cost") or 0.0)
+        except (TypeError, ValueError):
+            pass
+        try:
+            bucket["latency_sum"] += float(rec.get("latency_ms") or 0.0)
+        except (TypeError, ValueError):
+            pass
+        if str(rec.get("outcome") or "").lower() in ("ok", "success", "true"):
+            bucket["ok"] += 1
+    for cls in acc:
+        for combo, bucket in acc[cls].items():
+            calls = bucket["calls"]
+            acc[cls][combo] = {
+                "calls": calls,
+                "cost": round(bucket["cost"], 6),
+                "avg_latency_ms": round(bucket["latency_sum"] / calls, 3) if calls else 0.0,
+                "success_rate": round(bucket["ok"] / calls, 4) if calls else 0.0,
+            }
+    return acc
+
+
+def _dominates(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    """a dominates b: no worse on cost/latency/success, strictly better somewhere."""
+    return (
+        a["cost"] <= b["cost"]
+        and a["avg_latency_ms"] <= b["avg_latency_ms"]
+        and a["success_rate"] >= b["success_rate"]
+        and (
+            a["cost"] < b["cost"]
+            or a["avg_latency_ms"] < b["avg_latency_ms"]
+            or a["success_rate"] > b["success_rate"]
+        )
+    )
+
+
+def pareto_frontier(stats: Dict[ComboKey, Dict[str, Any]]) -> List[ComboKey]:
+    """Combos not dominated by any other — deterministic (sorted) order."""
+    frontier = [
+        combo
+        for combo, own in stats.items()
+        if not any(
+            other != combo and _dominates(stats[other], own) for other in stats
+        )
+    ]
+    return sorted(frontier)
+
+
+def build_report(records: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate + frontier per task class — the Slice-3 router baseline."""
+    agg = aggregate(records)
+    return {
+        "task_classes": {
+            cls: {"combos": stats, "pareto_frontier": pareto_frontier(stats)}
+            for cls, stats in agg.items()
+        }
+    }
+
+
+def main(argv: List[str]) -> int:
+    path = Path(argv[1]) if len(argv) > 1 else _store_path()
+    report = build_report(load_records(path))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_agentopt_report.py
+++ b/tests/scripts/test_evolution_agentopt_report.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 2 — aggregation + Pareto frontier tests (#2742)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution_agentopt_report import (  # noqa: E402
+    aggregate,
+    build_report,
+    combo_key,
+    load_records,
+    pareto_frontier,
+    task_class,
+)
+
+
+def _rec(model, outcome="ok", cost=0.01, latency=100.0, **extra):
+    return {"model": model, "outcome": outcome, "cost": cost,
+            "latency_ms": latency, **extra}
+
+
+def test_combo_key_models_and_field_variants():
+    assert combo_key({"model": "m1"}) == "m1"
+    assert combo_key({"combo": ["m2", "m1"], "model": "x"}) == "m1+m2"  # sorted
+    assert combo_key({"combo": "solo"}) == "solo"
+    assert combo_key({}) == "unknown"
+
+
+def test_task_class_fallback_chain():
+    assert task_class({"task_class": "coding"}) == "coding"
+    assert task_class({"task": "t1", "tool": "terminal"}) == "t1"
+    assert task_class({"tool": "terminal"}) == "terminal"
+    assert task_class({}) == "default"
+
+
+def test_aggregate_stats_math():
+    stats = aggregate([
+        _rec("m1", cost=0.02, latency=100.0, task_class="coding"),
+        _rec("m1", outcome="fail", cost=0.04, latency=300.0, task_class="coding"),
+        _rec("m2", cost=0.01, latency=50.0, task_class="coding"),
+    ])
+    coding = stats["coding"]
+    assert coding["m1"]["calls"] == 2
+    assert coding["m1"]["cost"] == 0.06
+    assert coding["m1"]["avg_latency_ms"] == 200.0
+    assert coding["m1"]["success_rate"] == 0.5
+    assert coding["m2"]["success_rate"] == 1.0
+
+
+def test_pareto_frontier_dominated_and_nondominated():
+    stats = {
+        "cheap-fast-good": {"cost": 0.01, "avg_latency_ms": 50.0, "success_rate": 0.99, "calls": 5},
+        "expensive-slow-bad": {"cost": 0.05, "avg_latency_ms": 200.0, "success_rate": 0.90, "calls": 5},
+        "cheap-but-inaccurate": {"cost": 0.005, "avg_latency_ms": 60.0, "success_rate": 0.70, "calls": 5},
+    }
+    frontier = pareto_frontier(stats)
+    # The all-round worse combo is dominated off; the two trade-off combos stay.
+    assert "cheap-fast-good" in frontier and "cheap-but-inaccurate" in frontier
+    assert "expensive-slow-bad" not in frontier
+
+
+def test_load_records_skips_malformed_lines(tmp_path):
+    store = tmp_path / "calls.jsonl"
+    store.write_text(
+        json.dumps(_rec("m1")) + "\nnot json\n" + json.dumps(_rec("m2")) + "\n",
+        encoding="utf-8",
+    )
+    assert [r["model"] for r in load_records(store)] == ["m1", "m2"]
+    assert load_records(tmp_path / "missing.jsonl") == []
+
+
+def test_build_report_end_to_end(tmp_path):
+    store = tmp_path / "calls.jsonl"
+    store.write_text(
+        json.dumps(_rec("m1", cost=0.1, latency=500.0, task_class="eval"))
+        + "\n"
+        + json.dumps(_rec("m2", cost=0.01, latency=50.0, task_class="eval"))
+        + "\n",
+        encoding="utf-8",
+    )
+    report = build_report(load_records(store))
+    eval_cls = report["task_classes"]["eval"]
+    assert eval_cls["pareto_frontier"] == ["m2"]  # dominates m1 outright
+    assert eval_cls["combos"]["m2"]["success_rate"] == 1.0


### PR DESCRIPTION
Slice 2 of #2695 (AgentOpt / client-side model-combination optimizer), consuming the merged Slice-1 telemetry (#2755).

## What
- **Grouping** — `combo_key`: the record's `combo` field (list or scalar; sorted, deduped, `+`-joined) or its single model; `task_class`: `task_class` → `task` → `tool` → `'default'`. Absent fields degrade, never crash.
- **`aggregate()`** — per task class × combo: `calls`, `cost`, `avg_latency_ms`, `success_rate` (ok/success/true outcomes).
- **`pareto_frontier()`** — non-dominated combos under (cost ↓, latency ↓, success ↑) with strict improvement in at least one axis; trade-off combos correctly stay on the frontier. Sorted output for determinism.
- **`build_report()` + CLI** (`scripts/evolution_agentopt_report.py`) — reads the Slice-1 store (`_store_path`), prints the per-class aggregate + frontier as JSON. This is the measured combo baseline Slice 3 (#2743) feeds into the router. Empty/missing store → empty report, exit 0 (a quiet cron tick, not an error).

## Tests (6)
grouping variants · stats math · domination semantics (an all-round-worse combo is dominated off; a cheap-but-inaccurate trade-off survives) · malformed-line skip · missing-store empty · end-to-end report. Plus the S1 suite green (14 total). ruff clean. Diff ~195 lines ≤ cap.