### PR TITLE
feat: RubricForge S3 — held-out false-pass gate for evolved-rubric adoption (Closes #2782)

### DIFF
--- a/evolution/lib/rubric_heldout_gate.py
+++ b/evolution/lib/rubric_heldout_gate.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""RubricForge Slice 3 — held-out false-pass gate (#2782).
+
+Child of #2760. An evolved rubric may overfit the labeled set it was
+selected on (agreement 1.0 by construction). Before ADOPTION the winner is
+re-measured on a HELD-OUT split it never saw: the gate permits adoption
+only when the evolved rubric's false-pass rate on the held-out examples
+does not exceed the GENERIC judge's baseline rate there.
+
+A "false pass" is a labeled-bad example the rubric accepts (verdict True on
+``label: False``) — the eval stage's failure mode RubricForge exists to
+halve. Pure functions over the S1 primitives; no LLM, no IO.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, Tuple
+
+from evolution.lib.rubric_forge import RubricJudge, score_rubric
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HeldOutVerdict", "split_labeled_set", "held_out_false_pass_gate"]
+
+
+@dataclass
+class HeldOutVerdict:
+    """Adoption decision for one evolved rubric."""
+
+    adopt: bool
+    evolved_false_pass_rate: float
+    baseline_false_pass_rate: float
+    held_out_size: int
+    reason: str
+
+
+def split_labeled_set(
+    labeled: Sequence[Any],
+    labels: Sequence[bool],
+    *,
+    holdout: int = 3,
+) -> Tuple[List[Any], List[bool], List[Any], List[bool]]:
+    """Deterministic tail split: the LAST ``holdout`` examples are held out.
+
+    Deterministic (no RNG) so adoption decisions are reproducible; callers
+    that want randomness shuffle before calling. Falls back to an empty
+    held-out set when the labeled set is too small to split.
+    """
+    if len(labeled) != len(labels):
+        raise ValueError("labeled and labels must be parallel sequences")
+    holdout = max(0, min(holdout, len(labeled) // 2))
+    cut = len(labeled) - holdout
+    return (
+        list(labeled[:cut]),
+        list(labels[:cut]),
+        list(labeled[cut:]),
+        list(labels[cut:]),
+    )
+
+
+def _false_pass_rate(
+    rubric: str, held_out: Sequence[Any], labels: Sequence[bool], judge: RubricJudge
+) -> float:
+    """Fraction of held-out labeled-BAD examples the rubric accepts anyway."""
+    bad = [(ex, lb) for ex, lb in zip(held_out, labels) if not lb]
+    if not bad:
+        return 0.0
+    false_passes = 0
+    for ex, _lb in bad:
+        try:
+            if bool(judge(rubric, ex)):
+                false_passes += 1
+        except Exception:  # noqa: BLE001 - a throwing judge accepts nothing
+            pass
+    return false_passes / len(bad)
+
+
+def held_out_false_pass_gate(
+    evolved_rubric: str,
+    generic_rubric: str,
+    labeled: Sequence[Any],
+    labels: Sequence[bool],
+    judge: RubricJudge,
+    *,
+    holdout: int = 3,
+) -> HeldOutVerdict:
+    """Gate evolved-rubric adoption on held-out false-pass parity (#2782).
+
+    Split the labeled set, re-check the evolved winner on the held-out tail,
+    and compare its false-pass rate there against the generic judge's.
+    Adoption is permitted only when the evolved rate does NOT exceed the
+    baseline (``<=``). An empty held-out set cannot prove parity — the gate
+    refuses (fail-closed) with the reason.
+    """
+    _, _, held_out, held_labels = split_labeled_set(labeled, labels, holdout=holdout)
+    if not held_out:
+        return HeldOutVerdict(
+            adopt=False,
+            evolved_false_pass_rate=0.0,
+            baseline_false_pass_rate=0.0,
+            held_out_size=0,
+            reason="held-out set empty — parity unprovable, refusing adoption",
+        )
+    evolved_rate = _false_pass_rate(evolved_rubric, held_out, held_labels, judge)
+    baseline_rate = _false_pass_rate(generic_rubric, held_out, held_labels, judge)
+    adopt = evolved_rate <= baseline_rate
+    reason = (
+        "evolved false-pass rate within baseline on held-out examples"
+        if adopt
+        else "evolved rubric false-passes MORE on held-out examples — overfit, blocked"
+    )
+    return HeldOutVerdict(
+        adopt=adopt,
+        evolved_false_pass_rate=evolved_rate,
+        baseline_false_pass_rate=baseline_rate,
+        held_out_size=len(held_out),
+        reason=reason,
+    )

--- a/scripts/evolution_rubric_judge.py
+++ b/scripts/evolution_rubric_judge.py
@@ -176,6 +176,15 @@ def _total_max() -> int:
     return sum(dim["max"] for dim in RUBRIC_DIMENSIONS.values())
 
 
+# Generic-judge baseline for the held-out gate (#2782): the shipped rubric
+# stated as text the keyword-requirements judge can apply — its criteria
+# labels are the requirements the generic judge has always enforced.
+_SHIPPED_RUBRIC_TEXT = "\n".join(
+    f"{dim}:\n" + "\n".join(f"  {c['label']}" for c in spec["criteria"].values())
+    for dim, spec in RUBRIC_DIMENSIONS.items()
+)
+
+
 def _keyword_requirements_judge(rubric_text: str, example: Any) -> bool:
     """Deterministic default judge for RubricForge agreement (#2780).
 
@@ -231,14 +240,44 @@ def resolve_active_rubric(evolution_dir: Path) -> Optional[Dict[str, Any]]:
         m = re.match(r"^([a-z_]+)\s*:\s*(\d+)\s*$", line.strip())
         if m and m.group(1) in RUBRIC_DIMENSIONS:
             max_overrides[m.group(1)] = float(m.group(2))
+    # Held-out false-pass gate (#2782): the winner was selected ON this
+    # labeled set, so before its overrides become the ACTIVE rubric it must
+    # prove false-pass parity on a held-out tail it never saw. Refusal
+    # means the shipped rubric runs (recorded as gate=blocked).
+    gate_verdict = None
+    active_text, active_agreement, active_overrides = best_text, agreement, max_overrides
+    try:
+        from evolution.lib.rubric_heldout_gate import held_out_false_pass_gate
+
+        gate_verdict = held_out_false_pass_gate(
+            best_text,
+            _SHIPPED_RUBRIC_TEXT,
+            labeled,
+            labels,
+            _keyword_requirements_judge,
+        )
+        if not gate_verdict.adopt:
+            active_text, active_agreement, active_overrides = "", 0.0, {}
+    except ImportError:
+        gate_verdict = None  # standalone deployment — no gate, run the winner
+
     try:
         rf_dir.mkdir(parents=True, exist_ok=True)
         (rf_dir / "selected.json").write_text(
             json.dumps(
                 {
-                    "rubric": best_text[:2000],
-                    "agreement": agreement,
-                    "max_overrides": max_overrides,
+                    "rubric": active_text[:2000],
+                    "agreement": active_agreement,
+                    "max_overrides": active_overrides,
+                    "held_out_gate": {
+                        "adopt": gate_verdict.adopt,
+                        "evolved_false_pass_rate": gate_verdict.evolved_false_pass_rate,
+                        "baseline_false_pass_rate": gate_verdict.baseline_false_pass_rate,
+                        "held_out_size": gate_verdict.held_out_size,
+                        "reason": gate_verdict.reason,
+                    }
+                    if gate_verdict is not None
+                    else None,
                     "selected_at": datetime.now().isoformat(),
                 },
                 indent=2,
@@ -247,7 +286,14 @@ def resolve_active_rubric(evolution_dir: Path) -> Optional[Dict[str, Any]]:
         )
     except OSError:
         pass
-    return {"rubric": best_text, "agreement": agreement, "max_overrides": max_overrides}
+    if not active_text:
+        return None  # gate blocked — the judge runs the shipped rubric
+    return {
+        "rubric": active_text,
+        "agreement": active_agreement,
+        "max_overrides": active_overrides,
+        "held_out_gate": gate_verdict,
+    }
 
 
 def _hot_path(evolution_dir: Path) -> Path:

--- a/tests/evolution/test_rubric_forge.py
+++ b/tests/evolution/test_rubric_forge.py
@@ -84,10 +84,16 @@ def test_resolve_active_rubric_absent_inputs_is_none(tmp_path):
 def test_score_applies_override_max(tmp_path, monkeypatch):
     """The judge's score() CONSUMES the winning rubric: dimension max follows
     the override line, and the run carries the rubric_forge verdict."""
+    # 4 examples: 2 train + 2 held-out (S3 gate needs a non-empty tail).
     _seed_rf(
         tmp_path,
         candidates=["research: 3\nmentions sources"],
-        labeled=[{"requires": ["sources"], "label": True}],
+        labeled=[
+            {"requires": ["sources"], "label": True},
+            {"requires": ["sources"], "label": True},
+            {"forbids": ["vibes"], "label": False},
+            {"forbids": ["guesses"], "label": False},
+        ],
     )
     judge = StrictRubricJudgeGrader()
     result = judge.score("2026-08-18", evolution_dir=tmp_path)

--- a/tests/evolution/test_rubric_heldout_gate.py
+++ b/tests/evolution/test_rubric_heldout_gate.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""RubricForge Slice 3 — held-out false-pass gate tests (#2782)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution.lib.rubric_heldout_gate import (  # noqa: E402
+    held_out_false_pass_gate,
+    split_labeled_set,
+)
+
+
+def _kw_judge(rubric: str, example) -> bool:
+    """Keyword-requirement judge mirroring the S1 wiring."""
+    ex = example if isinstance(example, dict) else {}
+    requires = [k for k in (ex.get("requires") or []) if isinstance(k, str)]
+    forbids = [k for k in (ex.get("forbids") or []) if isinstance(k, str)]
+    verdict = all(k in rubric for k in requires)
+    if forbids:
+        verdict = verdict and any(k in rubric for k in forbids)
+    return bool(verdict)
+
+
+def test_split_is_deterministic_tail_and_parallel():
+    train_x, train_y, held_x, held_y = split_labeled_set(
+        list(range(10)), [i % 2 == 0 for i in range(10)], holdout=3
+    )
+    assert train_x == list(range(7)) and held_x == [7, 8, 9]
+    assert held_y == [False, True, False]
+
+
+def test_split_too_small_degrades_to_empty_holdout():
+    _, _, held_x, held_y = split_labeled_set([1], [True], holdout=3)
+    assert held_x == [] and held_y == []
+
+
+def test_mismatched_inputs_raise():
+    try:
+        split_labeled_set([1, 2], [True])
+        raise SystemExit("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test_gate_blocks_overfit_evolved_rubric():
+    # Generic rubric covers the good examples; the evolved one ALSO waves
+    # through a held-out labeled-bad example → higher held-out false-pass.
+    labeled = [
+        {"requires": ["sources"], "label": True},
+        {"requires": ["urls"], "label": True},
+        {"requires": ["sources"], "label": True},
+        {"requires": ["depth"], "label": True},
+        {"requires": ["vibes"], "label": False},  # held-out bad example
+        {"requires": ["guesses"], "label": False},
+    ]
+    labels = [e["label"] for e in labeled]
+    generic = "sources urls depth"
+    overfit = "sources urls depth vibes guesses"  # accepts the bad ones
+    verdict = held_out_false_pass_gate(overfit, generic, labeled, labels, _kw_judge)
+    assert verdict.adopt is False
+    assert verdict.evolved_false_pass_rate == 1.0
+    assert verdict.baseline_false_pass_rate == 0.0
+    assert "overfit" in verdict.reason
+
+
+def test_gate_admits_parity_or_better():
+    labeled = [
+        {"requires": ["a"]},
+        {"requires": ["b"]},
+        {"requires": ["c"]},
+        {"requires": ["d"]},
+    ]
+    labels = [True, True, False, False]
+    generic = evolved = "a b c d"  # identical → parity
+    verdict = held_out_false_pass_gate(evolved, generic, labeled, labels, _kw_judge)
+    assert verdict.adopt is True
+    assert verdict.evolved_false_pass_rate == verdict.baseline_false_pass_rate
+
+
+def test_empty_holdout_fails_closed():
+    verdict = held_out_false_pass_gate("x", "y", [1], [True], _kw_judge)
+    assert verdict.adopt is False
+    assert "refusing" in verdict.reason
+
+
+def test_judge_throw_counts_as_no_false_pass():
+    def boom(rubric, example):
+        raise RuntimeError("gate crash")
+
+    labeled = [{"requires": ["a"]}, {"requires": ["b"]}]
+    labels = [True, False]
+    verdict = held_out_false_pass_gate("a b", "", labeled, labels, boom)
+    # A throwing judge accepts nothing → 0 false passes on both sides → parity.
+    assert verdict.adopt is True
+
+
+def test_judge_consumer_blocks_overfit_adoption(tmp_path):
+    """End-to-end through resolve_active_rubric (#2782 wiring): an evolved
+    rubric that wins the labeled set but false-passes on the held-out tail
+    is NOT adopted — the judge keeps the shipped rubric (None)."""
+    import json
+
+    from evolution_rubric_judge import resolve_active_rubric
+
+    rf = tmp_path / "rubric-forge"
+    rf.mkdir(parents=True)
+    # 4 train examples the evolved rubric fits perfectly...
+    (rf / "candidates.json").write_text(
+        json.dumps(["sources urls depth vibes guesses"]), encoding="utf-8"
+    )
+    labeled = (
+        [{"requires": [w], "label": True} for w in ("sources", "urls", "depth")]
+        + [{"requires": ["vibes"], "label": False}]      # train bad
+        + [{"requires": ["guesses"], "label": False}]    # held-out bad
+    )
+    (rf / "labeled.json").write_text(json.dumps(labeled), encoding="utf-8")
+
+    active = resolve_active_rubric(tmp_path)
+    # The winner accepts the held-out bad example → gate blocks adoption.
+    assert active is None
+    audit = json.loads((rf / "selected.json").read_text())
+    assert audit["held_out_gate"]["adopt"] is False
+    assert audit["held_out_gate"]["evolved_false_pass_rate"] == 1.0
+    assert audit["max_overrides"] == {}

--- a/tests/evolution/test_rubric_labeled_set.py
+++ b/tests/evolution/test_rubric_labeled_set.py
@@ -60,7 +60,15 @@ def test_default_store_path_is_what_the_judge_reads(tmp_path, monkeypatch):
     monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
     assert default_store_path() == tmp_path / "rubric-forge" / "labeled.json"
     # Round-trip with the S1 consumer: collect, then the judge reads it.
-    append_labeled_examples([{"requires": ["sources"], "label": True}])
+    # 4 examples so the S3 held-out gate has a tail to prove parity on.
+    append_labeled_examples(
+        [
+            {"requires": ["sources"], "label": True},
+            {"requires": ["sources"], "label": True},
+            {"forbids": ["vibes"], "label": False},
+            {"forbids": ["guesses"], "label": False},
+        ]
+    )
     (tmp_path / "rubric-forge" / "candidates.json").write_text(
         json.dumps(["mentions sources"]), encoding="utf-8"
     )


### PR DESCRIPTION
Slice 3 of #2760 (RubricForge), completing the held-out false-pass gate on top of the merged S1 (#2797) + S2 (#2805).

## What
- **`split_labeled_set()`** — deterministic tail split (the LAST `holdout` examples are held out; no RNG → adoption decisions reproduce; too-small sets degrade to an empty holdout instead of a bogus one).
- **`held_out_false_pass_gate(evolved, generic, labeled, labels, judge)`** — the winner was selected ON this set, so it must re-prove itself: false-pass rate = fraction of held-out labeled-BAD examples the rubric accepts anyway; adoption only when `evolved <= baseline`. An empty holdout cannot prove parity → fail-closed refusal. A throwing judge accepts nothing (0 false passes).
- **Wiring** — `resolve_active_rubric` now runs the gate before activating overrides: blocked ⇒ returns `None` (the judge runs the shipped rubric, byte-identical to pre-RubricForge), and the verdict lands in the `selected.json` audit (`held_out_gate` block: adopt, both rates, holdout size, reason). `_SHIPPED_RUBRIC_TEXT` renders the generic judge's criteria labels as the baseline.

## Tests (8)
deterministic split · small-set degradation · parallel-sequence ValueError · **overfit blocked end-to-end** (evolved rubric accepts a held-out bad example → 1.0 vs 0.0 → None + audited refusal) · parity adoption · empty-holdout fail-closed · throwing-judge parity. S1/S2 tests updated to seed 4 examples (2 train + 2 held-out) so their adoptions have a provable tail. Full RubricForge suite 39 passed. ruff clean.