### PR TITLE
feat(tools): wire Pydantic tool-schema validation into the runtime schema path (Closes #49)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -614,6 +614,19 @@ def _compute_tool_definitions(
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
 
+    # Validate sanitized schemas against the structural invariants the
+    # sanitizer enforces, so a malformed tool schema is surfaced (logged) at
+    # registration time instead of surfacing downstream as a cryptic
+    # provider 400 format_error / schema_validation_error. Diagnostic only —
+    # never raises, and a failure is reported rather than fatal.
+    try:
+        from tools.schema_sanitizer import validate_tool_schemas
+        schema_issues = validate_tool_schemas(filtered_tools)
+        for issue in schema_issues:
+            logger.warning("Tool schema validation: %s", issue)
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning("Tool schema validation skipped: %s", e)
+
     # ── Tool Search (progressive disclosure) ────────────────────────────
     # Conditionally replace MCP + plugin (non-core) tools with three bridge
     # tools (tool_search / tool_describe / tool_call) when the deferrable

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -13,6 +13,7 @@ from tools.schema_sanitizer import (
     sanitize_tool_schemas,
     strip_pattern_and_format,
     strip_slash_enum,
+    validate_tool_schemas,
 )
 
 
@@ -609,3 +610,46 @@ def test_collapse_is_deterministic():
     first = collapse_const_unions(copy.deepcopy(schema))
     second = collapse_const_unions(copy.deepcopy(schema))
     assert first == second == {"type": "string", "enum": ["b", "a"]}
+
+
+class TestValidateToolSchemas:
+    """The validator wired into the sanitizer's public surface (issue #49).
+
+    ``schema_sanitizer.validate_tool_schemas`` is the production call site
+    ``model_tools.get_tool_definitions`` invokes; these tests exercise the
+    Pydantic validator *through that call site*, proving a structurally
+    invalid schema is rejected there (not just in the validator's own unit
+    tests).
+    """
+
+    def test_valid_schema_produces_no_issues(self):
+        tools = [_tool("good", {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        })]
+        assert validate_tool_schemas(tools) == []
+
+    def test_invalid_root_type_is_reported_with_tool_name(self):
+        # Root must be an object; a bare-string schema node is a real-world
+        # malformed-MCP shape (mirrors the sanitizer's own docstring).
+        tools = [_tool("bad", {"type": "string", "properties": {}})]
+        issues = validate_tool_schemas(tools)
+        assert issues, "expected the invalid schema to be flagged"
+        assert issues[0].startswith("bad: ")
+
+    def test_required_naming_undefined_property_is_reported(self):
+        tools = [_tool("bad", {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q", "missing"],
+        })]
+        issues = validate_tool_schemas(tools)
+        assert issues, "expected the dangling required entry to be flagged"
+        assert any("required" in i for i in issues)
+
+    def test_responses_format_schema_is_validated(self):
+        # Bare Responses-format tool (no OpenAI wrapper) is also accepted.
+        tools = [{"name": "r", "parameters": {"type": "string", "properties": {}}}]
+        issues = validate_tool_schemas(tools)
+        assert issues and issues[0].startswith("r: ")

--- a/tests/tools/test_schema_validator.py
+++ b/tests/tools/test_schema_validator.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`tools.schema_validator` (issue #49).
+
+Covers the structural JSON-Schema checks the Pydantic layer enforces:
+valid schemas pass in every accepted shape (bare / function / wrapped),
+and each common failure mode (bad type, required referencing an unknown
+property, malformed enums, nested-object problems, non-dict input) yields
+an actionable error string instead of a crash.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.schema_validator import (
+    ToolSchemaValidationResult,
+    validate_tool_schema,
+    validate_tool_schema_or_raise,
+)
+
+
+def _ok(schema) -> ToolSchemaValidationResult:
+    return validate_tool_schema(schema)
+
+
+class TestValidSchemas:
+    """Every accepted shape must validate without modification."""
+
+    def test_bare_parameters_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "search text"},
+                "limit": {"type": "integer", "minimum": 1},
+            },
+            "required": ["query"],
+        }
+        result = _ok(schema)
+        assert result.ok is True
+        assert result.errors == []
+        assert result.normalized_parameters == schema
+
+    def test_bare_function_schema_with_name_and_description(self):
+        schema = {
+            "name": "search_web",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"],
+            },
+        }
+        result = _ok(schema)
+        assert result.ok is True
+        # Normalization unwraps to the parameters dict.
+        assert result.normalized_parameters is not None
+        assert result.normalized_parameters["type"] == "object"
+        assert "q" in result.normalized_parameters["properties"]
+
+    def test_openai_wrapped_form(self):
+        schema = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Weather lookup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+        result = _ok(schema)
+        assert result.ok is True
+
+    def test_empty_properties_and_no_required(self):
+        assert _ok({"type": "object", "properties": {}}).ok is True
+        assert (
+            _ok({"type": "object", "properties": {"a": {"type": "string"}}}).ok is True
+        )
+
+    def test_unknown_extra_keywords_pass_through(self):
+        """Provider-specific keywords must not break backward compatibility."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["fast", "slow"],
+                    "x-provider-hint": "ignored",
+                    "default": "fast",
+                    "deprecated": False,
+                }
+            },
+            "additionalProperties": False,
+            "x-root-extension": {"anything": "goes"},
+        }
+        result = _ok(schema)
+        assert result.ok is True
+
+    def test_nested_object_property(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "strict": {"type": "boolean"},
+                    },
+                    "required": ["tags"],
+                }
+            },
+            "required": ["filters"],
+        }
+        assert _ok(schema).ok is True
+
+    def test_union_type_list(self):
+        assert (
+            _ok({
+                "type": "object",
+                "properties": {"v": {"type": ["string", "null"]}},
+            }).ok
+            is True
+        )
+
+    def test_array_property_without_items_still_passes(self):
+        """Backward compat: some shipped schemas omit items; not a hard error."""
+        assert (
+            _ok({"type": "object", "properties": {"tags": {"type": "array"}}}).ok
+            is True
+        )
+
+
+class TestInvalidSchemas:
+    """Each structural failure must produce an actionable error string."""
+
+    def test_non_dict_input(self):
+        for bad in (None, "nope", 42, ["list"], object()):
+            result = _ok(bad)
+            assert result.ok is False
+            assert result.errors, f"expected an error message for {bad!r}"
+            assert result.normalized_parameters is None
+
+    def test_dict_without_parameters_shape(self):
+        result = _ok({"name": "no_parameters_here"})
+        assert result.ok is False
+        assert any("parameters" in e for e in result.errors)
+
+    def test_invalid_root_type(self):
+        result = _ok({"type": "string", "properties": {}})
+        assert result.ok is False
+        assert any("'object'" in e for e in result.errors)
+
+    def test_unknown_json_schema_type(self):
+        result = _ok({"type": "object", "properties": {"a": {"type": "banana"}}})
+        assert result.ok is False
+        assert any("banana" in e and "type" in e for e in result.errors)
+
+    def test_required_references_unknown_property(self):
+        result = _ok({
+            "type": "object",
+            "properties": {"known": {"type": "string"}},
+            "required": ["ghost"],
+        })
+        assert result.ok is False
+        assert any("'ghost'" in e for e in result.errors)
+        assert any("required" in e for e in result.errors)
+
+    def test_nested_required_references_unknown_property(self):
+        """The recursive validator must catch problems inside nested objects."""
+        result = _ok({
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                    "required": ["missing"],
+                }
+            },
+        })
+        assert result.ok is False
+        assert any("missing" in e for e in result.errors)
+
+    def test_enum_empty_list_rejected(self):
+        result = _ok({
+            "type": "object",
+            "properties": {"m": {"type": "string", "enum": []}},
+        })
+        assert result.ok is False
+        assert any("enum" in e for e in result.errors)
+
+    def test_enum_items_must_be_valid(self):
+        result = _ok({
+            "type": "object",
+            "properties": {"m": {"type": "string", "enum": ["a", "b"]}},
+        })
+        assert result.ok is True
+        # A non-string enum on a string property is still structurally fine at
+        # this layer (JSON Schema allows heterogeneous enums); the actionable
+        # guarantee is that the enum keyword itself is a non-empty list.
+
+    def test_required_must_be_strings(self):
+        result = _ok({
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": [1],
+        })
+        assert result.ok is False
+
+    def test_never_raises_on_garbage(self):
+        """The public API must return a result for any input, never throw."""
+        weird_inputs = [
+            {"type": "object", "properties": {"a": {"enum": [object()]}}},
+            {"type": 7},
+            {"properties": {"a": {"type": "string"}}, "required": {"not": "a list"}},
+        ]
+        for weird in weird_inputs:
+            result = _ok(weird)
+            assert isinstance(result, ToolSchemaValidationResult)
+
+
+class TestRaiseVariant:
+    def test_raises_with_joined_errors_on_invalid(self):
+        with pytest.raises(ValueError, match="invalid tool schema"):
+            validate_tool_schema_or_raise({
+                "type": "object",
+                "properties": {"a": {"type": 7}},
+            })
+
+    def test_returns_normalized_params_on_valid(self):
+        params = validate_tool_schema_or_raise({
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        })
+        assert params["type"] == "object"
+        assert params["required"] == ["q"]

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -41,6 +41,8 @@ import logging
 import re
 from typing import Any
 
+from tools.schema_validator import validate_tool_schema
+
 logger = logging.getLogger(__name__)
 
 
@@ -739,3 +741,39 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             stripped,
         )
     return tools, stripped
+
+
+def validate_tool_schemas(tools: list[dict]) -> list[str]:
+    """Validate tool schemas and return human-actionable issue strings.
+
+    The runtime sanitizer (this module) repairs known-hostile JSON-Schema
+    shapes; this function is the *diagnostic* half. It runs each tool schema
+    through :func:`tools.schema_validator.validate_tool_schema` — the
+    Pydantic-based structural validator — and returns one message per
+    structural problem found (an empty list means every schema is valid).
+
+    This is wired into :func:`model_tools.get_tool_definitions` so a
+    structurally invalid tool schema is surfaced (logged) at
+    tool-registration time instead of surfacing downstream as a cryptic
+    provider ``400 format_error`` / ``schema_validation_error``.
+
+    Never raises: a malformed schema is reported, not fatal. A tool entry
+    whose name cannot be resolved is labelled ``<unnamed>``.
+    """
+    issues: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        result = validate_tool_schema(tool)
+        if result.ok:
+            continue
+        fn = tool.get("function")
+        if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+            name = fn["name"]
+        elif isinstance(tool.get("name"), str):
+            name = tool["name"]
+        else:
+            name = "<unnamed>"
+        for err in result.errors:
+            issues.append(f"{name}: {err}")
+    return issues

--- a/tools/schema_validator.py
+++ b/tools/schema_validator.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+"""Type-safe tool schemas with Pydantic validation (issue #49).
+
+Tool schemas in Hermes are defined as raw Python dicts — there is no
+compile-time type checking or validation for tool input/output parameters.
+Schema mismatches surface only at runtime as cryptic provider errors
+(``400 format_error``, ``schema_validation_error``), wasting API calls and
+agent retries.
+
+This module is the standalone first slice of the type-safety layer: it wraps
+tool parameter definitions in Pydantic ``BaseModel`` classes that enforce the
+standard JSON Schema structure (``type``, ``properties``, ``required``) with
+validators for common tool-schema patterns (string enums, optional fields,
+nested objects, array constraints). It deliberately makes **no call-site
+changes**: existing schemas must pass validation without modification
+(backward compatibility is a success criterion of the issue).
+
+Design notes
+------------
+* ``validate_tool_schema()`` is the single public entry point. It accepts the
+  bare parameter schema, the bare function schema (``{"name": ...,
+  "description": ..., "parameters": {...}}``), or the OpenAI-wrapped form
+  (``{"type": "function", "function": {...}}``) and normalizes them all to
+  the parameter dict before validation.
+* Validation never raises on bad *input*: ``validate_tool_schema`` returns a
+  :class:`ToolSchemaValidationResult` with human-actionable error strings.
+  A Pydantic ``ValidationError`` from a malformed dict is translated into
+  those strings, so callers have one error shape to handle.
+* Unknown extra keywords pass through (``extra="allow"``): tool schemas carry
+  a lot of provider- and model-specific keywords (``x-*`` extensions,
+  ``default``, ``examples``, ``deprecated``...). Rejecting them would break
+  backward compatibility for no safety gain.
+
+The next planned slices (per the issue's split comment) consume this module:
+a ``hermes tools validate`` CLI and Forge integration that runs generated
+schemas through the validator before deployment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+__all__ = [
+    "JSON_SCHEMA_TYPES",
+    "PropertySchema",
+    "ToolSchema",
+    "ToolSchemaValidationResult",
+    "validate_tool_schema",
+    "validate_tool_schema_or_raise",
+]
+
+#: The standard JSON Schema primitive types. ``integer`` and ``number`` are
+#: distinct per JSON Schema (and per OpenAI tool schemas).
+JSON_SCHEMA_TYPES = frozenset({
+    "null",
+    "boolean",
+    "object",
+    "array",
+    "number",
+    "string",
+    "integer",
+})
+
+#: Keywords we validate structurally; everything else passes through.
+_VALIDATED_JSON_SCHEMA_KEYWORDS = frozenset({
+    "type",
+    "properties",
+    "required",
+    "items",
+    "enum",
+})
+
+#: Maximum nesting depth guard — a pathological schema must not blow the
+#: Python stack via recursive Pydantic validation. 64 levels is far beyond
+#: anything a real tool schema uses while staying safely under any limit.
+_MAX_SCHEMA_DEPTH = 64
+
+
+def _is_valid_schema_type(value: Any) -> bool:
+    """True when *value* is a JSON Schema type or a list of valid types."""
+    if isinstance(value, str):
+        return value in JSON_SCHEMA_TYPES
+    if isinstance(value, list) and value:
+        return all(
+            isinstance(item, str) and item in JSON_SCHEMA_TYPES for item in value
+        )
+    return False
+
+
+class PropertySchema(BaseModel):
+    """One JSON Schema property (recursive).
+
+    ``extra="allow"`` preserves provider-specific keywords; only the
+    structural keywords (``type``, ``properties``, ``required``, ``items``,
+    ``enum``) are validated.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Optional[Union[str, List[str]]] = None
+    properties: Optional[Dict[str, "PropertySchema"]] = None
+    required: Optional[List[str]] = None
+    items: Optional["PropertySchema"] = None
+    enum: Optional[List[Any]] = None
+
+    @field_validator("type")
+    @classmethod
+    def _check_type(
+        cls, value: Optional[Union[str, List[str]]]
+    ) -> Optional[Union[str, List[str]]]:
+        if value is None:
+            return value
+        if not _is_valid_schema_type(value):
+            raise ValueError(
+                f"type {value!r} is not a valid JSON Schema type "
+                f"(expected one of {sorted(JSON_SCHEMA_TYPES)})"
+            )
+        return value
+
+    @field_validator("required")
+    @classmethod
+    def _check_required(
+        cls,
+        value: Optional[List[str]],
+        info: Any,
+    ) -> Optional[List[str]]:
+        if value is None:
+            return value
+        if not isinstance(value, list):
+            raise ValueError("required must be a list of property names")
+        properties = info.data.get("properties") or {}
+        unknown = [name for name in value if name not in properties]
+        if unknown:
+            raise ValueError(
+                "required lists properties that are not defined in 'properties': "
+                + ", ".join(repr(n) for n in unknown)
+            )
+        return value
+
+    @field_validator("enum")
+    @classmethod
+    def _check_enum(cls, value: Optional[List[Any]]) -> Optional[List[Any]]:
+        if value is None:
+            return value
+        if not isinstance(value, list) or not value:
+            raise ValueError("enum must be a non-empty list of allowed values")
+        return value
+
+
+class ToolSchema(BaseModel):
+    """Root tool parameter schema.
+
+    Enforces the structure the model providers expect for tool parameters:
+    a JSON object whose properties are themselves valid JSON schemas, with
+    ``required`` naming a subset of those properties.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Union[str, List[str]] = "object"
+    properties: Dict[str, PropertySchema] = Field(default_factory=dict)
+    required: Optional[List[str]] = None
+    additionalProperties: Optional[bool] = None
+
+    @field_validator("type")
+    @classmethod
+    def _check_root_type(cls, value: Union[str, List[str]]) -> Union[str, List[str]]:
+        if not _is_valid_schema_type(value):
+            raise ValueError(
+                f"type {value!r} is not a valid JSON Schema type "
+                f"(expected one of {sorted(JSON_SCHEMA_TYPES)})"
+            )
+        # Tool parameters must describe an object: providers bind tool args to
+        # a JSON object of named properties. Anything else is a schema error.
+        if isinstance(value, str) and value != "object":
+            raise ValueError(
+                f"tool parameter schema type must be 'object', got {value!r} "
+                "(provider tool arguments are JSON objects)"
+            )
+        if isinstance(value, list) and "object" not in value:
+            raise ValueError(
+                f"tool parameter schema type list must include 'object', got {value!r}"
+            )
+        return value
+
+    @field_validator("required")
+    @classmethod
+    def _check_required(
+        cls,
+        value: Optional[List[str]],
+        info: Any,
+    ) -> Optional[List[str]]:
+        if value is None:
+            return value
+        if not isinstance(value, list):
+            raise ValueError("required must be a list of property names")
+        properties = info.data.get("properties") or {}
+        unknown = [name for name in value if name not in properties]
+        if unknown:
+            raise ValueError(
+                "required lists properties that are not defined in 'properties': "
+                + ", ".join(repr(n) for n in unknown)
+            )
+        return value
+
+
+# Resolve the forward references used for recursive property nesting.
+PropertySchema.model_rebuild()
+ToolSchema.model_rebuild()
+
+
+@dataclass
+class ToolSchemaValidationResult:
+    """Outcome of :func:`validate_tool_schema`.
+
+    ``errors`` is always a list of actionable, human-readable strings — one
+    per structural problem found (empty means the schema is valid).
+    """
+
+    ok: bool
+    errors: List[str] = field(default_factory=list)
+    #: The schema normalized to the bare parameter dict, or None when the
+    #: input was not a dict-shaped tool schema at all.
+    normalized_parameters: Optional[Dict[str, Any]] = None
+
+
+def _extract_parameters(schema: Any) -> Optional[Dict[str, Any]]:
+    """Normalize any accepted tool-schema shape to the parameter dict.
+
+    Accepts (mirroring :func:`agent.memory_manager.normalize_tool_schema`'s
+    unwrap logic):
+
+    * bare parameter schema  ``{"type": "object", "properties": ...}``
+    * bare function schema   ``{"name": ..., "parameters": {...}}``
+    * OpenAI-wrapped form    ``{"type": "function", "function": {...}}``
+
+    Returns None when the input is not a dict or has no resolvable parameters.
+    """
+    if not isinstance(schema, dict):
+        return None
+    # Unwrap an already-wrapped OpenAI tool entry.
+    if schema.get("type") == "function" and isinstance(schema.get("function"), dict):
+        schema = schema["function"]
+        if not isinstance(schema, dict):
+            return None
+    params = schema.get("parameters")
+    if params is not None:
+        if not isinstance(params, dict):
+            return None
+        return params
+    # No "parameters" key: the dict is either a bare parameter schema
+    # (identifiable by the JSON-Schema structural keys) or a function schema
+    # that forgot its parameters — the latter must NOT be mistaken for a
+    # bare parameter schema (a dict with only name/description would pass
+    # structural validation and silently lose its parameters).
+    if "type" in schema or "properties" in schema:
+        return schema
+    return None
+
+
+def validate_tool_schema(schema: Any) -> ToolSchemaValidationResult:
+    """Validate *schema* and return a :class:`ToolSchemaValidationResult`.
+
+    Never raises for malformed input — structural problems are collected into
+    ``errors``. The only exception is a genuine programmer error (e.g. a
+    non-JSON-serializable object that breaks Pydantic coercion), which is
+    also caught and reported as an error string so callers always get a
+    result object.
+    """
+    params = _extract_parameters(schema)
+    if params is None:
+        return ToolSchemaValidationResult(
+            ok=False,
+            errors=[
+                "tool schema must be a dict with a 'parameters' object (bare, function, or OpenAI-wrapped form)"
+            ],
+        )
+    try:
+        ToolSchema.model_validate(params)
+    except ValidationError as exc:
+        errors = _flatten_validation_errors(exc)
+        return ToolSchemaValidationResult(
+            ok=False, errors=errors, normalized_parameters=params
+        )
+    except Exception as exc:  # noqa: BLE001 — report, never crash the caller
+        return ToolSchemaValidationResult(
+            ok=False,
+            errors=[
+                f"unexpected schema validation failure: {type(exc).__name__}: {exc}"
+            ],
+            normalized_parameters=params,
+        )
+    return ToolSchemaValidationResult(ok=True, errors=[], normalized_parameters=params)
+
+
+def validate_tool_schema_or_raise(schema: Any) -> Dict[str, Any]:
+    """Validate *schema* and return the normalized parameter dict, or raise.
+
+    Useful for registration-time call sites that want fail-fast semantics
+    (a bad schema must never reach the provider). Raises ``ValueError`` with
+    all collected errors joined; never raises on structurally valid input.
+    """
+    result = validate_tool_schema(schema)
+    if not result.ok:
+        raise ValueError("invalid tool schema: " + "; ".join(result.errors))
+    assert result.normalized_parameters is not None
+    return result.normalized_parameters
+
+
+def _flatten_validation_errors(exc: ValidationError) -> List[str]:
+    """Turn a Pydantic ``ValidationError`` into flat, actionable strings.
+
+    Each error is rendered as ``<location>: <message>`` so a caller can point
+    a developer at the exact property (``properties.foo.required``) that is
+    broken, which is the actionable shape the issue asks for.
+    """
+    flat: List[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err.get("loc", ()))
+        msg = str(err.get("msg", "invalid")).replace("\n", " ")
+        flat.append(f"{loc}: {msg}" if loc else msg)
+    return flat


### PR DESCRIPTION
Automated evolution PR for issue #49 (needs-work rework).

## What changed

The previous PR (#2988) shipped `tools/schema_validator.py` with zero call sites and was rejected by the dead-code gate. This rework wires the validator into a real production call site:

- `tools/schema_validator.py` — Pydantic-based structural validator (re-landed).
- `tools/schema_sanitizer.validate_tool_schemas()` — new public function that runs each sanitized tool schema through the validator and returns actionable issue strings. This is the non-test module that imports the validator.
- `model_tools.get_tool_definitions()` — calls `validate_tool_schemas()` after `sanitize_tool_schemas()`, so a structurally invalid schema is logged at registration time instead of surfacing downstream as a cryptic provider 400.
- Tests: `tests/tools/test_schema_validator.py` (direct validation) + `tests/tools/test_schema_sanitizer.py::TestValidateToolSchemas` (exercises the validator *through* the sanitizer call site).

## Definition of done (per rework brief)

- [x] `tools/schema_validator` imported by a non-test module (`tools/schema_sanitizer.py`)
- [x] Test exercises the validator through that call site (`TestValidateToolSchemas`)
- [x] `grep schema_validator` returns real hits (`tools/schema_sanitizer.py:44`)

## Validation

- `ruff check .` — passes
- `pytest tests/tools/test_schema_validator.py tests/tools/test_schema_sanitizer.py` — 60 passed
