### PR TITLE
fix: fail fast on environmental network failures instead of retry storm (Closes #74)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -598,6 +598,26 @@ _TRANSPORT_ERROR_TYPES = frozenset({
     "APITimeoutError",
 })
 
+# Environmental network-failure signals (#74). DNS / routing / reachability
+# failures are environmental, not provider-side: retrying the identical
+# payload N times cannot succeed while the environment is broken, and only
+# amplifies a transient outage into a retry storm that burns tokens, delays
+# scheduled jobs, and floods the error-capture store. Match these BEFORE the
+# generic transport-timeout heuristic (§8) so a clearly environmental error
+# fails fast (with fallback to the next provider) instead of exhausting the
+# retry budget against an unreachable host. Genuinely transient provider
+# hiccups (read/connect timeouts, resets) still retry via §8.
+_ENV_NETWORK_SIGNALS = (
+    "temporary failure in name resolution",
+    "name or service not known",
+    "getaddrinfo failed",
+    "no route to host",
+    "network is unreachable",
+    "errno -2",   # EAI_NONAME — name resolution failed
+    "errno -3",   # EAI_AGAIN — temporary DNS failure
+    "errno 113",  # EHOSTUNREACH — no route to host
+)
+
 # Server disconnect patterns (no status code, but transport-level).
 # These are the "ambiguous" patterns — a plain connection close could be
 # transient transport hiccup OR server-side context overflow rejection
@@ -1087,6 +1107,27 @@ def classify_api_error(
         and "consecutive stale attempts" in error_msg
         and "aborting this call" in error_msg
     ):
+        return _result(
+            FailoverReason.timeout,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # ── 7c. Environmental network failures → fail fast (#74) ────────
+    # DNS resolution / routing / reachability failures are environmental,
+    # not provider-side: the identical request cannot succeed while the
+    # environment is broken, so the full fixed retry count only amplifies a
+    # transient outage into a retry storm (and, for scheduled jobs, a wall of
+    # failure records + request snapshots). Fail fast with a fallback to the
+    # next provider — if the environment is truly down the fallback also
+    # fails fast, and the loop surfaces a clear reason instead of silently
+    # burning the budget. Checked BEFORE §8 so a message carrying both an
+    # environmental signal and a transport type name does not fall through to
+    # the retryable timeout bucket.
+    if (
+        isinstance(error, OSError)
+        or error_type in _TRANSPORT_ERROR_TYPES
+    ) and any(s in error_msg for s in _ENV_NETWORK_SIGNALS):
         return _result(
             FailoverReason.timeout,
             retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -2380,6 +2380,60 @@ class Test408RequestTimeout:
         assert result.should_compress is False
 
 
+# ── Environmental network failure → fail fast (#74) ─────────────────────
+
+
+class TestEnvironmentalNetworkFailFast:
+    """DNS / routing / reachability failures are environmental, not
+    provider-side — retrying the identical payload cannot succeed while the
+    environment is broken. They must fail fast (non-retryable + fallback)
+    instead of exhausting the retry budget against an unreachable host."""
+
+    def test_dns_name_resolution_fails_fast(self):
+        e = OSError("Temporary failure in name resolution")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_getaddrinfo_fails_fast(self):
+        e = OSError("[Errno -2] Name or service not known")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_no_route_to_host_fails_fast(self):
+        e = OSError("[Errno 113] No route to host")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_network_unreachable_fails_fast(self):
+        e = OSError("Network is unreachable")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_transient_timeout_without_env_signal_still_retries(self):
+        # A plain timeout (no environmental signal) must keep retrying as a
+        # transient transport hiccup — the fail-fast branch is narrow.
+        e = TimeoutError("timed out")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_connection_reset_without_env_signal_still_retries(self):
+        # Connection reset is a provider-side transport hiccup, not an
+        # environmental DNS/route failure — must NOT fail fast.
+        e = ConnectionError("Connection reset by peer")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+
 # ── HTTP 504 gateway timeout ───────────────────────────────────────────
 
 


### PR DESCRIPTION
Automated evolution PR for issue #74.

## What
DNS / routing / reachability failures (name resolution, no route to host, network unreachable) are environmental, not provider-side. Retrying the identical payload N times cannot succeed while the environment is broken — it only amplifies a transient outage into a retry storm.

## Change
- New `_ENV_NETWORK_SIGNALS` constant in `agent/error_classifier.py`.
- New §7c classification branch (before §8 transport heuristic) that classifies environmental failures as `FailoverReason.timeout` with `retryable=False` + `should_fallback=True`, so the loop fails fast instead of exhausting the retry budget.
- 6 new tests in `tests/agent/test_error_classifier.py` (DNS, getaddrinfo, no-route, unreachable → fail fast; plain timeout / connection-reset → still retry).

## Validation
- `ruff check` passes on both files.
- `pytest tests/agent/test_error_classifier.py -q` → 220 passed.

Closes #74