### PR TITLE
feat: decision-level regression metrics from trajectory data (Closes #2917)

### DIFF
--- a/scripts/evolution_decision_metrics.py
+++ b/scripts/evolution_decision_metrics.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Decision-level regression metrics from trajectory data (#2917, slice 1 of #2899).
+
+Reads evolution trajectory data and emits per-run **tool-call rate** and
+**safety-refusal rate** — the measurement half of #2899's quantization
+margin-shrinkage ask (the admission gate is deferred until a routing/cost
+layer exists, #2317). Consumes the ``model_calls`` field #2877 wires onto
+the live trajectory seam (decisions: ``tool_call`` / ``refusal`` /
+``content``); both the evolution store (``TrajectoryLog`` JSONL) and the
+agent store (``trajectory_samples.jsonl``) shapes are accepted. Missing
+``model_calls`` is handled leniently — skip the run, never crash — so this
+is safe to land before #2877. Deterministic: pure functions + thin CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+__all__ = ["compute_run_metrics", "scan_trajectories", "main"]
+
+
+def _default_trajectory_dir() -> Path:
+    env = os.environ.get("EVOLUTION_PROFILE_DIR", "").strip()
+    if env:
+        return Path(env) / "trajectories"
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    return (
+        Path(hh) / "evolution" / "trajectories"
+        if hh
+        else Path.home() / ".hermes" / "evolution" / "trajectories"
+    )
+
+
+def compute_run_metrics(model_calls: Any) -> Dict[str, Any]:
+    """Per-run tool-call rate and safety-refusal rate from ``model_calls``.
+
+    Returns ``{}`` when the run carries no usable ``model_calls`` (missing,
+    malformed, empty, or all-unknown decisions) — \"not measured\", never a
+    zero-failure run.
+    """
+    if not isinstance(model_calls, list) or not model_calls:
+        return {}
+    decisions = len(model_calls)
+    tool_call_decisions = 0
+    tool_calls = 0
+    refusals = 0
+    content = 0
+    for mc in model_calls:
+        if not isinstance(mc, dict):
+            continue
+        decision = mc.get("decision")
+        if decision == "tool_call":
+            tool_call_decisions += 1
+            tool_calls += int(mc.get("tool_call_count", 0) or 0)
+        elif decision == "refusal":
+            refusals += 1
+        elif decision == "content":
+            content += 1
+    measured = tool_call_decisions + refusals + content
+    if measured == 0:
+        return {}
+    return {
+        "decisions": decisions,
+        "tool_calls": tool_calls,
+        "refusals": refusals,
+        "content": content,
+        "tool_call_rate": tool_calls / decisions,
+        "safety_refusal_rate": refusals / decisions,
+        "measured": measured,
+    }
+
+
+def _model_calls_from_entry(entry: Dict[str, Any]) -> Any:
+    if isinstance(entry, dict) and "model_calls" in entry:
+        return entry["model_calls"]
+    return None
+
+
+def scan_trajectories(trajectory_dir: Path) -> List[Dict[str, Any]]:
+    """Scan JSONL trajectory files, one entry per line; skip unreadable or
+    unmeasured entries. Returns one dict per measured run."""
+    results: List[Dict[str, Any]] = []
+    if not trajectory_dir.is_dir():
+        return results
+    for path in sorted(trajectory_dir.glob("*.jsonl")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            metrics = compute_run_metrics(_model_calls_from_entry(entry))
+            if not metrics:
+                continue
+            metrics["file"] = path.name
+            results.append(metrics)
+    return results
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    trajectory_dir = _default_trajectory_dir()
+    if "--dir" in args and args.index("--dir") + 1 < len(args):
+        trajectory_dir = Path(args[args.index("--dir") + 1])
+    results = scan_trajectories(trajectory_dir)
+    print(f"decision metrics for {trajectory_dir} ({len(results)} runs):")
+    for r in results:
+        print(
+            f"  {r['file']}: tool-call {r['tool_call_rate']:.2f} "
+            f"({r['tool_calls']}/{r['decisions']}), "
+            f"refusal {r['safety_refusal_rate']:.2f} ({r['refusals']}/{r['decisions']})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_decision_metrics.py
+++ b/tests/scripts/test_evolution_decision_metrics.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Tests for decision-level regression metrics (#2917, slice 1 of #2899)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_decision_metrics import (  # noqa: E402
+    compute_run_metrics,
+    scan_trajectories,
+)
+
+
+class TestComputeRunMetrics:
+    def test_rates_from_known_calls(self):
+        m = compute_run_metrics([
+            {"decision": "tool_call", "tool_call_count": 1},
+            {"decision": "tool_call", "tool_call_count": 2},
+            {"decision": "refusal"},
+            {"decision": "content"},
+        ])
+        assert m["decisions"] == 4
+        assert m["tool_calls"] == 3
+        assert m["refusals"] == 1
+        assert m["tool_call_rate"] == 0.75
+        assert m["safety_refusal_rate"] == 0.25
+
+    def test_invariants_hold(self):
+        m = compute_run_metrics([
+            {"decision": "tool_call", "tool_call_count": 2},
+            {"decision": "refusal"},
+            {"decision": "content"},
+        ])
+        assert 0 <= m["tool_call_rate"] <= 1
+        assert 0 <= m["safety_refusal_rate"] <= 1
+        assert m["measured"] == m["decisions"] == 3
+
+    def test_missing_or_unmeasurable_returns_empty(self):
+        assert compute_run_metrics(None) == {}
+        assert compute_run_metrics([]) == {}
+        assert compute_run_metrics([{"decision": "unknown"}]) == {}
+
+
+class TestScanTrajectories:
+    def test_skips_runs_without_model_calls(self, tmp_path):
+        p = tmp_path / "traj.jsonl"
+        p.write_text(
+            json.dumps({"session_id": "s1", "entries": []}) + "\n"
+            + json.dumps({"session_id": "s2", "model_calls": [
+                {"decision": "tool_call", "tool_call_count": 1},
+                {"decision": "content"},
+            ]}) + "\n",
+            encoding="utf-8",
+        )
+        results = scan_trajectories(tmp_path)
+        assert len(results) == 1
+        assert results[0]["tool_call_rate"] == 0.5
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        assert scan_trajectories(tmp_path / "nope") == []


### PR DESCRIPTION
Automated evolution PR — #2917, slice 1 of #2899 (quantization margin-shrinkage). The measurement half: reads trajectory `model_calls` and emits per-run tool-call rate + safety-refusal rate. The admission gate itself is deferred until a routing/cost layer exists (#2317).

**Changes:**
- `scripts/evolution_decision_metrics.py` (new): `compute_run_metrics()` (per-run rates; `{}` for missing/malformed/empty/all-unknown `model_calls` — "not measured", never a zero-failure run), `scan_trajectories()` (accepts both the evolution store `TrajectoryLog` JSONL and the agent `trajectory_samples.jsonl` shape; lenient on missing `model_calls` — safe to land before #2877), thin CLI.
- `tests/scripts/test_evolution_decision_metrics.py` (new): known-count fixtures, rate invariants (rates in [0,1], measured == decisions), missing-field leniency.

**Verification:** 5 tests green; ruff check clean; diff = 191 changed lines (inside the autonomous merge cap). CLI smoke-tested on synthetic trajectory: `tool-call 0.75 (3/4), refusal 0.25 (1/4)`.

Note: `#2899` stays OPEN — the admission gate remains deferred; this PR only lands the extractor it will consume.

Closes #2917