### PR TITLE
fix(cron): per-job exponential backoff + auto-pause circuit breaker (Closes #70)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -964,6 +964,63 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
+def _failure_backoff_config() -> Dict[str, Any]:
+    """Return the ``cron`` config section for failure-backoff tuning (#70).
+
+    Read-only: uses ``load_config_readonly`` so the hot path (every job run)
+    does not pay the defensive deepcopy. A missing config yields an empty
+    dict so all call sites fall back to their built-in defaults.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        cron_cfg = cfg.get("cron") if isinstance(cfg, dict) else None
+        return cron_cfg if isinstance(cron_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _advance_schedule_by_steps(
+    schedule: Dict[str, Any],
+    from_iso: str,
+    n_steps: int,
+) -> Optional[str]:
+    """Advance ``from_iso`` forward by ``n_steps`` schedule slots.
+
+    Used by #70 to skip scheduled runs after identical consecutive failures:
+    instead of running on the very next slot, the job is pushed out by
+    ``failure_backoff_skips`` slots. Returns ``from_iso`` unchanged when the
+    schedule kind is unsupported or the step count is non-positive.
+    """
+    if n_steps <= 0:
+        return from_iso
+    if not isinstance(schedule, dict):
+        return from_iso
+    kind = schedule.get("kind")
+    try:
+        base = _ensure_aware(datetime.fromisoformat(from_iso))
+    except Exception:
+        base = _hermes_now()
+
+    if kind == "interval":
+        minutes = schedule.get("minutes")
+        if minutes is None:
+            return from_iso
+        return (base + timedelta(minutes=minutes * n_steps)).isoformat()
+
+    if kind == "cron":
+        expr = schedule.get("expr")
+        if not expr or not _ensure_croniter():
+            return from_iso
+        cron = croniter(expr, base)
+        result = base
+        for _ in range(n_steps):
+            result = cron.get_next(datetime)
+        return result.isoformat()
+
+    return from_iso
+
+
 # =============================================================================
 # Ticker heartbeat (liveness signal for `hermes cron status`)
 # =============================================================================
@@ -2123,6 +2180,11 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
+            # #70: a manual resume is an explicit "try again" — clear the
+            # failure streak so a single immediate failure doesn't re-trip the
+            # auto-pause circuit breaker on a stale streak.
+            "failure_streak": 0,
+            "failure_backoff_skips": None,
             "next_run_at": next_run_at,
         },
     )
@@ -2320,6 +2382,7 @@ def _mark_job_run_locked(
                         )
                         return False
                 now = _hermes_now().isoformat()
+                _prev_err = job.get("last_error")
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
                 job["last_error"] = error if not success else None
@@ -2334,6 +2397,30 @@ def _mark_job_run_locked(
                     job.pop("drift_alerted", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                # #70: per-job failure accounting (exponential backoff + circuit
+                # breaker). An error byte-identical to the previous run is
+                # deterministic: the fixed schedule re-running it only burns
+                # tokens/disk and floods the failure store. Backoff skips
+                # 2**(streak-1)-1 scheduled slots (capped, see
+                # failure_backoff_max_skips); a changed error or a success
+                # resets the streak.
+                if success:
+                    job["failure_streak"] = 0
+                    job.pop("failure_backoff_skips", None)
+                else:
+                    _same = bool(_prev_err) and error == _prev_err
+                    job["failure_streak"] = (
+                        int(job.get("failure_streak") or 0) + 1 if _same else 1
+                    )
+                    _streak = int(job["failure_streak"])
+                    _max_skips = int(
+                        _failure_backoff_config().get(
+                            "failure_backoff_max_skips", 16
+                        )
+                    )
+                    job["failure_backoff_skips"] = min(
+                        2 ** (_streak - 1) - 1, _max_skips
+                    )
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -2412,6 +2499,33 @@ def _mark_job_run_locked(
                         job["state"] = "completed"
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
+
+                # #70: apply failure backoff (skip scheduled slots) and, past
+                # the auto-pause threshold, pause the job for operator review
+                # instead of retrying a deterministic failure indefinitely.
+                # Placed AFTER the next_run_at computation so a pause cleanly
+                # clears the schedule rather than tripping the missing-croniter
+                # error branch above.
+                if not success:
+                    _skips = int(job.get("failure_backoff_skips") or 0)
+                    if _skips > 0 and job["next_run_at"] is not None:
+                        job["next_run_at"] = _advance_schedule_by_steps(
+                            job["schedule"], job["next_run_at"], _skips
+                        )
+                    if int(job.get("failure_streak") or 0) >= int(
+                        _failure_backoff_config().get(
+                            "failure_auto_pause_threshold", 10
+                        )
+                    ):
+                        job["enabled"] = False
+                        job["state"] = "paused"
+                        job["paused_at"] = now
+                        job["paused_reason"] = (
+                            "auto-paused after %d identical consecutive "
+                            "failures (last error: %.200s) — resume to retry"
+                            % (int(job["failure_streak"]), error or "")
+                        )
+                        job["next_run_at"] = None
 
                 save_jobs(jobs)
                 return True

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -25,6 +25,8 @@ from cron.jobs import (
     get_due_jobs,
     save_job_output,
     _hermes_now,
+    _advance_schedule_by_steps,
+    _failure_backoff_config,
 )
 
 
@@ -515,6 +517,88 @@ class TestMarkJobRun:
         assert updated["next_run_at"] is None
         assert updated["last_error"]
         assert "croniter" in updated["last_error"].lower()
+
+
+class TestFailureBackoff:
+    """#70: per-job exponential backoff + circuit breaker for deterministically
+    failing jobs. An error byte-identical to the previous run is deterministic
+    — the fixed schedule re-running it only burns tokens/disk. Backoff skips
+    2**(streak-1)-1 slots (capped); past the threshold the job auto-pauses."""
+
+    def test_single_failure_sets_streak_one_no_backoff(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 1
+        assert updated["failure_backoff_skips"] == 0
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+
+    def test_identical_failures_increment_streak_and_backoff(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 2
+        assert updated["failure_backoff_skips"] == 1  # 2**(2-1)-1
+
+    def test_changed_error_resets_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="TypeError: bad op")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 1
+
+    def test_success_resets_streak_and_skips(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=True)
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 0
+        assert updated.get("failure_backoff_skips") in (None, 0)
+
+    def test_auto_pause_after_threshold_identical_failures(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 10
+        assert updated["enabled"] is False
+        assert updated["state"] == "paused"
+        assert updated["next_run_at"] is None
+        assert "auto-paused" in (updated.get("paused_reason") or "")
+
+    def test_resume_clears_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        resume_job(job["id"])
+        updated = get_job(job["id"])
+        assert updated["enabled"] is True
+        assert updated["failure_streak"] == 0
+
+    def test_advance_schedule_by_steps_interval(self):
+        from datetime import datetime, timedelta, timezone
+        base = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc).isoformat()
+        advanced = _advance_schedule_by_steps(
+            {"kind": "interval", "minutes": 10}, base, 3
+        )
+        dt = datetime.fromisoformat(advanced)
+        assert dt == datetime(2026, 8, 18, 12, 30, tzinfo=timezone.utc)
+
+    def test_advance_schedule_by_steps_zero_is_identity(self):
+        base = "2026-08-18T12:00:00+00:00"
+        assert _advance_schedule_by_steps(
+            {"kind": "interval", "minutes": 10}, base, 0
+        ) == base
+
+    def test_failure_backoff_config_returns_dict_with_defaults(self, tmp_cron_dir):
+        # Even with no explicit tuning, the config section is a dict and the
+        # call sites fall back to their built-in defaults.
+        cfg = _failure_backoff_config()
+        assert isinstance(cfg, dict)
+        assert cfg.get("failure_backoff_max_skips", 16) == 16
 
 
 class TestAdvanceNextRun:


### PR DESCRIPTION
Automated evolution PR for issue #70 (Da-Mikey/hermes-agent-evolution).

## What
Per-job failure accounting in `_mark_job_run_locked`: byte-identical consecutive errors accumulate `failure_streak`; backoff skips `2**(streak-1)-1` scheduled slots (cap `cron.failure_backoff_max_skips` default 16); a success or changed error resets the streak; at `cron.failure_auto_pause_threshold` (default 10) the job auto-pauses (enabled=False, state=paused, paused_reason) as a circuit breaker. Manual resume clears the streak. Adds `_advance_schedule_by_steps` for interval and cron schedules.

## Why
Introspection finding `cron_deterministic_400_burst_no_backoff`: cron job 0b013aa0bd43 failed 4 consecutive times on a byte-identical Gemini-400, re-running a deterministic failure on the fixed schedule and burning tokens/disk.

## Tests
- 9 new tests in `tests/cron/test_jobs.py::TestFailureBackoff` (streak accounting, backoff skips, changed-error reset, success reset, auto-pause at threshold, resume clears streak, advance-by-steps interval/zero, config defaults).
- Full cron suite: 879 passed, 4 skipped.
- `ruff check` clean.

## Notes
This was previously mis-triaged as "already-exists" because the analysis stage read the uncommitted working-tree copy of `cron/jobs.py` (which already contained this implementation) and attributed it to `canonical/main`. Verified this session: no `failure_backoff` symbol exists on `lexus/main`, `origin/main`, or `canonical/main` — the code existed only uncommitted.

Closes #70.