### PR TITLE
feat(delegation): attribution markers for subagent artifacts (Closes #67)

### DIFF
--- a/tests/tools/test_delegation_attribution.py
+++ b/tests/tools/test_delegation_attribution.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""Tests for delegation attribution markers (issue #67, slice 1).
+
+Covers the canonical marker format (build / parse / embed) and the real
+call-site wiring in :func:`tools.delegate_tool._build_child_system_prompt`:
+every delegated child's system prompt carries its attribution stamp and the
+artifact-stamping instruction, while a prompt built without a stamp is
+byte-identical in shape to the pre-#67 behavior (no ATTRIBUTION section).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.delegation_attribution import (
+    ATTRIBUTION_MARKER,
+    AttributionStamp,
+    attribution_prompt_block,
+    build_attribution_stamp,
+    parse_attribution_stamp,
+    stamp_for_artifact_header,
+)
+
+
+class TestBuildStamp:
+    def test_first_level_child_marks_parent_root(self):
+        stamp = build_attribution_stamp(subagent_id="sa-0-abc12345")
+        assert stamp.startswith(ATTRIBUTION_MARKER)
+        assert "subagent_id=sa-0-abc12345" in stamp
+        assert "parent=root" in stamp
+        assert "task_index=-" in stamp
+
+    def test_nested_child_marks_parent_subagent(self):
+        stamp = build_attribution_stamp(
+            subagent_id="sa-1-def67890",
+            parent_subagent_id="sa-0-abc12345",
+            task_index=3,
+        )
+        assert "parent=sa-0-abc12345" in stamp
+        assert "task_index=3" in stamp
+
+    def test_spawned_at_can_be_pinned(self):
+        stamp = build_attribution_stamp(
+            subagent_id="sa-0-x", spawned_at="2026-08-20T10:00:00+00:00"
+        )
+        assert "spawned_at=2026-08-20T10:00:00+00:00" in stamp
+
+    def test_rejects_empty_subagent_id(self):
+        with pytest.raises(ValueError):
+            build_attribution_stamp(subagent_id="")
+
+
+class TestParseStamp:
+    def test_roundtrip(self):
+        original = build_attribution_stamp(
+            subagent_id="sa-7-feedbeef",
+            parent_subagent_id="sa-2-cafebabe",
+            task_index=7,
+        )
+        parsed = parse_attribution_stamp(original)
+        assert parsed is not None
+        assert parsed.subagent_id == "sa-7-feedbeef"
+        assert parsed.parent_subagent_id == "sa-2-cafebabe"
+        assert parsed.task_index == 7
+        assert parsed.spawned_at  # non-empty ISO timestamp
+
+    def test_root_parent_parses_to_none(self):
+        stamp = build_attribution_stamp(subagent_id="sa-0-rootkid")
+        parsed = parse_attribution_stamp(stamp)
+        assert parsed is not None
+        assert parsed.parent_subagent_id is None
+
+    def test_non_marker_text_returns_none(self):
+        for bad in (None, "", "random text", "HERMES-SUBAGENT", "# a comment"):
+            assert parse_attribution_stamp(bad) is None
+
+    def test_malformed_marker_returns_none(self):
+        # Marker present but no subagent_id key.
+        assert parse_attribution_stamp(f"{ATTRIBUTION_MARKER} parent=root") is None
+
+    def test_extra_keys_ignored(self):
+        parsed = parse_attribution_stamp(
+            f"{ATTRIBUTION_MARKER} subagent_id=sa-0-x future_key=whatever"
+        )
+        assert parsed is not None
+        assert parsed.subagent_id == "sa-0-x"
+
+
+class TestEmbedding:
+    def test_prompt_block_carries_marker_and_instruction(self):
+        stamp = build_attribution_stamp(subagent_id="sa-0-xyz")
+        block = attribution_prompt_block(stamp)
+        assert ATTRIBUTION_MARKER in block
+        assert "sa-0-xyz" in block
+        assert "Stamp every artifact" in block
+
+    def test_artifact_header_line(self):
+        stamp = build_attribution_stamp(subagent_id="sa-0-xyz")
+        header = stamp_for_artifact_header(stamp)
+        assert header.startswith("# ")
+        assert ATTRIBUTION_MARKER in header
+
+
+class TestDelegateToolWiring:
+    """Integration with the real call site (the child system prompt)."""
+
+    def test_child_prompt_carries_attribution_when_stamped(self):
+        from tools.delegate_tool import _build_child_system_prompt
+
+        stamp = build_attribution_stamp(
+            subagent_id="sa-5-integration", parent_subagent_id=None, task_index=5
+        )
+        prompt = _build_child_system_prompt(
+            "Do the thing",
+            context="Some context",
+            attribution=stamp,
+        )
+        assert "ATTRIBUTION:" in prompt
+        assert stamp in prompt
+        assert "Do the thing" in prompt
+        assert "Some context" in prompt
+
+    def test_child_prompt_unchanged_without_attribution(self):
+        from tools.delegate_tool import _build_child_system_prompt
+
+        prompt = _build_child_system_prompt("Do the thing", context="Some context")
+        assert "ATTRIBUTION:" not in prompt
+        assert ATTRIBUTION_MARKER not in prompt
+        assert "Do the thing" in prompt
+        assert "Some context" in prompt
+
+    def test_attribution_stamp_roundtrip_through_prompt(self):
+        """The marker embedded in a prompt is still parseable (verifiability)."""
+        from tools.delegate_tool import _build_child_system_prompt
+
+        stamp = build_attribution_stamp(subagent_id="sa-9-parseback", task_index=2)
+        prompt = _build_child_system_prompt("Go", attribution=stamp)
+        # Pull the marker line out of the prompt and parse it back.
+        line = next(
+            line for line in prompt.splitlines() if line.startswith(ATTRIBUTION_MARKER)
+        )
+        parsed = parse_attribution_stamp(line)
+        assert parsed is not None
+        assert parsed.subagent_id == "sa-9-parseback"
+        assert parsed.task_index == 2

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -37,6 +37,10 @@ from urllib.parse import urlsplit, urlunsplit
 
 from toolsets import TOOLSETS
 from agent.interrupt_compat import request_hard_interrupt
+from tools.delegation_attribution import (
+    attribution_prompt_block,
+    build_attribution_stamp,
+)
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -1417,6 +1421,7 @@ def _build_child_system_prompt(
     max_spawn_depth: int = 2,
     child_depth: int = 1,
     denied_toolsets: Optional[List[str]] = None,
+    attribution: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -1440,12 +1445,23 @@ def _build_child_system_prompt(
     the prompt, rather than fixed by relaxing the parent-toolset
     intersection: that intersection is a security boundary (no privilege
     escalation via delegation), not a bug.
+
+    ``attribution`` (#67, slice 1): an optional canonical attribution
+    marker line (see :mod:`tools.delegation_attribution`). When present,
+    the child is told its run identity and instructed to stamp the
+    marker on every artifact it produces (file headers, commit bodies,
+    PR titles), making parallel-agent work traceable to the exact run.
+    Built at the spawn site, where the subagent identity is known.
     """
     parts = [
         "You are a focused subagent working on a specific delegated task.",
         "",
         f"YOUR TASK:\n{goal}",
     ]
+    if attribution and str(attribution).strip():
+        parts.append(
+            f"\nATTRIBUTION:\n{attribution_prompt_block(str(attribution).strip())}"
+        )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -2115,6 +2131,16 @@ def _build_child_agent(
                 _seen_denied.add(t)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    # Attribution (#67, slice 1): stamp this child run with its identity so
+    # every artifact it produces can be traced back to this exact delegation.
+    # parent_subagent_id is non-None exactly when the parent is itself a
+    # subagent (nested orchestrator -> worker chains), which is the attribution
+    # chain the red-team research calls out as untraceable.
+    _attribution_stamp = build_attribution_stamp(
+        subagent_id=subagent_id,
+        parent_subagent_id=parent_subagent_id,
+        task_index=task_index,
+    )
     child_prompt = _build_child_system_prompt(
         goal,
         context,
@@ -2123,6 +2149,7 @@ def _build_child_agent(
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
         denied_toolsets=denied_toolsets,
+        attribution=_attribution_stamp,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)

--- a/tools/delegation_attribution.py
+++ b/tools/delegation_attribution.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""Delegation attribution markers (issue #67, slice 1).
+
+Anthropic's multiagent red-team research (the source of #67) found that in
+parallel-agent runs, work becomes untraceable the moment two agents touch the
+same repo: shared-file conflicts, abandoned PRs, and turf wars all start with
+"whose artifact is this?". Slice 1 of the guardrails proposal is the smallest
+self-contained fix: give every subagent a traceable origin identity and make
+it stamp that identity on everything it produces.
+
+This module defines the canonical marker format. The marker is:
+
+    HERMES-SUBAGENT-ATTRIBUTION subagent_id=<id> parent=<id|root> task_index=<n|-> spawned_at=<ISO8601>
+
+``subagent_id`` is the child's own identity (stable across all its events),
+``parent`` is the spawning agent's subagent id (or ``root`` for a
+first-level child), and ``spawned_at`` pins the run. The marker is
+deliberately a single line with ``key=value`` pairs so it is:
+
+* greppable — ``grep HERMES-SUBAGENT-ATTRIBUTION <file>`` finds every
+  artifact a given subagent produced;
+* parseable — :func:`parse_attribution_stamp` round-trips it back into a
+  structured form for verification tooling;
+* embeddable — fits on one line in a file header, commit body, or PR body.
+
+The wiring lives in :mod:`tools.delegate_tool`: every delegated child's
+system prompt now carries its attribution stamp plus the instruction to
+include the marker in files it creates, commit bodies, and PR titles.
+
+Stdlib-only and import-safe (no side effects on import) — consistent with
+the other standalone tools modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+__all__ = [
+    "ATTRIBUTION_MARKER",
+    "AttributionStamp",
+    "attribution_prompt_block",
+    "build_attribution_stamp",
+    "parse_attribution_stamp",
+    "stamp_for_artifact_header",
+]
+
+#: The canonical marker token. Everything after it is ``key=value`` pairs.
+ATTRIBUTION_MARKER = "HERMES-SUBAGENT-ATTRIBUTION"
+
+#: Keys serialized in the canonical stamp line, in order.
+_STAMP_KEYS = ("subagent_id", "parent", "task_index", "spawned_at")
+
+#: How a subagent should stamp the artifacts it produces — this text rides
+#: in the child's system prompt, so the model stamps rather than improvises.
+_STAMPING_INSTRUCTION = (
+    "Stamp every artifact you produce with your attribution line (below): "
+    "put it in the header of files you create or modify, in the body of any "
+    "commit you make, and in the title/body of any PR you open. Use the exact "
+    "marker line, unmodified, so work can be traced back to this run."
+)
+
+
+@dataclass(frozen=True)
+class AttributionStamp:
+    """Structured form of one delegation attribution marker."""
+
+    subagent_id: str
+    #: The spawning agent's subagent id, or None for a first-level child
+    #: (serialized as ``root``).
+    parent_subagent_id: Optional[str] = None
+    task_index: Optional[int] = None
+    #: ISO-8601 UTC timestamp of the spawn.
+    spawned_at: str = ""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def build_attribution_stamp(
+    *,
+    subagent_id: str,
+    parent_subagent_id: Optional[str] = None,
+    task_index: Optional[int] = None,
+    spawned_at: Optional[str] = None,
+) -> str:
+    """Build the canonical attribution marker line for a subagent run.
+
+    Parameters mirror the identity available at the child-spawn site in
+    :mod:`tools.delegate_tool` (``subagent_id``, ``parent_subagent_id``,
+    ``task_index``). ``spawned_at`` defaults to now (UTC).
+    """
+    if not subagent_id or not isinstance(subagent_id, str):
+        raise ValueError("subagent_id is required and must be a non-empty string")
+    parent = parent_subagent_id or "root"
+    task = "-" if task_index is None else str(task_index)
+    ts = spawned_at or _now_iso()
+    pairs = [
+        f"subagent_id={subagent_id}",
+        f"parent={parent}",
+        f"task_index={task}",
+        f"spawned_at={ts}",
+    ]
+    return f"{ATTRIBUTION_MARKER} " + " ".join(pairs)
+
+
+def parse_attribution_stamp(text: Optional[str]) -> Optional[AttributionStamp]:
+    """Parse a marker line back into :class:`AttributionStamp`.
+
+    Tolerant by design: returns None for anything that does not start with
+    the canonical marker (a file simply may not carry one), and for a
+    malformed line (missing subagent_id). Unknown extra keys are ignored so
+    the format can grow without breaking older parsers.
+    """
+    if not isinstance(text, str):
+        return None
+    stripped = text.strip()
+    if not stripped.startswith(ATTRIBUTION_MARKER):
+        return None
+    body = stripped[len(ATTRIBUTION_MARKER) :].strip()
+    fields: dict = {}
+    for token in body.split():
+        if "=" not in token:
+            continue
+        key, _, value = token.partition("=")
+        fields[key] = value
+    subagent_id = fields.get("subagent_id")
+    if not subagent_id:
+        return None
+    parent = fields.get("parent")
+    task_raw = fields.get("task_index")
+    task_index = None
+    if task_raw not in (None, "", "-"):
+        try:
+            task_index = int(task_raw)
+        except ValueError:
+            task_index = None
+    return AttributionStamp(
+        subagent_id=subagent_id,
+        parent_subagent_id=None if parent in (None, "root") else parent,
+        task_index=task_index,
+        spawned_at=fields.get("spawned_at", ""),
+    )
+
+
+def attribution_prompt_block(stamp: str) -> str:
+    """The ATTRIBUTION block injected into a child's system prompt.
+
+    ``stamp`` is a canonical marker line from :func:`build_attribution_stamp`.
+    """
+    return (
+        "You are an attributed subagent run.\n"
+        f"Attribution line:\n{stamp}\n" + _STAMPING_INSTRUCTION
+    )
+
+
+def stamp_for_artifact_header(stamp: str) -> str:
+    """A one-line comment form of the marker for file headers.
+
+    Produces ``# HERMES-SUBAGENT-ATTRIBUTION ...`` so subagents can embed
+    the marker in a file header regardless of the file's language (the
+    ``#`` prefix is a valid comment in the overwhelming majority of
+    languages, including YAML, TOML, shell, Python, and most configs).
+
+    Parameters
+    ----------
+    stamp : str
+        A canonical marker line from :func:`build_attribution_stamp`.
+    """
+    return f"# {stamp}"


### PR DESCRIPTION
Automated evolution PR for issue #67 — slice 1 of the parallel-agent coordination guardrails (per the issue's needs-split decomposition comment: attribution markers are the smallest, self-contained slice).

Every delegated subagent now receives a canonical attribution stamp (subagent_id, parent subagent id or 'root', task_index, spawn timestamp) injected into its system prompt, plus the instruction to stamp the marker on files it creates, commit bodies, and PR titles — so parallel-agent work traces back to the exact run.

- tools/delegation_attribution.py (stdlib-only): canonical `HERMES-SUBAGENT-ATTRIBUTION` marker, build/parse round-trip, prompt block, artifact-header helper
- tools/delegate_tool.py: `_build_child_system_prompt` gains optional attribution block; child-spawn site stamps each run (incl. nested orchestrator->worker chains)
- 14 unit + integration tests; ruff check + footgun scan clean; existing delegation tests (test_agent_team) unaffected

Remaining slices (file-territory rules, conflict protocol, context/role variation) are separate future cycles — issue stays open.