### PR TITLE
fix: constrain dev sandbox package to Linux — unblocks nix flake check on macOS (Closes #2916)

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -27,7 +27,6 @@
             mkdir -p $out/bin
             install -Dm755 ${../hermes} $out/bin/hermes
           '')
-          self'.packages.sandbox
           uv
         ]
         # The Wayland E2E capture stack is Linux-only — `cage` and `grim` carry
@@ -36,7 +35,10 @@
         # `nix flake check` on macOS is this fork's own workflow (.github/
         # workflows/nix.yml, ubuntu + macos), and upstream has no such job.
         # nix/hermes-agent.nix already guards its own `cage` the same way.
+        # The dev sandbox is Linux-only too: sandbox.nix pulls bubblewrap,
+        # which refuses to evaluate on Darwin the same way (#2916).
         ++ lib.optionals stdenv.isLinux [
+          self'.packages.sandbox
           # Headless Wayland compositor for E2E tests (test:e2e:visual).
           # cage renders a single client with no window management, so
           # the Electron window opens at a fixed size without tiling.

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -54,8 +54,6 @@
           }).node-gyp;
         default = full;
 
-        inherit sandbox;
-
         inherit minimal;
 
         # Ships discord.py + python-telegram-bot + slack-sdk so a plain
@@ -70,6 +68,11 @@
         desktop = full.hermesDesktop;
 
         update-npm-lockfile = full.hermesNpmLib.updateNpmLockfile;
-      };
+      }
+      # The dev sandbox is Linux-only — sandbox.nix pulls bubblewrap, which
+      # carries `meta.platforms = [ linux ]` and REFUSES to evaluate on other
+      # hostPlatforms, taking `nix flake check` down with it on macOS. Same
+      # guard as the `matrix` group above (and `cage` in hermes-agent.nix).
+      // lib.optionalAttrs pkgs.stdenv.isLinux { inherit sandbox; };
     };
 }


### PR DESCRIPTION
Automated evolution PR for issue #2916 — the pipeline-wide blocker.

**Root cause:** `nix flake check` on macOS (aarch64-darwin) evaluates every flake output for that system. `nix/sandbox.nix` pulls **bubblewrap** (meta.platforms = [linux]), which refuses to evaluate on darwin (`Refusing to evaluate package 'bubblewrap-0.11.2' ... not available on the requested hostPlatform`), failing the `nix (macos-latest)` job and canceling `nix (ubuntu-latest)` via matrix fail-fast — on main AND every evolution/issue-* PR.

**Fix** (follows the repo's own established guard pattern — `lib.optionals stdenv.isLinux` for cage/ghostty/grim, and the `matrix` dependency group):
- `nix/packages.nix`: publish the `sandbox` package only on Linux via `lib.optionalAttrs pkgs.stdenv.isLinux`.
- `nix/devShell.nix`: move `self'.packages.sandbox` into the existing Linux-only `lib.optionals stdenv.isLinux [...]` list.

**Verified locally with `nix eval` (Nix 2.35.2):**
- `.#packages.aarch64-darwin` attrNames no longer contains `sandbox` (before: present and refusing to evaluate).
- `.#devShells.aarch64-darwin.default` evaluates cleanly (before the fix it aborted on bubblewrap).
- `.#packages.x86_64-linux.sandbox.name` still resolves — Linux unchanged.

Neither `flake.nix` nor `flake.lock` is touched (those would need human review); only `nix/packages.nix` + `nix/devShell.nix`.

Closes #2916