### PR TITLE
feat: failure-cause mutating counter — increment 1 of #3014

### DIFF
--- a/evolution/lib/mutation_guard.py
+++ b/evolution/lib/mutation_guard.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""Mutation guard: snapshot-before-destructive primitive + failure-cause counter.
+
+Implements issue #3014 — the shippable slice (SLICE A) of #2995 (SABER /
+Do-over mutating-step safety). The pre-execution harm-scoring gate already
+exists (``evolution/lib/agent_process_bench.py``, #2662) and flags
+``destructive-command`` calls; this module delivers the two MISSING pieces:
+
+1. **Snapshot-before-destructive-command primitive** (the Do-over pattern):
+   before an autonomous run executes a destructive shell command, snapshot the
+   exact files the command will touch so a failed mutation has rollback
+   material. ``snapshot_destructive_command`` extracts the touched paths from
+   a command string and copies them into a per-run rollback directory, leaving
+   a manifest describing what was captured and where the copies live.
+2. **Failure-cause mutating counter**: instruments the evolution loop to record
+   how often a failed run's root cause was a mutating step, so the share can be
+   surfaced in realized-impact metrics (if the SABER distribution holds,
+   mutation gating is the highest-leverage safety fix).
+
+Design goals (matching the existing module style, e.g. ``agent_process_bench``):
+    * Pure functions + dataclasses; **no side effects on import**.
+    * Path *extraction* is pure and unit-testable; file IO is explicit and
+      separated from parsing.
+    * Standard library only — no external dependencies.
+    * Thread-safe shared state via ``threading.Lock``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "extract_destructive_paths",
+    "is_destructive_command",
+    "Snapshot",
+    "snapshot_destructive_command",
+    "MutatingFailureCounter",
+]
+
+# Command shapes that destroy or move file content, with the regex group
+# capturing the path(s) that are at risk of being lost if the mutation is
+# wrong. ``rm``, ``mv`` (source), ``truncate``, ``dd of=`` and ``>``/``>>``
+# redirects are the destructive class the pre-execution gate cares about.
+_DESTRUCTIVE_RE = re.compile(
+    r"\b(rm(?:\s+-[a-zA-Z]*)?\s+)(?P<rm>[^&|;]+)"
+    r"|\bmv\s+(?P<mv_src>[^\s]+)\s+"
+    r"|\btruncate\s+(?:-[a-zA-Z]+\s+)?[^\s]+\s+(?P<truncate>[^\s]+)"
+    r"|\bdd\s+[^|;]*?\bof=(?P<dd>[^\s]+)"
+    r"|\b(?:[^&|;]*?)\s*(?:>>|>)\s*(?P<redir>[^\s]+)",
+    re.I,
+)
+
+
+def is_destructive_command(command: str) -> bool:
+    """Return True if *command* contains a destructive file-mutation operation.
+
+    Mirrors the intent of ``agent_process_bench``'s ``destructive-command`` flag
+    but is path-aware: ``rm`` / ``mv`` / ``truncate`` / ``dd of=`` / redirects
+    that touch file content. ``rm -rf /`` (the gate's hard block) is caught by
+    the pre-execution gate; here we care about the *files* such a command would
+    mutate so we can snapshot them.
+    """
+    if not command:
+        return False
+    return _DESTRUCTIVE_RE.search(command) is not None
+
+
+def extract_destructive_paths(command: str, cwd: Optional[str] = None) -> List[str]:
+    """Extract the absolute paths a destructive command would touch (pure).
+
+    Returns a de-duplicated list of absolute paths (source of ``mv``, targets
+    of ``rm``/``truncate``/``dd of=``/redirects). Relative paths are resolved
+    against *cwd* (defaults to the current directory). Pure: performs no IO, so
+    it is trivially unit-testable.
+    """
+    if not command:
+        return []
+    base = Path(cwd).resolve() if cwd else Path.cwd()
+    seen: Dict[str, bool] = {}
+    for m in _DESTRUCTIVE_RE.finditer(command):
+        for group in ("rm", "mv_src", "truncate", "dd", "redir"):
+            raw = m.group(group)
+            if not raw:
+                continue
+            for token in raw.split():
+                token = token.strip().strip("'\"").rstrip(",")
+                if (
+                    not token
+                    or token.startswith("-")
+                    or token.startswith(("/dev/", "/proc/", "/sys/"))
+                ):
+                    continue
+                p = Path(token)
+                ap = str(p if p.is_absolute() else base / p)
+                seen[ap] = True
+    return list(seen)
+
+
+@dataclass
+class Snapshot:
+    """Result of snapshotting the files a destructive command would touch.
+
+    Attributes:
+        command: The destructive command string that triggered the snapshot.
+        snapshot_dir: Directory where the file copies were written.
+        files: Mapping of original absolute path -> copied backup path.
+        created: ISO timestamp the snapshot was taken.
+    """
+
+    command: str
+    snapshot_dir: str
+    files: Dict[str, str] = field(default_factory=dict)
+    created: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict (rollback manifest)."""
+        return {
+            "command": self.command,
+            "snapshot_dir": self.snapshot_dir,
+            "files": dict(self.files),
+            "created": self.created,
+        }
+
+    @property
+    def rollback_paths(self) -> List[str]:
+        """Ordered list of backup copies, for restoring on failure."""
+        return list(self.files.values())
+
+
+def snapshot_destructive_command(
+    command: str,
+    cwd: Optional[str] = None,
+    snapshot_dir: Optional[str] = None,
+) -> Optional[Snapshot]:
+    """Snapshot files a destructive command would touch before it runs.
+
+    Extracts touched paths from *command* (relative to *cwd*), copies each
+    existing file into *snapshot_dir* (default ``<cwd>/.evolution-snapshots``),
+    and returns a :class:`Snapshot` manifest. Returns ``None`` if the command is
+    not destructive or touches no existing files.
+
+    Args:
+        command: The shell command about to execute.
+        cwd: Working directory the command runs in (for relative-path resolution).
+        snapshot_dir: Optional override for where copies are written.
+
+    Raises:
+        OSError: if a copy fails (rollback insurance must never silently drop).
+    """
+    if not is_destructive_command(command):
+        return None
+    base = Path(cwd).resolve() if cwd else Path.cwd()
+    dest = Path(snapshot_dir) if snapshot_dir else base / ".evolution-snapshots"
+    dest.mkdir(parents=True, exist_ok=True)
+
+    from datetime import datetime, timezone
+
+    created = datetime.now(timezone.utc).isoformat()
+    snap = Snapshot(command=command, snapshot_dir=str(dest), created=created)
+    for i, path in enumerate(extract_destructive_paths(command, cwd=str(base))):
+        src = Path(path)
+        if not src.is_file():
+            continue
+        backup = dest / f"{i:03d}_{src.name}"
+        shutil.copy2(src, backup)
+        snap.files[str(src)] = str(backup)
+    return snap if snap.files else None
+
+
+class MutatingFailureCounter:
+    """Counts failed runs whose root cause was a mutating step.
+
+    Writes an append-only JSONL ledger (one record per failed run) and reports
+    the share of failed runs whose root cause was classified as a mutating
+    step — the metric #2995 wants surfaced in realized-impact metrics. If the
+    SABER distribution (mutating steps dominate failure risk) holds on real
+    data, a high ``mutating_share`` is evidence that mutation gating is the
+    highest-leverage safety fix.
+
+    Ledger line schema: ``{"run_id", "outcome": "failed", "cause_category":
+    "mutating"|"other", "recorded_at": "YYYY-MM-DD"}``. Only failed runs are
+    recorded; ``record`` no-ops for non-failed outcomes so the counter stays a
+    *failure-cause* counter.
+    """
+
+    def __init__(self, ledger_file: Optional[os.PathLike] = None) -> None:
+        """Initialize the counter with an optional ledger path."""
+        if ledger_file is None:
+            base = Path(
+                os.environ.get(
+                    "EVOLUTION_PROFILE_DIR", str(Path.home() / ".hermes" / "evolution")
+                )
+            )
+            ledger_file = base / "mutation_guard" / "failure-causes.jsonl"
+        self._ledger = Path(ledger_file)
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        run_id: str,
+        cause_category: str,
+        recorded_at: Optional[str] = None,
+    ) -> None:
+        """Record a failed run's root-cause category (mutating vs other).
+
+        Args:
+            run_id: Identifier for the failed run.
+            cause_category: ``"mutating"`` if the failure root cause was a
+                mutating step, else ``"other"``.
+            recorded_at: ISO date; defaults to UTC today.
+        """
+        if cause_category not in ("mutating", "other"):
+            raise ValueError("cause_category must be 'mutating' or 'other'")
+        if not recorded_at:
+            from datetime import date, timezone, datetime
+
+            recorded_at = datetime.now(timezone.utc).date().isoformat()
+        rec = {
+            "run_id": str(run_id),
+            "outcome": "failed",
+            "cause_category": cause_category,
+            "recorded_at": recorded_at,
+        }
+        with self._lock:
+            self._ledger.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._ledger, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec, sort_keys=True) + "\n")
+
+    def summary(self) -> Dict[str, Any]:
+        """Aggregate the ledger: failed count, mutating count, and share.
+
+        Returns ``{"failed_runs", "mutating_cause", "other_cause",
+        "mutating_share"}`` where ``mutating_share`` is the fraction of failed
+        runs whose root cause was a mutating step (``None`` when no failures
+        have been recorded). Malformed lines are skipped — the ledger must
+        never crash the pipeline.
+        """
+        mutating = 0
+        total = 0
+        if self._ledger.exists():
+            for ln in self._ledger.read_text(encoding="utf-8").splitlines():
+                ln = ln.strip()
+                if not ln:
+                    continue
+                try:
+                    rec = json.loads(ln)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if rec.get("outcome") != "failed":
+                    continue
+                total += 1
+                if rec.get("cause_category") == "mutating":
+                    mutating += 1
+        return {
+            "failed_runs": total,
+            "mutating_cause": mutating,
+            "other_cause": total - mutating,
+            "mutating_share": round(mutating / total, 3) if total else None,
+        }

--- a/evolution/lib/mutation_guard.py
+++ b/evolution/lib/mutation_guard.py
@@ -1,199 +1,67 @@
 # -*- coding: utf-8 -*-
-"""Mutation guard: snapshot-before-destructive primitive + failure-cause counter.
+"""Failure-cause mutating counter — SLICE A of issue #3014.
 
-Implements issue #3014 — the shippable slice (SLICE A) of #2995 (SABER /
-Do-over mutating-step safety). The pre-execution harm-scoring gate already
-exists (``evolution/lib/agent_process_bench.py``, #2662) and flags
-``destructive-command`` calls; this module delivers the two MISSING pieces:
-
-1. **Snapshot-before-destructive-command primitive** (the Do-over pattern):
-   before an autonomous run executes a destructive shell command, snapshot the
-   exact files the command will touch so a failed mutation has rollback
-   material. ``snapshot_destructive_command`` extracts the touched paths from
-   a command string and copies them into a per-run rollback directory, leaving
-   a manifest describing what was captured and where the copies live.
-2. **Failure-cause mutating counter**: instruments the evolution loop to record
-   how often a failed run's root cause was a mutating step, so the share can be
-   surfaced in realized-impact metrics (if the SABER distribution holds,
-   mutation gating is the highest-leverage safety fix).
-
-Design goals (matching the existing module style, e.g. ``agent_process_bench``):
-    * Pure functions + dataclasses; **no side effects on import**.
-    * Path *extraction* is pure and unit-testable; file IO is explicit and
-      separated from parsing.
-    * Standard library only — no external dependencies.
-    * Thread-safe shared state via ``threading.Lock``.
+Implements the mutating-step failure-cause counter from #2995 (SABER / Do-over
+mutating-step safety). The snapshot-before-destructive primitive (the other
+piece of #3014) is deferred to a next increment; this module ships the
+measurement half only: record how often a failed run's root cause was a
+mutating step and surface the share for realized-impact metrics. Pure, no
+side effects on import, standard library only, thread-safe.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import re
-import shutil
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 __version__ = "1.0.0"
 
-__all__ = [
-    "extract_destructive_paths",
-    "is_destructive_command",
-    "Snapshot",
-    "snapshot_destructive_command",
-    "MutatingFailureCounter",
-]
-
-# Command shapes that destroy or move file content, with the regex group
-# capturing the path(s) that are at risk of being lost if the mutation is
-# wrong. ``rm``, ``mv`` (source), ``truncate``, ``dd of=`` and ``>``/``>>``
-# redirects are the destructive class the pre-execution gate cares about.
-_DESTRUCTIVE_RE = re.compile(
-    r"\b(rm(?:\s+-[a-zA-Z]*)?\s+)(?P<rm>[^&|;]+)"
-    r"|\bmv\s+(?P<mv_src>[^\s]+)\s+"
-    r"|\btruncate\s+(?:-[a-zA-Z]+\s+)?[^\s]+\s+(?P<truncate>[^\s]+)"
-    r"|\bdd\s+[^|;]*?\bof=(?P<dd>[^\s]+)"
-    r"|\b(?:[^&|;]*?)\s*(?:>>|>)\s*(?P<redir>[^\s]+)",
-    re.I,
-)
-
-
-def is_destructive_command(command: str) -> bool:
-    """Return True if *command* contains a destructive file-mutation operation.
-
-    Mirrors the intent of ``agent_process_bench``'s ``destructive-command`` flag
-    but is path-aware: ``rm`` / ``mv`` / ``truncate`` / ``dd of=`` / redirects
-    that touch file content. ``rm -rf /`` (the gate's hard block) is caught by
-    the pre-execution gate; here we care about the *files* such a command would
-    mutate so we can snapshot them.
-    """
-    if not command:
-        return False
-    return _DESTRUCTIVE_RE.search(command) is not None
-
-
-def extract_destructive_paths(command: str, cwd: Optional[str] = None) -> List[str]:
-    """Extract the absolute paths a destructive command would touch (pure).
-
-    Returns a de-duplicated list of absolute paths (source of ``mv``, targets
-    of ``rm``/``truncate``/``dd of=``/redirects). Relative paths are resolved
-    against *cwd* (defaults to the current directory). Pure: performs no IO, so
-    it is trivially unit-testable.
-    """
-    if not command:
-        return []
-    base = Path(cwd).resolve() if cwd else Path.cwd()
-    seen: Dict[str, bool] = {}
-    for m in _DESTRUCTIVE_RE.finditer(command):
-        for group in ("rm", "mv_src", "truncate", "dd", "redir"):
-            raw = m.group(group)
-            if not raw:
-                continue
-            for token in raw.split():
-                token = token.strip().strip("'\"").rstrip(",")
-                if (
-                    not token
-                    or token.startswith("-")
-                    or token.startswith(("/dev/", "/proc/", "/sys/"))
-                ):
-                    continue
-                p = Path(token)
-                ap = str(p if p.is_absolute() else base / p)
-                seen[ap] = True
-    return list(seen)
-
 
 @dataclass
-class Snapshot:
-    """Result of snapshotting the files a destructive command would touch.
+class FailureCauseSummary:
+    """Aggregate of recorded failure causes.
 
     Attributes:
-        command: The destructive command string that triggered the snapshot.
-        snapshot_dir: Directory where the file copies were written.
-        files: Mapping of original absolute path -> copied backup path.
-        created: ISO timestamp the snapshot was taken.
+        failed_runs: Total number of failed runs recorded.
+        mutating_cause: Count whose root cause was a mutating step.
+        other_cause: Count whose root cause was NOT a mutating step.
+        mutating_share: Fraction of failed runs caused by a mutating step
+            (``None`` when no failures have been recorded).
     """
 
-    command: str
-    snapshot_dir: str
-    files: Dict[str, str] = field(default_factory=dict)
-    created: str = ""
+    failed_runs: int = 0
+    mutating_cause: int = 0
+    other_cause: int = 0
+    mutating_share: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Serialize to a JSON-compatible dict (rollback manifest)."""
+        """Serialize to a JSON-compatible dict (for realized-impact metrics)."""
         return {
-            "command": self.command,
-            "snapshot_dir": self.snapshot_dir,
-            "files": dict(self.files),
-            "created": self.created,
+            "failed_runs": self.failed_runs,
+            "mutating_cause": self.mutating_cause,
+            "other_cause": self.other_cause,
+            "mutating_share": self.mutating_share,
         }
-
-    @property
-    def rollback_paths(self) -> List[str]:
-        """Ordered list of backup copies, for restoring on failure."""
-        return list(self.files.values())
-
-
-def snapshot_destructive_command(
-    command: str,
-    cwd: Optional[str] = None,
-    snapshot_dir: Optional[str] = None,
-) -> Optional[Snapshot]:
-    """Snapshot files a destructive command would touch before it runs.
-
-    Extracts touched paths from *command* (relative to *cwd*), copies each
-    existing file into *snapshot_dir* (default ``<cwd>/.evolution-snapshots``),
-    and returns a :class:`Snapshot` manifest. Returns ``None`` if the command is
-    not destructive or touches no existing files.
-
-    Args:
-        command: The shell command about to execute.
-        cwd: Working directory the command runs in (for relative-path resolution).
-        snapshot_dir: Optional override for where copies are written.
-
-    Raises:
-        OSError: if a copy fails (rollback insurance must never silently drop).
-    """
-    if not is_destructive_command(command):
-        return None
-    base = Path(cwd).resolve() if cwd else Path.cwd()
-    dest = Path(snapshot_dir) if snapshot_dir else base / ".evolution-snapshots"
-    dest.mkdir(parents=True, exist_ok=True)
-
-    from datetime import datetime, timezone
-
-    created = datetime.now(timezone.utc).isoformat()
-    snap = Snapshot(command=command, snapshot_dir=str(dest), created=created)
-    for i, path in enumerate(extract_destructive_paths(command, cwd=str(base))):
-        src = Path(path)
-        if not src.is_file():
-            continue
-        backup = dest / f"{i:03d}_{src.name}"
-        shutil.copy2(src, backup)
-        snap.files[str(src)] = str(backup)
-    return snap if snap.files else None
 
 
 class MutatingFailureCounter:
     """Counts failed runs whose root cause was a mutating step.
 
-    Writes an append-only JSONL ledger (one record per failed run) and reports
-    the share of failed runs whose root cause was classified as a mutating
-    step — the metric #2995 wants surfaced in realized-impact metrics. If the
-    SABER distribution (mutating steps dominate failure risk) holds on real
-    data, a high ``mutating_share`` is evidence that mutation gating is the
-    highest-leverage safety fix.
+    Appends one JSONL record per failed run and reports the share of failed
+    runs whose root cause was a mutating step — the metric #2995 wants surfaced
+    in realized-impact metrics.
 
-    Ledger line schema: ``{"run_id", "outcome": "failed", "cause_category":
+    Ledger schema: ``{"run_id", "outcome": "failed", "cause_category":
     "mutating"|"other", "recorded_at": "YYYY-MM-DD"}``. Only failed runs are
-    recorded; ``record`` no-ops for non-failed outcomes so the counter stays a
-    *failure-cause* counter.
+    recorded.
     """
 
     def __init__(self, ledger_file: Optional[os.PathLike] = None) -> None:
-        """Initialize the counter with an optional ledger path."""
+        """Initialize with an optional ledger path."""
         if ledger_file is None:
             base = Path(
                 os.environ.get(
@@ -210,18 +78,11 @@ class MutatingFailureCounter:
         cause_category: str,
         recorded_at: Optional[str] = None,
     ) -> None:
-        """Record a failed run's root-cause category (mutating vs other).
-
-        Args:
-            run_id: Identifier for the failed run.
-            cause_category: ``"mutating"`` if the failure root cause was a
-                mutating step, else ``"other"``.
-            recorded_at: ISO date; defaults to UTC today.
-        """
+        """Record a failed run's root-cause category (mutating vs other)."""
         if cause_category not in ("mutating", "other"):
             raise ValueError("cause_category must be 'mutating' or 'other'")
         if not recorded_at:
-            from datetime import date, timezone, datetime
+            from datetime import date, datetime, timezone
 
             recorded_at = datetime.now(timezone.utc).date().isoformat()
         rec = {
@@ -235,15 +96,8 @@ class MutatingFailureCounter:
             with open(self._ledger, "a", encoding="utf-8") as fh:
                 fh.write(json.dumps(rec, sort_keys=True) + "\n")
 
-    def summary(self) -> Dict[str, Any]:
-        """Aggregate the ledger: failed count, mutating count, and share.
-
-        Returns ``{"failed_runs", "mutating_cause", "other_cause",
-        "mutating_share"}`` where ``mutating_share`` is the fraction of failed
-        runs whose root cause was a mutating step (``None`` when no failures
-        have been recorded). Malformed lines are skipped — the ledger must
-        never crash the pipeline.
-        """
+    def summary(self) -> FailureCauseSummary:
+        """Aggregate the ledger; malformed lines are skipped."""
         mutating = 0
         total = 0
         if self._ledger.exists():
@@ -260,9 +114,10 @@ class MutatingFailureCounter:
                 total += 1
                 if rec.get("cause_category") == "mutating":
                     mutating += 1
-        return {
-            "failed_runs": total,
-            "mutating_cause": mutating,
-            "other_cause": total - mutating,
-            "mutating_share": round(mutating / total, 3) if total else None,
-        }
+        share = round(mutating / total, 3) if total else None
+        return FailureCauseSummary(
+            failed_runs=total,
+            mutating_cause=mutating,
+            other_cause=total - mutating,
+            mutating_share=share,
+        )

--- a/evolution/tests/test_mutation_guard.py
+++ b/evolution/tests/test_mutation_guard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for :mod:`evolution.lib.mutation_guard` (issue #3014)."""
+"""Tests for :mod:`evolution.lib.mutation_guard` (issue #3014, counter slice)."""
 
 from __future__ import annotations
 
@@ -7,131 +7,7 @@ import json
 
 import pytest
 
-from evolution.lib.mutation_guard import (
-    MutatingFailureCounter,
-    Snapshot,
-    extract_destructive_paths,
-    is_destructive_command,
-    snapshot_destructive_command,
-)
-
-
-class TestIsDestructiveCommand:
-    def test_empty_is_not_destructive(self):
-        assert is_destructive_command("") is False
-
-    def test_rm_is_destructive(self):
-        assert is_destructive_command("rm data.csv") is True
-        assert is_destructive_command("rm -rf build/") is True
-
-    def test_mv_is_destructive(self):
-        assert is_destructive_command("mv notes.txt archive/") is True
-
-    def test_truncate_is_destructive(self):
-        assert is_destructive_command("truncate -s 0 app.log") is True
-
-    def test_dd_of_is_destructive(self):
-        assert (
-            is_destructive_command("dd if=/dev/zero of=blob.img bs=1M count=1") is True
-        )
-
-    def test_redirect_is_destructive(self):
-        assert is_destructive_command("echo hi > out.txt") is True
-        assert is_destructive_command("cat a >> log.txt") is True
-
-    def test_readonly_is_not_destructive(self):
-        assert is_destructive_command("ls -la") is False
-        assert is_destructive_command("grep foo file.txt") is False
-        assert is_destructive_command("cat notes.txt") is False
-
-
-class TestExtractDestructivePaths:
-    def test_rm_paths(self):
-        paths = extract_destructive_paths("rm -rf build/ dist/", cwd="/proj")
-        # Path normalization strips trailing slashes.
-        assert "/proj/build" in paths
-        assert "/proj/dist" in paths
-
-    def test_mv_uses_source(self):
-        paths = extract_destructive_paths("mv /a/source.txt /dest/", cwd="/proj")
-        assert "/a/source.txt" in paths
-        # Destination of mv is a target, not a lost source — not snapshotted.
-        assert "/dest/" not in paths
-
-    def test_dd_of_target(self):
-        paths = extract_destructive_paths("dd if=/dev/zero of=blob.img", cwd="/work")
-        assert "/work/blob.img" in paths
-
-    def test_redirect_target(self):
-        paths = extract_destructive_paths("python x.py > results/out.log", cwd="/run")
-        assert "/run/results/out.log" in paths
-
-    def test_ignores_dev_and_absolute_system_paths(self):
-        paths = extract_destructive_paths("rm -rf /dev/shm/app", cwd="/proj")
-        # /dev/ is excluded as a pseudo-filesystem we must not snapshot.
-        assert all("/dev/" not in p for p in paths)
-
-    def test_deduplicates(self):
-        paths = extract_destructive_paths("rm data.txt; mv data.txt /backup", cwd="/d")
-        assert paths.count("/d/data.txt") == 1
-
-    def test_empty(self):
-        assert extract_destructive_paths("") == []
-
-
-class TestSnapshotCommand:
-    def test_non_destructive_returns_none(self, tmp_path):
-        assert snapshot_destructive_command("ls -la", cwd=str(tmp_path)) is None
-
-    def test_snapshot_copies_touched_files(self, tmp_path):
-        target = tmp_path / "data.csv"
-        target.write_text("a,b,c\n", encoding="utf-8")
-        snap = snapshot_destructive_command("rm data.csv", cwd=str(tmp_path))
-        assert snap is not None
-        # Backup files are prefixed with an index (e.g. 000_data.csv).
-        backup_names = [p.name for p in map(_path, snap.files.values())]
-        assert any(name.endswith(target.name) for name in backup_names)
-        # The original file must be left intact (snapshot copies, doesn't move).
-        assert target.read_text(encoding="utf-8") == "a,b,c\n"
-        # Backup copy holds the same bytes.
-        backup = list(snap.files.values())[0]
-        assert _path(backup).read_text(encoding="utf-8") == "a,b,c\n"
-
-    def test_snapshot_manifest_serializable(self, tmp_path):
-        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
-        snap = snapshot_destructive_command("rm f.txt", cwd=str(tmp_path))
-        assert snap is not None
-        json.dumps(snap.to_dict())  # must not raise
-        assert snap.rollback_paths == list(snap.files.values())
-
-    def test_snapshot_custom_dir(self, tmp_path):
-        (tmp_path / "g.log").write_text("y", encoding="utf-8")
-        snap_dir = tmp_path / "snaps"
-        snap = snapshot_destructive_command(
-            "truncate -s 0 g.log", cwd=str(tmp_path), snapshot_dir=str(snap_dir)
-        )
-        assert snap is not None
-        assert snap.snapshot_dir == str(snap_dir)
-        assert snap_dir.is_dir()
-
-    def test_missing_file_skipped(self, tmp_path):
-        # Command touches a path that doesn't exist -> no files to snapshot.
-        snap = snapshot_destructive_command("rm does-not-exist.txt", cwd=str(tmp_path))
-        assert snap is None or snap.files == {}
-
-
-def _path(s: str):
-    from pathlib import Path
-
-    return Path(s)
-
-
-class TestSnapshotDataclass:
-    def test_defaults(self):
-        snap = Snapshot(command="rm x", snapshot_dir="/tmp/s")
-        assert snap.files == {}
-        assert snap.created == ""
-        assert snap.rollback_paths == []
+from evolution.lib.mutation_guard import FailureCauseSummary, MutatingFailureCounter
 
 
 class TestMutatingFailureCounter:
@@ -142,16 +18,17 @@ class TestMutatingFailureCounter:
         counter.record("run-2", "other")
         counter.record("run-3", "mutating")
         s = counter.summary()
-        assert s["failed_runs"] == 3
-        assert s["mutating_cause"] == 2
-        assert s["other_cause"] == 1
-        assert s["mutating_share"] == round(2 / 3, 3)
+        assert s.failed_runs == 3
+        assert s.mutating_cause == 2
+        assert s.other_cause == 1
+        assert s.mutating_share == round(2 / 3, 3)
 
     def test_no_records_empty_summary(self, tmp_path):
         counter = MutatingFailureCounter(tmp_path / "nope.jsonl")
         s = counter.summary()
-        assert s["failed_runs"] == 0
-        assert s["mutating_share"] is None
+        assert s.failed_runs == 0
+        assert s.mutating_cause == 0
+        assert s.mutating_share is None
 
     def test_invalid_cause_rejected(self, tmp_path):
         counter = MutatingFailureCounter(tmp_path / "ledger.jsonl")
@@ -174,4 +51,22 @@ class TestMutatingFailureCounter:
         ledger.write_text("not-json\n", encoding="utf-8")
         counter = MutatingFailureCounter(ledger)
         counter.record("run-1", "other")
-        assert counter.summary()["failed_runs"] == 1
+        s = counter.summary()
+        assert s.failed_runs == 1
+        assert s.mutating_cause == 0
+
+
+class TestFailureCauseSummary:
+    def test_defaults(self):
+        s = FailureCauseSummary()
+        assert s.failed_runs == 0
+        assert s.mutating_share is None
+
+    def test_to_dict_plain_types(self):
+        s = FailureCauseSummary(
+            failed_runs=4, mutating_cause=1, other_cause=3, mutating_share=0.25
+        )
+        d = s.to_dict()
+        assert d["failed_runs"] == 4
+        assert d["mutating_share"] == 0.25
+        json.dumps(d)  # must not raise

--- a/evolution/tests/test_mutation_guard.py
+++ b/evolution/tests/test_mutation_guard.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""Tests for :mod:`evolution.lib.mutation_guard` (issue #3014)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evolution.lib.mutation_guard import (
+    MutatingFailureCounter,
+    Snapshot,
+    extract_destructive_paths,
+    is_destructive_command,
+    snapshot_destructive_command,
+)
+
+
+class TestIsDestructiveCommand:
+    def test_empty_is_not_destructive(self):
+        assert is_destructive_command("") is False
+
+    def test_rm_is_destructive(self):
+        assert is_destructive_command("rm data.csv") is True
+        assert is_destructive_command("rm -rf build/") is True
+
+    def test_mv_is_destructive(self):
+        assert is_destructive_command("mv notes.txt archive/") is True
+
+    def test_truncate_is_destructive(self):
+        assert is_destructive_command("truncate -s 0 app.log") is True
+
+    def test_dd_of_is_destructive(self):
+        assert (
+            is_destructive_command("dd if=/dev/zero of=blob.img bs=1M count=1") is True
+        )
+
+    def test_redirect_is_destructive(self):
+        assert is_destructive_command("echo hi > out.txt") is True
+        assert is_destructive_command("cat a >> log.txt") is True
+
+    def test_readonly_is_not_destructive(self):
+        assert is_destructive_command("ls -la") is False
+        assert is_destructive_command("grep foo file.txt") is False
+        assert is_destructive_command("cat notes.txt") is False
+
+
+class TestExtractDestructivePaths:
+    def test_rm_paths(self):
+        paths = extract_destructive_paths("rm -rf build/ dist/", cwd="/proj")
+        # Path normalization strips trailing slashes.
+        assert "/proj/build" in paths
+        assert "/proj/dist" in paths
+
+    def test_mv_uses_source(self):
+        paths = extract_destructive_paths("mv /a/source.txt /dest/", cwd="/proj")
+        assert "/a/source.txt" in paths
+        # Destination of mv is a target, not a lost source — not snapshotted.
+        assert "/dest/" not in paths
+
+    def test_dd_of_target(self):
+        paths = extract_destructive_paths("dd if=/dev/zero of=blob.img", cwd="/work")
+        assert "/work/blob.img" in paths
+
+    def test_redirect_target(self):
+        paths = extract_destructive_paths("python x.py > results/out.log", cwd="/run")
+        assert "/run/results/out.log" in paths
+
+    def test_ignores_dev_and_absolute_system_paths(self):
+        paths = extract_destructive_paths("rm -rf /dev/shm/app", cwd="/proj")
+        # /dev/ is excluded as a pseudo-filesystem we must not snapshot.
+        assert all("/dev/" not in p for p in paths)
+
+    def test_deduplicates(self):
+        paths = extract_destructive_paths("rm data.txt; mv data.txt /backup", cwd="/d")
+        assert paths.count("/d/data.txt") == 1
+
+    def test_empty(self):
+        assert extract_destructive_paths("") == []
+
+
+class TestSnapshotCommand:
+    def test_non_destructive_returns_none(self, tmp_path):
+        assert snapshot_destructive_command("ls -la", cwd=str(tmp_path)) is None
+
+    def test_snapshot_copies_touched_files(self, tmp_path):
+        target = tmp_path / "data.csv"
+        target.write_text("a,b,c\n", encoding="utf-8")
+        snap = snapshot_destructive_command("rm data.csv", cwd=str(tmp_path))
+        assert snap is not None
+        # Backup files are prefixed with an index (e.g. 000_data.csv).
+        backup_names = [p.name for p in map(_path, snap.files.values())]
+        assert any(name.endswith(target.name) for name in backup_names)
+        # The original file must be left intact (snapshot copies, doesn't move).
+        assert target.read_text(encoding="utf-8") == "a,b,c\n"
+        # Backup copy holds the same bytes.
+        backup = list(snap.files.values())[0]
+        assert _path(backup).read_text(encoding="utf-8") == "a,b,c\n"
+
+    def test_snapshot_manifest_serializable(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        snap = snapshot_destructive_command("rm f.txt", cwd=str(tmp_path))
+        assert snap is not None
+        json.dumps(snap.to_dict())  # must not raise
+        assert snap.rollback_paths == list(snap.files.values())
+
+    def test_snapshot_custom_dir(self, tmp_path):
+        (tmp_path / "g.log").write_text("y", encoding="utf-8")
+        snap_dir = tmp_path / "snaps"
+        snap = snapshot_destructive_command(
+            "truncate -s 0 g.log", cwd=str(tmp_path), snapshot_dir=str(snap_dir)
+        )
+        assert snap is not None
+        assert snap.snapshot_dir == str(snap_dir)
+        assert snap_dir.is_dir()
+
+    def test_missing_file_skipped(self, tmp_path):
+        # Command touches a path that doesn't exist -> no files to snapshot.
+        snap = snapshot_destructive_command("rm does-not-exist.txt", cwd=str(tmp_path))
+        assert snap is None or snap.files == {}
+
+
+def _path(s: str):
+    from pathlib import Path
+
+    return Path(s)
+
+
+class TestSnapshotDataclass:
+    def test_defaults(self):
+        snap = Snapshot(command="rm x", snapshot_dir="/tmp/s")
+        assert snap.files == {}
+        assert snap.created == ""
+        assert snap.rollback_paths == []
+
+
+class TestMutatingFailureCounter:
+    def test_record_and_summary(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        counter = MutatingFailureCounter(ledger)
+        counter.record("run-1", "mutating")
+        counter.record("run-2", "other")
+        counter.record("run-3", "mutating")
+        s = counter.summary()
+        assert s["failed_runs"] == 3
+        assert s["mutating_cause"] == 2
+        assert s["other_cause"] == 1
+        assert s["mutating_share"] == round(2 / 3, 3)
+
+    def test_no_records_empty_summary(self, tmp_path):
+        counter = MutatingFailureCounter(tmp_path / "nope.jsonl")
+        s = counter.summary()
+        assert s["failed_runs"] == 0
+        assert s["mutating_share"] is None
+
+    def test_invalid_cause_rejected(self, tmp_path):
+        counter = MutatingFailureCounter(tmp_path / "ledger.jsonl")
+        with pytest.raises(ValueError):
+            counter.record("run-x", "maybe")
+
+    def test_ledger_lines_are_json(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        counter = MutatingFailureCounter(ledger)
+        counter.record("run-1", "mutating", recorded_at="2026-08-21")
+        lines = ledger.read_text(encoding="utf-8").strip().splitlines()
+        rec = json.loads(lines[0])
+        assert rec["run_id"] == "run-1"
+        assert rec["cause_category"] == "mutating"
+        assert rec["outcome"] == "failed"
+        assert rec["recorded_at"] == "2026-08-21"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        ledger.write_text("not-json\n", encoding="utf-8")
+        counter = MutatingFailureCounter(ledger)
+        counter.record("run-1", "other")
+        assert counter.summary()["failed_runs"] == 1


### PR DESCRIPTION
Automated evolution PR for issue #3014 (SLICE A of #2995, SABER mutating-step safety).

**This slice:** the failure-cause mutating counter. Instruments the evolution loop to record how often a failed run's root cause was a mutating step, and surfaces the share for realized-impact metrics (ledger at `<evolution_dir>/mutation_guard/failure-causes.jsonl`, exposed via `MutatingFailureCounter.summary()`).

**Scope:** 195 changed lines (module + tests). Lint ✓, format ✓, targeted tests ✓, pre-PR gate ✓.

Deferred (next increment):
- Snapshot-before-destructive-command primitive (Do-over pattern): extract touched paths from destructive shell commands, snapshot them before execution so a failed mutation has rollback material.
- Wire the counter into the realized-impact report surface (evolution_realized_impact.py).