### PR TITLE
fix: lower DeepSeek v4 non-streaming stale-timeout floors (Closes #81)

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -70,10 +70,18 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # DeepSeek — R1 and V4 reasoning models on hosted NIM / DeepSeek direct.
     # V4 series emits reasoning_content in a separate delta field before
     # final content, requiring the same extended stale timeout floor.
+    # 2026-08-20 (evolution deepseek-failfast-verify): the 600s floor for the
+    # V4 series was empirically excessive — deepseek-v4-flash turns in this
+    # fleet complete in 3-9s (agent.log latency column), and a hung provider
+    # call was instead stalling the whole turn for the full 600s before the
+    # stale detector fired (three such 600s stalls in the 08-18/08-19 window).
+    # v4-flash keeps a 180s floor (equals the stream stale-detector default);
+    # v4-pro — the deeper-thinking variant — keeps a 300s floor. R1/reasoner
+    # genuinely need the extended thinking phase and stay at 600.
     ("deepseek-r1", 600),
     ("deepseek-reasoner", 600),
-    ("deepseek-v4-flash", 600),
-    ("deepseek-v4-pro", 600),
+    ("deepseek-v4-flash", 180),
+    ("deepseek-v4-pro", 300),
     # Qwen — QwQ reasoning + Qwen3 thinking variants.  QwQ-32B
     # preview is the stable slug; ``qwen3`` covers the family of
     # thinking-mode Qwen3 models (qwen3-235b-a22b, qwen3-32b, etc.)
@@ -201,10 +209,10 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     300.0
     >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-r1")
     600.0
-    >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-flash")
-    600.0
-    >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-pro")
-    600.0
+    >>> get_reasoning_stale_timeout_floor('deepseek/deepseek-v4-flash')
+    180.0
+    >>> get_reasoning_stale_timeout_floor('deepseek/deepseek-v4-pro')
+    300.0
     >>> get_reasoning_stale_timeout_floor("qwen/qwen3-235b-a22b-thinking")
     180.0
     >>> get_reasoning_stale_timeout_floor("x-ai/grok-4-fast-reasoning")

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -47,14 +47,17 @@ import pytest
     ("nvidia/nemotron-3-super-120b-a12b", 600.0),
     ("nvidia/nemotron-3-nano-30b-a3b", 300.0),
     # DeepSeek R1 + DeepSeek reasoner + V4 reasoning series.
-    # V4 emits reasoning_content in a separate delta before final
-    # content (same shape as R1), so it needs the same 600s floor.
+    # R1/reasoner genuinely need the extended thinking phase (600s).
+    # V4 turns in this fleet complete in 3-9s (agent.log latency), so the
+    # 600s floor only made a hung provider call stall the whole turn —
+    # evolution issue #81: v4-flash floor lowered to the stream
+    # stale-detector default (180s), v4-pro keeps headroom at 300s.
     ("deepseek/deepseek-r1", 600.0),
     ("deepseek/deepseek-r1-distill-llama-70b", 600.0),
     ("deepseek/deepseek-reasoner", 600.0),
-    ("deepseek/deepseek-v4-flash", 600.0),
-    ("deepseek/deepseek-v4-pro", 600.0),
-    ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
+    ("deepseek/deepseek-v4-flash", 180.0),
+    ("deepseek/deepseek-v4-pro", 300.0),
+    ("deepseek-v4-flash-free", 180.0),   # catalog -free variant inherits via separator anchor
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),


### PR DESCRIPTION
Automated evolution PR for issue #81 — DeepSeek v4 non-streaming timeout floors too long.

Fleet evidence (agent.log latency): v4-flash turns complete in 3-9s; three 600s stalls in the 08-18/08-19 window were hung provider calls stalling the full 600s before the stale detector fired. v4-flash floor 600→180s (stream stale-detector default), v4-pro 600→300s; R1/reasoner unchanged at 600s.

Local validation: tests/agent/test_reasoning_stale_timeout_floor.py 63 passed (anthropic dep installed locally); ruff check clean; doctests pass.