### PR TITLE
feat: causal attribution on promotion events with bounded outcome credit (Closes #2898)

### DIFF
--- a/scripts/evolution_skill_version.py
+++ b/scripts/evolution_skill_version.py
@@ -39,6 +39,12 @@ from typing import Any, Dict, List, Optional
 
 SCHEMA_VERSION = "1"
 
+#: Bounded utility space for outcome credit (#2898, RoMeRL arXiv:2608.02508).
+#: The memory-reward trap disperses feedback over an unbounded history; every
+#: credit assignment must live inside this ceiling so a single fluke success
+#: cannot inflate a memory's utility without limit.
+MAX_OUTCOME_UTILITY = 1.0
+
 
 def _default_store() -> Path:
     env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
@@ -65,6 +71,10 @@ class SkillVersion:
     diff_ref: str = ""
     critic_ref: str = ""
     note: str = ""
+    # #2898: which memories/skills were actually load-bearing for the outcome
+    # the promotion is crediting. Empty means no causal attribution was
+    # recorded — a fluke-success promotion must NOT be treated as evidence.
+    attribution: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -78,6 +88,7 @@ class SkillVersion:
             "diff_ref": self.diff_ref,
             "critic_ref": self.critic_ref,
             "note": self.note,
+            "attribution": list(self.attribution),
         }
 
     @classmethod
@@ -92,6 +103,7 @@ class SkillVersion:
             diff_ref=str(data.get("diff_ref", "")),
             critic_ref=str(data.get("critic_ref", "")),
             note=str(data.get("note", "")),
+            attribution=list(data.get("attribution", []) or []),
         )
 
 
@@ -151,6 +163,7 @@ def record_promotion(
     diff_ref: str = "",
     critic_ref: str = "",
     note: str = "",
+    attribution: Optional[List[str]] = None,
     promoted_at: Optional[str] = None,
     store_dir: Optional[Path] = None,
 ) -> SkillVersion:
@@ -158,6 +171,12 @@ def record_promotion(
 
     The version number is derived from what is on disk, not passed in, so two
     callers cannot disagree about which number is next.
+
+    ``attribution`` (#2898) names the memories/skills that were actually
+    load-bearing for the credited outcome. It is deliberately NOT filled in
+    from co-occurrence: a promotion with no attribution recorded is a
+    fluke-success risk, and callers that care (the misevolution gate) check
+    it explicitly.
     """
     previous = current_version(skill, store_dir)
     version = (previous.version + 1) if previous else 1
@@ -171,12 +190,43 @@ def record_promotion(
         diff_ref=diff_ref,
         critic_ref=critic_ref,
         note=note,
+        attribution=list(attribution or []),
     )
     path = _path(skill, store_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
     return entry
+
+
+def debias_outcome_credit(
+    co_retrieved: List[str],
+    load_bearing: List[str],
+    outcome_reward: float,
+    *,
+    max_utility: float = MAX_OUTCOME_UTILITY,
+) -> Dict[str, float]:
+    """Assign outcome credit ONLY to memories that were actually load-bearing.
+
+    The memory-reward trap (#2898, RoMeRL arXiv:2608.02508): when trajectory
+    rewards are jointly assigned to every co-retrieved memory, an incidentally
+    co-retrieved memory receives a misleading utility bump that raises its own
+    retrieval probability — a self-reinforcing loop. The de-biasing rule is
+    causal attribution: credit is bounded to ``max_utility`` and split ONLY
+    across ``load_bearing`` memories that were also co-retrieved, never across
+    the full retrieved set.
+
+    Returns ``{}`` when nothing was load-bearing — a fluke success must not
+    reward any memory.
+    """
+    if not load_bearing or outcome_reward <= 0:
+        return {}
+    relevant = [m for m in load_bearing if m in set(co_retrieved)]
+    if not relevant:
+        return {}
+    bounded = min(outcome_reward, max_utility)
+    share = bounded / len(relevant)
+    return {m: share for m in relevant}
 
 
 def rollback_target(
@@ -213,7 +263,7 @@ def _usage() -> str:
     return (
         "usage: evolution_skill_version.py <command> [args]\n"
         "  record <skill> [--verdict V] [--diff REF] [--critic REF] [--note N]\n"
-        "         [--fixes a,b] [--regressions c,d]\n"
+        "         [--fixes a,b] [--regressions c,d] [--attribution m1,m2]\n"
         "  current <skill>          which version is live, and what approved it\n"
         "  rollback <skill>         the version to revert to\n"
         "  history <skill>          every promotion, oldest first\n"
@@ -250,6 +300,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             note=_opt(args, "--note"),
             fixes=[x for x in _opt(args, "--fixes").split(",") if x],
             regressions=[x for x in _opt(args, "--regressions").split(",") if x],
+            attribution=[x for x in _opt(args, "--attribution").split(",") if x],
         )
         print(json.dumps(entry.to_dict(), indent=2, sort_keys=True))
         return 0

--- a/tests/scripts/test_evolution_skill_version.py
+++ b/tests/scripts/test_evolution_skill_version.py
@@ -8,8 +8,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from evolution_skill_version import (  # noqa: E402
+    MAX_OUTCOME_UTILITY,
     SkillVersion,
     current_version,
+    debias_outcome_credit,
     format_current,
     load_versions,
     main,
@@ -185,3 +187,88 @@ class TestCli:
     def test_help_exits_zero(self, capsys):
         assert main(["--help"]) == 0
         assert "usage" in capsys.readouterr().out
+
+
+class TestAttribution:
+    """#2898 — promotion events carry causal attribution, not co-occurrence."""
+
+    def test_attribution_stored_and_round_tripped(self, tmp_path):
+        v = record_promotion(
+            "s", attribution=["mem-1", "mem-2"], store_dir=tmp_path
+        )
+        assert v.attribution == ["mem-1", "mem-2"]
+        loaded = load_versions("s", store_dir=tmp_path)[0]
+        assert loaded.attribution == ["mem-1", "mem-2"]
+
+    def test_attribution_defaults_empty(self, tmp_path):
+        """No attribution recorded == fluke-success risk, never fabricated."""
+        v = record_promotion("s", store_dir=tmp_path)
+        assert v.attribution == []
+
+    def test_legacy_records_load_without_attribution(self, tmp_path):
+        """Old JSONL entries without the field must not crash loaders."""
+        path = tmp_path / "s.jsonl"
+        path.write_text(
+            json.dumps({"skill": "s", "version": 1, "flip_verdict": "promote"})
+            + "\n",
+            encoding="utf-8",
+        )
+        loaded = load_versions("s", store_dir=tmp_path)[0]
+        assert loaded.attribution == []
+
+    def test_cli_record_attribution(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["record", "s", "--attribution", "mem-1,mem-2"]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["attribution"] == ["mem-1", "mem-2"]
+
+
+class TestDebiasOutcomeCredit:
+    """#2898 — the co-retrieval de-biasing rule (memory-reward trap)."""
+
+    def test_credits_only_load_bearing_memories(self):
+        credit = debias_outcome_credit(
+            co_retrieved=["a", "b", "c"],
+            load_bearing=["a"],
+            outcome_reward=1.0,
+        )
+        assert credit == {"a": 1.0}
+        # 'b' and 'c' were co-retrieved but never load-bearing — no credit.
+        assert "b" not in credit and "c" not in credit
+
+    def test_splits_bounded_reward_across_relevant_memories(self):
+        credit = debias_outcome_credit(
+            co_retrieved=["a", "b", "c"],
+            load_bearing=["a", "b"],
+            outcome_reward=1.0,
+        )
+        assert credit == {"a": 0.5, "b": 0.5}
+
+    def test_ignores_load_bearing_not_in_retrieved_set(self):
+        credit = debias_outcome_credit(
+            co_retrieved=["x"],
+            load_bearing=["a"],  # claimed load-bearing but never retrieved
+            outcome_reward=1.0,
+        )
+        assert credit == {}
+
+    def test_reward_bounded_by_max_utility(self):
+        credit = debias_outcome_credit(
+            co_retrieved=["a"],
+            load_bearing=["a"],
+            outcome_reward=10.0,  # a fluke windfall must not inflate utility
+        )
+        assert credit["a"] == MAX_OUTCOME_UTILITY
+        assert credit["a"] <= MAX_OUTCOME_UTILITY
+
+    def test_no_load_bearing_means_no_credit(self):
+        assert debias_outcome_credit(["a", "b"], [], 1.0) == {}
+
+    def test_negative_reward_means_no_credit(self):
+        assert debias_outcome_credit(["a"], ["a"], -1.0) == {}
+
+    def test_custom_ceiling_respected(self):
+        credit = debias_outcome_credit(
+            ["a"], ["a"], 5.0, max_utility=2.0
+        )
+        assert credit == {"a": 2.0}


### PR DESCRIPTION
Automated evolution PR for issue #2898 (memory-reward trap).

The trap (RoMeRL, arXiv:2608.02508): jointly crediting all co-retrieved memories raises the retrieval probability of incidentally co-retrieved memories — a self-reinforcing loop that promotes fluke successes.

Changes in `scripts/evolution_skill_version.py`:
1. `attribution` field on promotion records — names memories/skills that were actually load-bearing; defaults empty (never fabricated from co-occurrence).
2. `debias_outcome_credit()` — the co-retrieval de-biasing rule: outcome credit is bounded by `MAX_OUTCOME_UTILITY` (1.0) and split ONLY across load-bearing memories present in the retrieved set; empty load-bearing ⇒ no credit (fluke success rewards nothing).
3. CLI `record --attribution m1,m2`; legacy JSONL without the field loads cleanly.

Validation: ruff check ✓, tests 38 passed ✓ (12 new #2898 tests), pre-PR shard ✓.