### PR TITLE
feat(evolution): GRASP-style balanced-probe regression gate for skill edits (Closes #2840)

### DIFF
--- a/evolution/lib/grasp_gate.py
+++ b/evolution/lib/grasp_gate.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""GRASP-style balanced-probe regression gate for the skill-evolution loop (#2840).
+
+GRASP (Gated Regression-Aware Skill Proposer, arXiv:2605.29668 v2) treats
+agent self-improvement as validated edits to a bounded, versioned skill
+library: a candidate skill edit is re-run on a BALANCED probe of
+previously-failing AND previously-passing examples, and is accepted only when
+it fixes more failures than it causes regressions AND introduces no regression
+beyond the existing baseline (hard regression budget). When a fix nets
+positive but regresses at least one case, a contrastive-revision step shows
+the skill-writer the regressed example so the trigger can be narrowed.
+
+This module supplies the pieces the codebase's earlier skill gates (SkillProx
+``verify_skill_edit``, ``rubric_heldout_gate``, ``skill_shrink``,
+``skill_hub_tx``) did not fully supply:
+
+1. **Balanced hold-out probe** — the hold-out split is stratified so it
+   contains BOTH previously-failing and previously-passing examples (a tail
+   split can be all-one-class and silently blind the gate to regressions).
+2. **Hard regression budget** — a candidate is accepted only when net fixes
+   exceed regressions AND regressions stay within the baseline threshold.
+3. **Contrastive revision** — a regress-but-positive candidate returns the
+   regressed examples so the writer can narrow the trigger and resubmit.
+
+Pure, deterministic, import-safe, no LLM, no IO. The judge signature reuses
+``RubricJudge`` from :mod:`evolution.lib.rubric_forge`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Sequence, Tuple
+
+from evolution.lib.rubric_forge import RubricJudge
+
+__all__ = [
+    "GraspVerdict",
+    "DECISION_ACCEPT",
+    "DECISION_REVISE",
+    "DECISION_REJECT",
+    "balanced_probe_split",
+    "grasp_regression_gate",
+]
+
+#: Candidate skill edits pass the hard gate (accepted into the library).
+DECISION_ACCEPT = "accept"
+#: Net-positive but regressed a case — contrastive revision should narrow it.
+DECISION_REVISE = "revise"
+#: Failed the hard budget / net-negative — rejected outright.
+DECISION_REJECT = "reject"
+
+
+@dataclass
+class GraspVerdict:
+    """Decision for one candidate skill edit on the balanced probe.
+
+    A "previously-failing" example is one the OLD skill accepted but should
+    have rejected (label ``False``): a new skill FIXES it by rejecting it.
+    A "previously-passing" example (label ``True``) is REGRESSED when the new
+    skill now rejects it. ``net_fixed`` = fixed - regressed.
+    """
+
+    decision: str
+    net_fixed: int
+    fixed: int
+    regressed: int
+    regression_budget: int
+    probe_size: int
+    regressed_examples: List[Any] = field(default_factory=list)
+    reason: str = ""
+
+
+def balanced_probe_split(
+    labeled: Sequence[Any],
+    labels: Sequence[bool],
+    *,
+    probe_size: int = 4,
+) -> Tuple[List[Any], List[bool], List[Any], List[bool]]:
+    """Stratified split: keep a balanced mix of failing and passing in the probe.
+
+    Returns ``(train_ex, train_lb, probe_ex, probe_lb)`` where the probe holds
+    up to ``probe_size`` examples drawn deterministically so that BOTH
+    previously-failing (label False) and previously-passing (label True)
+    examples are represented. Deterministic (no RNG) so decisions are
+    reproducible. Falls back to the whole set when it is too small to split.
+    """
+    if len(labeled) != len(labels):
+        raise ValueError("labeled and labels must be parallel sequences")
+
+    failing = [i for i, lb in enumerate(labels) if not lb]
+    passing = [i for i, lb in enumerate(labels) if lb]
+
+    probe_idx: List[int] = []
+    # Round-robin over failing/passing so both classes appear (balanced probe).
+    # Both branches respect the probe_size cap (the earlier failing branch
+    # could overflow past probe_size).
+    for i in range(max(0, probe_size)):
+        if i % 2 == 0:
+            if failing and len(probe_idx) < probe_size:
+                probe_idx.append(failing.pop(0))
+        elif passing and len(probe_idx) < probe_size:
+            probe_idx.append(passing.pop(0))
+
+    train_ex = [labeled[i] for i in range(len(labeled)) if i not in set(probe_idx)]
+    train_lb = [labels[i] for i in range(len(labeled)) if i not in set(probe_idx)]
+    probe_ex = [labeled[i] for i in probe_idx]
+    probe_lb = [labels[i] for i in probe_idx]
+    return train_ex, train_lb, probe_ex, probe_lb
+
+
+def _verdict_breakdown(
+    candidate: str,
+    probe_ex: Sequence[Any],
+    probe_lb: Sequence[bool],
+    judge: RubricJudge,
+) -> Tuple[int, int, List[Any]]:
+    """Count (fixed, regressed, regressed_examples) for ``candidate``.
+
+    - FIXED: a previously-FAILING example (label False) the candidate now
+      correctly REJECTS (judge -> False).
+    - REGRESSED: a previously-PASSING example (label True) the candidate now
+      wrongly REJECTS (judge -> False).
+    A throwing judge rejects nothing and accepts nothing it cannot judge.
+    """
+    fixed = 0
+    regressed = 0
+    regressed_examples: List[Any] = []
+    for ex, lb in zip(probe_ex, probe_lb):
+        try:
+            accepted = bool(judge(candidate, ex))
+        except Exception:  # noqa: BLE001 - a throwing judge proves nothing
+            continue  # unknown outcome: count as neither fixed nor regressed
+        if not lb and not accepted:
+            fixed += 1  # previously-failing, now correctly rejected
+        elif lb and not accepted:
+            regressed += 1  # previously-passing, now wrongly rejected
+            regressed_examples.append(ex)
+    return fixed, regressed, regressed_examples
+
+
+def grasp_regression_gate(
+    candidate: str,
+    baseline: str,
+    labeled: Sequence[Any],
+    labels: Sequence[bool],
+    judge: RubricJudge,
+    *,
+    probe_size: int = 4,
+    regression_budget: int = 0,
+) -> GraspVerdict:
+    """GRASP gate for a candidate skill edit (``candidate`` vs ``baseline``).
+
+    Splits into a balanced probe, re-runs the candidate on it, and decides:
+
+    * **accept** — the candidate fixes MORE previously-failing examples than
+      it regresses previously-passing ones (``net_fixed > 0``) AND the number
+      of regressions stays within ``regression_budget`` (hard budget, GRASP).
+    * **revise** — net-positive but regressed at least one passing example
+      beyond budget: contrastive-revision carries the regressed examples back
+      to the skill-writer so the trigger can be narrowed.
+    * **reject** — net non-positive, or the probe is empty (nothing provable).
+
+    The ``baseline`` is used only for the regression-budget comparison: the
+    candidate is not worse than the shipped baseline's own regressions. Pure
+    and deterministic.
+    """
+    _, _, probe_ex, probe_lb = balanced_probe_split(
+        labeled, labels, probe_size=probe_size
+    )
+    if not probe_ex:
+        return GraspVerdict(
+            decision=DECISION_REJECT,
+            net_fixed=0,
+            fixed=0,
+            regressed=0,
+            regression_budget=regression_budget,
+            probe_size=0,
+            reason="empty probe — regression parity unprovable, refusing acceptance",
+        )
+
+    fixed, regressed, regressed_examples = _verdict_breakdown(
+        candidate, probe_ex, probe_lb, judge
+    )
+    net_fixed = fixed - regressed
+
+    # Hard regression budget: regressions must not exceed the baseline's own.
+    baseline_regressed = 0
+    try:
+        _, baseline_regressed, _ = _verdict_breakdown(
+            baseline, probe_ex, probe_lb, judge
+        )
+    except Exception:  # noqa: BLE001 - a throwing baseline just means budget 0
+        baseline_regressed = 0
+    hard_budget = max(regression_budget, baseline_regressed)
+
+    if net_fixed > 0 and regressed <= hard_budget:
+        return GraspVerdict(
+            decision=DECISION_ACCEPT,
+            net_fixed=net_fixed,
+            fixed=fixed,
+            regressed=regressed,
+            regression_budget=hard_budget,
+            probe_size=len(probe_ex),
+            reason=f"net fixes {net_fixed:+d} (fixed {fixed}, regressed {regressed}) within hard budget {hard_budget}",
+        )
+    if net_fixed > 0 and regressed > hard_budget:
+        return GraspVerdict(
+            decision=DECISION_REVISE,
+            net_fixed=net_fixed,
+            fixed=fixed,
+            regressed=regressed,
+            regression_budget=hard_budget,
+            probe_size=len(probe_ex),
+            regressed_examples=regressed_examples,
+            reason=f"net-positive {net_fixed:+d} but {regressed} regressions exceed budget {hard_budget}",
+        )
+    return GraspVerdict(
+        decision=DECISION_REJECT,
+        net_fixed=net_fixed,
+        fixed=fixed,
+        regressed=regressed,
+        regression_budget=hard_budget,
+        probe_size=len(probe_ex),
+        regressed_examples=regressed_examples,
+        reason=f"net fixes {net_fixed:+d} is not positive — rejected",
+    )

--- a/tests/evolution/test_grasp_gate.py
+++ b/tests/evolution/test_grasp_gate.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Tests for evolution/lib/grasp_gate.py (#2840, GRASP regression gate)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution.lib.grasp_gate import (  # noqa: E402
+    DECISION_ACCEPT,
+    DECISION_REJECT,
+    DECISION_REVISE,
+    balanced_probe_split,
+    grasp_regression_gate,
+)
+from evolution.lib.rubric_forge import RubricJudge  # noqa: E402
+
+
+def _kw_judge(rubric: str, example) -> bool:
+    """Keyword-requirement judge mirroring the pipeline's S1 wiring.
+
+    A skill body (rubric) ACCEPTS an example when it contains every required
+    keyword and none of the forbidden keywords; otherwise it REJECTS it.
+    """
+    ex = example if isinstance(example, dict) else {}
+    requires = [k for k in (ex.get("requires") or []) if isinstance(k, str)]
+    forbids = [k for k in (ex.get("forbids") or []) if isinstance(k, str)]
+    verdict = all(k in rubric for k in requires)
+    if forbids:
+        verdict = verdict and not any(k in rubric for k in forbids)
+    return bool(verdict)
+
+
+def _tok_judge(rubric: str, example) -> bool:
+    """Declarative judge: ACCEPT iff the example's ``token`` is in ``rubric``.
+
+    Gives exact control over which probe examples a candidate accepts/rejects,
+    so the regression-budget tests are precise (no keyword ambiguities).
+    """
+    return bool(example.get("token") in rubric.split())
+
+
+# --- balanced probe split -------------------------------------------------
+
+class TestBalancedProbeSplit:
+    def test_split_is_deterministic_and_parallel(self):
+        xs = list(range(8))
+        lb = [False, True, False, True, False, True, False, True]
+        train_ex, train_lb, probe_ex, probe_lb = balanced_probe_split(xs, lb, probe_size=4)
+        # Round-robin failing-then-passing: failing idx {0,2,...} fill odd i.
+        assert probe_ex == [0, 1, 2, 3]
+        assert probe_lb == [False, True, False, True]
+        assert train_ex == [4, 5, 6, 7]
+
+    def test_probe_contains_both_classes_when_possible(self):
+        labeled = [{"requires": ["a"]}, {"requires": ["b"]}, {"requires": ["c"]},
+                   {"requires": ["d"]}]
+        labels = [True, True, False, False]
+        _, _, probe_ex, probe_lb = balanced_probe_split(labeled, labels, probe_size=4)
+        assert len(probe_ex) == 4
+        assert any(probe_lb) and any(not lb for lb in probe_lb)  # both classes
+
+    def test_mismatched_inputs_raise(self):
+        try:
+            balanced_probe_split([1, 2], [True])
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError for mismatched lengths")
+
+    def test_empty_degrades_to_empty_probe(self):
+        _, _, probe_ex, probe_lb = balanced_probe_split([1], [True], probe_size=4)
+        assert probe_ex == [1] and probe_lb == [True]
+
+    def test_probe_size_zero_yields_empty_probe(self):
+        _, _, probe_ex, _ = balanced_probe_split([1, 2], [True, False], probe_size=0)
+        assert probe_ex == []
+
+
+# --- the GRASP gate -------------------------------------------------------
+
+class TestGraspRegressionGate:
+    def test_accept_when_fixes_within_budget(self):
+        # Candidate "q" fixes both failing examples (drops the forbidden
+        # keyword) and regresses nothing.
+        labeled = [{"requires": ["q"]}, {"requires": ["q", "drop"]},
+                   {"requires": ["q", "drop"]}]
+        labels = [True, False, False]
+        v = grasp_regression_gate("q", "q drop", labeled, labels, _kw_judge, probe_size=5)
+        assert v.decision == DECISION_ACCEPT
+        assert v.net_fixed == 2 and v.regressed == 0
+
+    def test_reject_when_net_not_positive(self):
+        # Candidate "x" fixes the failing example but also regresses the
+        # passing one: net = 0 -> rejected outright.
+        labeled = [{"requires": ["q"]}, {"requires": ["q", "drop"]}]
+        labels = [True, False]
+        v = grasp_regression_gate("x", "q drop", labeled, labels, _kw_judge, probe_size=5)
+        assert v.decision == DECISION_REJECT
+        assert v.net_fixed == 0
+
+    def test_revise_when_regressed_beyond_budget(self):
+        # Candidate "T1" accepts only T1: fixes F1/F2 but regresses the passing
+        # T2. Net-positive yet regressions exceed budget 0 -> contrastive revise.
+        labeled = [{"token": "T1"}, {"token": "T2"},
+                   {"token": "F1"}, {"token": "F2"}, {"token": "F3"}]
+        labels = [True, True, False, False, False]
+        v = grasp_regression_gate("T1", "T1 T2", labeled, labels, _tok_judge,
+                                  probe_size=5, regression_budget=0)
+        assert v.decision == DECISION_REVISE
+        assert v.net_fixed == 2 and v.regressed == 1
+        # Contrastive revision feeds the regressed example back to the writer.
+        assert len(v.regressed_examples) == 1
+
+    def test_regression_budget_parameter_tightens(self):
+        # Candidate accepts only T1: fixes F1/F2/F3, regresses passing T2.
+        # Within budget 1 it is accepted; with budget 0 it must be revised.
+        labeled = [{"token": "T1"}, {"token": "T2"},
+                   {"token": "F1"}, {"token": "F2"}, {"token": "F3"}]
+        labels = [True, True, False, False, False]
+        loose = grasp_regression_gate("T1", "T1 T2", labeled, labels, _tok_judge,
+                                      probe_size=5, regression_budget=1)
+        tight = grasp_regression_gate("T1", "T1 T2", labeled, labels, _tok_judge,
+                                      probe_size=5, regression_budget=0)
+        assert loose.decision == DECISION_ACCEPT
+        assert loose.net_fixed == 2 and loose.regressed == 1
+        assert tight.decision == DECISION_REVISE
+
+    def test_empty_probe_is_fail_closed(self):
+        v = grasp_regression_gate("a", "a", [], [], _kw_judge)
+        assert v.decision == DECISION_REJECT
+        assert "unprovable" in v.reason
+
+    def test_throwing_judge_degrades_safely(self):
+        def _boom(_r, _e):
+            raise RuntimeError("network down")
+
+        labeled = [{"token": "T1"}, {"token": "F1"}]
+        labels = [True, False]
+        v = grasp_regression_gate("x", "y", labeled, labels, _boom, probe_size=5)
+        # A throwing judge proves nothing: neither fixed nor regressed counts,
+        # net 0 -> reject (never a false accept).
+        assert v.decision == DECISION_REJECT
+        assert v.fixed == 0 and v.regressed == 0
+
+    def test_baseline_supplies_budget_when_parameter_zero(self):
+        # The baseline itself regresses a passing example; with budget 0 the
+        # hard budget is still at least the baseline's own regressions.
+        labeled = [{"token": "T1"}, {"token": "T2"},
+                   {"token": "F1"}, {"token": "F2"}]
+        labels = [True, True, False, False]
+        v = grasp_regression_gate("T1 T2 F1 F2", "T1 T2", labeled, labels,
+                                  _tok_judge, probe_size=5, regression_budget=0)
+        assert v.regression_budget >= 0


### PR DESCRIPTION
Implements #2840 — the GRASP (Gated Regression-Aware Skill Proposer, arXiv:2605.29668) regression gate for the skill-evolution loop, supplying the three mechanisms the issue flags as "Missing today":

1. **Balanced probe split** (`balanced_probe_split`) — a stratified hold-out that guarantees BOTH previously-failing and previously-passing examples appear in the probe, so the gate can actually observe regressions (a deterministic tail split can be single-class and blind).
2. **Hard regression budget** — `grasp_regression_gate` accepts a candidate only when it fixes MORE previously-failing examples than it regresses passing ones (net_fixed > 0) AND its regressions stay within the baseline's own regression count / the caller's `regression_budget`.
3. **Contrastive revision** — a net-positive candidate that regressed a case returns `DECISION_REVISE` with the regressed examples attached, so the skill-writer can narrow the trigger and resubmit; `DECISION_ACCEPT` / `DECISION_REJECT` are the other verdicts, all reported for traceability.

Design mirrors the sibling skill-gate libs (`skill_prox.py`, `rubric_heldout_gate.py`): pure, import-safe, deterministic, no LLM/IO. Reuses `RubricJudge` from `evolution/lib/rubric_forge.py`. A throwing judge counts as *unknown* (never a false accept). Empty probe fails closed.

**Tests:** 12 new tests in `tests/evolution/test_grasp_gate.py` covering the balanced split, accept/reject/revise decisions, the regression-budget knob, contrastive-revision payloads, fail-closed empty probe, and throwing-judge degradation. All pass locally; ruff clean.