### PR TITLE
feat(security): bypass-proof shadow-MCP endpoint governance (Closes #90)

### DIFF
--- a/evolution/lib/shadow_mcp.py
+++ b/evolution/lib/shadow_mcp.py
@@ -1,0 +1,411 @@
+# -*- coding: utf-8 -*-
+"""Shadow-MCP governance — outbound endpoint visibility + approval (#90).
+
+The local counterpart to Cloudflare's 2026-08-14 Gateway ``shadow-MCP``
+selector (``experimental.is_mcp``). Enterprise gateways can now see and block
+*unapproved* MCP connections at the network layer; the local agent has no such
+view of what its MCP/tool traffic actually touches. This module provides that
+visibility without a gateway:
+
+1. **Contact log** — every outbound MCP/tool endpoint contact is recorded
+   (endpoint, owning server, contact count, first/last-seen).
+2. **Config-driven allow/deny** — a ``shadow_mcp`` policy in ``config.yaml``
+   declares which endpoints are approved, blocked, or (by default) simply
+   observed.
+3. **Alert on unapproved contact** — a contact outside the allow list raises
+   a warning-level alert; a contact on the deny list is a denial.
+4. **Audit digest** — the contact log and its unapproved subset are exposed
+   for the audit channel (see ``scripts/shadow_mcp_audit.py``).
+
+Policy (``config.yaml``)::
+
+    shadow_mcp:
+      enabled: true          # default true — log every outbound endpoint contact
+      allow: []              # empty = allow-all (observe only, never block)
+      deny: []               # explicit blocklist (deny verdict)
+
+Verbs returned by :meth:`ShadowMcpGovernor.record_contact`:
+
+* ``allow``      — approved (allow list empty, or endpoint matches it; and not denied).
+* ``alert``      — unapproved (allow list non-empty and endpoint not on it). Logged, not blocked.
+* ``deny``       — blocked (endpoint on the deny list). The caller should refuse the connection.
+
+The default (empty allow/deny) is **fail-open**: it observes everything and
+blocks nothing, so enabling the feature never breaks existing MCP servers.
+Tightening to ``allow: [ ... ]`` opts into alerting; ``deny: [ ... ]`` opts
+into blocking.
+
+Matching semantics (security-relevant, reworked after PR #3056 review): every
+entry — bare host, ``*.wildcard``, or full URL — is compared on the
+``urlparse().hostname`` of both sides. Scheme, userinfo, port, and trailing
+dot are all normalized away BEFORE comparison, so a deny entry for
+``evil.com`` also blocks ``https://user@evil.com./x`` and
+``http://evil.com:8443/y``, and an allow entry for ``good.com`` can never
+over-match ``good.com.attacker.net``. Full-URL entries match on hostname
+only — there is deliberately **no** ``str.startswith`` on the whole URL.
+
+Secrets are never written to the contact log: query strings and userinfo are
+redacted at ingestion (see :func:`redact_url`), so the audit CLI can print
+``endpoint`` without leaking tokens.
+
+This module is import-safe and dependency-light (stdlib only) so the MCP
+dispatch path can import it without pulling in the agent core.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ALLOW",
+    "ALERT",
+    "DENY",
+    "EndpointContact",
+    "ShadowMcpDeniedError",
+    "ShadowMcpPolicy",
+    "ShadowMcpGovernor",
+    "endpoint_host",
+    "endpoint_matches",
+    "redact_url",
+    "default_log_path",
+    "get_governor",
+]
+
+ALLOW = "allow"
+ALERT = "alert"
+DENY = "deny"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalize_host(value: str) -> str:
+    """Normalize a URL or bare host to a comparable, lowercased hostname.
+
+    Strips scheme, userinfo, port, path/query/fragment, surrounding IPv6
+    brackets, and any trailing dot. Returns ``""`` for empty/unparseable input.
+
+    This is the single source of truth for endpoint comparison: matching a
+    policy entry against an endpoint happens on the *hostname* only, so
+    userinfo / port / trailing-dot / scheme variants can never slip past a
+    deny entry, and an allow entry can never over-match across a domain
+    boundary (both failure modes of the original ``str.startswith`` matcher).
+    """
+    value = (value or "").strip()
+    if not value:
+        return ""
+    # Prefix a scheme when absent so urlparse treats a bare host / user@host /
+    # host:port string as a netloc instead of a (path-like) bare string.
+    parsed = urlparse(value if "://" in value else "//" + value)
+    host = parsed.hostname or ""
+    if host:
+        return host.rstrip(".").lower()
+    # urlparse() leaves hostname empty for inputs it cannot split — most
+    # commonly a BARE IPv6 literal ('::1' without brackets), or a
+    # userinfo/host with no scheme. Extract the host manually.
+    netloc = (parsed.netloc or value).strip()
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[-1]
+    if netloc.startswith("[") and "]" in netloc:
+        netloc = netloc[1 : netloc.index("]")]
+    elif netloc.count(":") > 1:
+        # Bare IPv6 literal: the whole netloc is the address (no port).
+        pass
+    elif ":" in netloc:
+        # host:port -> host
+        netloc = netloc.split(":", 1)[0]
+    return netloc.rstrip(".").lower()
+
+
+def endpoint_host(endpoint: str) -> str:
+    """Return the normalized hostname of a URL (or bare host).
+
+    Strips scheme, userinfo, port, path/query/fragment, and any trailing dot,
+    and lowercases. Returns ``""`` for empty input.
+    """
+    return _normalize_host(endpoint)
+
+
+def endpoint_matches(entry: str, endpoint: str) -> bool:
+    """True when a policy *entry* matches an *endpoint* URL or host.
+
+    Match rules (all on ``urlparse().hostname``, never on the whole URL):
+
+    * ``*.example.com`` — wildcard: matches ``example.com`` and any subdomain
+      (``api.example.com``, ``www.deep.example.com``), port and trailing dot
+      irrelevant.
+    * ``example.com`` / ``https://example.com/x`` — exact hostname match,
+      ignoring scheme, userinfo, port, path, query, and trailing dot.
+    """
+    entry_host = _normalize_host(entry)
+    endpoint_host_norm = _normalize_host(endpoint)
+    if not entry_host or not endpoint_host_norm:
+        return False
+
+    if entry_host.startswith("*."):
+        suffix = entry_host[2:]
+        if not suffix:
+            return False
+        return endpoint_host_norm == suffix or endpoint_host_norm.endswith("." + suffix)
+    return endpoint_host_norm == entry_host
+
+
+def redact_url(value: str) -> str:
+    """Return *value* with userinfo, query string, and fragment removed.
+
+    Only rewrites when *value* carries a scheme; bare hostnames and non-URL
+    strings are returned unchanged. Port and path are preserved so the contact
+    log stays useful for triage, but anything that could carry a secret
+    (``user:pass@``, ``?token=``, ``#fragment``) is dropped before it reaches
+    the JSONL log or the audit digest.
+    """
+    value = (value or "").strip()
+    if not value or "://" not in value:
+        return value
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return value
+    host = parsed.hostname or ""
+    if not host:
+        # Cannot safely rebuild — fall back to dropping query/fragment only.
+        return value.split("?", 1)[0].split("#", 1)[0]
+    # Rebuild a secrets-safe URL: scheme + host[:port] + path.
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+    else:
+        netloc = host
+    return urlunparse((parsed.scheme, netloc, parsed.path or "", "", "", ""))
+
+
+class ShadowMcpDeniedError(ConnectionError):
+    """Raised when an outbound endpoint is blocked by the shadow_mcp deny policy.
+
+    Subclasses :class:`ConnectionError` so callers that only catch the broad
+    class still treat it as a connection problem. It is a DISTINCT type so the
+    MCP reconnect loop can classify it as *permanent* — a deny verdict never
+    clears on retry, so the server task terminates immediately instead of
+    parking in the reconnect-backoff ladder (the original PR #3056 failure:
+    a denied endpoint warn-spammed through the retry loop).
+    """
+
+
+def default_log_path() -> Optional[Path]:
+    """Best-effort default on-disk contact-log path, or ``None`` if unavailable."""
+    try:
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+        return get_hermes_home() / "logs" / "shadow_mcp.jsonl"
+    except Exception:
+        return None
+
+
+@dataclass
+class EndpointContact:
+    """Aggregate of contacts to a single (server, endpoint) pair.
+
+    ``endpoint`` is the *redacted* URL (no query string / userinfo / fragment);
+    ``host`` is the normalized hostname. Both are safe to print in an audit.
+    """
+
+    server: str
+    endpoint: str
+    host: str = ""
+    count: int = 0
+    first_seen: str = ""
+    last_seen: str = ""
+    last_verdict: str = ALLOW
+
+    def __post_init__(self) -> None:
+        self.host = self.host or endpoint_host(self.endpoint)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "EndpointContact":
+        return cls(
+            server=str(d.get("server", "")),
+            endpoint=str(d.get("endpoint", "")),
+            host=str(d.get("host", "")),
+            count=int(d.get("count", 0)),
+            first_seen=str(d.get("first_seen", "")),
+            last_seen=str(d.get("last_seen", "")),
+            last_verdict=str(d.get("last_verdict", ALLOW)),
+        )
+
+
+@dataclass
+class ShadowMcpPolicy:
+    """Config-driven allow/deny policy for outbound endpoints.
+
+    ``allow`` and ``deny`` are lists of endpoint entries (host, wildcard
+    ``*.host``, or full URL). Empty ``allow`` means allow-all (observe-only).
+    Entries are matched via :func:`endpoint_matches`.
+    """
+
+    allow: List[str] = field(default_factory=list)
+    deny: List[str] = field(default_factory=list)
+    enabled: bool = True
+
+    @classmethod
+    def from_config(cls, config: Optional[Dict[str, Any]]) -> "ShadowMcpPolicy":
+        """Build a policy from a ``shadow_mcp`` config mapping (or ``None``)."""
+        if not isinstance(config, dict):
+            return cls()
+        allow = config.get("allow") or []
+        deny = config.get("deny") or []
+        enabled = bool(config.get("enabled", True))
+        return cls(
+            allow=[str(a) for a in allow] if isinstance(allow, (list, tuple)) else [],
+            deny=[str(d) for d in deny] if isinstance(deny, (list, tuple)) else [],
+            enabled=enabled,
+        )
+
+    def evaluate(self, endpoint: str) -> str:
+        """Return ``allow`` / ``alert`` / ``deny`` for an endpoint."""
+        if any(endpoint_matches(entry, endpoint) for entry in self.deny):
+            return DENY
+        if not self.allow:
+            return ALLOW
+        if any(endpoint_matches(entry, endpoint) for entry in self.allow):
+            return ALLOW
+        return ALERT
+
+
+class ShadowMcpGovernor:
+    """Runtime governor: records contacts, applies policy, alerts, and audits.
+
+    Keeps an in-memory aggregate keyed by ``(server, redacted_endpoint)`` and,
+    when ``log_path`` is set, appends each contact as a JSONL line for the
+    audit channel. Endpoints are redacted before storage so secrets never
+    reach memory or disk. The caller (the MCP dispatch path) is responsible
+    for *acting* on a ``deny`` verdict (refusing the connection); this class
+    only reports.
+    """
+
+    def __init__(
+        self,
+        policy: Optional[ShadowMcpPolicy] = None,
+        log_path: Optional[Path | str] = None,
+        alerter: Optional[Callable[[str, EndpointContact], None]] = None,
+    ) -> None:
+        self.policy = policy or ShadowMcpPolicy()
+        self.log_path = Path(log_path) if log_path else None
+        self._alerter = alerter
+        self._contacts: Dict[str, EndpointContact] = {}
+
+    def record_contact(self, server: str, endpoint: str) -> str:
+        """Record a contact, return its verdict (``allow``/``alert``/``deny``).
+
+        Always logs the contact when the policy is enabled. Emits a
+        warning-level alert (and invokes the optional alerter) when the
+        verdict is ``alert`` or ``deny``.
+        """
+        safe_endpoint = redact_url(endpoint)
+        key = f"{server}\x00{safe_endpoint}"
+        contact = self._contacts.get(key)
+        now = _now_iso()
+
+        verdict = self.policy.evaluate(endpoint) if self.policy.enabled else ALLOW
+
+        if contact is None:
+            contact = EndpointContact(
+                server=str(server),
+                endpoint=safe_endpoint,
+                count=1,
+                first_seen=now,
+                last_seen=now,
+                last_verdict=verdict,
+            )
+            self._contacts[key] = contact
+        else:
+            contact.count += 1
+            contact.last_seen = now
+            contact.last_verdict = verdict
+
+        if self.policy.enabled:
+            self._append_disk(contact)
+            if verdict in (ALERT, DENY):
+                self._alert(verdict, contact)
+        return verdict
+
+    def _alert(self, verdict: str, contact: EndpointContact) -> None:
+        logger.warning(
+            "shadow-mcp: %s outbound endpoint contact with %s (%s) via server '%s'",
+            verdict,
+            contact.endpoint,
+            contact.host,
+            contact.server,
+        )
+        if self._alerter is not None:
+            try:
+                self._alerter(verdict, contact)
+            except Exception:  # pragma: no cover - alerting must never break dispatch
+                logger.debug("shadow-mcp alerter failed", exc_info=True)
+
+    def _append_disk(self, contact: EndpointContact) -> None:
+        path = self.log_path
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(contact.to_dict()) + "\n")
+        except OSError as exc:
+            logger.debug("shadow-mcp disk append failed: %s", exc)
+
+    def audit_digest(self) -> List[Dict[str, Any]]:
+        """All recorded contacts, most-recently-seen first."""
+        contacts = list(self._contacts.values())
+        contacts.sort(key=lambda c: c.last_seen, reverse=True)
+        return [c.to_dict() for c in contacts]
+
+    def unapproved(self) -> List[Dict[str, Any]]:
+        """Contacts whose last verdict was ``alert`` or ``deny``."""
+        return [
+            c.to_dict()
+            for c in self._contacts.values()
+            if c.last_verdict in (ALERT, DENY)
+        ]
+
+    def clear(self) -> None:
+        """Drop all in-memory contacts (session boundary)."""
+        self._contacts.clear()
+
+
+_governor: Optional[ShadowMcpGovernor] = None
+
+
+def get_governor() -> ShadowMcpGovernor:
+    """Return the process-wide governor, lazily built from the active config."""
+    global _governor
+    if _governor is None:
+        policy = ShadowMcpPolicy()
+        try:
+            from hermes_cli.config import load_config  # noqa: PLC0415
+
+            policy = ShadowMcpPolicy.from_config(load_config().get("shadow_mcp"))
+        except Exception:
+            logger.debug("shadow-mcp config load failed; using default policy", exc_info=True)
+        _governor = ShadowMcpGovernor(policy=policy, log_path=default_log_path())
+    return _governor
+
+
+# Retained for reference: a caller can reset the singleton (e.g. tests).
+def _reset_governor() -> None:
+    global _governor
+    _governor = None

--- a/scripts/shadow_mcp_audit.py
+++ b/scripts/shadow_mcp_audit.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Audit the shadow-MCP outbound endpoint contact log (#90).
+
+Reads the append-only JSONL contact log written by
+``evolution.lib.shadow_mcp`` (default ``~/.hermes/logs/shadow_mcp.jsonl``) and
+prints a per-endpoint digest: owning MCP server, endpoint, host, contact count,
+first/last-seen, and the most recent verdict (``allow``/``alert``/``deny``).
+
+This is a **read-only audit**: it never mutates config or the log, and prints
+only endpoint metadata. Endpoints in the log are already redacted (no query
+strings / userinfo), so the CLI never surfaces secrets. Exit code 0 = no
+unapproved contacts, 1 = one or more ``alert``/``deny`` contacts, so it can
+gate a scheduled audit.
+
+Usage::
+
+    python3 scripts/shadow_mcp_audit.py [--log PATH] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _default_log() -> Path:
+    try:
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+        return get_hermes_home() / "logs" / "shadow_mcp.jsonl"
+    except Exception:
+        return Path.home() / ".hermes" / "logs" / "shadow_mcp.jsonl"
+
+
+def read_contacts(log_path: Path) -> list[dict[str, Any]]:
+    """Read the JSONL contact log and return the final aggregate per endpoint.
+
+    The log is append-only with one line per contact (each carrying the
+    cumulative count at that time); we keep the last line for each
+    ``(server, endpoint)`` key so the digest reports final state.
+    """
+    if not log_path.exists():
+        return []
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        key = (str(rec.get("server", "")), str(rec.get("endpoint", "")))
+        latest[key] = rec
+    contacts = list(latest.values())
+    contacts.sort(key=lambda c: str(c.get("last_seen", "")), reverse=True)
+    return contacts
+
+
+def _print_human(contacts: list[dict[str, Any]], source: str) -> None:
+    print(f"shadow-mcp-audit: {source} — {len(contacts)} endpoint(s) contacted")
+    unapproved = [
+        c for c in contacts if c.get("last_verdict") in ("alert", "deny")
+    ]
+    if not contacts:
+        print("no outbound endpoint contacts recorded")
+        return
+    for c in contacts:
+        flag = "  " if c.get("last_verdict") == "allow" else "!!"
+        print(
+            f"{flag} {c.get('last_verdict', 'allow'):5}  "
+            f"{c.get('host', '?'):40}  x{c.get('count', 0):<4}  "
+            f"server={c.get('server', '?')}  endpoint={c.get('endpoint', '?')}"
+        )
+    print(
+        f"{len(unapproved)} unapproved contact(s) of {len(contacts)}. "
+        "Tighten via the `shadow_mcp.allow`/`shadow_mcp.deny` config."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit the shadow-MCP outbound endpoint contact log."
+    )
+    parser.add_argument(
+        "--log",
+        help="Path to the shadow-mcp JSONL contact log (default: ~/.hermes/logs/shadow_mcp.jsonl).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON document instead of human-readable lines.",
+    )
+    args = parser.parse_args(argv)
+
+    log_path = Path(args.log).expanduser() if args.log else _default_log()
+    contacts = read_contacts(log_path)
+    unapproved = [
+        c for c in contacts if c.get("last_verdict") in ("alert", "deny")
+    ]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "source": str(log_path),
+                    "contacts": contacts,
+                    "unapproved": unapproved,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(contacts, str(log_path))
+
+    return 1 if unapproved else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evolution/test_shadow_mcp.py
+++ b/tests/evolution/test_shadow_mcp.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""Tests for shadow-MCP outbound endpoint governance (issue #90, rework r2).
+
+The rework (post PR #3056 review) made the matcher bypass-proof. These tests
+prove the six bypass classes the review flagged — trailing-dot FQDNs, userinfo,
+scheme variants, domain-crossing over-match, port, and IPv6 — evaluate
+correctly for BOTH allow and deny policies, plus redaction of query
+strings/userinfo and the terminal-denial exception.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evolution.lib.shadow_mcp import (
+    ALERT,
+    ALLOW,
+    DENY,
+    EndpointContact,
+    ShadowMcpDeniedError,
+    ShadowMcpGovernor,
+    ShadowMcpPolicy,
+    endpoint_host,
+    endpoint_matches,
+    redact_url,
+)
+
+
+# --- endpoint normalization ------------------------------------------------
+
+def test_endpoint_host_normalizes_scheme_userinfo_port_dot():
+    assert endpoint_host("https://api.example.com:443/v1/x") == "api.example.com"
+    assert endpoint_host("http://EXAMPLE.com") == "example.com"
+    assert endpoint_host("https://user:pass@example.com:8443/x") == "example.com"
+    assert endpoint_host("https://example.com./x") == "example.com"
+    assert endpoint_host("bare.host.name") == "bare.host.name"
+    assert endpoint_host("") == ""
+
+
+# --- matcher: the six bypass classes (allow AND deny) ----------------------
+
+def test_matcher_trailing_dot_fqdn():
+    # deny 'evil.com' MUST block 'https://evil.com./x' (trailing dot).
+    assert endpoint_matches("evil.com", "https://evil.com./x")
+    assert endpoint_matches("evil.com", "https://evil.com/x")
+    # allow 'good.com' MUST NOT match 'good.com.' (a different host) — here the
+    # trailing dot normalizes away, so it DOES match; the point is it matches
+    # the intended host, never a sibling.
+    assert endpoint_matches("good.com", "https://good.com./x")
+
+
+def test_matcher_userinfo_stripped():
+    # deny 'evil.com' MUST block 'https://user@evil.com/x'.
+    assert endpoint_matches("evil.com", "https://user@evil.com/x")
+    assert endpoint_matches("evil.com", "https://user:pass@evil.com/x")
+    # allow 'good.com' matches despite userinfo.
+    assert endpoint_matches("good.com", "https://user@good.com/x")
+    assert not endpoint_matches("good.com", "https://user@attacker.net/x")
+
+
+def test_matcher_scheme_variant():
+    # A full-URL deny entry 'https://evil.com' MUST also block 'http://evil.com/x'.
+    assert endpoint_matches("https://evil.com", "http://evil.com/x")
+    assert endpoint_matches("https://evil.com", "https://evil.com/x")
+    # allow entry matches regardless of scheme.
+    assert endpoint_matches("http://good.com", "https://good.com/x")
+
+
+def test_matcher_no_domain_crossing():
+    # allow 'https://good.com' MUST NOT match 'https://good.com.attacker.net/x'.
+    assert not endpoint_matches("https://good.com", "https://good.com.attacker.net/x")
+    assert not endpoint_matches("good.com", "https://good.com.attacker.net/x")
+    # and the true subdomain is still excluded unless wildcarded.
+    assert not endpoint_matches("good.com", "https://evilgood.com/x")
+
+
+def test_matcher_port_insensitive():
+    # deny 'evil.com' MUST block any port.
+    assert endpoint_matches("evil.com", "https://evil.com:8443/x")
+    assert endpoint_matches("evil.com:8443", "https://evil.com:443/x")
+    assert endpoint_matches("evil.com", "https://evil.com/x")
+
+
+def test_matcher_ipv6():
+    # deny '::1' (or bracketed '[::1]') MUST block a bracketed IPv6 endpoint.
+    assert endpoint_matches("::1", "https://[::1]:8080/x")
+    assert endpoint_matches("[::1]", "https://[::1]/x")
+    assert not endpoint_matches("::1", "https://[::2]/x")
+    assert not endpoint_matches("::2", "https://[::1]/x")
+
+
+def test_matcher_wildcard():
+    assert endpoint_matches("*.example.com", "https://api.example.com/x")
+    assert endpoint_matches("*.example.com", "https://example.com/x")
+    assert endpoint_matches("*.example.com", "https://www.deep.example.com/x")
+    assert not endpoint_matches("*.example.com", "https://evil.com/x")
+    assert not endpoint_matches("*.example.com", "https://example.com.attacker.net/x")
+
+
+def test_matcher_exact_host_no_url_prefix_overmatch():
+    # Full-URL entries match on hostname only, never str.startswith on the URL.
+    assert endpoint_matches("https://api.example.com/v1", "https://api.example.com/v2/x")
+    assert not endpoint_matches("https://api.example.com/v1", "https://api.example.net/v1/x")
+
+
+def test_matcher_empty_and_garbage():
+    assert not endpoint_matches("", "https://example.com")
+    assert not endpoint_matches("example.com", "")
+    assert not endpoint_matches("*", "https://example.com")
+    assert not endpoint_matches("*.", "https://example.com")
+
+
+# --- redaction -------------------------------------------------------------
+
+def test_redact_url_strips_query_userinfo_fragment():
+    assert redact_url("https://user:pass@a.com/path?token=SECRET#frag") == "https://a.com/path"
+    assert redact_url("https://a.com/x?api_key=abc") == "https://a.com/x"
+    assert redact_url("https://a.com/x") == "https://a.com/x"
+    assert redact_url("https://a.com:8443/x?q=1") == "https://a.com:8443/x"
+    assert redact_url("bare.host") == "bare.host"
+    assert redact_url("") == ""
+
+
+# --- policy ----------------------------------------------------------------
+
+def test_policy_default_is_allow_all():
+    assert ShadowMcpPolicy().evaluate("https://anything.example.com/x") == ALLOW
+
+
+def test_policy_allowlist_alerts_unapproved():
+    policy = ShadowMcpPolicy(allow=["approved.com"])
+    assert policy.evaluate("https://approved.com/x") == ALLOW
+    assert policy.evaluate("https://other.com/x") == ALERT
+
+
+def test_policy_denylist_blocks_bypass_variants():
+    policy = ShadowMcpPolicy(deny=["evil.com"])
+    assert policy.evaluate("https://evil.com./x") == DENY  # trailing dot
+    assert policy.evaluate("https://user@evil.com/x") == DENY  # userinfo
+    assert policy.evaluate("http://evil.com:8443/x") == DENY  # scheme + port
+    assert policy.evaluate("https://good.com/x") == ALLOW
+
+
+def test_policy_deny_wins_over_allow():
+    policy = ShadowMcpPolicy(allow=["example.com"], deny=["example.com"])
+    assert policy.evaluate("https://example.com/x") == DENY
+
+
+def test_policy_from_config():
+    policy = ShadowMcpPolicy.from_config(
+        {"enabled": False, "allow": ["a.com"], "deny": ["b.com"], "junk": [1, 2]}
+    )
+    assert policy.enabled is False
+    assert policy.allow == ["a.com"]
+    assert policy.deny == ["b.com"]
+
+
+def test_policy_from_config_none_or_garbage():
+    assert ShadowMcpPolicy.from_config(None).enabled is True
+    assert ShadowMcpPolicy.from_config("nope").allow == []
+
+
+# --- governor --------------------------------------------------------------
+
+def test_governor_records_and_counts(tmp_path):
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy())
+    assert gov.record_contact("srv", "https://a.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://a.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://b.com/x") == ALLOW
+
+    digest = gov.audit_digest()
+    assert len(digest) == 2
+    by_endpoint = {d["endpoint"]: d for d in digest}
+    assert by_endpoint["https://a.com/x"]["count"] == 2
+    assert by_endpoint["https://b.com/x"]["count"] == 1
+    assert gov.unapproved() == []
+
+
+def test_governor_redacts_endpoints_in_memory_and_on_disk(tmp_path):
+    log_path = tmp_path / "shadow.jsonl"
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(), log_path=log_path)
+    gov.record_contact("srv", "https://user:pass@a.com/path?token=SECRET#frag")
+
+    # In-memory digest must be redacted (no secret).
+    digest = gov.audit_digest()
+    assert digest[0]["endpoint"] == "https://a.com/path"
+    assert "SECRET" not in json.dumps(digest)
+
+    # Disk JSONL must be redacted too.
+    line = log_path.read_text(encoding="utf-8").strip()
+    assert "SECRET" not in line
+    assert "user:pass" not in line
+    assert "token=" not in line
+
+
+def test_governor_alerts_unapproved():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(allow=["ok.com"]))
+    assert gov.record_contact("srv", "https://ok.com/x") == ALLOW
+    assert gov.record_contact("srv", "https://unapproved.com/x") == ALERT
+    assert [d["endpoint"] for d in gov.unapproved()] == ["https://unapproved.com/x"]
+
+
+def test_governor_deny_verdict():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(deny=["bad.com"]))
+    assert gov.record_contact("srv", "https://bad.com/x") == DENY
+    assert gov.unapproved()[0]["last_verdict"] == DENY
+
+
+def test_governor_disabled_policy_never_blocks_or_alerts():
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(allow=["ok.com"], enabled=False))
+    assert gov.record_contact("srv", "https://whatever.com/x") == ALLOW
+    assert gov.unapproved() == []
+
+
+def test_governor_writes_jsonl(tmp_path):
+    log_path = tmp_path / "shadow.jsonl"
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(), log_path=log_path)
+    gov.record_contact("srv", "https://a.com/x")
+    gov.record_contact("srv", "https://a.com/x")
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    rec = json.loads(lines[0])
+    assert rec["server"] == "srv"
+    assert rec["endpoint"] == "https://a.com/x"
+    assert rec["host"] == "a.com"
+    assert rec["count"] == 1
+
+
+def test_governor_alerter_called_on_alert():
+    seen = []
+
+    def _alerter(verdict, contact):
+        seen.append((verdict, contact.endpoint))
+
+    gov = ShadowMcpGovernor(policy=ShadowMcpPolicy(allow=["ok.com"]), alerter=_alerter)
+    gov.record_contact("srv", "https://ok.com/x")
+    gov.record_contact("srv", "https://nope.com/x")
+    assert seen == [(ALERT, "https://nope.com/x")]
+
+
+def test_governor_clear_drops_contacts():
+    gov = ShadowMcpGovernor()
+    gov.record_contact("srv", "https://a.com/x")
+    gov.clear()
+    assert gov.audit_digest() == []
+
+
+def test_endpoint_contact_roundtrip():
+    c = EndpointContact(server="srv", endpoint="https://a.com/x", count=3)
+    d = c.to_dict()
+    assert EndpointContact.from_dict(d).to_dict() == d
+
+
+def test_denied_error_is_distinct_and_connection_error():
+    err = ShadowMcpDeniedError("blocked")
+    assert isinstance(err, ConnectionError)
+    # Distinct from the generic ConnectionError so the reconnect loop can
+    # classify it as permanent.
+    assert type(err) is ShadowMcpDeniedError
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/scripts/test_shadow_mcp_audit.py
+++ b/tests/scripts/test_shadow_mcp_audit.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/shadow_mcp_audit.py (issue #90)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from shadow_mcp_audit import (  # noqa: E402
+    main,
+    read_contacts,
+)
+
+
+def _write_log(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+
+def test_read_contacts_keeps_final_aggregate(tmp_path):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://a.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+            {"server": "srv", "endpoint": "https://a.com/x", "count": 2,
+             "last_verdict": "alert", "last_seen": "2026-01-01T00:00:01Z"},
+            {"server": "srv", "endpoint": "https://b.com/x", "count": 1,
+             "last_verdict": "deny", "last_seen": "2026-01-01T00:00:02Z"},
+        ],
+    )
+    contacts = read_contacts(log)
+    assert len(contacts) == 2
+    by_endpoint = {c["endpoint"]: c for c in contacts}
+    assert by_endpoint["https://a.com/x"]["count"] == 2
+    assert by_endpoint["https://a.com/x"]["last_verdict"] == "alert"
+    assert by_endpoint["https://b.com/x"]["last_verdict"] == "deny"
+
+
+def test_read_contacts_missing_or_corrupt(tmp_path):
+    assert read_contacts(tmp_path / "nope.jsonl") == []
+    log = tmp_path / "shadow.jsonl"
+    _write_log(log, [{"bad": "not-a-record"}])
+    contacts = read_contacts(log)
+    assert len(contacts) == 1
+    # Records without server/endpoint keys are still surfaced; the CLI reads
+    # them defensively via .get().
+    assert contacts[0].get("server", "") == ""
+    assert contacts[0]["bad"] == "not-a-record"
+
+
+def test_main_json_reports_unapproved_and_exit_code(tmp_path, capsys):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://ok.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+            {"server": "srv", "endpoint": "https://bad.com/x", "count": 1,
+             "last_verdict": "alert", "last_seen": "2026-01-01T00:00:01Z"},
+        ],
+    )
+    rc = main(["--log", str(log), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unapproved"][0]["endpoint"] == "https://bad.com/x"
+
+
+def test_main_clean_returns_zero(tmp_path, capsys):
+    log = tmp_path / "shadow.jsonl"
+    _write_log(
+        log,
+        [
+            {"server": "srv", "endpoint": "https://ok.com/x", "count": 1,
+             "last_verdict": "allow", "last_seen": "2026-01-01T00:00:00Z"},
+        ],
+    )
+    assert main(["--log", str(log)]) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/tools/test_shadow_mcp_governance.py
+++ b/tests/tools/test_shadow_mcp_governance.py
@@ -1,0 +1,75 @@
+"""Tests for the shadow-MCP wiring in tools/mcp_tool.py (issue #90, rework r2)."""
+
+from __future__ import annotations
+
+import pytest
+
+import evolution.lib.shadow_mcp as sm
+from tools.mcp_tool import _classify_mcp_failure, _govern_outbound_endpoint
+
+
+@pytest.fixture(autouse=True)
+def _isolate_governor():
+    """Each test starts from a clean governor singleton, then resets it."""
+    sm._reset_governor()
+    yield
+    sm._reset_governor()
+
+
+def test_empty_url_is_a_noop():
+    # Must not raise and must not instantiate a governor for a bare/empty URL.
+    _govern_outbound_endpoint("srv", "")
+    assert sm._governor is None
+
+
+def test_allow_path_does_not_raise():
+    sm._governor = sm.ShadowMcpGovernor(policy=sm.ShadowMcpPolicy())
+    # Default (allow-all) policy: contact is logged, connection is not blocked.
+    _govern_outbound_endpoint("srv", "https://example.com/x")
+    assert sm._governor.audit_digest()[0]["endpoint"] == "https://example.com/x"
+
+
+def test_deny_path_raises_distinct_denied_error():
+    sm._governor = sm.ShadowMcpGovernor(policy=sm.ShadowMcpPolicy(deny=["example.com"]))
+    with pytest.raises(sm.ShadowMcpDeniedError):
+        _govern_outbound_endpoint("srv", "https://example.com/x")
+
+
+def test_deny_path_is_still_a_connection_error():
+    # Subclasses ConnectionError so broad exception handlers keep working.
+    sm._governor = sm.ShadowMcpGovernor(policy=sm.ShadowMcpPolicy(deny=["example.com"]))
+    with pytest.raises(ConnectionError):
+        _govern_outbound_endpoint("srv", "https://example.com/x")
+
+
+def test_deny_verdict_classified_permanent_no_backoff():
+    # A deny verdict must terminate the server task immediately — the reconnect
+    # loop classifies ShadowMcpDeniedError as permanent (no backoff/park).
+    exc = sm.ShadowMcpDeniedError("blocked by deny policy")
+    assert _classify_mcp_failure(exc) == "permanent"
+    # And the generic ConnectionError (e.g. a real network blip) stays transient.
+    assert _classify_mcp_failure(ConnectionError("boom")) == "transient"
+
+
+def test_deny_verdict_redacts_secret_in_error_and_log(tmp_path):
+    log_path = tmp_path / "shadow.jsonl"
+    sm._governor = sm.ShadowMcpGovernor(
+        policy=sm.ShadowMcpPolicy(deny=["example.com"]), log_path=log_path
+    )
+    with pytest.raises(sm.ShadowMcpDeniedError):
+        _govern_outbound_endpoint("srv", "https://example.com/x?token=SECRET")
+    # The contact was logged (redacted) before the deny was raised.
+    logged = log_path.read_text(encoding="utf-8")
+    assert "SECRET" not in logged
+    assert "token=" not in logged
+
+
+def test_alert_path_logs_but_does_not_raise():
+    sm._governor = sm.ShadowMcpGovernor(policy=sm.ShadowMcpPolicy(allow=["ok.com"]))
+    # Unapproved endpoint: alert verdict, but fail-open (no raise).
+    _govern_outbound_endpoint("srv", "https://unapproved.com/x")
+    assert sm._governor.unapproved()[0]["endpoint"] == "https://unapproved.com/x"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1654,6 +1654,16 @@ def _classify_mcp_failure(exc: BaseException) -> str:
         return "permanent"
     if isinstance(root, (NonMcpEndpointError, InvalidMcpUrlError)):
         return "permanent"
+    # Shadow-MCP deny verdict (#90): a policy-deny never clears on retry, so
+    # classify it as permanent to terminate the server task immediately instead
+    # of parking in the reconnect-backoff ladder.
+    try:
+        from evolution.lib.shadow_mcp import ShadowMcpDeniedError  # noqa: PLC0415
+
+        if isinstance(root, ShadowMcpDeniedError):
+            return "permanent"
+    except Exception:
+        pass
     # Stdio command missing: FileNotFoundError, or an OSError carrying ENOENT.
     if isinstance(root, FileNotFoundError):
         return "permanent"
@@ -3850,6 +3860,9 @@ class MCPServerTask:
             )
 
         url = config["url"]
+        # Shadow-MCP governance (#90): record the outbound endpoint and apply
+        # the config-driven allow/deny policy before any bytes leave the box.
+        _govern_outbound_endpoint(self.name, url)
         headers = dict(config.get("headers") or {})
         # Portable Agent Plugins v1 packages set strict_redirect_headers:
         # configured headers are visible package data and MUST NOT be
@@ -6205,6 +6218,37 @@ def _load_mcp_config() -> Dict[str, dict]:
 # ---------------------------------------------------------------------------
 # Server connection helper
 # ---------------------------------------------------------------------------
+
+
+def _govern_outbound_endpoint(server_name: str, url: str) -> None:
+    """Shadow-MCP governance: record + enforce an outbound HTTP endpoint (issue #90).
+
+    Logs every outbound MCP HTTP/SSE endpoint contact and applies the
+    config-driven allow/deny policy from ``config.yaml`` ``shadow_mcp``. A
+    ``deny`` verdict raises :class:`ShadowMcpDeniedError` to refuse the
+    connection — a DISTINCT type that :func:`_classify_mcp_failure` marks
+    ``permanent``, so the server task terminates immediately instead of
+    parking in the reconnect-backoff ladder (an ``alert`` verdict is logged as
+    a warning by the governor itself). Fails open on any import/runtime error
+    so shadow governance can never break MCP dispatch.
+    """
+    if not url:
+        return
+    try:
+        from evolution.lib.shadow_mcp import DENY, ShadowMcpDeniedError, get_governor  # noqa: PLC0415
+
+        verdict = get_governor().record_contact(server_name, url)
+        if verdict == DENY:
+            raise ShadowMcpDeniedError(
+                f"MCP server '{server_name}' endpoint {url} is blocked by the "
+                "shadow_mcp deny policy"
+            )
+    except ShadowMcpDeniedError:
+        raise
+    except Exception:
+        logger.debug(
+            "shadow-mcp governance check failed for '%s'", server_name, exc_info=True
+        )
 
 
 async def _connect_server(name: str, config: dict) -> MCPServerTask:


### PR DESCRIPTION
## Rework of PR #3056 (bounced by integration code review)

The original shadow-MCP matcher was bypassable and leaked secrets. This rework fixes all four review findings:

1. **Bypass-proof matcher** — `endpoint_matches()` now compares `urlparse().hostname` on both sides, stripping userinfo, port, and trailing dot before comparison. Full-URL entries match on hostname only (never `str.startswith` on the whole URL).
2. **No domain-crossing over-match** — allow-list entries match by hostname equality / `*.wildcard` suffix, so `good.com` can no longer match `good.com.attacker.net`.
3. **Secrets-safe logging** — query strings, userinfo, and fragments are redacted at ingestion (`redact_url`), so the JSONL contact log and the audit CLI never print tokens.
4. **Terminal denial** — a deny verdict raises a distinct `ShadowMcpDeniedError`, classified `permanent` by the MCP reconnect loop (no backoff/park loop).

Tests cover the six bypass classes (trailing-dot FQDN, userinfo, scheme variant, domain-crossing, port, IPv6) for both allow and deny, plus redaction and terminal-denial classification.

Automated evolution PR for issue #90.