### PR TITLE
fix: cron scheduler backoff/circuit breaker (Closes #70) [replaces #2856]

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -964,6 +964,97 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
+def _failure_backoff_config() -> Dict[str, Any]:
+    """Return the ``cron`` config section for failure-backoff tuning (#70).
+
+    Read-only: uses ``load_config_readonly`` so the hot path (every job run)
+    does not pay the defensive deepcopy. A missing config yields an empty
+    dict so all call sites fall back to their built-in defaults.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        cron_cfg = cfg.get("cron") if isinstance(cfg, dict) else None
+        return cron_cfg if isinstance(cron_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+# #70: last_status values recording a SYNTHETIC failure — scheduler restart
+# / forced release — rather than a real agent failure. These must never feed
+# the failure-streak circuit breaker: a restart mid-run (or a stale in-flight
+# claim force-released by the scheduler) is not evidence the job is
+# deterministically broken, and counting it would let scheduler restarts
+# false-positive auto-pause a healthy job.
+_SYNTHETIC_FAILURE_STATUSES = frozenset({"interrupted", "released"})
+
+
+def _failure_backoff_max_skips() -> int:
+    """Resolve ``cron.failure_backoff_max_skips`` (default 16).
+
+    A non-int value in config.yaml degrades to the default instead of
+    crashing the failure path of ``_mark_job_run_locked`` (#70).
+    """
+    try:
+        return int(_failure_backoff_config().get("failure_backoff_max_skips", 16))
+    except (TypeError, ValueError):
+        return 16
+
+
+def _failure_auto_pause_threshold() -> int:
+    """Resolve ``cron.failure_auto_pause_threshold`` (default 10).
+
+    A non-int value in config.yaml degrades to the default instead of
+    crashing the failure path of ``_mark_job_run_locked`` (#70).
+    """
+    try:
+        return int(_failure_backoff_config().get("failure_auto_pause_threshold", 10))
+    except (TypeError, ValueError):
+        return 10
+
+
+def _advance_schedule_by_steps(
+    schedule: Dict[str, Any],
+    from_iso: str,
+    n_steps: int,
+) -> Optional[str]:
+    """Advance ``from_iso`` forward by ``n_steps`` schedule slots.
+
+    Used by #70 to skip scheduled runs after identical consecutive failures:
+    instead of running on the very next slot, the job is pushed out by
+    ``failure_backoff_skips`` slots. Returns ``from_iso`` unchanged when the
+    schedule kind is unsupported or the step count is non-positive.
+    """
+    if n_steps <= 0:
+        return from_iso
+    if not isinstance(schedule, dict):
+        return from_iso
+    kind = schedule.get("kind")
+    try:
+        base = _ensure_aware(datetime.fromisoformat(from_iso))
+    except Exception:
+        base = _hermes_now()
+
+    if kind == "interval":
+        minutes = schedule.get("minutes")
+        if minutes is None:
+            return from_iso
+        return (base + timedelta(minutes=minutes * n_steps)).isoformat()
+
+    if kind == "cron":
+        expr = schedule.get("expr")
+        if not expr or not _ensure_croniter():
+            return from_iso
+        cron = croniter(expr, base)
+        result = base
+        for _ in range(n_steps):
+            result = cron.get_next(datetime)
+        return result.isoformat()
+
+    return from_iso
+
+
 # =============================================================================
 # Ticker heartbeat (liveness signal for `hermes cron status`)
 # =============================================================================
@@ -2081,6 +2172,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     )
                 updated["next_run_at"] = next_run
 
+            # #70: an update that transitions the job into an enabled,
+            # scheduled state is an operator re-enable — clear the failure
+            # streak so the auto-pause circuit breaker doesn't re-trip on a
+            # stale deterministic-failure chain (e.g. a dashboard/API update
+            # flipping enabled back on). Updates that leave the job disabled
+            # or paused, or that merely edit an already-live job, keep the
+            # streak intact.
+            if (
+                updated.get("enabled", True)
+                and updated.get("state") != "paused"
+                and (not job.get("enabled") or job.get("state") == "paused")
+            ):
+                updated["failure_streak"] = 0
+                updated.pop("failure_backoff_skips", None)
+
             jobs[i] = updated
             save_jobs(jobs)
             return _normalize_job_record(jobs[i])
@@ -2123,6 +2229,11 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
+            # #70: a manual resume is an explicit "try again" — clear the
+            # failure streak so a single immediate failure doesn't re-trip the
+            # auto-pause circuit breaker on a stale streak.
+            "failure_streak": 0,
+            "failure_backoff_skips": None,
             "next_run_at": next_run_at,
         },
     )
@@ -2140,6 +2251,11 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
+            # #70: a manual trigger is an explicit re-enable — clear the
+            # failure streak so a single immediate failure doesn't re-trip
+            # the auto-pause circuit breaker on a stale streak.
+            "failure_streak": 0,
+            "failure_backoff_skips": None,
             "next_run_at": _hermes_now().isoformat(),
         },
     )
@@ -2320,6 +2436,7 @@ def _mark_job_run_locked(
                         )
                         return False
                 now = _hermes_now().isoformat()
+                _prev_err = job.get("last_error")
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
                 job["last_error"] = error if not success else None
@@ -2334,6 +2451,33 @@ def _mark_job_run_locked(
                     job.pop("drift_alerted", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                # #70: per-job failure accounting (exponential backoff + circuit
+                # breaker). An error byte-identical to the previous run is
+                # deterministic: the fixed schedule re-running it only burns
+                # tokens/disk and floods the failure store. Backoff skips
+                # 2**(streak-1)-1 scheduled slots (capped, see
+                # failure_backoff_max_skips); a changed error or a success
+                # resets the streak. Synthetic failures (interruption / forced
+                # release — status in _SYNTHETIC_FAILURE_STATUSES) never touch
+                # the streak: a scheduler restart mid-run is not evidence the
+                # job is deterministically broken, and counting it would let
+                # restarts false-positive auto-pause a healthy job.
+                if success:
+                    job["failure_streak"] = 0
+                    job.pop("failure_backoff_skips", None)
+                elif status in _SYNTHETIC_FAILURE_STATUSES:
+                    # Recorded (last_status/last_error) but excluded from the
+                    # failure-streak circuit breaker (#70 review).
+                    pass
+                else:
+                    _same = bool(_prev_err) and error == _prev_err
+                    job["failure_streak"] = (
+                        int(job.get("failure_streak") or 0) + 1 if _same else 1
+                    )
+                    _streak = int(job["failure_streak"])
+                    job["failure_backoff_skips"] = min(
+                        2 ** (_streak - 1) - 1, _failure_backoff_max_skips()
+                    )
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -2412,6 +2556,34 @@ def _mark_job_run_locked(
                         job["state"] = "completed"
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
+
+                # #70: apply failure backoff (skip scheduled slots) and, past
+                # the auto-pause threshold, pause the job for operator review
+                # instead of retrying a deterministic failure indefinitely.
+                # Placed AFTER the next_run_at computation so a pause cleanly
+                # clears the schedule rather than tripping the missing-croniter
+                # error branch above. Synthetic failures (interruption /
+                # forced release) never advance the streak, so they must not
+                # trigger the backoff/pause either.
+                if not success and status not in _SYNTHETIC_FAILURE_STATUSES:
+                    _skips = int(job.get("failure_backoff_skips") or 0)
+                    if _skips > 0 and job["next_run_at"] is not None:
+                        job["next_run_at"] = _advance_schedule_by_steps(
+                            job["schedule"], job["next_run_at"], _skips
+                        )
+                    if (
+                        int(job.get("failure_streak") or 0)
+                        >= _failure_auto_pause_threshold()
+                    ):
+                        job["enabled"] = False
+                        job["state"] = "paused"
+                        job["paused_at"] = now
+                        job["paused_reason"] = (
+                            "auto-paused after %d identical consecutive "
+                            "failures (last error: %.200s) — resume to retry"
+                            % (int(job["failure_streak"]), error or "")
+                        )
+                        job["next_run_at"] = None
 
                 save_jobs(jobs)
                 return True
@@ -2729,6 +2901,11 @@ def _claim_job_for_fire_locked(
                 job["state"] = "scheduled"
                 job["paused_at"] = None
                 job["paused_reason"] = None
+                # #70: a forced fire is an explicit operator re-enable —
+                # clear the failure streak so the circuit breaker doesn't
+                # re-trip on a stale deterministic-failure chain.
+                job["failure_streak"] = 0
+                job.pop("failure_backoff_skips", None)
             # Per-acquisition token: a process may legitimately reclaim its own
             # stale lease, and the previous runner must not heartbeat the new
             # claim merely because hostname + PID are unchanged.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -897,6 +897,7 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
                 f"Stale in-flight claim force-released after {age / 60:.1f}m "
                 f"(allowance {allowance / 60:.1f}m); previous run never released "
                 f"the scheduler in-flight guard",
+                status="released",
             )
         except Exception as e:
             logger.warning("Could not record forced release for job %s: %s", job_id, e)
@@ -981,6 +982,7 @@ def mark_running_jobs_interrupted(
                     job_id,
                     False,
                     reason,
+                    status="interrupted",
                     expected_fire_owner=fire_owner,
                 ):
                     marked.append(job_id)
@@ -6282,6 +6284,7 @@ def _run_one_job_body(
                     job["id"],
                     False,
                     "Interrupted by shutdown before terminal completion.",
+                    status="interrupted",
                     expected_fire_owner=fire_owner,
                 )
                 finish_execution(
@@ -6445,6 +6448,7 @@ def _run_one_job_body(
                     job["id"],
                     False,
                     "Interrupted by shutdown before terminal completion.",
+                    status="interrupted",
                     expected_fire_owner=fire_owner,
                 )
                 finish_execution(

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -16,6 +16,7 @@ from cron.jobs import (
     update_job,
     pause_job,
     resume_job,
+    trigger_job,
     remove_job,
     mark_job_run,
     advance_next_run,
@@ -25,6 +26,8 @@ from cron.jobs import (
     get_due_jobs,
     save_job_output,
     _hermes_now,
+    _advance_schedule_by_steps,
+    _failure_backoff_config,
 )
 
 
@@ -515,6 +518,223 @@ class TestMarkJobRun:
         assert updated["next_run_at"] is None
         assert updated["last_error"]
         assert "croniter" in updated["last_error"].lower()
+
+
+class TestFailureBackoff:
+    """#70: per-job exponential backoff + circuit breaker for deterministically
+    failing jobs. An error byte-identical to the previous run is deterministic
+    — the fixed schedule re-running it only burns tokens/disk. Backoff skips
+    2**(streak-1)-1 slots (capped); past the threshold the job auto-pauses."""
+
+    def test_single_failure_sets_streak_one_no_backoff(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 1
+        assert updated["failure_backoff_skips"] == 0
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+
+    def test_identical_failures_increment_streak_and_backoff(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 2
+        assert updated["failure_backoff_skips"] == 1  # 2**(2-1)-1
+
+    def test_changed_error_resets_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="TypeError: bad op")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 1
+
+    def test_success_resets_streak_and_skips(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=True)
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 0
+        assert updated.get("failure_backoff_skips") in (None, 0)
+
+    def test_auto_pause_after_threshold_identical_failures(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 10
+        assert updated["enabled"] is False
+        assert updated["state"] == "paused"
+        assert updated["next_run_at"] is None
+        assert "auto-paused" in (updated.get("paused_reason") or "")
+
+    def test_resume_clears_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        resume_job(job["id"])
+        updated = get_job(job["id"])
+        assert updated["enabled"] is True
+        assert updated["failure_streak"] == 0
+
+    def test_advance_schedule_by_steps_interval(self):
+        from datetime import datetime, timedelta, timezone
+        base = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc).isoformat()
+        advanced = _advance_schedule_by_steps(
+            {"kind": "interval", "minutes": 10}, base, 3
+        )
+        dt = datetime.fromisoformat(advanced)
+        assert dt == datetime(2026, 8, 18, 12, 30, tzinfo=timezone.utc)
+
+    def test_advance_schedule_by_steps_zero_is_identity(self):
+        base = "2026-08-18T12:00:00+00:00"
+        assert (
+            _advance_schedule_by_steps({"kind": "interval", "minutes": 10}, base, 0)
+            == base
+        )
+
+    def test_failure_backoff_config_returns_dict_with_defaults(self, tmp_cron_dir):
+        # Even with no explicit tuning, the config section is a dict and the
+        # call sites fall back to their built-in defaults.
+        cfg = _failure_backoff_config()
+        assert isinstance(cfg, dict)
+        assert cfg.get("failure_backoff_max_skips", 16) == 16
+
+    def test_non_int_max_skips_config_falls_back_to_default(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A non-int ``cron.failure_backoff_max_skips`` must not crash the
+        failure path — the built-in default (16) applies instead."""
+        monkeypatch.setattr(
+            "cron.jobs._failure_backoff_config",
+            lambda: {
+                "failure_backoff_max_skips": "not-an-int",
+                "failure_auto_pause_threshold": 10,
+            },
+        )
+        job = create_job(prompt="Fail", schedule="every 10m")
+        for _ in range(5):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 5
+        # 2**(5-1)-1 = 15, capped at the default 16 — no crash, no cap blowout.
+        assert updated["failure_backoff_skips"] == 15
+
+    def test_non_int_pause_threshold_config_falls_back_to_default(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A non-int ``cron.failure_auto_pause_threshold`` must not crash the
+        failure path — auto-pause still trips at the built-in default (10)."""
+        monkeypatch.setattr(
+            "cron.jobs._failure_backoff_config",
+            lambda: {
+                "failure_backoff_max_skips": 16,
+                "failure_auto_pause_threshold": "oops",
+            },
+        )
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = get_job(job["id"])
+        assert updated["enabled"] is False
+        assert updated["state"] == "paused"
+        assert "auto-paused" in (updated.get("paused_reason") or "")
+
+    def test_interruption_marked_failure_not_counted_in_streak(self, tmp_cron_dir):
+        """A synthetic interruption mark (scheduler restart) must not advance
+        the failure streak — restarts are not evidence of a deterministic
+        job failure."""
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["failure_streak"] == 2
+        mark_job_run(
+            job["id"],
+            success=False,
+            error="Interrupted by shutdown before terminal completion.",
+            status="interrupted",
+        )
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 2, (
+            "interruption mark must not increment the streak"
+        )
+        assert updated["enabled"] is True
+        # A subsequent REAL identical failure resumes normal accounting. The
+        # synthetic mark replaced last_error, so the byte-identity comparison
+        # restarts the streak at 1 — conservative, and it can never
+        # false-positive auto-pause after a restart.
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["failure_streak"] == 1
+
+    def test_interruption_mark_cannot_trip_auto_pause(self, tmp_cron_dir):
+        """Scheduler-restart marks must not false-positive auto-pause: a job
+        one failure below the threshold stays live through a restart mark."""
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(9):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["failure_streak"] == 9
+        assert get_job(job["id"])["enabled"] is True
+        mark_job_run(
+            job["id"],
+            success=False,
+            error="Interrupted by shutdown before terminal completion.",
+            status="interrupted",
+        )
+        updated = get_job(job["id"])
+        assert updated["failure_streak"] == 9
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+
+    def test_trigger_job_clears_streak(self, tmp_cron_dir):
+        """`cronjob run` / `hermes cron run` (trigger_job) is a re-enable:
+        it must clear the streak so one immediate failure doesn't re-trip."""
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["enabled"] is False
+        trigger_job(job["id"])
+        updated = get_job(job["id"])
+        assert updated["enabled"] is True
+        assert updated["failure_streak"] == 0
+        assert updated.get("failure_backoff_skips") in (None, 0)
+
+    def test_forced_fire_claim_clears_streak(self, tmp_cron_dir):
+        """A forced fire on a paused job (claim_job_for_fire(force=True) —
+        trigger-now) re-enables it and must clear the streak."""
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["enabled"] is False
+        claimed = claim_job_for_fire(job["id"], force=True, return_job=True)
+        assert isinstance(claimed, dict)
+        assert claimed["enabled"] is True
+        assert claimed["failure_streak"] == 0
+        assert claimed.get("failure_backoff_skips") in (None, 0)
+
+    def test_update_job_re_enable_clears_streak(self, tmp_cron_dir):
+        """An update that transitions the job back into an enabled, scheduled
+        state is a re-enable and must clear the streak."""
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for _ in range(10):
+            mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        assert get_job(job["id"])["enabled"] is False
+        updated = update_job(job["id"], {"enabled": True, "state": "scheduled"})
+        assert updated is not None
+        assert updated["enabled"] is True
+        assert updated["failure_streak"] == 0
+        assert updated.get("failure_backoff_skips") in (None, 0)
+
+    def test_plain_update_keeps_streak(self, tmp_cron_dir):
+        """An update that does NOT re-enable (already-live job, unrelated
+        field) must leave the failure streak intact."""
+        job = create_job(prompt="Fail", schedule="every 10m")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        mark_job_run(job["id"], success=False, error="KeyError: 'foo'")
+        updated = update_job(job["id"], {"prompt": "Fail harder"})
+        assert updated is not None
+        assert updated["failure_streak"] == 2
 
 
 class TestAdvanceNextRun:

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -196,7 +196,7 @@ class TestRunningFireOwnerRegistry:
             release.wait(timeout=2)
             return True
 
-        def mark(_job_id, _success, _reason, *, expected_fire_owner):
+        def mark(_job_id, _success, _reason, *, expected_fire_owner, status=None):
             marked_owners.append(expected_fire_owner)
             return True
 
@@ -234,7 +234,7 @@ class TestRunningFireOwnerRegistry:
             object(): ("owner-b", profile_b),
         }
 
-        def mark(job_id, success, reason, *, expected_fire_owner):
+        def mark(job_id, success, reason, *, expected_fire_owner, status=None):
             observed.append(
                 (
                     job_id,


### PR DESCRIPTION
Replaces #2856 (head lives on a contributor fork, so the follow-up fix below cannot land there). Content: identical rework commit + one repair.

## Repair on top of the rework
`tests/cron/test_shutdown_interrupt.py` mark stubs now accept the `status` kwarg — `mark_running_jobs_interrupted` passes `status='interrupted'` through to `mark_job_run` (landed via the merged backoff PRs), the monkeypatched stubs still had the old 3-arg signature, every call raised TypeError inside the except path, and the registry tests saw zero marks (the exact 2 CI reds on #2856, slice 11).

Local: `pytest tests/cron/test_shutdown_interrupt.py` → 28 passed.