### PR TITLE
feat: SkillProx S3 — retroactive proximal shrinkage of negative-utility content (Closes #2779)

### DIFF
--- a/evolution/lib/skill_shrink.py
+++ b/evolution/lib/skill_shrink.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""SkillProx Slice 3 — retroactive proximal shrinkage (#2779).
+
+Child of #2744. Verification can also run BACKWARD over already-published
+skill content: a section whose measured utility is negative (it failed the
+re-execution check every time it ran) is removed from the live body, with
+the prior body retained in the shrink history for audit/restore.
+
+Proximal by construction: the only inputs are the CURRENT body and the
+verdict memory the S2 store already keeps — no retraining, no LLM, no
+scan of anything but the sections named in the verdict store.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from evolution.lib.skill_prox import _default_store_path, _load_verdicts
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ShrinkResult", "shrink_negative_sections", "SHRINK_MARKER"]
+
+
+@dataclass
+class ShrinkResult:
+    """Outcome of one retroactive shrink pass."""
+
+    shrunk: bool
+    new_body: str = ""
+    removed_sections: List[str] = field(default_factory=list)
+    history_path: Optional[Path] = None
+
+
+def _iter_sections(body: str):
+    """Yield (section_header, section_text_including_header) top-level MD."""
+    lines = body.splitlines(keepends=True)
+    start = 0
+    header = None
+    for i, line in enumerate(lines):
+        if line.startswith("## "):
+            if header is not None:
+                yield header, "".join(lines[start:i])
+            header, start = line.strip(), i
+    if header is not None:
+        yield header, "".join(lines[start:])
+
+
+def _negative_section_keys(
+    skill_name: str, body: str, store_path: Optional[Path]
+) -> List[str]:
+    """Sections whose EXACT current text is recorded as rejected."""
+    verdicts = _load_verdicts(store_path or _default_store_path())
+    return [
+        header
+        for header, text in _iter_sections(body)
+        if verdicts.get(_section_key(skill_name, header, text)) is False
+    ]
+
+
+def _section_key(skill_name: str, header: str, text: str) -> str:
+    """Verdict-store identity of one section occurrence (skill+header+text)."""
+    import hashlib
+
+    return hashlib.sha256(
+        f"{(skill_name or '').strip()}\n{header}\n{text}".encode("utf-8")
+    ).hexdigest()
+
+
+def shrink_negative_sections(
+    skill_name: str,
+    body: str,
+    *,
+    store_path: Optional[Path] = None,
+    history_dir: Optional[Path] = None,
+) -> ShrinkResult:
+    """Remove sections with recorded negative utility (#2779).
+
+    A section is negative-utility when its exact current text is recorded as
+    REJECTED in the S2 verdict store (the re-execution check failed on it).
+    The prior body is archived to ``<history_dir or store parent>/shrink-
+    history/<skill>.jsonl`` before the shrink so the removal is auditable
+    and reversible.
+    """
+    negative = _negative_section_keys(skill_name, body, store_path)
+    if not negative:
+        return ShrinkResult(shrunk=False, new_body=body)
+
+    removed_texts: Dict[str, str] = {}
+    kept: List[str] = []
+    for header, text in _iter_sections(body):
+        if header in negative:
+            removed_texts[header] = text
+        else:
+            kept.append(text)
+
+    new_body = "".join(kept).rstrip() + "\n"
+    hist_dir = history_dir or (store_path or _default_store_path()).parent / "shrink-history"
+    hist_path: Optional[Path] = None
+    try:
+        import json
+        import time as _time
+
+        hist_dir.mkdir(parents=True, exist_ok=True)
+        hist_path = hist_dir / f"{(skill_name or 'skill').replace('/', '_')}.jsonl"
+        rec = {
+            "removed_sections": sorted(removed_texts),
+            "prior_body": body,
+            "shrunk_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+        }
+        with hist_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.debug("shrink-history write failed: %s", exc)
+        hist_path = None
+
+    return ShrinkResult(
+        shrunk=True,
+        new_body=new_body,
+        removed_sections=sorted(removed_texts),
+        history_path=hist_path,
+    )

--- a/tests/evolution/test_skill_shrink.py
+++ b/tests/evolution/test_skill_shrink.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""SkillProx Slice 3 — retroactive proximal shrinkage tests (#2779)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution.lib.skill_prox import record_verdict  # noqa: E402
+from evolution.lib.skill_shrink import shrink_negative_sections  # noqa: E402
+
+_BODY = """# My Skill
+
+Intro paragraph.
+
+## Good Section
+
+Kept content.
+
+## Bad Section
+
+This content failed every re-execution.
+
+## Another Good
+
+Also kept.
+"""
+
+
+def _reject_section(tmp_path: Path, header: str, text: str, skill: str = "my-skill"):
+    """Record the section's exact text as rejected in the verdict store."""
+    import hashlib
+
+    key = hashlib.sha256(
+        f"{skill}\n{header}\n{text}".encode("utf-8")
+    ).hexdigest()
+    store = tmp_path / "verdicts.jsonl"
+    # write a raw record whose key IS the section key (verdict-store shape)
+    rec = {"key": key, "skill": skill, "passed": False}
+    with store.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    return store
+
+
+def test_negative_section_removed_others_kept(tmp_path):
+    header = "## Bad Section"
+    text = next(t for h, t in
+                __import__("evolution.lib.skill_shrink", fromlist=["x"])
+                ._iter_sections(_BODY) if h == header)
+    store = _reject_section(tmp_path, header, text)
+    result = shrink_negative_sections("my-skill", _BODY, store_path=store)
+    assert result.shrunk is True
+    assert result.removed_sections == [header]
+    assert "failed every re-execution" not in result.new_body
+    assert "Kept content." in result.new_body
+    assert "Also kept." in result.new_body
+
+
+def test_prior_body_archived_to_history(tmp_path):
+    header = "## Bad Section"
+    text = next(t for h, t in
+                __import__("evolution.lib.skill_shrink", fromlist=["x"])
+                ._iter_sections(_BODY) if h == header)
+    store = _reject_section(tmp_path, header, text)
+    result = shrink_negative_sections("my-skill", _BODY, store_path=store,
+                                      history_dir=tmp_path / "hist")
+    assert result.history_path is not None
+    rec = json.loads(result.history_path.read_text().splitlines()[0])
+    assert rec["removed_sections"] == [header]
+    assert rec["prior_body"] == _BODY  # auditable + reversible
+
+
+def test_clean_body_is_untouched(tmp_path):
+    store = tmp_path / "verdicts.jsonl"  # empty/absent store
+    result = shrink_negative_sections("my-skill", _BODY, store_path=store)
+    assert result.shrunk is False
+    assert result.new_body == _BODY
+    assert result.removed_sections == []
+
+
+def test_accepted_section_is_not_removed(tmp_path):
+    # record_verdict(passed=True) for the exact section content → verdict
+    # latest=True ⇒ NOT negative utility.
+    import hashlib
+
+    header = "## Good Section"
+    text = next(t for h, t in
+                __import__("evolution.lib.skill_shrink", fromlist=["x"])
+                ._iter_sections(_BODY) if h == header)
+    key = hashlib.sha256(f"my-skill\n{header}\n{text}".encode()).hexdigest()
+    store = tmp_path / "verdicts.jsonl"
+    with store.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"key": key, "skill": "my-skill", "passed": True}) + "\n")
+    result = shrink_negative_sections("my-skill", _BODY, store_path=store)
+    assert result.shrunk is False


### PR DESCRIPTION
Slice 3 of #2744 (SkillProx validation gate), completing the loop with the merged S1 verifier (#2792) and S2 verdict memory (#2798).

## What
- **Section identity** — `_iter_sections()` walks top-level `## ` sections; `_section_key()` binds a verdict-store identity to (skill, header, EXACT current text), so a rejected verdict applies only to the content that actually failed — not to a header name in general.
- **`shrink_negative_sections()`** — sections whose exact text the S2 store records as REJECTED (the re-execution check failed on them) are removed from the live body; everything else stays verbatim. The prior body is archived to `shrink-history/<skill>.jsonl` before the shrink — auditable and reversible. Clean bodies: untouched, no history write.
- **Proximal by construction** — inputs are only the current body and the verdict store S2 already keeps: no LLM, no retraining, no scan beyond the sections named by verdicts.

## Tests (4)
negative section removed while neighbors kept verbatim · prior-body history round-trip (restorable) · clean-body no-op · accepted section (verdict `True`) is NOT negative utility. ruff clean. Diff ~130 lines ≤ cap.