### PR TITLE
feat: AgentOpt S3 — measured-combo router feed (Closes #2743)

### DIFF
--- a/scripts/evolution_agentopt_router_feed.py
+++ b/scripts/evolution_agentopt_router_feed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 3 — measured-combo router feed (#2743).
+
+Child of #2695. Consumes the Slice-2 Pareto report
+(``evolution_agentopt_report.build_report``) and feeds the measured
+per-combo outcomes into the delegation routing table
+(``tools.model_routing_table.RoutingTable.record_outcome``), replacing
+static exploration-only signal with measured preference where it exists.
+
+Deterministic, no LLM, no network; the table is persisted via its own
+JSON round-trip so the next ``_route_subagent_model`` consultation
+exploits the measured winners instead of cold-starting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from evolution_agentopt_report import build_report, load_records  # noqa: E402
+
+
+def feed_routing_table(
+    report: Dict[str, Any],
+    table: Any,
+    *,
+    min_calls: int = 5,
+    only_frontier: bool = True,
+) -> int:
+    """Record measured outcomes into a RoutingTable; returns records added.
+
+    Per task class (dimension): every frontier combo (or every combo when
+    ``only_frontier=False``) with at least ``min_calls`` measured calls gets
+    ONE success/failure outcome per call weighted by its success rate —
+    using the table's own ``record_outcome`` API so persistence and
+    epsilon-greedy semantics stay single-sourced. Models inside a multi-model
+    combo each receive the combo-level signal (a combo succeeded together).
+    """
+    added = 0
+    for cls, block in (report.get("task_classes") or {}).items():
+        combos = block.get("combos") or {}
+        frontier = set(block.get("pareto_frontier") or [])
+        for combo, stats in combos.items():
+            if only_frontier and combo not in frontier:
+                continue
+            calls = int(stats.get("calls") or 0)
+            if calls < min_calls:
+                continue
+            successes = round(float(stats.get("success_rate") or 0.0) * calls)
+            for model in combo.split("+"):
+                for _ in range(successes):
+                    table.record_outcome(model, cls, True)
+                for _ in range(calls - successes):
+                    table.record_outcome(model, cls, False)
+                added += calls
+    return added
+
+
+def default_table_path() -> Path:
+    """Where the delegation router already persists C-A-F tables (#2258)."""
+    import os
+
+    base = (
+        os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+        or str(Path.home() / ".hermes" / "evolution")
+    )
+    return Path(base) / "agentopt-routing-table.json"
+
+
+def run_feed(
+    store: Optional[Path] = None, table_path: Optional[Path] = None
+) -> int:
+    """CLI entry: telemetry store -> Pareto report -> routing table file."""
+    from tools.model_routing_table import RoutingTable
+
+    table_path = table_path or default_table_path()
+    try:
+        table = RoutingTable.from_dict(json.loads(table_path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, KeyError, TypeError):
+        table = RoutingTable(models=[])
+    added = feed_routing_table(build_report(load_records(store or _store())), table)
+    if added:
+        table_path.parent.mkdir(parents=True, exist_ok=True)
+        table_path.write_text(json.dumps(table.to_dict(), indent=2), encoding="utf-8")
+    return added
+
+
+def _store():
+    from agent.agentopt_telemetry import _store_path
+
+    return _store_path()
+
+
+def main(argv: list) -> int:
+    print(json.dumps({"outcomes_recorded": run_feed(Path(argv[1]) if len(argv) > 1 else None)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_agentopt_router_feed.py
+++ b/tests/scripts/test_evolution_agentopt_router_feed.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 3 — measured-combo router feed tests (#2743)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution_agentopt_report import build_report  # noqa: E402
+from evolution_agentopt_router_feed import (  # noqa: E402
+    default_table_path,
+    feed_routing_table,
+    run_feed,
+)
+from tools.model_routing_table import RoutingTable  # noqa: E402
+
+
+def _report():
+    return build_report([
+        # coding: m1 frontier (perfect, 6 calls), m2 dominated (fails)
+        {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 50.0, "task_class": "coding"},
+        {"model": "m2", "outcome": "fail", "cost": 0.09, "latency_ms": 500.0, "task_class": "coding"},
+    ] + [
+        {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 55.0, "task_class": "coding"}
+    ] * 5 + [
+        {"model": "m2", "outcome": "fail", "cost": 0.09, "latency_ms": 480.0, "task_class": "coding"}
+    ] * 5)
+
+
+def test_feed_records_measured_outcomes_on_frontier_only():
+    table = RoutingTable(models=[])
+    added = feed_routing_table(_report(), table, min_calls=5)
+    # Only m1 is on the frontier with >=5 calls: 6 ok outcomes recorded.
+    assert added == 6
+    assert table.best_model("coding") == "m1"
+    # m2 (dominated, off-frontier) received NO records — static preference
+    # is not fabricated for measured-bad combos.
+    rec = table._records.get("m2::coding")
+    assert rec is None
+
+
+def test_feed_all_combos_mode_records_failure_signal_too():
+    table = RoutingTable(models=[])
+    feed_routing_table(_report(), table, min_calls=5, only_frontier=False)
+    m2 = table._records["m2::coding"]
+    assert m2.attempts == 6 and m2.successes == 0
+
+
+def test_min_calls_gate_skips_thin_signal():
+    table = RoutingTable(models=[])
+    report = build_report([
+        {"model": "m1", "outcome": "ok", "task_class": "ops"},
+    ])
+    assert feed_routing_table(report, table, min_calls=5) == 0
+    assert table.best_model("ops") is None
+
+
+def test_run_feed_persists_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    store = tmp_path / "calls.jsonl"
+    store.write_text(
+        "\n".join(json.dumps(r) for r in [
+            {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 50.0, "task_class": "eval"},
+        ] * 6)
+        + "\n",
+        encoding="utf-8",
+    )
+    added = run_feed(store=store, table_path=tmp_path / "table.json")
+    assert added == 6
+    persisted = json.loads((tmp_path / "table.json").read_text())
+    revived = RoutingTable.from_dict(persisted)
+    assert revived.best_model("eval") == "m1"
+    assert default_table_path() == tmp_path / "agentopt-routing-table.json"


### PR DESCRIPTION
Slice 3 of #2695 (AgentOpt), closing the loop: S1 telemetry (#2755) → S2 Pareto report (#2800) → **the router that actually decides**.

## Consumer (the real one)
`_route_subagent_model` in `tools/delegate_tool.py` consults `tools.model_routing_table.RoutingTable.select_model` — an epsilon-greedy table whose signal so far comes only from exploration. This slice feeds MEASURED preference into it.

## What
- **`feed_routing_table(report, table)`** — per task class: every FRONTIER combo with ≥`min_calls` (default 5) measured calls gets its success-rate-weighted outcomes recorded through the table's own `record_outcome` API (single source for persistence + epsilon-greedy semantics). Dominated combos receive nothing — no static preference is fabricated for measured-bad combos. `only_frontier=False` records failure signal too.
- **`run_feed()` + CLI** — telemetry store → `build_report` (S2) → the table persisted at `$EVOLUTION_PROFILE_DIR/agentopt-routing-table.json` via the table's own JSON round-trip; an existing file is revived and extended, not clobbered.
- Multi-model combos: each member model receives the combo-level signal (the combo succeeded together).

## Tests (4)
frontier-only records (dominated m2 gets zero records) · all-combos mode records failure signal · min_calls gate skips thin signal · end-to-end persistence round-trip (`best_model` revived from disk). ruff clean. Diff ~110 lines ≤ cap.