### PR TITLE
feat: versioned thought-memory store for the promotion gate (Closes #2900)

### DIFF
--- a/scripts/evolution_thought_memory.py
+++ b/scripts/evolution_thought_memory.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Versioned thought-memory store — persist/retrieve the agent's own reasoning (issue #2900).
+
+Thought-Retriever (arXiv:2604.12231): the pipeline's memory layer stores notes
+and observations, but not the *intermediate reasoning* that produced them.
+When the memory→skill promotion gate evaluates a candidate, it sees only the
+final outcome — the reasoning that led there is gone. This module is Slice 1
+of that pattern: a capture hook that snapshots intermediate reasoning at the
+end of task cycles, a filter/dedup pass, and a versioned store plus a
+deterministic retrieval path that later slices wire into the promotion gate.
+
+Deterministic: no LLM, no network. Pure functions plus a thin CLI, matching
+the ``evolution_*.py`` idiom (JSON to stdout, distinct exit codes).
+
+Scope of this slice (honest): capture + store + retrieval. The retrieval
+results are NOT yet fed into the promotion gate — that wiring (retrieval
+extension + promotion-gate evidence) is the next increment, and this store is
+the substrate it consumes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = "1"
+
+#: A captured "thought" shorter than this is almost certainly noise (a bare
+#: tool name, a single word) — filtering meaningless thoughts is step 2 of
+#: the Thought-Retriever pattern.
+MIN_THOUGHT_CHARS = 20
+
+#: Upper bound per captured thought; giant reasoning dumps are not thoughts.
+MAX_THOUGHT_CHARS = 4000
+
+#: Store growth cap. Versioned and append-only, but unbounded history would
+#: disperse retrieval signal — beyond this many entries the oldest are
+#: archived (see :func:`_archive_overflow`).
+MAX_STORE_ENTRIES = 500
+
+#: Default number of thoughts returned by :func:`retrieve_thoughts`.
+DEFAULT_RETRIEVE_K = 5
+
+#: Distinctive prefix so thought files never collide with trajectory files.
+_FILE_PREFIX = "thoughts-"
+
+
+def _default_store_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / "thought_memory"
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / "thought_memory"
+        if hh
+        else Path.home() / ".hermes" / "evolution" / "thought_memory"
+    )
+
+
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize_thought(text: str) -> str:
+    """Collapse whitespace and strip — the dedup basis for filtering."""
+    return _WS_RE.sub(" ", text.strip())
+
+
+def thought_dedup_key(text: str) -> str:
+    """Opaque hash of the normalized text; two identical thoughts share it."""
+    return hashlib.sha256(normalize_thought(text).encode("utf-8", "replace")).hexdigest()[:16]
+
+
+@dataclass
+class Thought:
+    """One captured reasoning fragment, versioned across the store."""
+
+    text: str
+    captured_at: str = ""
+    task_key: str = ""
+    source: str = "task-cycle"
+    version: int = 1
+    dedup_key: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.captured_at:
+            self.captured_at = datetime.now(timezone.utc).isoformat()
+        if not self.dedup_key:
+            self.dedup_key = thought_dedup_key(self.text)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "text": self.text,
+            "captured_at": self.captured_at,
+            "task_key": self.task_key,
+            "source": self.source,
+            "version": self.version,
+            "dedup_key": self.dedup_key,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Thought":
+        return cls(
+            text=str(data.get("text", "")),
+            captured_at=str(data.get("captured_at", "")),
+            task_key=str(data.get("task_key", "")),
+            source=str(data.get("source", "task-cycle")),
+            version=int(data.get("version", 1) or 1),
+            dedup_key=str(data.get("dedup_key", "")),
+        )
+
+
+def _store_path(store_dir: Optional[Path] = None) -> Path:
+    base = store_dir or _default_store_dir()
+    return base / f"{_FILE_PREFIX}store.jsonl"
+
+
+def _archive_path(store_dir: Optional[Path] = None) -> Path:
+    base = store_dir or _default_store_dir()
+    return base / f"{_FILE_PREFIX}archive.jsonl"
+
+
+def load_thoughts(store_dir: Optional[Path] = None) -> List[Thought]:
+    """Every thought in the store, oldest first. Corrupt lines are skipped."""
+    path = _store_path(store_dir)
+    if not path.exists():
+        return []
+    out: List[Thought] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("text"):
+            out.append(Thought.from_dict(data))
+    return out
+
+
+def _next_version(thoughts: List[Thought]) -> int:
+    return (max((t.version for t in thoughts), default=0) or 0) + 1
+
+
+def _append(path: Path, thought: Thought) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(thought.to_dict(), sort_keys=True) + "\n")
+
+
+def _archive_overflow(store_dir: Path) -> None:
+    """Move the oldest half beyond MAX_STORE_ENTRIES into the archive file.
+
+    The store stays bounded (retrieval signal is not dispersed across
+    unbounded history); the archive keeps the history itself for audit.
+    """
+    thoughts = load_thoughts(store_dir)
+    if len(thoughts) <= MAX_STORE_ENTRIES:
+        return
+    overflow = thoughts[: len(thoughts) - MAX_STORE_ENTRIES]
+    keep = thoughts[len(thoughts) - MAX_STORE_ENTRIES :]
+    archive = _archive_path(store_dir)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with open(archive, "a", encoding="utf-8") as fh:
+        for t in overflow:
+            fh.write(json.dumps(t.to_dict(), sort_keys=True) + "\n")
+    path = _store_path(store_dir)
+    path.write_text(
+        "".join(json.dumps(t.to_dict(), sort_keys=True) + "\n" for t in keep),
+        encoding="utf-8",
+    )
+
+
+def capture_thought(
+    text: str,
+    *,
+    task_key: str = "",
+    source: str = "task-cycle",
+    store_dir: Optional[Path] = None,
+) -> Optional[Thought]:
+    """Capture one thought: filter meaningless, dedup identical, version, persist.
+
+    Returns the stored :class:`Thought`, or ``None`` when the text is too
+    short/long or is an exact duplicate of an already-stored thought.
+    """
+    normalized = normalize_thought(text)
+    if len(normalized) < MIN_THOUGHT_CHARS or len(normalized) > MAX_THOUGHT_CHARS:
+        return None
+    base = store_dir or _default_store_dir()
+    thoughts = load_thoughts(base)
+    dedup_key = thought_dedup_key(normalized)
+    if any(t.dedup_key == dedup_key for t in thoughts):
+        return None
+    thought = Thought(
+        text=normalized,
+        task_key=task_key,
+        source=source,
+        version=_next_version(thoughts),
+        dedup_key=dedup_key,
+    )
+    _append(_store_path(base), thought)
+    _archive_overflow(base)
+    return thought
+
+
+def retrieve_thoughts(
+    query: str,
+    *,
+    k: int = DEFAULT_RETRIEVE_K,
+    store_dir: Optional[Path] = None,
+) -> List[Thought]:
+    """Return the top-k thoughts most relevant to ``query``.
+
+    Deterministic token-overlap scoring over the normalized text — no LLM, no
+    embeddings. This is the retrieval substrate; later slices feed it to the
+    promotion gate as reasoning evidence.
+    """
+    q_tokens = set(normalize_thought(query).lower().split())
+    if not q_tokens:
+        return []
+    scored: List[tuple] = []
+    for t in load_thoughts(store_dir):
+        t_tokens = set(normalize_thought(t.text).lower().split())
+        if not t_tokens:
+            continue
+        overlap = len(q_tokens & t_tokens) / len(q_tokens | t_tokens)
+        if overlap > 0:
+            scored.append((overlap, t))
+    scored.sort(key=lambda x: (-x[0], x[1].version))
+    return [t for _, t in scored[:k]]
+
+
+def stats(store_dir: Optional[Path] = None) -> Dict[str, Any]:
+    thoughts = load_thoughts(store_dir)
+    versions = [t.version for t in thoughts]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "count": len(thoughts),
+        "max_version": max(versions, default=0),
+        "sources": sorted({t.source for t in thoughts}),
+    }
+
+
+def _usage() -> str:
+    return (
+        "usage: evolution_thought_memory.py <command> [args]\n"
+        "  capture <text> [--task-key K] [--source S]\n"
+        "  retrieve <query> [--k N]\n"
+        "  stats\n"
+        "  Exit 0 ok, 2 bad input, 1 nothing to report."
+    )
+
+
+def _opt(args: List[str], name: str, default: str = "") -> str:
+    if name in args:
+        i = args.index(name)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return default
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or "--help" in args or "-h" in args:
+        print(_usage())
+        return 0 if args else 2
+
+    cmd = args[0]
+
+    if cmd == "capture":
+        if len(args) < 2:
+            print(_usage(), file=sys.stderr)
+            return 2
+        thought = capture_thought(
+            args[1],
+            task_key=_opt(args, "--task-key"),
+            source=_opt(args, "--source", "task-cycle"),
+        )
+        if thought is None:
+            print("captured: none (filtered or duplicate)", file=sys.stderr)
+            return 1
+        print(json.dumps(thought.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if cmd == "retrieve":
+        if len(args) < 2:
+            print(_usage(), file=sys.stderr)
+            return 2
+        k = DEFAULT_RETRIEVE_K
+        if "--k" in args:
+            try:
+                k = int(_opt(args, "--k"))
+            except ValueError:
+                k = DEFAULT_RETRIEVE_K
+        hits = retrieve_thoughts(args[1], k=k)
+        print(json.dumps([t.to_dict() for t in hits], indent=2, sort_keys=True))
+        return 0 if hits else 1
+
+    if cmd == "stats":
+        print(json.dumps(stats(), indent=2, sort_keys=True))
+        return 0
+
+    print(_usage(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_evolution_thought_memory.py
+++ b/tests/scripts/test_evolution_thought_memory.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""Tests for the versioned thought-memory store (issue #2900, Thought-Retriever)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_thought_memory import (  # noqa: E402
+    MAX_STORE_ENTRIES,
+    MIN_THOUGHT_CHARS,
+    Thought,
+    capture_thought,
+    load_thoughts,
+    main,
+    normalize_thought,
+    retrieve_thoughts,
+    stats,
+    thought_dedup_key,
+)
+
+
+class TestCapture:
+    def test_captures_and_persists(self, tmp_path):
+        t = capture_thought(
+            "The promotion gate needs reasoning evidence, not just outcomes.",
+            task_key="tk-1",
+            store_dir=tmp_path,
+        )
+        assert t is not None
+        assert t.version == 1
+        assert t.task_key == "tk-1"
+        loaded = load_thoughts(tmp_path)
+        assert len(loaded) == 1
+        assert loaded[0].text == t.text
+
+    def test_versions_increment(self, tmp_path):
+        for expected in (1, 2):
+            t = capture_thought(f"distinct thought number {expected} here", store_dir=tmp_path)
+            assert t.version == expected
+
+    def test_filters_meaningless_short_thoughts(self, tmp_path):
+        short = "x" * (MIN_THOUGHT_CHARS - 1)
+        assert capture_thought(short, store_dir=tmp_path) is None
+        assert load_thoughts(tmp_path) == []
+
+    def test_filters_oversized_thoughts(self, tmp_path):
+        big = "y" * 5000
+        assert capture_thought(big, store_dir=tmp_path) is None
+
+    def test_dedups_identical_thoughts(self, tmp_path):
+        text = "The same reasoning fragment captured twice must be stored once."
+        first = capture_thought(text, store_dir=tmp_path)
+        second = capture_thought(text, store_dir=tmp_path)
+        assert first is not None
+        assert second is None
+        assert len(load_thoughts(tmp_path)) == 1
+
+    def test_dedup_ignores_whitespace_variance(self, tmp_path):
+        a = capture_thought("split   across   many   spaces", store_dir=tmp_path)
+        b = capture_thought("split across many spaces", store_dir=tmp_path)
+        assert a is not None
+        assert b is None
+
+
+class TestRetrieve:
+    def _seed(self, tmp_path):
+        capture_thought("The agent should prefer tools over raw shell.", store_dir=tmp_path)
+        capture_thought("Quantization shrinks decision margins on tool calls.", store_dir=tmp_path)
+        capture_thought("Skill retrieval is the bottleneck as pools grow.", store_dir=tmp_path)
+
+    def test_returns_top_k_by_token_overlap(self, tmp_path):
+        self._seed(tmp_path)
+        hits = retrieve_thoughts("tool calls and shell", k=2, store_dir=tmp_path)
+        assert len(hits) <= 2
+        # Both tool-related thoughts must outrank the unrelated skill thought.
+        joined = " ".join(h.text.lower() for h in hits)
+        assert "tool" in joined
+        assert "skill retrieval" not in joined
+
+    def test_empty_query_returns_nothing(self, tmp_path):
+        self._seed(tmp_path)
+        assert retrieve_thoughts("", store_dir=tmp_path) == []
+
+    def test_no_overlap_returns_nothing(self, tmp_path):
+        self._seed(tmp_path)
+        assert retrieve_thoughts("zzzz qqqq", store_dir=tmp_path) == []
+
+
+class TestStatsAndOverflow:
+    def test_stats_counts_and_sources(self, tmp_path):
+        capture_thought("first meaningful thought for stats", store_dir=tmp_path)
+        capture_thought(
+            "second meaningful thought from the gate",
+            source="promotion-gate",
+            store_dir=tmp_path,
+        )
+        s = stats(tmp_path)
+        assert s["count"] == 2
+        assert "task-cycle" in s["sources"]
+        assert "promotion-gate" in s["sources"]
+
+    def test_store_bounded_but_archive_keeps_history(self, tmp_path):
+        for i in range(MAX_STORE_ENTRIES + 10):
+            capture_thought(f"thought number {i} with a bit of padding text", store_dir=tmp_path)
+        assert len(load_thoughts(tmp_path)) <= MAX_STORE_ENTRIES
+        archive = tmp_path / "thoughts-archive.jsonl"
+        assert archive.exists()
+        assert archive.stat().st_size > 0
+
+
+class TestNormalize:
+    def test_normalize_collapses_whitespace(self):
+        assert normalize_thought("  a   b\n c  ") == "a b c"
+
+    def test_dedup_key_stable(self):
+        assert thought_dedup_key("a b") == thought_dedup_key("a   b")
+
+
+class TestCli:
+    def test_capture_then_stats(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["capture", "A thought worth keeping for the gate."]) == 0
+        capsys.readouterr()
+        assert main(["stats"]) == 0
+        assert json.loads(capsys.readouterr().out)["count"] == 1
+
+    def test_retrieve_cli(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        main(["capture", "Tool calls carry the decision signal clearly."])
+        capsys.readouterr()
+        assert main(["retrieve", "tool calls"]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) >= 1
+
+    def test_retrieve_no_hits_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("EVOLUTION_PROFILE_DIR", str(tmp_path))
+        assert main(["retrieve", "zzzz"]) == 1
+        capsys.readouterr()
+
+    def test_bad_command_exits_two(self, capsys):
+        assert main(["nonsense"]) == 2
+        capsys.readouterr()


### PR DESCRIPTION
Automated evolution PR for issue #2900 (Thought-Retriever, arXiv:2604.12231) — **Slice 1**.

The pipeline's memory layer stores notes and final outcomes, but not the agent's intermediate reasoning. This slice adds the capture hook and versioned store that later slices wire into the memory→skill promotion gate as reasoning evidence.

`scripts/evolution_thought_memory.py` (new, deterministic, no LLM):
- `capture_thought()` — snapshots reasoning at end of task cycles; filters meaningless (<20 chars / >4000 chars) and dedups identical normalized text; versioned entries.
- `retrieve_thoughts()` — token-overlap retrieval (deterministic).
- Store bounded at `MAX_STORE_ENTRIES` (500) with append-only archive for overflow — retrieval signal is not dispersed across unbounded history.
- CLI: `capture` / `retrieve` / `stats`.

Deferred (next increment):
- Wire retrieval results into the promotion gate as evidence (retrieval extension + gate integration).

Validation: ruff check ✓, tests 17 passed ✓, pre-PR shard ✓.