### PR TITLE
feat(audit): structured audit trail for autonomous work and subagents (Closes #3065)

### DIFF
--- a/agent/audit_trail.py
+++ b/agent/audit_trail.py
@@ -1,19 +1,80 @@
-"""Tamper-evident append-only audit trail (issue #1719).
+"""Tamper-evident append-only audit trail (issue #1719, issue #3065).
 
 Hash-chained JSONL: each entry stores the SHA-256 of the previous entry's hash
 plus its payload, so tampering is detectable via ``verify()``. Retention via
 ``security.audit.retention_days`` (default 90); ``prune()`` re-anchors the chain.
+
+Issue #3065: structured event schema linking action -> artifact -> validation,
+with causal DAG reconstruction and query helpers for autonomous long-horizon runs.
 """
 
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
 import hashlib
 import json
-import time
 from pathlib import Path
+import re
+import time
+from typing import Any, Dict, List, Optional, Set
+import uuid
 
 from hermes_constants import get_hermes_home
 
 DEFAULT_RETENTION_DAYS = 90
 _GENESIS = "genesis"
+
+
+@dataclass
+class AuditEvent:
+    """Structured audit event for autonomous agent actions and subagents."""
+
+    event_id: str
+    event_type: str  # "action", "artifact", "validation", "delegation"
+    session_id: str
+    task_id: Optional[str] = None
+    parent_event_id: Optional[str] = None
+    tool_name: Optional[str] = None
+    inputs_digest: Optional[str] = None
+    artifact_refs: List[str] = field(default_factory=list)
+    validation_refs: List[str] = field(default_factory=list)
+    status: str = "success"  # "success", "failure", "denied", "interrupted"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    ts: int = field(default_factory=lambda: int(time.time()))
+
+    def to_record(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_record(cls, data: dict) -> AuditEvent:
+        return cls(
+            event_id=str(data.get("event_id", "")),
+            event_type=str(data.get("event_type", "action")),
+            session_id=str(data.get("session_id", "")),
+            task_id=data.get("task_id"),
+            parent_event_id=data.get("parent_event_id"),
+            tool_name=data.get("tool_name"),
+            inputs_digest=data.get("inputs_digest"),
+            artifact_refs=list(data.get("artifact_refs", [])),
+            validation_refs=list(data.get("validation_refs", [])),
+            status=str(data.get("status", "success")),
+            metadata=dict(data.get("metadata", {})),
+            ts=int(data.get("ts", time.time())),
+        )
+
+    @staticmethod
+    def hash_inputs(inputs: Any) -> str:
+        """Compute deterministic SHA-256 digest of input parameters."""
+        if inputs is None:
+            return ""
+        if isinstance(inputs, (dict, list)):
+            try:
+                raw = json.dumps(inputs, sort_keys=True, default=str)
+            except Exception:
+                raw = str(inputs)
+        else:
+            raw = str(inputs)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def retention_days() -> int:
@@ -26,6 +87,17 @@ def retention_days() -> int:
         return val if val > 0 else DEFAULT_RETENTION_DAYS
     except Exception:
         return DEFAULT_RETENTION_DAYS
+
+
+def is_audit_enabled() -> bool:
+    """Return whether the audit trail is enabled (default True)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = (load_config_readonly().get("security") or {}).get("audit") or {}
+        return bool(cfg.get("enabled", True))
+    except Exception:
+        return True
 
 
 def _audit_path() -> Path:
@@ -63,6 +135,209 @@ def append(record: dict, *, path: Path | None = None) -> dict:
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, sort_keys=True) + "\n")
     return entry
+
+
+def extract_artifact_refs(
+    tool_name: str, args: Optional[Dict[str, Any]] = None, result: Any = None
+) -> List[str]:
+    """Extract artifact references (file://, git://) from tool invocations."""
+    refs: Set[str] = set()
+    args = args or {}
+    name = (tool_name or "").strip().lower()
+
+    # File-modifying tools
+    for key in (
+        "file",
+        "path",
+        "file_path",
+        "target_file",
+        "targetfile",
+        "destination",
+        "dest",
+        "filename",
+    ):
+        val = args.get(key)
+        if val and isinstance(val, str) and not val.startswith(("http://", "https://")):
+            refs.add(f"file://{val.strip()}")
+
+    # Git operations in terminal or git tools
+    if isinstance(result, str):
+        # Look for commit hashes (e.g. [main abc1234] or commit abc1234567890)
+        commit_match = re.search(
+            r"\[[\w.\-/]+\s+([0-9a-f]{7,40})\]|\bcommit\s+([0-9a-f]{7,40})\b", result
+        )
+        if commit_match:
+            commit_sha = commit_match.group(1) or commit_match.group(2)
+            if commit_sha:
+                refs.add(f"git://{commit_sha}")
+
+    # URL artifacts from web/export tools
+    if name in ("browser_navigate", "web_fetch", "export", "download"):
+        url = args.get("url") or args.get("uri")
+        if url and isinstance(url, str) and url.startswith(("http://", "https://")):
+            refs.add(url.strip())
+
+    return sorted(list(refs))
+
+
+def extract_validation_refs(
+    tool_name: str, args: Optional[Dict[str, Any]] = None, result: Any = None
+) -> List[str]:
+    """Extract validation references (test://, check://, exit://) from executions."""
+    refs: Set[str] = set()
+    args = args or {}
+    name = (tool_name or "").strip().lower()
+    cmd = str(args.get("command") or args.get("cmd") or "").strip()
+    result_text = str(result or "")
+
+    if name in ("terminal", "bash", "execute_command", "run_command") or cmd:
+        if any(keyword in cmd for keyword in ("pytest", "python -m unittest", "cargo test", "npm test", "go test", "ruff", "flake8", "mypy", "lint")):
+            # Test or linter run detected
+            test_tag = "test" if "test" in cmd else "lint"
+            passed = "passed" in result_text or "All checks passed" in result_text or "SUCCESS" in result_text
+            failed = "failed" in result_text or "ERROR" in result_text or "FAIL" in result_text
+            status = "passed" if (passed and not failed) else ("failed" if failed else "completed")
+            refs.add(f"{test_tag}://{cmd[:60].strip()}:{status}")
+
+    return sorted(list(refs))
+
+
+def record_event(
+    event_type: str,
+    session_id: str,
+    *,
+    task_id: Optional[str] = None,
+    parent_event_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+    inputs: Any = None,
+    artifact_refs: Optional[List[str]] = None,
+    validation_refs: Optional[List[str]] = None,
+    status: str = "success",
+    metadata: Optional[Dict[str, Any]] = None,
+    path: Optional[Path] = None,
+) -> Optional[dict]:
+    """Construct a structured AuditEvent and append it to the tamper-evident log."""
+    if not is_audit_enabled():
+        return None
+
+    # Auto-extract refs if not explicitly provided
+    extracted_artifacts = list(artifact_refs or [])
+    extracted_validations = list(validation_refs or [])
+
+    if tool_name and isinstance(inputs, dict):
+        if not artifact_refs:
+            extracted_artifacts.extend(extract_artifact_refs(tool_name, inputs, metadata.get("result") if metadata else None))
+        if not validation_refs:
+            extracted_validations.extend(extract_validation_refs(tool_name, inputs, metadata.get("result") if metadata else None))
+
+    event = AuditEvent(
+        event_id=uuid.uuid4().hex,
+        event_type=event_type,
+        session_id=session_id,
+        task_id=task_id,
+        parent_event_id=parent_event_id,
+        tool_name=tool_name,
+        inputs_digest=AuditEvent.hash_inputs(inputs) if inputs is not None else None,
+        artifact_refs=sorted(list(set(extracted_artifacts))),
+        validation_refs=sorted(list(set(extracted_validations))),
+        status=status,
+        metadata=metadata or {},
+    )
+    return append(event.to_record(), path=path)
+
+
+def query_trail(
+    *,
+    session_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+    limit: int = 500,
+    path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """Query audit trail records with filtering."""
+    path = path or _audit_path()
+    if not path.exists():
+        return []
+
+    results: List[Dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            payload_raw = entry.get("payload", "{}")
+            payload = json.loads(payload_raw) if isinstance(payload_raw, str) else payload_raw
+            if not isinstance(payload, dict):
+                continue
+            if session_id and payload.get("session_id") != session_id:
+                continue
+            if task_id and payload.get("task_id") != task_id:
+                continue
+            if event_type and payload.get("event_type") != event_type:
+                continue
+            results.append({"entry": entry, "payload": payload})
+            if len(results) >= limit:
+                break
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return results
+
+
+def reconstruct_run(session_id: str, *, path: Optional[Path] = None) -> Dict[str, Any]:
+    """Reconstruct action -> artifact -> validation DAG and summary for a session."""
+    events = query_trail(session_id=session_id, limit=5000, path=path)
+    chain_valid, total_entries = verify(path)
+
+    actions: List[Dict[str, Any]] = []
+    artifacts: Set[str] = set()
+    validations: List[str] = []
+    delegations: List[Dict[str, Any]] = []
+    successful_actions = 0
+    failed_actions = 0
+
+    for e in events:
+        p = e["payload"]
+        etype = p.get("event_type", "action")
+        status = p.get("status", "success")
+
+        if p.get("artifact_refs"):
+            artifacts.update(p["artifact_refs"])
+        if p.get("validation_refs"):
+            validations.extend(p["validation_refs"])
+
+        if etype == "delegation":
+            delegations.append(p)
+        else:
+            actions.append(p)
+
+        if status == "success":
+            successful_actions += 1
+        elif status in ("failure", "error", "interrupted"):
+            failed_actions += 1
+
+    total_ops = len(actions) + len(delegations)
+    success_rate = (successful_actions / total_ops) if total_ops > 0 else 1.0
+
+    return {
+        "session_id": session_id,
+        "event_count": len(events),
+        "valid_chain": chain_valid,
+        "actions": actions,
+        "artifacts": sorted(list(artifacts)),
+        "validations": validations,
+        "delegations": delegations,
+        "summary": {
+            "total_events": len(events),
+            "actions_count": len(actions),
+            "artifacts_count": len(artifacts),
+            "validations_count": len(validations),
+            "delegations_count": len(delegations),
+            "successful_ops": successful_actions,
+            "failed_ops": failed_actions,
+            "success_rate": round(success_rate, 4),
+        },
+    }
 
 
 def verify(path: Path | None = None) -> tuple[bool, int]:

--- a/hermes_cli/audit_cmd.py
+++ b/hermes_cli/audit_cmd.py
@@ -1,0 +1,102 @@
+"""Implementation of ``hermes audit`` CLI commands (issue #3065)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import time
+
+from agent import audit_trail
+
+
+def cmd_audit(args) -> None:
+    subcmd = getattr(args, "audit_command", None) or "verify"
+
+    if subcmd == "verify":
+        path = Path(args.path) if getattr(args, "path", None) else None
+        valid, count = audit_trail.verify(path)
+        if valid:
+            print(f"✓ Audit trail valid: hash chain intact ({count} events verified).")
+        else:
+            print(f"✗ Audit trail integrity verification FAILED at entry {count}!", file=sys.stderr)
+            sys.exit(1)
+
+    elif subcmd == "show":
+        session_id = args.session_id
+        path = Path(args.path) if getattr(args, "path", None) else None
+        recon = audit_trail.reconstruct_run(session_id, path=path)
+
+        if getattr(args, "json", False):
+            print(json.dumps(recon, indent=2, ensure_ascii=False))
+            return
+
+        print(f"═══ Audit Trail for Session: {session_id} ═══")
+        chain_icon = "✓" if recon["valid_chain"] else "✗"
+        print(f"Chain Integrity: {chain_icon} ({recon['event_count']} events in session)")
+        summary = recon["summary"]
+        print(
+            f"Summary: {summary['actions_count']} actions, "
+            f"{summary['artifacts_count']} artifacts, "
+            f"{summary['validations_count']} validations, "
+            f"{summary['delegations_count']} delegations "
+            f"(success rate: {summary['success_rate'] * 100:.1f}%)"
+        )
+        print()
+
+        if recon["artifacts"]:
+            print("📦 Artifacts:")
+            for art in recon["artifacts"]:
+                print(f"  • {art}")
+            print()
+
+        if recon["validations"]:
+            print("🧪 Validations:")
+            for val in recon["validations"]:
+                print(f"  • {val}")
+            print()
+
+        if recon["delegations"]:
+            print("🔀 Subagent Delegations:")
+            for d in recon["delegations"]:
+                status = d.get("status", "unknown")
+                tid = d.get("task_id", "")
+                inp = d.get("inputs", {})
+                goal = inp.get("goal") if isinstance(inp, dict) else str(inp)
+                print(f"  [{status}] {tid}: {str(goal)[:80]}")
+            print()
+
+        if recon["actions"]:
+            print("⚡ Actions:")
+            for act in recon["actions"][:30]:
+                tool = act.get("tool_name", "unknown")
+                st = act.get("status", "ok")
+                ts_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(act.get("ts", 0)))
+                print(f"  {ts_str} [{st}] {tool}")
+            if len(recon["actions"]) > 30:
+                print(f"  ... and {len(recon['actions']) - 30} more actions")
+
+    elif subcmd == "list":
+        session_id = getattr(args, "session_id", None)
+        event_type = getattr(args, "event_type", None)
+        limit = getattr(args, "limit", 50)
+        events = audit_trail.query_trail(session_id=session_id, event_type=event_type, limit=limit)
+
+        if getattr(args, "json", False):
+            print(json.dumps([e["payload"] for e in events], indent=2, ensure_ascii=False))
+            return
+
+        print(f"Found {len(events)} audit event(s):")
+        for e in events:
+            p = e["payload"]
+            ts_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(p.get("ts", 0)))
+            etype = p.get("event_type", "action")
+            sid = p.get("session_id", "")[:12]
+            tool = p.get("tool_name") or p.get("status", "")
+            print(f"{ts_str} | {etype:<11} | {sid} | {tool}")
+
+    elif subcmd == "prune":
+        days = getattr(args, "days", None)
+        now = time.time()
+        removed = audit_trail.prune(now=now)
+        print(f"✓ Pruned {removed} expired audit trail event(s). Hash chain re-anchored.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -456,6 +456,7 @@ from hermes_cli.subcommands.hooks import build_hooks_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
 from hermes_cli.subcommands.verify import build_verify_parser
 from hermes_cli.subcommands.security import build_security_parser
+from hermes_cli.subcommands.audit import build_audit_parser
 from hermes_cli.subcommands.approvals import build_approvals_parser
 from hermes_cli.subcommands.dump import build_dump_parser
 from hermes_cli.subcommands.debug import build_debug_parser
@@ -5586,6 +5587,13 @@ def cmd_security(args):
         sys.exit(int(code or 0))
     print(f"unknown security subcommand: {sub}", file=sys.stderr)
     sys.exit(2)
+
+
+def cmd_audit(args):
+    """Dispatch `hermes audit <subcmd>`."""
+    from hermes_cli.audit_cmd import cmd_audit as _cmd_audit
+
+    return _cmd_audit(args)
 
 
 def cmd_approvals(args):
@@ -12668,6 +12676,12 @@ def main():
     # security command  (parser built in hermes_cli/subcommands/security.py)
     # =========================================================================
     build_security_parser(subparsers, cmd_security=cmd_security)
+
+    # =========================================================================
+    # audit command — execution audit trail (action -> artifact -> validation)
+    # (parser built in hermes_cli/subcommands/audit.py)
+    # =========================================================================
+    build_audit_parser(subparsers, cmd_audit=cmd_audit)
 
     # =========================================================================
     # approvals command  (parser built in hermes_cli/subcommands/approvals.py)

--- a/hermes_cli/subcommands/audit.py
+++ b/hermes_cli/subcommands/audit.py
@@ -1,0 +1,98 @@
+"""``hermes audit`` subcommand parser (issue #3065).
+
+Structured audit trail inspection, verification, and causal DAG reconstruction
+for autonomous agent sessions and subagent work.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_audit_parser(subparsers, *, cmd_audit: Callable) -> None:
+    """Attach the ``audit`` subcommand to ``subparsers``."""
+    audit_parser = subparsers.add_parser(
+        "audit",
+        help="Inspect and verify the tamper-evident structured audit trail",
+        description=(
+            "Query, verify, and reconstruct the action -> artifact -> validation "
+            "trail for autonomous runs and subagent delegations."
+        ),
+    )
+    audit_subparsers = audit_parser.add_subparsers(
+        dest="audit_command",
+        metavar="<subcommand>",
+    )
+
+    # 1. verify
+    verify_parser = audit_subparsers.add_parser(
+        "verify",
+        help="Verify the cryptographic integrity of the audit trail hash chain",
+    )
+    verify_parser.add_argument(
+        "--path",
+        default=None,
+        help="Custom path to audit trail JSONL file",
+    )
+
+    # 2. show
+    show_parser = audit_subparsers.add_parser(
+        "show",
+        help="Reconstruct action -> artifact -> validation DAG for a session",
+    )
+    show_parser.add_argument(
+        "session_id",
+        help="Session ID to inspect",
+    )
+    show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON instead of formatted text",
+    )
+    show_parser.add_argument(
+        "--path",
+        default=None,
+        help="Custom path to audit trail JSONL file",
+    )
+
+    # 3. list / query
+    list_parser = audit_subparsers.add_parser(
+        "list",
+        help="List recent audit trail events",
+    )
+    list_parser.add_argument(
+        "--session-id",
+        default=None,
+        help="Filter by session ID",
+    )
+    list_parser.add_argument(
+        "--event-type",
+        default=None,
+        choices=["action", "artifact", "validation", "delegation"],
+        help="Filter by event type",
+    )
+    list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum events to return (default: 50)",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON",
+    )
+
+    # 4. prune
+    prune_parser = audit_subparsers.add_parser(
+        "prune",
+        help="Prune entries older than retention window and re-anchor hash chain",
+    )
+    prune_parser.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Override retention window in days",
+    )
+
+    audit_parser.set_defaults(func=cmd_audit)

--- a/tests/agent/test_audit_trail.py
+++ b/tests/agent/test_audit_trail.py
@@ -71,3 +71,156 @@ def test_retention_days_default_and_config(tmp_path, monkeypatch):
     cfg._LOAD_CONFIG_CACHE.clear()
     cfg._RAW_CONFIG_CACHE.clear()
     assert audit_trail.retention_days() == 30
+
+
+def test_audit_event_hash_inputs_and_serialization():
+    evt = audit_trail.AuditEvent(
+        event_id="evt-123",
+        event_type="action",
+        session_id="session-abc",
+        task_id="task-1",
+        tool_name="write_file",
+        inputs_digest=audit_trail.AuditEvent.hash_inputs({"file": "src/app.py", "content": "print(1)"}),
+        artifact_refs=["file://src/app.py"],
+        validation_refs=["test://pytest:passed"],
+        status="success",
+        metadata={"duration_ms": 42},
+    )
+    rec = evt.to_record()
+    assert rec["event_id"] == "evt-123"
+    assert rec["inputs_digest"] is not None
+    assert "file://src/app.py" in rec["artifact_refs"]
+
+    restored = audit_trail.AuditEvent.from_record(rec)
+    assert restored.event_id == evt.event_id
+    assert restored.inputs_digest == evt.inputs_digest
+    assert restored.artifact_refs == evt.artifact_refs
+
+
+def test_extract_artifact_refs():
+    # File write args
+    refs = audit_trail.extract_artifact_refs("write_to_file", {"target_file": "src/main.py"})
+    assert "file://src/main.py" in refs
+
+    # Git commit in terminal output
+    git_res = "[main abc1234] feat: add new feature\n 1 file changed"
+    refs_git = audit_trail.extract_artifact_refs("terminal", {"command": "git commit -m 'feat'"}, result=git_res)
+    assert "git://abc1234" in refs_git
+
+    # Browser navigate URL
+    refs_url = audit_trail.extract_artifact_refs("browser_navigate", {"url": "https://example.com/docs"})
+    assert "https://example.com/docs" in refs_url
+
+
+def test_extract_validation_refs():
+    pytest_res = "====== 10 passed in 0.5s ======"
+    refs = audit_trail.extract_validation_refs("terminal", {"command": "pytest tests/"}, result=pytest_res)
+    assert len(refs) == 1
+    assert "test://pytest tests/:passed" == refs[0]
+
+    pytest_fail = "====== 1 failed, 9 passed in 0.5s ======"
+    refs_fail = audit_trail.extract_validation_refs("terminal", {"command": "pytest tests/"}, result=pytest_fail)
+    assert "test://pytest tests/:failed" == refs_fail[0]
+
+
+def test_record_event_and_query_trail(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    entry1 = audit_trail.record_event(
+        event_type="action",
+        session_id="session-1",
+        tool_name="write_file",
+        inputs={"file": "src/test.py"},
+        path=log,
+    )
+    entry2 = audit_trail.record_event(
+        event_type="validation",
+        session_id="session-1",
+        tool_name="terminal",
+        inputs={"command": "pytest tests/"},
+        metadata={"result": "10 passed"},
+        path=log,
+    )
+    entry3 = audit_trail.record_event(
+        event_type="action",
+        session_id="session-2",
+        tool_name="browser",
+        inputs={"url": "https://example.com"},
+        path=log,
+    )
+
+    assert entry1 is not None and entry2 is not None and entry3 is not None
+
+    # Query filtered by session
+    s1_events = audit_trail.query_trail(session_id="session-1", path=log)
+    assert len(s1_events) == 2
+    assert s1_events[0]["payload"]["event_type"] == "action"
+    assert s1_events[1]["payload"]["event_type"] == "validation"
+
+    # Query filtered by event_type
+    val_events = audit_trail.query_trail(event_type="validation", path=log)
+    assert len(val_events) == 1
+    assert val_events[0]["payload"]["session_id"] == "session-1"
+
+
+def test_reconstruct_run_dag(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    audit_trail.record_event(
+        event_type="action",
+        session_id="session-dag",
+        tool_name="write_file",
+        inputs={"target_file": "src/model.py"},
+        path=log,
+    )
+    audit_trail.record_event(
+        event_type="delegation",
+        session_id="session-dag",
+        task_id="sub-1",
+        tool_name="delegate_task",
+        inputs={"goal": "Verify the model"},
+        artifact_refs=["file://src/model.py"],
+        status="success",
+        path=log,
+    )
+    audit_trail.record_event(
+        event_type="validation",
+        session_id="session-dag",
+        tool_name="terminal",
+        inputs={"command": "pytest tests/test_model.py"},
+        metadata={"result": "5 passed"},
+        path=log,
+    )
+
+    recon = audit_trail.reconstruct_run("session-dag", path=log)
+    assert recon["session_id"] == "session-dag"
+    assert recon["event_count"] == 3
+    assert recon["valid_chain"] is True
+    assert "file://src/model.py" in recon["artifacts"]
+    assert any("test://pytest tests/test_model.py:passed" in v for v in recon["validations"])
+    assert len(recon["delegations"]) == 1
+    assert recon["summary"]["success_rate"] == 1.0
+    assert recon["summary"]["actions_count"] == 2
+    assert recon["summary"]["delegations_count"] == 1
+
+
+def test_cmd_audit_cli_verify_and_show(tmp_path, capsys):
+    log = tmp_path / "audit.jsonl"
+    audit_trail.record_event(
+        event_type="action",
+        session_id="session-cli",
+        tool_name="write_file",
+        inputs={"file": "app.py"},
+        path=log,
+    )
+    from argparse import Namespace
+    from hermes_cli.audit_cmd import cmd_audit
+
+    # Test verify
+    cmd_audit(Namespace(audit_command="verify", path=str(log)))
+    captured = capsys.readouterr()
+    assert "Audit trail valid" in captured.out
+
+    # Test show
+    cmd_audit(Namespace(audit_command="show", session_id="session-cli", json=False, path=str(log)))
+    captured = capsys.readouterr()
+    assert "Audit Trail for Session: session-cli" in captured.out
+    assert "file://app.py" in captured.out

--- a/tests/tools/test_delegate_audit_trail.py
+++ b/tests/tools/test_delegate_audit_trail.py
@@ -1,0 +1,80 @@
+"""Tests for structured audit trail recording during delegate_task execution (issue #3065)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent import audit_trail
+from tools.delegate_tool import delegate_task
+
+
+@pytest.fixture(autouse=True)
+def isolate_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def _make_mock_parent(session_id="parent-session-123", depth=0):
+    parent = MagicMock()
+    parent.session_id = session_id
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def test_delegate_task_records_audit_event():
+    parent = _make_mock_parent(session_id="session-subagent-test")
+
+    mock_child_result = {
+        "task_index": 0,
+        "status": "completed",
+        "summary": "Generated test report at report.md",
+        "api_calls": 2,
+        "duration_seconds": 1.5,
+        "live_transcript": "/tmp/test.log",
+    }
+
+    with patch("tools.delegate_tool._run_single_child", return_value=mock_child_result):
+        res_str = delegate_task(
+            goal="Generate a comprehensive test report",
+            parent_agent=parent,
+        )
+        res = json.loads(res_str)
+        assert res["results"][0]["status"] == "completed"
+
+    events = audit_trail.query_trail(session_id="session-subagent-test")
+    assert len(events) >= 1
+    delegation_event = events[0]["payload"]
+    assert delegation_event["event_type"] == "delegation"
+    assert delegation_event["session_id"] == "session-subagent-test"
+    assert delegation_event["tool_name"] == "delegate_task"
+    assert delegation_event["status"] == "success"
+    assert any("task-0.log" in ref for ref in delegation_event["artifact_refs"])
+    assert delegation_event["metadata"]["api_calls"] == 2
+
+    # Verify DAG reconstruction
+    recon = audit_trail.reconstruct_run("session-subagent-test")
+    assert recon["event_count"] == len(events)
+    assert recon["valid_chain"] is True
+    assert len(recon["delegations"]) == 1
+    assert any("task-0.log" in art for art in recon["artifacts"])
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5487,6 +5487,37 @@ def delegate_task(
                     entry["live_transcript"] = live_paths[_idx]
         update_manifest_statuses(live_deleg_id, results)
 
+        # Audit trail (issue #3065): record structured delegation events in the tamper-evident log
+        try:
+            from agent.audit_trail import record_event
+
+            _sid = str(getattr(parent_agent, "session_id", "") or _origin_ui_session_id or "delegation")
+            for _entry in results:
+                _t_idx = _entry.get("task_index", 0)
+                _tid = f"{live_deleg_id}_task_{_t_idx}" if live_deleg_id else None
+                _art_refs = []
+                if _entry.get("live_transcript"):
+                    _art_refs.append(f"file://{_entry['live_transcript']}")
+                if _entry.get("spill_path"):
+                    _art_refs.append(f"file://{_entry['spill_path']}")
+                _st = "success" if _entry.get("status") == "completed" else str(_entry.get("status", "failure"))
+                record_event(
+                    event_type="delegation",
+                    session_id=_sid,
+                    task_id=_tid,
+                    tool_name="delegate_task",
+                    inputs={"goal": task_labels[_t_idx] if _t_idx < len(task_labels) else "", "summary": _entry.get("summary")},
+                    artifact_refs=_art_refs,
+                    status=_st,
+                    metadata={
+                        "duration_seconds": _entry.get("duration_seconds", 0),
+                        "api_calls": _entry.get("api_calls", 0),
+                        "error": _entry.get("error"),
+                    },
+                )
+        except Exception:
+            logger.debug("Audit trail delegation record failed", exc_info=True)
+
         combined: Dict[str, Any] = {
             "results": results,
             "total_duration_seconds": total_duration,


### PR DESCRIPTION
## Summary
Implements **Issue #3065**: Structured audit trail for autonomous work and subagents.

### Key Changes
1. **Structured Event Schema & DAG Reconstruction** in `agent/audit_trail.py`:
   - `AuditEvent` dataclass capturing `action_id`, `event_type`, `session_id`, `task_id`, `tool_name`, `inputs_digest`, `artifact_refs`, `validation_refs`, `status`, `metadata`.
   - Automatic reference extraction for artifacts (`extract_artifact_refs`) and validations (`extract_validation_refs`).
   - Querying and causal DAG reconstruction (`query_trail`, `reconstruct_run`) linking actions to produced artifacts and test validations.
2. **Subagent Delegation Instrumentation** in `tools/delegate_tool.py`:
   - Emits structured delegation events into the tamper-evident audit log with live transcript and spill artifacts upon completion.
3. **CLI Command Suite** (`hermes audit`):
   - `hermes audit verify`: cryptographically verifies SHA-256 hash-chain integrity.
   - `hermes audit show <session_id>`: displays formatted action → artifact → validation trail and summary statistics (with `--json` support).
   - `hermes audit list`: queries and filters audit events.
   - `hermes audit prune`: drops expired events and re-anchors the hash chain.
4. **Test Suite**:
   - Comprehensive unit tests in `tests/agent/test_audit_trail.py` and `tests/tools/test_delegate_audit_trail.py` (11/11 tests pass).

Closes #3065.