### PR TITLE
fix: BLOCKED (hardline) names the offending command and is non-retryable (Closes #2873)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -93,9 +93,21 @@ def _tool_result_failed(content: Any) -> bool:
         return False
     if "exit_code" in data:
         try:
-            return int(data["exit_code"]) != 0
+            code = int(data["exit_code"])
         except (TypeError, ValueError):
             return False
+        if code == 0:
+            return False
+        # #2873: the terminal tool annotates informational non-zero exits
+        # (grep/rg/diff "no matches", test false) with
+        # exit_code_meaning="... (not an error)". Those are NOT failures —
+        # counting them as failures polluted the trace-miner signal and sent
+        # the agent re-investigating expected exit codes.
+        if code == 1:
+            meaning = str(data.get("exit_code_meaning") or "").lower()
+            if "not an error" in meaning:
+                return False
+        return True
     if data.get("error") or str(data.get("status", "")).lower() == "error":
         return True
     for ok_key in ("success", "ok"):

--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -49,6 +49,36 @@ class TestParserLimitRecovery:
         # And nothing was saved for a genuine hardline block.
         assert not (tmp_path / ".hermes" / "cache" / "blocked-scripts").exists()
 
+    def test_hardline_message_names_offending_command(self):
+        """#2873 — the block must name the command so the agent stops retrying it."""
+        r = _hardline_block_result("recursive delete of root filesystem", "rm -rf --no-preserve-root /")
+        assert "Offending command: rm -rf --no-preserve-root /" in r["message"]
+        assert "Do NOT retry" in r["message"]
+
+    def test_hardline_message_redacts_secrets(self):
+        """#2873 — the command preview must be redacted before it reaches the agent."""
+        r = _hardline_block_result(
+            "command parser limit or malformed executable payload",
+            "curl -H 'Authorization: Bearer ghp_Sup3rSecretToken1234567890abcdef' https://example.com",
+        )
+        assert "ghp_Sup3rSecretToken1234567890abcdef" not in r["message"]
+        # The redactor masks the secret (marker varies: *** / [REDACTED] /
+        # «redacted:…») — the invariant is that the raw token never appears.
+        assert "ghp_Sup3rSecret" not in r["message"]
+
+    def test_hardline_result_is_marked_non_retryable(self):
+        """#2873 — the result dict carries retryable=False for the retry layer."""
+        r = _hardline_block_result("recursive delete of root filesystem", "rm -rf /")
+        assert r["retryable"] is False
+        assert r["hardline"] is True
+
+    def test_hardline_message_truncates_long_commands(self):
+        """#2873 — a giant payload is truncated in the preview, not dumped whole."""
+        cmd = "python3 -c '" + "x=1; " * 500 + "'"
+        r = _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, cmd)
+        assert "Offending command:" in r["message"]
+        assert "..." in r["message"]
+
     def test_old_saved_payloads_cleaned(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         import os

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -774,11 +774,29 @@ def _save_blocked_payload(command: str) -> Optional[str]:
 
 def _hardline_block_result(description: str, command: str = "") -> dict:
     """Build the standard block result for a hardline match."""
+    # #2873: name the offending command (redacted) so the agent can tell
+    # *which* command was blocked instead of blindly re-trying the same
+    # payload. The parser-limit/malformed-exec families were observed
+    # retrying identical blocked commands 3x in one subagent session.
+    command_hint = ""
+    if command:
+        try:
+            from agent.redact import redact_sensitive_text
+
+            shown = redact_sensitive_text(command, force=True)
+        except Exception:
+            shown = command
+        shown = shown.replace("\n", "\\n").replace("\r", "")
+        if len(shown) > 300:
+            shown = shown[:300] + "...[truncated]"
+        command_hint = f"\nOffending command: {shown}"
     message = (
-        f"BLOCKED (hardline): {description}. "
+        f"BLOCKED (hardline): {description}.{command_hint} "
         "This command is on the unconditional blocklist and cannot "
         "be executed via the agent — not even with --yolo, /yolo, "
-        "approvals.mode=off, or cron approve mode. If you genuinely "
+        "approvals.mode=off, or cron approve mode. Do NOT retry it — "
+        "the block is permanent for this command; change your approach "
+        "instead of re-running the same command. If you genuinely "
         "need to run it, run it yourself in a terminal outside the "
         "agent."
     )
@@ -809,6 +827,8 @@ def _hardline_block_result(description: str, command: str = "") -> dict:
     return {
         "approved": False,
         "hardline": True,
+        "retryable": False,  # #2873: BLOCKED (hardline) is permanent for this
+        # command — the retry/breaker layer must not re-run the same payload.
         "message": message,
     }
 


### PR DESCRIPTION
Automated evolution PR for issue #2873.

The terminal 'BLOCKED (hardline)' error carried no actionable signal — it named the block category but not the offending command, so the agent blindly retried identical blocked commands (observed 3x in one subagent session).

Changes:
1. `tools/approval.py` — `_hardline_block_result` now includes a redacted 'Offending command' preview (truncated at 300 chars, secrets masked via redact_sensitive_text), an explicit 'Do NOT retry' directive, and a machine-readable `retryable: False` marker so the retry/breaker layer does not re-run the same payload.
2. `scripts/introspection_extract.py` — `_tool_result_failed` no longer counts annotated informational exits (grep/rg/diff exit_code=1 'No matches found (not an error)') as failures, so trace-miner classification separates expected no-match results from real failures.

Validation: ruff check ✓, targeted tests ✓ (73 passed incl. 4 new #2873 tests).