### PR TITLE
fix: provision terminal for shell-dependent subagents of terminal-less parents (Closes #2826)

### DIFF
--- a/tests/tools/test_delegate_terminal_compat.py
+++ b/tests/tools/test_delegate_terminal_compat.py
@@ -9,7 +9,11 @@ Verifies that:
 
 from types import SimpleNamespace
 
-from tools.delegate_tool import _goal_needs_terminal, _strip_blocked_tools
+from tools.delegate_tool import (
+    _goal_needs_terminal,
+    _host_has_shell_capability,
+    _strip_blocked_tools,
+)
 
 
 class TestGoalNeedsTerminal:
@@ -63,15 +67,43 @@ class TestAutoAddTerminalLogic:
         expanded = _expand_parent_toolsets(parent_toolsets)
         assert "terminal" in expanded
 
-    def test_no_auto_add_when_parent_lacks_terminal(self):
-        """Goal needs shell, parent also lacks terminal → no widening."""
-        from tools.delegate_tool import _expand_parent_toolsets
+    def test_no_auto_add_when_parent_and_host_lack_terminal(self):
+        """Goal needs shell, parent lacks terminal AND host cannot execute →
+        no widening (guard preserved for genuinely host-less environments)."""
+        from unittest.mock import patch
 
-        parent_toolsets = {"file", "web"}
-        child_toolsets = _strip_blocked_tools(["file", "web"])
-        assert _goal_needs_terminal("Run git log")
-        expanded = _expand_parent_toolsets(parent_toolsets)
-        assert "terminal" not in expanded  # guard prevents add
+        from tools.delegate_tool import _should_auto_add_terminal
+
+        with patch(
+            "tools.delegate_tool._host_has_shell_capability", return_value=False
+        ):
+            assert not _should_auto_add_terminal(
+                goal="Run git log",
+                context=None,
+                child_toolsets=_strip_blocked_tools(["file", "web"]),
+                parent_toolsets={"file", "web"},
+            )
+
+    def test_auto_add_when_parent_lacks_terminal_but_host_can_shell(self):
+        """#2826: an orchestrator parent (e.g. evolution Hydra: file +
+        delegation) lacks `terminal`, but its host can execute git/gh
+        (proven by the #2758 P-001 preflight gate). A shell-dependent child
+        must still be provisioned with `terminal` — otherwise delegated
+        implementation/integration stages cannot run git/gh/pytest at all."""
+        from unittest.mock import patch
+
+        from tools.delegate_tool import _should_auto_add_terminal
+
+        with patch("tools.delegate_tool._host_has_shell_capability", return_value=True):
+            assert _should_auto_add_terminal(
+                goal="Run git log and open a PR with gh",
+                context=None,
+                child_toolsets=_strip_blocked_tools(["file", "delegation"]),
+                parent_toolsets={"file", "delegation"},
+            ), (
+                "shell-dependent child of a terminal-less orchestrator parent "
+                "must be provisioned with terminal when the host can execute"
+            )
 
     def test_no_auto_add_when_already_present(self):
         """Goal needs shell, child already has terminal → no-op."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1658,6 +1658,58 @@ _SHELL_DEPENDENT_VERBS = frozenset({
 })
 
 
+def _should_auto_add_terminal(
+    goal: str,
+    context: Optional[str],
+    child_toolsets: List[str],
+    parent_toolsets: set,
+) -> bool:
+    """Decision helper for the #1369/#2826 auto-add: should ``terminal`` be
+    added to the child toolset before dispatch?
+
+    True when the goal/context references shell-dependent verbs, the child
+    toolset omits ``terminal``, AND at least one of:
+      - the parent can provide terminal (its toolset or a composite expands
+        to it) — the original #1369 guard; or
+      - the HOST can execute shell work (git on PATH) — the #2826 fallback
+        for orchestrator parents (e.g. the evolution Hydra: file+delegation
+        only) that legitimately lack terminal while their host can still run
+        git/gh, as proven by the #2758 P-001 preflight gate.
+
+    Pure and unit-testable; ``_host_has_shell_capability`` is consulted via
+    the module so tests can patch it.
+    """
+    if not _goal_needs_terminal(goal, context):
+        return False
+    if "terminal" in child_toolsets:
+        return False
+    if "terminal" in _expand_parent_toolsets(parent_toolsets):
+        return True
+    return _host_has_shell_capability()
+
+
+def _host_has_shell_capability() -> bool:
+    """Return True when the HOST can actually execute shell work (P-001).
+
+    Orchestrator parents (e.g. the evolution Hydra) deliberately run without
+    the ``terminal`` toolset — they must never run stage scripts themselves —
+    but their delegated children still need a shell for git/gh/test work.
+    The preflight gate (#2758, evolution_hydra_gate.py P-001) already proved
+    the host has execution capability before such a parent is woken, so the
+    auto-add decision can consult the host directly instead of requiring the
+    parent toolset to include ``terminal``.
+
+    Returns True on positive evidence of capability; fails open (True) if the
+    probe itself errors, matching the gate's fail-open policy.
+    """
+    import shutil
+
+    try:
+        return shutil.which("git") is not None
+    except (OSError, ValueError):
+        return True
+
+
 def _goal_needs_terminal(goal: str, context: Optional[str] = None) -> bool:
     """Return True if the task goal/context text references shell-dependent work.
 
@@ -2044,22 +2096,28 @@ def _build_child_agent(
     # but the resolved toolset omits `terminal`, auto-add it.  Without this,
     # leaf subagents arrive without a shell and emit "I have no shell tool"
     # spirals, wasting a full delegation cycle.  The parent intersection
-    # already bounded the child to parent-capable toolsets, so we only add
-    # `terminal` when the parent itself can provide it (parent_toolsets has
-    # it or a composite that expands to it).  This prevents widening the
-    # child beyond the parent's real capabilities.
+    # already bounded the child to parent-capable toolsets, so we prefer to
+    # add `terminal` only when the parent itself can provide it
+    # (parent_toolsets has it or a composite that expands to it) — this
+    # prevents widening the child beyond the parent's real capabilities.
+    # BUT an orchestrator parent (e.g. the evolution Hydra: file+delegation
+    # only) legitimately lacks `terminal` while its HOST can still execute
+    # git/gh (proven by the #2758 P-001 preflight gate).  Refusing to
+    # provision the shell for that parent's children left implementation /
+    # integration subagents terminal-less (#2826), so when the parent lacks
+    # terminal we fall back to the live host probe instead of denying.
     _toolset_adjusted = False
-    if _goal_needs_terminal(goal, context) and "terminal" not in child_toolsets:
-        expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        if "terminal" in expanded_parent:
-            child_toolsets.append("terminal")
-            _toolset_adjusted = True
-            logger.info(
-                "delegate_task: auto-added 'terminal' toolset for task %d "
-                "(goal references shell-dependent verbs but resolved toolset "
-                "omitted it) — #1369 regression fix",
-                task_index,
-            )
+    if _should_auto_add_terminal(goal, context, child_toolsets, parent_toolsets):
+        child_toolsets.append("terminal")
+        _toolset_adjusted = True
+        logger.info(
+            "delegate_task: auto-added 'terminal' toolset for task %d "
+            "(goal references shell-dependent verbs but resolved toolset "
+            "omitted it; parent-can=%s host-can=%s) — #1369/#2826 fix",
+            task_index,
+            "terminal" in _expand_parent_toolsets(parent_toolsets),
+            _host_has_shell_capability(),
+        )
 
     # Blocked tools also live inside mixed platform bundles (hermes-cli,
     # hermes-telegram, etc.) that _strip_blocked_tools must keep because they


### PR DESCRIPTION
Automated evolution PR for issue #2826.

## Problem
Subagent environments in the cron pipeline lack any shell/terminal tool, so implementation/integration stages cannot run git/gh/pytest and either BLOCK with no artifact or improvise read-only verification. The #2758 preflight (P-001) only DETECTS the missing capability; it does not provision it.

## Root cause
`_build_child_agent`'s #1369 auto-add guard provisions `terminal` ONLY when the parent toolset can provide it. The evolution Hydra (file+delegation) legitimately lacks terminal (pure delegator by design), so its delegated stage children could never inherit or auto-add it — even though the host has git (verified by the P-001 gate before dispatch).

## Fix
- New pure helper `_should_auto_add_terminal(goal, context, child_toolsets, parent_toolsets)`: shell-dependent goal + child lacks terminal → add when parent can shell OR host can shell.
- New `_host_has_shell_capability()`: live `git on PATH` probe (same signal as the gate's P-001), fail-open.
- Auto-add block now falls back to the host probe when the parent lacks terminal, so a Hydra-dispatched implementation/integration child is provisioned with `terminal` and can actually run git/gh/pytest.
- Unit tests for both branches (host-can add; host-cannot no-add).

## Validation
- `pytest tests/tools/test_delegate_terminal_compat.py`: 13 passed.
- Delegation-adjacent suite (delegate*/async_delegation*/terminal_tool.py + hydra gate tests): 391 passed; the 38 failures are byte-identical to clean origin/main (18/18 in the two shared files) — zero new failures, environmental (broken pydantic_core/PIL/numpy/fastapi in site-packages).
- `ruff check .`: clean.
- `scripts/evolution_skill_lint.py --skill-edit-budget`: OK (no SKILL.md touched).
- Diff: 140 changed lines (≤ 200 auto-merge cap).