### PR TITLE
feat: temporal-validity evaluation axis for dated evidence (Closes #2842)

### DIFF
--- a/evolution/lib/temporal_validity.py
+++ b/evolution/lib/temporal_validity.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""Temporal-validity evaluation axis (issue #2842).
+
+A positive evaluation criterion for any pipeline stage that reasons over dated
+data: for a target date, verify each selected evidence/skill/memory item was
+valid *as of* that date (not anachronistic or future-dated), and report a
+temporal-validity pass rate alongside outcome metrics.
+
+This is distinct from the 08-13 gist-compression temporal-preservation concern
+(destroying timestamps in context); it is a *verification* criterion.  It
+asserts against the same substrate that ``plugins/memory/mem0`` and
+``tools/skill_usage.py`` write (``valid_from`` / ``valid_until`` windows), but
+does not depend on those modules — it accepts any evidence carrying ISO-8601
+``valid_from``/``valid_until`` (or ``timestamp``) fields, so it is a drop-in
+assertion harness for eval/research stages.
+
+Pure dataclasses, no external deps, import-safe, JSON round-trip, explicit
+``encoding`` (ruff PLW1514).
+"""
+
+from __future__ import annotations
+
+import calendar
+import datetime
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "EvidenceItem",
+    "TemporalValidityReport",
+    "evaluate_temporal_validity",
+    "parse_iso_epoch",
+]
+
+_ISO_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def parse_iso_epoch(value: Optional[str]) -> Optional[float]:
+    """Parse an ISO-8601 timestamp to a UTC POSIX epoch, or None if malformed."""
+    if not value or not isinstance(value, str):
+        return None
+    if not _ISO_RE.match(value):
+        return None
+    norm = value[:-1] + "+00:00" if value.endswith("Z") else value
+    # Strip a trailing offset and parse the naive UTC wall-clock part.
+    base = norm[:19]
+    try:
+        return calendar.timegm((
+            int(base[0:4]),
+            int(base[5:7]),
+            int(base[8:10]),
+            int(base[11:13]),
+            int(base[14:16]),
+            int(base[17:19]),
+            0,
+            0,
+            0,
+        ))
+    except ValueError:
+        return None
+
+
+@dataclass
+class EvidenceItem:
+    """One dated evidence/result selected by a stage.
+
+    ``valid_from`` / ``valid_until`` are ISO-8601 (or epoch float) bounds of
+    when the evidence was true; ``timestamp`` is an optional shorthand for a
+    single point-in-time item.  ``evidence`` links the audit trail.
+    """
+
+    id: str
+    valid_from: Optional[str] = None
+    valid_until: Optional[str] = None
+    timestamp: Optional[str] = None
+    evidence: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EvidenceItem":
+        return cls(
+            id=str(data.get("id", "")),
+            valid_from=data.get("valid_from"),
+            valid_until=data.get("valid_until"),
+            timestamp=data.get("timestamp"),
+            evidence=list(data.get("evidence", [])),
+        )
+
+
+@dataclass
+class TemporalValidityReport:
+    """Aggregate temporal-validity result for one stage decision.
+
+    ``pass_rate`` is the fraction of items valid as of ``as_of`` (0.0–1.0).
+    ``violations`` lists the offending item ids with the reason.
+    """
+
+    as_of: str = ""
+    total: int = 0
+    passed: int = 0
+    violations: List[Dict[str, str]] = field(default_factory=list)
+
+    @property
+    def pass_rate(self) -> float:
+        return self.passed / self.total if self.total else 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TemporalValidityReport":
+        return cls(
+            as_of=str(data.get("as_of", "")),
+            total=int(data.get("total", 0)),
+            passed=int(data.get("passed", 0)),
+            violations=list(data.get("violations", [])),
+        )
+
+
+def evaluate_temporal_validity(
+    items: List[EvidenceItem],
+    as_of: str,
+) -> TemporalValidityReport:
+    """Verify each item was valid *as of* ``as_of`` (ISO-8601).
+
+    Rules:
+    * Item with neither window nor timestamp → skipped (counted as passed,
+      not a violation) — a piece of evidence with no date can't be anachronistic.
+    * ``valid_from`` in the future relative to as_of → ``future-dated``.
+    * ``valid_until`` (or ``timestamp``) before as_of → ``expired``.
+    * ``timestamp`` after as_of → ``future-dated``.
+    Returns a :class:`TemporalValidityReport`.
+    """
+    target = parse_iso_epoch(as_of)
+    report = TemporalValidityReport(as_of=as_of)
+    if target is None:
+        return report  # malformed target: report empty (fail-open, no violations)
+    for item in items:
+        report.total += 1
+        reason = _validity_reason(item, target)
+        if reason is None:
+            report.passed += 1
+        else:
+            report.violations.append({"id": item.id, "reason": reason})
+    return report
+
+
+def _validity_reason(item: EvidenceItem, target: float) -> Optional[str]:
+    """Return a violation reason string, or None if the item is valid as-of."""
+    from_ts = parse_iso_epoch(item.valid_from)
+    until_ts = parse_iso_epoch(item.valid_until)
+    point_ts = parse_iso_epoch(item.timestamp)
+    if from_ts is None and until_ts is None and point_ts is None:
+        return None  # undated → not anachronistic
+    if from_ts is not None and target < from_ts:
+        return "future-dated"
+    if until_ts is not None and target >= until_ts:
+        return "expired"
+    if point_ts is not None and target < point_ts:
+        return "future-dated"
+    return None

--- a/evolution/tests/test_temporal_validity.py
+++ b/evolution/tests/test_temporal_validity.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`evolution.lib.temporal_validity` (issue #2842)."""
+
+from __future__ import annotations
+
+from evolution.lib.temporal_validity import (
+    EvidenceItem,
+    TemporalValidityReport,
+    evaluate_temporal_validity,
+    parse_iso_epoch,
+)
+
+_REF = "2026-08-19T00:00:00Z"  # reference as-of date
+
+
+class TestParseIsoEpoch:
+    def test_parses_utc_z(self):
+        # Compute the expected epoch programmatically rather than hardcoding a
+        # constant that is easy to mistype.
+        import calendar
+
+        expected = calendar.timegm((2026, 8, 19, 0, 0, 0, 0, 0, 0))
+        assert parse_iso_epoch("2026-08-19T00:00:00Z") == expected
+
+    def test_rejects_malformed(self):
+        assert parse_iso_epoch("not-a-date") is None
+        assert parse_iso_epoch(None) is None
+        assert parse_iso_epoch("") is None
+
+    def test_rejects_fractional_offsets(self):
+        assert parse_iso_epoch("2026-08-19T00:00:00+01:00") is not None
+
+
+class TestEvaluateTemporalValidity:
+    def test_valid_item_passes(self):
+        items = [
+            EvidenceItem(
+                id="a",
+                valid_from="2026-01-01T00:00:00Z",
+                valid_until="2026-12-31T00:00:00Z",
+            )
+        ]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.total == 1
+        assert r.passed == 1
+        assert r.pass_rate == 1.0
+        assert r.violations == []
+
+    def test_future_dated_from_violates(self):
+        items = [EvidenceItem(id="a", valid_from="2026-09-01T00:00:00Z")]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.passed == 0
+        assert r.violations[0]["reason"] == "future-dated"
+
+    def test_expired_until_violates(self):
+        items = [EvidenceItem(id="a", valid_until="2026-01-01T00:00:00Z")]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.violations[0]["reason"] == "expired"
+
+    def test_undated_item_skipped_not_violation(self):
+        items = [EvidenceItem(id="a")]  # no date at all
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.passed == 1
+        assert r.violations == []
+
+    def test_point_timestamp_future_violates(self):
+        items = [EvidenceItem(id="a", timestamp="2026-09-01T00:00:00Z")]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.violations[0]["reason"] == "future-dated"
+
+    def test_point_timestamp_past_passes(self):
+        items = [EvidenceItem(id="a", timestamp="2026-01-01T00:00:00Z")]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.passed == 1
+
+    def test_mixed_set_pass_rate(self):
+        items = [
+            EvidenceItem(id="ok", valid_until="2026-12-31T00:00:00Z"),
+            EvidenceItem(id="bad1", valid_from="2026-09-01T00:00:00Z"),
+            EvidenceItem(id="bad2", valid_until="2026-01-01T00:00:00Z"),
+            EvidenceItem(id="nodate"),
+        ]
+        r = evaluate_temporal_validity(items, _REF)
+        assert r.total == 4
+        assert r.passed == 2
+        assert r.pass_rate == 0.5
+        assert {v["id"] for v in r.violations} == {"bad1", "bad2"}
+
+    def test_malformed_as_of_fails_open(self):
+        r = evaluate_temporal_validity(
+            [EvidenceItem(id="a", valid_until="2026-01-01T00:00:00Z")],
+            "garbage",
+        )
+        assert r.total == 0
+        assert r.pass_rate == 1.0
+
+
+class TestReportSerialisation:
+    def test_to_dict_from_dict_roundtrip(self):
+        items = [EvidenceItem(id="a", valid_from="2026-09-01T00:00:00Z")]
+        r = evaluate_temporal_validity(items, _REF)
+        d = r.to_dict()
+        r2 = TemporalValidityReport.from_dict(d)
+        assert r2.as_of == _REF
+        assert r2.passed == 0
+        assert r2.total == 1
+
+    def test_evidence_item_roundtrip(self):
+        e = EvidenceItem(id="x", valid_from="2026-01-01T00:00:00Z", evidence=["p"])
+        e2 = EvidenceItem.from_dict(e.to_dict())
+        assert e2.id == "x"
+        assert e2.valid_from == "2026-01-01T00:00:00Z"
+        assert e2.evidence == ["p"]


### PR DESCRIPTION
Automated evolution PR for issue #2842.

Adds a cutoff-aware/temporal-validity evaluation axis: for a target date, verify each selected evidence/skill/memory item was valid as of that date (not anachronistic or future-dated) and report a temporal-validity pass rate alongside outcome metrics. Asserts against the valid_from/valid_until window substrate written by plugins/memory/mem0 and tools/skill_usage.py without depending on those modules.

Files: evolution/lib/temporal_validity.py, evolution/tests/test_temporal_validity.py
Checks: lint passed, format passed, 13 tests passed, pre-PR test shard passed.

Note: 279 changed lines exceed the 200-line autonomous self-merge cap (DIFF_TOO_LARGE), so this PR will wait for human review. The module + its tests are a single coherent verification harness.