### PR TITLE
fix: classify empty tool_calls array 400 as non-retryable format_error (Closes #33)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -432,6 +432,17 @@ _INVALID_MESSAGE_BODY_PATTERNS = [
     "text content blocks must be non-empty",
     "content field is required",
     "messages: at least one message is required",
+    # Empty tool_calls arrays (#33): strict OpenAI-compatible providers
+    # (DeepSeek v4, Moonshot/Kimi) reject ``"tool_calls": []`` with HTTP 400
+    # "Invalid 'messages[N].tool_calls': empty array. Expected an array with
+    # minimum length 1, but got an empty array instead." The pre-API
+    # sanitizer (agent_runtime_helpers.py) strips the empty array at the
+    # chokepoint, but a transport that bypasses it would otherwise retry the
+    # byte-identical payload into the same deterministic 400 — classify as a
+    # non-retryable format_error safety net instead of looping.
+    "tool_calls': empty array",
+    "tool_calls: empty array",
+    "expected an array with minimum length 1",
     # Qwen / vLLM chat templates raise this when the request has no surviving
     # non-empty user turn (oversized session truncation, compression that
     # dropped the only user message, or a resumed lineage that opens with

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1562,6 +1562,43 @@ class TestClassifyApiError:
             "Malformed message array 400" in r.getMessage() for r in caplog.records
         ), "Expected a distinct warning identifying the malformed-body 400"
 
+    def test_400_empty_tool_calls_array_is_non_retryable_format_error(self):
+        """Empty ``tool_calls: []`` rejection → non-retryable format_error (#33).
+
+        DeepSeek v4 rejects an assistant message carrying ``"tool_calls": []``
+        with HTTP 400 "Invalid 'messages[N].tool_calls': empty array.
+        Expected an array with minimum length 1...". This is a deterministic
+        request-shape rejection — the pre-API sanitizer strips [] at the
+        chokepoint, but if it ever reaches the classifier it must be a
+        non-retryable format_error, not a retry loop on the identical payload.
+        """
+        e = MockAPIError(
+            "Invalid 'messages[2].tool_calls': empty array. Expected an array "
+            "with minimum length 1, but got an empty array instead.",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e,
+            provider="deepseek",
+            model="deepseek-v4",
+            approx_tokens=5000,
+            context_length=200000,
+            num_messages=12,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_400_empty_tool_calls_array_non_apostrophe_variant(self):
+        """Same rejection without the field-path apostrophe → format_error."""
+        e = MockAPIError(
+            "Invalid messages[2].tool_calls: empty array. Expected an array "
+            "with minimum length 1.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="moonshot", model="kimi")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
 
 # ── Test: Adversarial / edge cases (from live testing) ─────────────────
 


### PR DESCRIPTION
Automated evolution PR for issue #33.

## Context
Owner reopened #33 (2026-08-18) with recurring evidence: empty `tool_calls: []` arrays cause HTTP 400 `format_error` from strict OpenAI-compatible providers, and the in-place mitigation was not catching every transport path. Requested: treat this 400 as non-retryable rather than retrying the identical payload.

## Change
- Added the empty-tool_calls rejection shapes to `_INVALID_MESSAGE_BODY_PATTERNS` in `agent/error_classifier.py`:
  - `"tool_calls': empty array"`
  - `"tool_calls: empty array"`
  - `"expected an array with minimum length 1"`
- These route to `FailoverReason.format_error` (non-retryable, fallback) — the existing pre-API sanitizer (`agent_runtime_helpers.py`) already strips `[]` at the chokepoint; this is the classifier safety net for transports that bypass it.

## Validation
- `ruff check` passes.
- `pytest tests/agent/test_error_classifier.py -q` → 216 passed (2 new tests).

Closes #33