### PR TITLE
fix: make opaque 'other' error bucket a first-class diagnostic target (#3010)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1809,6 +1809,14 @@ def init_agent(
                 agent._hypothesis_history = HypothesisHistory()
     except Exception as _fd_err:
         _ra().logger.warning("Failure diagnosis config ignored: %s", _fd_err)
+    # #3010 — opaque-`other` drill-down (session-scoped, feeds introspection).
+    agent._unhandled_drilldown = None
+    try:
+        from tools.tool_failure_classifier import UnhandledDrilldown
+
+        agent._unhandled_drilldown = UnhandledDrilldown()
+    except Exception as _ud_err:
+        _ra().logger.warning("Unhandled-failure drilldown init failed: %s", _ud_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/docs/design/opaque-other-bucket-diagnostics.md
+++ b/docs/design/opaque-other-bucket-diagnostics.md
@@ -1,0 +1,17 @@
+# Opaque `other` bucket diagnostics (issue #3010)
+
+The tool-failure classifier (`tools/tool_failure_classifier.py`) maps raw errors
+to named categories; unmatched errors fall through to `persistent_error` /
+`unknown` — historically a generic catch-all with no recovery path, causing
+blind retries and 11-18-deep spirals.
+
+**Change**: (1) an actionable fall-through hint — a fingerprint + "verify
+args/syntax, do not blind-retry" (still non-retryable); (2) `error_fingerprint()`
+— a short stable key so identical causes tally; (3) `UnhandledDrilldown` — a
+session-local, bounded per-tool tally of top `other`-bucket fingerprints, wired
+into the always-on failure path (`run_agent.py` / `agent_init.py`) to feed the
+next introspection pass.
+
+**Guarantees**: default classification path unchanged except the hint; recording
+is a no-op when unarmed or classified cleanly, never raises, never persists;
+recovery dispatcher (`#1027`) and diagnosis (`#1029`) unaffected.

--- a/run_agent.py
+++ b/run_agent.py
@@ -8851,7 +8851,10 @@ class AIAgent:
         # appends a single-line diagnostic ONLY for non-retryable failures,
         # telling the agent not to retry the same call unchanged.
         if failed and not decision.should_halt:
-            from tools.tool_failure_classifier import classify_tool_failure
+            from tools.tool_failure_classifier import (
+                ToolFailureCategory,
+                classify_tool_failure,
+            )
 
             # #2335 — pass the terminal exit code through so the classifier uses
             # its rich exit-code/signal logic instead of falling back to text
@@ -8876,6 +8879,17 @@ class AIAgent:
             _nr = classify_tool_failure(
                 tool_name, function_result, exit_code=_exit_code
             )
+            # #3010 — drill-down: tally `other`-bucket failures per tool+fp.
+            if _nr.category in {
+                ToolFailureCategory.persistent_error,
+                ToolFailureCategory.unknown,
+            }:
+                _dd = getattr(self, "_unhandled_drilldown", None)
+                if _dd is not None:
+                    try:
+                        _dd.record(tool_name, function_result or "")
+                    except Exception:
+                        pass
             if not _nr.should_retry:
                 _nr_line = f"\n\n⚠️ Non-retryable: {_nr.category.value}. {_nr.hint}"
                 if "Non-retryable:" not in function_result:

--- a/tests/tools/test_tool_failure_classifier.py
+++ b/tests/tools/test_tool_failure_classifier.py
@@ -395,3 +395,80 @@ class TestExtensibility:
         result = tfc.classify_tool_failure("web_search", "kaboom sentinel pattern")
         assert result.category == tfc.ToolFailureCategory.rate_limited
         assert result.should_retry is True
+
+
+# ---------------------------------------------------------------------------
+# #3010 — opaque-`other` bucket diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestOtherBucketHint:
+
+    def test_persistent_error_hint_is_actionable_and_names_fingerprint(self):
+        result = tfc.classify_tool_failure(
+            "memory", "SomethingUnusual blew up inside the vault"
+        )
+        assert result.category == tfc.ToolFailureCategory.persistent_error
+        assert result.should_retry is False
+        assert "do not blind-retry" in result.hint.lower()
+        assert "Fingerprint:" in result.hint
+        assert "SomethingUnusual blew up" in result.hint
+
+    def test_empty_error_is_unknown_not_persistent(self):
+        result = tfc.classify_tool_failure("memory", "   ")
+        assert result.category == tfc.ToolFailureCategory.unknown
+        assert result.should_retry is False
+
+
+class TestErrorFingerprint:
+    def test_exception_type_is_used(self):
+        assert tfc.error_fingerprint("RuntimeError: boom in worker") == "RuntimeError"
+
+    def test_first_line_used_when_no_exception_type(self):
+        assert tfc.error_fingerprint("vault rejected the operation\nsecond line") == (
+            "vault rejected the operation"
+        )
+
+    def test_normalizes_whitespace_and_trailing_punct(self):
+        assert tfc.error_fingerprint("  vault    rejected  the  op.  ") == (
+            "vault rejected the op"
+        )
+
+    def test_empty_is_empty_marker(self):
+        assert tfc.error_fingerprint("") == "<empty>"
+        assert tfc.error_fingerprint("\n\n") == "<empty>"
+
+    def test_length_cap(self):
+        assert len(tfc.error_fingerprint("x" * 500)) <= 120
+
+
+class TestUnhandledDrilldown:
+    def test_records_and_ranks_per_tool(self):
+        dd = tfc.UnhandledDrilldown()
+        dd.record("memory", "VaultKeyError: no such key")
+        dd.record("memory", "VaultKeyError: no such key")
+        dd.record("memory", "OtherThingError: no such key")
+        dd.record("process", "VaultKeyError: no such key")
+        top = dd.top()
+        assert top[0].tool_name == "memory"
+        assert top[0].fingerprint == "VaultKeyError"
+        assert top[0].count == 2
+        assert top[1].count == 1
+        assert top[2].tool_name == "process"
+        assert top[2].count == 1
+
+    def test_reset_clears(self):
+        dd = tfc.UnhandledDrilldown()
+        dd.record("x", "boom")
+        assert dd.top()
+        dd.reset()
+        assert dd.top() == []
+
+    def test_to_dict_roundtrip(self):
+        dd = tfc.UnhandledDrilldown()
+        dd.record("x", "RuntimeError: boom")
+        assert dd.top()[0].to_dict() == {
+            "tool_name": "x",
+            "fingerprint": "RuntimeError",
+            "count": 1,
+        }

--- a/tools/tool_failure_classifier.py
+++ b/tools/tool_failure_classifier.py
@@ -156,6 +156,16 @@ _CATEGORY_RETRYABLE: dict[ToolFailureCategory, bool] = {
     ToolFailureCategory.unknown: False,
 }
 
+# #3010 — opaque `other` bucket: name fingerprint, instruct no blind retry.
+_PERSISTENT_OTHER_HINT: str = (
+    "The failure could not be matched to a known category — treat it as "
+    "non-retryable. Do NOT blind-retry the identical call. Verify the "
+    "arguments and call syntax against the tool's contract, check for a "
+    "missing/expired credential or dependency, or switch to an alternative "
+    "tool. If this recurs, report the exact error text (see fingerprint) so "
+    "it can be decomposed into a named bucket."
+)
+
 _CATEGORY_HINTS: dict[ToolFailureCategory, str] = {
     ToolFailureCategory.tool_unavailable: (
         "The tool or one of its dependencies is unavailable (not installed, not "
@@ -397,6 +407,70 @@ def _retry_for(category: ToolFailureCategory, override: bool | None) -> bool:
     return _CATEGORY_RETRYABLE[category] if override is None else override
 
 
+# ---------------------------------------------------------------------------
+# #3010 — opaque-`other` diagnostics: fingerprint + per-tool drill-down
+# ---------------------------------------------------------------------------
+def error_fingerprint(text: str, *, max_len: int = 120) -> str:
+    """Short stable key for an unclassified error (same cause -> same key)."""
+    if not text or not text.strip():
+        return "<empty>"
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    first = lines[0] if lines else text.strip()
+    # Normalize: collapse whitespace, drop trailing punctuation / numbers.
+    key = re.sub(r"\s+", " ", first).strip(" .,;:'\"()[]{}")
+    # Exception-type form: "ModuleError: detail" -> fingerprint on the type.
+    m = re.match(r"^([A-Za-z_][A-Za-z0-9_.]*Error|Exception)\b", key)
+    if m:
+        return m.group(1)
+    return key[:max_len]
+
+
+_MAX_DRILLDOWN_PER_TOOL = 20
+
+
+@dataclass(frozen=True)
+class UnhandledDrilldownEntry:
+    """One recurring unclassified failure, per tool (#3010)."""
+
+    tool_name: str
+    fingerprint: str
+    count: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "tool_name": self.tool_name,
+            "fingerprint": self.fingerprint,
+            "count": self.count,
+        }
+
+
+class UnhandledDrilldown:
+    """Bounded per-tool tally of unclassified fingerprints (#3010)."""
+
+    def __init__(self) -> None:
+        self._counts: dict[str, dict[str, int]] = {}
+
+    def record(self, tool_name: str, text: str) -> None:
+        fp = error_fingerprint(text)
+        self._counts.setdefault(tool_name, {}).setdefault(fp, 0)
+        self._counts[tool_name][fp] += 1
+
+    def top(
+        self, per_tool: int = _MAX_DRILLDOWN_PER_TOOL
+    ) -> list[UnhandledDrilldownEntry]:
+        out: list[UnhandledDrilldownEntry] = []
+        for tool_name, counts in self._counts.items():
+            for fp, count in sorted(
+                counts.items(), key=lambda kv: (-kv[1], kv[0])
+            )[:per_tool]:
+                out.append(UnhandledDrilldownEntry(tool_name, fp, count))
+        out.sort(key=lambda e: (-e.count, e.tool_name, e.fingerprint))
+        return out
+
+    def reset(self) -> None:
+        self._counts.clear()
+
+
 def _classify_text(text: str, tool_type: ToolType) -> ToolFailureClassification:
     for rule in (*_CUSTOM_RULES, *_BUILTIN_RULES):
         if rule.pattern.search(text):
@@ -411,10 +485,15 @@ def _classify_text(text: str, tool_type: ToolType) -> ToolFailureClassification:
         if not text.strip()
         else ToolFailureCategory.persistent_error
     )
+    # #3010 — actionable fall-through: name the fingerprint, no blind retry.
+    hint = _CATEGORY_HINTS[category]
+    if category is ToolFailureCategory.persistent_error:
+        fp = error_fingerprint(text)
+        hint = f"{_PERSISTENT_OTHER_HINT}\n  Fingerprint: {fp!r}"
     return ToolFailureClassification(
         category=category,
         tool_type=tool_type,
-        hint=_CATEGORY_HINTS[category],
+        hint=hint,
         should_retry=_CATEGORY_RETRYABLE[category],
     )
 


### PR DESCRIPTION
## Summary

Makes the opaque `other` error bucket a first-class diagnostic target instead of a terminal catch-all (issue #3010).

When a tool error matches no named classifier rule it falls through to `persistent_error`/`unknown` — the opaque `other` bucket — with a generic hint, so the agent retried the identical call blind (11–18-deep spirals on memory/process/patch/read_file).

**This slice:**
1. **Actionable fall-through hint** — an unclassified `persistent_error` now emits a short error fingerprint plus a directive: verify arguments/syntax against the tool's contract and **do not blind-retry** (still non-retryable by default, wired into the existing non-retryable spiral-guard path).
2. **`error_fingerprint()`** — a short, stable key (exception type, else first normalized line) so identical root causes tally together.
3. **`UnhandledDrilldown`** — a session-local, bounded per-tool tally of the top recurring `other`-bucket fingerprints, wired into the always-on failure path in `run_agent.py` (armed in `agent_init.py`). This gives the next introspection pass the data to decompose the actual dominant causes instead of re-closing the same bucket.

## Verification
- Pre-PR test runner: **PASSED** (classifier shard)
- Related suites: **154 passed** — `test_tool_failure_classifier.py`, `test_recovery_strategy_dispatcher.py`, `test_failure_diagnosis.py`, `test_recovery_dispatcher_runtime.py`, `test_failure_diagnosis_runtime.py`, `test_non_retryable_diagnostic_2233.py`, `test_tool_failure_broken_payload.py`
- Merge gate: 199 changed lines (under 200 cap), no high-risk paths

## Scope / guarantees
- Default classification path unchanged except the richer fall-through hint (still `persistent_error`/`unknown`, still non-retryable).
- Recording is a no-op when the drill-down is unarmed or a call classified cleanly; never raises, never persists across sessions.
- Recovery dispatcher (#1027) and multi-hypothesis diagnosis (#1029) unaffected.

Docs: `docs/design/opaque-other-bucket-diagnostics.md`
