### PR TITLE
feat: provider-balance preflight for cron wake-gates (Closes #2872)

### DIFF
--- a/cron/evolution_preflight.py
+++ b/cron/evolution_preflight.py
@@ -10,6 +10,7 @@ useful input instead of failing silently.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -270,6 +271,170 @@ def preflight_provider(
         return f"pre-flight ping failed: {type(exc).__name__}: {exc}"
 
 
+# ── Provider-balance preflight (HTTP 402) ────────────────────────────────
+# HTTP 402 Insufficient Balance is NON-retryable billing exhaustion: every
+# agent wake immediately fails, burning scheduler cycles and spamming
+# errors.log (08-19 incident: 50 cron failures across 6 jobs, 6.5h pipeline
+# outage). The scheduler's preflight chain must detect an exhausted account
+# and suppress wake attempts instead of launching agents that will 402.
+#
+# Balance state is cached on disk with a TTL so the check is cheap (one
+# max_tokens=1 ping per TTL window, not per wake) and survives restarts.
+# A `BALANCE_LOW` marker in jobs.json is published by the scheduler when
+# the preflight returns the reason below (see scheduler._preflight_job_config).
+
+#: Distinct marker embedded in the preflight error so the scheduler can
+#: classify HTTP 402 (billing exhaustion) apart from other ping failures.
+BALANCE_LOW_ERROR_MARKER = "HTTP 402 Insufficient Balance"
+
+#: Default TTL for the on-disk balance-low marker (seconds).
+_BALANCE_LOW_TTL_SECONDS = 15 * 60  # 15 min
+
+
+def _balance_cache_path(hermes_home: Optional[Path] = None) -> Path:
+    return _evolution_dir(hermes_home) / "balance-low.json"
+
+
+def _balance_state(hermes_home: Optional[Path] = None) -> Dict[str, Any]:
+    """Read the balance-verdict marker file; never raises."""
+    try:
+        path = _balance_cache_path(hermes_home)
+        if path.is_file():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    except Exception as exc:
+        logger.debug("Could not read balance cache: %s", exc)
+    return {}
+
+
+def _balance_verdict(
+    provider: str, *, hermes_home: Optional[Path] = None, now: Optional[float] = None
+) -> Optional[str]:
+    """Return the FRESH cached verdict for ``provider``: ``"ok"`` or
+    ``"low"``, or None when no fresh verdict exists (cache miss / stale).
+
+    Fail-safe: any read/parse error or missing marker means no verdict —
+    a broken cache must never suppress jobs (#2872, same spirit as #913).
+    """
+    if not provider:
+        return None
+    marker = _balance_state(hermes_home).get(provider)
+    if not isinstance(marker, dict):
+        return None
+    try:
+        expires_at = float(marker.get("expires_at") or 0)
+    except (TypeError, ValueError):
+        return None
+    now = time.time() if now is None else now
+    if now >= expires_at:
+        return None
+    return marker.get("status") if marker.get("status") in ("ok", "low") else None
+
+
+def provider_balance_low(
+    provider: str, *, hermes_home: Optional[Path] = None, now: Optional[float] = None
+) -> bool:
+    """Return whether a FRESH balance-low verdict exists for ``provider``."""
+    return _balance_verdict(provider, hermes_home=hermes_home, now=now) == "low"
+
+
+def _set_provider_balance_verdict(
+    provider: str,
+    status: str,
+    *,
+    hermes_home: Optional[Path] = None,
+    ttl_seconds: float = _BALANCE_LOW_TTL_SECONDS,
+) -> None:
+    """Persist a balance verdict for ``provider`` with a TTL."""
+    if not provider or status not in ("ok", "low"):
+        return
+    try:
+        state = _balance_state(hermes_home)
+        state[provider] = {"status": status, "expires_at": time.time() + ttl_seconds}
+        path = _balance_cache_path(hermes_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as exc:
+        logger.debug("Could not persist balance verdict: %s", exc)
+
+
+def mark_provider_balance_low(
+    provider: str,
+    *,
+    hermes_home: Optional[Path] = None,
+    ttl_seconds: float = _BALANCE_LOW_TTL_SECONDS,
+) -> None:
+    """Persist a balance-low verdict for ``provider`` with a TTL."""
+    _set_provider_balance_verdict(provider, "low", hermes_home=hermes_home, ttl_seconds=ttl_seconds)
+
+
+def mark_provider_balance_ok(
+    provider: str,
+    *,
+    hermes_home: Optional[Path] = None,
+    ttl_seconds: float = _BALANCE_LOW_TTL_SECONDS,
+) -> None:
+    """Persist a healthy-balance verdict so healthy accounts are NOT pinged
+    on every wake — one ping per provider per TTL window across all jobs."""
+    _set_provider_balance_verdict(provider, "ok", hermes_home=hermes_home, ttl_seconds=ttl_seconds)
+
+
+def clear_provider_balance_low(
+    provider: str, *, hermes_home: Optional[Path] = None
+) -> None:
+    """Clear the balance verdict for ``provider`` (forces a re-check)."""
+    if not provider:
+        return
+    try:
+        state = _balance_state(hermes_home)
+        if provider in state:
+            del state[provider]
+            path = _balance_cache_path(hermes_home)
+            path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as exc:
+        logger.debug("Could not clear balance verdict: %s", exc)
+
+
+def preflight_provider_balance(
+    runtime: Dict[str, Any], *, cfg: Optional[Any] = None, hermes_home: Optional[Path] = None
+) -> Optional[str]:
+    """Provider-balance preflight: None when the account has balance (or the
+    check cannot run), or a BALANCE_LOW reason when the account is exhausted.
+
+    Cache-first: a fresh ``ok`` verdict short-circuits with NO ping (healthy
+    accounts are not pinged on every wake — at most one ping per provider per
+    TTL window); a fresh ``low`` verdict returns the reason WITHOUT a ping —
+    repeated wake attempts are suppressed until the TTL expires (the 08-19
+    incident shape). Otherwise the standard max_tokens=1 ping runs; an HTTP
+    402 response marks balance low and returns the reason; success marks ok.
+    Any other ping failure (network, timeout, 401) is NOT treated as balance
+    exhaustion — it falls through to the caller's existing handling
+    (fail-open) and forces a re-check on the next wake.
+    """
+    provider = runtime.get("provider") or ""
+    verdict = _balance_verdict(provider, hermes_home=hermes_home)
+    if verdict == "low":
+        return (
+            f"{BALANCE_LOW_ERROR_MARKER} — provider '{provider}' account "
+            "balance is exhausted; waiting for balance (recheck on TTL expiry)"
+        )
+    if verdict == "ok":
+        return None
+
+    err = preflight_provider(runtime, cfg=cfg)
+    if err is None:
+        mark_provider_balance_ok(provider, hermes_home=hermes_home)
+        return None
+    if BALANCE_LOW_ERROR_MARKER in err:
+        mark_provider_balance_low(provider, hermes_home=hermes_home)
+        return (
+            f"{BALANCE_LOW_ERROR_MARKER} — provider '{provider}' account "
+            "balance is exhausted; waiting for balance (recheck on TTL expiry)"
+        )
+    return None
+
+
 def _preflight_openai_compatible(
     api_key: str,
     base_url: str,
@@ -285,12 +450,21 @@ def _preflight_openai_compatible(
     client = OpenAI(**client_kwargs)
     start = time.time()
     try:
-        client.chat.completions.create(
-            model=model or "default",
-            messages=[{"role": "user", "content": "ping"}],
-            max_tokens=1,
-            stream=False,
-        )
+        try:
+            client.chat.completions.create(
+                model=model or "default",
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+                stream=False,
+            )
+        except Exception as exc:
+            # Classify HTTP 402 Insufficient Balance (billing exhaustion)
+            # distinctly — it is non-retryable and means every wake will
+            # fail, so the scheduler must suppress jobs rather than treat
+            # it as a transient ping failure (#2872).
+            if _is_http_status(exc, 402):
+                return f"{BALANCE_LOW_ERROR_MARKER}: {exc}"
+            raise
         elapsed = time.time() - start
         logger.debug("Pre-flight ping to %s succeeded in %.2fs", provider, elapsed)
         return None
@@ -299,6 +473,34 @@ def _preflight_openai_compatible(
             client.close()
         except Exception:
             pass
+
+
+def _is_http_status(exc: Exception, status: int) -> bool:
+    """Return whether ``exc`` carries an HTTP status code (402 etc.).
+
+    Handles OpenAI/Anthropic SDK ``APIStatusError`` (``status_code``), the
+    underlying ``httpx`` errors (``response.status_code``), and the generic
+    ``RuntimeError: HTTP 402`` shape the scheduler logs when a provider
+    returns an error mid-run.
+    """
+    for attr in ("status_code", "code"):
+        value = getattr(exc, attr, None)
+        if value is not None:
+            try:
+                if int(value) == status:
+                    return True
+            except (TypeError, ValueError):
+                pass
+    response = getattr(exc, "response", None)
+    if response is not None:
+        value = getattr(response, "status_code", None)
+        if value is not None:
+            try:
+                if int(value) == status:
+                    return True
+            except (TypeError, ValueError):
+                pass
+    return f"HTTP {status}" in str(exc)
 
 
 def _preflight_anthropic(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3879,6 +3879,11 @@ def _guard_job_credential_exfil(job: dict) -> None:
 # a previous tick — do not deliver again".
 BLOCKED_CONFIG_MARKER = "[blocked_config]"
 BLOCKED_CONFIG_SILENT_MARKER = "[blocked_config:silent]"
+# Provider-balance exhaustion (HTTP 402) — distinct from a config block so
+# `cronjob list` shows the account is out of balance, not that the job's
+# configuration is broken (#2872). Alert-once shape mirrors blocked_config.
+BALANCE_LOW_MARKER = "[balance_low]"
+BALANCE_LOW_SILENT_MARKER = "[balance_low:silent]"
 
 # Marker prefix for a #44585 drift-guard skip. Same alert-once contract as
 # blocked_config: run_one_job keys off it to record last_status and the
@@ -4044,6 +4049,61 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
+def _preflight_check_provider_balance(job: dict, cfg: dict) -> Optional[str]:
+    """Billing-exhaustion preflight: would this job's provider 402 on wake?
+
+    HTTP 402 Insufficient Balance is non-retryable billing exhaustion — the
+    08-19 incident shape where 50 cron failures across 6 jobs and the whole
+    evolution pipeline sat dead for 6.5h because the scheduler kept waking
+    agents that immediately 402'd. This check mirrors the provider-key
+    probe (same resolution, same fail-open discipline) and asks the
+    evolution-preflight module for the provider's BALANCE verdict, which is
+    cached on disk with a TTL so repeated wake attempts are suppressed
+    (``BALANCE_LOW`` in jobs.json) instead of burning scheduler cycles.
+
+    Fail-open: ANY error here (resolution failure, cache error, non-402 ping
+    failure) returns None — balance preflight must never block a runnable
+    job on a transient condition, only on an affirmative 402 verdict.
+    """
+    try:
+        if get_fallback_chain(cfg):
+            return None  # a fallback may carry a funded account
+    except Exception:
+        return None
+
+    if job.get("no_agent"):
+        return None  # no LLM call — nothing to preflight
+
+    try:
+        from cron import evolution_preflight
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        requested = (
+            job.get("provider")
+            or str((cfg.get("cron") or {}).get("model_provider") or "").strip()
+            or None
+        )
+        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        kwargs = {"requested": requested, "target_model": model}
+        if job.get("base_url"):
+            kwargs["explicit_base_url"] = job.get("base_url")
+        runtime = resolve_runtime_provider(**kwargs)
+        hermes_home = _get_hermes_home()
+        reason = evolution_preflight.preflight_provider_balance(
+            runtime, cfg=cfg, hermes_home=hermes_home
+        )
+    except Exception:
+        logger.debug(
+            "Job '%s': provider-balance preflight errored — failing open",
+            job.get("id"),
+            exc_info=True,
+        )
+        return None
+    if reason is None:
+        return None
+    return f"{BALANCE_LOW_MARKER} {reason}"
+
+
 def _preflight_check_delivery(job: dict) -> Optional[str]:
     """Check the job's delivery target(s) resolve to configured platforms.
 
@@ -4174,6 +4234,9 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
         ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
         ("skills", lambda: _preflight_check_skills(job)),
         ("delivery", lambda: _preflight_check_delivery(job)),
+        # Provider-balance (HTTP 402) preflight — cheap config checks first,
+        # then the TTL-cached balance verdict (#2872). Fails open.
+        ("provider_balance", lambda: _preflight_check_provider_balance(job, cfg)),
     ):
         try:
             reason = check()
@@ -5204,23 +5267,43 @@ def _run_job_impl(
                     "Job '%s': could not persist preflight alert marker",
                     job_id, exc_info=True,
                 )
-            marker = (
-                BLOCKED_CONFIG_SILENT_MARKER if already_alerted
-                else BLOCKED_CONFIG_MARKER
-            )
-            blocked_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-                f"**Status:** BLOCKED (configuration)\n\n"
-                "Pre-dispatch validation found a configuration problem and "
-                "the agent was NOT run (no tokens spent).\n\n"
-                f"**Reason:** {_pf_reason}\n\n"
-                "The job will stay blocked (without re-alerting) until the "
-                "configuration is fixed; the next healthy run clears this "
-                "state. Set `cron.preflight: false` in config.yaml to "
-                "disable this validation."
-            )
+            is_balance_low = BALANCE_LOW_MARKER in str(_pf_reason)
+            if is_balance_low:
+                marker = (
+                    BALANCE_LOW_SILENT_MARKER if already_alerted
+                    else BALANCE_LOW_MARKER
+                )
+                blocked_doc = (
+                    f"# Cron Job: {job_name}\n\n"
+                    f"**Job ID:** {job_id}\n"
+                    f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                    f"**Status:** BLOCKED (provider balance low)\n\n"
+                    "The provider account is out of balance (HTTP 402) and "
+                    "the agent was NOT run (no tokens spent, no 402 burn).\n\n"
+                    f"**Reason:** {_pf_reason}\n\n"
+                    "The job is parked in `balance_low` state and will retry "
+                    "automatically when the balance recheck succeeds. "
+                    "Set `cron.preflight: false` in config.yaml to disable "
+                    "this validation."
+                )
+            else:
+                marker = (
+                    BLOCKED_CONFIG_SILENT_MARKER if already_alerted
+                    else BLOCKED_CONFIG_MARKER
+                )
+                blocked_doc = (
+                    f"# Cron Job: {job_name}\n\n"
+                    f"**Job ID:** {job_id}\n"
+                    f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                    f"**Status:** BLOCKED (configuration)\n\n"
+                    "Pre-dispatch validation found a configuration problem and "
+                    "the agent was NOT run (no tokens spent).\n\n"
+                    f"**Reason:** {_pf_reason}\n\n"
+                    "The job will stay blocked (without re-alerting) until the "
+                    "configuration is fixed; the next healthy run clears this "
+                    "state. Set `cron.preflight: false` in config.yaml to "
+                    "disable this validation."
+                )
             return False, blocked_doc, "", f"{marker} {_pf_reason}"
 
         primary_model_for_drift = model
@@ -6315,6 +6398,7 @@ def _run_one_job_body(
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         blocked_config = False
+        balance_low = False
         side_effect_ownership_lost = False
         try:
             with _side_effect_fence() as owns_output:
@@ -6353,6 +6437,15 @@ def _run_one_job_body(
             blocked_config = blocked_config_silent or (
                 bool(error) and BLOCKED_CONFIG_MARKER in str(error)
             )
+            # Provider-balance (HTTP 402) block — same alert-once contract as
+            # blocked_config, but recorded as a DISTINCT last_status so
+            # `cronjob list` shows the account is out of balance (#2872).
+            balance_low_silent = (
+                bool(error) and BALANCE_LOW_SILENT_MARKER in str(error)
+            )
+            balance_low = balance_low_silent or (
+                bool(error) and BALANCE_LOW_MARKER in str(error)
+            )
             # Drift-guard skip (#44585): same alert-once contract as
             # blocked_config — the silent marker means the operator already
             # got the alert on a previous tick.
@@ -6362,21 +6455,29 @@ def _run_one_job_body(
             drift_skip = drift_skip_silent or (
                 bool(error) and DRIFT_SKIP_MARKER in str(error)
             )
-            if blocked_config and not success:
+            if (blocked_config or balance_low) and not success:
                 # Blocked-config alert: bypass the generic failure summarizer
                 # (whose auth/timeout heuristics would mislabel this as a
                 # provider runtime failure) — say plainly that config
                 # validation blocked the run and nothing was spent.
                 _pf_text = re.sub(
-                    r"\[blocked_config[^\]]*\]\s*", "", str(error)
+                    r"\[(?:blocked_config|balance_low)[^\]]*\]\s*", "", str(error)
                 ).strip()
-                deliver_content = (
-                    f"⛔ Cron '{job.get('name') or job['id']}' blocked by "
-                    f"configuration validation (no LLM call was made): "
-                    f"{_pf_text} "
-                    "This alert is sent once; the job stays blocked until "
-                    "the configuration is fixed."
-                )
+                if balance_low:
+                    deliver_content = (
+                        f"🪫 Cron '{job.get('name') or job['id']}' paused: "
+                        f"provider account balance is low (HTTP 402) — no LLM "
+                        f"call was made: {_pf_text} This alert is sent once; "
+                        "the job retries automatically when balance returns."
+                    )
+                else:
+                    deliver_content = (
+                        f"⛔ Cron '{job.get('name') or job['id']}' blocked by "
+                        f"configuration validation (no LLM call was made): "
+                        f"{_pf_text} "
+                        "This alert is sent once; the job stays blocked until "
+                        "the configuration is fixed."
+                    )
             else:
                 deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
                 if drift_skip and not success:
@@ -6395,7 +6496,7 @@ def _run_one_job_body(
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
-            if blocked_config_silent or drift_skip_silent:
+            if blocked_config_silent or balance_low_silent or drift_skip_silent:
                 should_deliver = False
             unresolved_origin = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
@@ -6526,6 +6627,8 @@ def _run_one_job_body(
             mark_kwargs["expected_fire_owner"] = fire_owner
         if blocked_config:
             mark_kwargs["status"] = "blocked_config"
+        elif balance_low:
+            mark_kwargs["status"] = "balance_low"
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
         if fire_owner is not None and not marked:
             finish_execution(

--- a/tests/cron/test_evolution_preflight.py
+++ b/tests/cron/test_evolution_preflight.py
@@ -1,6 +1,7 @@
 """Tests for cron/evolution_preflight.py."""
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -298,6 +299,97 @@ class TestPreflightProvider:
         assert err is not None
         assert "connection refused" in err
 
+
+class TestBalancePreflight:
+    """Provider-balance preflight (#2872): HTTP 402 billing exhaustion must
+    be detected before a cron wake, cached with a TTL, and exposed as a
+    distinct BALANCE_LOW verdict so the scheduler suppresses wakes."""
+
+    def _runtime(self, provider="deepseek"):
+        return {
+            "api_key": "k",
+            "model": "m",
+            "provider": provider,
+            "api_mode": "chat_completions",
+        }
+
+    def test_no_marker_means_not_low(self, tmp_path):
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is False
+
+    def test_mark_then_low(self, tmp_path):
+        ep.mark_provider_balance_low("deepseek", hermes_home=tmp_path, ttl_seconds=60)
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is True
+
+    def test_marker_expires(self, tmp_path):
+        ep.mark_provider_balance_low("deepseek", hermes_home=tmp_path, ttl_seconds=60)
+        assert ep.provider_balance_low(
+            "deepseek", hermes_home=tmp_path, now=time.time() + 61
+        ) is False
+
+    def test_marker_is_provider_scoped(self, tmp_path):
+        ep.mark_provider_balance_low("deepseek", hermes_home=tmp_path, ttl_seconds=60)
+        assert ep.provider_balance_low("openrouter", hermes_home=tmp_path) is False
+
+    def test_corrupt_cache_fails_safe_to_not_low(self, tmp_path):
+        evo_dir = tmp_path / "evolution"
+        evo_dir.mkdir(parents=True, exist_ok=True)
+        (evo_dir / "balance-low.json").write_text("{not json", encoding="utf-8")
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is False
+
+    def test_cached_low_returns_reason_without_ping(self, tmp_path):
+        ep.mark_provider_balance_low("deepseek", hermes_home=tmp_path, ttl_seconds=60)
+        with patch.object(ep, "preflight_provider") as mock_ping:
+            reason = ep.preflight_provider_balance(
+                self._runtime(), hermes_home=tmp_path
+            )
+        assert reason is not None
+        assert ep.BALANCE_LOW_ERROR_MARKER in reason
+        mock_ping.assert_not_called()  # TTL cache suppresses the wake
+
+    def test_402_ping_marks_low_and_returns_reason(self, tmp_path):
+        with patch.object(
+            ep,
+            "preflight_provider",
+            return_value=f"{ep.BALANCE_LOW_ERROR_MARKER}: test",
+        ):
+            reason = ep.preflight_provider_balance(
+                self._runtime(), hermes_home=tmp_path
+            )
+        assert reason is not None
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is True
+
+    def test_ok_ping_clears_and_returns_none(self, tmp_path):
+        # No pre-existing low marker: a successful ping marks ok and passes.
+        with patch.object(ep, "preflight_provider", return_value=None):
+            reason = ep.preflight_provider_balance(
+                self._runtime(), hermes_home=tmp_path
+            )
+        assert reason is None
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is False
+
+    def test_non_402_failure_fails_open(self, tmp_path):
+        with patch.object(ep, "preflight_provider", return_value="connection refused"):
+            reason = ep.preflight_provider_balance(
+                self._runtime(), hermes_home=tmp_path
+            )
+        assert reason is None  # only an affirmative 402 verdict blocks
+        assert ep.provider_balance_low("deepseek", hermes_home=tmp_path) is False
+
+
+class TestHttpStatusClassification:
+    def test_openai_402_error_classified(self):
+        err = MagicMock()
+        err.status_code = 402
+        assert ep._is_http_status(err, 402) is True
+        assert ep._is_http_status(err, 429) is False
+
+    def test_runtime_error_string_classified(self):
+        err = RuntimeError("Job failed: RuntimeError: HTTP 402")
+        assert ep._is_http_status(err, 402) is True
+
+    def test_other_status_not_classified(self):
+        assert ep._is_http_status(RuntimeError("timeout"), 402) is False
+
     def test_anthropic_success(self):
         pytest.importorskip("anthropic")
         fake_client = MagicMock()
@@ -390,7 +482,11 @@ class TestSchedulerIntegration:
         assert kwargs["api_key"] is None
         assert kwargs["base_url"] is None
 
-    def test_non_evolution_job_skips_preflight(self, tmp_path):
+    def test_non_evolution_job_balance_preflight_fails_open(self, tmp_path):
+        # A non-evolution job DOES get the provider-balance preflight (#2872:
+        # any LLM cron must not wake into an exhausted account), but a
+        # NON-402 ping failure is fail-open — the job proceeds as before and
+        # the old preflight digest-fallback behavior stays evolution-only.
         from cron.scheduler import _run_job_impl
 
         job = {"id": "morning-digest", "name": "morning-digest", "prompt": "hi"}
@@ -422,7 +518,8 @@ class TestSchedulerIntegration:
 
         assert success is True
         assert final_response == "ok"
-        mock_preflight.assert_not_called()
+        # Balance preflight ran (one ping, fail-open on non-402).
+        mock_preflight.assert_called_once()
         mock_agent_cls.assert_called_once()
 
 class TestSchedulerHaltGate:

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -340,3 +340,116 @@ class TestDeliveryPlatform:
 
         assert success is True
         assert agent_constructed is True
+
+
+class TestBalanceLowBlock:
+    """Provider-balance exhaustion (#2872): HTTP 402 must block the run with
+    a DISTINCT `balance_low` status (not blocked_config) and alert exactly
+    once, so an exhausted account suppresses wakes instead of burning
+    scheduler cycles on agents that would immediately 402."""
+
+    def _balance_reason(self):
+        from cron.evolution_preflight import BALANCE_LOW_ERROR_MARKER
+
+        return (
+            f"[balance_low] {BALANCE_LOW_ERROR_MARKER} — provider 'deepseek' "
+            "account balance is exhausted"
+        )
+
+    def test_balance_low_blocks_before_agent(self, tmp_path):
+        job = _job()
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "cron.scheduler._preflight_check_provider_balance",
+                return_value=self._balance_reason(),
+            ):
+                success, output, final_response, error, agent_constructed = \
+                    _run_job_patched(job, tmp_path)
+
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None and "[balance_low]" in error
+        assert "[blocked_config]" not in error
+        assert "balance" in output.lower() or "balance" in str(error).lower()
+
+    def test_balance_low_not_treated_as_config_block(self, tmp_path):
+        """The BALANCE_LOW marker must NOT also trip blocked_config — the
+        status recorded downstream is distinct (`balance_low`)."""
+        job = _job()
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "cron.scheduler._preflight_check_provider_balance",
+                return_value=self._balance_reason(),
+            ):
+                success, _output, _final_response, error, _agent = \
+                    _run_job_patched(job, tmp_path)
+
+        assert success is False
+        assert error is not None and "[balance_low]" in error
+        assert sched.BLOCKED_CONFIG_MARKER not in error
+        assert sched.BALANCE_LOW_MARKER in error
+
+    def test_single_alert_across_two_ticks_and_balance_low_status(self, tmp_path):
+        """Two ticks of a balance-low job deliver exactly ONE alert and
+        persist last_status='balance_low' in jobs.json (#2872)."""
+        job = _job()
+        deliveries = []
+
+        def fake_deliver(job, content, adapters=None, loop=None):
+            deliveries.append(content)
+            return None
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fake_db = MagicMock()
+            for _tick in range(2):
+                fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+                with patch("cron.scheduler._hermes_home", tmp_path), \
+                     patch("cron.scheduler._resolve_origin", return_value=None), \
+                     patch("cron.scheduler._preflight_check_provider_key",
+                           return_value=None), \
+                     patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+                     patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                     patch("hermes_state.SessionDB", return_value=fake_db), \
+                     patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+                     patch(
+                         "cron.scheduler._preflight_check_provider_balance",
+                         return_value=self._balance_reason(),
+                     ), \
+                     patch.object(sched, "_deliver_result", side_effect=fake_deliver), \
+                     patch("run_agent.AIAgent") as mock_agent_cls:
+                    ok = sched.run_one_job(fresh)
+                    assert ok is True
+                    assert mock_agent_cls.called is False
+
+            stored = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+
+        assert stored["last_status"] == "balance_low"
+        assert len(deliveries) == 1, (
+            f"expected exactly one alert across two ticks, got {len(deliveries)}: "
+            f"{deliveries!r}"
+        )
+        assert "balance" in deliveries[0].lower()
+
+    def test_healthy_run_clears_balance_alert_marker(self, tmp_path):
+        """After a balance-low tick, a healthy tick clears the alert-dedup
+        marker so a FUTURE balance drop re-alerts."""
+        job = _job()
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "cron.scheduler._preflight_check_provider_balance",
+                return_value=self._balance_reason(),
+            ):
+                _run_job_patched(job, tmp_path)
+            stored = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            assert stored.get("preflight_alerted")
+            # Balance restored → healthy run clears the marker.
+            fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            success, *_rest, agent_constructed = _run_job_patched(fresh, tmp_path)
+            assert success is True
+            assert agent_constructed is True
+            stored = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            assert not stored.get("preflight_alerted")


### PR DESCRIPTION
Automated evolution PR for issue #2872 — the live 08-19 incident (50 cron failures across 6 jobs, whole evolution pipeline dead 6.5h on HTTP 402 Insufficient Balance).

**Fix:** provider-balance preflight in the cron wake gate, billing-layer mirror of #2758, complementing PR #2856 (reactive backoff).

- `cron/evolution_preflight.py`: TTL-cached per-provider balance verdict (`balance-low.json`). `preflight_provider_balance()` is cache-first — fresh `low` suppresses wakes with no ping; fresh `ok` short-circuits (one max_tokens=1 ping per provider per TTL window); otherwise the ping runs and HTTP 402 is classified distinctly (APIStatusError.status_code / httpx response / `RuntimeError: HTTP 402` string).
- `cron/scheduler.py`: new `provider_balance` preflight check (fail-open like provider_key/skills/delivery). Balance-low blocks BEFORE agent construction, publishes a distinct `last_status=balance_low` in jobs.json, and alerts exactly once (same alert-once shape as `blocked_config`); the job retries automatically when the TTL recheck succeeds.
- Tests: cache TTL/expiry/provider-scope/corrupt-cache fail-safe, 402 vs non-402 classification, cached-low suppresses ping, block-before-agent, distinct status, alert-once across two ticks, recovery clears the alert marker.

**Note on size:** 585 changed lines (feature + tests) exceeds the 200-line autonomous-merge cap, so this PR is expected to wait for human merge — the work is complete and green (67 cron-preflight tests, ruff clean, pre-PR shard PASS).

Checks: lint ✓, format ✓ (only blocking ruff gate is `ruff check`, which passes), tests ✓ (67 passed), pre-PR targeted shard ✓