### PR TITLE
fix(model_tools): stop spurious JSON-parse WARNING on scalar read_file path (Closes #3026)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1069,20 +1069,32 @@ def _coerce_value(
     expected_type,
     schema: dict | None = None,
     context: str = "",
+    quiet: bool = False,
 ):
     """Attempt to coerce a string *value* to *expected_type*.
 
     Returns the original string when coercion is not applicable or fails.
     ``context`` (e.g. ``"tool_name.param"``) is forwarded into parse-failure
-    warnings so the agent gets a deterministic recovery hint.
+    warnings so the agent gets a deterministic recovery hint.  ``quiet``
+    suppresses parse-failure warnings for unions that also accept ``string``
+    (the value is already valid, so a failed JSON parse is expected, not an
+    error — see the read_file.path ``["string","array"]`` noise).
     """
     if _schema_allows_null(schema) and value.strip().lower() == "null":
         return None
 
     if isinstance(expected_type, list):
-        # Union type — try each in order, return first successful coercion
+        # Union type — try each in order, return first successful coercion.
+        # If the union also accepts ``string`` and the value is already a
+        # string, the value is valid as-is: silence the parse-failure WARNING
+        # from later non-string members (array/object) so a legitimate scalar
+        # (e.g. read_file.path on ["string","array"]) does not log a
+        # misleading "failed to parse string as JSON for expected type list".
+        quiet = quiet or ("string" in expected_type and isinstance(value, str))
         for t in expected_type:
-            result = _coerce_value(value, t, schema=schema, context=context)
+            result = _coerce_value(
+                value, t, schema=schema, context=context, quiet=quiet
+            )
             if result is not value:
                 return result
         return value
@@ -1092,9 +1104,9 @@ def _coerce_value(
     if expected_type == "boolean":
         return _coerce_boolean(value)
     if expected_type == "array":
-        return _coerce_json(value, list, context=context)
+        return _coerce_json(value, list, context=context, quiet=quiet)
     if expected_type == "object":
-        return _coerce_json(value, dict, context=context)
+        return _coerce_json(value, dict, context=context, quiet=quiet)
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
@@ -1240,11 +1252,16 @@ def _split_path_list(value: str) -> Optional[List[str]]:
     return None
 
 
-def _coerce_json(value: str, expected_python_type: type, context: str = ""):
+def _coerce_json(
+    value: str, expected_python_type: type, context: str = "", quiet: bool = False
+):
     """Parse *value* as JSON when the schema expects an array or object.
 
     ``context`` (e.g. ``"tool_name.param"``) is included in the parse-failure
     WARNING so the agent gets a deterministic recovery hint (issue #2953).
+    ``quiet`` suppresses that WARNING when the value is already valid for a
+    sibling union member (e.g. a scalar string on ``["string","array"]``),
+    where a failed JSON parse is expected rather than an error.
     """
     if not value or not value.strip():
         if expected_python_type is list:
@@ -1265,15 +1282,16 @@ def _coerce_json(value: str, expected_python_type: type, context: str = ""):
                     items,
                 )
                 return items
-        ctx = f"{context} " if context else ""
-        logger.warning(
-            "coerce_tool_args: %sfailed to parse string as JSON for expected type %s "
-            "(value %.80r): %s",
-            ctx,
-            expected_python_type.__name__,
-            value,
-            exc,
-        )
+        if not quiet:
+            ctx = f"{context} " if context else ""
+            logger.warning(
+                "coerce_tool_args: %sfailed to parse string as JSON for expected type %s "
+                "(value %.80r): %s",
+                ctx,
+                expected_python_type.__name__,
+                value,
+                exc,
+            )
         return value
     if isinstance(parsed, expected_python_type):
         logger.debug(

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -302,6 +302,21 @@ class TestCoerceToolArgs:
         result = coerce_tool_args("read_file", args)
         assert result["path"] == "src/main.py"
 
+    def test_real_read_file_scalar_path_no_misleading_warning(self, caplog):
+        """Regression for #3026 — a scalar path on read_file's
+        ``["string", "array"]`` union is valid as-is, so it must NOT emit the
+        misleading ``failed to parse string as JSON for expected type list``
+        WARNING (previously logged 126+ times/day for reads that succeeded)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            args = {"path": "/root/.hermes/evolution/.hydra-dispatch-ledger.json"}
+            result = coerce_tool_args("read_file", args)
+        assert result["path"] == "/root/.hermes/evolution/.hydra-dispatch-ledger.json"
+        joined = "\n".join(r.message for r in caplog.records)
+        assert "failed to parse string as JSON for expected type list" not in joined
+        assert "read_file.path" not in joined
+
     def test_real_read_file_single_element_json_array_parses_to_list(self):
         """A single-element JSON array string should parse to a
         single-element list (the model intended a batch read)."""


### PR DESCRIPTION
Automated evolution PR for #3026.

## What / why
`read_file.path` has a `["string","array"]` union schema. A scalar path is already type-valid, but `_coerce_value`'s union loop continued past the valid `"string"` member into the `"array"` member, where `_coerce_json` failed to parse the plain path as JSON and logged a **misleading WARNING**:

```
coerce_tool_args: read_file.path failed to parse string as JSON for expected type list (value '/some/file.py'): Expecting value...
```

This fired **126+ times/day** in `errors.log` for reads that all **succeeded** — and the noise itself falsely drove the 08-21 introspection into classifying working reads as a high-severity "coercion regression" (a false positive).

## Fix
Thread a `quiet` flag through `_coerce_value` / `_coerce_json`. When a union has a `"string"` member and the value is already a `str`, later non-string coercion attempts (array/object) suppress the parse-failure WARNING — the value is valid as-is, so a failed JSON parse is expected, not an error.

- The `[array,null]` case (#2953) has **no** string member → `quiet` stays False → still warns (existing test `test_union_array_null_wraps_bare_string` stays green).
- All existing return values are preserved unchanged (verified: scalar passes through, stringified arrays still parse to lists for #1681).
- Added regression test `test_real_read_file_scalar_path_no_misleading_warning`.

## Validation
- Targeted: `tests/run_agent/test_tool_arg_coercion.py` — **50 passed**
- CI blocking gate `ruff check .` — **passed**
- My test file: `ruff format --check` clean.
- Pre-PR gate fallback shard tripped on `test_auxiliary_main_first.py::test_custom_main_forwards_runtime_endpoint` — verified **pre-existing, order-dependent flake**: it passes in isolation on pristine `origin/main`, and this change has zero overlap with `agent/auxiliary_client.py`.
- Landability: 63 changed lines (≤ 200 auto-merge cap) ✓

Closes #3026