### PR TITLE
feat(security): shadow-MCP outbound endpoint visibility + approval (Closes #90)

### DIFF
--- a/evolution/lib/shadow_mcp.py
+++ b/evolution/lib/shadow_mcp.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+"""Shadow-MCP governance — outbound endpoint visibility + approval (#90).
+
+The local counterpart to Cloudflare's 2026-08-14 Gateway ``shadow-MCP``
+selector (``experimental.is_mcp``). Enterprise gateways can now see and block
+*unapproved* MCP connections at the network layer; the local agent has no such
+view of what its MCP/tool traffic actually touches. This module provides that
+visibility without a gateway:
+
+1. **Contact log** — every outbound MCP/tool endpoint contact is recorded
+   (endpoint, owning server, contact count, first/last-seen).
+2. **Config-driven allow/deny** — a ``shadow_mcp`` policy in ``config.yaml``
+   declares which endpoints are approved, blocked, or (by default) simply
+   observed.
+3. **Alert on unapproved contact** — a contact outside the allow list raises
+   a warning-level alert; a contact on the deny list is a denial.
+4. **Audit digest** — the contact log and its unapproved subset are exposed
+   for the audit channel (see ``scripts/shadow_mcp_audit.py``).
+
+Policy (``config.yaml``)::
+
+    shadow_mcp:
+      enabled: true          # default true — log every outbound endpoint contact
+      allow: []              # empty = allow-all (observe only, never block)
+      deny: []               # explicit blocklist (deny verdict)
+
+Verbs returned by :meth:`ShadowMcpGovernor.record_contact`:
+
+* ``allow``      — approved (allow list empty, or endpoint matches it; and not denied).
+* ``alert``      — unapproved (allow list non-empty and endpoint not on it). Logged, not blocked.
+* ``deny``       — blocked (endpoint on the deny list). The caller should refuse the connection.
+
+The default (empty allow/deny) is **fail-open**: it observes everything and
+blocks nothing, so enabling the feature never breaks existing MCP servers.
+Tightening to ``allow: [ ... ]`` opts into alerting; ``deny: [ ... ]`` opts
+into blocking.
+
+This module is import-safe and dependency-light (stdlib only) so the MCP
+dispatch path can import it without pulling in the agent core.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ALLOW",
+    "ALERT",
+    "DENY",
+    "EndpointContact",
+    "ShadowMcpPolicy",
+    "ShadowMcpGovernor",
+    "endpoint_host",
+    "endpoint_matches",
+    "default_log_path",
+    "get_governor",
+]
+
+ALLOW = "allow"
+ALERT = "alert"
+DENY = "deny"
+
+# Endpoints that never need shadow governance: loopback is local, and a stdio
+# command has no network endpoint to approve.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def endpoint_host(endpoint: str) -> str:
+    """Return the ``host[:port]`` (netloc) of a URL, or the raw string.
+
+    Non-URL strings (e.g. a bare hostname) are returned unchanged and lower-
+    cased so callers can still match them against policy entries.
+    """
+    if not endpoint:
+        return ""
+    parsed = urlparse(endpoint)
+    if parsed.netloc:
+        return parsed.netloc.lower()
+    return endpoint.lower()
+
+
+def endpoint_matches(entry: str, endpoint: str) -> bool:
+    """True when a policy *entry* matches an *endpoint* URL or host.
+
+    Match rules, in order:
+
+    * full-URL entry (contains ``://``) — prefix match against the endpoint URL.
+    * ``*.example.com`` — wildcard: matches ``example.com`` and any subdomain
+      (``api.example.com``, ``www.deep.example.com``) and their ``host:port``
+      forms.
+    * ``example.com`` — exact host match, ignoring any port and scheme.
+    """
+    entry = (entry or "").strip().lower()
+    endpoint = (endpoint or "").strip()
+    if not entry or not endpoint:
+        return False
+
+    if "://" in entry:
+        return endpoint.lower().startswith(entry)
+
+    host = endpoint_host(endpoint)
+    # Strip a port from the entry if present, then compare host without port.
+    entry_host = entry.split(":")[0] if ":" in entry else entry
+    host_no_port = host.split(":")[0] if ":" in host else host
+
+    if entry_host.startswith("*."):
+        suffix = entry_host[2:]
+        if not suffix:
+            return False
+        if host_no_port == suffix:
+            return True
+        return host_no_port.endswith("." + suffix)
+    return host_no_port == entry_host
+
+
+def default_log_path() -> Optional[Path]:
+    """Best-effort default on-disk contact-log path, or ``None`` if unavailable."""
+    try:
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+        return get_hermes_home() / "logs" / "shadow_mcp.jsonl"
+    except Exception:
+        return None
+
+
+@dataclass
+class EndpointContact:
+    """Aggregate of contacts to a single (server, endpoint) pair."""
+
+    server: str
+    endpoint: str
+    host: str = ""
+    count: int = 0
+    first_seen: str = ""
+    last_seen: str = ""
+    last_verdict: str = ALLOW
+
+    def __post_init__(self) -> None:
+        self.host = self.host or endpoint_host(self.endpoint)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "EndpointContact":
+        return cls(
+            server=str(d.get("server", "")),
+            endpoint=str(d.get("endpoint", "")),
+            host=str(d.get("host", "")),
+            count=int(d.get("count", 0)),
+            first_seen=str(d.get("first_seen", "")),
+            last_seen=str(d.get("last_seen", "")),
+            last_verdict=str(d.get("last_verdict", ALLOW)),
+        )
+
+
+@dataclass
+class ShadowMcpPolicy:
+    """Config-driven allow/deny policy for outbound endpoints.
+
+    ``allow`` and ``deny`` are lists of endpoint entries (host, wildcard
+    ``*.host``, or full-URL prefix). Empty ``allow`` means allow-all
+    (observe-only). Entries are matched via :func:`endpoint_matches`.
+    """
+
+    allow: List[str] = field(default_factory=list)
+    deny: List[str] = field(default_factory=list)
+    enabled: bool = True
+
+    @classmethod
+    def from_config(cls, config: Optional[Dict[str, Any]]) -> "ShadowMcpPolicy":
+        """Build a policy from a ``shadow_mcp`` config mapping (or ``None``)."""
+        if not isinstance(config, dict):
+            return cls()
+        allow = config.get("allow") or []
+        deny = config.get("deny") or []
+        enabled = bool(config.get("enabled", True))
+        return cls(
+            allow=[str(a) for a in allow] if isinstance(allow, (list, tuple)) else [],
+            deny=[str(d) for d in deny] if isinstance(deny, (list, tuple)) else [],
+            enabled=enabled,
+        )
+
+    def evaluate(self, endpoint: str) -> str:
+        """Return ``allow`` / ``alert`` / ``deny`` for an endpoint."""
+        if any(endpoint_matches(entry, endpoint) for entry in self.deny):
+            return DENY
+        if not self.allow:
+            return ALLOW
+        if any(endpoint_matches(entry, endpoint) for entry in self.allow):
+            return ALLOW
+        return ALERT
+
+
+class ShadowMcpGovernor:
+    """Runtime governor: records contacts, applies policy, alerts, and audits.
+
+    Keeps an in-memory aggregate keyed by ``(server, endpoint)`` and, when
+    ``log_path`` is set, appends each contact as a JSONL line for the audit
+    channel. The caller (the MCP dispatch path) is responsible for *acting* on
+    a ``deny`` verdict (refusing the connection); this class only reports.
+    """
+
+    def __init__(
+        self,
+        policy: Optional[ShadowMcpPolicy] = None,
+        log_path: Optional[Path | str] = None,
+        alerter: Optional[Callable[[str, EndpointContact], None]] = None,
+    ) -> None:
+        self.policy = policy or ShadowMcpPolicy()
+        self.log_path = Path(log_path) if log_path else None
+        self._alerter = alerter
+        self._contacts: Dict[str, EndpointContact] = {}
+
+    def record_contact(self, server: str, endpoint: str) -> str:
+        """Record a contact, return its verdict (``allow``/``alert``/``deny``).
+
+        Always logs the contact when the policy is enabled. Emits a
+        warning-level alert (and invokes the optional alerter) when the
+        verdict is ``alert`` or ``deny``.
+        """
+        key = f"{server}\x00{endpoint}"
+        contact = self._contacts.get(key)
+        now = _now_iso()
+
+        if contact is None:
+            verdict = self.policy.evaluate(endpoint) if self.policy.enabled else ALLOW
+            contact = EndpointContact(
+                server=str(server),
+                endpoint=str(endpoint),
+                count=1,
+                first_seen=now,
+                last_seen=now,
+                last_verdict=verdict,
+            )
+            self._contacts[key] = contact
+        else:
+            verdict = self.policy.evaluate(endpoint) if self.policy.enabled else ALLOW
+            contact.count += 1
+            contact.last_seen = now
+            contact.last_verdict = verdict
+
+        if self.policy.enabled:
+            self._append_disk(contact)
+            if verdict in (ALERT, DENY):
+                self._alert(verdict, contact)
+        return verdict
+
+    def _alert(self, verdict: str, contact: EndpointContact) -> None:
+        logger.warning(
+            "shadow-mcp: %s outbound endpoint contact with %s (%s) via server '%s'",
+            verdict,
+            contact.endpoint,
+            contact.host,
+            contact.server,
+        )
+        if self._alerter is not None:
+            try:
+                self._alerter(verdict, contact)
+            except Exception:  # pragma: no cover - alerting must never break dispatch
+                logger.debug("shadow-mcp alerter failed", exc_info=True)
+
+    def _append_disk(self, contact: EndpointContact) -> None:
+        path = self.log_path
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(contact.to_dict()) + "\n")
+        except OSError as exc:
+            logger.debug("shadow-mcp disk append failed: %s", exc)
+
+    def audit_digest(self) -> List[Dict[str, Any]]:
+        """All recorded contacts, most-recently-seen first."""
+        contacts = list(self._contacts.values())
+        contacts.sort(key=lambda c: c.last_seen, reverse=True)
+        return [c.to_dict() for c in contacts]
+
+    def unapproved(self) -> List[Dict[str, Any]]:
+        """Contacts whose last verdict was ``alert`` or ``deny``."""
+        return [
+            c.to_dict()
+            for c in self._contacts.values()
+            if c.last_verdict in (ALERT, DENY)
+        ]
+
+    def clear(self) -> None:
+        """Drop all in-memory contacts (session boundary)."""
+        self._contacts.clear()
+
+
+_governor: Optional[ShadowMcpGovernor] = None
+
+
+def get_governor() -> ShadowMcpGovernor:
+    """Return the process-wide governor, lazily built from the active config."""
+    global _governor
+    if _governor is None:
+        policy = ShadowMcpPolicy()
+        try:
+            from hermes_cli.config import load_config  # noqa: PLC0415
+
+            policy = ShadowMcpPolicy.from_config(load_config().get("shadow_mcp"))
+        except Exception:
+            logger.debug("shadow-mcp config load failed; using default policy", exc_info=True)
+        _governor = ShadowMcpGovernor(policy=policy, log_path=default_log_path())
+    return _governor
+
+
+# Retained for reference: a caller can reset the singleton (e.g. tests).
+def _reset_governor() -> None:
+    global _governor
+    _governor = None

--- a/scripts/shadow_mcp_audit.py
+++ b/scripts/shadow_mcp_audit.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Audit the shadow-MCP outbound endpoint contact log (#90).
+
+Reads the append-only JSONL contact log written by
+``evolution.lib.shadow_mcp`` (default ``~/.hermes/logs/shadow_mcp.jsonl``) and
+prints a per-endpoint digest: owning MCP server, endpoint, host, contact count,
+first/last-seen, and the most recent verdict (``allow``/``alert``/``deny``).
+
+This is a **read-only audit**: it never mutates config or the log, and prints
+only endpoint metadata (no secrets). Exit code 0 = no unapproved contacts,
+1 = one or more ``alert``/``deny`` contacts, so it can gate a scheduled audit.
+
+Usage::
+
+    python3 scripts/shadow_mcp_audit.py [--log PATH] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _default_log() -> Path:
+    try:
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+        return get_hermes_home() / "logs" / "shadow_mcp.jsonl"
+    except Exception:
+        return Path.home() / ".hermes" / "logs" / "shadow_mcp.jsonl"
+
+
+def read_contacts(log_path: Path) -> list[dict[str, Any]]:
+    """Read the JSONL contact log and return the final aggregate per endpoint.
+
+    The log is append-only with one line per contact (each carrying the
+    cumulative count at that time); we keep the last line for each
+    ``(server, endpoint)`` key so the digest reports final state.
+    """
+    if not log_path.exists():
+        return []
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        key = (str(rec.get("server", "")), str(rec.get("endpoint", "")))
+        latest[key] = rec
+    contacts = list(latest.values())
+    contacts.sort(key=lambda c: str(c.get("last_seen", "")), reverse=True)
+    return contacts
+
+
+def _print_human(contacts: list[dict[str, Any]], source: str) -> None:
+    print(f"shadow-mcp-audit: {source} — {len(contacts)} endpoint(s) contacted")
+    unapproved = [
+        c for c in contacts if c.get("last_verdict") in ("alert", "deny")
+    ]
+    if not contacts:
+        print("no outbound endpoint contacts recorded")
+        return
+    for c in contacts:
+        flag = "  " if c.get("last_verdict") == "allow" else "!!"
+        print(
+            f"{flag} {c.get('last_verdict', 'allow'):5}  "
+            f"{c.get('host', '?'):40}  x{c.get('count', 0):<4}  "
+            f"server={c.get('server', '?')}  endpoint={c.get('endpoint', '?')}"
+        )
+    print(
+        f"{len(unapproved)} unapproved contact(s) of {len(contacts)}. "
+        "Tighten via the `shadow_mcp.allow`/`shadow_mcp.deny` config."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit the shadow-MCP outbound endpoint contact log."
+    )
+    parser.add_argument(
+        "--log",
+        help="Path to the shadow-mcp JSONL contact log (default: ~/.hermes/logs/shadow_mcp.jsonl).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON document instead of human-readable lines.",
+    )
+    args = parser.parse_args(argv)
+
+    log_path = Path(args.log).expanduser() if args.log else _default_log()
+    contacts = read_contacts(log_path)
+    unapproved = [
+        c for c in contacts if c.get("last_verdict") in ("alert", "deny")
+    ]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "source": str(log_path),
+                    "contacts": contacts,
+                    "unapproved": unapproved,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(contacts, str(log_path))
+
+    return 1 if unapproved else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evolution/test_shadow_mcp.py
+++ b/tests/evolution/test_shadow_mcp.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""Tests for shadow-MCP outbound endpoint governance (issue #90)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evolution.lib.shadow_mcp import (
+    ALERT,
+    ALLOW,
+    DENY,
+    EndpointContact,
+    ShadowMcpGovernor,
+    ShadowMcpPolicy,
+    endpoint_host,
+    endpoint_matches,
+)
+
+
+# --- endpoint normalization / matching ------------------------------------
+
+
+def test_endpoint_host_parses_netloc():
+    assert endpoint_host("https://api.example.com:443/v1/x") == "api.example.com:443"
+    assert endpoint_host("http://EXAMPLE.com") == "example.com"
+    assert endpoint_host("bare.host.name") == "bare.host.name"
+
+
+def test_endpoint_matches_exact_host():
+    assert endpoint_matches("example.com", "https://example.com/x")
+    assert endpoint_matches("example.com", "http://example.com:8080/x")
+    assert not endpoint_matches("example.com", "https://evil.com/x")
+
+
+def test_endpoint_matches_wildcard():
+    assert endpoint_matches("*.example.com", "https://api.example.com/x")
+    assert endpoint_matches("*.example.com", "https://example.com/x")
+    assert endpoint_matches("*.example.com", "https://www.deep.example.com/x")
+    assert not endpoint_matches("*.example.com", "https://evil.com/x")
+
+
+def test_endpoint_matches_url_prefix():
+    assert endpoint_matches("https://api.example.com/v1", "https://api.example.com/v1/x")
+    assert not endpoint_matches("https://api.example.com/v1", "https://api.example.com/v2/x")
+
+
+def test_endpoint_matches_empty_and_garbage():
+    assert not endpoint_matches("", "https://example.com")
+    assert not endpoint_matches("example.com", "")
+
+
+# --- policy ----------------------------------------------------------------
+
+
+def test_policy_default_is_allow_all():
+    policy = ShadowMcpPolicy()
+    assert policy.evaluate("https://anything.example.com/x") == ALLOW
+
+
+def test_policy_allowlist_alerts_unapproved():
+    policy = ShadowMcpPolicy(allow=["approved.com"])
+    assert policy.evaluate("https://approved.com/x") == ALLOW
+    assert policy.evaluate("https://other.com/x") == ALERT
+
+
+def test_policy_denylist_blocks():
+    policy = ShadowMcpPolicy(deny=["*.evil.com"])
+    assert policy.evaluate("https://phish.evil.com/x") == DENY
+    assert policy.evaluate("https://good.com/x") == ALLOW
+
+
+def test_policy_deny_wins_over_allow():
+    policy = ShadowMcpPolicy(allow=["example.com"], deny=["example.com"])
+    assert policy.evaluate("https://example.com/x") == DENY
+
+
+def test_policy_from_config():
+    policy = ShadowMcpPolicy.from_config(
+        {"enabled": False, "allow": ["a.com"], "deny": ["b.com"], "junk": [1, 2]}
+    )
+    assert policy.enabled is False
+    assert policy.allow == ["a.com"]
+    assert policy.deny == ["b.com"]
+
+
+def test_policy_from_config_none_or_garbage():
+    assert ShadowMcpPolicy.from_config(None).enabled is True
+    assert ShadowMcpPolicy.from_config("nope").allow == []
+
+
+# --- governor --------------------------------------------------------------
+
+
+def test_governor_records_and_counts(tmp_path):
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy())
+    assert gov.record_contact("srv", "https://a.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://a.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://b.com/x") == ALLOW
+
+    digest = gov.audit_digest()
+    assert len(digest) == 2
+    by_endpoint = {d["endpoint"]: d for d in digest}
+    assert by_endpoint["https://a.com/x"]["count"] == 2
+    assert by_endpoint["https://b.com/x"]["count"] == 1
+    assert gov.unapproved() == []
+
+
+def test_governor_alerts_unapproved():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(allow=["ok.com"]))
+    assert gov.record_contact("srv", "https://ok.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://unapproved.com/x") == ALERT
+    assert [d["endpoint"] for d in gov.unapproved()] == ["https://unapproved.com/x"]
+
+
+def test_governor_deny_verdict():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(deny=["bad.com"]))
+    assert gov.record_contact("srv", "https://bad.com/x") == DENY
+    assert gov.unapproved()[0]["last_verdict"] == DENY
+
+
+def test_governor_disabled_policy_never_blocks_or_alerts():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(allow=["ok.com"], enabled=False))
+    assert gov.record_contact("srv", "https://whatever.com/x") == ALLOW
+    assert gov.unapproved() == []
+
+
+def test_governor_writes_jsonl(tmp_path):
+    log_path = tmp_path / "shadow.jsonl"
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(), log_path=log_path)
+    gov.record_contact("srv", "https://a.com/x")
+    gov.record_contact("srv", "https://a.com/x")
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    rec = json.loads(lines[0])
+    assert rec["server"] == "srv"
+    assert rec["endpoint"] == "https://a.com/x"
+    assert rec["host"] == "a.com"
+    assert rec["count"] == 1
+
+
+def test_governor_alerter_called_on_alert():
+    seen = []
+
+    def _alerter(verdict, contact):
+        seen.append((verdict, contact.endpoint))
+
+    gov = ShadowMcpGovernor(
+        policy=ShadowMcpPolicy(allow=["ok.com"]), alerter=_alerter
+    )
+    gov.record_contact("srv", "https://ok.com/x")
+    gov.record_contact("srv", "https://nope.com/x")
+    assert seen == [(ALERT, "https://nope.com/x")]
+
+
+def test_governor_clear_drops_contacts():
+    gov = ShadowMcpGovernor()
+    gov.record_contact("srv", "https://a.com/x")
+    gov.clear()
+    assert gov.audit_digest() == []
+
+
+def test_endpoint_contact_roundtrip():
+    c = EndpointContact(server="srv", endpoint="https://a.com/x", count=3)
+    d = c.to_dict()
+    assert EndpointContact.from_dict(d).to_dict() == d
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/scripts/test_shadow_mcp_audit.py
+++ b/tests/scripts/test_shadow_mcp_audit.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/shadow_mcp_audit.py (issue #90)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from shadow_mcp_audit import (  # noqa: E402
+    main,
+    read_contacts,
+)
+
+
+def _write_log(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+
+def test_read_contacts_keeps_final_aggregate(tmp_path):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://a.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+            {"server": "srv", "endpoint": "https://a.com/x", "count": 2,
+             "last_verdict": "alert", "last_seen": "2026-01-01T00:00:01Z"},
+            {"server": "srv", "endpoint": "https://b.com/x", "count": 1,
+             "last_verdict": "deny", "last_seen": "2026-01-01T00:00:02Z"},
+        ],
+    )
+    contacts = read_contacts(log)
+    assert len(contacts) == 2
+    by_endpoint = {c["endpoint"]: c for c in contacts}
+    assert by_endpoint["https://a.com/x"]["count"] == 2
+    assert by_endpoint["https://a.com/x"]["last_verdict"] == "alert"
+    assert by_endpoint["https://b.com/x"]["last_verdict"] == "deny"
+
+
+def test_read_contacts_missing_or_corrupt(tmp_path):
+    assert read_contacts(tmp_path / "nope.jsonl") == []
+    log = tmp_path / "shadow.jsonl"
+    _write_log(log, [{"bad": "not-a-record"}])
+    contacts = read_contacts(log)
+    assert len(contacts) == 1
+    # Records without server/endpoint keys are still surfaced; the CLI reads
+    # them defensively via .get().
+    assert contacts[0].get("server", "") == ""
+    assert contacts[0]["bad"] == "not-a-record"
+
+
+def test_main_json_reports_unapproved_and_exit_code(tmp_path, capsys):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://ok.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+            {"server": "srv", "endpoint": "https://bad.com/x", "count": 1,
+             "last_verdict": "alert", "last_seen": "2026-01-01T00:00:01Z"},
+        ],
+    )
+    rc = main(["--log", str(log), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unapproved"][0]["endpoint"] == "https://bad.com/x"
+
+
+def test_main_clean_returns_zero(tmp_path, capsys):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://ok.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+        ],
+    )
+    assert main(["--log", str(log)]) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/tools/test_shadow_mcp_governance.py
+++ b/tests/tools/test_shadow_mcp_governance.py
@@ -1,0 +1,50 @@
+"""Tests for the shadow-MCP wiring in tools/mcp_tool.py (issue #90)."""
+
+from __future__ import annotations
+
+import pytest
+
+import evolution.lib.shadow_mcp as sm
+from tools.mcp_tool import _govern_outbound_endpoint
+
+
+@pytest.fixture(autouse=True)
+def _isolate_governor():
+    """Each test starts from a clean governor singleton, then resets it."""
+    sm._reset_governor()
+    yield
+    sm._reset_governor()
+
+
+def test_empty_url_is_a_noop():
+    # Must not raise and must not instantiate a governor for a bare/empty URL.
+    _govern_outbound_endpoint("srv", "")
+    assert sm._governor is None
+
+
+def test_allow_path_does_not_raise():
+    sm._governor = sm.ShadowMcpGovernor(policy=sm.ShadowMcpPolicy())
+    # Default (allow-all) policy: contact is logged, connection is not blocked.
+    _govern_outbound_endpoint("srv", "https://example.com/x")
+    assert sm._governor.audit_digest()[0]["endpoint"] == "https://example.com/x"
+
+
+def test_deny_path_raises_connection_error():
+    sm._governor = sm.ShadowMcpGovernor(
+        policy=sm.ShadowMcpPolicy(deny=["example.com"])
+    )
+    with pytest.raises(ConnectionError):
+        _govern_outbound_endpoint("srv", "https://example.com/x")
+
+
+def test_alert_path_logs_but_does_not_raise():
+    sm._governor = sm.ShadowMcpGovernor(
+        policy=sm.ShadowMcpPolicy(allow=["ok.com"])
+    )
+    # Unapproved endpoint: alert verdict, but fail-open (no raise).
+    _govern_outbound_endpoint("srv", "https://unapproved.com/x")
+    assert sm._governor.unapproved()[0]["endpoint"] == "https://unapproved.com/x"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3850,6 +3850,9 @@ class MCPServerTask:
             )
 
         url = config["url"]
+        # Shadow-MCP governance (#90): record the outbound endpoint and apply
+        # the config-driven allow/deny policy before any bytes leave the box.
+        _govern_outbound_endpoint(self.name, url)
         headers = dict(config.get("headers") or {})
         # Portable Agent Plugins v1 packages set strict_redirect_headers:
         # configured headers are visible package data and MUST NOT be
@@ -6205,6 +6208,35 @@ def _load_mcp_config() -> Dict[str, dict]:
 # ---------------------------------------------------------------------------
 # Server connection helper
 # ---------------------------------------------------------------------------
+
+
+def _govern_outbound_endpoint(server_name: str, url: str) -> None:
+    """Shadow-MCP governance: record + enforce an outbound HTTP endpoint (issue #90).
+
+    Logs every outbound MCP HTTP/SSE endpoint contact and applies the
+    config-driven allow/deny policy from ``config.yaml`` ``shadow_mcp``. A
+    ``deny`` verdict raises :class:`ConnectionError` to refuse the connection
+    (surfaced as a failed server start by ``_connect_server``); an ``alert``
+    verdict is logged as a warning by the governor itself. Fails open on any
+    import/runtime error so shadow governance can never break MCP dispatch.
+    """
+    if not url:
+        return
+    try:
+        from evolution.lib.shadow_mcp import DENY, get_governor  # noqa: PLC0415
+
+        verdict = get_governor().record_contact(server_name, url)
+        if verdict == DENY:
+            raise ConnectionError(
+                f"MCP server '{server_name}' endpoint {url} is blocked by the "
+                "shadow_mcp deny policy"
+            )
+    except ConnectionError:
+        raise
+    except Exception:
+        logger.debug(
+            "shadow-mcp governance check failed for '%s'", server_name, exc_info=True
+        )
 
 
 async def _connect_server(name: str, config: dict) -> MCPServerTask:


### PR DESCRIPTION
Automated evolution PR for issue #90.

**Shadow-MCP governance** — the local counterpart to Cloudflare's 2026-08-14 Gateway `shadow-MCP` selector: give the agent a network-layer view of what its MCP/tool traffic actually touches, with a config-driven allow/deny policy.

**What's included:**
- `evolution/lib/shadow_mcp.py` — `ShadowMcpPolicy` (allow/deny, config-driven) + `ShadowMcpGovernor` (contact log + alert + audit digest). Fail-open default: empty allow/deny observes everything and blocks nothing.
- `tools/mcp_tool.py` — `_govern_outbound_endpoint()` wired into the HTTP/SSE transport path, recording every outbound endpoint before bytes leave; a `deny` verdict refuses the connection, `alert` is logged.
- `scripts/shadow_mcp_audit.py` — read-only CLI that surfaces the endpoint contact digest (exit 1 on unapproved contacts).

**Policy** (documented default = observe-only): `config.yaml` → `shadow_mcp: { enabled, allow: [], deny: [] }`.

**Local validation (pre-PR):**
- `ruff check .` — clean.
- New tests: 27 passed across `tests/evolution/test_shadow_mcp.py`, `tests/tools/test_shadow_mcp_governance.py`, `tests/scripts/test_shadow_mcp_audit.py`.

Note: the MCP SDK is not installed in the local venv, so HTTP-transport tests that mock `streamable_http_client` fail locally for a pre-existing reason (they also fail on a clean `main` checkout) — unrelated to this change.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>