### PR TITLE
fix(nix): gate dev sandbox to Linux so macOS flake check evaluates (Closes #79)

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -27,7 +27,6 @@
             mkdir -p $out/bin
             install -Dm755 ${../hermes} $out/bin/hermes
           '')
-          self'.packages.sandbox
           uv
         ]
         # The Wayland E2E capture stack is Linux-only — `cage` and `grim` carry
@@ -37,6 +36,9 @@
         # workflows/nix.yml, ubuntu + macos), and upstream has no such job.
         # nix/hermes-agent.nix already guards its own `cage` the same way.
         ++ lib.optionals stdenv.isLinux [
+          # The dev sandbox (bubblewrap/slirp4netns) is Linux-only — see
+          # nix/packages.nix. Keep it out of the darwin devShell evaluation.
+          self'.packages.sandbox
           # Headless Wayland compositor for E2E tests (test:e2e:visual).
           # cage renders a single client with no window management, so
           # the Electron window opens at a fixed size without tiling.

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -54,8 +54,6 @@
           }).node-gyp;
         default = full;
 
-        inherit sandbox;
-
         inherit minimal;
 
         # Ships discord.py + python-telegram-bot + slack-sdk so a plain
@@ -70,6 +68,14 @@
         desktop = full.hermesDesktop;
 
         update-npm-lockfile = full.hermesNpmLib.updateNpmLockfile;
-      };
+      }
+      # The dev sandbox is Linux-only: it pulls bubblewrap/slirp4netns (and
+      # the X11 electron runtime) unconditionally, and nixpkgs refuses to
+      # evaluate those on darwin. Gate the package to Linux so
+      # `nix flake check` on macOS stops failing with "Refusing to evaluate
+      # package 'bubblewrap-0.11.2' ... not available on the requested
+      # hostPlatform" (#79). The `let`-bound `sandbox` stays lazy, so it is
+      # never forced on darwin.
+      // lib.optionalAttrs pkgs.stdenv.isLinux { inherit sandbox; };
     };
 }


### PR DESCRIPTION
## Summary

The `nix (macos-latest)` job has failed deterministically on every PR and on `main` since 08-06 with:

```
error: Refusing to evaluate package 'bubblewrap-0.11.2' ... not available on the requested hostPlatform
```

Root cause: `nix/sandbox.nix` pulls `bubblewrap` + `slirp4netns` (and the X11 electron runtime) **unconditionally**, and it was exposed via `inherit sandbox;` in `nix/packages.nix` for every system — including `aarch64-darwin`, which nixpkgs refuses to evaluate for these Linux-only packages.

## Fix

Follow the existing Linux-gating pattern already used for `cage`/libglvnd/grim/ghostty in `devShell.nix` and `hermes-agent.nix`:

- **nix/packages.nix** — expose the sandbox package only on Linux: `packages // lib.optionalAttrs pkgs.stdenv.isLinux { inherit sandbox; }`. The `let`-bound `sandbox` stays lazy, so it is never forced on darwin.
- **nix/devShell.nix** — move `self'.packages.sandbox` into the `lib.optionals stdenv.isLinux [ … ]` block.

## Verification

Validated locally with nix-portable (Nix 2.20.6):

```
$ nix eval --raw .#packages.x86_64-linux.sandbox.name
sandbox                      # Linux still exposes the sandbox

$ nix eval --raw .#packages.aarch64-darwin.sandbox.name
error: … does not provide attribute 'packages.aarch64-darwin.sandbox.name'
                             # gated out on darwin — no more bubblewrap eval

$ nix eval --raw .#devShells.aarch64-darwin.default.name
nix-shell                    # darwin devShell evaluates cleanly
```

This should unblock the 10 open `evolution/issue-*` PRs (2914, 2911, 2906, 2905, 2904, 2903, 2902, 2894, 2884, 2882) that fail only this job.

Closes #79.