### PR TITLE
feat(evolution): harness component inventory — file-level observability (#39, slice 1)

### DIFF
--- a/evolution/harness_inventory.py
+++ b/evolution/harness_inventory.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Harness component inventory CLI (issue #39, slice 1).
+
+Prints the file-level inventory of editable harness components (skills,
+system-prompt assembly, tool modules, config schema) as markdown. The
+inventory is the "component observability" foundation for the forge
+pipeline: every entry is a file path, so edits are diffable and revertible
+at single-file granularity.
+
+Usage:
+    python evolution/harness_inventory.py [ROOT]
+
+ROOT defaults to the repository root (discovered from this file's path).
+
+Same convention as ``evolution/detect_mode.py`` — a plain, runnable script
+wrapping a ``evolution/lib`` module.
+"""
+
+from evolution.lib.harness_inventory import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evolution/lib/harness_inventory.py
+++ b/evolution/lib/harness_inventory.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Harness component observability — file-level inventory (issue #39, slice 1).
+
+The Agentic Harness Engineering research behind #39 starts from one premise:
+a harness (the system prompt + skills + tool prompts an agent runs on) can
+only be evolved safely when its components are observable — i.e. every
+editable component has a *file-level* representation, so edits are clean,
+diffable, and revertible at the granularity of a single file.
+
+This module is that first slice: it inventories the editable harness
+components of THIS repository as file-level entries. Component kinds:
+
+* ``skill`` — skill definitions (``skills/**/SKILL.md``), the largest class
+  of harness components and the primary forge edit target;
+* ``system_prompt`` — system-prompt assembly code (``agent/prompt_builder.py``),
+  where the prompt sections the forge rewrites are composed;
+* ``tool_prompt`` — tool modules (``tools/*.py``) that ship tool schemas and
+  descriptions, i.e. the prompts the model sees for each tool;
+* ``config`` — the CLI config schema (``cli-config.yaml.example``), the
+  config surface the harness runs under.
+
+Each entry is ``(component_id, kind, path, title, editable)`` — a stable,
+file-level handle a future forge pipeline can diff, edit, and revert at
+single-file granularity (the "component observability" pillar of #39).
+
+The real consumer is the ``evolution/harness_inventory.py`` CLI (same
+convention as ``evolution/detect_mode.py``): it renders the manifest as
+markdown so a human — or a future forge cycle — can see exactly which files
+constitute the editable harness.
+
+Stdlib-only and import-safe.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+__all__ = [
+    "COMPONENT_KINDS",
+    "HarnessComponent",
+    "build_harness_inventory",
+    "render_inventory_markdown",
+]
+
+#: The component kinds the inventory recognizes, in render order.
+COMPONENT_KINDS = ("skill", "system_prompt", "tool_prompt", "config")
+
+#: Relative (to the repo root) paths of non-skill harness components.
+#: ``*`` is expanded via sorted glob; the value is the human title.
+_NON_SKILL_COMPONENTS = (
+    ("system_prompt", "agent/prompt_builder.py", "System prompt assembly"),
+    ("tool_prompt", "tools/*.py", "Tool prompt modules"),
+    ("config", "cli-config.yaml.example", "CLI config schema"),
+)
+
+#: Repo root: two levels up from ``evolution/lib/``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@dataclass(frozen=True)
+class HarnessComponent:
+    """One file-level harness component."""
+
+    component_id: str
+    kind: str
+    #: Path relative to the repo root (forward slashes).
+    path: str
+    title: str
+    editable: bool = True
+
+
+def _find_skill_files(skills_dir: Path) -> List[Path]:
+    """Return skill definition files under *skills_dir*.
+
+    The convention is ``<category>/<skill-name>/SKILL.md``. We match
+    ``SKILL.md`` exactly and ALSO any file whose name lowercases to
+    ``skill.md`` (union, deduped) — the inventory must never miss a skill
+    just because of a filename case difference.
+    """
+    if not skills_dir.is_dir():
+        return []
+    exact = list(skills_dir.rglob("SKILL.md"))
+    case_variants = [
+        p
+        for p in skills_dir.rglob("*")
+        if p.is_file() and p.name.lower() == "skill.md" and p not in exact
+    ]
+    return sorted(exact + case_variants)
+
+
+def build_harness_inventory(root: Optional[Path] = None) -> List[HarnessComponent]:
+    """Build the file-level harness inventory for the repo at *root*.
+
+    Defaults to this repository's root (discovered from the module path).
+    Deterministic ordering: skills sorted by path, then the fixed non-skill
+    components in ``COMPONENT_KINDS`` order. Missing paths are skipped, so a
+    partial checkout still yields a valid (possibly empty) inventory.
+    """
+    base = Path(root).resolve() if root is not None else _REPO_ROOT
+    components: List[HarnessComponent] = []
+
+    skills_dir = base / "skills"
+    for skill_file in _find_skill_files(skills_dir):
+        rel = skill_file.relative_to(base)
+        # component_id: the skill's stable name, e.g. "evolution-orchestrator".
+        component_id = skill_file.parent.name
+        components.append(
+            HarnessComponent(
+                component_id=component_id,
+                kind="skill",
+                path=rel.as_posix(),
+                title=f"Skill: {component_id}",
+            )
+        )
+
+    for kind, pattern, title in _NON_SKILL_COMPONENTS:
+        if "*" in pattern:
+            matches = sorted(m for m in base.glob(pattern) if m.name != "__init__.py")
+        else:
+            candidate = base / pattern
+            matches = [candidate] if candidate.is_file() else []
+        for match in matches:
+            rel = match.relative_to(base)
+            components.append(
+                HarnessComponent(
+                    component_id=rel.as_posix().replace("/", ".").replace(".py", ""),
+                    kind=kind,
+                    path=rel.as_posix(),
+                    title=title,
+                )
+            )
+    return components
+
+
+def render_inventory_markdown(
+    components: List[HarnessComponent], *, root: Optional[Path] = None
+) -> str:
+    """Render the inventory as a human-readable markdown manifest.
+
+    Groups components by kind (in ``COMPONENT_KINDS`` order) and lists each
+    as ``- ``kind``: ``path`` — title``. The root is printed as a header so
+    the manifest is self-describing when saved to a file.
+    """
+    base = Path(root).resolve() if root is not None else _REPO_ROOT
+    lines = [
+        f"# Harness component inventory",
+        "",
+        f"Repository root: `{base}`",
+        "",
+        f"{len(components)} editable components",
+        "",
+    ]
+    for kind in COMPONENT_KINDS:
+        of_kind = [c for c in components if c.kind == kind]
+        if not of_kind:
+            continue
+        lines.append(f"## {kind}")
+        lines.append("")
+        for component in of_kind:
+            lines.append(f"- `{component.path}` — {component.title}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point: print the harness inventory as markdown.
+
+    Usage: ``python evolution/harness_inventory.py [ROOT]`` — ROOT defaults
+    to the repository root. Exit code 0 on success.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    root = Path(argv[0]).resolve() if argv else None
+    components = build_harness_inventory(root)
+    print(render_inventory_markdown(components, root=root))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evolution/tests/test_harness_inventory.py
+++ b/evolution/tests/test_harness_inventory.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`evolution.lib.harness_inventory` (issue #39, slice 1).
+
+The inventory is the "component observability" foundation for the forge
+pipeline: a deterministic, file-level list of editable harness components.
+Tests cover a synthetic temp checkout (fully deterministic) AND the real
+repo layout (the inventory must actually find this repository's skills and
+prompt assembly — a self-referential but load-bearing check).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evolution.lib.harness_inventory import (
+    HarnessComponent,
+    build_harness_inventory,
+    render_inventory_markdown,
+)
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """A minimal synthetic repo: two skills, prompt builder, one tool, config."""
+    root = tmp_path / "repo"
+    (root / "skills" / "category-a" / "alpha").mkdir(parents=True)
+    (root / "skills" / "category-a" / "beta").mkdir(parents=True)
+    (root / "agent").mkdir()
+    (root / "tools").mkdir()
+    (root / "skills" / "category-a" / "alpha" / "SKILL.md").write_text(
+        "# Alpha", encoding="utf-8"
+    )
+    (root / "skills" / "category-a" / "beta" / "skill.md").write_text(
+        "# Beta", encoding="utf-8"
+    )
+    (root / "agent" / "prompt_builder.py").write_text("", encoding="utf-8")
+    (root / "tools" / "widget_tool.py").write_text("", encoding="utf-8")
+    (root / "tools" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "cli-config.yaml.example").write_text("", encoding="utf-8")
+    return root
+
+
+class TestBuildInventory:
+    def test_synthetic_repo_finds_all_kinds(self, fake_repo: Path):
+        components = build_harness_inventory(fake_repo)
+        by_kind = {
+            kind: [c for c in components if c.kind == kind]
+            for kind in ("skill", "system_prompt", "tool_prompt", "config")
+        }
+        # Both skills found regardless of filename case (SKILL.md / skill.md).
+        assert sorted(c.component_id for c in by_kind["skill"]) == ["alpha", "beta"]
+        assert [c.path for c in by_kind["system_prompt"]] == ["agent/prompt_builder.py"]
+        # __init__.py is not a component.
+        assert all(c.path != "tools/__init__.py" for c in by_kind["tool_prompt"])
+        assert [c.path for c in by_kind["tool_prompt"]] == ["tools/widget_tool.py"]
+        assert [c.path for c in by_kind["config"]] == ["cli-config.yaml.example"]
+
+    def test_components_have_stable_ids_and_paths(self, fake_repo: Path):
+        components = build_harness_inventory(fake_repo)
+        ids = [c.component_id for c in components]
+        assert len(ids) == len(set(ids)), "component ids must be unique"
+        for c in components:
+            assert isinstance(c, HarnessComponent)
+            assert c.path == str(c.path) and not c.path.startswith("/")
+            assert c.editable is True
+
+    def test_missing_dirs_yield_empty_not_crash(self, tmp_path: Path):
+        assert build_harness_inventory(tmp_path / "nowhere") == []
+
+    def test_real_repo_contains_its_own_skills(self):
+        """Load-bearing: the inventory must find THIS repo's harness."""
+        components = build_harness_inventory()
+        paths = {c.path for c in components}
+        assert "agent/prompt_builder.py" in paths
+        assert "cli-config.yaml.example" in paths
+        # The evolution skill set is part of the harness.
+        assert any(
+            "skills/evolution/evolution-orchestrator/SKILL.md" == p for p in paths
+        )
+        assert any(p.startswith("tools/") for p in paths)
+
+
+class TestRender:
+    def test_render_groups_by_kind_and_counts(self, fake_repo: Path):
+        components = build_harness_inventory(fake_repo)
+        md = render_inventory_markdown(components, root=fake_repo)
+        assert md.startswith("# Harness component inventory")
+        assert "Repository root: `" in md
+        assert "## skill" in md
+        assert "## system_prompt" in md
+        assert "## config" in md
+        assert "`skills/category-a/alpha/SKILL.md`" in md
+        assert f"{len(components)} editable components" in md
+
+    def test_render_with_empty_inventory(self):
+        md = render_inventory_markdown([], root=Path("/tmp"))
+        assert "0 editable components" in md


### PR DESCRIPTION
Automated evolution PR for issue #39 — slice 1 (component observability).

## What changed

Slice 1 of the Agentic Harness Engineering work: a deterministic, file-level
inventory of the editable harness components (skills, system-prompt assembly,
tool modules, config schema), so edits are diffable and revertible at
single-file granularity — the foundation the forge pipeline needs before
per-edit attribution (#40) can land.

- `evolution/lib/harness_inventory.py` (stdlib-only) — `build_harness_inventory()`
  → stable component ids + relative paths; case-tolerant `SKILL.md` discovery;
  `render_inventory_markdown()` for human/forge-readable manifests.
- `evolution/harness_inventory.py` — CLI (detect_mode.py convention).
- `evolution/tests/test_harness_inventory.py` — 6 tests (synthetic repo +
  real-repo load-bearing checks).

## Scope note

This is slice 1 only. Remaining slices (change manifest #40, auto-revert,
dashboard) are tracked under the still-open issue #39 (`needs-split`).

## Validation

- `ruff check` + `ruff format --check` — clean
- `pytest evolution/tests/test_harness_inventory.py` — 6 passed
- Manual: `python evolution/harness_inventory.py` emits the 241-component
  manifest.
