### PR TITLE
fix(trajectory): fold real tool-call metadata into the live trajectory writer (Closes #2877)

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -8,7 +8,7 @@ the file-write logic live here.
 import json
 import logging
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,8 @@ def has_incomplete_scratchpad(content: str) -> bool:
 
 
 def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
-                    completed: bool, filename: str = None):
+                    completed: bool, filename: str = None,
+                    model_calls: Optional[List[Dict[str, Any]]] = None):
     """Append a trajectory entry to a JSONL file.
 
     Args:
@@ -37,6 +38,12 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
         completed: Whether the conversation completed successfully.
         filename: Override output filename. Defaults to trajectory_samples.jsonl
                   or failed_trajectories.jsonl based on ``completed``.
+        model_calls: Optional structured tool-call metadata (``extract_tool_calls``
+                     output). Written verbatim under ``model_calls`` when present
+                     so the evolution pipeline can consume real per-call
+                     tool/args/status without re-parsing the ShareGPT text
+                     (#2877). Defaults to no field — the pre-#2877 shape is
+                     preserved for callers that don't supply it.
     """
     if filename is None:
         filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
@@ -47,6 +54,8 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
         "model": model,
         "completed": completed,
     }
+    if model_calls:
+        entry["model_calls"] = model_calls
 
     try:
         with open(filename, "a", encoding="utf-8") as f:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2650,8 +2650,24 @@ class AIAgent:
         if not self.save_trajectories:
             return
 
+        # Fold the real tool-call metadata into the saved entry (#2877).
+        # ``extract_tool_calls`` reads the RAW internal messages, which carry
+        # structured ``tool_calls`` + per-call results; by the time the
+        # ShareGPT trajectory form is produced those calls are flattened into
+        # XML text and the per-call status/args are gone. Emitting the
+        # structured form alongside keeps the evolution pipeline's consumers
+        # working against real per-call data instead of re-parsing prose.
+        try:
+            from agent.tool_call_capture import extract_tool_calls
+
+            model_calls = extract_tool_calls(messages)
+        except Exception:
+            # Instrumentation must never be able to discard a completed turn.
+            model_calls = None
+
         trajectory = self._convert_to_trajectory_format(messages, user_query, completed)
-        _save_trajectory_to_file(trajectory, self.model, completed)
+        _save_trajectory_to_file(trajectory, self.model, completed,
+                                 model_calls=model_calls)
 
     @staticmethod
     def _is_entitlement_failure(

--- a/tests/scripts/test_evolution_synthetic_trajectory.py
+++ b/tests/scripts/test_evolution_synthetic_trajectory.py
@@ -128,6 +128,62 @@ class TestSchemaRoundTrip:
         assert _is_schema_valid_entry(reloaded)
 
 
+class TestModelCallsPersistence:
+    """#2877 — the rework wired real tool-call metadata into the live writer.
+
+    ``agent.trajectory.save_trajectory`` now accepts an optional ``model_calls``
+    list and persists it under that key. When absent, the pre-#2877 shape is
+    preserved byte-for-byte (callers that never supplied it, and old files,
+    must load unchanged).
+    """
+
+    def test_absent_model_calls_keeps_legacy_shape(self, tmp_path):
+        """No model_calls argument -> no model_calls key (legacy callers)."""
+        from agent.trajectory import save_trajectory
+
+        ep = generate_episode("tool_augmented_planning", {"seed": 5})
+        out = tmp_path / "trajectory_samples.jsonl"
+        save_trajectory(ep["conversations"], model=ep["model"],
+                        completed=ep["completed"], filename=str(out))
+        reloaded = json.loads(out.read_text(encoding="utf-8").splitlines()[0])
+        assert "model_calls" not in reloaded
+
+    def test_empty_model_calls_is_omitted(self, tmp_path):
+        """An empty list is not written — matches ``extract_tool_calls`` for a
+        turn with no tool calls, which must not add a noisy empty key."""
+        from agent.trajectory import save_trajectory
+
+        ep = generate_episode("tool_augmented_planning", {"seed": 7})
+        out = tmp_path / "trajectory_samples.jsonl"
+        save_trajectory(ep["conversations"], model=ep["model"],
+                        completed=ep["completed"], filename=str(out),
+                        model_calls=[])
+        reloaded = json.loads(out.read_text(encoding="utf-8").splitlines()[0])
+        assert "model_calls" not in reloaded
+
+    def test_model_calls_are_persisted_verbatim(self, tmp_path):
+        """The structured per-call metadata survives the round-trip exactly —
+        this is what the evolution pipeline's consumers read."""
+        from agent.trajectory import save_trajectory
+
+        ep = generate_episode("tool_augmented_planning", {"seed": 11})
+        calls = [
+            {"tool": "read_file", "args": {"path": "a.py"},
+             "result": "ok", "status": "success", "duration_ms": None},
+            {"tool": "patch", "args": {"path": "a.py"},
+             "result": "applied", "status": "success", "duration_ms": 250},
+        ]
+        out = tmp_path / "trajectory_samples.jsonl"
+        save_trajectory(ep["conversations"], model=ep["model"],
+                        completed=ep["completed"], filename=str(out),
+                        model_calls=calls)
+        reloaded = json.loads(out.read_text(encoding="utf-8").splitlines()[0])
+        assert reloaded["model_calls"] == calls
+        # The ShareGPT conversations are untouched by the extra metadata.
+        assert reloaded["conversations"] == ep["conversations"]
+        assert _is_schema_valid_entry(reloaded)
+
+
 class TestLabels:
     def test_labels_present_and_typed(self):
         ep = generate_episode("tool_augmented_planning", {"seed": 1})


### PR DESCRIPTION
Automated evolution rework for issue #2877.

**Brief (owner comment 5343115402, 2026-08-19):** PR #2906 was rejected as dead code — `build_trajectory_log`/`extract_model_calls` had no production call site. `run_agent.py` saves via `agent.trajectory.save_trajectory` which never invoked them. DoD: "a real session produces a trajectory file whose model_calls field is populated."

**Fix:** wire the structured tool-call metadata into the live trajectory-save seam.
- `agent/trajectory.py:save_trajectory` now accepts an optional `model_calls` list and persists it under that key when present; absent callers keep the exact pre-#2877 shape (byte-compatible, so old files / synthetic episodes load unchanged).
- `run_agent.py:_save_trajectory` computes `model_calls = extract_tool_calls(messages)` from the RAW internal messages (which still carry structured `tool_calls` + per-call results) and passes it to the writer. The ShareGPT trajectory form flattens tool calls into XML text, so this is where the structured data must be captured — not after conversion. Guarded in try/except so instrumentation can never discard a completed turn (#8049 pattern).
- Tests: `TestModelCallsPersistence` in `tests/scripts/test_evolution_synthetic_trajectory.py` (legacy-shape preserved, empty list omitted, structured calls round-trip verbatim). 57 tests pass across `test_evolution_synthetic_trajectory.py` + `test_tool_call_capture.py`.

**Verification note:** the pre-PR shard `tests/agent` shows 1 failure (`test_custom_main_forwards_runtime_endpoint`) that I confirmed is PRE-EXISTING and unrelated: it passes in isolation (17/17 in its file) and reproduces identically on a clean origin/main clone (738 passed / 1 failed, same test) — an order-dependent vision-provider flake, untouched by this diff.

Closes #2877