### PR TITLE
fix: request-dump cap counts writes not attempts (Closes #73)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1944,15 +1944,83 @@ def dump_api_request_debug(
 
             dump_payload["error"] = error_info
 
+        # ── #73: request-dump dedup window + per-session cap ──────────────
+        # The preflight call site (conversation_loop.py) fires on EVERY API
+        # call while HERMES_DUMP_REQUESTS is set, so a burst of identical
+        # attempts would otherwise write one full multi-hundred-KB snapshot
+        # per call. Content-hash the request body and skip re-dumps of an
+        # identical payload within the window; additionally cap the number of
+        # preflight dumps per session so a long-lived session cannot flood
+        # logs_dir. Both knobs live under ``request_dump`` in config.yaml:
+        # ``dedup_window_seconds`` (default 60) and
+        # ``max_dumps_per_session`` (default 8; 0 disables the cap).
+        # The error path below keeps its finer-grained failure-category dedup
+        # and is deliberately NOT capped — post-mortem debugging must always
+        # get its dump.
+        import hashlib
+
+        _body_for_hash = json.dumps(body, sort_keys=True, default=str)
+        _body_hash = hashlib.sha256(_body_for_hash.encode("utf-8")).hexdigest()[:32]
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            _dump_cfg = (load_config_readonly() or {}).get("request_dump") or {}
+        except Exception:
+            _dump_cfg = {}
+        try:
+            _dedup_window = int(_dump_cfg.get("dedup_window_seconds", 60))
+        except (TypeError, ValueError):
+            _dedup_window = 60
+        try:
+            _cap = int(_dump_cfg.get("max_dumps_per_session", 8))
+        except (TypeError, ValueError):
+            _cap = 8
+
+        if error is None:
+            # Preflight dumps (no error) previously bypassed dedup entirely.
+            # Dedup by (session, reason, body hash) within the window, then
+            # enforce the per-session cap. The cap counts dumps actually
+            # written, NOT attempts: a suppressed duplicate must not burn the
+            # budget, otherwise a burst of identical preflight attempts would
+            # exhaust the cap and silence genuinely new dumps for the rest of
+            # the session (issue #73).
+            _dump_cache_key = (agent.session_id, reason, _body_hash)
+            _dump_cache = getattr(agent, "_request_dump_cache", None)
+            if _dump_cache is None:
+                _dump_cache = {}
+                agent._request_dump_cache = _dump_cache
+            _now = time.time()
+            _last_dump_time = _dump_cache.get(_dump_cache_key)
+            if _last_dump_time is not None and (_now - _last_dump_time) < _dedup_window:
+                _ra().logger.info(
+                    "Suppressing duplicate request dump for session %s (%s, %s) within %ss",
+                    agent.session_id,
+                    reason,
+                    _body_hash,
+                    _dedup_window,
+                )
+                return None
+            _dump_cache[_dump_cache_key] = _now
+            if _cap > 0 and int(getattr(agent, "_request_dump_count", 0)) >= _cap:
+                _ra().logger.info(
+                    "Suppressing request dump for session %s: cap %d reached",
+                    agent.session_id,
+                    _cap,
+                )
+                return None
+
+        if error is not None:
             # ── Suppress duplicate dumps of identical failing payloads ─────
             # Re-dumping the same ~1 MB request on every retry against a
             # dead endpoint wastes disk I/O and can leak identical secrets
             # repeatedly.  Cache the last dump per (session, failure category,
             # request body hash) tuple and skip if the same dump was written
-            # within 60 seconds.
-            import hashlib
-            _body_for_hash = json.dumps(body, sort_keys=True, default=str)
-            _body_hash = hashlib.sha256(_body_for_hash.encode("utf-8")).hexdigest()[:32]
+            # within the dedup window (configurable via
+            # ``request_dump.dedup_window_seconds``; ``_body_hash`` and
+            # ``_dedup_window`` are computed above, before the error branch).
+            # Unlike the preflight path, this path is NOT subject to
+            # ``request_dump.max_dumps_per_session`` — post-mortem debugging
+            # must always get its dump.
             _failure_category = error_info.get("failure_category", "unknown")
             _dump_cache_key = (agent.session_id, _failure_category, _body_hash)
             _dump_cache = getattr(agent, "_request_dump_cache", None)
@@ -1961,12 +2029,13 @@ def dump_api_request_debug(
                 agent._request_dump_cache = _dump_cache
             _now = time.time()
             _last_dump_time = _dump_cache.get(_dump_cache_key)
-            if _last_dump_time is not None and (_now - _last_dump_time) < 60:
+            if _last_dump_time is not None and (_now - _last_dump_time) < _dedup_window:
                 _ra().logger.info(
-                    "Suppressing duplicate request dump for session %s (%s, %s) within 60s",
+                    "Suppressing duplicate request dump for session %s (%s, %s) within %ss",
                     agent.session_id,
                     _failure_category,
                     _body_hash,
+                    _dedup_window,
                 )
                 return None
             _dump_cache[_dump_cache_key] = _now
@@ -1989,6 +2058,14 @@ def dump_api_request_debug(
         _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
         _redacted_payload = json.loads(redact_sensitive_text(_serialized, force=True))
         atomic_json_write(dump_file, _redacted_payload, default=str)
+
+        # Count only dumps actually written, and only on the capped preflight
+        # path: a suppressed duplicate must not burn the per-session budget,
+        # and error dumps stay uncapped for post-mortem debugging (#73).
+        if error is None:
+            agent._request_dump_count = (
+                int(getattr(agent, "_request_dump_count", 0)) + 1
+            )
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2631,6 +2631,19 @@ DEFAULT_CONFIG = {
         "backup_count": 3,     # Number of rotated backup files to keep
     },
 
+    # Debug request dumps (request_dump_*.json, written when
+    # HERMES_DUMP_REQUESTS is set; see conversation_loop preflight + the
+    # API-error path in agent_runtime_helpers.dump_api_request_debug).
+    # Dedup suppresses re-dumping an identical request payload within
+    # ``dedup_window_seconds`` (e.g. the same preflight body on every retry),
+    # and ``max_dumps_per_session`` caps how many *preflight* dumps are
+    # written per session (0 disables the cap). The error path is never
+    # capped — post-mortem debugging always gets its dump. #73
+    "request_dump": {
+        "dedup_window_seconds": 60,
+        "max_dumps_per_session": 8,
+    },
+
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches
     # curated model lists for OpenRouter and Nous Portal from this URL,
     # falling back to the in-repo snapshot on network failure.  Lets us

--- a/tests/agent/test_dump_duplicate_suppression.py
+++ b/tests/agent/test_dump_duplicate_suppression.py
@@ -124,3 +124,165 @@ def test_dump_payload_includes_failure_category(tmp_path: Path):
     data = json.loads(dump_file.read_text())
     assert data["error"]["failure_category"] == "billing"
     assert data["error"]["retryable"] is False
+
+
+# ── Issue #73: preflight dumps are deduped + capped; the cap counts writes ──
+
+
+def _config_with_request_dump(**kwargs: object) -> dict:
+    """A minimal config dict carrying a ``request_dump`` section."""
+    return {"request_dump": kwargs}
+
+
+def _dump_count(agent: AIAgent) -> int:
+    return int(getattr(agent, "_request_dump_count", 0))
+
+
+def test_preflight_duplicates_suppressed_within_window(tmp_path: Path):
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    first = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+    assert first is not None
+    assert first.exists()
+
+    second = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+    assert second is None
+
+
+def test_suppressed_duplicates_do_not_burn_cap_budget(tmp_path: Path):
+    """#73 — a suppressed duplicate must not consume the per-session cap.
+
+    A burst of identical preflight attempts writes ONE dump; the suppressed
+    duplicates leave the budget intact, so a genuinely new failure payload is
+    still dumped instead of being silenced for the rest of the session.
+    """
+    agent = _make_agent(tmp_path)
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config_with_request_dump(
+            dedup_window_seconds=60, max_dumps_per_session=2
+        ),
+    ):
+        api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+        # Three identical attempts: only the first is a write.
+        for _ in range(3):
+            dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        assert len(list(agent.logs_dir.glob("request_dump_*.json"))) == 1
+        assert _dump_count(agent) == 1
+
+        # A genuinely new payload still gets dumped: the two suppressed
+        # duplicates did NOT burn the budget.
+        new_kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "different"}],
+        }
+        second = dump_api_request_debug(agent, new_kwargs, reason="preflight")
+        assert second is not None
+        assert _dump_count(agent) == 2
+
+        # Cap (2) now reached: a third distinct payload is suppressed.
+        third = dump_api_request_debug(
+            agent,
+            {"model": "gpt-4", "messages": [{"role": "user", "content": "another"}]},
+            reason="preflight",
+        )
+        assert third is None
+        assert _dump_count(agent) == 2
+
+
+def test_config_driven_dedup_window(tmp_path: Path):
+    """Changing request_dump.dedup_window_seconds changes suppression."""
+    agent = _make_agent(tmp_path)
+    api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config_with_request_dump(dedup_window_seconds=0),
+    ):
+        # A window of 0 disables dedup: identical preflight bodies all write.
+        first = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        second = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        assert first is not None
+        assert second is not None
+
+
+def test_config_driven_cap(tmp_path: Path):
+    """Changing request_dump.max_dumps_per_session changes the cap."""
+    agent = _make_agent(tmp_path)
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config_with_request_dump(
+            dedup_window_seconds=0, max_dumps_per_session=0
+        ),
+    ):
+        # A cap of 0 disables the cap entirely.
+        for content in ("a", "b", "c", "d", "e"):
+            result = dump_api_request_debug(
+                agent,
+                {"model": "gpt-4", "messages": [{"role": "user", "content": content}]},
+                reason="preflight",
+            )
+            assert result is not None
+        assert len(list(agent.logs_dir.glob("request_dump_*.json"))) == 5
+
+
+def test_non_int_config_values_fall_back_to_defaults(tmp_path: Path):
+    """Non-int request_dump values must not crash the dump path."""
+    agent = _make_agent(tmp_path)
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config_with_request_dump(
+            dedup_window_seconds="soon", max_dumps_per_session="lots"
+        ),
+    ):
+        api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+        first = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        assert first is not None
+
+        # Default window (60s) still suppresses the identical follow-up.
+        second = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        assert second is None
+
+        # The error path still dumps despite the junk config values.
+        err = ValueError("boom")
+        err.status_code = 500  # type: ignore[attr-defined]
+        error_dump = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+        assert error_dump is not None
+        assert error_dump.exists()
+
+
+def test_error_path_not_capped(tmp_path: Path):
+    """#73 — max_dumps_per_session must not silence error dumps.
+
+    Once the preflight cap is exhausted, the error path still writes its
+    dump: post-mortem debugging must always get its snapshot.
+    """
+    agent = _make_agent(tmp_path)
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=_config_with_request_dump(
+            dedup_window_seconds=60, max_dumps_per_session=1
+        ),
+    ):
+        api_kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+        first = dump_api_request_debug(agent, api_kwargs, reason="preflight")
+        assert first is not None
+
+        # Cap of 1 reached: a second, distinct preflight dump is suppressed.
+        suppressed = dump_api_request_debug(
+            agent,
+            {"model": "gpt-4", "messages": [{"role": "user", "content": "new"}]},
+            reason="preflight",
+        )
+        assert suppressed is None
+
+        # ...but the error path still dumps after the cap is exhausted.
+        err = ValueError("boom")
+        err.status_code = 500  # type: ignore[attr-defined]
+        error_dump = dump_api_request_debug(agent, api_kwargs, reason="auth", error=err)
+        assert error_dump is not None
+        assert error_dump.exists()


### PR DESCRIPTION
Automated evolution PR for issue 73-request-dump-dedup-r2. Rework of a prior closed PR per the issue's review brief; validated locally (ruff check clean, targeted tests green) before opening.