### PR TITLE
fix(nix): guard devShell sandbox behind Linux so nix flake check passes on macOS (Closes #2916)

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -27,15 +27,16 @@
             mkdir -p $out/bin
             install -Dm755 ${../hermes} $out/bin/hermes
           '')
-          self'.packages.sandbox
           uv
         ]
-        # The Wayland E2E capture stack is Linux-only — `cage` and `grim` carry
+        # The Wayland E2E capture stack AND the bwrap sandbox are Linux-only.
+        # `cage`/`grim` and `bubblewrap`/`slirp4netns` all carry
         # `meta.platforms = [ ... -linux ]`, so merely EVALUATING them on Darwin
-        # aborts with "Refusing to evaluate package". Upstream never notices:
-        # `nix flake check` on macOS is this fork's own workflow (.github/
-        # workflows/nix.yml, ubuntu + macos), and upstream has no such job.
-        # nix/hermes-agent.nix already guards its own `cage` the same way.
+        # aborts with "Refusing to evaluate package" (observed on this fork's
+        # own `nix flake check` macos job, 2026-08-19). Upstream never notices:
+        # `nix flake check` on macOS is this fork's own workflow (and upstream
+        # has no such job). nix/hermes-agent.nix already guards its own `cage`
+        # the same way.
         ++ lib.optionals stdenv.isLinux [
           # Headless Wayland compositor for E2E tests (test:e2e:visual).
           # cage renders a single client with no window management, so
@@ -48,6 +49,11 @@
           # live compositor; grim runs inside that isolated client session.
           ghostty
           grim
+          # The `sandbox` script wraps `bwrap` (bubblewrap), so it only makes
+          # sense on Linux — and forcing its evaluation on Darwin pulls
+          # bubblewrap's derivation into the devShell closure and aborts
+          # `nix flake check`.
+          self'.packages.sandbox
         ]
         ++ self'.packages.default.passthru.devDeps;
         shellHook = ''


### PR DESCRIPTION
Automated evolution PR for issue #2916.

**Root cause** (confirmed from this fork's own CI log, `gh run view 32273122898`):
- `nix/devShell.nix` included `self'.packages.sandbox` **unconditionally** in the devShell packages.
- The `sandbox` package (`nix/sandbox.nix`) lists Linux-only `bubblewrap` + `slirp4netns` in its `runtimeInputs`.
- Merely *evaluating* the devShell derivation on macOS therefore forces `bubblewrap-0.11.2`''s derivation, which aborts `nix flake check` with:
  ```
  error: Refusing to evaluate package 'bubblewrap-0.11.2' ... because it is not available on the requested hostPlatform: hostPlatform.system = "aarch64-darwin"
  ```
- The file already guards the Wayland capture stack (`cage`/`grim`) behind `lib.optionals stdenv.isLinux` for this exact failure class — the sandbox just was not guarded.

**Fix:** move `self'.packages.sandbox` into the existing `lib.optionals stdenv.isLinux [...]` block. This is the established pattern in the same file, is semantically correct (a bwrap-based sandbox cannot run on macOS), and restores the green `nix flake check` gate that was blocking all evolution self-merges.

No local nix binary is available here, so CI (`nix.yml`, ubuntu + macos) is the verifier; the diff mirrors the exact guard the Wayland stack already uses.

Closes #2916