### PR TITLE
feat(cron): refusal-recovery nudge for cron dispatch (#2240)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5704,6 +5704,17 @@ def _run_job_impl(
                 job_name,
             )
 
+        # ── Refusal-recovery nudge for cron dispatch (#2240) ────────────────
+        # The main conversation loop wires maybe_refusal_nudge (loop_guard.py)
+        # to detect over-refusal and inject recovery directives. Cron dispatch
+        # bypasses conversation_loop.py, so refusals in cron contexts were
+        # unrecoverable (76% of refusals/7d unrecovered, majority in cron).
+        # Re-run ONCE with the recovery directive and adopt only on a genuine
+        # recovery (see _maybe_cron_refusal_recovery). Bounded: 1 re-run.
+        result = _maybe_cron_refusal_recovery(
+            result, agent, job_name, _cron_context.run
+        )
+
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":
@@ -7124,6 +7135,105 @@ def _count_tool_calls(messages) -> int:
     if not isinstance(messages, list):
         return 0
     return sum(1 for m in messages if isinstance(m, dict) and m.get("role") == "tool")
+
+
+def _maybe_cron_refusal_recovery(
+    result: Dict[str, Any],
+    agent: Optional[Any],
+    job_name: str,
+    run_in_context,
+) -> Dict[str, Any]:
+    """Attempt a single refusal-recovery re-run for a cron dispatch result.
+
+    Cron dispatch bypasses ``conversation_loop.py``, so refusals in cron
+    contexts never received the loop-guard recovery nudge (#2240). If the
+    original run completed text-only with refusal language, re-run ONCE with
+    the recovery directive and adopt the re-run ONLY on a genuine recovery:
+    completed AND not failed AND (made tool calls OR no longer reads as a
+    refusal). A re-run that raises, returns non-dict, fails, or still reads
+    as a refusal leaves the original result untouched.
+    """
+    if not isinstance(result, dict):
+        return result
+    if agent is None:
+        return result
+    if not result.get("completed") or result.get("failed"):
+        return result
+    if _count_tool_calls(result.get("messages")) != 0:
+        return result
+
+    _cron_messages = result.get("messages") or []
+    _refusal_nudge = None
+    try:
+        from agent.loop_guard import maybe_refusal_nudge as _maybe_refusal
+
+        _refusal_nudge = _maybe_refusal(_cron_messages, already_nudged=False)
+    except Exception:
+        _refusal_nudge = None
+    if not _refusal_nudge:
+        return result
+
+    logger.info(
+        "Cron job '%s' refusal detected; re-running once with recovery nudge",
+        job_name,
+    )
+    _refusal_result = None
+    try:
+        _refusal_result = run_in_context(
+            lambda: agent.run_conversation(
+                user_message=_refusal_nudge,
+                conversation_history=_cron_messages,
+            )
+        )
+    except Exception as _rf_exc:
+        logger.warning(
+            "Cron job '%s' refusal-recovery re-run raised %s; keeping original",
+            job_name,
+            type(_rf_exc).__name__,
+        )
+    if not isinstance(_refusal_result, dict):
+        return result
+
+    # Adopt ONLY a genuine completion (defect #3): a failed re-run
+    # (completed=False / failed=True) must never be laundered into a success.
+    if not (_refusal_result.get("completed") is True) or bool(
+        _refusal_result.get("failed")
+    ):
+        logger.info(
+            "Cron job '%s' refusal-recovery re-run did not complete; keeping original",
+            job_name,
+        )
+        return result
+
+    _rf_tool_calls = _count_tool_calls(_refusal_result.get("messages"))
+    # Recovery must be real: tool calls in the re-run OR the response no
+    # longer reads as a refusal.
+    _rf_still_refusal = False
+    try:
+        from agent.loop_guard import maybe_refusal_nudge as _mr2
+
+        _rf_still_refusal = (
+            _mr2(
+                _refusal_result.get("messages") or [],
+                already_nudged=True,
+            )
+            is not None
+        )
+    except Exception:
+        pass
+    if not (_rf_tool_calls or not _rf_still_refusal):
+        logger.info(
+            "Cron job '%s' refusal-recovery re-run still a refusal; keeping original",
+            job_name,
+        )
+        return result
+
+    logger.info(
+        "Cron job '%s' refusal recovery adopted (%d tool calls in re-run)",
+        job_name,
+        _rf_tool_calls,
+    )
+    return _refusal_result
 
 
 # Tool-call counts per job id for the CURRENT run, written by _run_job_impl

--- a/tests/cron/test_cron_refusal_nudge.py
+++ b/tests/cron/test_cron_refusal_nudge.py
@@ -167,3 +167,91 @@ class TestRefusalNudgeCron:
         assert still_refusal
         assert tool_calls == 0
         assert not (tool_calls or not still_refusal)  # adopt gate is False
+
+
+class TestMaybeCronRefusalRecovery:
+    """Exercises _maybe_cron_refusal_recovery (#2240 re-implementation).
+
+    The original #2240 Slice B tests verified the adopt-gate LOGIC in
+    isolation. These test the REAL helper wired into _run_job_impl: a
+    text-only refusal triggers ONE grounded re-run (conversation_history
+    passthrough — defect #2), and adoption requires a genuine recovery —
+    completed AND not failed (defect #3) AND made tool calls OR no longer
+    reads as a refusal.
+    """
+
+    class _FakeAgent:
+        """Minimal fake exposing the run_conversation method the helper calls."""
+
+        def __init__(self, fn):
+            self._fn = fn
+
+        def run_conversation(self, user_message=None, conversation_history=None, **kw):
+            return self._fn(user_message, conversation_history)
+
+    def test_refusal_triggers_grounded_rerun_and_adopts(self):
+        from cron.scheduler import _maybe_cron_refusal_recovery
+
+        refusal = _make_result(
+            "I'm sorry, I can't help with that.",
+            messages=[
+                {"role": "user", "content": "do the cron task"},
+                {
+                    "role": "assistant",
+                    "content": "I'm sorry, I can't help with that.",
+                },
+            ],
+        )
+
+        calls = []
+
+        def fake_run(user_message, conversation_history):
+            calls.append((user_message, conversation_history))
+            # Recovery re-run that made a tool call
+            return _make_result(
+                "Done! I ran the cron task.",
+                messages=[
+                    {"role": "user", "content": "do the cron task"},
+                    {"role": "assistant", "content": "I cannot assist."},
+                    {"role": "user", "content": "[loop-guard] re-check tools"},
+                    {
+                        "role": "assistant",
+                        "content": "Running the task now.",
+                        "tool_calls": [
+                            {"function": {"name": "terminal", "arguments": "{}"}}
+                        ],
+                    },
+                    {"role": "tool", "content": "output"},
+                ],
+            )
+
+        out = _maybe_cron_refusal_recovery(
+            refusal,
+            agent=self._FakeAgent(fake_run),
+            job_name="job1",
+            run_in_context=lambda f: f(),
+        )
+        assert len(calls) == 1
+        user_msg, history = calls[0]
+        # Defect #2: the re-run is grounded — original history is passed through
+        assert history == refusal["messages"]
+        assert _count_tool_calls(out["messages"]) > 0
+
+    def test_failed_rerun_is_not_adopted(self):
+        """A re-run that does not complete must not be adopted —
+        otherwise a refusal is laundered into a fake completion."""
+        from cron.scheduler import _maybe_cron_refusal_recovery
+
+        refusal = _make_result("I can't help.")
+
+        def fake_run(user_message, conversation_history):
+            return {"completed": False, "failed": True, "messages": []}
+
+        out = _maybe_cron_refusal_recovery(
+            refusal,
+            agent=self._FakeAgent(fake_run),
+            job_name="job1",
+            run_in_context=lambda f: f(),
+        )
+        # Original preserved; failed re-run NOT adopted
+        assert out is refusal


### PR DESCRIPTION
## Summary

Re-implements the cron dispatch refusal-recovery nudge for issue #2240. Upstream sync `a6cbea137e` (v2026.8.16, PR #2719) clobbered the earlier #2301 wiring from `cron/scheduler.py`; only `_count_tool_calls` and the (logic-only) tests survived on `origin/main`.

This is a clean re-implementation that fixes the two defects that were live in the clobbered code and the earlier unmerged rework:

- **Defect #2 (context-free re-run):** the recovery re-run now passes `conversation_history=` (the original run's messages) so the model is grounded in the job's full prompt/context — not just the one-line nudge.
- **Defect #3 (failed re-run adopted as success):** adoption now requires the re-run to have `completed=True` AND `failed != True` AND (made tool calls OR no longer reads as a refusal). A failed/still-refusing re-run leaves the original result untouched.

## Wiring (real call site)

`_run_job_impl` now calls the new `_maybe_cron_refusal_recovery(result, agent, job_name, _cron_context.run)` helper right after the failure-check block, so the nudge only fires on genuinely completed, text-only refusal runs. Exactly one re-run is attempted; it is a single `run_conversation` turn and never double-executes job side effects.

## Testing

- New `TestMaybeCronRefusalRecovery` class in `tests/cron/test_cron_refusal_nudge.py` exercises the real helper via a fake agent with `run_conversation`, asserting:
  - refusal triggers ONE grounded re-run with original history passed through;
  - a failed re-run is NOT adopted (original preserved).
- Existing `TestRefusalNudgeCron` (survived on main) retained unchanged.
- `evolution_pre_pr_test_runner.py` shard for `tests/cron/test_scheduler.py`: PASS.
- `ruff check` on changed files: clean.

## Scope

Closes #2240. Does not touch #2826 (delegation toolset inheritance).