### PR TITLE
feat: record tool-call provenance for memory/skill writes (Closes #2994)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1338,6 +1338,28 @@ def _tool_result_observer_fields(
     return "ok", None, None
 
 
+def _derive_provenance_source_id(
+    function_name: str,
+    function_args: Dict[str, Any],
+) -> str:
+    """Derive a bounded provenance source id for a completed tool call.
+
+    Used by the background-review source chain (#2994) so a skill promoted
+    from a fork can attribute its evidence to the concrete source that
+    produced it.  Prefers a URL / path / host when one is present in the
+    args (that is what a provenance gate can taint-flag); falls back to the
+    tool name alone.  Bounded to keep the chain compact and to avoid
+    embedding large payloads in the usage record.
+    """
+    if not isinstance(function_args, dict):
+        return function_name
+    for key in ("url", "path", "command", "query", "session_id"):
+        val = function_args.get(key)
+        if isinstance(val, str) and val.strip():
+            return f"{function_name}:{val.strip()[:200]}"
+    return function_name
+
+
 def _emit_post_tool_call_hook(
     *,
     function_name: str,
@@ -1834,6 +1856,24 @@ def handle_function_call(
             duration_ms=duration_ms,
             middleware_trace=list(_tool_middleware_trace),
         )
+
+        # ── Provenance recording (#2994, CoSnitch-class defense) ──────────
+        # Record this tool call into the background-review source chain so
+        # ``provenance_ok()`` at skill-admission time has real entries to
+        # evaluate.  ``add_provenance_entry`` is a no-op outside a
+        # background-review fork with an initialized chain, so this is cheap
+        # on the foreground path.  Without this wiring the source chain is
+        # always empty, the provenance gate trivially passes, and a
+        # content-ingestion poisoning vector (CoSnitch) goes undefended.
+        try:
+            from tools.skill_provenance import add_provenance_entry
+
+            add_provenance_entry(
+                function_name,
+                _derive_provenance_source_id(function_name, function_args),
+            )
+        except Exception:
+            pass  # fail-open: provenance must never block a tool call
 
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -924,3 +924,62 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+# =========================================================================
+# Provenance recording on dispatch (#2994)
+# =========================================================================
+
+class TestProvenanceRecordingOnDispatch:
+    """A completed tool call must record its source into the background-review
+    source chain, so the provenance gate at skill-admission time has real
+    entries to evaluate (CoSnitch-class defense)."""
+
+    def test_successful_dispatch_records_provenance(self, monkeypatch):
+        from tools.skill_provenance import (
+            init_source_chain,
+            reset_source_chain,
+            set_current_write_origin,
+            reset_current_write_origin,
+            get_recorded_chain,
+            BACKGROUND_REVIEW,
+        )
+
+        token_origin = set_current_write_origin(BACKGROUND_REVIEW)
+        chain_token = init_source_chain()
+        try:
+            with patch("model_tools.registry.dispatch", return_value='{"ok":true}'):
+                handle_function_call("web_search", {"url": "https://evil.example"})
+            chain = get_recorded_chain()
+            # web_search is untrusted ingestion; it must be recorded and tainted.
+            assert any(
+                e["source_type"] == "web_search"
+                and e["source_id"].startswith("web_search:https://evil.example")
+                and e["trusted"] is False
+                for e in chain
+            ), f"web_search not recorded as untrusted provenance: {chain}"
+        finally:
+            reset_source_chain(chain_token)
+            reset_current_write_origin(token_origin)
+
+    def test_dispatch_outside_fork_is_noop(self, monkeypatch):
+        """No source chain is initialized outside background-review, so the
+        dispatch must not raise and must not record anything."""
+        with (
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
+        ):
+            result = handle_function_call("read_file", {"path": "/tmp/x"})
+        assert result == '{"ok":true}'
+
+    def test_derive_provenance_source_id_prefers_url(self):
+        from model_tools import _derive_provenance_source_id
+
+        assert _derive_provenance_source_id(
+            "web_extract", {"url": "https://a.example"}
+        ) == "web_extract:https://a.example"
+        assert _derive_provenance_source_id(
+            "read_file", {"path": "/etc/passwd"}
+        ) == "read_file:/etc/passwd"
+        assert _derive_provenance_source_id("calc", {}) == "calc"
+        assert _derive_provenance_source_id("calc", None) == "calc"  # type: ignore[arg-type]
+


### PR DESCRIPTION
Automated evolution PR for issue #2994.

## What
Wires `add_provenance_entry` into the `handle_function_call` dispatch success path so the background-review source chain is actually populated. Previously the chain was always empty, `provenance_ok()` trivially passed at skill-admission time, and a content-ingestion poisoning vector (CoSnitch) went undefended.

## Changes
- `model_tools.py`: call `add_provenance_entry(function_name, source_id)` after successful dispatch; add `_derive_provenance_source_id` helper to extract a bounded URL/path source id.
- `tests/test_model_tools.py`: tests verifying provenance is recorded during a background-review fork, no-op outside a fork, and source-id derivation.

## Validation
- Blocking CI lint (`ruff check .`): passes
- Scoped tests (test_model_tools + provenance suites): 70 passed
- Diff: 99 insertions / 0 deletions (under the 200-line autonomous-merge cap)

Closes #2994