### PR TITLE
feat: dedup device-state flaps before LLM round-trip (Closes #71)

### DIFF
--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -19,7 +19,7 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, Tuple
 
 try:
     import aiohttp
@@ -61,6 +61,97 @@ def _get_scoped_secret(name, default=None):
 
 
 logger = logging.getLogger(__name__)
+
+# Default flap-suppression window: an identical (entity, toggled-to state)
+# event arriving within this many seconds of the last forwarded one is
+# dropped before it costs an LLM round-trip.  See FlapSuppressor.
+_DEFAULT_FLAP_SUPPRESSION_SECONDS = 60.0
+
+
+def _parse_window_seconds(
+    value: Any, default: float = _DEFAULT_FLAP_SUPPRESSION_SECONDS
+) -> float:
+    """Coerce a config flap-suppression window to seconds.
+
+    Accepts int/float or numeric strings; anything unparseable (including
+    ``bool``, which is an ``int`` subclass and would otherwise read as
+    1/0) falls back to ``default``.  Values <= 0 disable suppression, so
+    ``flap_suppression_seconds: 0`` is an explicit config-driven off
+    switch.
+    """
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed != parsed or parsed in (float("inf"), float("-inf")):
+        return default
+    return parsed
+
+
+class FlapSuppressor:
+    """Deduplicate repeated (entity, state) toggles within a window.
+
+    Home Assistant presence / location trackers and binary sensors
+    oscillate: a device flaps A -> B -> A -> B with a period longer than
+    the per-entity ``cooldown_seconds``, and every toggle currently costs
+    a full LLM round-trip that answers "known flap -- no action".  This
+    suppressor keys on ``(entity_id, toggled-to state)`` so an identical
+    toggle arriving within ``window_seconds`` of the last *forwarded* one
+    is dropped, while a genuine state change (a different target state)
+    always passes through.  Re-notification resumes once the window since
+    the last forwarded occurrence expires, and entities are fully
+    independent (each has its own ``(entity, state)`` key).
+
+    The window anchors on the last forwarded occurrence: suppressed
+    events do not extend it, so a continuously flapping device re-notifies
+    at most once per window instead of never.
+
+    A window <= 0 disables suppression entirely.
+    """
+
+    def __init__(self, window_seconds: float) -> None:
+        self.window_seconds = max(0.0, float(window_seconds))
+        self._last_seen: Dict[Tuple[str, str], float] = {}
+
+    def should_suppress(
+        self, entity_id: str, new_state: str, now: Optional[float] = None
+    ) -> bool:
+        """Return True when this (entity, state) toggle is a known flap.
+
+        Records the occurrence timestamp only when the event is NOT
+        suppressed (i.e. when it will be forwarded to the LLM).  Expired
+        keys are pruned opportunistically so memory stays bounded for a
+        long-running gateway.
+        """
+        if self.window_seconds <= 0:
+            return False
+        now = time.time() if now is None else now
+        key = (entity_id, new_state)
+        last = self._last_seen.get(key)
+        if last is not None and (now - last) < self.window_seconds:
+            return True
+        self._last_seen[key] = now
+        self._prune(now)
+        return False
+
+    def _prune(self, now: float) -> None:
+        """Drop keys whose window has fully expired.
+
+        An expired key would let the event through anyway, so pruning is
+        semantics-preserving and keeps the tracker bounded.
+        """
+        if self.window_seconds <= 0:
+            self._last_seen.clear()
+            return
+        expired = [
+            key
+            for key, ts in self._last_seen.items()
+            if (now - ts) >= self.window_seconds
+        ]
+        for key in expired:
+            del self._last_seen[key]
 
 
 def check_ha_requirements() -> bool:
@@ -111,6 +202,14 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._ignore_entities: Set[str] = set(extra.get("ignore_entities", []))
         self._watch_all: bool = bool(extra.get("watch_all", False))
         self._cooldown_seconds: int = int(extra.get("cooldown_seconds", 30))
+
+        # Flap suppression: repeat (entity, toggled-to state) events within
+        # this window are dropped before they reach the LLM.  Config-driven
+        # via ``extra.flap_suppression_seconds`` (default 60s; 0 disables;
+        # unparseable values fall back to the default).
+        self._flap_suppressor = FlapSuppressor(
+            _parse_window_seconds(extra.get("flap_suppression_seconds"))
+        )
 
         # Cooldown tracking: entity_id -> last_event_timestamp
         self._last_event_time: Dict[str, float] = {}
@@ -322,6 +421,20 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         message = self._format_state_change(entity_id, old_state, new_state)
 
         if not message:
+            return
+
+        # Flap suppression: drop repeat (entity, toggled-to state) events
+        # within the window BEFORE the message reaches the LLM.  Only
+        # genuine state changes (old != new, which is what produced a
+        # message) are consulted, so no-op events never extend the window.
+        new_val = new_state.get("state", "unknown") if new_state else "unknown"
+        if self._flap_suppressor.should_suppress(entity_id, new_val):
+            logger.debug(
+                "[%s] suppressing known flap for %s -> %s (within window)",
+                self.name,
+                entity_id,
+                new_val,
+            )
             return
 
         # Build MessageEvent and forward to handler

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -15,7 +15,9 @@ from gateway.config import (
     PlatformConfig,
 )
 from plugins.platforms.homeassistant.adapter import (
+    FlapSuppressor,
     HomeAssistantAdapter,
+    _parse_window_seconds,
     check_ha_requirements,
     validate_ha_config,
 )
@@ -226,6 +228,243 @@ class TestCooldown:
                              new_attrs={"friendly_name": "Temp"})
         await adapter._handle_ha_event(event2)
         assert adapter.handle_message.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Flap suppression (issue #71): dedup repeated (entity, state) toggles
+# before they cost an LLM round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestFlapSuppression:
+    """Known-flap events are suppressed at the integration layer; novel
+    state changes always pass through."""
+
+    @staticmethod
+    def _clock(monkeypatch, start=1000.0):
+        """Freeze ``time.time`` in the adapter module on a controllable clock."""
+        state = {"now": start}
+        monkeypatch.setattr(
+            "plugins.platforms.homeassistant.adapter.time.time",
+            lambda: state["now"],
+        )
+        return state
+
+    @staticmethod
+    def _adapter(**extra) -> HomeAssistantAdapter:
+        # cooldown_seconds=0 so only the flap suppressor gates the event.
+        return _make_adapter(watch_all=True, cooldown_seconds=0, **extra)
+
+    @pytest.mark.asyncio
+    async def test_identical_flap_within_window_suppressed(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=60)
+        event = _make_event(
+            "device_tracker.person",
+            "home",
+            "away",
+            new_attrs={"friendly_name": "Person"},
+        )
+
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+        # Same entity toggling to the same state again inside the window.
+        clock["now"] += 10
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_state_change_within_window_passes_through(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=60)
+        away_event = _make_event(
+            "device_tracker.person",
+            "home",
+            "away",
+            new_attrs={"friendly_name": "Person"},
+        )
+        home_event = _make_event(
+            "device_tracker.person",
+            "away",
+            "home",
+            new_attrs={"friendly_name": "Person"},
+        )
+
+        await adapter._handle_ha_event(away_event)
+        assert adapter.handle_message.call_count == 1
+
+        # A genuine toggle back is a different target state: must pass.
+        clock["now"] += 5
+        await adapter._handle_ha_event(home_event)
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_window_expiry_allows_re_notification(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=60)
+        event = _make_event(
+            "device_tracker.person",
+            "home",
+            "away",
+            new_attrs={"friendly_name": "Person"},
+        )
+
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+        # After the window expires the identical flap is novel again.
+        clock["now"] += 61
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_different_entities_independent(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=60)
+
+        await adapter._handle_ha_event(
+            _make_event(
+                "device_tracker.person_a",
+                "home",
+                "away",
+                new_attrs={"friendly_name": "Person A"},
+            )
+        )
+        assert adapter.handle_message.call_count == 1
+
+        # Same state, different entity: independent key, must pass.
+        clock["now"] += 5
+        await adapter._handle_ha_event(
+            _make_event(
+                "device_tracker.person_b",
+                "home",
+                "away",
+                new_attrs={"friendly_name": "Person B"},
+            )
+        )
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_config_driven_window(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=30)
+        assert adapter._flap_suppressor.window_seconds == 30.0
+        event = _make_event(
+            "binary_sensor.motion",
+            "off",
+            "on",
+            new_attrs={"friendly_name": "Motion"},
+        )
+
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+        # Inside the configured 30s window: suppressed.
+        clock["now"] += 20
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+        # Past the configured window: re-notified.
+        clock["now"] += 11
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_int_window_falls_back_to_default(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds="not-a-number")
+        # Unparseable config falls back to the 60s default...
+        assert adapter._flap_suppressor.window_seconds == 60.0
+
+        event = _make_event(
+            "binary_sensor.motion",
+            "off",
+            "on",
+            new_attrs={"friendly_name": "Motion"},
+        )
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+        # ...so a repeat inside 60s is still suppressed.
+        clock["now"] += 10
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_zero_window_disables_suppression(self, monkeypatch):
+        clock = self._clock(monkeypatch)
+        adapter = self._adapter(flap_suppression_seconds=0)
+        event = _make_event(
+            "binary_sensor.motion",
+            "off",
+            "on",
+            new_attrs={"friendly_name": "Motion"},
+        )
+
+        await adapter._handle_ha_event(event)
+        clock["now"] += 1
+        await adapter._handle_ha_event(event)
+        assert adapter.handle_message.call_count == 2
+
+
+class TestFlapSuppressorUnit:
+    """Direct unit tests for the FlapSuppressor tracker (explicit ``now``)."""
+
+    def test_should_suppress_keyed_on_entity_and_state(self):
+        suppressor = FlapSuppressor(window_seconds=60)
+        assert suppressor.should_suppress("sensor.a", "on", now=1000.0) is False
+        # Same (entity, state) inside the window.
+        assert suppressor.should_suppress("sensor.a", "on", now=1010.0) is True
+        # Same entity, different state: novel.
+        assert suppressor.should_suppress("sensor.a", "off", now=1010.0) is False
+        # Same state, different entity: novel.
+        assert suppressor.should_suppress("sensor.b", "on", now=1010.0) is False
+        # Window expiry: identical flap is novel again.
+        assert suppressor.should_suppress("sensor.a", "on", now=1070.0) is False
+
+    def test_suppressed_events_do_not_extend_window(self):
+        suppressor = FlapSuppressor(window_seconds=60)
+        assert suppressor.should_suppress("sensor.a", "on", now=1000.0) is False
+        assert suppressor.should_suppress("sensor.a", "on", now=1010.0) is True
+        assert suppressor.should_suppress("sensor.a", "on", now=1020.0) is True
+        # Still anchored on the forwarded occurrence at t=1000.
+        assert suppressor.should_suppress("sensor.a", "on", now=1061.0) is False
+
+    def test_zero_window_never_suppresses(self):
+        suppressor = FlapSuppressor(window_seconds=0)
+        assert suppressor.should_suppress("sensor.a", "on", now=1.0) is False
+        assert suppressor.should_suppress("sensor.a", "on", now=1.0) is False
+
+    def test_prune_keeps_tracker_bounded(self):
+        suppressor = FlapSuppressor(window_seconds=60)
+        for i in range(100):
+            suppressor.should_suppress(f"sensor.e{i}", "on", now=1000.0 + i * 0.1)
+        # Advance far past the window: everything expires on the next call.
+        suppressor.should_suppress("sensor.fresh", "on", now=2000.0)
+        assert all(ts >= 2000.0 - 60.0 for ts in suppressor._last_seen.values())
+
+
+class TestParseWindowSeconds:
+    def test_accepts_int_float_and_numeric_string(self):
+        assert _parse_window_seconds(30) == 30.0
+        assert _parse_window_seconds(30.5) == 30.5
+        assert _parse_window_seconds("45") == 45.0
+
+    def test_unparseable_falls_back_to_default(self):
+        assert _parse_window_seconds("nope") == 60.0
+        assert _parse_window_seconds(None) == 60.0
+        assert _parse_window_seconds([]) == 60.0
+        # bool is an int subclass; a YAML `true` must not read as 1s.
+        assert _parse_window_seconds(True) == 60.0
+        assert _parse_window_seconds(False) == 60.0
+        assert _parse_window_seconds(float("inf")) == 60.0
+
+    def test_zero_and_negative_disable(self):
+        assert _parse_window_seconds(0) == 0.0
+        assert _parse_window_seconds(-5) == -5.0
+        suppressor = FlapSuppressor(_parse_window_seconds(0))
+        assert suppressor.window_seconds == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/homeassistant.md
+++ b/website/docs/user-guide/messaging/homeassistant.md
@@ -149,6 +149,10 @@ platforms:
         - sensor.cpu_usage
         - sensor.memory_usage
       cooldown_seconds: 30
+      # Suppress repeat toggles of the same entity to the same state within
+      # this window (dedupes presence/location-tracker flaps before they
+      # reach the LLM; `0` disables). Default: 60.
+      flap_suppression_seconds: 60
 ```
 
 | Setting | Default | Description |
@@ -158,6 +162,7 @@ platforms:
 | `watch_all` | `false` | Set to `true` to receive **all** state changes (not recommended for most setups) |
 | `ignore_entities` | *(none)* | Always ignore these entities (applied before domain/entity filters) |
 | `cooldown_seconds` | `30` | Minimum seconds between events for the same entity |
+| `flap_suppression_seconds` | `60` | Suppress repeat toggles of the same entity to the same state within this window before they reach the LLM (`0` disables; unparseable values fall back to `60`) |
 
 :::tip
 Start with a focused set of domains — `climate`, `binary_sensor`, and `alarm_control_panel` cover the most useful automations. Add more as needed. Use `ignore_entities` to suppress noisy sensors like CPU temperature or uptime counters.


### PR DESCRIPTION
Automated evolution PR for issue 71-device-flap-dedup. Rework of a prior closed PR per the issue's review brief; validated locally (ruff check clean, targeted tests green) before opening.