### PR TITLE
feat(skills): log skill-retrieval events to a JSONL sidecar (Closes #2918)

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -598,6 +598,39 @@ class TestUnifiedSearchDedup:
         results = unified_search("query", [failing, ok])
         assert len(results) == 1
 
+    def test_retrieval_event_logged_to_sidecar(self, tmp_path, monkeypatch):
+        """#2918: a retrieval must append one JSONL event (query + retrieved
+        identifiers) so a later slice can compute used-when-retrieved rate."""
+        import tools.skills_hub as hub
+
+        sidecar = tmp_path / "retrieval_events.jsonl"
+        monkeypatch.setattr(hub, "RETRIEVAL_EVENTS_FILE", sidecar)
+        s1 = SkillMeta(name="s1", description="d", source="ok",
+                       identifier="a/one", trust_level="community")
+        results = unified_search("find me", [self._make_source("a", [s1])])
+        assert results == [s1]
+        line = sidecar.read_text(encoding="utf-8").strip().splitlines()
+        assert len(line) == 1
+        event = json.loads(line[0])
+        assert event["query"] == "find me"
+        assert event["retrieved"] == ["a/one"]
+        assert "ts" in event
+
+    def test_retrieval_never_fails_on_log_io_error(self, tmp_path, monkeypatch):
+        """Best-effort logging: an unwritable sidecar must not break a search."""
+        import tools.skills_hub as hub
+
+        # Make the sidecar's parent a regular file so opening it raises OSError.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("i am a file")
+        monkeypatch.setattr(hub, "RETRIEVAL_EVENTS_FILE", blocker / "events.jsonl")
+        s1 = SkillMeta(name="s1", description="d", source="ok",
+                       identifier="x", trust_level="community")
+        results = unified_search("query", [self._make_source("a", [s1])])
+        assert len(results) == 1
+        # Nothing written, nothing raised.
+        assert not (blocker / "events.jsonl").exists()
+
 
 # ---------------------------------------------------------------------------
 # GitHub tap provider labeling + index search/filter

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -89,6 +89,11 @@ def _audit_log() -> Path:
     return Path(forced) if forced is not None else _hub_dir() / "audit.log"
 
 
+def _retrieval_events_file() -> Path:
+    forced = _override("RETRIEVAL_EVENTS_FILE")
+    return Path(forced) if forced is not None else _skills_dir() / "retrieval_events.jsonl"
+
+
 def _taps_file() -> Path:
     forced = _override("TAPS_FILE")
     return Path(forced) if forced is not None else _hub_dir() / "taps.json"
@@ -108,6 +113,7 @@ _DYNAMIC_PATH_RESOLVERS = {
     "AUDIT_LOG": _audit_log,
     "TAPS_FILE": _taps_file,
     "INDEX_CACHE_DIR": _index_cache_dir,
+    "RETRIEVAL_EVENTS_FILE": _retrieval_events_file,
 }
 
 
@@ -4618,4 +4624,33 @@ def unified_search(query: str, sources: List[SkillSource],
             seen[r.identifier] = r
     deduped = list(seen.values())
 
+    _record_retrieval(query, deduped)
+
     return deduped[:limit]
+
+
+def _record_retrieval(query: str, results: List[SkillMeta]) -> None:
+    """Append one retrieval event to the sidecar for future precision math.
+
+    Issue #2918 (slice 1 of #2897): actual-use gating exists (#2286), but
+    actual-use *precision* (used-when-retrieved rate) needs a log of which
+    skills were retrieved for which query — none exists. This writes one JSONL
+    line per retrieval so a later slice can compute retrieved∩used over pool
+    growth. Records the retrieved identifiers, not full descriptions, to keep
+    the sidecar small. Best-effort: a retrieval must never fail because
+    logging did — IO/encode errors are swallowed.
+    """
+    if not query:
+        return
+    try:
+        path = _retrieval_events_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "query": query,
+            "retrieved": [r.identifier for r in results if r.identifier],
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except (OSError, ValueError, TypeError):
+        return


### PR DESCRIPTION
Slice 1 of #2897 (evidence-based skill-use taxonomy).

## What
Adds retrieval-event logging to the skill-retrieval path: `unified_search` (the single retrieval seam used by the CLI and /skills) now appends one JSONL event per retrieval to `~/.hermes/skills/retrieval_events.jsonl` — timestamp, query, and the retrieved skill identifiers.

## Why
Actual-use gating already exists (#2286, evolution_utility_audit), but actual-use *precision* (used-when-retrieved rate over pool growth) needs a log of which skills were retrieved per query — none existed. No gating in this slice; the precision metric lands later once events accumulate.

## Design
- Best-effort: a logging failure can never break a search (IO/encode errors swallowed).
- Isolated behind the same `_override` path-resolution pattern as the other hub paths (`RETRIEVAL_EVENTS_FILE`), so tests and future tooling can redirect it.
- Records identifiers only (not full descriptions) to keep the sidecar small; format is JSONL readable by a future precision computation.

## Verification
- Live retrieval (sandboxed HERMES_HOME): sidecar written with expected JSONL shape (`{"ts":..., "query":..., "retrieved":[...]}`).
- Unit tests: retrieval event logged; unwritable sidecar does not break a search.
- `ruff` clean; 68 changed lines (≤200).