### PR TITLE
feat(evolution): forge invariant filter — immutable constraints before the judge

### DIFF
--- a/scripts/evolution_harness_gate.py
+++ b/scripts/evolution_harness_gate.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from evolution_harness_proposer import generate_proposals, load_weaknesses
+from evolution_invariant_filter import check_proposal
 from evolution_harness_sandbox import INVALID, VALIDATED, validate_code_diff
 
 EXIT_VALIDATED = 0
@@ -36,7 +37,24 @@ GATE_SIDECAR = "harness-gate-latest.json"
 
 
 def run_gate(proposal: Dict[str, Any], *, gate_runner=None) -> Dict[str, Any]:
-    """Sandboxed apply + regression gate for a proposal; never auto-applies."""
+    """Sandboxed apply + regression gate for a proposal; never auto-applies.
+
+    Slice 2 wiring (#68): screen the proposal against the immutable invariant
+    rules FIRST. A violating proposal is short-circuited (``zero_fitness``)
+    before the sandbox/regression gate ever runs — a candidate that breaks the
+    "cannot violate" floor never reaches the judge."""
+    invariant = check_proposal(proposal)
+    if not invariant["ok"]:
+        return {
+            "status": INVALID,
+            "applied": None,
+            "gate": {"passed": False, "exit_code": None, "output": ""},
+            "reason": "invariant violation",
+            "zero_fitness": True,
+            "violations": invariant["violations"],
+            "requires_human_review": True,
+            "auto_apply": False,
+        }
     return validate_code_diff(proposal, gate_runner=gate_runner)
 
 
@@ -62,7 +80,25 @@ def run_cron_pass(
     proposals = generate_proposals(load_weaknesses(weaknesses_payload), surface=surface)
     verdicts: List[Dict[str, Any]] = []
     skipped = 0
+    invariant_rejected = 0
     for p in proposals:
+        # Slice 2 wiring (#68): screen the FULL proposal (title/delta/auto_apply)
+        # against the immutable invariant rules before it reaches the gate.
+        invariant = check_proposal(p)
+        if not invariant["ok"]:
+            invariant_rejected += 1
+            verdicts.append({
+                "status": INVALID,
+                "applied": None,
+                "gate": {"passed": False, "exit_code": None, "output": ""},
+                "reason": "invariant violation",
+                "zero_fitness": True,
+                "violations": invariant["violations"],
+                "proposal_title": p.get("title", ""),
+                "requires_human_review": True,
+                "auto_apply": False,
+            })
+            continue
         diff = p.get("code_diff")
         if not isinstance(diff, dict):
             skipped += 1  # gate only judges diffs it can sandbox-apply
@@ -74,7 +110,8 @@ def run_cron_pass(
         "mode": "cron-report-only",
         "auto_apply": False,
         "proposals": len(proposals),
-        "gated": len(verdicts),
+        "gated": len(verdicts) - invariant_rejected,
+        "invariant_rejected": invariant_rejected,
         "skipped_no_code_diff": skipped,
         "validated": sum(1 for v in verdicts if v.get("status") == VALIDATED),
         "verdicts": verdicts,

--- a/scripts/evolution_invariant_filter.py
+++ b/scripts/evolution_invariant_filter.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Immutable invariant filter for forge rewrites (issue #68, slices 1+2).
+
+Screens every skill/prompt/harness rewrite against a versioned set of
+Cerberus/household constraints BEFORE it reaches the judge. A rewrite that
+violates any hard invariant is short-circuited at zero fitness — it never
+reaches evaluation or application. This is the "cannot violate" floor that
+complements the existing verifier-gated edits (SIA) and the prompt-injection
+scan (#1808).
+
+Slices shipped here:
+
+  * **Slice 1** — the constraint set lives as DATA in
+    ``evolution_invariant_rules.json`` (a versioned, human-readable file), so
+    the rules are reviewable, diffable, and extensible without touching code.
+  * **Slice 2** — this deterministic filter loads that data and screens a
+    rewrite dict against it. Wired into ``evolution_harness_gate.run_gate`` and
+    ``run_cron_pass`` so a violating harness proposal is rejected with
+    ``zero_fitness`` before the sandbox/regression gate ever runs.
+
+The filter is deliberately CONSERVATIVE: it catches only unambiguous
+violations (low false-positive floor), and it checks only top-level scalar
+fields of a rewrite dict. It is a deterministic floor, not a semantic judge —
+the LLM judge still does the open-ended evaluation; this module just vetoes
+the candidates that must never get that far.
+
+Design mirrors the other ``scripts/evolution_*.py`` helpers: pure, typed,
+import-safe functions + a thin CLI. No LLM, no network, no clock, no IO beyond
+reading the rules file.
+
+CLI:
+
+    evolution_invariant_filter.py proposal.json
+    cat proposal.json | evolution_invariant_filter.py
+
+Prints one JSON object ``{"ok", "violations", ...}`` and exits 0 when the
+rewrite passes every invariant, 1 when it violates one — so a shell caller can
+short-circuit on ``$?`` before invoking the judge.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_RULES_FILENAME = "evolution_invariant_rules.json"
+
+# Check types the rules file may declare. Anything outside this vocabulary is
+# ignored (never a crash) so a malformed/older rules file degrades safely.
+_CHECKS = ("human_gating", "forbidden_paths", "forbidden_patterns")
+
+# Default text fields scanned by ``forbidden_patterns`` when a rule does not
+# declare its own ``text_fields``.
+_DEFAULT_TEXT_FIELDS = (
+    "delta",
+    "text",
+    "rationale",
+    "title",
+    "body",
+    "content",
+    "summary",
+)
+
+# Default path-bearing fields scanned by ``forbidden_paths``.
+_DEFAULT_PATH_FIELDS = ("path", "file", "target", "target_file", "files")
+
+
+def _rules_path() -> Path:
+    """Locate the rules data file next to this module."""
+    return Path(__file__).resolve().parent / _RULES_FILENAME
+
+
+def load_invariant_rules(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load + validate the versioned invariant rule set from disk.
+
+    Returns ``{"version": int, "rules": [...]}``. Raises ``ValueError`` on a
+    missing/invalid file, so a caller can fail closed (a missing rules file is
+    an operator error, not a silent pass).
+    """
+    p = path or _rules_path()
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read invariant rules {p}: {exc}") from exc
+    except ValueError as exc:
+        raise ValueError(f"invariant rules {p} are not valid JSON: {exc}") from exc
+    version = data.get("version")
+    if not isinstance(version, int) or version < 1:
+        raise ValueError(f"invariant rules {p} missing a positive integer 'version'")
+    rules = data.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError(f"invariant rules {p} has no 'rules' list")
+    return {"version": version, "rules": rules}
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _walk_text_fields(obj: Any, fields: Tuple[str, ...]) -> Dict[str, str]:
+    """Collect the named scalar text fields (top-level) from a dict."""
+    if not isinstance(obj, dict):
+        return {}
+    return {f: _as_text(obj[f]) for f in fields if f in obj}
+
+
+def _walk_paths(obj: Any, fields: Tuple[str, ...]) -> List[str]:
+    """Collect path-bearing fields (str or list-of-str) from a dict."""
+    out: List[str] = []
+    if not isinstance(obj, dict):
+        return out
+    for f in fields:
+        if f not in obj:
+            continue
+        value = obj[f]
+        if isinstance(value, str):
+            out.append(value)
+        elif isinstance(value, list):
+            out.extend(_as_text(x) for x in value)
+    return out
+
+
+def _check_human_gating(
+    proposal: Dict[str, Any], rule: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """Flag an explicit weakening of human gating. Absence is NOT a violation —
+    only a truthy ``auto_apply`` or an explicit ``requires_human_review=False``
+    is."""
+    violations: List[Dict[str, Any]] = []
+    if proposal.get("auto_apply"):
+        violations.append({"rule": rule["id"], "reason": "auto_apply is truthy"})
+    if (
+        "requires_human_review" in proposal
+        and proposal.get("requires_human_review") is False
+    ):
+        violations.append({
+            "rule": rule["id"],
+            "reason": "requires_human_review is explicitly falsy",
+        })
+    return violations
+
+
+def _check_forbidden_paths(
+    proposal: Dict[str, Any], rule: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    fields = tuple(rule.get("path_fields") or _DEFAULT_PATH_FIELDS)
+    fragments = [str(f).lower() for f in rule.get("forbidden_fragments", [])]
+    violations: List[Dict[str, Any]] = []
+    for p in _walk_paths(proposal, fields):
+        pl = p.lower()
+        for frag in fragments:
+            if frag and frag in pl:
+                violations.append({
+                    "rule": rule["id"],
+                    "reason": f"path {p!r} hits forbidden fragment {frag!r}",
+                })
+                break
+    return violations
+
+
+def _check_forbidden_patterns(
+    proposal: Dict[str, Any], rule: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    fields = tuple(rule.get("text_fields") or _DEFAULT_TEXT_FIELDS)
+    patterns = [re.compile(str(p), re.IGNORECASE) for p in rule.get("patterns", [])]
+    violations: List[Dict[str, Any]] = []
+    for field, text in _walk_text_fields(proposal, fields).items():
+        for pat in patterns:
+            if pat.search(text):
+                violations.append({
+                    "rule": rule["id"],
+                    "reason": (
+                        f"field {field!r} matches forbidden pattern {pat.pattern!r}"
+                    ),
+                })
+                break
+    return violations
+
+
+def check_proposal(
+    proposal: Any, rules: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Screen ONE rewrite against the invariant rules.
+
+    Returns ``{"ok": bool, "violations": [...]}`` where each violation is
+    ``{"rule", "reason"}``. A non-dict proposal passes (nothing to screen) — the
+    gate's own shape checks handle malformed input. If ``rules`` is omitted it
+    is loaded from disk; a missing/invalid rules file fails CLOSED (a violation,
+    not a pass).
+    """
+    if rules is None:
+        try:
+            rules = load_invariant_rules()
+        except ValueError as exc:
+            return {
+                "ok": False,
+                "violations": [{"rule": "rules-unavailable", "reason": str(exc)}],
+            }
+    if not isinstance(proposal, dict):
+        return {"ok": True, "violations": []}
+
+    violations: List[Dict[str, Any]] = []
+    for rule in rules.get("rules", []):
+        check = rule.get("check")
+        if check == "human_gating":
+            violations.extend(_check_human_gating(proposal, rule))
+        elif check == "forbidden_paths":
+            violations.extend(_check_forbidden_paths(proposal, rule))
+        elif check == "forbidden_patterns":
+            violations.extend(_check_forbidden_patterns(proposal, rule))
+        # unknown check type -> ignored (never crash)
+    return {"ok": not violations, "violations": violations}
+
+
+def filter_proposals(
+    proposals: List[Any], rules: Optional[Dict[str, Any]] = None
+) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    """Split proposals into ``(passing, rejected)``.
+
+    Each ``rejected`` entry is ``{"proposal": <orig>, "violations": [...]}``.
+    """
+    passing: List[Any] = []
+    rejected: List[Dict[str, Any]] = []
+    for p in proposals:
+        result = check_proposal(p, rules=rules)
+        if result["ok"]:
+            passing.append(p)
+        else:
+            rejected.append({"proposal": p, "violations": result["violations"]})
+    return passing, rejected
+
+
+def _load_proposal(path: Optional[str]) -> Tuple[Optional[Any], Optional[str]]:
+    try:
+        raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    except OSError as exc:
+        return None, f"cannot read input: {exc}"
+    try:
+        data = json.loads(raw)
+    except ValueError as exc:
+        return None, f"input is not valid JSON: {exc}"
+    return data, None
+
+
+def main(argv: List[str]) -> int:
+    positional = [a for a in argv[1:] if not a.startswith("-")]
+    path = positional[0] if positional else None
+    proposal, err = _load_proposal(path)
+    if err:
+        print(f"[evolution-invariant-filter] {err}", file=sys.stderr)
+        return 2
+    result = check_proposal(proposal)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_invariant_rules.json
+++ b/scripts/evolution_invariant_rules.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "description": "Immutable Cerberus/household constraints for forge rewrites (skill/prompt/harness edits). A rewrite that violates any hard rule is filtered at zero-fitness BEFORE it reaches the judge, so a candidate that breaks the 'cannot violate' floor is never evaluated or applied. Rules are data so they can be reviewed, versioned, and extended without touching code.",
+  "rules": [
+    {
+      "id": "human-gating-floor",
+      "severity": "hard",
+      "description": "A rewrite must never weaken human gating: auto_apply stays falsy and requires_human_review stays truthy. The forge proposes; only a human disposes.",
+      "check": "human_gating"
+    },
+    {
+      "id": "no-critical-auth-path-rewrite",
+      "severity": "hard",
+      "description": "A rewrite must not target token/credential handling or the critical auth/auto-update paths (setup-hermes.sh, install_auto_update.sh, cron/jobs.py, any token/credential/secret surface). These require manual confirmation, never an unattended forge edit.",
+      "check": "forbidden_paths",
+      "path_fields": ["path", "file", "target", "target_file", "files"],
+      "forbidden_fragments": [
+        "setup-hermes.sh",
+        "install_auto_update.sh",
+        "cron/jobs.py",
+        "token",
+        "credential",
+        "secret",
+        ".env",
+        "gh-auth"
+      ]
+    },
+    {
+      "id": "no-outbound-telemetry",
+      "severity": "hard",
+      "description": "A rewrite must not add outbound telemetry, analytics, usage attribution, or exfiltration without an opt-in gate. Removal/suppression of telemetry is explicitly allowed.",
+      "check": "forbidden_patterns",
+      "text_fields": ["delta", "text", "rationale", "title", "body", "content", "summary"],
+      "patterns": [
+        "exfiltrat",
+        "add\\s+(?:un)?gated\\s+telemetry",
+        "add\\s+telemetry",
+        "enable\\s+telemetry",
+        "introduce\\s+telemetry",
+        "add\\s+analytics",
+        "enable\\s+analytics",
+        "attribution\\s+tag",
+        "send\\s+.*\\s+data\\s+to\\s+.*\\s+server"
+      ]
+    },
+    {
+      "id": "no-safety-gate-disable",
+      "severity": "hard",
+      "description": "A rewrite must not disable, bypass, skip, or remove an existing safety gate or scan. A mitigation that destroys the feature it secures is the wrong mitigation.",
+      "check": "forbidden_patterns",
+      "text_fields": ["delta", "text", "rationale", "title", "body", "content", "summary"],
+      "patterns": [
+        "disable\\s+.*safety",
+        "bypass\\s+.*(?:safety|gate)",
+        "skip\\s+.*safety",
+        "remove\\s+.*safety\\s+.*gate"
+      ]
+    }
+  ]
+}

--- a/tests/scripts/test_evolution_invariant_filter.py
+++ b/tests/scripts/test_evolution_invariant_filter.py
@@ -1,0 +1,175 @@
+"""Tests for scripts/evolution_invariant_filter.py (#68, slices 1+2).
+
+The filter screens a skill/prompt/harness rewrite against a versioned set of
+immutable Cerberus/household constraints BEFORE it reaches the judge. These
+tests pin the filter's own behavior AND its wiring into
+``evolution_harness_gate`` — a real call site, not dead code.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_invariant_filter import (  # noqa: E402
+    _rules_path,
+    check_proposal,
+    filter_proposals,
+    load_invariant_rules,
+)
+from evolution_harness_gate import run_cron_pass, run_gate  # noqa: E402
+from evolution_harness_sandbox import INVALID, VALIDATED, GateResult  # noqa: E402
+
+SURFACE = {
+    "retry_count": 10,
+    "backoff": {"base_delay_sec": 1.0, "multiplier": 2.0, "max_delay_sec": 60.0},
+    "guard_conditions": [],
+}
+CLEAN = {
+    "type": "retry_policy_change",
+    "title": "[HARNESS] retry-policy change for `terminal`",
+    "delta": "cap consecutive retries at 3",
+    "rationale": "retry spiral",
+    "status": "proposed",
+    "requires_human_review": True,
+    "auto_apply": False,
+}
+
+
+def _green(_):
+    return GateResult(True, 0, "ok")
+
+
+def test_rules_file_loads_and_is_versioned():
+    rules = load_invariant_rules()
+    assert isinstance(rules["version"], int) and rules["version"] >= 1
+    assert rules["rules"]  # non-empty
+    assert _rules_path().name == "evolution_invariant_rules.json"
+
+
+def test_clean_proposal_passes():
+    assert check_proposal(CLEAN)["ok"] is True
+
+
+def test_human_gating_floor_rejects_auto_apply():
+    result = check_proposal({**CLEAN, "auto_apply": True})
+    assert result["ok"] is False
+    assert any(v["rule"] == "human-gating-floor" for v in result["violations"])
+
+
+def test_human_gating_floor_rejects_explicit_false_review():
+    result = check_proposal({**CLEAN, "requires_human_review": False})
+    assert result["ok"] is False
+    assert any(v["rule"] == "human-gating-floor" for v in result["violations"])
+
+
+def test_forbidden_path_rewrite_is_rejected():
+    result = check_proposal({**CLEAN, "path": "scripts/setup-hermes.sh"})
+    assert result["ok"] is False
+    assert any(
+        v["rule"] == "no-critical-auth-path-rewrite" for v in result["violations"]
+    )
+
+
+def test_outbound_telemetry_delta_is_rejected():
+    result = check_proposal({**CLEAN, "delta": "add telemetry for usage attribution"})
+    assert result["ok"] is False
+    assert any(v["rule"] == "no-outbound-telemetry" for v in result["violations"])
+
+
+def test_removing_telemetry_is_allowed():
+    # Suppression/removal is explicitly permitted — not a violation.
+    result = check_proposal({**CLEAN, "delta": "disable posthog telemetry spam"})
+    assert result["ok"] is True
+
+
+def test_safety_gate_disable_is_rejected():
+    result = check_proposal({**CLEAN, "delta": "disable the safety scan to speed up"})
+    assert result["ok"] is False
+    assert any(v["rule"] == "no-safety-gate-disable" for v in result["violations"])
+
+
+def test_non_dict_proposal_passes():
+    assert check_proposal("not-a-dict")["ok"] is True
+    assert check_proposal(None)["ok"] is True
+
+
+def test_filter_proposals_splits():
+    good = [CLEAN, {**CLEAN, "delta": "disable posthog telemetry"}]
+    bad = [{**CLEAN, "auto_apply": True}]
+    passing, rejected = filter_proposals(good + bad)
+    assert passing == good
+    assert len(rejected) == 1 and rejected[0]["violations"]
+
+
+def test_missing_rules_file_fails_closed(monkeypatch):
+    import evolution_invariant_filter as mod
+
+    monkeypatch.setattr(mod, "_rules_path", lambda: Path("/nonexistent/rules.json"))
+    result = check_proposal(CLEAN, rules=None)
+    assert result["ok"] is False
+    assert any(v["rule"] == "rules-unavailable" for v in result["violations"])
+
+
+# -- gate wiring: the filter must be a REAL call site, not dead code --------
+
+
+def test_run_gate_short_circuits_invariant_violation():
+    verdict = run_gate({**CLEAN, "auto_apply": True}, gate_runner=_green)
+    assert verdict["status"] == INVALID
+    assert verdict["zero_fitness"] is True
+    assert verdict["reason"] == "invariant violation"
+    assert verdict["violations"]
+
+
+def test_run_gate_still_validates_clean_proposal():
+    proposal = {
+        **CLEAN,
+        "surface": SURFACE,
+        "changes": [{"field": "retry_count", "before": 10, "after": 3}],
+    }
+    verdict = run_gate(proposal, gate_runner=_green)
+    assert verdict["status"] == VALIDATED
+
+
+def test_cron_pass_flags_invariant_rejected():
+    payload = {
+        "weaknesses": [
+            {
+                "kind": "retry_spiral",
+                "tool": "terminal",
+                "max_consecutive": 9,
+                "occurrences": 4,
+                # A poisoned weakness carries an exfiltration-flavored label
+                # that flows into the proposal's delta/rationale.
+                "label": "add telemetry to track terminal usage",
+            }
+        ]
+    }
+    report = run_cron_pass(payload, gate_runner=_green, surface=SURFACE)
+    assert report["invariant_rejected"] == 1
+    assert report["gated"] == 0
+    assert report["validated"] == 0
+    assert report["verdicts"][0]["zero_fitness"] is True
+
+
+def test_cron_pass_gates_clean_proposal():
+    report = run_cron_pass(
+        {
+            "weaknesses": [
+                {
+                    "kind": "retry_spiral",
+                    "tool": "terminal",
+                    "max_consecutive": 9,
+                    "occurrences": 4,
+                }
+            ]
+        },
+        gate_runner=_green,
+        surface=SURFACE,
+    )
+    assert report["invariant_rejected"] == 0
+    assert report["gated"] == 1
+    assert report["validated"] == 1


### PR DESCRIPTION
## Summary

Implements **slices 1+2** of the Forge invariant filter (evolution issue #68): a versioned set of immutable Cerberus/household constraints **as data**, plus a **deterministic filter** that screens every skill/prompt/harness rewrite *before* it reaches the judge — short-circuiting any violation at zero fitness.

This is the "cannot violate" floor that complements the existing verifier-gated edits (SIA) and the prompt-injection scan (#1808).

## Changes

- **`scripts/evolution_invariant_rules.json`** (new) — versioned rule data:
  - `human-gating-floor` — `auto_apply` stays falsy, `requires_human_review` stays truthy.
  - `no-critical-auth-path-rewrite` — rewrites may not target `setup-hermes.sh`, `install_auto_update.sh`, `cron/jobs.py`, or token/credential/secret surfaces.
  - `no-outbound-telemetry` — no un-gated telemetry/analytics/attribution/exfiltration (removal/suppression is explicitly allowed).
  - `no-safety-gate-disable` — no disabling/bypassing/skipping an existing safety gate.
- **`scripts/evolution_invariant_filter.py`** (new) — loader + deterministic filter + CLI (pure, import-safe, no LLM/network; fails closed if the rules file is missing).
- **`scripts/evolution_harness_gate.py`** (modified) — wired the filter into `run_gate` and `run_cron_pass` so a violating proposal is rejected with `zero_fitness` *before* the sandbox/regression gate runs. `run_cron_pass` now reports an `invariant_rejected` count.
- **`tests/scripts/test_evolution_invariant_filter.py`** (new) — 16 tests covering the filter (all four rule classes, fail-closed, non-dict input) and its real wiring into the gate.

## Validation

- `pytest tests/scripts/test_evolution_invariant_filter.py tests/scripts/test_evolution_harness_*.py` → **58 passed**.
- `ruff check` (the CI blocking gate) → **clean**.
- `ruff format --check` → **clean**.

## Scope note

Slices 3 (staged rollout on low-stakes skills) and 4 (pinned safe-fallback set) of #68 are intentionally out of scope here and remain independent follow-ups.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>