### PR TITLE
fix: typed fail-fast for environmental network errors (Closes #74)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -12,7 +12,10 @@ that the main retry loop in run_agent.py consults for every API failure.
 from __future__ import annotations
 
 import enum
+import errno
 import logging
+import re
+import socket
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -598,6 +601,43 @@ _TRANSPORT_ERROR_TYPES = frozenset({
     "APITimeoutError",
 })
 
+# Environmental network-failure fail-fast set (#74) — TYPED errno matching.
+#
+# DNS / routing / reachability failures are environmental, not
+# provider-side: retrying the identical payload N times cannot succeed while
+# the environment is broken, and only amplifies a transient outage into a
+# retry storm that burns tokens, delays scheduled jobs, and floods the
+# error-capture store. Match on the ``.errno`` ATTRIBUTE (set by the
+# OS/socket layer), never on bare "errno -2" substring text — a tool error
+# like ``OSError("tool reported errno -2 from its own syscall...")`` carries
+# no errno attribute and must stay retryable.
+_ENV_NETWORK_FAILFAST_ERRNOS = frozenset(
+    {
+        socket.EAI_NONAME,  # -2  Name or service not known — definitive DNS miss
+        socket.EAI_FAIL,  # -4  Non-recoverable failure in name resolution
+        errno.EHOSTUNREACH,  # 113 No route to host — routing failure
+        errno.ENETUNREACH,  # 101 Network is unreachable
+    }
+)
+# EAI_AGAIN (-3, "temporary failure in name resolution") is deliberately
+# EXCLUDED: it is transient by definition and a 1-2s retry usually succeeds.
+
+# Anchored message-pattern fallback for SDK-wrapped shapes that lost the
+# typed errno — e.g. openai.APIConnectionError whose __cause__ chain holds an
+# httpx.ConnectError stringified from the socket error, or a Node bridge's
+# "getaddrinfo ENOTFOUND <host>". Word-boundary-bounded tokens / full
+# phrases only — never bare "errno N" substring scans, which misclassify
+# unrelated errors that merely quote errno text.
+_ENV_NETWORK_FAILFAST_MESSAGE_PATTERNS = (
+    re.compile(r"\bname or service not known\b"),
+    re.compile(r"\bgetaddrinfo\s+failed\b"),
+    re.compile(r"\bENOTFOUND\b"),
+    re.compile(r"\bno route to host\b"),
+    re.compile(r"\bnetwork is unreachable\b"),
+    re.compile(r"\bEHOSTUNREACH\b"),
+    re.compile(r"\bENETUNREACH\b"),
+)
+
 # Server disconnect patterns (no status code, but transport-level).
 # These are the "ambiguous" patterns — a plain connection close could be
 # transient transport hiccup OR server-side context overflow rejection
@@ -670,6 +710,72 @@ _SSL_TRANSIENT_PATTERNS = [
     # Python ssl module prefix, e.g. "[SSL: BAD_RECORD_MAC]"
     "[ssl:",
 ]
+
+
+# ── Environmental network-failure detection (#74) ───────────────────────
+
+
+def _iter_exception_chain(error: BaseException):
+    """Yield ``error`` and every exception reachable via ``__cause__`` /
+    ``__context__`` links, deduplicated.
+
+    SDKs wrap the underlying transport failure: openai.APIConnectionError
+    carries the httpx.ConnectError as its ``__cause__``, which in turn
+    carries the originating ``socket.gaierror``. The classifier must look
+    through those wrappers to find the typed error — ``str()`` of the
+    top-level wrapper is just "Connection error.".
+    """
+    seen = set()
+    stack: list[Optional[BaseException]] = [error]
+    while stack:
+        exc = stack.pop()
+        if exc is None or id(exc) in seen:
+            continue
+        seen.add(id(exc))
+        yield exc
+        stack.append(exc.__cause__)
+        stack.append(exc.__context__)
+
+
+def _is_environmental_network_failure(error: BaseException, error_msg: str) -> bool:
+    """True when the failure is environmental (DNS / routing / reachability).
+
+    Matching is TYPED — never a bare substring scan of "errno -2" /
+    "errno -3" / "errno 113" text, which misclassifies unrelated errors
+    (e.g. ``OSError("tool reported errno -2 from its own syscall...")``)
+    as environmental network failures.
+
+    1. Any exception in the cause/context chain that is OSError-family
+       (``socket.gaierror`` subclasses ``OSError``) whose ``.errno`` is one
+       of the environmental codes fails fast. ``errno`` attributes are set
+       by the OS/socket layer and cannot be spoofed by message text.
+    2. Anchored message patterns as a fallback ONLY for non-OSError SDK
+       transport wrappers (e.g. openai.APIConnectionError) whose chain
+       carries the DNS/route text without a typed errno — e.g. an
+       ``httpx.ConnectError`` whose message is "[Errno -2] Name or service
+       not known" but whose underlying socket error object was consumed, or
+       a Node bridge's "getaddrinfo ENOTFOUND <host>". Plain OSErrors are
+       deliberately excluded from the message fallback: a real OS failure
+       always sets ``.errno``, and message-only OSErrors (including tool
+       errors that quote errno text) stay retryable.
+
+    EAI_AGAIN ("temporary failure in name resolution", errno -3) is
+    deliberately NOT in the fail-fast set — it is transient by definition
+    and a short retry usually succeeds, so it must stay retryable.
+    """
+    chain = list(_iter_exception_chain(error))
+    for exc in chain:
+        if isinstance(exc, OSError) and exc.errno in _ENV_NETWORK_FAILFAST_ERRNOS:
+            return True
+    if isinstance(error, OSError):
+        return False
+    parts = [error_msg]
+    for exc in chain:
+        text = str(exc).lower()
+        if text and text not in parts:
+            parts.append(text)
+    haystack = " ".join(parts)
+    return any(p.search(haystack) for p in _ENV_NETWORK_FAILFAST_MESSAGE_PATTERNS)
 
 
 # ── Classification pipeline ─────────────────────────────────────────────
@@ -1087,6 +1193,26 @@ def classify_api_error(
         and "consecutive stale attempts" in error_msg
         and "aborting this call" in error_msg
     ):
+        return _result(
+            FailoverReason.timeout,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # ── 7c. Environmental network failures → fail fast (#74) ────────
+    # DNS resolution / routing / reachability failures are environmental,
+    # not provider-side: the identical request cannot succeed while the
+    # environment is broken, so the full fixed retry count only amplifies a
+    # transient outage into a retry storm (and, for scheduled jobs, a wall of
+    # failure records + request snapshots). Fail fast with a fallback to the
+    # next provider — if the environment is truly down the fallback also
+    # fails fast, and the loop surfaces a clear reason instead of silently
+    # burning the budget. Checked BEFORE §8 so an SDK-wrapped DNS failure
+    # (e.g. openai.APIConnectionError) does not fall through to the
+    # retryable transport bucket.
+    if (
+        isinstance(error, OSError) or error_type in _TRANSPORT_ERROR_TYPES
+    ) and _is_environmental_network_failure(error, error_msg):
         return _result(
             FailoverReason.timeout,
             retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1,5 +1,9 @@
 """Tests for agent.error_classifier — structured API error classification."""
 
+import errno
+import socket
+
+import httpx
 import pytest
 from agent.error_classifier import (
     ClassifiedError,
@@ -42,6 +46,13 @@ class RemoteProtocolError(MockTransportError):
 
 class ServerDisconnectedError(MockTransportError):
     pass
+
+
+class APIConnectionError(MockTransportError):
+    """Simulates openai.APIConnectionError — the SDK transport wrapper whose
+    __cause__/__context__ chain carries the underlying httpx/socket error.
+    Named to match the real class so the type-name-based transport gate in
+    the classifier treats it identically."""
 
 
 # ── Test: FailoverReason enum ──────────────────────────────────────────
@@ -2378,6 +2389,170 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
+
+
+# ── Environmental network failure → fail fast (#74) ─────────────────────
+
+
+class TestEnvironmentalNetworkFailFast:
+    """DNS / routing / reachability failures are environmental, not
+    provider-side — retrying the identical payload cannot succeed while the
+    environment is broken. They must fail fast (non-retryable + fallback)
+    instead of exhausting the retry budget against an unreachable host.
+
+    Matching is TYPED (errno attributes / anchored patterns), never a bare
+    "errno -2" substring scan, and EAI_AGAIN ("temporary failure in name
+    resolution") is transient by definition and stays retryable.
+    """
+
+    # ── Typed errno matching: fail-fast shapes ──────────────────────
+
+    def test_gaierror_eai_noname_fails_fast(self):
+        # Definitive DNS miss ("Name or service not known") — retrying the
+        # identical hostname cannot succeed while the environment is broken.
+        e = socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_gaierror_eai_fail_fails_fast(self):
+        # EAI_FAIL is "Non-recoverable failure in name resolution" — by
+        # definition not transient.
+        e = socket.gaierror(
+            socket.EAI_FAIL, "Non-recoverable failure in name resolution"
+        )
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_host_unreachable_errno_fails_fast(self):
+        # EHOSTUNREACH (113) — routing failure, environmental.
+        e = OSError(errno.EHOSTUNREACH, "No route to host")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_network_unreachable_errno_fails_fast(self):
+        # ENETUNREACH (101) — no network path, environmental.
+        e = OSError(errno.ENETUNREACH, "Network is unreachable")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    # ── EAI_AGAIN stays retryable (transient by definition) ─────────
+
+    def test_gaierror_eai_again_stays_retryable(self):
+        # "Temporary failure in name resolution" (errno -3) is transient by
+        # definition — a 1-2s retry usually succeeds. MUST stay retryable.
+        e = socket.gaierror(socket.EAI_AGAIN, "Temporary failure in name resolution")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_message_only_temporary_dns_failure_stays_retryable(self):
+        # Message-only OSError (no errno attribute) quoting the EAI_AGAIN
+        # text — conservative: a real OS failure always sets .errno.
+        e = OSError("Temporary failure in name resolution")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    # ── SDK-wrapped shapes (openai.APIConnectionError) ──────────────
+
+    def test_sdk_connection_error_with_gaierror_cause_fails_fast(self):
+        # openai.APIConnectionError str()s to "Connection error." — the
+        # underlying DNS failure lives in the __cause__ chain.
+        e = APIConnectionError("Connection error.")
+        e.__cause__ = socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_sdk_connection_error_with_full_httpx_chain_fails_fast(self):
+        # The realistic openai SDK chain: APIConnectionError → httpx
+        # ConnectError("[Errno -2] Name or service not known") → gaierror.
+        req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        gaierr = socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        transport_err = httpx.ConnectError(str(gaierr), request=req)
+        transport_err.__cause__ = gaierr
+        e = APIConnectionError("Connection error.")
+        e.__cause__ = transport_err
+        result = classify_api_error(e, provider="openai", model="gpt-5.5")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_sdk_connection_error_with_stringified_transport_cause_fails_fast(self):
+        # Shape where the socket error object was consumed and only the
+        # stringified message survives in the chain (some SDK/async paths):
+        # the anchored message fallback must catch it via the chain text.
+        req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        e = APIConnectionError("Connection error.")
+        e.__cause__ = httpx.ConnectError(
+            "[Errno -2] Name or service not known", request=req
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-5.5")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_sdk_connection_error_with_eai_again_cause_stays_retryable(self):
+        # Even SDK-wrapped, EAI_AGAIN stays retryable.
+        e = APIConnectionError("Connection error.")
+        e.__cause__ = socket.gaierror(
+            socket.EAI_AGAIN, "Temporary failure in name resolution"
+        )
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_sdk_connection_error_without_env_signal_still_retries(self):
+        # A bare APIConnectionError ("Connection error.") with no env signal
+        # in the chain is a transient transport hiccup — must NOT fail fast.
+        e = APIConnectionError("Connection error.")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    # ── Message-text spoofing must NOT fail fast ────────────────────
+
+    def test_errno_text_in_unrelated_oserror_message_stays_retryable(self):
+        # Regression guard from the rework brief: a tool error whose message
+        # QUOTES errno text carries no errno attribute and must not be
+        # misclassified as an environmental network failure. Bare substring
+        # scans of "errno -2" / "errno -3" / "errno 113" would misfire here;
+        # note the quoted "getaddrinfo failed" is also ignored because the
+        # message fallback only applies to non-OSError SDK wrappers.
+        for msg in (
+            "tool reported errno -2 from its own syscall: getaddrinfo failed inside the tool",
+            "tool reported errno -3 from its own syscall: temporary failure inside the tool",
+            "tool reported errno 113 from its own syscall: route lookup inside the tool",
+        ):
+            e = OSError(msg)
+            result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+            assert result.reason == FailoverReason.timeout
+            assert result.retryable is True, msg
+
+    def test_transient_timeout_without_env_signal_still_retries(self):
+        # A plain timeout (no environmental signal) must keep retrying as a
+        # transient transport hiccup — the fail-fast branch is narrow.
+        e = TimeoutError("timed out")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_connection_reset_without_env_signal_still_retries(self):
+        # Connection reset is a provider-side transport hiccup, not an
+        # environmental DNS/route failure — must NOT fail fast.
+        e = ConnectionError("Connection reset by peer")
+        result = classify_api_error(e, provider="deepseek", model="deepseek-chat")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
 
 
 # ── HTTP 504 gateway timeout ───────────────────────────────────────────


### PR DESCRIPTION
Automated evolution PR for issue 74-env-network-failfast-r2. Rework of a prior closed PR per the issue's review brief; validated locally (ruff check clean, targeted tests green) before opening.