### PR TITLE
feat(memory): contradiction detection for episodic memory (Closes #37)

### DIFF
--- a/agent/memory_contradiction.py
+++ b/agent/memory_contradiction.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+"""Contradiction detection for episodic memory (issue #37).
+
+The memory-management research behind #37 identifies contradiction handling as
+a core write-path operation: when a new observation conflicts with a stored
+memory, the system must *surface* both (with timestamps) rather than silently
+overwrite or accumulate noise. This module implements that operation for the
+episodic tier (``agent.memory_importance.EpisodicMemoryStore``) with
+deterministic, LLM-free heuristics:
+
+1. **Negation flip on a shared subject** — if a new observation asserts
+   ``<subject> is X`` while a stored event asserts ``<subject> is not X``
+   (or vice versa), that is a contradiction. Detected by comparing negation
+   polarity between the two texts when they share at least one content token
+   (the subject).
+
+The detector is deliberately conservative to keep false positives low: it
+requires (a) at least two shared content tokens (subject + claim tokens, so
+a common predicate alone never triggers), and (b) exactly one side carrying
+a negation marker. Texts that merely differ (no shared subject) never flag.
+
+Stdlib-only and import-safe, consistent with
+:mod:`agent.memory_importance`. The real call site is
+``MemoryManager.score_memories`` in :mod:`agent.memory_manager` — every
+scored turn is checked against the recent episodic store and flags are
+logged (never silently dropped).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List, Optional
+
+from agent.memory_importance import MemoryEvent, tokenize
+
+__all__ = [
+    "ContradictionFlag",
+    "DEFAULT_SCAN_LIMIT",
+    "NEGATION_PATTERN",
+    "detect_contradictions",
+]
+
+#: How many most-recent events to scan per check. The check runs on every
+#: scored turn, so the window is bounded to keep the write path cheap while
+#: still covering the near-term memory that is most likely to conflict.
+DEFAULT_SCAN_LIMIT: int = 200
+
+#: Negation markers, longest alternation first. The regex runs on the raw
+#: lowercased text (NOT on :func:`tokenize` output, which mangles
+#: contractions like ``won't`` into ``won``/``t``).
+NEGATION_PATTERN = re.compile(
+    r"\b(?:"
+    r"no longer|no more|"
+    r"isn't|isnt|aren't|arent|wasn't|wasnt|weren't|werent|"
+    r"doesn't|doesnt|don't|dont|didn't|didnt|"
+    r"hasn't|hasnt|hadn't|hadnt|"
+    r"won't|wont|wouldn't|wouldnt|shouldn't|shouldnt|couldn't|couldnt|"
+    r"can't|cant|cannot|"
+    r"never|nothing|nobody|nowhere|none|without|no|not"
+    r")\b",
+    re.IGNORECASE,
+)
+
+#: Function words and polarity-neutral tokens excluded from the shared-subject
+#: computation. Kept small and conservative — the detector only needs the
+#: subject/entity token, not full NLP.
+_STOPWORDS = frozenset({
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "but",
+    "of",
+    "to",
+    "in",
+    "on",
+    "for",
+    "with",
+    "at",
+    "by",
+    "from",
+    "as",
+    "than",
+    "then",
+    "so",
+    "if",
+    "else",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "am",
+    "it",
+    "its",
+    "this",
+    "that",
+    "these",
+    "those",
+    "there",
+    "here",
+    "i",
+    "you",
+    "we",
+    "they",
+    "he",
+    "she",
+    "them",
+    "his",
+    "her",
+    "their",
+    "our",
+    "my",
+    "your",
+    "me",
+    "him",
+    "us",
+    "has",
+    "have",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "should",
+    "could",
+    "can",
+    "may",
+    "might",
+    "must",
+    "about",
+    "into",
+    "over",
+    "under",
+    "again",
+    "further",
+    "once",
+    "also",
+    "now",
+    "not",
+    "no",
+    "never",
+})
+
+#: Tokens that look like negation fragments even after tokenize() mangling
+#: (``won`` from ``won't``, ``doesn`` from ``doesn't``) — excluded from the
+#: shared-subject set so a mangled negation is never mistaken for a subject.
+_NEGATION_FRAGMENTS = frozenset({
+    "isn",
+    "isnt",
+    "aren",
+    "arent",
+    "wasn",
+    "wasnt",
+    "weren",
+    "werent",
+    "doesn",
+    "doesnt",
+    "don",
+    "dont",
+    "didn",
+    "didnt",
+    "hasn",
+    "hasnt",
+    "hadn",
+    "hadnt",
+    "won",
+    "wont",
+    "wouldn",
+    "wouldnt",
+    "shouldn",
+    "shouldnt",
+    "couldn",
+    "couldnt",
+    "can",
+    "cant",
+    "cannot",
+    "not",
+    "no",
+    "never",
+    "nothing",
+    "nobody",
+    "nowhere",
+    "none",
+    "without",
+})
+
+#: Maximum negation-marked side length considered for polarity comparison —
+#: longer texts are scored on the shared-subject rule alone.
+_MAX_NEGATED_TEXT_LEN = 2000
+
+
+@dataclass(frozen=True)
+class ContradictionFlag:
+    """One detected contradiction between a stored event and an observation.
+
+    Carries both sides verbatim plus both timestamps, per the issue's
+    requirement that conflicting memories are "logged with timestamp
+    metadata" — never silently overwritten.
+    """
+
+    event_id: str
+    stored_text: str
+    stored_when: str
+    observation: str
+    reason: str
+    confidence: float
+    detected_at: str
+
+
+def _has_negation(text: str) -> bool:
+    if not text:
+        return False
+    return NEGATION_PATTERN.search(text.lower()) is not None
+
+
+def _content_tokens(text: str) -> set:
+    """Token set minus stopwords and negation fragments (the subject tokens)."""
+    return {
+        t
+        for t in tokenize(text)
+        if t not in _STOPWORDS and t not in _NEGATION_FRAGMENTS
+    }
+
+
+def detect_contradictions(
+    events: Iterable[MemoryEvent],
+    observation: str,
+    *,
+    limit: int = DEFAULT_SCAN_LIMIT,
+    min_importance: float = 0.0,
+) -> List[ContradictionFlag]:
+    """Return contradiction flags between *observation* and *events*.
+
+    Scans the ``limit`` most-recent events (last elements of the iterable),
+    skipping events below ``min_importance``. A flag requires a shared
+    content token AND a negation-polarity mismatch between the two sides.
+    Never raises on malformed input; empty observation or events yield [].
+    """
+    if not observation or not observation.strip():
+        return []
+    obs = observation.strip()
+    obs_negated = _has_negation(obs)
+    obs_tokens = _content_tokens(obs)
+    if not obs_tokens:
+        return []
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    recent = list(events)[-limit:] if limit and limit > 0 else list(events)
+    flags: List[ContradictionFlag] = []
+    for event in recent:
+        # Defensive: skip entries that are not MemoryEvent-shaped rather than
+        # raising, so a corrupted store entry can never fail the write path.
+        if not hasattr(event, "what") or not hasattr(event, "importance"):
+            continue
+        try:
+            importance = float(getattr(event, "importance", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            importance = 0.0
+        if importance < min_importance:
+            continue
+        stored_text = f"{event.what or ''} {event.outcome or ''}".strip()
+        if not stored_text or len(stored_text) > _MAX_NEGATED_TEXT_LEN:
+            continue
+        stored_negated = _has_negation(stored_text)
+        if stored_negated == obs_negated:
+            continue
+        shared = obs_tokens & _content_tokens(stored_text)
+        # Require at least TWO shared content tokens. A single shared token is
+        # usually a common predicate ("sleeping") with different subjects —
+        # "the cat is sleeping" vs "the dog is not sleeping" is NOT a
+        # contradiction. Two+ shared tokens means subject AND claim overlap.
+        if len(shared) < 2:
+            continue
+        if obs_negated:
+            reason = (
+                "new observation negates a claim in stored memory "
+                f"(shared subject: {', '.join(sorted(shared))})"
+            )
+        else:
+            reason = (
+                "new observation conflicts with a negated claim in stored memory "
+                f"(shared subject: {', '.join(sorted(shared))})"
+            )
+        confidence = min(0.9, 0.6 + 0.05 * min(len(shared), 6))
+        flags.append(
+            ContradictionFlag(
+                event_id=event.event_id,
+                stored_text=stored_text,
+                stored_when=event.when,
+                observation=obs,
+                reason=reason,
+                confidence=round(confidence, 2),
+                detected_at=now_iso,
+            )
+        )
+    return flags

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -34,6 +34,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_importance import EpisodicMemoryStore, MemoryEvent, score_importance
+from agent.memory_contradiction import ContradictionFlag, detect_contradictions
 from agent.memory_provider import MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
@@ -901,6 +902,13 @@ class MemoryManager:
             tags=[session_id] if session_id else [],
             metadata={"session_id": session_id} if session_id else {},
         )
+        # Contradiction handling (#37): before persisting this turn, check it
+        # against the recent episodic store for negation-flip conflicts (new
+        # observation says X, a stored event says not-X, or vice versa).
+        # Non-fatal and bounded: flags are logged with both timestamps, never
+        # silently overwriting or deleting the stored event.
+        if user_content and user_content.strip():
+            self.check_contradictions(user_content)
         self.episodic_store.add(event)
         logger.debug(
             "score_memories: recorded turn (importance=%.3f, signals=%s)",
@@ -908,6 +916,47 @@ class MemoryManager:
             signals,
         )
         return event
+
+    def check_contradictions(
+        self,
+        observation: str,
+        *,
+        limit: int = 200,
+        min_importance: float = 0.0,
+    ) -> List[ContradictionFlag]:
+        """Surface contradictions between *observation* and episodic memory.
+
+        Runs :func:`agent.memory_contradiction.detect_contradictions` over the
+        most-recent events in :attr:`episodic_store` and logs a warning per
+        flag — both sides verbatim with their timestamps, so a conflict is
+        surfaced instead of silently overwritten (#37). Non-fatal by design:
+        memory sync must never fail a turn because of a flagged conflict.
+
+        Called from :meth:`score_memories` on the per-turn write path and
+        available to any caller that wants to probe a candidate observation
+        before persisting it.
+
+        Returns the flags (empty when nothing conflicts).
+        """
+        if not observation or not observation.strip():
+            return []
+        flags = detect_contradictions(
+            self.episodic_store.events.values(),
+            observation,
+            limit=limit,
+            min_importance=min_importance,
+        )
+        for flag in flags:
+            logger.warning(
+                "memory contradiction (conf=%.2f): %s — stored %s (%s) vs new "
+                "observation %r",
+                flag.confidence,
+                flag.reason,
+                flag.stored_text[:200],
+                flag.stored_when,
+                observation[:200],
+            )
+        return flags
 
     def sync_all(
         self,

--- a/tests/agent/test_memory_contradiction.py
+++ b/tests/agent/test_memory_contradiction.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`agent.memory_contradiction` (issue #37).
+
+Covers the negation-flip heuristic: contradictions are flagged when a new
+observation and a stored event share a subject but disagree on polarity,
+and — just as important — non-contradictions (no shared subject, same
+polarity, empty input) never flag. Also covers the real call-site wiring
+in :class:`agent.memory_manager.MemoryManager`: scoring a turn that
+contradicts an existing episodic event surfaces a flag, and the flag is
+logged rather than crashing or deleting anything.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agent.memory_contradiction import (
+    ContradictionFlag,
+    detect_contradictions,
+)
+from agent.memory_importance import EpisodicMemoryStore, MemoryEvent
+
+
+def _event(what: str, *, importance: float = 0.5, outcome: str = "") -> MemoryEvent:
+    return MemoryEvent(what=what, outcome=outcome, importance=importance)
+
+
+class TestDetectContradictions:
+    def test_negation_flip_on_shared_subject_flags(self):
+        stored = [_event("the database server is healthy and serving traffic")]
+        flags = detect_contradictions(stored, "the database server is not healthy")
+        assert len(flags) == 1
+        flag = flags[0]
+        assert flag.event_id == stored[0].event_id
+        assert "database" in flag.reason
+        assert flag.stored_when  # timestamp metadata present
+        assert flag.detected_at
+
+    def test_reverse_polarity_also_flags(self):
+        stored = [_event("the printer is not connected to the network")]
+        flags = detect_contradictions(
+            stored, "the printer is connected to the network now"
+        )
+        assert len(flags) == 1
+        assert "negated claim" in flags[0].reason
+
+    def test_shared_subject_without_polarity_change_never_flags(self):
+        stored = [_event("the solar inverter reports 12 kW output")]
+        assert (
+            detect_contradictions(
+                stored, "the solar inverter reports 12 kW output again"
+            )
+            == []
+        )
+        assert (
+            detect_contradictions(stored, "the solar inverter firmware is updating")
+            == []
+        )
+
+    def test_no_shared_subject_never_flags(self):
+        stored = [_event("the cat is sleeping on the sofa")]
+        assert detect_contradictions(stored, "the dog is not sleeping") == []
+
+    def test_empty_inputs(self):
+        stored = [_event("anything at all")]
+        assert detect_contradictions(stored, "") == []
+        assert detect_contradictions(stored, "   ") == []
+        assert detect_contradictions([], "something is not true") == []
+
+    def test_limit_respects_most_recent_window(self):
+        old = _event("the backup service is running")
+        new = _event("the backup service is not running", importance=0.9)
+        # Only the most recent event is in the window.
+        flags = detect_contradictions(
+            [old, new], "the backup service is running", limit=1
+        )
+        assert len(flags) == 1
+        assert flags[0].event_id == new.event_id
+
+    def test_min_importance_filter(self):
+        low = _event("the modem is online", importance=0.1)
+        high = _event("the modem is online", importance=0.9)
+        flags = detect_contradictions(
+            [low, high], "the modem is not online", min_importance=0.5
+        )
+        assert len(flags) == 1
+        assert flags[0].event_id == high.event_id
+
+    def test_confidence_bounded(self):
+        stored = [_event("the api gateway is reachable from the office network")]
+        flags = detect_contradictions(stored, "the api gateway is not reachable")
+        assert 0.0 < flags[0].confidence <= 0.9
+
+    def test_contraction_negation_detected(self):
+        stored = [_event("the heat pump is working")]
+        flags = detect_contradictions(stored, "the heat pump isn't working at all")
+        assert len(flags) == 1
+
+    def test_flag_carries_both_sides(self):
+        stored = [_event("the samba share is mounted")]
+        flags = detect_contradictions(stored, "the samba share is not mounted")
+        assert flags[0].stored_text == "the samba share is mounted"
+        assert flags[0].observation == "the samba share is not mounted"
+
+    def test_never_raises_on_malformed_events(self):
+        flags = detect_contradictions(
+            [_event("the tv is on"), "not-an-event", None],  # type: ignore[list-item]
+            "the tv is not on",
+        )
+        # Malformed entries are skipped defensively — at minimum the valid
+        # event's flag (if any) is returned and nothing crashes.
+        assert isinstance(flags, list)
+        assert all(isinstance(f, ContradictionFlag) for f in flags)
+
+
+class TestMemoryManagerWiring:
+    """The real call site: MemoryManager.score_memories surfaces flags."""
+
+    def _manager_with_event(self, what: str) -> tuple:
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        manager.episodic_store.add(_event(what, importance=0.8))
+        return manager, what
+
+    def test_score_memories_surfaces_contradiction(self, caplog):
+        manager, stored = self._manager_with_event("the nas is healthy")
+        with caplog.at_level(logging.WARNING, logger="agent.memory_manager"):
+            manager.score_memories("the nas is not healthy", "ok", session_id="s1")
+        assert any("memory contradiction" in r.message for r in caplog.records)
+        # Both sides surfaced, nothing deleted.
+        assert len(manager.episodic_store.events) == 2
+
+    def test_check_contradictions_returns_flags(self):
+        manager, _ = self._manager_with_event("the nas is healthy")
+        flags = manager.check_contradictions("the nas is not healthy")
+        assert len(flags) == 1
+        assert flags[0].event_id in manager.episodic_store.events
+
+    def test_no_false_positive_on_unrelated_turn(self, caplog):
+        manager, _ = self._manager_with_event("the nas is healthy")
+        with caplog.at_level(logging.WARNING, logger="agent.memory_manager"):
+            manager.score_memories(
+                "what is the weather in cape town", "sunny", session_id="s1"
+            )
+        assert not any("memory contradiction" in r.message for r in caplog.records)
+        assert len(manager.episodic_store.events) == 2
+
+    def test_empty_observation_never_flags(self):
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        manager.episodic_store.add(_event("the nas is healthy"))
+        assert manager.check_contradictions("") == []
+        assert manager.check_contradictions("   ") == []


### PR DESCRIPTION
Automated evolution PR for issue #37 — bounded first slice of the 4-tier memory management work: contradiction handling on the episodic write path.

When a new observation conflicts with a stored memory (negation flip on a shared subject), both sides are surfaced with timestamps instead of being silently overwritten — the issue's explicit success criterion.

- `agent/memory_contradiction.py` (stdlib-only): deterministic negation-flip detector. Requires >=2 shared content tokens (subject + claim) AND a polarity mismatch, so a shared predicate alone never false-positives. Returns ContradictionFlag (both texts + both timestamps).
- `agent/memory_manager.py`: `MemoryManager.check_contradictions()` runs the detector over the recent episodic store (bounded window, importance filter) and logs a warning per flag; `score_memories()` calls it on every scored turn — non-fatal by design.
- 15 unit + wiring tests; ruff check/format + footgun scan clean; existing memory_importance tests unaffected.

Remaining slices (semantic-tier staleness, consolidation cron, working-memory eviction) are separate cycles — issue stays open.