### PR TITLE
feat(tools): exec-capability gate for shell-requiring subagents (#2826)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3795,3 +3795,56 @@ class TestDeniedToolsetsSurfacedToChild(unittest.TestCase):
         prompt = call_kwargs["ephemeral_system_prompt"]
         self.assertIn("TOOLSET LIMITATION", prompt)
         self.assertIn("delegation", prompt)
+
+
+class TestChildExecCapabilityGate(unittest.TestCase):
+    """#2826: shell-requiring subagents whose resolved toolset lacks
+    `terminal` must be blocked VISIBLY (not dispatched to a doomed run)."""
+
+    def _child(self, toolsets):
+        c = MagicMock()
+        c.enabled_toolsets = toolsets
+        return c
+
+    def test_shell_goal_without_terminal_blocked(self):
+        from tools.delegate_tool import _child_blocked_no_terminal
+
+        child = self._child(["web", "browser"])
+        out = _child_blocked_no_terminal(0, "run git status in the repo", child)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out["status"], "blocked")
+        self.assertEqual(out["exit_reason"], "blocked_no_terminal")
+        self.assertEqual(out["api_calls"], 0)  # no doomed LLM call
+
+    def test_shell_goal_with_terminal_proceeds(self):
+        from tools.delegate_tool import _child_blocked_no_terminal
+
+        child = self._child(["web", "terminal"])
+        out = _child_blocked_no_terminal(0, "git status in the repo", child)
+        self.assertIsNone(out)  # terminal present → proceed
+
+    def test_non_shell_goal_proceeds_without_terminal(self):
+        from tools.delegate_tool import _child_blocked_no_terminal
+
+        child = self._child(["web", "browser"])
+        out = _child_blocked_no_terminal(0, "summarize the page content", child)
+        self.assertIsNone(out)  # no shell verbs → no gate
+
+    def test_run_single_child_returns_blocked_before_run(self):
+        """The gate is wired into _run_single_child: a child whose resolved
+        toolset lacks terminal for a shell goal returns a blocked result and
+        never calls run_conversation."""
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child.enabled_toolsets = ["web", "browser"]
+        child.run_conversation = MagicMock()
+
+        out = _run_single_child(
+            task_index=0,
+            goal="git clone and build the repo",
+            child=child,
+        )
+        self.assertEqual(out["status"], "blocked")
+        child.run_conversation.assert_not_called()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2959,6 +2959,50 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _child_blocked_no_terminal(task_index: int, goal: str, child) -> Optional[Dict[str, Any]]:
+    """#2826 exec-capability gate: visible BLOCKED outcome for shell-requiring
+    subagents whose resolved toolset lacks `terminal`.
+
+    Returns a blocked result dict when the goal needs shell access but the
+    child cannot run with it, else None (proceed). Checks the ACTUAL toolset
+    the child was provisioned with — not the parent's environment — which is
+    the exact gap #2826 documents (subagents provisioned without shell while
+    the task needs one). The _build_child_agent auto-add already widened the
+    child when the parent could provide terminal; reaching here without it
+    means dispatch would be doomed, so we block visibly instead.
+    """
+    if not _goal_needs_terminal(goal):
+        return None
+    _child_ts = getattr(child, "enabled_toolsets", None)
+    # Fail-open: only gate when the child declares a concrete toolset list.
+    # Real children built by _build_child_agent always carry one; bare mocks
+    # (used by heartbeat/observability tests) do not, and blocking them would
+    # be a false positive.
+    if not isinstance(_child_ts, (list, tuple, set, frozenset)):
+        return None
+    if "terminal" in _expand_parent_toolsets(set(_child_ts)):
+        return None
+    logger.warning(
+        "delegate_task: subagent %d goal requires shell access but child "
+        "toolset lacks 'terminal' — blocking dispatch (#2826)", task_index,
+    )
+    return {
+        "task_index": task_index,
+        "status": "blocked",
+        "summary": None,
+        "error": (
+            "Subagent goal requires shell/terminal access but the resolved "
+            "child toolset does not include 'terminal', so dispatch cannot "
+            "succeed. The parent could not provision terminal for the "
+            "subagent. (#2826 exec-capability gate)"
+        ),
+        "exit_reason": "blocked_no_terminal",
+        "api_calls": 0,
+        "duration_seconds": 0.0,
+        "_child_role": getattr(child, "_delegate_role", None),
+    }
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2975,6 +3019,12 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+
+    # #2826: block a doomed dispatch before any thread/credential setup so
+    # nothing (heartbeat thread, subagent contextvar, credential lease) leaks.
+    _blocked = _child_blocked_no_terminal(task_index, goal, child)
+    if _blocked is not None:
+        return _blocked
 
     # Agent-team identity (issue #252): rebind this worker thread's team
     # identity so the team tools resolve the right team + member when the


### PR DESCRIPTION
## Summary

Implements the #2826 exec-capability gate rejected PR #2836 was sent back for. The repo owner's critique was precise: the old gate probed the **parent scheduler env** for git on PATH (a category error — the issue is about **subagents** provisioned without terminal), and returned a **silent success** that hid the defect from digests.

This PR fixes both:

1. **Probes the ACTUAL child toolset, not the parent env.** The new `_child_blocked_no_terminal()` helper reads the child's resolved `enabled_toolsets` — the toolset the subagent will actually run with. The `_build_child_agent` auto-add (#1369) already widens the child when the parent can provide terminal; if the child still lacks it here, the parent itself didn't have it — the exact gap #2826 documents.

2. **Returns a VISIBLE BLOCKED outcome** (`status: "blocked"`, `exit_reason: "blocked_no_terminal"`, descriptive `error` string), not a silent success. The blocked result propagates through `delegate_task`'s normal result-surfacing path, so the defect stays observable in digests and the parent agent sees a clear error.

## Wiring (real call site)

`_run_single_child` calls `_child_blocked_no_terminal(task_index, goal, child)` as its **first statement** (before any thread, contextvar, or credential-lease setup), so a blocked dispatch returns immediately with zero resource leaks and zero LLM calls spent on a doomed subagent.

## Fail-open design

The gate only fires when the child declares a concrete `enabled_toolsets` list/tuple/set. Bare mocks (used by heartbeat/observability tests) don't carry one, so the gate returns `None` (proceed) for them — no false positives.

## Testing

New `TestChildExecCapabilityGate` class in `tests/tools/test_delegate.py` (4 tests):
- shell-requiring goal + child without terminal → **blocked** (visible, 0 API calls)
- shell-requiring goal + child with terminal → **proceeds** (gate returns None)
- non-shell goal + child without terminal → **proceeds** (no shell verbs, no gate)
- `_run_single_child` integration: blocked child never calls `run_conversation`

Full `tests/tools/test_delegate.py`: **188 passed**, `ruff check`: **clean**.

## Pre-existing CI note

The `tests/tools` directory shard in `evolution_pre_pr_test_runner.py` fails on `tests/tools/test_approval.py::TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` — this failure is **pre-existing on origin/main** (reproduced on a clean main checkout) and is **unrelated to this PR's changes**. The shard uses `-x` (stop on first failure), so it never reaches the delegate tests in that run; the direct delegate test run is green.

## Scope

Closes #2826. Does not touch #2240 (separate PR #2844).