### PR TITLE
fix: coerce_tool_args JSON-parse-failure warning includes tool.param (Closes #2953)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -848,7 +848,9 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         # (e.g. read_file's normalize_read_pagination) already handle it.
         if expected == "array" and value is not None and not isinstance(value, (list, tuple)):
             if isinstance(value, str):
-                coerced = _coerce_value(value, expected, schema=prop_schema)
+                coerced = _coerce_value(
+                    value, expected, schema=prop_schema, tool_name=tool_name, key=key
+                )
                 if coerced is not value:
                     # _coerce_value handled it (JSON-parsed list or
                     # nullable "null" → None).
@@ -932,7 +934,9 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
             continue
         if not expected and not _schema_allows_null(prop_schema):
             continue
-        coerced = _coerce_value(value, expected, schema=prop_schema)
+        coerced = _coerce_value(
+            value, expected, schema=prop_schema, tool_name=tool_name, key=key
+        )
         if coerced is not value:
             args[key] = coerced
             # If we just JSON-parsed a string into a container, recurse so
@@ -1041,10 +1045,13 @@ def _normalize_json_strings_for_schema(value: Any, schema: Any) -> Any:
     return value
 
 
-def _coerce_value(value: str, expected_type, schema: dict | None = None):
+def _coerce_value(
+    value: str, expected_type, schema: dict | None = None, tool_name=None, key=None
+):
     """Attempt to coerce a string *value* to *expected_type*.
 
     Returns the original string when coercion is not applicable or fails.
+    *tool_name*/*key* are optional context (used to enrich warning text).
     """
     if _schema_allows_null(schema) and value.strip().lower() == "null":
         return None
@@ -1052,7 +1059,9 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if isinstance(expected_type, list):
         # Union type — try each in order, return first successful coercion
         for t in expected_type:
-            result = _coerce_value(value, t, schema=schema)
+            result = _coerce_value(
+                value, t, schema=schema, tool_name=tool_name, key=key
+            )
             if result is not value:
                 return result
         return value
@@ -1062,9 +1071,9 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if expected_type == "boolean":
         return _coerce_boolean(value)
     if expected_type == "array":
-        return _coerce_json(value, list)
+        return _coerce_json(value, list, tool_name=tool_name, key=key)
     if expected_type == "object":
-        return _coerce_json(value, dict)
+        return _coerce_json(value, dict, tool_name=tool_name, key=key)
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
@@ -1210,8 +1219,12 @@ def _split_path_list(value: str) -> Optional[List[str]]:
     return None
 
 
-def _coerce_json(value: str, expected_python_type: type):
-    """Parse *value* as JSON when the schema expects an array or object."""
+def _coerce_json(value: str, expected_python_type: type, tool_name=None, key=None):
+    """Parse *value* as JSON when the schema expects an array or object.
+
+    *tool_name*/*key* are optional (when known) and only used to enrich the
+    warning text so failures name the offending tool parameter.
+    """
     if not value or not value.strip():
         if expected_python_type is list:
             return []
@@ -1231,8 +1244,10 @@ def _coerce_json(value: str, expected_python_type: type):
                     items,
                 )
                 return items
+        _ctx = f"{tool_name}.{key} " if tool_name and key else ""
         logger.warning(
-            "coerce_tool_args: failed to parse string as JSON for expected type %s: %s",
+            "coerce_tool_args: %sfailed to parse string as JSON for expected type %s: %s",
+            _ctx,
             expected_python_type.__name__,
             exc,
         )
@@ -1243,8 +1258,10 @@ def _coerce_json(value: str, expected_python_type: type):
             expected_python_type.__name__,
         )
         return parsed
+    _ctx = f"{tool_name}.{key} " if tool_name and key else ""
     logger.warning(
-        "coerce_tool_args: JSON-parsed value is %s, expected %s — skipping coercion",
+        "coerce_tool_args: %sJSON-parsed value is %s, expected %s — skipping coercion",
+        _ctx,
         type(parsed).__name__,
         expected_python_type.__name__,
     )

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -405,3 +405,54 @@ class TestCoerceToolArgsNested:
         }
         result = coerce_tool_args("todo", args)
         assert result["todos"][0] == {"id": "1", "content": "x", "status": "pending"}
+
+
+# ── #2953: JSON-parse-failure warning names tool.param ────────────────────
+
+
+class TestCoerceJsonWarning:
+    """The _coerce_json list-failure warning must include tool.param context."""
+
+    def _mock_schema(self, properties):
+        return {
+            "name": "test_tool",
+            "description": "test",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+            },
+        }
+
+    def test_non_json_string_wrapped_and_warning_names_tool_param(self, caplog):
+        """#2953 — a non-JSON string on an array param falls back to a
+        single-element list (no double-wrap) and the warning names the tool
+        and parameter instead of being ambiguous."""
+        schema = self._mock_schema({
+            "urls": {"type": "array", "items": {"type": "string"}}
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            with caplog.at_level("WARNING", logger="model_tools"):
+                result = coerce_tool_args("test_tool", {"urls": "https://a.com"})
+
+        # Single-element fallback, NOT double-wrapped into a nested list.
+        assert result["urls"] == ["https://a.com"]
+
+        # The list-failure warning must name both the tool and the parameter.
+        assert any(
+            "test_tool.urls" in record.getMessage()
+            and "failed to parse string as JSON" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_directly_called_json_failure_warns(self, caplog):
+        """_coerce_json names the tool.param when called directly with them."""
+        from model_tools import _coerce_json
+
+        with caplog.at_level("WARNING", logger="model_tools"):
+            out = _coerce_json("not json", list, tool_name="fake_tool", key="items")
+        assert out == "not json"  # raw string on failure, no wrap here
+        assert any(
+            "fake_tool.items" in record.getMessage()
+            and "failed to parse string as JSON" in record.getMessage()
+            for record in caplog.records
+        )


### PR DESCRIPTION
Automated evolution PR for issue #2953. Threads tool_name.key through _coerce_value to _coerce_json so the list-failure warning names the tool/param. Single-element wrap already handled at call site; no double-wrap.