### PR TITLE
fix(delegation): expand unexpanded template markers at dispatch time (Closes #95)

### DIFF
--- a/tests/tools/test_delegate_template_markers.py
+++ b/tests/tools/test_delegate_template_markers.py
@@ -1,0 +1,180 @@
+"""Tests for template-marker expansion at delegate_task dispatch (issue #95).
+
+The cron orchestrator (and other LLM-driven dispatchers) can copy prompt
+placeholders (<NOW-ISO>, <session_id>, <generated-timestamp>) verbatim into a
+delegate_task goal. delegate_task's batch quality gate then rejects the call
+and the delegated stage silently no-ops. These tests prove the fix:
+
+1. Known markers are substituted with real values at dispatch time.
+2. Unresolvable markers are reported as residual (still rejected loudly).
+3. A batch carrying a known marker no longer trips the rejection gate.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    _marker_token,
+    delegate_task,
+    expand_template_markers,
+    strip_residual_template_markers,
+)
+
+
+def _make_mock_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _call(tasks):
+    return json.loads(delegate_task(tasks=tasks, parent_agent=_make_mock_parent()))
+
+
+GOOD_A = "Refactor the login handler to use the new session helper"
+GOOD_B = "Write regression tests for the session expiry watcher"
+
+
+# --- pure helpers ----------------------------------------------------------
+
+def test_marker_token_normalizes_separators_and_case():
+    assert _marker_token("<NOW-ISO>") == "now-iso"
+    assert _marker_token("<now_iso>") == "now-iso"
+    assert _marker_token("<now iso>") == "now-iso"
+    assert _marker_token("{generated-timestamp}") == "generated-timestamp"
+    assert _marker_token("<session_id>") == "session-id"
+    assert _marker_token("<real citation>") == "real-citation"
+
+
+def test_expand_substitutes_known_timestamp_markers():
+    expanded, substituted, residual = expand_template_markers(
+        "Write report dated <NOW-ISO> and <generated-timestamp> to disk",
+        now_iso="2026-08-21T22:00:00Z",
+    )
+    assert "2026-08-21T22:00:00Z" in expanded
+    assert "<NOW-ISO>" not in expanded
+    assert "<generated-timestamp>" not in expanded
+    assert set(substituted) == {"<NOW-ISO>", "<generated-timestamp>"}
+    assert residual == []
+
+
+def test_expand_substitutes_session_id_when_available():
+    expanded, substituted, residual = expand_template_markers(
+        "tag the record with <session_id>",
+        now_iso="2026-08-21T22:00:00Z",
+        session_id="cron_abc123",
+    )
+    assert "cron_abc123" in expanded
+    assert "<session_id>" not in expanded
+    assert substituted == ["<session_id>"]
+    assert residual == []
+
+
+def test_expand_leaves_unknown_marker_as_residual():
+    expanded, substituted, residual = expand_template_markers(
+        "Summarize the paper and add <real citation> for each claim",
+        now_iso="2026-08-21T22:00:00Z",
+    )
+    assert "<real citation>" in expanded
+    assert substituted == []
+    assert residual == ["<real citation>"]
+
+
+def test_expand_session_id_without_value_stays_residual():
+    # No session id available -> <session_id> is NOT substituted; it is
+    # reported residual so the caller can strip/reject rather than silently
+    # emit an empty value.
+    expanded, substituted, residual = expand_template_markers(
+        "store under <session_id>/out.json",
+        now_iso="2026-08-21T22:00:00Z",
+        session_id=None,
+    )
+    assert "<session_id>" in expanded
+    assert substituted == []
+    assert residual == ["<session_id>"]
+
+
+def test_expand_brace_form_too():
+    expanded, substituted, _ = expand_template_markers(
+        "generated at {NOW-ISO}", now_iso="2026-08-21T22:00:00Z"
+    )
+    assert "{NOW-ISO}" not in expanded
+    assert "2026-08-21T22:00:00Z" in expanded
+    assert substituted == ["{NOW-ISO}"]
+
+
+def test_expand_leaves_code_brackets_untouched():
+    # The narrow regex must never fire on generics / HTML / f-strings.
+    text = "Return Vec<T> inside a <div> and interpolate {i} and {a,b}"
+    expanded, substituted, residual = expand_template_markers(
+        text, now_iso="2026-08-21T22:00:00Z"
+    )
+    assert expanded == text
+    assert substituted == []
+    assert residual == []
+
+
+def test_strip_residual_removes_markers():
+    cleaned, removed = strip_residual_template_markers(
+        "add <real citation> and <feature_name> here"
+    )
+    assert "<real citation>" not in cleaned
+    assert "<feature_name>" not in cleaned
+    assert set(removed) == {"<real citation>", "<feature_name>"}
+
+
+# --- integration: dispatch no longer rejects known markers -----------------
+
+def _completed(idx):
+    return {
+        "task_index": idx,
+        "status": "completed",
+        "summary": "ok",
+        "api_calls": 1,
+        "duration_seconds": 1.0,
+        "_child_role": None,
+    }
+
+
+def test_batch_with_known_marker_proceeds_after_substitution():
+    # A goal carrying <NOW-ISO> must be substituted and dispatched, not
+    # rejected — the exact silent no-op reported in issue #95.
+    goal = f"Record the pipeline run timestamp <NOW-ISO> in the output file"
+    with patch("tools.delegate_tool._run_single_child") as mock_run:
+        mock_run.side_effect = [_completed(0), _completed(1)]
+        result = _call([{"goal": GOOD_A}, {"goal": goal}])
+    assert "error" not in result
+    assert len(result["results"]) == 2
+
+
+def test_batch_with_unknown_marker_still_rejected():
+    # Residual markers (unresolvable) still reject — the protection from
+    # #81141 is preserved, only now it is loud.
+    result = _call([{"goal": GOOD_A}, {"goal": "Implement <feature_name> end to end"}])
+    assert "error" in result
+    assert "template" in result["error"].lower()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -34,6 +34,7 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
+from datetime import datetime, timezone
 
 from toolsets import TOOLSETS
 from agent.interrupt_compat import request_hard_interrupt
@@ -4700,6 +4701,89 @@ _TEMPLATE_MARKER_RE = re.compile(
 _MIN_BATCH_GOAL_LEN = 10
 
 
+# Known template markers the cron/orchestrator dispatch path can leave behind
+# unexpanded in a delegate_task goal (issue #95). These are the *mechanically
+# resolvable* ones — timestamps and session identity — that we can substitute
+# with a real value at dispatch time so a delegated stage never silently
+# no-ops on delegate_task's rejection guard. Anything else (e.g. ``<real
+# citation>``) is a genuine incomplete instruction and stays a residual marker
+# for the batch quality gate to reject loudly.
+_MARKER_SEP_RE = re.compile(r"[ _-]+")
+
+# Marker keys (normalized via _marker_token) that resolve to the current UTC
+# timestamp. Only multi-word markers are listed — the marker regex is
+# deliberately narrow and never fires on single-word brackets like <now>.
+_TIMESTAMP_MARKER_KEYS = frozenset(
+    {
+        "now-iso",
+        "generated-timestamp",
+        "current-datetime",
+        "current-date",
+    }
+)
+# Marker keys that resolve to the originating session id.
+_SESSION_MARKER_KEYS = frozenset({"session-id"})
+
+
+def _marker_token(marker: str) -> str:
+    """Normalize a matched marker (e.g. ``<NOW-ISO>``) to a canonical key."""
+    inner = (marker or "").strip()
+    if len(inner) >= 2 and inner[0] in "<{" and inner[-1] in ">}":
+        inner = inner[1:-1]
+    return _MARKER_SEP_RE.sub("-", inner.strip().lower())
+
+
+def _now_iso_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def expand_template_markers(
+    text: str,
+    *,
+    now_iso: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> "tuple[str, list[str], list[str]]":
+    """Substitute known template markers in *text* with concrete values.
+
+    Returns ``(expanded, substituted, residual)``:
+
+    * ``expanded`` — ``text`` with known markers replaced by real values.
+    * ``substituted`` — the raw marker strings that were replaced.
+    * ``residual`` — the raw marker strings that could not be resolved and
+      remain in ``expanded`` (to be stripped or rejected by the caller).
+    """
+    now_iso = now_iso if now_iso is not None else _now_iso_utc()
+    values: Dict[str, str] = {key: now_iso for key in _TIMESTAMP_MARKER_KEYS}
+    if session_id:
+        values.update({key: session_id for key in _SESSION_MARKER_KEYS})
+
+    substituted: List[str] = []
+    residual: List[str] = []
+
+    def _repl(match: "re.Match[str]") -> str:
+        raw = match.group(0)
+        key = _marker_token(raw)
+        if key in values:
+            substituted.append(raw)
+            return values[key]
+        residual.append(raw)
+        return raw
+
+    expanded = _TEMPLATE_MARKER_RE.sub(_repl, text)
+    return expanded, substituted, residual
+
+
+def strip_residual_template_markers(text: str) -> "tuple[str, list[str]]":
+    """Remove any remaining template markers, returning ``(cleaned, removed)``."""
+    removed: List[str] = []
+
+    def _repl(match: "re.Match[str]") -> str:
+        removed.append(match.group(0))
+        return ""
+
+    return _TEMPLATE_MARKER_RE.sub(_repl, text), removed
+
+
 def _validate_batch_tasks(task_list: List[Dict[str, Any]]) -> Optional[str]:
     """Validate a tasks=[...] batch beyond per-task goal presence.
 
@@ -4730,6 +4814,14 @@ def _validate_batch_tasks(task_list: List[Dict[str, Any]]) -> Optional[str]:
             )
         marker = _TEMPLATE_MARKER_RE.search(goal)
         if marker:
+            logger.warning(
+                "delegate_task: rejecting task %d goal with unexpanded template "
+                "marker %r — the dispatch layer failed to substitute it; "
+                "surfacing so the caller fixes the goal instead of silently "
+                "skipping the delegated stage (issue #95)",
+                i,
+                marker.group(0),
+            )
             return (
                 f"Task {i} goal contains an unexpanded template marker "
                 f"({marker.group(0)!r}). Substitute the real value before "
@@ -4921,6 +5013,45 @@ def delegate_task(
             return tool_error(f"Task {i} must be an object, got {type(task).__name__}.")
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Issue #95: substitute known template markers (<NOW-ISO>, <session_id>,
+    # <generated-timestamp>) at dispatch time so a cron/orchestrator-dispatched
+    # goal that still carries them never silently no-ops on the batch quality
+    # gate. Residual markers that cannot be mechanically resolved are left for
+    # the gate to reject loudly (see _validate_batch_tasks).
+    _dispatch_now = _now_iso_utc()
+    _dispatch_sid = ""
+    try:
+        from tools.async_delegation import _current_origin_session_id  # noqa: PLC0415
+
+        _dispatch_sid = _current_origin_session_id() or os.environ.get(
+            "HERMES_SESSION_ID", ""
+        )
+    except Exception:
+        _dispatch_sid = os.environ.get("HERMES_SESSION_ID", "")
+    for _i, _task in enumerate(task_list):
+        _goal = _task.get("goal")
+        if not isinstance(_goal, str):
+            continue
+        _expanded, _substituted, _residual = expand_template_markers(
+            _goal, now_iso=_dispatch_now, session_id=_dispatch_sid
+        )
+        if _substituted:
+            logger.warning(
+                "delegate_task: expanded unexpanded template marker(s) %s in "
+                "task %d goal with dispatch-time values (issue #95)",
+                _substituted,
+                _i,
+            )
+        if _residual:
+            logger.warning(
+                "delegate_task: task %d goal still carries unexpanded template "
+                "marker(s) %s that could not be resolved (issue #95)",
+                _i,
+                _residual,
+            )
+        if _expanded != _goal:
+            _task["goal"] = _expanded
 
     # Batch-only quality gate: catch malformed fan-outs (placeholder goals,
     # unexpanded multi-word template markers, 1-task batches) before any


### PR DESCRIPTION
## Fix: unexpanded template markers silently no-op delegated cron stages

The cron orchestrator (and other LLM-driven dispatchers) copy prompt placeholders (`<NOW-ISO>`, `<session_id>`, `<generated-timestamp>`) verbatim into `delegate_task` goals. `delegate_task`'s batch quality gate then rejected the call, and the delegated stage silently no-op'd every ~30 minutes across days — invisible unless someone read the logs.

**Changes:**

1. **Substitute at dispatch time** — `expand_template_markers()` substitutes the mechanically-resolvable markers (timestamps, session id) with real values inside `delegate_task`, so the common case just works and never trips the rejection guard.
2. **Loud residual rejection** — unresolvable markers (`<real citation>`, `<feature_name>`) are still rejected (the #81141 protection is preserved), but now with a `logger.warning` so the failure surfaces instead of silently skipping the stage.

New `tests/tools/test_delegate_template_markers.py` covers substitution, residual reporting, and the dispatch-integration path (a batch carrying `<NOW-ISO>` now proceeds).

Automated evolution PR for issue #95.