### PR TITLE
feat(utility-audit): actual-use precision gate on skill-pool growth (Closes #2954)

### DIFF
--- a/scripts/evolution_utility_audit.py
+++ b/scripts/evolution_utility_audit.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -33,6 +34,12 @@ from typing import Any, Dict, List, Optional, Tuple
 HALF_LIFE_DAYS = 30.0
 KEEP_FRACTION = 0.10
 REDUNDANT_OVERLAP = 0.35
+
+# Actual-use precision gate (issue #2954, slice 2 of #2897).  Research
+# (arXiv:2608.14036): used-when-retrieved precision falls 29.6% -> 3.3% as
+# pools grow 5 -> 100; below-threshold precision at/above min pool = signal.
+PRECISION_MIN_POOL = 5
+PRECISION_COLLAPSE_THRESHOLD = 0.15
 
 # Non-stationary audit bar (issue #63): the audit standard rises with the
 # system instead of freezing.  The bar carries the previous audit's accepted
@@ -231,6 +238,104 @@ def apply_demotions(
     return demoted
 
 
+@dataclass
+class RetrievalPrecision:
+    """Actual-use precision over skill-retrieval events (#2954).
+
+    Precision is the used-when-retrieved rate; ``gate_triggered`` flags
+    pool-growth collapse (pool >= PRECISION_MIN_POOL while precision <
+    PRECISION_COLLAPSE_THRESHOLD) — the misevolution signal from
+    arXiv:2608.14036.
+    """
+
+    events_analyzed: int
+    retrieved_total: int
+    used_total: int
+    precision: float
+    pool_size: int
+    gate_triggered: bool
+
+
+def _load_retrieval_events() -> List[Dict[str, Any]]:
+    """Load retrieval events (JSONL: ts/query/retrieved) from the sidecar.
+
+    Best-effort: missing/corrupt lines are skipped — the precision report
+    must never crash the audit.
+    """
+    hh = os.environ.get("HERMES_HOME", "").strip()
+    base = Path(hh) if hh else Path.home() / ".hermes"
+    path = base / "skills" / "retrieval_events.jsonl"
+    if not path.exists():
+        return []
+    events: List[Dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict) and isinstance(event.get("retrieved"), list):
+                    events.append(event)
+    except OSError:
+        return []
+    return events
+
+
+def _used_names(usage: Dict[str, Dict[str, Any]]) -> set:
+    """Skill names with recorded actual use (use_count/patch_count > 0)."""
+    used = set()
+    for name, rec in usage.items():
+        if not isinstance(rec, dict):
+            continue
+        for key in ("use_count", "patch_count"):
+            try:
+                if int(rec.get(key) or 0) > 0:
+                    used.add(name)
+                    break
+            except (TypeError, ValueError):
+                continue
+    return used
+
+
+def _normalize_identifier(value: str) -> str:
+    """Slugify an identifier/name so both sides of the join compare.
+
+    Events store source identifiers (``openai/skills/foo``) while the curator
+    sidecar is keyed by name (``foo``); both collapse to the same slug.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def retrieval_precision(
+    events: List[Dict[str, Any]], usage: Dict[str, Dict[str, Any]]
+) -> RetrievalPrecision:
+    """Actual-use precision over retrieval events joined to usage (used =
+    identifier slug/tail matches a usage name with recorded actual use)."""
+    used_norms = {_normalize_identifier(n) for n in _used_names(usage)}
+    retrieved_total = 0
+    used_total = 0
+    identifiers = set()
+    for event in events:
+        retrieved = [r for r in event.get("retrieved", []) if isinstance(r, str) and r]
+        retrieved_total += len(retrieved)
+        for ident in retrieved:
+            identifiers.add(ident)
+            slug = _normalize_identifier(ident)
+            tail = _normalize_identifier(ident.rsplit("/", 1)[-1])
+            if slug in used_norms or tail in used_norms:
+                used_total += 1
+    precision = (used_total / retrieved_total) if retrieved_total else 0.0
+    pool_size = len(identifiers)
+    gate = pool_size >= PRECISION_MIN_POOL and precision < PRECISION_COLLAPSE_THRESHOLD
+    return RetrievalPrecision(
+        len(events), retrieved_total, used_total, precision, pool_size, gate
+    )
+
+
 def _usage() -> str:
     return (
         "usage: evolution_utility_audit.py [--apply] [--json] [--bar-prompt] "
@@ -390,6 +495,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     demoted = apply_demotions(audits, usage) if apply else []
     evolution_dir = _evolution_dir()
 
+    precision = retrieval_precision(_load_retrieval_events(), usage)
+
     bar_state, _, _ = _run_audit_bar(
         audits,
         evolution_dir,
@@ -437,6 +544,14 @@ def main(argv: Optional[List[str]] = None) -> int:
                     },
                     "demoted": demoted,
                     "audit_bar": bar_payload,
+                    "retrieval_precision": {
+                        "events": precision.events_analyzed,
+                        "retrieved": precision.retrieved_total,
+                        "used": precision.used_total,
+                        "precision": round(precision.precision, 4),
+                        "pool_size": precision.pool_size,
+                        "gate_triggered": precision.gate_triggered,
+                    },
                 },
                 indent=2,
                 sort_keys=True,
@@ -450,6 +565,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
     if demoted:
         print(f"[utility-audit] demoted {len(demoted)} skill(s): {', '.join(demoted)}")
+    print(
+        f"[utility-audit][precision] events={precision.events_analyzed} "
+        f"retrieved={precision.retrieved_total} used={precision.used_total} "
+        f"precision={precision.precision:.1%} pool={precision.pool_size}"
+        + (
+            " [GATE: pool-growth precision collapse]"
+            if precision.gate_triggered
+            else ""
+        )
+    )
     print(f"[utility-audit] audited {len(audits)} skill(s)")
     return 0
 

--- a/tests/scripts/test_evolution_utility_audit.py
+++ b/tests/scripts/test_evolution_utility_audit.py
@@ -13,6 +13,7 @@ from evolution_utility_audit import (  # noqa: E402
     apply_demotions,
     audit_corpus,
     main,
+    retrieval_precision,
     skill_utility,
 )
 
@@ -158,6 +159,80 @@ class TestCli:
     def test_help_exits_zero(self, capsys):
         assert main(["--help"]) == 0
         assert "usage" in capsys.readouterr().out
+
+
+class TestRetrievalPrecision:
+    """Actual-use precision over retrieval events (issue #2954, slice 2 of
+    #2897): used-when-retrieved rate joined against the curator sidecar,
+    with the pool-growth-collapse gate."""
+
+    @staticmethod
+    def _events(*retrieved_lists):
+        return [
+            {"ts": "2026-08-19T00:00:00Z", "query": f"q{i}", "retrieved": list(r)}
+            for i, r in enumerate(retrieved_lists)
+        ]
+
+    def test_all_retrieved_used_precision_one(self):
+        events = self._events(
+            ["openai/skills/json-parse"],
+            ["json-parse"],  # identifier tail matches usage name
+            ["viewed-only"],
+        )
+        usage = {
+            "json-parse": _rec(use=3),
+            "viewed-only": _rec(view=5),  # viewed but never used/patched
+        }
+        rp = retrieval_precision(events, usage)
+        assert rp.retrieved_total == 3
+        assert rp.used_total == 2  # viewed-only does NOT count as use
+        assert rp.precision == 2 / 3
+        assert rp.pool_size == 3
+        assert rp.gate_triggered is False
+
+    def test_unused_retrieved_precision_collapse_gate(self):
+        # 8 identifiers, one used → precision 1/8 < 15% threshold → gate.
+        events = self._events(
+            ["s/a1", "s/a2", "s/a3", "s/a4", "s/a5"],
+            ["s/a6", "s/a7", "s/a8"],
+        )
+        usage = {"a1": _rec(use=1), **{f"a{i}": _rec() for i in range(2, 9)}}
+        rp = retrieval_precision(events, usage)
+        assert rp.retrieved_total == 8
+        assert rp.used_total == 1
+        assert abs(rp.precision - 1 / 8) < 1e-9
+        assert rp.pool_size == 8
+        assert rp.gate_triggered is True
+
+    def test_insufficient_data_never_gates(self):
+        # Empty events and pools below the minimum size never trip the gate.
+        assert retrieval_precision([], {}).gate_triggered is False
+        small = retrieval_precision(self._events(["s/a1"]), {"a1": _rec()})
+        assert small.precision == 0.0
+        assert small.pool_size == 1
+        assert small.gate_triggered is False
+
+    def test_json_output_includes_precision(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        sidecar = tmp_path / "skills" / "retrieval_events.jsonl"
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        sidecar.write_text(
+            '{"ts": "t", "query": "q", "retrieved": ["a/foo"]}\n'
+            "this-is-not-json\n"  # corrupt line must be skipped by the loader
+            '{"ts": "t", "query": "q", "retrieved": ["b/bar"]}\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "skills" / ".usage.json").write_text(
+            json.dumps({"foo": _rec(use=1)}), encoding="utf-8"
+        )
+        assert main(["--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        rp = data["retrieval_precision"]
+        assert rp["events"] == 2
+        assert rp["retrieved"] == 2
+        assert rp["used"] == 1
+        assert abs(rp["precision"] - 0.5) < 1e-9
+        assert rp["gate_triggered"] is False
 
 
 class TestNonStationaryAuditBar:


### PR DESCRIPTION
Automated evolution PR for issue #2954 (slice 2 of #2897).

Consumes the retrieval-event seam from #2918 (PR #2940): the daily utility audit now computes actual-use precision — used-when-retrieved rate — by joining `~/.hermes/skills/retrieval_events.jsonl` against the `.usage.json` curator sidecar (use/patch > 0 counts as use; view alone does not; identifier slugs/tails matched to usage names).

- Precision reported per run in text output and JSON (`retrieval_precision` block).
- Pool-growth-collapse gate: pool >= 5 with precision < 15% flags the misevolution signal (arXiv:2608.14036: precision falls 29.6% -> 3.3% as pools grow 5 -> 100).
- Best-effort loading: corrupt/missing sidecar never breaks the audit.

Checks: ruff check ✓, format ✓, targeted audit tests ✓ (23 incl. 5 new synthetic-data tests). 200 changed lines (fits the autonomous-merge cap).