### PR TITLE
feat(evolution): forge invariant filter slices 3+4 — staged rollout + pinned safe fallbacks (Closes #2978)

### DIFF
--- a/scripts/evolution_invariant_filter.py
+++ b/scripts/evolution_invariant_filter.py
@@ -17,6 +17,19 @@ Slices shipped here:
     rewrite dict against it. Wired into ``evolution_harness_gate.run_gate`` and
     ``run_cron_pass`` so a violating harness proposal is rejected with
     ``zero_fitness`` before the sandbox/regression gate ever runs.
+  * **Slice 3** (staged rollout) — ``classify_stakes`` buckets a proposal into
+    low/medium/high from its explicit ``stakes`` field (else its target path).
+    Each rule may declare an ``enforce_at`` floor; below that floor a finding is
+    demoted to ADVISORY instead of blocking. A rule with no ``enforce_at``
+    defaults to high and blocks everything (unchanged behavior), so a new strict
+    rule can be rolled out staged — advisory on high-stakes targets first,
+    blocking on low-stakes ones — with zero behavior change for existing rules.
+  * **Slice 4** (pinned safe-fallback set) — ``load_safe_fallbacks`` /
+    ``resolve_pinned_fallback`` expose a versioned ``safe_fallbacks`` set of
+    human-vetted, pinned alternative targets. When a proposal is blocked on a
+    forbidden path that has a pinned fallback, the filter attaches
+    ``safe_fallback`` to the result so the rejection is actionable, not a dead
+    end. Additive: a rules file that predates slice 4 simply yields no fallbacks.
 
 The filter is deliberately CONSERVATIVE: it catches only unambiguous
 violations (low false-positive floor), and it checks only top-level scalar
@@ -51,6 +64,22 @@ _RULES_FILENAME = "evolution_invariant_rules.json"
 # Check types the rules file may declare. Anything outside this vocabulary is
 # ignored (never a crash) so a malformed/older rules file degrades safely.
 _CHECKS = ("human_gating", "forbidden_paths", "forbidden_patterns")
+
+# Stakes ladder (slice 3 — staged rollout). A proposal's ``stakes`` (explicit
+# field, else inferred from its target path) selects how aggressively the
+# immutable floor is applied. Rules declare ``enforce_at`` — the minimum stakes
+# at which the rule BLOCKS. A violation of a rule whose threshold is above the
+# proposal's stakes is demoted to an ADVISORY (non-blocking) finding, so a new
+# strict rule can be rolled out staged (advisory on high-stakes targets first,
+# blocking on low-stakes ones) without an abrupt all-or-nothing flip.
+_STAKES_ORDER = ("low", "medium", "high")
+_DEFAULT_STAKES = "high"  # fail safe: an unclassifiable proposal is high-stakes
+# Backward-compatible default for a rule's ``enforce_at`` floor: a rule with no
+# ``enforce_at`` always blocks (threshold = low — the easiest to meet). This
+# preserves the pre-slice-3 behavior where every hard rule blocked every
+# proposal. Staged rollout is OPT-IN: a rule that wants advisory-on-high-stakes
+# explicitly declares ``enforce_at: high`` (or ``medium``).
+_DEFAULT_ENFORCE_AT = "low"
 
 # Default text fields scanned by ``forbidden_patterns`` when a rule does not
 # declare its own ``text_fields``.
@@ -93,7 +122,13 @@ def load_invariant_rules(path: Optional[Path] = None) -> Dict[str, Any]:
     rules = data.get("rules")
     if not isinstance(rules, list) or not rules:
         raise ValueError(f"invariant rules {p} has no 'rules' list")
-    return {"version": version, "rules": rules}
+    loaded: Dict[str, Any] = {"version": version, "rules": rules}
+    # Slice 4: carry the versioned safe-fallback set forward verbatim (if the
+    # rules file declares one) so downstream consumers can resolve pinned
+    # alternatives. Absent in older files -> the key is simply omitted.
+    if "safe_fallbacks" in data:
+        loaded["safe_fallbacks"] = data["safe_fallbacks"]
+    return loaded
 
 
 def _as_text(value: Any) -> str:
@@ -125,6 +160,135 @@ def _walk_paths(obj: Any, fields: Tuple[str, ...]) -> List[str]:
         elif isinstance(value, list):
             out.extend(_as_text(x) for x in value)
     return out
+
+
+# -- Slice 3: stakes classification (staged rollout) --------------------------
+
+
+def _stakes_rank(stakes: Any) -> int:
+    """Rank a stakes label on the ``low < medium < high`` ladder.
+
+    Unknown values are coerced to the safe default (high). Returns an index
+    into ``_STAKES_ORDER`` so callers can compare with ``>=``.
+    """
+    label = str(stakes or "").strip().lower()
+    if label in _STAKES_ORDER:
+        return _STAKES_ORDER.index(label)
+    return _STAKES_ORDER.index(_DEFAULT_STAKES)
+
+
+def classify_stakes(obj: Any) -> Tuple[str, str]:
+    """Classify a proposal's stakes as ``(label, source)``.
+
+    ``label`` is one of ``low``/``medium``/``high``. ``source`` is ``"explicit"``
+    (the proposal carried its own ``stakes`` field), ``"inferred"`` (from its
+    target path), or ``"default"`` (fail-safe high for a pathless/unclassifiable
+    proposal). Pure + deterministic — no IO, no clock.
+    """
+    if isinstance(obj, dict) and isinstance(obj.get("stakes"), str):
+        label = obj["stakes"].strip().lower()
+        if label in _STAKES_ORDER:
+            return label, "explicit"
+        # An explicit but unknown label is not silently trusted — fail safe.
+        return _DEFAULT_STAKES, "default"
+    if isinstance(obj, dict):
+        # Infer from the target path. Distinguish an inferred-HIGH (a path hit
+        # the high-risk fragments) from a fail-safe default-HIGH (no path at
+        # all): both return "high", but only the former is source="inferred".
+        paths = _walk_paths(obj, _DEFAULT_PATH_FIELDS)
+        if not paths:
+            return _DEFAULT_STAKES, "default"
+        high_fragments = (
+            "evolution_merge_gate",
+            "evolution_harness_gate",
+            "register_evolution_cron",
+            "evolution_orchestrator",
+            "tools/approval",
+            "evolution_*_gate.py",
+        )
+        for p in paths:
+            pl = p.lower()
+            if any(frag in pl for frag in high_fragments):
+                return "high", "inferred"
+        return "medium", "inferred"
+    return _DEFAULT_STAKES, "default"
+
+
+def _rule_enforces_at(rule: Dict[str, Any], stakes_rank: int) -> bool:
+    """True if a rule's ``enforce_at`` threshold is met at the given stakes.
+
+    A rule with no ``enforce_at`` defaults to ``_DEFAULT_ENFORCE_AT`` (low) —
+    i.e. it blocks every proposal, backwards compatible with the pre-slice-3
+    behavior where every hard rule always blocked. A rule that explicitly
+    declares a higher floor (e.g. ``enforce_at: high``) is rolled out staged:
+    below that floor a finding becomes advisory instead of blocking.
+    """
+    threshold = str(rule.get("enforce_at") or _DEFAULT_ENFORCE_AT).strip().lower()
+    return stakes_rank >= _stakes_rank(threshold)
+
+
+# -- Slice 4: pinned safe-fallback set ----------------------------------------
+
+
+def load_safe_fallbacks(rules: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract the versioned ``safe_fallbacks`` set from a loaded rules dict.
+
+    Each entry is ``{"id", "target", "replacement"}``: a pinned, human-vetted
+    alternative for a high-stakes target path that the forge must never rewrite
+    unattended. When a proposal violates ``no-critical-auth-path-rewrite`` (or
+    any rule with ``safe_fallback_key``), the filter can offer the matching
+    fallback as the allowed path instead of a flat rejection — so the blocker
+    becomes actionable, not a dead end. Returns ``[]`` for a rules file that
+    predates slice 4 (safe fallback is additive).
+    """
+    if not isinstance(rules, dict):
+        return []
+    data = rules.get("safe_fallbacks")
+    if not isinstance(data, list):
+        return []
+    out = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("id") and entry.get("replacement"):
+            out.append(
+                {
+                    "id": str(entry["id"]),
+                    "target": str(entry.get("target") or ""),
+                    "replacement": str(entry["replacement"]),
+                    "description": str(entry.get("description") or ""),
+                }
+            )
+    return out
+
+
+def resolve_pinned_fallback(
+    proposal: Any,
+    rules: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return a pinned safe fallback for a proposal that hit a forbidden path.
+
+    Scans the versioned ``safe_fallbacks`` set for an entry whose ``target`` is
+    a fragment of a path the proposal rewrites. Returns ``None`` when the
+    proposal does not target a pinned path (or no fallback is pinned) — the
+    caller then treats the violation as an un-cachable hard block. Pure +
+    deterministic. When ``rules`` is omitted it is loaded from disk.
+    """
+    if rules is None:
+        try:
+            rules = load_invariant_rules()
+        except ValueError:
+            return None
+    if not isinstance(proposal, dict):
+        return None
+    paths = _walk_paths(proposal, _DEFAULT_PATH_FIELDS)
+    if not paths:
+        return None
+    for entry in load_safe_fallbacks(rules):
+        target = entry["target"].lower()
+        if target and any(target in p.lower() for p in paths):
+            return entry
+    return None
 
 
 def _check_human_gating(
@@ -206,17 +370,47 @@ def check_proposal(
     if not isinstance(proposal, dict):
         return {"ok": True, "violations": []}
 
-    violations: List[Dict[str, Any]] = []
+    # Slice 3: classify stakes once for this proposal (explicit > inferred >
+    # fail-safe default) and use each rule's ``enforce_at`` floor to decide
+    # whether a finding BLOCKS or is merely advisory. Backwards compatible:
+    # a rule with no ``enforce_at`` blocks every proposal, exactly as before.
+    stakes, stakes_source = classify_stakes(proposal)
+    stakes_rank = _stakes_rank(stakes)
+
+    blocking: List[Dict[str, Any]] = []
+    advisory: List[Dict[str, Any]] = []
     for rule in rules.get("rules", []):
         check = rule.get("check")
         if check == "human_gating":
-            violations.extend(_check_human_gating(proposal, rule))
+            found = _check_human_gating(proposal, rule)
         elif check == "forbidden_paths":
-            violations.extend(_check_forbidden_paths(proposal, rule))
+            found = _check_forbidden_paths(proposal, rule)
         elif check == "forbidden_patterns":
-            violations.extend(_check_forbidden_patterns(proposal, rule))
-        # unknown check type -> ignored (never crash)
-    return {"ok": not violations, "violations": violations}
+            found = _check_forbidden_patterns(proposal, rule)
+        else:  # unknown check type -> ignored (never crash)
+            continue
+        if not found:
+            continue
+        if _rule_enforces_at(rule, stakes_rank):
+            blocking.extend(found)
+        else:
+            advisory.extend(found)
+
+    result: Dict[str, Any] = {
+        "ok": not blocking,
+        "violations": blocking,
+        "advisory": advisory,
+        "stakes": stakes,
+        "stakes_source": stakes_source,
+    }
+
+    # Slice 4: for a forbidden-path block with a pinned safe fallback, surface
+    # the allowed alternative so the rejection is actionable, not a dead end.
+    if blocking:
+        fallback = resolve_pinned_fallback(proposal, rules=rules)
+        if fallback is not None:
+            result["safe_fallback"] = fallback
+    return result
 
 
 def filter_proposals(

--- a/scripts/evolution_invariant_rules.json
+++ b/scripts/evolution_invariant_rules.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "description": "Immutable Cerberus/household constraints for forge rewrites (skill/prompt/harness edits). A rewrite that violates any hard rule is filtered at zero-fitness BEFORE it reaches the judge, so a candidate that breaks the 'cannot violate' floor is never evaluated or applied. Rules are data so they can be reviewed, versioned, and extended without touching code.",
+  "version": 2,
+  "description": "Immutable Cerberus/household constraints for forge rewrites (skill/prompt/harness edits). A rewrite that violates any hard rule is filtered at zero-fitness BEFORE it reaches the judge, so a candidate that breaks the 'cannot violate' floor is never evaluated or applied. Rules are data so they can be reviewed, versioned, and extended without touching code. v2 adds the versioned 'safe_fallbacks' set (slice 4): a pinned, human-vetted alternative target for a high-stakes path that must never be rewritten unattended, surfaced on a forbidden-path block so the rejection stays actionable.",
   "rules": [
     {
       "id": "human-gating-floor",
@@ -55,6 +55,20 @@
         "skip\\s+.*safety",
         "remove\\s+.*safety\\s+.*gate"
       ]
+    }
+  ],
+  "safe_fallbacks": [
+    {
+      "id": "cron-jobs-config-surface",
+      "target": "cron/jobs.py",
+      "replacement": "cron/config/*.json",
+      "description": "The cron registrar's job definitions carry the safety instructions; never rewrite cron/jobs.py unattended. Change job cadence/parameters via the per-job JSON config surface instead."
+    },
+    {
+      "id": "setup-hermes-config-surface",
+      "target": "setup-hermes.sh",
+      "replacement": "config/hermes.yaml",
+      "description": "The bootstrap installer must not be rewritten unattended. Adjust runtime behavior via the YAML config file, which the installer reads at run time."
     }
   ]
 }

--- a/tests/scripts/test_evolution_invariant_filter.py
+++ b/tests/scripts/test_evolution_invariant_filter.py
@@ -16,8 +16,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from evolution_invariant_filter import (  # noqa: E402
     _rules_path,
     check_proposal,
+    classify_stakes,
     filter_proposals,
     load_invariant_rules,
+    load_safe_fallbacks,
+    resolve_pinned_fallback,
 )
 from evolution_harness_gate import run_cron_pass, run_gate  # noqa: E402
 from evolution_harness_sandbox import INVALID, VALIDATED, GateResult  # noqa: E402
@@ -173,3 +176,111 @@ def test_cron_pass_gates_clean_proposal():
     assert report["invariant_rejected"] == 0
     assert report["gated"] == 1
     assert report["validated"] == 1
+
+
+# -- Slice 3: stakes classification + staged rollout -------------------------
+
+
+def test_classify_stakes_explicit_field():
+    label, source = classify_stakes({**CLEAN, "stakes": "low"})
+    assert label == "low" and source == "explicit"
+
+
+def test_classify_stakes_explicit_unknown_fails_safe_to_high():
+    label, source = classify_stakes({**CLEAN, "stakes": "extreme"})
+    assert label == "high" and source == "default"
+
+
+def test_classify_stakes_infer_medium_from_path():
+    label, source = classify_stakes({**CLEAN, "path": "scripts/evolution_foo.py"})
+    assert label == "medium" and source == "inferred"
+
+
+def test_classify_stakes_infer_high_from_gate_path():
+    label, source = classify_stakes(
+        {**CLEAN, "path": "scripts/evolution_harness_gate.py"}
+    )
+    assert label == "high" and source == "inferred"
+
+
+def test_classify_stakes_defaults_high_for_pathless():
+    label, source = classify_stakes(CLEAN)
+    assert label == "high" and source == "default"
+
+
+def test_backcompat_rule_blocks_at_low_stakes():
+    # A rule with NO enforce_at still blocks a low-stakes proposal (unchanged).
+    result = check_proposal({**CLEAN, "stakes": "low", "auto_apply": True})
+    assert result["ok"] is False
+    assert result["violations"]  # demoted to advisory, not dropped
+    assert result["advisory"] == []
+
+
+def test_staged_rule_advisory_on_high_stakes():
+    # A rule with enforce_at: high does NOT block a high-stakes proposal;
+    # the finding surfaces as advisory so rollout is observable, not silent.
+    staged_rule = {
+        "id": "staged-rule",
+        "severity": "hard",
+        "check": "forbidden_paths",
+        "enforce_at": "high",
+        "forbidden_fragments": ["staging-target.py"],
+    }
+    rules = {
+        "version": 1,
+        "rules": [staged_rule],
+    }
+    result = check_proposal({**CLEAN, "path": "scripts/staging-target.py"}, rules=rules)
+    assert result["ok"] is True
+    assert result["advisory"]
+
+
+def test_staged_rule_blocks_when_threshold_met():
+    # Same staged rule now meets its floor on a LOW-stakes proposal -> blocks.
+    staged_rule = {
+        "id": "staged-rule",
+        "severity": "hard",
+        "check": "forbidden_paths",
+        "enforce_at": "low",
+        "forbidden_fragments": ["staging-target"],
+    }
+    rendered = {"version": 1, "rules": [staged_rule]}
+    result = check_proposal({**CLEAN, "path": "scripts/staging-target.py"}, rules=rendered)
+    assert result["ok"] is False
+    assert any(v["rule"] == "staged-rule" for v in result["violations"])
+
+
+def test_check_proposal_reports_stakes_meta():
+    result = check_proposal(CLEAN)
+    assert result["stakes"] == "high"
+    assert result["stakes_source"] == "default"
+
+
+# -- Slice 4: pinned safe-fallback set ---------------------------------------
+
+
+def test_load_safe_fallbacks_reads_versioned_set():
+    rules = load_invariant_rules()
+    fb = load_safe_fallbacks(rules)
+    assert fb  # the shipped rules file declares a non-empty set
+    assert all(e["id"] and e["replacement"] for e in fb)
+
+
+def test_safe_fallback_attached_on_forbidden_path_block():
+    result = check_proposal({**CLEAN, "path": "cron/jobs.py"})
+    assert result["ok"] is False
+    assert result["safe_fallback"]["target"] == "cron/jobs.py"
+    assert result["safe_fallback"]["replacement"] == "cron/config/*.json"
+
+
+def test_safe_fallback_absent_for_unpinned_block():
+    result = check_proposal({**CLEAN, "path": "scripts/setup-hermes.sh"})
+    assert result["ok"] is False
+    # setup-hermes.sh IS in the forbidden set, and it DOES have a pinned
+    # fallback in the shipped rules -> assert it is surfaced.
+    assert result["safe_fallback"]["replacement"] == "config/hermes.yaml"
+
+
+def test_resolve_pinned_fallback_none_when_no_blocking_path():
+    assert resolve_pinned_fallback(CLEAN) is None
+    assert resolve_pinned_fallback({"path": "scripts/evolution_foo.py"}) is None


### PR DESCRIPTION
## Summary

Implements slices 3+4 of the forge invariant filter (#2978), extending the foundation shipped in #2974 (slices 1+2).

### Slice 3 — staged rollout via stakes classification
- `classify_stakes(proposal)` buckets a proposal into **low/medium/high** from its explicit `stakes` field, else inferred from its target path (core agent machinery ⇒ high; other path ⇒ medium; pathless ⇒ high fail-safe).
- Each rule may declare an `enforce_at` floor. Below that floor, a finding is demoted to **ADVISORY** (non-blocking) instead of blocking.
- **Backwards compatible:** a rule with no `enforce_at` defaults to `low` (always blocks), so all existing hard rules behave exactly as before. Staged rollout is strictly opt-in — a new strict rule can ship advisory-on-high-stakes first, then flip to blocking.

### Slice 4 — pinned safe-fallback set
- `load_safe_fallbacks` / `resolve_pinned_fallback` expose a versioned `safe_fallbacks` set (human-vetted, pinned alternative targets).
- When a proposal is blocked on a forbidden path that has a pinned fallback, `check_proposal` attaches `safe_fallback` to the result — the rejection becomes actionable instead of a dead end.
- Additive: an older rules file that predates slice 4 yields no fallbacks (no behavior change).

## Files changed
- `scripts/evolution_invariant_filter.py` — slices 3+4 logic
- `scripts/evolution_invariant_rules.json` — version bumped to 2, `safe_fallbacks` set added
- `tests/scripts/test_evolution_invariant_filter.py` — 13 new tests (28 total pass)

## Verification
- `pytest tests/scripts/test_evolution_invariant_filter.py` → **28 passed**
- `ruff check` → clean
- Cross-suite: harness-gate + harness-proposer tests → **65 passed**

## Merge note
Diff is **328 insertions**, exceeding the repo's `DIFF_TOO_LARGE` self-merge cap (200). This PR is **NOT auto-merged** — it requires human review per the evolution merge-gate policy. Rollback is trivial: revert this single commit.