### PR TITLE
fix(schema): hoist array keywords into anyOf array branch (Closes #80)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -200,6 +200,98 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_keywords_hoisted_into_anyof_array_branch():
+    # The read_file ``path`` schema: ``type: ["string", "array"]`` with a
+    # top-level ``items``. Emitting ``items`` as a sibling of the generated
+    # ``anyOf`` (instead of inside the ``array`` branch) is malformed and 400s
+    # on Gemini with both ``properties[path].items: field predicate failed``
+    # and ``properties[path].any_of[1].items: missing field``. Regression guard
+    # for the "read_file path schema" issue.
+    tools = [_tool("read_file", {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "description": "Path or list of paths",
+            },
+        },
+        "required": ["path"],
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["path"]
+    assert "type" not in prop
+    assert "items" not in prop, "top-level items must be hoisted into the array branch"
+    assert prop["anyOf"] == [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}},
+    ]
+    assert prop["description"] == "Path or list of paths"
+
+
+def test_array_keywords_not_hoisted_for_plain_array_type():
+    # A single ``type: "array"`` (not a union) keeps ``items`` at the top
+    # level — that is already a valid JSON Schema shape and must not move.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "bag": {"type": "array", "items": {"type": "string"}},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["bag"]
+    assert prop["type"] == "array"
+    assert prop["items"] == {"type": "string"}
+
+
+def test_multiple_array_keywords_hoisted_together():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": ["string", "array"],
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 10,
+                "uniqueItems": True,
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["path"]
+    assert prop["anyOf"][1] == {
+        "type": "array",
+        "items": {"type": "string"},
+        "minItems": 1,
+        "maxItems": 10,
+        "uniqueItems": True,
+    }
+    for kw in ("items", "minItems", "maxItems", "uniqueItems"):
+        assert kw not in prop, f"{kw} must be hoisted into the array branch"
+
+
+def test_nullable_multitype_array_keeps_nullable_and_hoists_items():
+    # ``type: ["string", "array", "null"]`` — the null branch is lifted into
+    # ``nullable: true`` while ``items`` still lands in the array branch.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": ["string", "array", "null"],
+                "items": {"type": "string"},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["path"]
+    assert prop["nullable"] is True
+    assert prop["anyOf"] == [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}},
+    ]
+    assert "items" not in prop
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # strip_pattern_and_format — reactive recovery when llama.cpp rejects a
 # schema with an HTTP 400 grammar-parse error. Must be opt-in (only

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -398,6 +398,24 @@ def collapse_const_unions(schema: Any) -> Any:
     return out
 
 
+# Array-specific JSON Schema keywords that only have meaning on a node whose
+# declared ``type`` is ``array``. When a multi-type ``type`` list (e.g.
+# ``["string", "array"]``) is normalized into an ``anyOf`` below, these must be
+# hoisted INTO the ``array`` branch of the union — emitting them as siblings of
+# ``anyOf`` is malformed and is rejected by Gemini with HTTP 400 INVALID_ARGUMENT.
+_ARRAY_KEYWORDS = frozenset({
+    "items",
+    "prefixItems",
+    "contains",
+    "unevaluatedItems",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "minContains",
+    "maxContains",
+})
+
+
 def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment.
 
@@ -446,7 +464,30 @@ def _sanitize_node(node: Any, path: str) -> Any:
         prop_renames = _rename_property_keys(node["properties"], f"{path}.properties")
 
     out: dict = {}
+    # When ``type`` is a multi-type list that will be normalized into ``anyOf``
+    # below, any array-specific keywords sitting as siblings of ``type``
+    # (``items``, ``minItems``, ...) must move INTO the ``array`` branch of the
+    # generated union. Leaving them at the top level produces a malformed shape
+    # Gemini rejects with two distinct 400s:
+    #   * ``properties[x].items: field predicate failed`` (``items`` is not
+    #     valid on a node whose type is a union), and
+    #   * ``properties[x].any_of[1].items: missing field`` (the array branch
+    #     lost its ``items``).
+    # This is the root cause of the ``read_file`` ``path`` schema failure that
+    # killed Gemini sessions (issue: read_file path schema).
+    array_keywords: dict[str, Any] = {}
+    if isinstance(node.get("type"), list) and "array" in node["type"]:
+        non_null = [
+            t for t in node["type"] if isinstance(t, str) and t != "null"
+        ]
+        if len(non_null) >= 2:
+            array_keywords = {k: node[k] for k in _ARRAY_KEYWORDS if k in node}
+
     for key, value in node.items():
+        # Array keywords already captured for hoisting are re-attached to the
+        # ``array`` branch when the ``type`` list is normalized below.
+        if key in array_keywords:
+            continue
         # JSON Schema ``type`` arrays (e.g. ``["number", "string"]``, common
         # in MCP tool schemas) are rejected by several tool-call backends:
         #   * llama.cpp's grammar generator only accepts a singular string type.
@@ -472,8 +513,21 @@ def _sanitize_node(node: Any, path: str) -> Any:
                     out.setdefault("nullable", True)
                 continue
             if len(non_null) >= 2:
-                # Preserve all branches as a union instead of dropping them.
-                out["anyOf"] = [{"type": t} for t in non_null]
+                # Preserve all branches as a union instead of dropping them,
+                # and attach hoisted array keywords to the ``array`` branch so
+                # it remains a complete, self-describing array schema.
+                branches: list[dict] = []
+                for t in non_null:
+                    branch: dict = {"type": t}
+                    if t == "array" and array_keywords:
+                        for ak, av in array_keywords.items():
+                            branch[ak] = (
+                                _sanitize_node(av, f"{path}.{ak}")
+                                if isinstance(av, (dict, list))
+                                else av
+                            )
+                    branches.append(branch)
+                out["anyOf"] = branches
                 if has_null:
                     out.setdefault("nullable", True)
                 continue


### PR DESCRIPTION
## Summary

Fixes the malformed `read_file` `path` schema that Gemini rejects with HTTP 400 INVALID_ARGUMENT, killing sessions (18/59 error dumps over ~5 weeks — the single most frequent failure mode).

## Root cause

`tools/file_tools.py` declares `path` as `type: ["string", "array"]` with a top-level `items`. `tools/schema_sanitizer.py` normalizes the type array into an `anyOf`, but left `items` as a *sibling* of the union — producing both Gemini 400 errors:

- `properties[path].items: field predicate failed` (items not valid on a union node)
- `properties[path].any_of[1].items: missing field` (array branch lost its items)

## Fix

In `_sanitize_node`, when a multi-type `type` list is normalized into `anyOf`, hoist array-specific keywords (`items`, `prefixItems`, `contains`, `minItems`, `maxItems`, `uniqueItems`, etc.) into the `array` branch. Result:

```json
{ "anyOf": [ {"type": "string"}, {"type": "array", "items": {"type": "string"}} ] }
```

This fixes the whole class (any MCP/plugin schema with the same shape), not just `read_file`.

## Tests

Added 4 regression tests in `tests/tools/test_schema_sanitizer.py` (36 total in the file, all passing; `ruff check` clean). Local: `pytest tests/tools/test_schema_sanitizer.py -q` → 36 passed.

Automated evolution PR for issue #80.