### PR TITLE
feat(evolution): adversarial reviewer-to-critic gate (Closes #92)

### DIFF
--- a/evolution/lib/stage_gate.py
+++ b/evolution/lib/stage_gate.py
@@ -50,6 +50,7 @@ __all__ = [
     "GateDecision",
     "decide",
     "record_decision",
+    "record_review_critic_verdict",
     "load_decisions",
     "compute_gate_rates",
     "gate_flags",
@@ -208,6 +209,51 @@ def record_decision(ledger_file: Path, decision: GateDecision) -> None:
         ledger_file.parent.mkdir(parents=True, exist_ok=True)
         with open(ledger_file, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(decision.to_dict(), sort_keys=True) + "\n")
+    except OSError:
+        pass
+
+
+def record_review_critic_verdict(
+    ledger_file: Path,
+    *,
+    verdict: str,
+    reviewer_ok: bool,
+    dissent: bool,
+    grounded: bool,
+    failure_mode: str = "",
+    agreement_reason: str = "",
+) -> None:
+    """Append one adversarial reviewer-to-critic verdict to the stage-gate ledger.
+
+    Distinct from :func:`record_decision` (which logs the accept/refine/restart
+    branch): this records the outcome of the reviewer-to-critic adversarial gate
+    (#92) so disagreement verdicts are inspectable in the SAME append-only
+    ledger. Records carry a ``kind`` discriminator so :func:`load_decisions`
+    (which filters on ``branch``) skips them rather than confusing critic
+    verdicts with branch decisions. Never raises — instrumentation must not
+    take a pipeline boundary down with it.
+    """
+    try:
+        from datetime import datetime, timezone
+
+        ledger_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(ledger_file, "a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "kind": "review_critic",
+                        "verdict": verdict,
+                        "reviewer_ok": bool(reviewer_ok),
+                        "dissent": bool(dissent),
+                        "grounded": bool(grounded),
+                        "failure_mode": failure_mode,
+                        "agreement_reason": agreement_reason,
+                        "recorded_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
     except OSError:
         pass
 

--- a/evolution/tests/test_stage_gate.py
+++ b/evolution/tests/test_stage_gate.py
@@ -159,6 +159,43 @@ class TestDecisionLedger:
         record_decision(target / "nested" / "ledger.jsonl", decide(_result(90)))
 
 
+class TestReviewCriticLedger:
+    """Adversarial reviewer-to-critic verdicts share the stage-gate ledger (#92)."""
+
+    def test_record_and_load_are_distinct_streams(self, tmp_path):
+        from evolution.lib.stage_gate import (
+            load_decisions,
+            record_decision,
+            record_review_critic_verdict,
+        )
+
+        ledger = tmp_path / "stage_gate.jsonl"
+        record_decision(ledger, decide(_result(90, ["a.json"])))
+        record_review_critic_verdict(
+            ledger,
+            verdict="rework",
+            reviewer_ok=True,
+            dissent=True,
+            grounded=True,
+            failure_mode="unbounded retry",
+        )
+        # branch decisions are unaffected by critic records, and vice versa
+        assert [r["branch"] for r in load_decisions(ledger)] == [ACCEPT]
+
+    def test_record_critic_verdict_never_raises(self, tmp_path):
+        from evolution.lib.stage_gate import record_review_critic_verdict
+
+        target = tmp_path / "file"
+        target.write_text("x", encoding="utf-8")
+        record_review_critic_verdict(
+            target / "nested" / "ledger.jsonl",
+            verdict="proceed",
+            reviewer_ok=True,
+            dissent=False,
+            grounded=False,
+        )
+
+
 class TestGateRates:
     @staticmethod
     def _recs(*branches, stage="local_triage"):

--- a/scripts/evolution_qc_review.py
+++ b/scripts/evolution_qc_review.py
@@ -77,6 +77,157 @@ def parse_qc_report(subagent_output: str) -> Dict[str, Any]:
     return {"verdict": verdict, "has_blocking": hb, "issues": issues, "recommendations": recs, "ok": verdict == "pass" and not hb}  # fmt: skip
 
 
+def _files_from_args(args: List[str]) -> List[str]:
+    files_str = _flag(args, "--files") or ""
+    return [f.strip() for f in files_str.split(",") if f.strip()]
+
+
+def build_critic_task(
+    summary: str,
+    files: List[str],
+    *,
+    issue_number: int = 0,
+    toolsets: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build a leaf-subagent adversarial critic task for delegate_task (#92).
+
+    Runs AFTER the reviewer has approved a diff: the critic's only job is to
+    try to prove the change WRONG with one evidence-grounded, concrete failure
+    mode. If it cannot construct such an objection, it must say so explicitly
+    — the review then proceeds. This is the structured-disagreement pass that
+    breaks reviewer/coder rubber-stamping (Adversarial Review, arXiv:2608.18167).
+    """
+    file_list = "\n".join(f"  - {f}" for f in files) if files else "  (no files listed)"
+    goal = (
+        "You are an adversarial code critic. The reviewer has APPROVED the "
+        "following implementation. Your job is to try to prove it WRONG.\n\n"
+        "Attempt to articulate ONE concrete, evidence-grounded failure mode: a "
+        "specific way this change breaks, regresses, or introduces a bug, tied "
+        "to the summary or a file below. Do NOT manufacture objections to seem "
+        "rigorous — a fabricated disagreement is as harmful as rubber-stamped "
+        "approval.\n\n"
+        f"## Summary\n{summary}\n\n"
+        f"## Files Changed\n{file_list}\n\n"
+        "## Output Format\nReturn JSON:\n"
+        '- "dissent": bool — true ONLY if you found a concrete failure mode\n'
+        '- "grounded": bool — true only if your objection cites specific evidence\n'
+        '- "failure_mode": string — the concrete failure mode (empty if none)\n'
+        '- "agreement_reason": string — why you could NOT object (empty if dissenting)\n'
+    )
+    context = (
+        f"You are the adversarial critic gate. Issue #{issue_number}. "
+        "Only dissent when you can point to a concrete, evidence-grounded "
+        "failure mode; otherwise agree explicitly and explain why."
+    )
+    return {
+        "goal": goal,
+        "context": context,
+        "toolsets": list(toolsets) if toolsets is not None else ["file", "search"],
+        "role": "leaf",
+    }
+
+
+def parse_critic_report(subagent_output: str) -> Dict[str, Any]:
+    """Parse the adversarial critic subagent output (#92).
+
+    A report is ``ok`` when it is coherent: either a grounded dissent (a
+    concrete ``failure_mode``) or an explicit agreement with a reason. A
+    dissent WITHOUT a failure_mode is un-grounded noise and is not ok.
+    """
+    raw = _extract_json(_s(subagent_output))
+    if raw is None:
+        return {
+            "dissent": False,
+            "grounded": False,
+            "failure_mode": "",
+            "agreement_reason": "",
+            "ok": False,
+        }
+    dissent = bool(raw.get("dissent", False))
+    failure_mode = _s(raw.get("failure_mode"))
+    grounded = dissent and bool(failure_mode)
+    agreement_reason = _s(raw.get("agreement_reason"))
+    ok = grounded if dissent else bool(agreement_reason)
+    return {
+        "dissent": dissent,
+        "grounded": grounded,
+        "failure_mode": failure_mode,
+        "agreement_reason": agreement_reason,
+        "ok": ok,
+    }
+
+
+def adjudicate_review(
+    reviewer_report: Dict[str, Any],
+    critic_report: Dict[str, Any],
+    *,
+    critic_enabled: bool = True,
+) -> Dict[str, Any]:
+    """Deterministic reviewer-to-critic gate (#92).
+
+    Returns ``{"block", "verdict", "reason"}``:
+    - reviewer not ok → block ("rework"), regardless of critic.
+    - reviewer ok + critic disabled → proceed.
+    - reviewer ok + grounded dissent → block ("rework").
+    - reviewer ok + no grounded objection → proceed.
+    """
+    reviewer_ok = bool(reviewer_report.get("ok"))
+    if not reviewer_ok:
+        return {
+            "block": True,
+            "verdict": "rework",
+            "reason": "reviewer did not approve",
+        }
+    if not critic_enabled:
+        return {
+            "block": False,
+            "verdict": "proceed",
+            "reason": "adversarial critic disabled",
+        }
+    dissent = bool(critic_report.get("dissent"))
+    grounded = bool(critic_report.get("grounded"))
+    if dissent and grounded:
+        fm = _s(critic_report.get("failure_mode"))
+        return {
+            "block": True,
+            "verdict": "rework",
+            "reason": f"critic grounded objection: {fm[:200]}",
+        }
+    return {
+        "block": False,
+        "verdict": "proceed",
+        "reason": "no grounded objection from critic",
+    }
+
+
+def record_critic_verdict(
+    ledger_file: str,
+    verdict: Dict[str, Any],
+    *,
+    reviewer_report: Dict[str, Any],
+    critic_report: Dict[str, Any],
+) -> None:
+    """Record the adversarial-critic verdict into the stage-gate ledger (#92).
+
+    Best-effort instrumentation: a failed import or write must never take the
+    review flow down, so any exception is swallowed.
+    """
+    try:
+        from evolution.lib.stage_gate import record_review_critic_verdict
+
+        record_review_critic_verdict(
+            Path(ledger_file),
+            verdict=str(verdict.get("verdict", "proceed")),
+            reviewer_ok=bool(reviewer_report.get("ok")),
+            dissent=bool(critic_report.get("dissent")),
+            grounded=bool(critic_report.get("grounded")),
+            failure_mode=_s(critic_report.get("failure_mode")),
+            agreement_reason=_s(critic_report.get("agreement_reason")),
+        )
+    except Exception:  # noqa: BLE001 - instrumentation must not raise
+        pass
+
+
 def _load_text(path: Optional[str]) -> Tuple[str, Optional[str]]:
     try:
         raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
@@ -95,20 +246,35 @@ def _flag(args: List[str], name: str) -> Optional[str]:
 
 def main(argv: List[str]) -> int:
     if len(argv) < 2 or argv[1] in ("-h", "--help"):
-        print("usage: evolution_qc_review.py {build,parse} ...", file=sys.stderr)
+        print(
+            "usage: evolution_qc_review.py "
+            "{build,parse,build-critic,parse-critic,adjudicate} ...",
+            file=sys.stderr,
+        )
         return 2
     cmd, args = argv[1], argv[2:]
     if cmd == "build":
         summary = _flag(args, "--summary") or ""
         if not _s(summary):
             return 2
-        files_str = _flag(args, "--files") or ""
-        files = [f.strip() for f in files_str.split(",") if f.strip()]
+        files = _files_from_args(args)
         try:
             issue_num = int(_flag(args, "--issue") or "0")
         except ValueError:
             issue_num = 0
         task = build_qc_review_task(summary, files, issue_number=issue_num)
+        print(json.dumps(task, ensure_ascii=False))
+        return 0
+    if cmd == "build-critic":
+        summary = _flag(args, "--summary") or ""
+        if not _s(summary):
+            return 2
+        files = _files_from_args(args)
+        try:
+            issue_num = int(_flag(args, "--issue") or "0")
+        except ValueError:
+            issue_num = 0
+        task = build_critic_task(summary, files, issue_number=issue_num)
         print(json.dumps(task, ensure_ascii=False))
         return 0
     if cmd == "parse":
@@ -119,6 +285,35 @@ def main(argv: List[str]) -> int:
         report = parse_qc_report(data)
         print(json.dumps(report, ensure_ascii=False))
         return 0 if report["ok"] else 1
+    if cmd == "parse-critic":
+        path = args[0] if args and not args[0].startswith("-") else None
+        data, err = _load_text(path)
+        if err:
+            return 2
+        report = parse_critic_report(data)
+        print(json.dumps(report, ensure_ascii=False))
+        return 0 if report["ok"] else 1
+    if cmd == "adjudicate":
+        reviewer_path = _flag(args, "--reviewer")
+        critic_path = _flag(args, "--critic")
+        if not reviewer_path or not critic_path:
+            return 2
+        rev_data, rev_err = _load_text(reviewer_path)
+        crit_data, crit_err = _load_text(critic_path)
+        if rev_err or crit_err:
+            return 2
+        reviewer = parse_qc_report(rev_data)
+        critic = parse_critic_report(crit_data)
+        verdict = adjudicate_review(
+            reviewer, critic, critic_enabled="--no-critic" not in args
+        )
+        ledger = _flag(args, "--ledger")
+        if ledger:
+            record_critic_verdict(
+                ledger, verdict, reviewer_report=reviewer, critic_report=critic
+            )
+        print(json.dumps(verdict, ensure_ascii=False))
+        return 1 if verdict["block"] else 0
     return 2
 
 

--- a/tests/scripts/test_evolution_review_critic.py
+++ b/tests/scripts/test_evolution_review_critic.py
@@ -1,0 +1,204 @@
+"""Tests for the adversarial reviewer-to-critic gate (#92).
+
+The critic pass runs AFTER the reviewer approves a diff: it must either
+articulate a concrete, evidence-grounded failure mode (block → rework) or
+explicitly agree (proceed). Un-grounded dissent is treated as noise and does
+not block. Verdicts are recorded into the stage-gate ledger.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+from evolution_qc_review import (  # noqa: E402  # fmt: skip
+    adjudicate_review,
+    build_critic_task,
+    main,
+    parse_critic_report,
+    record_critic_verdict,
+)
+
+_j = json.dumps
+
+
+def _critic(dissent, failure_mode="", agreement_reason="", grounded=None):
+    if grounded is None:
+        grounded = bool(dissent and failure_mode)
+    return {
+        "dissent": dissent,
+        "grounded": grounded,
+        "failure_mode": failure_mode,
+        "agreement_reason": agreement_reason,
+    }
+
+
+def _reviewer(ok=True):
+    return {"ok": ok, "verdict": "pass" if ok else "fail", "has_blocking": not ok}
+
+
+class TestBuildCriticTask:
+    def test_build_task(self):
+        task = build_critic_task("Implemented X", ["a.py", "b.py"], issue_number=92)
+        assert task["role"] == "leaf"
+        assert "Implemented X" in task["goal"]
+        assert "a.py" in task["goal"]
+        assert "#92" in task["context"]
+        assert "file" in task["toolsets"]
+
+    def test_build_no_files(self):
+        assert "no files listed" in build_critic_task("s", [])["goal"]
+
+    def test_goal_is_adversarial(self):
+        goal = build_critic_task("s", [])["goal"]
+        assert "critic" in goal.lower()
+        assert "prove it WRONG" in goal
+
+
+class TestParseCriticReport:
+    def test_grounded_dissent(self):
+        raw = _j({
+            "dissent": True,
+            "grounded": True,
+            "failure_mode": "drops messages on retry",
+        })
+        r = parse_critic_report(raw)
+        assert r["dissent"] and r["grounded"] and r["ok"]
+        assert "drops messages" in r["failure_mode"]
+
+    def test_explicit_agreement(self):
+        raw = _j({"dissent": False, "agreement_reason": "no failure mode found"})
+        r = parse_critic_report(raw)
+        assert not r["dissent"] and r["ok"]
+
+    def test_ungrounded_dissent_is_noise(self):
+        # dissent without a concrete failure_mode is not a valid objection
+        raw = _j({"dissent": True, "failure_mode": ""})
+        r = parse_critic_report(raw)
+        assert r["dissent"] and not r["grounded"] and not r["ok"]
+
+    def test_garbage(self):
+        for bad in ("", "no json", None):
+            assert not parse_critic_report(bad)["ok"]
+
+
+class TestAdjudicateReview:
+    def test_reviewer_fail_blocks(self):
+        v = adjudicate_review(_reviewer(ok=False), _critic(False))
+        assert v["block"] and v["verdict"] == "rework"
+
+    def test_known_flaw_diff_caught_by_critic(self):
+        # regression fixture: reviewer approved, critic found a grounded flaw
+        critic = _critic(True, failure_mode="unbounded retry loop under SIGINT")
+        v = adjudicate_review(_reviewer(ok=True), critic)
+        assert v["block"] and v["verdict"] == "rework"
+        assert "retry loop" in v["reason"]
+
+    def test_clean_diff_not_blocked(self):
+        critic = _critic(False, agreement_reason="nothing to object to")
+        v = adjudicate_review(_reviewer(ok=True), critic)
+        assert not v["block"] and v["verdict"] == "proceed"
+
+    def test_ungrounded_dissent_does_not_block(self):
+        # dissent without a grounded failure mode is noise → proceed
+        v = adjudicate_review(_reviewer(ok=True), _critic(True, grounded=False))
+        assert not v["block"] and v["verdict"] == "proceed"
+
+    def test_critic_disabled_proceeds(self):
+        v = adjudicate_review(
+            _reviewer(ok=True), _critic(True, "flaw"), critic_enabled=False
+        )
+        assert not v["block"]
+
+
+class TestRecordCriticVerdict:
+    def test_writes_ledger_record(self, tmp_path):
+        ledger = tmp_path / "stage_gate.jsonl"
+        verdict = {"block": True, "verdict": "rework", "reason": "x"}
+        record_critic_verdict(
+            str(ledger),
+            verdict,
+            reviewer_report=_reviewer(ok=True),
+            critic_report=_critic(True, "concrete flaw"),
+        )
+        lines = ledger.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["kind"] == "review_critic"
+        assert rec["verdict"] == "rework"
+        assert rec["reviewer_ok"] is True
+        assert rec["dissent"] is True and rec["grounded"] is True
+
+
+class TestCli:
+    def test_cli_build_critic(self, capsys):
+        rc = main([
+            "x",
+            "build-critic",
+            "--summary",
+            "impl X",
+            "--files",
+            "a.py",
+            "--issue",
+            "92",
+        ])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert "impl X" in out["goal"] and out["role"] == "leaf"
+        assert main(["x", "build-critic", "--files", "a.py"]) == 2  # missing --summary
+
+    def test_cli_parse_critic(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            sys, "stdin", io.StringIO(_j({"dissent": False, "agreement_reason": "ok"}))
+        )
+        assert main(["x", "parse-critic"]) == 0
+        assert json.loads(capsys.readouterr().out)["ok"]
+        monkeypatch.setattr(
+            sys, "stdin", io.StringIO(_j({"dissent": True, "failure_mode": ""}))
+        )
+        assert main(["x", "parse-critic"]) == 1
+
+    def test_cli_adjudicate(self, tmp_path, capsys):
+        reviewer = tmp_path / "reviewer.json"
+        critic = tmp_path / "critic.json"
+        reviewer.write_text(
+            _j({"verdict": "pass", "has_blocking": False}), encoding="utf-8"
+        )
+        critic.write_text(
+            _j({"dissent": True, "grounded": True, "failure_mode": "known flaw"}),
+            encoding="utf-8",
+        )
+        rc = main([
+            "x",
+            "adjudicate",
+            "--reviewer",
+            str(reviewer),
+            "--critic",
+            str(critic),
+        ])
+        assert rc == 1  # blocked → rework
+        assert json.loads(capsys.readouterr().out)["block"] is True
+
+    def test_cli_adjudicate_ledger(self, tmp_path, capsys):
+        reviewer = tmp_path / "reviewer.json"
+        critic = tmp_path / "critic.json"
+        ledger = tmp_path / "ledger.jsonl"
+        reviewer.write_text(
+            _j({"verdict": "pass", "has_blocking": False}), encoding="utf-8"
+        )
+        critic.write_text(
+            _j({"dissent": False, "agreement_reason": "fine"}), encoding="utf-8"
+        )
+        rc = main([
+            "x",
+            "adjudicate",
+            "--reviewer",
+            str(reviewer),
+            "--critic",
+            str(critic),
+            "--ledger",
+            str(ledger),
+        ])
+        assert rc == 0
+        assert json.loads(ledger.read_text(encoding="utf-8"))["verdict"] == "proceed"


### PR DESCRIPTION
Automated evolution PR for issue #92.

## Summary
The Forge review stage self-reviews diffs, vulnerable to reviewer/coder rubber-stamping. This adds an adversarial critic pass (Adversarial Review, arXiv:2608.18167): after the reviewer approves, a critic must articulate an evidence-grounded failure mode or agree explicitly.

## Change
- `evolution_qc_review.py` — `build_critic_task`, `parse_critic_report`, `adjudicate_review` (deterministic gate), `record_critic_verdict`; new CLI subcommands `build-critic`, `parse-critic`, `adjudicate`.
- `evolution/lib/stage_gate.py` — `record_review_critic_verdict` appends a kind-discriminated critic verdict to the stage-gate ledger (distinct from accept/refine/restart branch decisions; `load_decisions` still skips them).
- Tests: `tests/scripts/test_evolution_review_critic.py` (15 tests) + `TestReviewCriticLedger` in `test_stage_gate.py`.

## Validation (local, pre-PR)
- `ruff check .` — clean.
- `pytest` on the 5 affected test files — 77 passed (incl. the prompt-injection safety scan + evaluator-isolation checks that statically scan `evolution_qc_review.py`).

Success criteria covered: a known-flaw diff (grounded dissent) is blocked; a clean diff (no objection) proceeds; un-grounded dissent does not block; verdicts land in the stage-gate ledger.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>