### PR TITLE
fix(cron): wire refusal-recovery nudge into cron dispatch (Closes #2240)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5754,7 +5754,87 @@ def _run_job_impl(
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
-        
+
+        # ── Refusal-recovery nudge for cron dispatch (#2240) ──────────────
+        # The conversation loop wires maybe_refusal_nudge (loop_guard.py) to
+        # detect over-refusal and inject recovery directives. Cron jobs run
+        # through _run_job_impl directly and bypass conversation_loop.py, so
+        # refusals in cron contexts (where the evolution stages run) were
+        # unrecoverable — the recovery rate stayed flat after #2168 because
+        # the nudge was never surfaced here. Mirror the delegate_tool.py
+        # nudge: if the run completed with a text-only refusal (no tool
+        # calls), re-run the SAME job's agent once with the recovery
+        # directive. Adopt only on actual recovery (tool calls made or the
+        # summary no longer reads as a refusal). Bounded: 1 re-run.
+        if (
+            result.get("completed") is True
+            and _count_tool_calls(result.get("messages") or []) == 0
+        ):
+            _child_messages = result.get("messages") or []
+            _refusal_nudge = None
+            try:
+                from agent.loop_guard import maybe_refusal_nudge as _maybe_refusal
+
+                _refusal_nudge = _maybe_refusal(_child_messages, already_nudged=False)
+            except Exception:
+                _refusal_nudge = None
+            if _refusal_nudge:
+                logger.info(
+                    "Job '%s': refusal detected; re-running once with recovery "
+                    "nudge (#2240)",
+                    job_name,
+                )
+                _refusal_result = None
+                try:
+                    # Reassert the job workdir (same as the original run) and
+                    # re-run the agent with the recovery directive injected as
+                    # the new user turn. run_conversation(task_id=None) is the
+                    # cron default — we do not thread a subagent task_id here.
+                    _cron_run_reassert_workdir()
+                    _refusal_result = agent.run_conversation(_refusal_nudge)
+                except Exception as _rf_exc:
+                    logger.warning(
+                        "Job '%s': refusal-recovery re-run raised %s; keeping "
+                        "original",
+                        job_name,
+                        type(_rf_exc).__name__,
+                    )
+                    _refusal_result = None
+                if _refusal_result and isinstance(_refusal_result, dict):
+                    _rf_still_refusal = False
+                    try:
+                        from agent.loop_guard import maybe_refusal_nudge as _mr2
+
+                        _rf_still_refusal = (
+                            _mr2(
+                                _refusal_result.get("messages") or [],
+                                already_nudged=True,
+                            )
+                            is not None
+                        )
+                    except Exception:
+                        pass
+                    _rf_tool_calls = _count_tool_calls(
+                        _refusal_result.get("messages") or []
+                    )
+                    if _rf_tool_calls > 0 or not _rf_still_refusal:
+                        # Recovery happened — adopt the re-run.
+                        result = _refusal_result
+                        final_response = (
+                            _refusal_result.get("final_response") or ""
+                        )
+                        if final_response.strip() == "(No response generated)":
+                            final_response = ""
+                        logged_response = (
+                            final_response
+                            if final_response
+                            else "(No response generated)"
+                        )
+                        logger.info(
+                            "Job '%s': refusal recovered via nudge — adopting "
+                            "re-run result (#2240)",
+                            job_name,
+                        )
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}

--- a/tests/cron/test_cron_refusal_nudge.py
+++ b/tests/cron/test_cron_refusal_nudge.py
@@ -167,3 +167,97 @@ class TestRefusalNudgeCron:
         assert still_refusal
         assert tool_calls == 0
         assert not (tool_calls or not still_refusal)  # adopt gate is False
+
+
+class TestRefusalNudgeWiring:
+    """The nudge must be wired into _run_job_impl (not just tested in
+    isolation) — this was the #2240 regression: the recovery directive was
+    never surfaced to cron-context agents, so the recovery rate stayed flat."""
+
+    def _make_job(self, stage):
+        return {
+            "id": f"evolution-{stage}",
+            "name": f"evolution-{stage}",
+            "prompt": "do work",
+        }
+
+    def test_run_job_impl_wires_refusal_nudge(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from cron.scheduler import _run_job_impl
+
+        (tmp_path / "evolution").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: cfg-model\n  provider: anthropic\n",
+            encoding="utf-8",
+        )
+        job = self._make_job("implementation")
+
+        refusal_msg = {
+            "role": "assistant",
+            "content": "I can't help with that.",
+        }
+        recovery_msg = {
+            "role": "assistant",
+            "content": "Running the task now.",
+            "tool_calls": [{"function": {"name": "terminal", "arguments": "{}"}}],
+        }
+        tool_msg = {"role": "tool", "content": "done"}
+
+        first_result = {
+            "final_response": "I can't help with that.",
+            "completed": True,
+            "messages": [
+                {"role": "user", "content": "do work"},
+                refusal_msg,
+            ],
+        }
+        recovery_result = {
+            "final_response": "Running the task now.",
+            "completed": True,
+            "messages": [
+                {"role": "user", "content": "do work"},
+                refusal_msg,
+                {"role": "user", "content": "[loop-guard] take action"},
+                recovery_msg,
+                tool_msg,
+            ],
+        }
+
+        class FakeAgent:
+            def __init__(self, *a, **k):
+                self._call = 0
+
+            def run_conversation(self, *a, **k):
+                self._call += 1
+                if self._call == 1:
+                    return first_result
+                return recovery_result
+
+        with (
+            patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=MagicMock()),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "model": "openrouter/model",
+                },
+            ),
+            patch("cron.evolution_preflight.preflight_provider", return_value=None),
+            patch("run_agent.AIAgent", FakeAgent),
+        ):
+            success, output, final_response, error = _run_job_impl(job)
+
+        # The refusal was recovered via the wired nudge — the re-run's tool
+        # calls replaced the original refusal response.
+        assert success is True
+        assert error is None
+        assert final_response == "Running the task now."
+        assert "Running the task now." in output
+        assert "I can't help with that." not in output


### PR DESCRIPTION
Automated evolution PR for issue #2240.

## Problem
The refusal-recovery nudge (`maybe_refusal_nudge`) was tested in isolation but never wired into the actual cron dispatch path (`_run_job_impl`). Cron-context agents (where the evolution stages run) bypass `conversation_loop.py`, so refusals there were unrecoverable — the recovery rate stayed flat (23.5% → 26.65%) after #2168 because the directive was never surfaced in cron runs.

## Fix
Mirror the `delegate_tool.py` nudge (#2292): if a cron run completes with a text-only refusal (no tool calls), re-run the same agent once with the recovery directive. Adopt only on actual recovery (tool calls made or no longer a refusal). Bounded: 1 re-run.

- `cron/scheduler.py`: wire the nudge into `_run_job_impl` after the run_conversation result is validated.
- `tests/cron/test_cron_refusal_nudge.py`: add `TestRefusalNudgeWiring` — a full `_run_job_impl` integration test proving the nudge fires and recovery is adopted (was the missing regression coverage).

## Checks
- Pre-PR test runner: PASSED (tests/cron/test_scheduler.py shard)
- `pytest tests/cron/test_cron_refusal_nudge.py`: 6 passed (incl. new wiring test)
- `pytest tests/cron/test_cron_refusal_nudge.py tests/cron/test_evolution_preflight.py`: 47 passed
- `ruff check`: All checks passed
- Diff: 176 lines (within 200-line self-merge cap)

Closes #2240