### PR TITLE
feat(security): add 'sensitive' MCP trust tier (Closes #3040)

### DIFF
--- a/docs/security/mcp-nsa-guidance.md
+++ b/docs/security/mcp-nsa-guidance.md
@@ -1,0 +1,86 @@
+# MCP Security Policy — NSA Guidance Alignment (#3040)
+
+This document is the **reviewable in-repo policy** for consuming third-party MCP
+servers. It adopts the three systemic risk areas named in the NSA Artificial
+Intelligence Security Center's first formal US-government MCP guidance (CSI
+U/OO/6030316-26, May 2026) as the governing principles for every MCP server
+Hermes connects to, and maps each to the enforcement mechanism already in the
+codebase plus the one this document introduces (`sensitive` trust tier).
+
+## Principles
+
+### 1. Per-call re-authorization, not login-time trust
+
+A connected MCP server is **not** trusted by default. Every call to a server
+that is not `trust: full` is authorized **at call time**, not at connect time.
+
+- **Enforcement:** `tools/mcp_tool.py::_trust_gate_check` runs before ANY
+  transport work (including the lazy first-use spawn) for servers configured
+  `trust: untrusted` or `trust: sensitive`. A denied call never touches the
+  server. The approval routes to whichever surface owns the session (CLI, TUI,
+  Telegram, Slack, …) via `tools.approval.request_elicitation_consent`.
+- **Tiers (config `trust:` key on the server entry):**
+  - `full` (default, backward compatible) — gate off; operator has explicitly
+    vetted the server.
+  - `untrusted` — every **write-capable** tool (no `readOnlyHint=true`
+    annotation) is approved per call; read-only tools pass.
+  - `sensitive` (added by this policy) — **every** tool call, read or write,
+    is approved per call, because the server handles sensitive/regulated data
+    and must be isolated accordingly.
+  - Any unrecognized value normalizes to `untrusted` (fail closed).
+
+### 2. Trust-level isolation: public vs sensitive data
+
+Tools handling public data and tools handling sensitive/regulated data are
+**separated** at the trust boundary, so a compromise of a public-facing server
+cannot silently read from a sensitive one.
+
+- **Enforcement:** the `sensitive` tier above is the mechanism — mark a
+  sensitive-data server `trust: sensitive` and every one of its tools is
+  gated per call. Public-data servers can stay at `full` or `untrusted`
+  without widening access to the sensitive tier.
+
+### 3. Unverified task propagation
+
+Tasks passed between MCP servers/components, and stages passed between
+delegated subagents, carry **origin, scope, and intent**. The agent must not
+blindly forward a task from an untrusted source to a privileged target.
+
+- **Enforcement:** task-extension responses from MCP servers
+  (`tools/mcp_tool.py` MCP Tasks Extension handling) are only driven to
+  completion when the originating tool call itself passed the trust gate; a
+  `sensitive` server's spawned tasks therefore also inherit per-call
+  authorization. Delegation guidance (see `docs/evolution/`) instructs
+  subagent teams to treat forwarded tasks as requiring the same
+  origin/scope/intent scrutiny as direct calls.
+
+## Configuration reference
+
+```yaml
+mcp_servers:
+  public-readonly:
+    command: npx
+    args: ["-y", "public-server"]
+    # default: full  -> no gate (vetted public data)
+  home-files:
+    command: python
+    args: ["mcp.py"]
+    trust: untrusted        # write-capable tools gated per call
+  finance-records:
+    command: python
+    args: ["finance-mcp.py"]
+    trust: sensitive        # ALL tools gated per call (isolation)
+```
+
+## Review cadence
+
+This policy is reviewable in-repo. It lives with the security audits under
+`docs/security/` and is expected to be re-read (and updated) whenever a new
+third-party MCP server is onboarded at scale, per the NSA guidance's emphasis
+on re-evaluating implicit trust relationships.
+
+## References
+
+- NSA press release on MCP security guidance (CSI U/OO/6030316-26, May 2026).
+- Reed Smith analysis of the NSA MCP guidance.
+- Issue #3040.

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -179,6 +179,32 @@ class TestTrustGateAtCallTime:
         fake_session.call_tool.assert_not_awaited()
         assert "error" in json.loads(raw)
 
+    def test_read_only_tool_on_sensitive_server_is_gated(self, fake_session):
+        """#3040: on `sensitive`, even read-only tools are authorized per call."""
+        _set_trust("srv", "sensitive")
+        _set_read_only("srv", "list_repos", True)
+        handler = mcp_tool._make_tool_handler("srv", "list_repos", 30.0)
+        with patch(
+            "tools.approval.request_elicitation_consent",
+            return_value="accept",
+        ) as consent:
+            raw = handler({})
+        consent.assert_called_once()
+        assert json.loads(raw) == {"result": "ok"}
+
+    def test_denied_sensitive_call_blocks_rpc(self, fake_session):
+        """A denied sensitive call never reaches the server."""
+        _set_trust("srv", "sensitive")
+        _set_read_only("srv", "list_repos", True)
+        handler = mcp_tool._make_tool_handler("srv", "list_repos", 30.0)
+        with patch(
+            "tools.approval.request_elicitation_consent",
+            return_value="decline",
+        ):
+            raw = handler({})
+        fake_session.call_tool.assert_not_awaited()
+        assert "error" in json.loads(raw)
+
 
 class TestTrustNormalization:
     def test_unknown_trust_value_treated_as_untrusted(self):
@@ -191,6 +217,11 @@ class TestTrustNormalization:
         assert mcp_tool._normalize_server_trust("  Full ") == "full"
         # Missing key → default full (backward compatible; documented).
         assert mcp_tool._normalize_server_trust(None) == "full"
+
+    def test_sensitive_tier_recognized(self):
+        """#3040: the sensitive tier normalizes to itself, case-insensitively."""
+        assert mcp_tool._normalize_server_trust("sensitive") == "sensitive"
+        assert mcp_tool._normalize_server_trust("SENSITIVE") == "sensitive"
 
 
 class TestAnnotationCaptureAtDiscovery:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5473,14 +5473,21 @@ _tool_read_only_hints: Dict[str, Dict[str, bool]] = {}
 
 _TRUST_FULL = "full"
 _TRUST_UNTRUSTED = "untrusted"
+_TRUST_SENSITIVE = "sensitive"
 
 
 def _normalize_server_trust(value: Any) -> str:
-    """Normalize a config ``trust`` value to ``full`` or ``untrusted``.
+    """Normalize a config ``trust`` value to ``full``, ``untrusted``, or
+    ``sensitive``.
 
     Missing (None) → ``full`` (backward-compatible default, documented
-    above). Any string other than the two known tiers → ``untrusted``:
+    above). Any string other than the three known tiers → ``untrusted``:
     a misspelled tier must fail closed, never silently disable gating.
+
+    ``sensitive`` (added by #3040, NSA MCP guidance alignment): every tool
+    call — read or write — is gated per call, because the server handles
+    sensitive/regulated data and must be isolated from public-data tools.
+    See ``docs/security/mcp-nsa-guidance.md`` for the full policy.
     """
     if value is None:
         return _TRUST_FULL
@@ -5489,9 +5496,11 @@ def _normalize_server_trust(value: Any) -> str:
         return _TRUST_FULL
     if text == _TRUST_UNTRUSTED:
         return _TRUST_UNTRUSTED
+    if text == _TRUST_SENSITIVE:
+        return _TRUST_SENSITIVE
     logger.warning(
         "MCP trust: unrecognized trust value %r — treating as 'untrusted' "
-        "(valid values: full, untrusted)",
+        "(valid values: full, untrusted, sensitive)",
         value,
     )
     return _TRUST_UNTRUSTED
@@ -5531,17 +5540,43 @@ def _record_tool_trust_metadata(
 
 
 def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
-    """Consult the approval path for write-capable tools on untrusted servers.
+    """Consult the approval path for calls on untrusted/sensitive servers.
 
     Returns None when the call may proceed, or an error string (already
     formatted via ``tool_error``) when the call is blocked. Fail-closed:
     approval-system errors block the call.
+
+    Tiers (#3040, NSA MCP guidance alignment):
+    - ``full``: no gate.
+    - ``untrusted``: gate write-capable tools (no ``readOnlyHint=true``
+      annotation); read-only tools pass.
+    - ``sensitive``: gate EVERY tool, read or write — the server handles
+      sensitive/regulated data and must be isolated from public-data tools.
     """
     trust = _server_trust_levels.get(server_name, _TRUST_FULL)
-    if trust != _TRUST_UNTRUSTED:
+    if trust == _TRUST_FULL:
         return None
-    if _tool_read_only_hints.get(server_name, {}).get(tool_name) is True:
+    # On `untrusted`, a read-only tool passes without gating.
+    if trust == _TRUST_UNTRUSTED and (
+        _tool_read_only_hints.get(server_name, {}).get(tool_name) is True
+    ):
         return None
+
+    gate_label = (
+        "SENSITIVE server"
+        if trust == _TRUST_SENSITIVE
+        else "UNTRUSTED server"
+    )
+    if trust == _TRUST_SENSITIVE:
+        gate_hint = (
+            "This server handles sensitive/regulated data (trust: sensitive), "
+            "so EVERY tool call — read or write — is authorized per call."
+        )
+    else:
+        gate_hint = (
+            f"Server '{server_name}' is configured 'trust: untrusted'. "
+            f"Approve to run '{tool_name}' once, or deny to block it."
+        )
 
     # Lazy import mirrors the elicitation handler's pattern: tools.approval
     # routes the prompt to whichever surface owns the session (CLI, TUI,
@@ -5551,13 +5586,11 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
 
         answer = request_elicitation_consent(
             (
-                f"MCP tool '{tool_name}' on UNTRUSTED server "
-                f"'{server_name}' wants to run. This tool is write-capable "
-                f"(no readOnlyHint=true annotation) and may modify external "
-                f"state."
+                f"MCP tool '{tool_name}' on {gate_label} '{server_name}' "
+                f"wants to run. {gate_hint}"
             ),
             (
-                f"Server '{server_name}' is configured 'trust: untrusted'. "
+                f"Server '{server_name}' is configured 'trust: {trust}'. "
                 f"Approve to run '{tool_name}' once, or deny to block it."
             ),
             surface=f"mcp-trust/{server_name}",
@@ -5571,7 +5604,7 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
             exc_info=True,
         )
         return tool_error(
-            f"MCP tool '{tool_name}' on untrusted server '{server_name}' "
+            f"MCP tool '{tool_name}' on {trust} server '{server_name}' "
             f"was blocked: the approval system was unavailable "
             f"(fail-closed)."
         )
@@ -5579,15 +5612,16 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     if answer == "accept":
         return None
     logger.info(
-        "MCP trust gate: user %s '%s' on untrusted server '%s'",
+        "MCP trust gate: user %s '%s' on %s server '%s'",
         "cancelled" if answer == "cancel" else "denied",
         tool_name,
+        trust,
         server_name,
     )
     return tool_error(
-        f"The user did not approve running write-capable MCP tool "
-        f"'{tool_name}' on untrusted server '{server_name}'. The command "
-        f"was NOT run. Do not retry without explicit user direction."
+        f"The user did not approve running MCP tool '{tool_name}' on "
+        f"{trust} server '{server_name}'. The command was NOT run. Do not "
+        f"retry without explicit user direction."
     )
 
 


### PR DESCRIPTION
Automated evolution PR for issue #3040.

Adopts the NSA MCP security guidance (CSI U/OO/6030316-26) as reviewable in-repo policy:
- New `sensitive` trust tier: per-call authorization for EVERY tool (read or write) on a sensitive-data server, isolating it from public-data tools.
- `untrusted` tier unchanged (write-capable tools gated).
- New policy doc: docs/security/mcp-nsa-guidance.md.
- Tests: sensitive tier normalizes; read-only tool on sensitive server IS gated; denied sensitive call blocks RPC.