### PR TITLE
fix(cron): env-exec capability gate for direct stage dispatch (Closes #2826)

### DIFF
--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from hermes_constants import get_hermes_home
 from hermes_cli.config import load_config_readonly
@@ -43,6 +44,18 @@ _HALT_GATED_STAGES = frozenset({
     "analysis",
     "implementation",
     "research",
+})
+
+# Stages whose deliverable REQUIRES a real execution environment (git/gh/
+# tests) — the subagent must be able to run commands, not just read/write
+# files. If the environment lacks the execution tooling (no git on PATH),
+# dispatching these stages is doomed: the subagent returns BLOCKED and writes
+# no artifact. `implementation` writes code+PRs (needs git/gh/ruff/pytest);
+# `integration` merges PRs (needs git/gh/hermes update). Introspection and
+# analysis are read-only (file/web) and never exec-gated (#2826).
+_EXEC_REQUIRED_STAGES = frozenset({
+    "implementation",
+    "integration",
 })
 
 
@@ -130,6 +143,52 @@ def should_skip_for_halt(
     if stage not in _HALT_GATED_STAGES:
         return False
     return _halt_state_active(hermes_home)
+
+
+def stage_requires_exec(stage: Optional[str]) -> bool:
+    """Return True if ``stage`` needs a real execution environment.
+
+    Implementation/integration stages must run git/gh/tests to produce their
+    deliverable. Introspection/analysis are read-only (file/web) and never
+    exec-gated (#2826).
+    """
+    return stage in _EXEC_REQUIRED_STAGES
+
+
+def _check_exec_capability() -> Tuple[bool, str]:
+    """Probe whether the environment can actually EXECUTE work (P-001).
+
+    Mirrors ``scripts/evolution_hydra_gate.py::_check_env_capability``. The
+    Hydra gate already blocks doomed orchestrator subagent spawns, but the
+    DIRECT stage crons (evolution-implementation, evolution-integration) run
+    through the scheduler and bypass that gate — so a terminal-less env would
+    still dispatch a stage that immediately returns BLOCKED and writes nothing.
+
+    Subagents inherit the parent environment, so a missing git here means any
+    spawned subagent cannot run the pipeline's git/gh/ruff/pytest workflow
+    either. Fail fast with an explicit BLOCKED verdict.
+
+    Returns (capable, reason). Conservative: we only BLOCK on POSITIVE
+    evidence of absence (git genuinely not on PATH). If the probe errors or is
+    inconclusive, we assume capable so a transient probe failure never starves
+    a genuine stage run (#2826).
+    """
+    try:
+        r = subprocess.run(
+            ["python3", "-c", "import shutil; print(bool(shutil.which('git')))"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode == 0:
+            if r.stdout.strip() == "True":
+                return True, "execution capability present (git on PATH)"
+            # Positive evidence of absence → BLOCKED (P-001 fast-fail).
+            return False, "no execution capability (git not on PATH)"
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    # Fail-open: if we can't determine capability, assume capable.
+    return True, "capability probe inconclusive — assuming capable (fail-open)"
 
 
 def _preflight_timeout_seconds(cfg: Optional[Any] = None) -> float:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4685,6 +4685,52 @@ def _run_job_impl(
         )
         return True, silent_doc, SILENT_MARKER, None
 
+    # Env-exec capability gate (P-001, #2826): implementation/integration
+    # stages must run git/gh/tests to produce their deliverable. If the
+    # environment lacks the execution tooling (no git on PATH), dispatching
+    # the stage is doomed — the subagent returns BLOCKED and writes nothing.
+    # The Hydra gate already blocks orchestrator spawns; extend the same
+    # fail-fast to the direct stage crons that bypass it. Read-only stages
+    # (introspection/analysis) are never exec-gated. Fail-open on probe
+    # error so a transient failure never starves a genuine run.
+    exec_blocked = False
+    exec_reason = ""
+    try:
+        if evolution_preflight.stage_requires_exec(stage):
+            _capable, _cap_reason = evolution_preflight._check_exec_capability()
+            exec_blocked = not _capable
+            exec_reason = _cap_reason
+    except Exception as exc:  # pragma: no cover - defense in depth
+        logger.debug(
+            "Job '%s': exec-capability gate check failed, proceeding without "
+            "it: %s",
+            job_id,
+            exc,
+        )
+        exec_blocked = False
+        exec_reason = ""
+
+    if exec_blocked:
+        logger.warning(
+            "Job '%s' (evolution-%s): SKIPPED — %s. No LLM agent was spawned "
+            "(P-001 fail-fast, #2826).",
+            job_id,
+            stage,
+            exec_reason,
+        )
+        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        silent_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {now_iso}\n"
+            f"**Status:** silent (no execution capability)\n\n"
+            f"The '{stage}' evolution stage requires a real execution "
+            f"environment (git/gh/tests) but the environment cannot provide "
+            f"it: {exec_reason}. Dispatching would produce a BLOCKED subagent "
+            f"and no artifact. The stage was skipped (P-001 fail-fast, #2826).\n"
+        )
+        return True, silent_doc, SILENT_MARKER, None
+
     from run_agent import AIAgent
 
     # Initialize SQLite session store so cron job messages are persisted

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -621,3 +621,49 @@ class TestSchedulerHaltGate:
         assert success is True
         assert final_response == "ok"
         mock_agent_cls.assert_called_once()
+
+
+class TestExecCapabilityGate:
+    """Env-exec capability gate (P-001, #2826): implementation/integration
+    stages need a real execution environment; introspection/analysis are
+    read-only and never exec-gated."""
+
+    def test_stage_requires_exec_implementation(self):
+        assert ep.stage_requires_exec("implementation") is True
+
+    def test_stage_requires_exec_integration(self):
+        assert ep.stage_requires_exec("integration") is True
+
+    def test_stage_requires_exec_read_only_stages_false(self):
+        for stage in ("introspection", "analysis", "research", "funnel"):
+            assert ep.stage_requires_exec(stage) is False
+
+    def test_stage_requires_exec_none_false(self):
+        assert ep.stage_requires_exec(None) is False
+
+    def test_check_exec_capability_git_present(self, monkeypatch):
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout.strip.return_value = "True"
+        monkeypatch.setattr(ep.subprocess, "run", lambda *a, **k: fake)
+        capable, reason = ep._check_exec_capability()
+        assert capable is True
+        assert "present" in reason
+
+    def test_check_exec_capability_git_absent_blocks(self, monkeypatch):
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout.strip.return_value = "False"
+        monkeypatch.setattr(ep.subprocess, "run", lambda *a, **k: fake)
+        capable, reason = ep._check_exec_capability()
+        assert capable is False
+        assert "no execution capability" in reason
+
+    def test_check_exec_capability_probe_error_fail_open(self, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("probe failed")
+
+        monkeypatch.setattr(ep.subprocess, "run", boom)
+        capable, reason = ep._check_exec_capability()
+        assert capable is True
+        assert "inconclusive" in reason


### PR DESCRIPTION
Automated evolution PR for issue #2826.

## Problem
Implementation/integration stage crons (`evolution-implementation`, `evolution-integration`) run directly through the scheduler and bypass the Hydra gate's P-001 env-capability check. When the environment lacks execution tooling (no terminal/shell/git), a stage is dispatched and immediately returns BLOCKED — wasting an orchestrator tick and writing no artifact.

The preflight (#2758) detects the missing capability for the Hydra orchestrator only; the direct stage crons were never covered.

## Fix
Extend the fail-fast P-001 exec-capability gate to the scheduler's direct stage dispatch:
- `cron/evolution_preflight.py`: add `stage_requires_exec()` (implementation/integration require execution; introspection/analysis are read-only) and `_check_exec_capability()` (mirrors Hydra gate: git on PATH; fail-open on probe error).
- `cron/scheduler.py`: after the halt-state gate, skip exec-required stages with a silent doc when capability is absent.
- Tests: `TestExecCapabilityGate` covers stage classification + capability probe paths.

## Checks
- Pre-PR test runner: PASSED (tests/cron/test_scheduler.py shard)
- `pytest tests/cron/test_evolution_preflight.py`: 48 passed
- `ruff check`: All checks passed
- Diff: 152 lines (within 200-line self-merge cap)

Closes #2826