### PR TITLE
feat: verified external task-state ledger for long-horizon stages (Closes #2841)

### DIFF
--- a/evolution/lib/task_state_ledger.py
+++ b/evolution/lib/task_state_ledger.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""Verified external task-state ledger (issue #2841).
+
+Manage-execute-audit primitive: an append-only durable record of
+``(step, verified outcome, evidence link)`` written on each completed stage and
+read on resume/rewind, so a long-horizon stage re-anchors to *verified* progress
+rather than recalled context.  Complements versioned_harness_state.py
+(instruction rollback) and stage_cache.py (output caching): those persist
+runnable state; this persists a traceable verdict that a step passed its audit.
+
+Pure dataclasses, no external deps, import-safe, JSON round-trip, explicit
+``encoding`` (ruff PLW1514).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+__all__ = ["LedgerEntry", "TaskStateLedger", "get_default_ledger_dir"]
+
+
+def get_default_ledger_dir() -> Path:
+    """Default ledger storage dir (under HERMES_HOME)."""
+    base = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    p = Path(base) / "task_state_ledger"
+    try:
+        p.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    return p
+
+
+@dataclass
+class LedgerEntry:
+    """One verified completion. ``verified`` = externally audited (gate/CI);
+    ``evidence`` = audit links substantiating the outcome."""
+
+    step: str
+    verified: bool = True
+    outcome: str = ""
+    evidence: List[str] = field(default_factory=list)
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LedgerEntry":
+        return cls(
+            step=str(data.get("step", "")),
+            verified=bool(data.get("verified", True)),
+            outcome=str(data.get("outcome", "")),
+            evidence=list(data.get("evidence", [])),
+            timestamp=float(data.get("timestamp", time.time())),
+        )
+
+
+class TaskStateLedger:
+    """Append-only durable record of verified completed steps for one task."""
+
+    def __init__(
+        self,
+        task_id: str,
+        storage_dir: Optional[Union[str, Path]] = None,
+        auto_save: bool = True,
+    ) -> None:
+        self.task_id = task_id
+        self.storage_dir = (
+            Path(storage_dir) if storage_dir else get_default_ledger_dir()
+        )
+        self.auto_save = auto_save
+        self._entries: List[LedgerEntry] = []
+        if self.storage_file.exists():
+            self.load()
+
+    @property
+    def storage_file(self) -> Path:
+        safe_id = "".join(
+            c if c.isalnum() or c in ("-", "_") else "_" for c in self.task_id
+        )
+        return self.storage_dir / f"ledger_{safe_id}.json"
+
+    @property
+    def entries(self) -> List[LedgerEntry]:
+        return list(self._entries)
+
+    @property
+    def last_verified_step(self) -> Optional[LedgerEntry]:
+        return self._entries[-1] if self._entries else None
+
+    def append(self, entry: LedgerEntry) -> LedgerEntry:
+        """Record a verified completion; persist when auto_save."""
+        self._entries.append(entry)
+        if self.auto_save:
+            self.save()
+        return entry
+
+    def completed(self, step: str) -> bool:
+        """True if ``step`` already has a verified ledger entry."""
+        return any(e.step == step for e in self._entries)
+
+    def summary(self) -> str:
+        """Compact resume anchor, one line per verified step."""
+        if not self._entries:
+            return "no verified steps recorded"
+        return "\n".join(
+            f"- {e.step}: {'verified' if e.verified else 'unverified'} — "
+            f"{e.outcome or '(done)'} [{', '.join(e.evidence) or 'no evidence'}]"
+            for e in self._entries
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "entries": [e.to_dict() for e in self._entries],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TaskStateLedger":
+        ledger = cls(task_id=str(data.get("task_id", "default")), auto_save=False)
+        entries = data.get("entries", [])
+        if isinstance(entries, list):
+            ledger._entries = [
+                LedgerEntry.from_dict(e) for e in entries if isinstance(e, dict)
+            ]
+        return ledger
+
+    def save(self, path: Optional[Union[str, Path]] = None) -> Path:
+        """Atomically persist to disk (tmp + replace)."""
+        target = Path(path) if path else self.storage_file
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            tmp = target.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(self.to_dict(), indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp.replace(target)
+        except OSError:
+            pass
+        return target
+
+    def load(self, path: Optional[Union[str, Path]] = None) -> bool:
+        """Load entries from disk; True on success."""
+        target = Path(path) if path else self.storage_file
+        if not target.exists():
+            return False
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+            entries = data.get("entries", [])
+            if isinstance(entries, list):
+                self._entries = [
+                    LedgerEntry.from_dict(e) for e in entries if isinstance(e, dict)
+                ]
+                return True
+        except (OSError, ValueError):
+            pass
+        return False

--- a/evolution/tests/test_task_state_ledger.py
+++ b/evolution/tests/test_task_state_ledger.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`evolution.lib.task_state_ledger` (issue #2841)."""
+
+from __future__ import annotations
+
+import json
+
+from evolution.lib.task_state_ledger import LedgerEntry, TaskStateLedger
+
+
+class TestLedgerEntrySerialisation:
+    """to_dict / from_dict round-trip."""
+
+    def test_roundtrip_basic(self):
+        e = LedgerEntry(
+            step="analysis/select",
+            verified=True,
+            outcome="picked 2 issues",
+            evidence=["issues/2026-08-19.json", "abc123"],
+            timestamp=1755600000.0,
+        )
+        e2 = LedgerEntry.from_dict(e.to_dict())
+        assert e2.step == e.step
+        assert e2.verified is True
+        assert e2.outcome == e.outcome
+        assert e2.evidence == e.evidence
+        assert e2.timestamp == e.timestamp
+
+    def test_roundtrip_defaults(self):
+        e2 = LedgerEntry.from_dict(LedgerEntry(step="x").to_dict())
+        assert e2.verified is True
+        assert e2.outcome == ""
+        assert e2.evidence == []
+        assert e2.step == "x"
+
+    def test_to_dict_json_serialisable(self):
+        json.dumps(LedgerEntry(step="s", outcome="o", evidence=["p"]).to_dict())
+
+
+class TestTaskStateLedger:
+    """Append / read / persist behaviour."""
+
+    def test_append_and_completed(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t1", storage_dir=tmp_path, auto_save=False)
+        assert ledger.completed("step1") is False
+        ledger.append(LedgerEntry(step="step1", outcome="done"))
+        assert ledger.completed("step1") is True
+        assert ledger.completed("step2") is False
+        last = ledger.last_verified_step
+        assert last is not None
+        assert last.step == "step1"
+
+    def test_empty_ledger(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t2", storage_dir=tmp_path, auto_save=False)
+        assert ledger.last_verified_step is None
+        assert ledger.summary() == "no verified steps recorded"
+
+    def test_persistence_across_instances(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t3", storage_dir=tmp_path, auto_save=True)
+        ledger.append(
+            LedgerEntry(step="impl/write", outcome="added", evidence=["x.py"])
+        )
+        reloaded = TaskStateLedger(task_id="t3", storage_dir=tmp_path)
+        assert reloaded.completed("impl/write") is True
+        assert reloaded.entries[0].outcome == "added"
+
+    def test_to_dict_from_dict_roundtrip(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t4", storage_dir=tmp_path, auto_save=False)
+        ledger.append(LedgerEntry(step="a", verified=False, outcome="o"))
+        ledger2 = TaskStateLedger.from_dict(ledger.to_dict())
+        assert ledger2.task_id == "t4"
+        assert ledger2.entries[0].verified is False
+        assert ledger2.completed("a") is True
+
+    def test_load_missing_file_returns_false(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t5", storage_dir=tmp_path, auto_save=False)
+        assert ledger.load(tmp_path / "nope.json") is False
+        assert ledger.entries == []
+
+    def test_summary_lists_verified_steps(self, tmp_path):
+        ledger = TaskStateLedger(task_id="t6", storage_dir=tmp_path, auto_save=False)
+        ledger.append(LedgerEntry(step="a", outcome="done", evidence=["f1"]))
+        ledger.append(LedgerEntry(step="b", verified=False, outcome="partial"))
+        text = ledger.summary()
+        assert "- a: verified" in text
+        assert "- b: unverified" in text
+        assert "done" in text


### PR DESCRIPTION
Automated evolution PR for issue #2841.

Adds a manage-execute-audit task-state ledger primitive: an append-only durable record of (step, verified outcome, evidence link) written per completed stage and read on resume/rewind, so long-horizon stages re-anchor on verified progress rather than recalled context. Complements versioned_harness_state.py (instruction rollback) and stage_cache.py (output caching) without duplicating them.

Files: evolution/lib/task_state_ledger.py, evolution/tests/test_task_state_ledger.py
Checks: lint passed, format passed, 9 tests passed, pre-PR test shard passed.

Note: 250 changed lines exceed the 200-line autonomous self-merge cap (DIFF_TOO_LARGE), so this PR will wait for human review unless split. The module + its tests are a single coherent unit; a smaller split would strip the tests the primitive needs.