### PR TITLE
fix(session): guard SessionDB connection + JSONL spool fallback (Closes #82)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -646,6 +646,106 @@ class AIAgent:
             logger.debug("SessionDB unavailable for %s", reason, exc_info=True)
             return None
 
+    def _ensure_session_db_usable(self) -> bool:
+        """Guarantee a usable SessionDB handle (or a live connection) before writes.
+
+        Two failure shapes were observed in the wild (evolution
+        session-db-conn-guard, 2026-08-18/19): (a) ``self._session_db`` is
+        ``None`` because an entrypoint never opened the handle — previously
+        this made ``_flush_messages_to_session_db_unlocked`` silently drop
+        the turn's messages; (b) the handle EXISTS but its SQLite connection
+        was closed/reaped underneath it, so ``append_messages_batch`` failed
+        with ``'NoneType' object has no attribute 'execute'`` (6 of 8
+        observed failures). Both are repaired here: open the canonical DB
+        lazily (same path as recall) or force a fresh connection, so the
+        flush below has a real connection to write to.
+
+        Returns False only when the store genuinely cannot be opened — the
+        caller then falls back to the JSONL spool instead of writing nothing.
+        """
+        if getattr(self, "_persist_disabled", False):
+            return False
+        db = self._session_db
+        if db is None:
+            # No handle yet: open the canonical DB lazily (same path recall
+            # uses) so writes have a real connection. Fall through to the
+            # re-open below.
+            pass
+        elif not hasattr(db, "_conn"):
+            # Not a real SessionDB (test stand-in, proxy, or duck-typed
+            # wrapper): there is no ``_conn`` to introspect, so this is not a
+            # reaped connection — trust it as usable.
+            return True
+        elif db._conn is not None:
+            return True
+        else:
+            # Real SessionDB whose SQLite connection was closed/reaped
+            # underneath it (previously surfaced as "'NoneType' object has no
+            # attribute 'execute'"). Release the dead handle (close() is
+            # idempotent) and re-open below.
+            try:
+                db.close()
+            except Exception:
+                logger.debug(
+                    "close of stale SessionDB handle failed", exc_info=True
+                )
+            self._session_db = None
+        try:
+            from hermes_state import SessionDB
+
+            self._session_db = SessionDB()
+            self._owns_session_db = True
+            return True
+        except Exception as exc:
+            logger.warning(
+                "Session DB unavailable for flush (re-init failed): %s", exc
+            )
+            return False
+
+    def _spool_unpersisted_messages_to_jsonl(
+        self, messages: List[Dict]
+    ) -> None:
+        """Best-effort JSONL spool of un-persisted messages after DB failure.
+
+        Runs on the flush failure path only: writes every message that never
+        received the ``_DB_PERSISTED_MARKER`` to
+        ``HERMES_HOME/sessions/spool-<session_id>.jsonl`` (append-only), so
+        a storage outage degrades to a recoverable on-disk trace instead of
+        silent message loss. Never raises — the flush failure path must stay
+        non-fatal.
+        """
+        if not messages:
+            return
+        try:
+            pending = [
+                m for m in messages
+                if not m.get(_DB_PERSISTED_MARKER)
+            ]
+            if not pending:
+                return
+            from hermes_constants import get_hermes_home
+
+            sessions_dir = get_hermes_home() / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            spool_path = sessions_dir / f"spool-{self.session_id}.jsonl"
+            import json as _json
+
+            with open(spool_path, "a", encoding="utf-8") as fh:
+                for m in pending:
+                    fh.write(
+                        _json.dumps(m, ensure_ascii=False, default=str) + "\n"
+                    )
+            logger.warning(
+                "Session DB flush failed; spooled %d un-persisted message(s) "
+                "to %s",
+                len(pending),
+                spool_path,
+            )
+        except Exception:
+            logger.debug(
+                "JSONL session spool failed", exc_info=True
+            )
+
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if getattr(self, "_persist_disabled", False):
@@ -2239,7 +2339,14 @@ class AIAgent:
         # "becomes" the curator. Hard-stop before any DB touch.
         if getattr(self, "_persist_disabled", False):
             return None
-        if not self._session_db:
+        # Guarantee a live connection before writing (evolution
+        # session-db-conn-guard): a nil handle OR a handle whose SQLite
+        # connection was closed underneath it previously dropped this turn's
+        # messages silently ('NoneType' object has no attribute 'execute').
+        # Re-open lazily here; only a genuinely unopenable store falls
+        # through to the JSONL spool in the failure path below.
+        if not self._ensure_session_db_usable():
+            self._spool_unpersisted_messages_to_jsonl(messages)
             return None
         # Persist user-message override (#48677 chokepoint): historically this
         # mutated the live `messages` list in place, which — on the early

--- a/tests/agent/test_session_rotation_flush_cold_resume_68454.py
+++ b/tests/agent/test_session_rotation_flush_cold_resume_68454.py
@@ -37,6 +37,12 @@ def _make_flush_agent(db: SessionDB, session_id: str):
         _pending_cli_user_message=None,
     )
     agent._ensure_db_session = lambda: None
+    agent._ensure_session_db_usable = (
+        AIAgent._ensure_session_db_usable.__get__(agent, AIAgent)
+    )
+    agent._spool_unpersisted_messages_to_jsonl = (
+        AIAgent._spool_unpersisted_messages_to_jsonl.__get__(agent, AIAgent)
+    )
     agent._flush_messages_to_session_db = (
         AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
     )

--- a/tests/run_agent/test_compression_closed_adoption.py
+++ b/tests/run_agent/test_compression_closed_adoption.py
@@ -46,6 +46,12 @@ def _flush_agent(db, session_id):
         _compression_adoption_failed=False,
     )
     agent._ensure_db_session = lambda: None
+    agent._ensure_session_db_usable = (
+        AIAgent._ensure_session_db_usable.__get__(agent, AIAgent)
+    )
+    agent._spool_unpersisted_messages_to_jsonl = (
+        AIAgent._spool_unpersisted_messages_to_jsonl.__get__(agent, AIAgent)
+    )
     agent._flush_messages_to_session_db = (
         AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
     )

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -589,6 +589,12 @@ def _flush_agent(db, session_id):
         _last_persistence_error_cause=None,
     )
     agent._ensure_db_session = lambda: None
+    agent._ensure_session_db_usable = (
+        AIAgent._ensure_session_db_usable.__get__(agent, AIAgent)
+    )
+    agent._spool_unpersisted_messages_to_jsonl = (
+        AIAgent._spool_unpersisted_messages_to_jsonl.__get__(agent, AIAgent)
+    )
     agent._flush_messages_to_session_db = (
         AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
     )

--- a/tests/run_agent/test_session_db_conn_guard.py
+++ b/tests/run_agent/test_session_db_conn_guard.py
@@ -1,0 +1,159 @@
+"""Tests for issue #82 — session-DB connection guard + JSONL spool fallback.
+
+Verifies that ``_flush_messages_to_session_db`` no longer silently drops a
+turn's messages when the SessionDB handle is missing or its SQLite connection
+has been closed/reaped underneath it:
+
+1. ``_ensure_session_db_usable`` returns True and keeps a live handle.
+2. A reaped connection (``_conn is None``) is re-opened lazily.
+3. A genuinely unopenable store degrades to a recoverable JSONL spool instead
+   of silent loss.
+4. The spool only writes messages that never received the persist marker.
+5. Persist-disabled forks never spool (they must not write to canonical home).
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+
+
+def _make_agent(session_db):
+    """Create a minimal AIAgent with a (possibly None) session DB handle."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id="test-session-82",
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+class TestEnsureSessionDbUsable:
+    def test_live_handle_returns_true_and_is_kept(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            agent = _make_agent(db)
+            assert agent._ensure_session_db_usable() is True
+            assert agent._session_db is db
+        finally:
+            db.close()
+
+    def test_persist_disabled_returns_false(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            agent = _make_agent(db)
+            agent._persist_disabled = True
+            assert agent._ensure_session_db_usable() is False
+        finally:
+            db.close()
+
+    def test_reaped_connection_is_reopened(self, tmp_path, monkeypatch):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test-session-82", source="test")
+        agent = _make_agent(db)
+        # Simulate the connection being reaped underneath the live handle.
+        db.close()
+        assert getattr(db, "_conn", None) is None
+
+        # Redirect the lazy re-open to a temp path instead of canonical home.
+        from hermes_state import SessionDB as RealSessionDB
+
+        monkeypatch.setattr(
+            "hermes_state.SessionDB",
+            lambda *a, **k: RealSessionDB(db_path=tmp_path / "reopened.db"),
+        )
+        assert agent._ensure_session_db_usable() is True
+        assert agent._session_db is not db
+        assert getattr(agent._session_db, "_conn", None) is not None
+
+    def test_unopenable_store_returns_false(self, tmp_path, monkeypatch):
+        agent = _make_agent(None)
+
+        def _boom(*a, **k):
+            raise RuntimeError("state.db cannot be opened")
+
+        monkeypatch.setattr("hermes_state.SessionDB", _boom)
+        assert agent._ensure_session_db_usable() is False
+
+
+class TestSpoolFallback:
+    def test_flush_spools_when_store_unopenable(self, tmp_path, monkeypatch):
+        agent = _make_agent(None)
+
+        def _boom(*a, **k):
+            raise RuntimeError("state.db cannot be opened")
+
+        monkeypatch.setattr("hermes_state.SessionDB", _boom)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: Path(tmp_path)
+        )
+
+        messages = [{"role": "user", "content": "spool me"}]
+        # The flush must not raise, and must degrade to the JSONL spool.
+        result = agent._flush_messages_to_session_db(messages, [])
+        assert result is None
+
+        spool_path = tmp_path / "sessions" / "spool-test-session-82.jsonl"
+        assert spool_path.exists()
+        lines = spool_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["content"] == "spool me"
+
+    def test_spool_skips_already_persisted_messages(self, tmp_path, monkeypatch):
+        agent = _make_agent(None)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: Path(tmp_path)
+        )
+
+        from run_agent import _DB_PERSISTED_MARKER
+
+        messages = [
+            {"role": "user", "content": "new", _DB_PERSISTED_MARKER: False},
+            {"role": "assistant", "content": "old", _DB_PERSISTED_MARKER: True},
+        ]
+        agent._spool_unpersisted_messages_to_jsonl(messages)
+
+        spool_path = tmp_path / "sessions" / "spool-test-session-82.jsonl"
+        lines = spool_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["content"] == "new"
+
+    def test_spool_is_append_only_and_never_raises(self, tmp_path, monkeypatch):
+        agent = _make_agent(None)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: Path(tmp_path)
+        )
+        agent._spool_unpersisted_messages_to_jsonl(
+            [{"role": "user", "content": "first"}]
+        )
+        agent._spool_unpersisted_messages_to_jsonl(
+            [{"role": "user", "content": "second"}]
+        )
+        spool_path = tmp_path / "sessions" / "spool-test-session-82.jsonl"
+        lines = spool_path.read_text(encoding="utf-8").splitlines()
+        assert [json.loads(ln)["content"] for ln in lines] == ["first", "second"]
+
+    def test_persist_disabled_never_spools(self, tmp_path, monkeypatch):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = _make_agent(db)
+        agent._persist_disabled = True
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: Path(tmp_path)
+        )
+        result = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "must not persist"}], []
+        )
+        assert result is None
+        spool_path = tmp_path / "sessions" / "spool-test-session-82.jsonl"
+        assert not spool_path.exists()
+        db.close()


### PR DESCRIPTION
Automated evolution PR for issue #82.

## Summary
`_flush_messages_to_session_db_unlocked` silently dropped a turn's messages when the SessionDB handle was nil or its SQLite connection had been closed/reaped underneath it (`'NoneType' object has no attribute 'execute'`).

## Change
1. New `_ensure_session_db_usable()` — before any flush, (re-)opens the canonical state.db lazily when the handle is missing or its connection was reaped. Trusts non-SessionDB handles (proxies/stand-ins) and persists-disabled forks are hard-stopped as before.
2. New `_spool_unpersisted_messages_to_jsonl()` — best-effort, non-raising JSONL spool of un-persisted messages to `HERMES_HOME/sessions/spool-<session_id>.jsonl` when the store genuinely cannot be opened.
3. Flush entry point uses the guard; the failure path spools instead of returning silently.

## Validation (local, pre-PR)
- `ruff check .` — clean (blocking gate).
- Flush-path regression suite (49 tests across 8 files) — all pass.
- New `tests/run_agent/test_session_db_conn_guard.py` (8 tests): live-handle passthrough, reaped-connection reopen, unopenable-store spool, marker skip, append-only spool, persist-disabled no-spool.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>