### PR TITLE
fix: CI-diagnosis dedup by (PR, root-cause) to stop duplicate issue flooding (Closes #2952)

### DIFF
--- a/scripts/evolution_ci_diagnosis.py
+++ b/scripts/evolution_ci_diagnosis.py
@@ -619,22 +619,25 @@ def _extract_from_text(text: str) -> Tuple[str, str]:
 # -----------------------------------------------------------------------------
 
 
-def _issue_key(pr_number: int) -> str:
-    """One dedup key per PR (not per check run)."""
-    return f"{_REPO}#{pr_number}"
+def _issue_key(pr_number: int, error_class: str) -> str:
+    """One dedup key per (PR, root-cause signature)."""
+    return f"{_REPO}#{pr_number}:{error_class}"
 
 
 def _find_existing_issue(
     client: Client,
     pr_number: int,
+    error_class: str,
     repo: str = _REPO,
 ) -> Optional[str]:
     recorded = _load_recorded()
-    key = _issue_key(pr_number)
+    key = _issue_key(pr_number, error_class)
     if key in recorded:
         return recorded[key]
-    # Search open issues referencing the PR number in the title/body.
-    query = f'is:issue is:open repo:{repo} "CI failure on PR #{pr_number}"'
+    # Search open issues referencing the PR number AND error_class in the title.
+    query = (
+        f'is:issue is:open repo:{repo} "CI failure on PR #{pr_number}" "{error_class}"'
+    )
     encoded = urllib.parse.quote(query)
     url = f"{_GITHUB_API}/search/issues?q={encoded}"
     data = _get(client, url)
@@ -648,19 +651,47 @@ def _find_existing_issue(
     return None
 
 
+def _comment_on_existing(
+    client: Client,
+    existing_url: str,
+    pr: PRInfo,
+    failures: List[Tuple[FailedCheck, FailureDetails]],
+    error_class: str,
+) -> None:
+    """Attach additional failing check runs to an existing issue."""
+    match = re.search(r"/issues/(\d+)$", existing_url)
+    if not match:
+        return
+    lines = [
+        f"Additional failing check run(s) for `{error_class}` on PR "
+        f"#{pr.number} (HEAD `{pr.head_sha}`):",
+        "",
+    ]
+    for check, failure in failures:
+        lines.append(f"- {check.name}: {check.details_url}")
+    url = f"{_GITHUB_API}/repos/{_REPO}/issues/{match.group(1)}/comments"
+    status, response = client("POST", url, json.dumps({"body": "\n".join(lines)}))
+    if status not in {201, 200}:
+        print(
+            f"[ci-diagnosis] failed to comment on existing issue: {status} {response}",
+            file=sys.stderr,
+        )
+
+
 def create_child_issue(
     client: Client,
     pr: PRInfo,
     failures: List[Tuple[FailedCheck, FailureDetails]],
+    error_class: str,
     dry_run: bool = False,
     recorded_state_path: Optional[Path] = None,
 ) -> Optional[str]:
-    """Create ONE aggregated issue for all failed checks on a PR.
+    """Create ONE focused issue for a single root cause on a PR.
 
-    Classified (complex, root-caused) failures get a focused section; failures
-    whose pattern is still unrecognised get their raw log/annotation excerpt
-    surfaced so a human or LLM can diagnose them (rather than being silently
-    dropped). Skips entirely only when nothing is actionable (all trivial).
+    Dedups by (PR, error_class): if an open CI-failure issue for the same
+    root cause already exists, no new issue is created — the extra failing
+    check runs are attached as a comment instead. Returns None when nothing
+    actionable is present.
     """
     # Complex failures with a recognised root cause.
     classified = [
@@ -680,16 +711,21 @@ def create_child_issue(
         )
         return None
 
-    key = _issue_key(pr.number)
-    existing = _find_existing_issue(client, pr.number)
+    key = _issue_key(pr.number, error_class)
+    existing = _find_existing_issue(client, pr.number, error_class)
     if existing:
-        print(f"[ci-diagnosis] issue already exists for PR #{pr.number}: {existing}")
+        print(
+            f"[ci-diagnosis] issue already exists for PR #{pr.number} "
+            f"({error_class}): {existing}"
+        )
+        if not dry_run:
+            _comment_on_existing(client, existing, pr, failures, error_class)
         return existing
 
     # Aggregate error classes for the title
     error_classes = sorted({f.error_class for _, f in classified})
     if not error_classes:
-        error_classes = ["unrecognized"]
+        error_classes = [error_class or "unrecognized"]
     title = f"CI failure on PR #{pr.number}: {', '.join(error_classes)}"
 
     # Build body with all failed checks
@@ -877,7 +913,7 @@ def diagnose_prs(
             print(f"  PR #{pr.number}: no failed checks")
             continue
 
-        # Collect all failures for this PR, then create ONE aggregated issue.
+        # Collect all failures for this PR, then create ONE issue per root cause.
         all_failures: List[Tuple[FailedCheck, FailureDetails]] = []
         for check in failed_checks:
             failure = extract_failure(check)
@@ -886,15 +922,22 @@ def diagnose_prs(
                 f"  PR #{pr.number} check '{check.name}': {failure.classification} ({failure.error_class})"
             )
 
-        # Create a single issue per PR (aggregates all classified failures,
-        # skips entirely if all are 'unknown').
-        child_issue_url: Optional[str] = create_child_issue(
-            api,
-            pr,
-            all_failures,
-            dry_run=dry_run,
-            recorded_state_path=recorded_state_path,
-        )
+        # Group complex failures by root-cause signature; each group becomes
+        # one focused issue, deduped by (PR, error_class).
+        groups: Dict[str, List[Tuple[FailedCheck, FailureDetails]]] = {}
+        for check, failure in all_failures:
+            if failure.classification == "complex":
+                groups.setdefault(failure.error_class, []).append((check, failure))
+        issue_by_error: Dict[str, Optional[str]] = {}
+        for error_class, group in sorted(groups.items()):
+            issue_by_error[error_class] = create_child_issue(
+                api,
+                pr,
+                group,
+                error_class,
+                dry_run=dry_run,
+                recorded_state_path=recorded_state_path,
+            )
 
         for check, failure in all_failures:
             results.append({
@@ -909,7 +952,7 @@ def diagnose_prs(
                 "error_class": failure.error_class,
                 "mast_mode": failure.mast_mode,
                 "message": failure.message,
-                "child_issue_url": child_issue_url,
+                "child_issue_url": issue_by_error.get(failure.error_class),
             })
 
     save_diagnosis_report(results, report_dir=report_dir)

--- a/tests/scripts/test_evolution_ci_diagnosis.py
+++ b/tests/scripts/test_evolution_ci_diagnosis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.parse
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -211,7 +212,10 @@ def test_diagnose_prs_detects_failure_and_creates_child_issue(hermes_home, monke
     # Verify state was recorded.
     assert state_path.is_file()
     recorded = json.loads(state_path.read_text(encoding="utf-8"))
-    assert recorded["Lexus2016/hermes-agent-evolution#42"] == issue_response["html_url"]
+    assert (
+        recorded["Lexus2016/hermes-agent-evolution#42:key-error"]
+        == issue_response["html_url"]
+    )
 
 
 def test_diagnose_prs_dry_run_does_not_create_issue(hermes_home, monkeypatch):
@@ -408,7 +412,9 @@ def test_create_child_issue_surfaces_unclassified_raw_excerpt(hermes_home):
             },
         ),
     ])
-    url = diag.create_child_issue(client, pr, [(check, failure)], dry_run=False)
+    url = diag.create_child_issue(
+        client, pr, [(check, failure)], "unknown", dry_run=False
+    )
     assert url == "https://github.com/Lexus2016/hermes-agent-evolution/issues/999"
     post_body = json.loads(client.calls[-1][2] or "{}")
     assert "opaque detail" in post_body["body"]
@@ -433,7 +439,9 @@ def test_classify_mast_mode_by_error_class():
 
 def test_classify_mast_mode_message_hint_overrides():
     # a "timeout" keyword in the message wins over a non-timeout error class
-    assert diag.classify_mast_mode("exit-code", "Operation timed out after 120s") == "3.1"
+    assert (
+        diag.classify_mast_mode("exit-code", "Operation timed out after 120s") == "3.1"
+    )
     assert diag.classify_mast_mode("key-error", "assert x == y failed") == "3.3"
 
 
@@ -466,3 +474,91 @@ def test_extract_failure_tags_mast_mode():
     )
     failure = diag.extract_failure(check)
     assert failure.mast_mode == "2.6"  # key-error -> reasoning-action mismatch
+
+
+# --- #2952: dedup by (PR, root-cause signature) ---
+
+
+def test_issue_key_includes_error_class():
+    assert diag._issue_key(42, "key-error") == (
+        "Lexus2016/hermes-agent-evolution#42:key-error"
+    )
+    assert diag._issue_key(42, "test-failure") != diag._issue_key(42, "key-error")
+
+
+def test_find_existing_issue_searches_error_class_in_query():
+    item = {
+        "html_url": "https://github.com/Lexus2016/hermes-agent-evolution/issues/777"
+    }
+    client = FakeClient([(200, {"total_count": 1, "items": [item]})])
+    url = diag._find_existing_issue(client, 42, "key-error")
+    assert url == item["html_url"]
+    query_url = client.calls[-1][1]
+    assert urllib.parse.quote('"CI failure on PR #42"') in query_url
+    assert urllib.parse.quote('"key-error"') in query_url
+
+
+def test_create_child_issue_separate_issues_per_error_class(hermes_home, monkeypatch):
+    """Distinct root causes on the same PR must create distinct issues."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    report_dir = hermes_home / "reports"
+
+    pr = _pr_payload(61, "feat: multi failure", "sha61")
+    # fmt: off
+    checks = _check_runs_payload([
+        {"id": 1, "name": "tests", "conclusion": "failure", "details_url": "https://d/1"},
+        {"id": 2, "name": "build", "conclusion": "failure", "details_url": "https://d/2"},
+    ])
+    ann_key = [{"path": "tests/x.py", "start_line": 1, "annotation_level": "failure",
+                "message": "KeyError: 'missing'", "title": "t"}]
+    ann_timeout = [{"path": "tests/y.py", "start_line": 1, "annotation_level": "failure",
+                    "message": "Operation timed out after 120s", "title": "t"}]
+    issue1 = {"html_url": "https://github.com/Lexus2016/hermes-agent-evolution/issues/500"}
+    issue2 = {"html_url": "https://github.com/Lexus2016/hermes-agent-evolution/issues/501"}
+    # fmt: on
+
+    client = FakeClient([
+        (200, [pr]),
+        (200, checks),
+        (200, ann_key),  # check 1 -> key-error
+        (200, ann_timeout),  # check 2 -> timeout
+        (200, {"total_count": 0, "items": []}),  # search key-error
+        (201, issue1),
+        (200, {"total_count": 0, "items": []}),  # search timeout
+        (201, issue2),
+    ])
+
+    results = diag.diagnose_prs(dry_run=False, client=client, report_dir=report_dir)
+    assert len(results) == 2
+    urls = {r["error_class"]: r["child_issue_url"] for r in results}
+    assert urls["key-error"] == issue1["html_url"]
+    assert urls["timeout"] == issue2["html_url"]
+    assert urls["key-error"] != urls["timeout"]
+    posts = [(m, u) for m, u, _ in client.calls if m == "POST" and "/issues" in u]
+    assert len(posts) == 2
+
+
+def test_dry_run_two_failures_shared_error_creates_one_issue(hermes_home, monkeypatch):
+    """Two failures sharing a root cause group into ONE issue, not two."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    report_dir = hermes_home / "reports"
+
+    pr = _pr_payload(62, "pr: dup root cause", "sha62")
+    # fmt: off
+    checks = _check_runs_payload([
+        {"id": 1, "name": "tests (slice 1)", "conclusion": "failure", "details_url": "https://d/1"},
+        {"id": 2, "name": "tests (slice 2)", "conclusion": "failure", "details_url": "https://d/2"},
+    ])
+    ann = [{"path": "tests/x.py", "start_line": 1, "annotation_level": "failure",
+            "message": "KeyError: 'missing'", "title": "t"}]
+    # fmt: on
+    client = FakeClient([
+        (200, [pr]),
+        (200, checks),
+        (200, ann),  # check 1 -> key-error
+        (200, ann),  # check 2 -> key-error
+        (200, {"total_count": 0, "items": []}),  # single dedup search
+    ])
+    diag.diagnose_prs(dry_run=True, client=client, report_dir=report_dir)
+    searches = [u for m, u, _ in client.calls if m == "GET" and "/search/issues" in u]
+    assert len(searches) == 1  # one group -> one dedup search -> one issue


### PR DESCRIPTION
Automated evolution PR for issue #2952. The CI-diagnosis stage deduplicated only by PR number, so the same root-cause failure across check runs created separate near-identical issues (~22 open duplicates). This changes the dedup key to (PR, error_class) and creates one issue per distinct root cause.