### PR TITLE
fix(tests): nous-refresh test must not assume a quiet runner

### DIFF
--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -8023,7 +8023,12 @@ class TestNousCredentialRefresh:
         closed = {"value": False}
         retired = {"value": False}
         rebuilt = {"kwargs": None}
-        captured = {}
+        # Append-only call log: a leaked background refresher from an earlier
+        # test may ALSO hit the patched resolve mid-test (order-dependent,
+        # observed 3x on CI runners). A single dict got clobbered by that
+        # extra force_refresh=False call; a log lets the assertions target
+        # OUR call without assuming a quiet runner.
+        resolve_calls: list = []
 
         class _ExistingClient:
             def close(self):
@@ -8033,7 +8038,7 @@ class TestNousCredentialRefresh:
             pass
 
         def _fake_resolve(**kwargs):
-            captured.update(kwargs)
+            resolve_calls.append(kwargs)
             return {
                 "api_key": "new-nous-key",
                 "base_url": "https://inference-api.nousresearch.com/v1",
@@ -8069,7 +8074,9 @@ class TestNousCredentialRefresh:
         # TLS-FD→SQLite corruption vector.
         assert retired["value"] is True
         assert closed["value"] is False
-        assert captured["force_refresh"] is True
+        assert any(
+            c.get("force_refresh") is True for c in resolve_calls
+        ), f"our force=True call missing from {resolve_calls!r}"
         assert rebuilt["kwargs"]["api_key"] == "new-nous-key"
         assert (
             rebuilt["kwargs"]["base_url"] == "https://inference-api.nousresearch.com/v1"


### PR DESCRIPTION
De-flakes `TestNousCredentialRefresh::test_try_refresh_nous_client_credentials_rebuilds_client` — 3 CI reds on unrelated PRs in 2 days (slice 6 on 08-17, #2796 slice 12, #2805 slice 10; passes in isolation every time).

## Mechanism
The test captured `resolve_nous_runtime_credentials` kwargs in a single dict. A leaked background refresher thread from an earlier test in the same file-process can ALSO hit the patched symbol mid-test with `force_refresh=False`, clobbering the dict before the assertion — classic order dependence under the parallel runner.

## Fix
Append-only call log (`resolve_calls`) + `any(force_refresh is True)` assertion: an extra concurrent caller can append its own call but can never erase ours. All other assertions unchanged.