### PR TITLE
feat(trajectory): record coordination-network edges on TrajectoryLog — inc 1 of #2996

### DIFF
--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 
 __all__ = [
     "TrajectoryEntry",
+    "CoordinationEdge",
     "TrajectoryLog",
     "redact_args",
     "summarize_result",
@@ -80,6 +81,52 @@ def summarize_result(result: Any) -> str:
         if len(text) > _MAX_RESULT_SUMMARY_LEN
         else text
     )
+
+
+class CoordinationEdge:
+    """A timestamped, typed edge in a multi-agent coordination network (#2996).
+
+    Models one message / file-write / file-read interaction between two actors
+    (agents, stages, or a subagent and a shared artifact) with its cost, so
+    delegation overhead is measurable and comparable across topologies. This is
+    the smallest coherent slice of the "coordination measurement pass" — pure
+    logging on the existing TrajectoryLog; no behavior change.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        cost_tokens: Optional[int] = None,
+        timestamp: str = "",
+    ) -> None:
+        self.source = source
+        self.target = target
+        self.edge_type = edge_type
+        self.cost_tokens = cost_tokens
+        self.timestamp = timestamp or datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "timestamp": self.timestamp,
+            "source": self.source,
+            "target": self.target,
+            "type": self.edge_type,
+        }
+        if self.cost_tokens is not None:
+            d["cost_tokens"] = self.cost_tokens
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "CoordinationEdge":
+        return cls(
+            source=str(d.get("source", "")),
+            target=str(d.get("target", "")),
+            edge_type=str(d.get("type", "message")),
+            cost_tokens=d.get("cost_tokens"),
+            timestamp=str(d.get("timestamp", "")),
+        )
 
 
 @dataclass
@@ -149,9 +196,29 @@ class TrajectoryLog:
         # is user prose and must not enter the pipeline's store.
         self.completed = completed
         self.task_key = task_key
+        # Coordination network edges (#2996). Optional, append-only; empty by
+        # default so existing callers are unaffected and the serialized shape
+        # of a trajectory with no edges is byte-identical to before.
+        self.edges: List[CoordinationEdge] = []
 
     def add(self, entry: TrajectoryEntry) -> None:
         self.entries.append(entry)
+
+    def add_coordination_edge(
+        self,
+        source: str,
+        target: str,
+        edge_type: str = "message",
+        cost_tokens: Optional[int] = None,
+    ) -> None:
+        """Record one message / file-write / file-read edge (#2996).
+
+        Pure logging: measures delegation overhead (who talked to whom, via
+        which channel, at what token cost) without changing behavior.
+        """
+        self.edges.append(
+            CoordinationEdge(source, target, edge_type, cost_tokens)
+        )
 
     def add_tool_call(
         self,
@@ -178,6 +245,8 @@ class TrajectoryLog:
             out["completed"] = bool(self.completed)
         if self.task_key:
             out["task_key"] = self.task_key
+        if self.edges:
+            out["edges"] = [e.to_dict() for e in self.edges]
         return out
 
     def to_json(self) -> str:
@@ -273,6 +342,9 @@ def load_trajectory(path: Path) -> Optional[TrajectoryLog]:
                     duration_ms=ed.get("duration_ms"),
                 )
             )
+    for ed in data.get("edges", []):
+        if isinstance(ed, dict):
+            log.edges.append(CoordinationEdge.from_dict(ed))
     return log
 
 

--- a/tests/scripts/test_evolution_coordination_edges.py
+++ b/tests/scripts/test_evolution_coordination_edges.py
@@ -1,0 +1,100 @@
+"""Tests for coordination-network edge recording on TrajectoryLog (#2996).
+
+The "coordination measurement pass" slice: multi-agent runs record message /
+file-write / file-read edges with token cost, so delegation overhead is
+visible and comparable across topologies. Pure logging on the existing
+TrajectoryLog — no behavior change, and the serialized shape of a trajectory
+with no edges is byte-identical to before the feature.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_trajectory_logger import (  # noqa: E402
+    CoordinationEdge,
+    TrajectoryLog,
+    load_trajectory,
+)
+
+
+class TestCoordinationEdge:
+    def test_default_timestamp(self):
+        e = CoordinationEdge("agent-a", "agent-b", "message")
+        assert e.source == "agent-a"
+        assert e.target == "agent-b"
+        assert e.edge_type == "message"
+        assert e.cost_tokens is None
+        assert e.timestamp
+
+    def test_to_dict_omits_cost_when_unset(self):
+        e = CoordinationEdge("a", "b", "file_write")
+        d = e.to_dict()
+        assert "cost_tokens" not in d
+        assert d["type"] == "file_write"
+
+    def test_to_dict_includes_cost(self):
+        e = CoordinationEdge("a", "shared.md", "file_write", cost_tokens=320)
+        d = e.to_dict()
+        assert d["cost_tokens"] == 320
+
+    def test_from_dict_roundtrip(self):
+        e = CoordinationEdge("a", "b", "message", cost_tokens=10, timestamp="t")
+        restored = CoordinationEdge.from_dict(e.to_dict())
+        assert restored.source == "a"
+        assert restored.target == "b"
+        assert restored.edge_type == "message"
+        assert restored.cost_tokens == 10
+        assert restored.timestamp == "t"
+
+
+class TestTrajectoryLogEdges:
+    def test_edges_absent_by_default(self):
+        """A trajectory with no edges serializes exactly as before (no key)."""
+        log = TrajectoryLog(session_id="s", date="2026-08-21")
+        log.add_tool_call("terminal", {"cmd": "ls"}, "out")
+        d = log.to_dict()
+        assert "edges" not in d
+
+    def test_add_and_serialize_edge(self):
+        log = TrajectoryLog(session_id="s", date="2026-08-21")
+        log.add_coordination_edge("research", "analysis", "message", cost_tokens=150)
+        d = log.to_dict()
+        assert d["edges"] == [
+            {
+                "timestamp": d["edges"][0]["timestamp"],
+                "source": "research",
+                "target": "analysis",
+                "type": "message",
+                "cost_tokens": 150,
+            }
+        ]
+
+    def test_load_roundtrip_preserves_edges(self, tmp_path):
+        log = TrajectoryLog(session_id="s1", date="2026-08-21")
+        log.add_tool_call("patch", {"path": "x"})
+        log.add_coordination_edge("agent-a", "shared.md", "file_write", cost_tokens=88)
+        p = log.save(tmp_path)
+        restored = load_trajectory(p)
+        assert restored is not None
+        assert len(restored.edges) == 1
+        e = restored.edges[0]
+        assert e.source == "agent-a"
+        assert e.target == "shared.md"
+        assert e.edge_type == "file_write"
+        assert e.cost_tokens == 88
+        # entries unaffected
+        assert len(restored.entries) == 1
+
+    def test_load_ignores_non_dict_edges(self, tmp_path):
+        p = tmp_path / "x.json"
+        p.write_text(json.dumps({"date": "2026-08-21", "edges": [1, "bad", {}]}),
+                     encoding="utf-8")
+        restored = load_trajectory(p)
+        assert restored is not None
+        # Non-dict entries (1, "bad") are skipped; the empty dict {} is a
+        # valid dict and produces a default edge (source="", target="", …).
+        assert len(restored.edges) == 1
+        assert restored.edges[0].source == ""


### PR DESCRIPTION
Automated evolution PR — coordination-measurement slice of #2996.

Adds the edge-recording primitive the issue asks for, on the existing TrajectoryLog (the natural seam the prior cycle flagged):
- New CoordinationEdge type: source/target/type (message, file_write, file_read)/cost_tokens + timestamp.
- add_coordination_edge() on TrajectoryLog — append-only, empty by default (no serialized-shape change for existing trajectories).
- Round-trip via save()/load_trajectory().
- Tests: 8 (edge model, serialization, round-trip, non-dict tolerance).

Deferred (next increment):
- Wire edge capture into the actual delegation/tool-call path (tools/agent_team*, async_delegation) so real multi-agent runs emit edges.
- A summary/report consumer that renders the measured coordination network.
- The two policy asks (prefer shared-file channels; sealed-eval integrity) are guidance, not code — out of scope for implementation.