### PR TITLE
feat: decision-level model-call capture on the evolution trajectory seam (Closes #2877)

### DIFF
--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -68,6 +68,7 @@ __all__ = [
     "capture_enabled",
     "task_key",
     "extract_tool_calls",
+    "extract_model_calls",
     "build_trajectory_log",
     "capture_turn",
 ]
@@ -231,6 +232,46 @@ def extract_tool_calls(
     return calls
 
 
+def _classify_model_decision(msg: Dict[str, Any]) -> str:
+    """Classify an assistant message's decision: tool_call / refusal / content."""
+    if msg.get("tool_calls"):
+        return "tool_call"
+    content = msg.get("content")
+    if isinstance(content, str):
+        lowered = content.strip().lower()
+        if "i can't" in lowered or "i cannot" in lowered or "i won't" in lowered:
+            return "refusal"
+    return "content"
+
+
+def extract_model_calls(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Pull decision-level model-call metadata out of a finished turn (#2877).
+
+    Walks assistant messages — each is one model call — and records *what the
+    model decided*: model name (when present on the message), decision class
+    (tool_call / refusal / content), and the number of tool calls emitted.
+    No prompt text and no completion prose: this is the structured
+    distillation signal OpenForgeRL's proxy-recording pattern feeds on, scoped
+    to metadata so the privacy floor from #1363 is preserved.
+    """
+    if not isinstance(messages, list):
+        return []
+    calls: List[Dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        calls.append(
+            {
+                "model": str(msg.get("model") or ""),
+                "decision": _classify_model_decision(msg),
+                "tool_call_count": len(msg.get("tool_calls") or []),
+            }
+        )
+    return calls
+
+
 def build_trajectory_log(
     messages: List[Dict[str, Any]],
     *,
@@ -261,6 +302,14 @@ def build_trajectory_log(
             result=call["result"],
             status=call["status"],
             duration_ms=call.get("duration_ms"),
+        )
+    # #2877: model-call metadata rides the same trajectory — each assistant
+    # message is one model call. Metadata only; never user prose.
+    for mc in extract_model_calls(messages):
+        log.add_model_call(
+            model=mc["model"],
+            decision=mc["decision"],
+            tool_call_count=mc["tool_call_count"],
         )
     return log
 

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 
 __all__ = [
     "TrajectoryEntry",
+    "ModelCallEntry",
     "TrajectoryLog",
     "redact_args",
     "summarize_result",
@@ -125,6 +126,41 @@ class TrajectoryEntry:
         )
 
 
+@dataclass
+class ModelCallEntry:
+    """One model-call record on the evolution-run telemetry seam (#2877).
+
+    OpenForgeRL (arXiv:2607.21557) records the harness's model-call traffic
+    as training data — same pattern here, scoped to structured *metadata*:
+    which model was asked, what it decided, how long it took. No prompt or
+    completion text — only decision-level signal for trajectory→skill
+    distillation.
+    """
+
+    model: str = ""
+    decision: str = "unknown"  # tool_call | refusal | content | unknown
+    tool_call_count: int = 0
+    summary: str = ""
+    timestamp: str = ""
+    duration_ms: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "model": self.model,
+            "decision": self.decision,
+            "tool_call_count": self.tool_call_count,
+            "summary": self.summary,
+            "timestamp": self.timestamp,
+        }
+        if self.duration_ms is not None:
+            d["duration_ms"] = self.duration_ms
+        return d
+
+
 class TrajectoryLog:
     """In-memory trajectory log for a single cron session."""
 
@@ -138,6 +174,10 @@ class TrajectoryLog:
         self.session_id = session_id
         self.date = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
         self.entries: List[TrajectoryEntry] = []
+        # #2877: decision-level model-call metadata alongside the tool calls.
+        # Optional so the existing cron-stage caller is unaffected, and only
+        # emitted in to_dict() when recorded (old readers see the same shape).
+        self.model_calls: List[ModelCallEntry] = []
         # Task-level outcome and pairing key (#1363). Both are optional so the
         # existing cron-stage caller is unaffected, and both are omitted from
         # to_dict() when unset so old readers see the exact shape they expect.
@@ -165,6 +205,26 @@ class TrajectoryLog:
             TrajectoryEntry.from_tool_call(tool, args, result, status, duration_ms)
         )
 
+    def add_model_call(
+        self,
+        model: str = "",
+        decision: str = "unknown",
+        tool_call_count: int = 0,
+        result: Any = None,
+        duration_ms: Optional[int] = None,
+    ) -> None:
+        """Record one decision-level model call (#2877): model, decision,
+        tool-call count, short result summary, latency. Metadata only."""
+        self.model_calls.append(
+            ModelCallEntry(
+                model=model,
+                decision=decision,
+                tool_call_count=tool_call_count,
+                summary=summarize_result(result),
+                duration_ms=duration_ms,
+            )
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {
             "date": self.date,
@@ -174,6 +234,8 @@ class TrajectoryLog:
         # Only emitted when set, so a reader written against the pre-#1363
         # shape sees no new keys on the cron-stage trajectories it already
         # handles.
+        if self.model_calls:
+            out["model_calls"] = [m.to_dict() for m in self.model_calls]
         if self.completed is not None:
             out["completed"] = bool(self.completed)
         if self.task_key:
@@ -271,6 +333,18 @@ def load_trajectory(path: Path) -> Optional[TrajectoryLog]:
                     result_summary=ed.get("result_summary", ""),
                     timestamp=ed.get("timestamp", ""),
                     duration_ms=ed.get("duration_ms"),
+                )
+            )
+    for mc in data.get("model_calls", []):
+        if isinstance(mc, dict):
+            log.model_calls.append(
+                ModelCallEntry(
+                    model=str(mc.get("model", "")),
+                    decision=str(mc.get("decision", "unknown")),
+                    tool_call_count=int(mc.get("tool_call_count", 0) or 0),
+                    summary=str(mc.get("summary", "")),
+                    timestamp=str(mc.get("timestamp", "")),
+                    duration_ms=mc.get("duration_ms"),
                 )
             )
     return log

--- a/tests/agent/test_tool_call_capture.py
+++ b/tests/agent/test_tool_call_capture.py
@@ -16,6 +16,7 @@ from agent.tool_call_capture import (  # noqa: E402
     build_trajectory_log,
     capture_enabled,
     capture_turn,
+    extract_model_calls,
     extract_tool_calls,
     task_key,
 )
@@ -349,3 +350,78 @@ class TestPerCallTimings:
     def test_extract_without_timings_still_works(self):
         calls = extract_tool_calls([_call("read_file", {}, "c1"), _ok("c1")])
         assert calls[0]["duration_ms"] is None
+
+
+class TestModelCallCapture:
+    """#2877 — decision-level model-call metadata on the trajectory seam."""
+
+    def _turn(self):
+        return [
+            {"role": "user", "content": "run the check"},
+            {
+                "role": "assistant",
+                "model": "hermes-small",
+                "tool_calls": [
+                    {"id": "c1", "type": "function",
+                     "function": {"name": "terminal", "arguments": "{}"}}
+                ],
+            },
+            _ok("c1"),
+            {"role": "assistant", "model": "hermes-small", "content": "done"},
+        ]
+
+    def test_extract_records_one_entry_per_assistant_message(self):
+        calls = extract_model_calls(self._turn())
+        assert len(calls) == 2
+        assert calls[0]["model"] == "hermes-small"
+        assert calls[0]["decision"] == "tool_call"
+        assert calls[0]["tool_call_count"] == 1
+        assert calls[1]["decision"] == "content"
+
+    def test_extract_classifies_refusal(self):
+        calls = extract_model_calls(
+            [{"role": "assistant", "content": "I can't run that without approval."}]
+        )
+        assert calls[0]["decision"] == "refusal"
+
+    def test_extract_ignores_non_assistant_messages(self):
+        calls = extract_model_calls(
+            [{"role": "user", "content": "hi"}, {"role": "tool", "tool_call_id": "x", "content": "{}"}]
+        )
+        assert calls == []
+
+    def test_extract_never_raises_on_bad_input(self):
+        assert extract_model_calls(None) == []
+        assert extract_model_calls("not a list") == []
+
+    def test_model_calls_ride_the_trajectory(self, tmp_path, capture_on):
+        path = capture_turn(self._turn(), session_id="s", trajectory_dir=tmp_path)
+        data = json.loads(path.read_text(encoding="utf-8").strip())
+        assert "model_calls" in data
+        assert len(data["model_calls"]) == 2
+        assert data["model_calls"][0]["decision"] == "tool_call"
+        assert data["model_calls"][1]["decision"] == "content"
+        # No prompt/completion prose — metadata only.
+        assert "run the check" not in json.dumps(data)
+
+    def test_logger_round_trips_model_calls(self, tmp_path):
+        from evolution_trajectory_logger import TrajectoryLog, load_trajectory
+
+        log = TrajectoryLog(session_id="s")
+        log.add_model_call(model="m", decision="tool_call", tool_call_count=2)
+        path = log.save(tmp_path)
+        loaded = load_trajectory(path)
+        assert loaded is not None
+        assert len(loaded.model_calls) == 1
+        assert loaded.model_calls[0].model == "m"
+        assert loaded.model_calls[0].tool_call_count == 2
+
+    def test_old_trajectories_without_model_calls_load_clean(self, tmp_path):
+        from evolution_trajectory_logger import TrajectoryLog, load_trajectory
+
+        log = TrajectoryLog(session_id="s")
+        log.add_tool_call("terminal", {})
+        path = log.save(tmp_path)
+        loaded = load_trajectory(path)
+        assert loaded is not None
+        assert loaded.model_calls == []


### PR DESCRIPTION
Automated evolution PR for issue #2877 (OpenForgeRL, arXiv:2607.21557).

The proxy-records-calls pattern is a direct blueprint for trajectory→skill distillation. This adopts it on the existing evolution telemetry seam (#1363) — no new network path.

Changes:
- `scripts/evolution_trajectory_logger.py`: `ModelCallEntry` + optional `model_calls` on `TrajectoryLog` — model name, decision class (tool_call / refusal / content), tool-call count, short summary, latency. Metadata only; no prompt/completion prose (privacy floor preserved). Old readers see the same shape when absent; `load_trajectory` round-trips it.
- `agent/tool_call_capture.py`: `extract_model_calls()` (one entry per assistant message) wired into `build_trajectory_log`.

Validation: ruff check ✓, tests 47 passed ✓ (7 new #2877 tests), pre-PR shard ✓, 199 changed lines (≤200).