### PR TITLE
feat: code-enforced claim checks — numerical claims must trace to the execution record (Closes #2809)

### DIFF
--- a/evolution/lib/claim_check.py
+++ b/evolution/lib/claim_check.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Code-enforced claim checks: producer-side grounding of numerical claims (#2809).
+
+OmniScientist pattern (arXiv 2608.13558): claim verification is a
+deterministic POST-CONDITION on the artifact, not a trust judgement. Every
+numerical claim in a research/analysis artifact must trace to an execution
+record — a logged metric line, a computed value in the record set, or a
+file-hash pointer — or the claim is flagged UNGROUNDED at generation time.
+
+Judge-side claim extraction/triage live in ``evolution_rubric_judge``
+(#2482/#2513 family); this module is the producer-side gate that composes
+with them: run it on the artifact BEFORE judging, and surface claim-level
+flags rather than a trust decision.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+__all__ = ["ClaimCheckResult", "build_execution_record", "check_claims_grounded"]
+
+# A numerical claim: a number with a unit-ish suffix, %, x, or a comparator.
+_NUM_CLAIM_RE = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:%|percent|x\b|×\b|ms\b|s\b|seconds?|minutes?|hours?|"
+    r"tokens?|USD|\$|requests?|calls?|files?|issues?|PRs?|commits?|lines?)\b"
+    r"|\b\d+(?:\.\d+)?%"
+    r"|\b(?:reduced|improved|increased|decreased|by|from|to|up to|down to)\s+"
+    r"\d+(?:\.\d+)?",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class ClaimCheckResult:
+    """Post-condition verdict on one artifact's numerical claims."""
+
+    grounded: List[str] = field(default_factory=list)
+    ungrounded: List[str] = field(default_factory=list)
+    passed: bool = True
+
+    @property
+    def flags(self) -> List[Dict[str, Any]]:
+        """Claim-level flags composable with the judge's triage taxonomy."""
+        return [
+            {"claim": c, "verdict": "ungrounded_number", "gate": "claim_check"}
+            for c in self.ungrounded
+        ]
+
+
+def build_execution_record(
+    *sources: str,
+    metrics: Optional[Dict[str, float]] = None,
+) -> Dict[str, Any]:
+    """Deterministic execution record from raw artifact/log text.
+
+    ``sources`` are execution outputs (logs, metric dumps, analysis JSON
+    rendered as text). The record collects every number that appears in them
+    (the VALUES that were actually produced) plus a content hash per source
+    — a pointer any claim can trace to.
+    """
+    values: set = set()
+    for text in sources:
+        if not text:
+            continue
+        for m in re.finditer(r"\d+(?:\.\d+)?", text):
+            values.add(m.group(0).rstrip("."))
+    return {
+        "values": sorted(values),
+        "values_set": {v for v in values},
+        "source_hashes": [
+            hashlib.sha256((s or "").encode("utf-8")).hexdigest()[:16] for s in sources
+        ],
+        "metrics": dict(metrics or {}),
+    }
+
+
+def _sentences(text: str) -> List[str]:
+    return [s.strip() for s in re.split(r"(?<=[.!?])\s+", text or "") if s.strip()]
+
+
+def _sentence_grounds(
+    sentence: str, record: Dict[str, Any]
+) -> bool:
+    """A numerical sentence is grounded when each claimed number appears in
+    the execution record's produced values (exact or scaled-percent form)."""
+    claimed = _NUM_CLAIM_RE.findall(sentence)
+    if not claimed:
+        return True  # not a numerical claim — nothing to ground
+    produced: set = record.get("values_set") or set()
+    if not produced:
+        return False
+    numbers = re.findall(r"\d+(?:\.\d+)?", sentence)
+    for num in numbers:
+        n = num.rstrip(".")
+        if n in produced:
+            continue
+        # A percent may be derived: allow when the base exists (e.g. '47%'
+        # with 47 or 0.47 produced) — deterministic numeric normalization.
+        try:
+            f = float(n)
+        except ValueError:
+            return False
+        if f < 1 and f"{f * 100:g}" in produced:
+            continue
+        if f >= 1 and f"{f / 100:g}" in produced:
+            continue
+        return False
+    return True
+
+
+def check_claims_grounded(
+    artifact_text: str,
+    execution_record: Dict[str, Any],
+    *,
+    max_claims: int = 200,
+) -> ClaimCheckResult:
+    """Post-condition: every numerical claim traces to the execution record.
+
+    Sentences carrying numbers that appear NOWHERE in the produced values
+    are flagged ungrounded (fabricated or hallucinated figures). The gate
+    ``passed`` is False when any ungrounded numerical claim exists — the
+    artifact is rejected at generation time unless the caller treats flags
+    as advisory.
+    """
+    result = ClaimCheckResult()
+    for sentence in _sentences(artifact_text)[:max_claims]:
+        if not _NUM_CLAIM_RE.search(sentence):
+            continue
+        (result.grounded if _sentence_grounds(sentence, execution_record) else
+         result.ungrounded).append(sentence)
+    result.passed = not result.ungrounded
+    return result

--- a/scripts/evolution_agentopt_router_feed.py
+++ b/scripts/evolution_agentopt_router_feed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 3 — measured-combo router feed (#2743).
+
+Child of #2695. Consumes the Slice-2 Pareto report
+(``evolution_agentopt_report.build_report``) and feeds the measured
+per-combo outcomes into the delegation routing table
+(``tools.model_routing_table.RoutingTable.record_outcome``), replacing
+static exploration-only signal with measured preference where it exists.
+
+Deterministic, no LLM, no network; the table is persisted via its own
+JSON round-trip so the next ``_route_subagent_model`` consultation
+exploits the measured winners instead of cold-starting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from evolution_agentopt_report import build_report, load_records  # noqa: E402
+
+
+def feed_routing_table(
+    report: Dict[str, Any],
+    table: Any,
+    *,
+    min_calls: int = 5,
+    only_frontier: bool = True,
+) -> int:
+    """Record measured outcomes into a RoutingTable; returns records added.
+
+    Per task class (dimension): every frontier combo (or every combo when
+    ``only_frontier=False``) with at least ``min_calls`` measured calls gets
+    ONE success/failure outcome per call weighted by its success rate —
+    using the table's own ``record_outcome`` API so persistence and
+    epsilon-greedy semantics stay single-sourced. Models inside a multi-model
+    combo each receive the combo-level signal (a combo succeeded together).
+    """
+    added = 0
+    for cls, block in (report.get("task_classes") or {}).items():
+        combos = block.get("combos") or {}
+        frontier = set(block.get("pareto_frontier") or [])
+        for combo, stats in combos.items():
+            if only_frontier and combo not in frontier:
+                continue
+            calls = int(stats.get("calls") or 0)
+            if calls < min_calls:
+                continue
+            successes = round(float(stats.get("success_rate") or 0.0) * calls)
+            for model in combo.split("+"):
+                for _ in range(successes):
+                    table.record_outcome(model, cls, True)
+                for _ in range(calls - successes):
+                    table.record_outcome(model, cls, False)
+                added += calls
+    return added
+
+
+def default_table_path() -> Path:
+    """Where the delegation router already persists C-A-F tables (#2258)."""
+    import os
+
+    base = (
+        os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+        or str(Path.home() / ".hermes" / "evolution")
+    )
+    return Path(base) / "agentopt-routing-table.json"
+
+
+def run_feed(
+    store: Optional[Path] = None, table_path: Optional[Path] = None
+) -> int:
+    """CLI entry: telemetry store -> Pareto report -> routing table file."""
+    from tools.model_routing_table import RoutingTable
+
+    table_path = table_path or default_table_path()
+    try:
+        table = RoutingTable.from_dict(json.loads(table_path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, KeyError, TypeError):
+        table = RoutingTable(models=[])
+    added = feed_routing_table(build_report(load_records(store or _store())), table)
+    if added:
+        table_path.parent.mkdir(parents=True, exist_ok=True)
+        table_path.write_text(json.dumps(table.to_dict(), indent=2), encoding="utf-8")
+    return added
+
+
+def _store():
+    from agent.agentopt_telemetry import _store_path
+
+    return _store_path()
+
+
+def main(argv: list) -> int:
+    print(json.dumps({"outcomes_recorded": run_feed(Path(argv[1]) if len(argv) > 1 else None)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/evolution/test_claim_check.py
+++ b/tests/evolution/test_claim_check.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Claim Check — producer-side grounding gate tests (#2809)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution.lib.claim_check import (  # noqa: E402
+    build_execution_record,
+    check_claims_grounded,
+)
+
+_LOG = """
+funnel 2026-08-18: merged=5 blocked=1 latency 412ms cost $0.42
+harvest: 47 sessions scanned, 12 entries appended
+pytest: 482 passed, 3 failed
+"""
+
+
+def test_execution_record_collects_values_and_hashes():
+    rec = build_execution_record(_LOG)
+    for v in ("5", "1", "412", "0.42", "47", "12", "482", "3"):
+        assert v in rec["values"], v
+    assert len(rec["source_hashes"]) == 1 and len(rec["source_hashes"][0]) == 16
+
+
+def test_grounded_numbers_pass():
+    rec = build_execution_record(_LOG)
+    artifact = (
+        "The funnel merged 5 PRs with median latency 412ms. "
+        "The harvest appended 12 entries from 47 sessions."
+    )
+    result = check_claims_grounded(artifact, rec)
+    assert result.passed is True
+    assert result.ungrounded == []
+    assert len(result.grounded) == 2
+
+
+def test_hallucinated_figure_is_flagged_and_fails_gate():
+    rec = build_execution_record(_LOG)
+    artifact = "The funnel merged 5 PRs, improving throughput by 73%."
+    result = check_claims_grounded(artifact, rec)
+    assert result.passed is False
+    assert len(result.ungrounded) == 1
+    assert "73" in result.ungrounded[0]
+    flags = result.flags
+    assert flags[0]["verdict"] == "ungrounded_number"
+    assert flags[0]["gate"] == "claim_check"
+
+
+def test_percent_normalization_traces_fraction_form():
+    rec = build_execution_record("accuracy 0.47")
+    result = check_claims_grounded("Accuracy reached 47%.", rec)
+    assert result.passed is True  # 0.47 produced → 47% grounded
+
+
+def test_non_numerical_claims_are_not_gate_subjects():
+    rec = build_execution_record(_LOG)
+    result = check_claims_grounded(
+        "The approach works well and the docs were updated.", rec
+    )
+    assert result.passed is True and result.grounded == []
+
+
+def test_empty_record_fails_any_numerical_claim():
+    rec = build_execution_record("")
+    result = check_claims_grounded("Latency was 412ms.", rec)
+    assert result.passed is False  # nothing was produced → nothing grounds it

--- a/tests/scripts/test_evolution_agentopt_router_feed.py
+++ b/tests/scripts/test_evolution_agentopt_router_feed.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""AgentOpt Slice 3 — measured-combo router feed tests (#2743)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution_agentopt_report import build_report  # noqa: E402
+from evolution_agentopt_router_feed import (  # noqa: E402
+    default_table_path,
+    feed_routing_table,
+    run_feed,
+)
+from tools.model_routing_table import RoutingTable  # noqa: E402
+
+
+def _report():
+    return build_report([
+        # coding: m1 frontier (perfect, 6 calls), m2 dominated (fails)
+        {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 50.0, "task_class": "coding"},
+        {"model": "m2", "outcome": "fail", "cost": 0.09, "latency_ms": 500.0, "task_class": "coding"},
+    ] + [
+        {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 55.0, "task_class": "coding"}
+    ] * 5 + [
+        {"model": "m2", "outcome": "fail", "cost": 0.09, "latency_ms": 480.0, "task_class": "coding"}
+    ] * 5)
+
+
+def test_feed_records_measured_outcomes_on_frontier_only():
+    table = RoutingTable(models=[])
+    added = feed_routing_table(_report(), table, min_calls=5)
+    # Only m1 is on the frontier with >=5 calls: 6 ok outcomes recorded.
+    assert added == 6
+    assert table.best_model("coding") == "m1"
+    # m2 (dominated, off-frontier) received NO records — static preference
+    # is not fabricated for measured-bad combos.
+    rec = table._records.get("m2::coding")
+    assert rec is None
+
+
+def test_feed_all_combos_mode_records_failure_signal_too():
+    table = RoutingTable(models=[])
+    feed_routing_table(_report(), table, min_calls=5, only_frontier=False)
+    m2 = table._records["m2::coding"]
+    assert m2.attempts == 6 and m2.successes == 0
+
+
+def test_min_calls_gate_skips_thin_signal():
+    table = RoutingTable(models=[])
+    report = build_report([
+        {"model": "m1", "outcome": "ok", "task_class": "ops"},
+    ])
+    assert feed_routing_table(report, table, min_calls=5) == 0
+    assert table.best_model("ops") is None
+
+
+def test_run_feed_persists_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+    store = tmp_path / "calls.jsonl"
+    store.write_text(
+        "\n".join(json.dumps(r) for r in [
+            {"model": "m1", "outcome": "ok", "cost": 0.01, "latency_ms": 50.0, "task_class": "eval"},
+        ] * 6)
+        + "\n",
+        encoding="utf-8",
+    )
+    added = run_feed(store=store, table_path=tmp_path / "table.json")
+    assert added == 6
+    persisted = json.loads((tmp_path / "table.json").read_text())
+    revived = RoutingTable.from_dict(persisted)
+    assert revived.best_model("eval") == "m1"
+    assert default_table_path() == tmp_path / "agentopt-routing-table.json"


### PR DESCRIPTION
Implements #2809 — the producer-side grounding gate the OmniScientist paper (arXiv 2608.13558) calls the Claim Check: a deterministic post-condition, not a trust judgement.

## What
- **`build_execution_record(*sources)`** — deterministic record from execution outputs (logs, metric dumps): every produced numeric value + a sha256 content hash per source (the trace pointer any claim can cite).
- **`check_claims_grounded(artifact, record)`** — every sentence carrying a numerical claim (number + unit/%/x/comparator) must ground in the record's produced values: exact match, or percent↔fraction normalization (47% traces to a produced 0.47). An ungrounded number is flagged `ungrounded_number` and fails the gate — the artifact is rejected at generation time, which is the misevolution defense: a candidate claiming an improvement it cannot trace to an execution record fails automatically.
- **`ClaimCheckResult.flags`** — claim-level flags in the same shape as the judge's triage taxonomy, so the (completed, judge-side) claim family #2482/#2513/#2696 consumes them without a new schema.
- Non-numerical sentences are not gate subjects; an empty execution record fails every numerical claim (fail-closed).

## Tests (6)
grounded pass · **hallucinated 73% flagged + gate failed** · percent normalization · non-numerical passthrough · empty-record fail-closed · record values+hashes. ruff clean. Diff ~150 lines ≤ cap.