### PR TITLE
fix: actionable BLOCKED (hardline) signal + honor exit_code_meaning in introspection (Closes #2873)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -71,7 +71,15 @@ def _tool_result_failed(content: Any) -> bool:
     genuine errors (read_file/skill_view), corrupting the introspection signal.
 
     A result counts as a failure ONLY when its structured status says so:
-      * ``exit_code`` present (terminal/code-exec) → failure iff it is not 0;
+      * ``exit_code`` present (terminal/code-exec) → failure iff it is not 0,
+        UNLESS the envelope carries an ``exit_code_meaning`` note marking the
+        non-zero code as informational (e.g. grep=1 "No matches found (not an
+        error)", diff=1 "Files differ", test=1 "condition is false").  The
+        terminal tool sets ``exit_code_meaning`` via ``_interpret_exit_code``
+        precisely so downstream consumers can distinguish an expected
+        non-zero exit from a genuine failure — #2873 part 3.  Without this
+        honor, every grep/diff/test "no match" exit was counted as a terminal
+        failure, corrupting the introspection signal with false positives;
       * a truthy ``error`` field, or ``status == "error"``;
       * an explicit ``success``/``ok`` field that is falsy.
     A result with no recognised status field — including any non-JSON / plain
@@ -93,9 +101,27 @@ def _tool_result_failed(content: Any) -> bool:
         return False
     if "exit_code" in data:
         try:
-            return int(data["exit_code"]) != 0
+            code = int(data["exit_code"])
         except (TypeError, ValueError):
             return False
+        if code == 0:
+            return False
+        # Honor the terminal tool's informational exit-code note (#2873 part
+        # 3).  When the envelope carries ``exit_code_meaning`` the terminal
+        # tool has already interpreted the code: grep/diff/test/git return 1
+        # for "no matches"/"files differ"/"false" — expected, not a failure.
+        meaning = data.get("exit_code_meaning")
+        if isinstance(meaning, str) and meaning:
+            # The note text from _interpret_exit_code is phrased as "not an
+            # error" / "expected" for the informational cases.  Only the
+            # informational notes suppress failure counting; genuine errors
+            # (permission denied, command not found, timeouts) either have no
+            # exit_code_meaning at all or carry a note that does NOT contain
+            # the "not an error"/"expected" markers.
+            low = meaning.lower()
+            if "not an error" in low or "expected" in low:
+                return False
+        return True
     if data.get("error") or str(data.get("status", "")).lower() == "error":
         return True
     for ok_key in ("success", "ok"):

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -14,6 +14,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from introspection_extract import build_digest, scan_session  # noqa: E402
@@ -202,71 +204,36 @@ class TestScanSession:
 class TestInformationalExitCodeMeaning:
     """#2873 part 3 — a non-zero exit_code that the terminal tool already
     annotated as informational (via ``exit_code_meaning``) must NOT be counted
-    as a tool failure.  grep/diff/test/git return 1 for "no matches"/"files
+    as a tool failure.  grep/diff/test return 1 for "no matches"/"files
     differ"/"condition false" — expected, not a failure.  Before this fix,
-    ``_tool_result_failed`` counted every exit_code != 0 as a failure,
-    corrupting the introspection signal with false positives."""
+    ``_tool_result_failed`` counted every exit_code != 0 as a failure.
+    A bare non-zero exit (no informational note) and a curl timeout note
+    (no "not an error"/"expected" markers) still count as failures.
+    """
 
-    def test_grep_no_matches_not_a_failure(self, tmp_path):
+    @pytest.mark.parametrize(
+        "meaning",
+        [
+            "No matches found (not an error)",
+            "Files differ (expected, not an error)",
+            "Condition evaluated to false (expected, not an error)",
+        ],
+    )
+    def test_informational_exit_code_meaning_not_a_failure(self, tmp_path, meaning):
         p = _session(
             tmp_path,
-            "grep_ok",
+            "info_ok",
             [
                 _asst("terminal", "c1"),
-                _tool(
-                    "c1",
-                    _term(
-                        "",
-                        exit_code=1,
-                        exit_code_meaning="No matches found (not an error)",
-                    ),
-                ),
+                _tool("c1", _term("", exit_code=1, exit_code_meaning=meaning)),
             ],
         )
         s = scan_session(p)
         assert s["tool_failures"] == {}
         assert s["tool_failures_by_reason"] == {}
 
-    def test_diff_files_differ_not_a_failure(self, tmp_path):
-        p = _session(
-            tmp_path,
-            "diff_ok",
-            [
-                _asst("terminal", "c1"),
-                _tool(
-                    "c1",
-                    _term(
-                        "",
-                        exit_code=1,
-                        exit_code_meaning="Files differ (expected, not an error)",
-                    ),
-                ),
-            ],
-        )
-        s = scan_session(p)
-        assert s["tool_failures"] == {}
-
-    def test_test_condition_false_not_a_failure(self, tmp_path):
-        p = _session(
-            tmp_path,
-            "test_ok",
-            [
-                _asst("terminal", "c1"),
-                _tool(
-                    "c1",
-                    _term(
-                        "",
-                        exit_code=1,
-                        exit_code_meaning="Condition evaluated to false (expected, not an error)",
-                    ),
-                ),
-            ],
-        )
-        s = scan_session(p)
-        assert s["tool_failures"] == {}
-
-    def test_non_zero_without_meaning_still_failure(self, tmp_path):
-        """A bare non-zero exit (no informational note) is still a failure."""
+    def test_bare_non_zero_without_meaning_still_failure(self, tmp_path):
+        """A non-zero exit with no informational note is still a failure."""
         p = _session(
             tmp_path,
             "no_meaning",
@@ -280,8 +247,8 @@ class TestInformationalExitCodeMeaning:
         assert s["tool_failures_by_reason"] == {"terminal": {"non-zero-exit": 1}}
 
     def test_curl_timeout_meaning_still_failure(self, tmp_path):
-        """curl exit 28 'Operation timed out' carries a note WITHOUT the
-        informational markers — it is still a real failure, not suppressed."""
+        """curl exit 28 'Operation timed out' lacks the informational markers
+        — it is still a real failure, not suppressed."""
         p = _session(
             tmp_path,
             "curl_timeout",

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -42,11 +42,18 @@ def _tool(cid, content):
 
 
 # --- realistic tool-result envelopes (#347) ----------------------------------
-def _term(output="", *, exit_code=0, error=None):
-    """Terminal / code-exec envelope: failure is signalled by exit_code != 0."""
-    return json.dumps(
-        {"output": output, "exit_code": exit_code, "error": error}, ensure_ascii=False
-    )
+def _term(output="", *, exit_code=0, error=None, exit_code_meaning=None):
+    """Terminal / code-exec envelope: failure is signalled by exit_code != 0.
+
+    ``exit_code_meaning`` carries the terminal tool's informational note for
+    expected non-zero exits (grep=1 "No matches found (not an error)"). When
+    present and phrased as informational, ``_tool_result_failed`` must NOT
+    count the result as a failure (#2873 part 3).
+    """
+    envelope = {"output": output, "exit_code": exit_code, "error": error}
+    if exit_code_meaning is not None:
+        envelope["exit_code_meaning"] = exit_code_meaning
+    return json.dumps(envelope, ensure_ascii=False)
 
 
 def _ok(**fields):
@@ -190,6 +197,110 @@ class TestScanSession:
         # names — never the raw content/error text.
         assert s["tool_failures"] == {"terminal": 1}
         assert secret not in json.dumps(s)
+
+
+class TestInformationalExitCodeMeaning:
+    """#2873 part 3 — a non-zero exit_code that the terminal tool already
+    annotated as informational (via ``exit_code_meaning``) must NOT be counted
+    as a tool failure.  grep/diff/test/git return 1 for "no matches"/"files
+    differ"/"condition false" — expected, not a failure.  Before this fix,
+    ``_tool_result_failed`` counted every exit_code != 0 as a failure,
+    corrupting the introspection signal with false positives."""
+
+    def test_grep_no_matches_not_a_failure(self, tmp_path):
+        p = _session(
+            tmp_path,
+            "grep_ok",
+            [
+                _asst("terminal", "c1"),
+                _tool(
+                    "c1",
+                    _term(
+                        "",
+                        exit_code=1,
+                        exit_code_meaning="No matches found (not an error)",
+                    ),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {}
+        assert s["tool_failures_by_reason"] == {}
+
+    def test_diff_files_differ_not_a_failure(self, tmp_path):
+        p = _session(
+            tmp_path,
+            "diff_ok",
+            [
+                _asst("terminal", "c1"),
+                _tool(
+                    "c1",
+                    _term(
+                        "",
+                        exit_code=1,
+                        exit_code_meaning="Files differ (expected, not an error)",
+                    ),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {}
+
+    def test_test_condition_false_not_a_failure(self, tmp_path):
+        p = _session(
+            tmp_path,
+            "test_ok",
+            [
+                _asst("terminal", "c1"),
+                _tool(
+                    "c1",
+                    _term(
+                        "",
+                        exit_code=1,
+                        exit_code_meaning="Condition evaluated to false (expected, not an error)",
+                    ),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {}
+
+    def test_non_zero_without_meaning_still_failure(self, tmp_path):
+        """A bare non-zero exit (no informational note) is still a failure."""
+        p = _session(
+            tmp_path,
+            "no_meaning",
+            [
+                _asst("terminal", "c1"),
+                _tool("c1", _term("something went wrong", exit_code=2)),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {"terminal": 1}
+        assert s["tool_failures_by_reason"] == {"terminal": {"non-zero-exit": 1}}
+
+    def test_curl_timeout_meaning_still_failure(self, tmp_path):
+        """curl exit 28 'Operation timed out' carries a note WITHOUT the
+        informational markers — it is still a real failure, not suppressed."""
+        p = _session(
+            tmp_path,
+            "curl_timeout",
+            [
+                _asst("terminal", "c1"),
+                _tool(
+                    "c1",
+                    _term(
+                        "",
+                        exit_code=28,
+                        error="Operation timed out",
+                        exit_code_meaning="Operation timed out",
+                    ),
+                ),
+            ],
+        )
+        s = scan_session(p)
+        assert s["tool_failures"] == {"terminal": 1}
+        assert s["tool_failures_by_reason"] == {"terminal": {"timeout": 1}}
 
 
 class TestFailureReasonClassification:

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -431,6 +431,31 @@ def test_check_all_command_guards_blocks_hardline(clean_session):
     assert "BLOCKED (hardline)" in result["message"]
 
 
+def test_hardline_message_echoes_command_and_forbids_retry(clean_session):
+    """#2873 part 1 — the hardline message must name the offending command
+    (redacted + truncated) and explicitly forbid retrying it, so the agent can
+    tell what caused the block and stop blindly re-attempting.  The old message
+    only named the category, leaving the agent to guess whether the command
+    itself, its payload, or an unrelated parser limit caused the block."""
+    result = check_all_command_guards("rm -rf /", "local")
+    assert result["approved"] is False
+    assert "BLOCKED (hardline): recursive delete of root filesystem" in result["message"]
+    assert "Command (redacted):" in result["message"]
+    assert "rm -rf /" in result["message"]
+    assert "Do NOT retry this command or any variant of it" in result["message"]
+    assert "change approach entirely" in result["message"]
+
+
+def test_hardline_message_truncates_long_commands(clean_session):
+    """A very long hardline command is truncated (not dumped raw) in the
+    message, and redaction does not error."""
+    long_cmd = "rm -rf / " + "x" * 500
+    result = check_all_command_guards(long_cmd, "local")
+    assert result["approved"] is False
+    assert "Command (redacted):" in result["message"]
+    assert len(result["message"].split("Command (redacted):", 1)[1].split("\n")[0]) <= 130
+
+
 def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
     """HERMES_YOLO_MODE=1 must not bypass the hardline floor."""
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -116,6 +116,20 @@ class TestPermissionDenied:
         assert result.category == tfc.ToolFailureCategory.permission_denied
         assert result.should_retry is False
 
+    def test_hardline_blocked_is_permission_denied_non_retryable(self):
+        """#2873 part 2 — the unconditional hardline block was previously
+        classified as a generic persistent_error, which left retry machinery
+        free to attempt command variants.  It must be classified as
+        ``permission_denied`` with ``should_retry=False`` so the agent stops
+        immediately."""
+        error = (
+            "BLOCKED (hardline): rm -rf / hits the unconditional blocklist. "
+            "Do NOT retry this command or any variant of it — change approach entirely."
+        )
+        result = tfc.classify_tool_failure("terminal", error)
+        assert result.category == tfc.ToolFailureCategory.permission_denied
+        assert result.should_retry is False
+
 
 class TestRateLimited:
     @pytest.mark.parametrize(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -774,13 +774,33 @@ def _save_blocked_payload(command: str) -> Optional[str]:
 
 def _hardline_block_result(description: str, command: str = "") -> dict:
     """Build the standard block result for a hardline match."""
+    # Echo which command was blocked (redacted + truncated) so the failure
+    # signal is actionable: #2873 part 1 — the previous message named the
+    # category but not the offending command, so the agent could not tell
+    # whether the command itself, its payload, or an unrelated parser limit
+    # caused the block.  Redaction is display-only, reusing the same
+    # redact_sensitive_text pass the approval prompts use.
+    preview = ""
+    if command:
+        try:
+            from agent.redact import redact_sensitive_text
+
+            preview = redact_sensitive_text(command, force=True)
+        except Exception:
+            preview = command
+        preview = preview if len(preview) <= 120 else preview[:117] + "..."
     message = (
         f"BLOCKED (hardline): {description}. "
         "This command is on the unconditional blocklist and cannot "
         "be executed via the agent — not even with --yolo, /yolo, "
-        "approvals.mode=off, or cron approve mode. If you genuinely "
-        "need to run it, run it yourself in a terminal outside the "
-        "agent."
+        "approvals.mode=off, or cron approve mode. Do NOT retry this "
+        "command or any variant of it — change approach entirely."
+    )
+    if preview:
+        message += f" Command (redacted):\n{preview}"
+    message += (
+        " If you genuinely need to run it, run it yourself in a "
+        "terminal outside the agent."
     )
     # The parser-limit block is almost always a giant inline payload
     # (heredoc script, base64 blob, one-line python -c program) — not a

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -296,6 +296,16 @@ _BUILTIN_RULES: list[_Rule] = [
     _rule(r"\btimeout\b", ToolFailureCategory.timeout),
     # Security/policy block (after transient/timeout so a "blocked: <transient>"
     # message is not misread as a hard permission failure).
+    # #2873 part 2 — the unconditional hardline block (tools/approval.py) was
+    # previously classified as generic persistent_error. Make it an explicit,
+    # non-retryable permission_denied so the agent knows no command variant can
+    # pass and must change approach entirely (mirrors #2228's non-retryable
+    # diagnostic for the retry-spiral family).
+    _rule(
+        r"BLOCKED \(hardline\)",
+        ToolFailureCategory.permission_denied,
+        should_retry=False,
+    ),
     _rule(r"^\s*blocked:", ToolFailureCategory.permission_denied),
     # Tool / dependency unavailable (includes the "command not found" text form
     # before the generic not_found rule). "<component> not available" is scoped


### PR DESCRIPTION
Automated evolution PR for issue #2873 — the terminal `BLOCKED (hardline)` error carried no actionable signal, so the agent retried identical blocked commands (3x in one session 20260819_004618_b8fc0a).

**Part 1 — actionable signal** (`tools/approval.py`): `_hardline_block_result` now echoes the offending command (redacted + truncated to 120 chars) and explicitly forbids retry ("Do NOT retry this command or any variant of it — change approach entirely"). The old message named only the category, leaving the agent to guess whether the command, its payload, or an unrelated parser limit caused the block.

**Part 2 — non-retryable classification** (`tools/tool_failure_classifier.py`): added an explicit `BLOCKED (hardline)` rule → `permission_denied`, `should_retry=False`. Previously this fell to the generic `persistent_error` default; now the non-retryable signal is explicit (mirrors #2228's non-retryable diagnostic).

**Part 3 — separate exit_code=1 'no matches' from real failures** (`scripts/introspection_extract.py`): `_tool_result_failed` now honors `exit_code_meaning` for informational non-zero exits — grep=1 "No matches found (not an error)", diff=1 "Files differ", test=1 "condition false" — which the terminal tool already sets via `_interpret_exit_code`. Stops counting expected non-zero exits as terminal failures, which was corrupting the introspection signal with false positives.

**Tests**: `tests/tools/test_hardline_blocklist.py`, `tests/tools/test_tool_failure_classifier.py`, `tests/scripts/test_introspection_extract.py` — all green locally (323 passed; the single pre-existing `test_redirect_to_sensitive_target` failure in `test_approval.py` reproduces identically on clean `origin/main` at 9fa0809712, so it is not caused by this change).

Closes #2873

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>