### PR TITLE
fix(audit): harden audit trail locking, event extraction, secret redaction, and CLI

### DIFF
--- a/agent/audit_trail.py
+++ b/agent/audit_trail.py
@@ -5,14 +5,17 @@ plus its payload, so tampering is detectable via ``verify()``. Retention via
 ``security.audit.retention_days`` (default 90); ``prune()`` re-anchors the chain.
 
 Issue #3065: structured event schema linking action -> artifact -> validation,
-with causal DAG reconstruction and query helpers for autonomous long-horizon runs.
+with flock-safe concurrent append, secret-redacted metadata, causal DAG reconstruction,
+and query helpers for autonomous long-horizon runs.
 """
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+import fcntl
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import time
@@ -23,6 +26,18 @@ from hermes_constants import get_hermes_home
 
 DEFAULT_RETENTION_DAYS = 90
 _GENESIS = "genesis"
+
+WRITE_TOOLS = {
+    "write_file",
+    "write_to_file",
+    "edit_file",
+    "replace_file_content",
+    "patch_file",
+    "create_file",
+    "append_to_file",
+    "save_file",
+    "write_code",
+}
 
 
 @dataclass
@@ -48,7 +63,7 @@ class AuditEvent:
     @classmethod
     def from_record(cls, data: dict) -> AuditEvent:
         return cls(
-            event_id=str(data.get("event_id", "")),
+            event_id=str(data.get("event_id") or uuid.uuid4().hex),
             event_type=str(data.get("event_type", "action")),
             session_id=str(data.get("session_id", "")),
             task_id=data.get("task_id"),
@@ -108,68 +123,106 @@ def _hash(prev_hash: str, payload: str) -> str:
     return hashlib.sha256((prev_hash + payload).encode("utf-8")).hexdigest()
 
 
-def _last_hash(path: Path) -> str:
-    if not path.exists():
-        return _GENESIS
-    for line in reversed(path.read_text(encoding="utf-8").splitlines()):
-        if line.strip():
+def sanitize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Redact sensitive keys/tokens and truncate long output strings."""
+    if not metadata:
+        return {}
+    cleaned: Dict[str, Any] = {}
+    for k, v in metadata.items():
+        if k in ("api_key", "token", "password", "secret", "authorization"):
+            cleaned[k] = "[REDACTED]"
+        elif isinstance(v, str):
+            # Redact key/token patterns
+            redacted = re.sub(
+                r"(?i)\b(key|token|secret|password|bearer)(?:[:=\s]+)['\"]?([^\s'\"]+)",
+                r"\1=[REDACTED]",
+                v,
+            )
+            cleaned[k] = redacted[:500] + ("..." if len(redacted) > 500 else "")
+        elif isinstance(v, (int, float, bool)):
+            cleaned[k] = v
+        elif isinstance(v, (list, dict)):
             try:
-                return json.loads(line)["hash"]
-            except (json.JSONDecodeError, KeyError):
-                return _GENESIS
-    return _GENESIS
+                s = json.dumps(v, default=str)
+                cleaned[k] = s[:500]
+            except Exception:
+                cleaned[k] = str(v)[:500]
+        else:
+            cleaned[k] = str(v)[:500]
+    return cleaned
 
 
-def append(record: dict, *, path: Path | None = None) -> dict:
-    """Append a record to the chained log and return it with hash fields."""
+def append(record: dict, *, path: Path | None = None) -> Optional[dict]:
+    """Append a record to the chained log under flock and return with hash fields."""
+    if not is_audit_enabled():
+        return None
+
     path = path or _audit_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(record, sort_keys=True)
-    prev = _last_hash(path)
-    entry = {
-        "ts": int(time.time()),
-        "prev_hash": prev,
-        "payload": payload,
-        "hash": _hash(prev, payload),
-    }
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(entry, sort_keys=True) + "\n")
-    return entry
+
+    with open(path, "a+", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            fh.seek(0)
+            prev = _GENESIS
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        prev = json.loads(line).get("hash", prev)
+                    except Exception:
+                        pass
+
+            entry = {
+                "ts": int(time.time()),
+                "prev_hash": prev,
+                "payload": payload,
+                "hash": _hash(prev, payload),
+            }
+            fh.seek(0, 2)  # seek to end
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+            fh.flush()
+            return entry
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
 
 def extract_artifact_refs(
     tool_name: str, args: Optional[Dict[str, Any]] = None, result: Any = None
 ) -> List[str]:
-    """Extract artifact references (file://, git://) from tool invocations."""
+    """Extract artifact references (file://, git://, http://) from tool invocations."""
     refs: Set[str] = set()
     args = args or {}
     name = (tool_name or "").strip().lower()
 
-    # File-modifying tools
-    for key in (
-        "file",
-        "path",
-        "file_path",
-        "target_file",
-        "targetfile",
-        "destination",
-        "dest",
-        "filename",
-    ):
-        val = args.get(key)
-        if val and isinstance(val, str) and not val.startswith(("http://", "https://")):
-            refs.add(f"file://{val.strip()}")
+    # File-modifying tools ONLY (read_file / search tools do not produce artifacts)
+    if name in WRITE_TOOLS:
+        for key in (
+            "file",
+            "path",
+            "file_path",
+            "target_file",
+            "targetfile",
+            "destination",
+            "dest",
+            "filename",
+        ):
+            val = args.get(key)
+            if val and isinstance(val, str) and not val.startswith(("http://", "https://")):
+                refs.add(f"file://{val.strip()}")
 
     # Git operations in terminal or git tools
-    if isinstance(result, str):
-        # Look for commit hashes (e.g. [main abc1234] or commit abc1234567890)
-        commit_match = re.search(
-            r"\[[\w.\-/]+\s+([0-9a-f]{7,40})\]|\bcommit\s+([0-9a-f]{7,40})\b", result
-        )
-        if commit_match:
-            commit_sha = commit_match.group(1) or commit_match.group(2)
-            if commit_sha:
-                refs.add(f"git://{commit_sha}")
+    cmd = str(args.get("command") or args.get("cmd") or "").strip()
+    if (name in ("terminal", "bash", "execute_command", "run_command") and "git commit" in cmd) or name == "git_commit":
+        if isinstance(result, str):
+            commit_match = re.search(
+                r"\[[\w.\-/]+\s+([0-9a-f]{7,40})\]|\bcommit\s+([0-9a-f]{7,40})\b", result
+            )
+            if commit_match:
+                commit_sha = commit_match.group(1) or commit_match.group(2)
+                if commit_sha:
+                    refs.add(f"git://{commit_sha}")
 
     # URL artifacts from web/export tools
     if name in ("browser_navigate", "web_fetch", "export", "download"):
@@ -183,21 +236,34 @@ def extract_artifact_refs(
 def extract_validation_refs(
     tool_name: str, args: Optional[Dict[str, Any]] = None, result: Any = None
 ) -> List[str]:
-    """Extract validation references (test://, check://, exit://) from executions."""
+    """Extract validation references (test://, lint://, check://) from executions."""
     refs: Set[str] = set()
     args = args or {}
     name = (tool_name or "").strip().lower()
     cmd = str(args.get("command") or args.get("cmd") or "").strip()
     result_text = str(result or "")
 
-    if name in ("terminal", "bash", "execute_command", "run_command") or cmd:
-        if any(keyword in cmd for keyword in ("pytest", "python -m unittest", "cargo test", "npm test", "go test", "ruff", "flake8", "mypy", "lint")):
-            # Test or linter run detected
-            test_tag = "test" if "test" in cmd else "lint"
-            passed = "passed" in result_text or "All checks passed" in result_text or "SUCCESS" in result_text
-            failed = "failed" in result_text or "ERROR" in result_text or "FAIL" in result_text
-            status = "passed" if (passed and not failed) else ("failed" if failed else "completed")
-            refs.add(f"{test_tag}://{cmd[:60].strip()}:{status}")
+    if name in ("terminal", "bash", "execute_command", "run_command") and cmd:
+        # Linter detection
+        if any(
+            linter in cmd
+            for linter in ("ruff", "flake8", "mypy", "eslint", "golangci-lint", "black --check", "isort --check")
+        ):
+            failed = "error:" in result_text.lower() or "failed" in result_text.lower()
+            status = "failed" if failed else "passed"
+            refs.add(f"lint://{cmd[:60].strip()}:{status}")
+        # Test runner detection
+        elif any(
+            runner in cmd
+            for runner in ("pytest", "python -m unittest", "cargo test", "npm test", "go test", "ctest", "mvn test")
+        ):
+            # Accurate check: match 'N failed' where N > 0, or FAIL keyword
+            failed_match = re.search(r"\b([1-9]\d*)\s+failed\b", result_text)
+            passed_match = re.search(r"\b([1-9]\d*)\s+passed\b", result_text)
+            has_fail = bool(failed_match) or ("FAIL" in result_text and "FAILED" in result_text)
+            has_pass = bool(passed_match) or "SUCCESS" in result_text or "passed" in result_text
+            status = "failed" if has_fail else ("passed" if has_pass else "completed")
+            refs.add(f"test://{cmd[:60].strip()}:{status}")
 
     return sorted(list(refs))
 
@@ -226,9 +292,19 @@ def record_event(
 
     if tool_name and isinstance(inputs, dict):
         if not artifact_refs:
-            extracted_artifacts.extend(extract_artifact_refs(tool_name, inputs, metadata.get("result") if metadata else None))
+            extracted_artifacts.extend(
+                extract_artifact_refs(
+                    tool_name, inputs, metadata.get("result") if metadata else None
+                )
+            )
         if not validation_refs:
-            extracted_validations.extend(extract_validation_refs(tool_name, inputs, metadata.get("result") if metadata else None))
+            extracted_validations.extend(
+                extract_validation_refs(
+                    tool_name, inputs, metadata.get("result") if metadata else None
+                )
+            )
+
+    cleaned_metadata = sanitize_metadata(metadata)
 
     event = AuditEvent(
         event_id=uuid.uuid4().hex,
@@ -241,7 +317,7 @@ def record_event(
         artifact_refs=sorted(list(set(extracted_artifacts))),
         validation_refs=sorted(list(set(extracted_validations))),
         status=status,
-        metadata=metadata or {},
+        metadata=cleaned_metadata,
     )
     return append(event.to_record(), path=path)
 
@@ -251,17 +327,20 @@ def query_trail(
     session_id: Optional[str] = None,
     task_id: Optional[str] = None,
     event_type: Optional[str] = None,
-    limit: int = 500,
+    limit: Optional[int] = 500,
+    newest_first: bool = True,
     path: Optional[Path] = None,
 ) -> List[Dict[str, Any]]:
-    """Query audit trail records with filtering."""
+    """Query audit trail records with filtering and optional limit (newest first)."""
     path = path or _audit_path()
     if not path.exists():
         return []
 
     results: List[Dict[str, Any]] = []
     lines = path.read_text(encoding="utf-8").splitlines()
-    for line in lines:
+    iterable = reversed(lines) if newest_first else lines
+
+    for line in iterable:
         if not line.strip():
             continue
         try:
@@ -277,7 +356,7 @@ def query_trail(
             if event_type and payload.get("event_type") != event_type:
                 continue
             results.append({"entry": entry, "payload": payload})
-            if len(results) >= limit:
+            if limit is not None and len(results) >= limit:
                 break
         except (json.JSONDecodeError, KeyError):
             continue
@@ -286,20 +365,29 @@ def query_trail(
 
 def reconstruct_run(session_id: str, *, path: Optional[Path] = None) -> Dict[str, Any]:
     """Reconstruct action -> artifact -> validation DAG and summary for a session."""
-    events = query_trail(session_id=session_id, limit=5000, path=path)
-    chain_valid, total_entries = verify(path)
+    # Query all events for this session in chronological order without truncation
+    events = query_trail(session_id=session_id, limit=None, newest_first=False, path=path)
+    chain_valid, _ = verify(path)
 
     actions: List[Dict[str, Any]] = []
     artifacts: Set[str] = set()
     validations: List[str] = []
     delegations: List[Dict[str, Any]] = []
-    successful_actions = 0
-    failed_actions = 0
+    parent_map: Dict[str, List[str]] = {}
+
+    successful_ops = 0
+    failed_ops = 0
+    denied_ops = 0
 
     for e in events:
         p = e["payload"]
         etype = p.get("event_type", "action")
         status = p.get("status", "success")
+        eid = p.get("event_id", "")
+        peid = p.get("parent_event_id")
+
+        if peid and eid:
+            parent_map.setdefault(peid, []).append(eid)
 
         if p.get("artifact_refs"):
             artifacts.update(p["artifact_refs"])
@@ -308,16 +396,22 @@ def reconstruct_run(session_id: str, *, path: Optional[Path] = None) -> Dict[str
 
         if etype == "delegation":
             delegations.append(p)
+        elif etype == "validation":
+            # Distinct validation events
+            if not p.get("validation_refs") and p.get("tool_name"):
+                validations.append(f"{p.get('tool_name')}:{status}")
         else:
             actions.append(p)
 
         if status == "success":
-            successful_actions += 1
+            successful_ops += 1
         elif status in ("failure", "error", "interrupted"):
-            failed_actions += 1
+            failed_ops += 1
+        elif status == "denied":
+            denied_ops += 1
 
-    total_ops = len(actions) + len(delegations)
-    success_rate = (successful_actions / total_ops) if total_ops > 0 else 1.0
+    total_ops = successful_ops + failed_ops + denied_ops
+    success_rate = (successful_ops / total_ops) if total_ops > 0 else 1.0
 
     return {
         "session_id": session_id,
@@ -327,14 +421,16 @@ def reconstruct_run(session_id: str, *, path: Optional[Path] = None) -> Dict[str
         "artifacts": sorted(list(artifacts)),
         "validations": validations,
         "delegations": delegations,
+        "causal_graph": parent_map,
         "summary": {
             "total_events": len(events),
             "actions_count": len(actions),
             "artifacts_count": len(artifacts),
             "validations_count": len(validations),
             "delegations_count": len(delegations),
-            "successful_ops": successful_actions,
-            "failed_ops": failed_actions,
+            "successful_ops": successful_ops,
+            "failed_ops": failed_ops,
+            "denied_ops": denied_ops,
             "success_rate": round(success_rate, 4),
         },
     }
@@ -362,35 +458,52 @@ def verify(path: Path | None = None) -> tuple[bool, int]:
     return True, count
 
 
-def prune(*, now: float | None = None, path: Path | None = None) -> int:
-    """Drop entries older than the retention window; re-anchor the chain."""
+def prune(
+    *, days: Optional[int] = None, now: Optional[float] = None, path: Optional[Path] = None
+) -> int:
+    """Drop entries older than the retention window; re-anchor the chain atomically."""
     path = path or _audit_path()
     if not path.exists():
         return 0
-    cutoff = (now if now is not None else time.time()) - retention_days() * 86400
+
+    retention = days if days is not None and days > 0 else retention_days()
+    cutoff = (now if now is not None else time.time()) - retention * 86400
     kept, removed = [], 0
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
+
+    with open(path, "r+", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
         try:
-            ts = json.loads(line)["ts"]
-        except (json.JSONDecodeError, KeyError, TypeError):
-            kept.append(line)
-            continue
-        if ts < cutoff:
-            removed += 1
-        else:
-            kept.append(line)
-    if not removed:
-        return 0
-    reanchored, prev = [], _GENESIS
-    for line in kept:
-        entry = json.loads(line)
-        entry["prev_hash"] = prev
-        entry["hash"] = _hash(prev, entry["payload"])
-        reanchored.append(json.dumps(entry, sort_keys=True))
-        prev = entry["hash"]
-    out = "\n".join(reanchored) + ("\n" if reanchored else "")
-    path.write_text(out, encoding="utf-8")
-    return removed
+            fh.seek(0)
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ts = json.loads(line)["ts"]
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    kept.append(line)
+                    continue
+                if ts < cutoff:
+                    removed += 1
+                else:
+                    kept.append(line)
+
+            if not removed:
+                return 0
+
+            reanchored, prev = [], _GENESIS
+            for line in kept:
+                entry = json.loads(line)
+                entry["prev_hash"] = prev
+                entry["hash"] = _hash(prev, entry["payload"])
+                reanchored.append(json.dumps(entry, sort_keys=True))
+                prev = entry["hash"]
+
+            out = "\n".join(reanchored) + ("\n" if reanchored else "")
+            tmp_path = path.with_suffix(".tmp")
+            tmp_path.write_text(out, encoding="utf-8")
+            os.replace(tmp_path, path)
+            return removed
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+

--- a/hermes_cli/audit_cmd.py
+++ b/hermes_cli/audit_cmd.py
@@ -33,7 +33,7 @@ def cmd_audit(args) -> None:
 
         print(f"═══ Audit Trail for Session: {session_id} ═══")
         chain_icon = "✓" if recon["valid_chain"] else "✗"
-        print(f"Chain Integrity: {chain_icon} ({recon['event_count']} events in session)")
+        print(f"Global Hash-Chain Integrity: {chain_icon} ({recon['event_count']} events in session)")
         summary = recon["summary"]
         print(
             f"Summary: {summary['actions_count']} actions, "
@@ -60,9 +60,9 @@ def cmd_audit(args) -> None:
             print("🔀 Subagent Delegations:")
             for d in recon["delegations"]:
                 status = d.get("status", "unknown")
-                tid = d.get("task_id", "")
-                inp = d.get("inputs", {})
-                goal = inp.get("goal") if isinstance(inp, dict) else str(inp)
+                tid = d.get("task_id", "subagent")
+                meta = d.get("metadata", {})
+                goal = meta.get("goal") or d.get("inputs_digest") or ""
                 print(f"  [{status}] {tid}: {str(goal)[:80]}")
             print()
 
@@ -80,7 +80,10 @@ def cmd_audit(args) -> None:
         session_id = getattr(args, "session_id", None)
         event_type = getattr(args, "event_type", None)
         limit = getattr(args, "limit", 50)
-        events = audit_trail.query_trail(session_id=session_id, event_type=event_type, limit=limit)
+        path = Path(args.path) if getattr(args, "path", None) else None
+        events = audit_trail.query_trail(
+            session_id=session_id, event_type=event_type, limit=limit, path=path
+        )
 
         if getattr(args, "json", False):
             print(json.dumps([e["payload"] for e in events], indent=2, ensure_ascii=False))
@@ -97,6 +100,12 @@ def cmd_audit(args) -> None:
 
     elif subcmd == "prune":
         days = getattr(args, "days", None)
+        path = Path(args.path) if getattr(args, "path", None) else None
         now = time.time()
-        removed = audit_trail.prune(now=now)
+        removed = audit_trail.prune(days=days, now=now, path=path)
         print(f"✓ Pruned {removed} expired audit trail event(s). Hash chain re-anchored.")
+
+    else:
+        print(f"unknown audit subcommand: {subcmd}", file=sys.stderr)
+        sys.exit(2)
+

--- a/hermes_cli/subcommands/audit.py
+++ b/hermes_cli/subcommands/audit.py
@@ -94,5 +94,10 @@ def build_audit_parser(subparsers, *, cmd_audit: Callable) -> None:
         default=None,
         help="Override retention window in days",
     )
+    prune_parser.add_argument(
+        "--path",
+        default=None,
+        help="Custom path to audit trail JSONL file",
+    )
 
     audit_parser.set_defaults(func=cmd_audit)

--- a/model_tools.py
+++ b/model_tools.py
@@ -1943,6 +1943,26 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # Structured audit trail (issue #3065)
+        try:
+            from agent.audit_trail import is_audit_enabled, record_event
+
+            if is_audit_enabled() and function_name != "delegate_task":
+                _eff_sid = session_id or task_id or "default"
+                _is_error = isinstance(result, str) and result.startswith("[TOOL_ERROR]")
+                _st = "failure" if _is_error else "success"
+                record_event(
+                    event_type="action",
+                    session_id=_eff_sid,
+                    task_id=task_id,
+                    tool_name=function_name,
+                    inputs=function_args,
+                    status=_st,
+                    metadata={"result": result, "duration_ms": duration_ms},
+                )
+        except Exception:
+            logger.debug("Audit trail tool call record failed", exc_info=True)
+
         return result
 
     except Exception as e:
@@ -1969,6 +1989,24 @@ def handle_function_call(
             error_message=str(e),
             middleware_trace=list(_tool_middleware_trace),
         )
+
+        try:
+            from agent.audit_trail import is_audit_enabled, record_event
+
+            if is_audit_enabled() and function_name != "delegate_task":
+                _eff_sid = session_id or task_id or "default"
+                record_event(
+                    event_type="action",
+                    session_id=_eff_sid,
+                    task_id=task_id,
+                    tool_name=function_name,
+                    inputs=function_args,
+                    status="failure",
+                    metadata={"result": result, "duration_ms": duration_ms, "error": str(e)},
+                )
+        except Exception:
+            logger.debug("Audit trail tool call error record failed", exc_info=True)
+
         return result
 
 

--- a/tests/agent/test_audit_trail.py
+++ b/tests/agent/test_audit_trail.py
@@ -150,11 +150,16 @@ def test_record_event_and_query_trail(tmp_path):
 
     assert entry1 is not None and entry2 is not None and entry3 is not None
 
-    # Query filtered by session
+    # Query filtered by session (default newest_first=True)
     s1_events = audit_trail.query_trail(session_id="session-1", path=log)
     assert len(s1_events) == 2
-    assert s1_events[0]["payload"]["event_type"] == "action"
-    assert s1_events[1]["payload"]["event_type"] == "validation"
+    assert s1_events[0]["payload"]["event_type"] == "validation"
+    assert s1_events[1]["payload"]["event_type"] == "action"
+
+    # Query with newest_first=False
+    s1_events_chrono = audit_trail.query_trail(session_id="session-1", newest_first=False, path=log)
+    assert s1_events_chrono[0]["payload"]["event_type"] == "action"
+    assert s1_events_chrono[1]["payload"]["event_type"] == "validation"
 
     # Query filtered by event_type
     val_events = audit_trail.query_trail(event_type="validation", path=log)
@@ -198,8 +203,77 @@ def test_reconstruct_run_dag(tmp_path):
     assert any("test://pytest tests/test_model.py:passed" in v for v in recon["validations"])
     assert len(recon["delegations"]) == 1
     assert recon["summary"]["success_rate"] == 1.0
-    assert recon["summary"]["actions_count"] == 2
+    assert recon["summary"]["actions_count"] == 1
+    assert recon["summary"]["validations_count"] == 1
     assert recon["summary"]["delegations_count"] == 1
+
+
+def test_concurrent_append_maintains_hash_chain(tmp_path):
+    import concurrent.futures
+
+    log = tmp_path / "concurrent_audit.jsonl"
+    num_threads = 10
+    records_per_thread = 15
+
+    def _worker(thread_idx):
+        for i in range(records_per_thread):
+            audit_trail.record_event(
+                event_type="action",
+                session_id=f"session-{thread_idx}",
+                tool_name="terminal",
+                inputs={"cmd": f"echo {thread_idx}_{i}"},
+                path=log,
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(_worker, t) for t in range(num_threads)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    valid, count = audit_trail.verify(log)
+    assert valid is True
+    assert count == num_threads * records_per_thread
+
+
+def test_sanitize_metadata_redacts_and_truncates():
+    raw_meta = {
+        "api_key": "sk-secret-12345",
+        "result": "Authorization: Bearer my-top-secret-token-abcdef12345\nOutput details here...",
+        "status_code": 200,
+        "huge_output": "x" * 1000,
+    }
+    sanitized = audit_trail.sanitize_metadata(raw_meta)
+    assert sanitized["api_key"] == "[REDACTED]"
+    assert "[REDACTED]" in sanitized["result"]
+    assert len(sanitized["huge_output"]) <= 503  # 500 + '...'
+
+
+def test_extract_artifact_and_validation_accuracy():
+    # read_file should NOT produce an artifact
+    read_refs = audit_trail.extract_artifact_refs("read_file", {"path": "secrets.env"})
+    assert len(read_refs) == 0
+
+    # write_to_file SHOULD produce an artifact
+    write_refs = audit_trail.extract_artifact_refs("write_to_file", {"target_file": "app.py"})
+    assert "file://app.py" in write_refs
+
+    # xfailed should NOT count as failed test
+    xfailed_res = "1 xfailed, 9 passed in 2.0s"
+    val_refs1 = audit_trail.extract_validation_refs("terminal", {"command": "pytest tests/"}, result=xfailed_res)
+    assert len(val_refs1) == 1
+    assert "passed" in val_refs1[0] and "failed" not in val_refs1[0]
+
+    # '10 passed, 0 failed' should be passed, not failed
+    zero_failed_res = "10 passed, 0 failed in 1.2s"
+    val_refs2 = audit_trail.extract_validation_refs("terminal", {"command": "pytest tests/"}, result=zero_failed_res)
+    assert len(val_refs2) == 1
+    assert "passed" in val_refs2[0]
+
+    # Linter tagging
+    lint_res = "ruff check --fix"
+    lint_val = audit_trail.extract_validation_refs("terminal", {"command": lint_res}, result="All checks passed!")
+    assert len(lint_val) == 1
+    assert lint_val[0].startswith("lint://")
 
 
 def test_cmd_audit_cli_verify_and_show(tmp_path, capsys):
@@ -224,3 +298,41 @@ def test_cmd_audit_cli_verify_and_show(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "Audit Trail for Session: session-cli" in captured.out
     assert "file://app.py" in captured.out
+
+    # Test prune with days
+    cmd_audit(Namespace(audit_command="prune", days=1, path=str(log)))
+    captured = capsys.readouterr()
+    assert "Pruned" in captured.out
+
+
+def test_handle_function_call_records_audit_trail(tmp_path, monkeypatch):
+    log = tmp_path / "model_tools_audit.jsonl"
+    monkeypatch.setattr(audit_trail, "_audit_path", lambda: log)
+
+    from model_tools import handle_function_call
+    from tools.registry import registry
+
+    # Register dummy tool for testing
+    registry.register(
+        name="dummy_audit_tool",
+        toolset="core",
+        schema={"type": "function", "function": {"name": "dummy_audit_tool", "parameters": {"type": "object"}}},
+        handler=lambda args, **kw: f"result_{args.get('arg1')}",
+    )
+
+    res = handle_function_call(
+        function_name="dummy_audit_tool",
+        function_args={"arg1": "test_val"},
+        session_id="session-model-tools-test",
+    )
+    assert "result_test_val" in res
+
+    events = audit_trail.query_trail(session_id="session-model-tools-test", path=log)
+    assert len(events) == 1
+    p = events[0]["payload"]
+    assert p["event_type"] == "action"
+    assert p["tool_name"] == "dummy_audit_tool"
+    assert p["status"] == "success"
+    assert "result_test_val" in p["metadata"]["result"]
+
+

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -14,6 +14,7 @@ import argparse
 import pytest
 
 from hermes_cli.subcommands.auth import build_auth_parser
+from hermes_cli.subcommands.audit import build_audit_parser
 from hermes_cli.subcommands.backup import build_backup_parser
 from hermes_cli.subcommands.config import build_config_parser
 from hermes_cli.subcommands.dashboard import build_dashboard_parser
@@ -62,6 +63,7 @@ SINGLE_HANDLER_CASES = [
     ("hooks", build_hooks_parser, "cmd_hooks", ["hooks"]),
     ("doctor", build_doctor_parser, "cmd_doctor", ["doctor"]),
     ("security", build_security_parser, "cmd_security", ["security"]),
+    ("audit", build_audit_parser, "cmd_audit", ["audit", "verify"]),
     ("dump", build_dump_parser, "cmd_dump", ["dump"]),
     ("debug", build_debug_parser, "cmd_debug", ["debug"]),
     ("backup", build_backup_parser, "cmd_backup", ["backup"]),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5501,15 +5501,17 @@ def delegate_task(
                 if _entry.get("spill_path"):
                     _art_refs.append(f"file://{_entry['spill_path']}")
                 _st = "success" if _entry.get("status") == "completed" else str(_entry.get("status", "failure"))
+                _goal_text = task_labels[_t_idx] if _t_idx < len(task_labels) else ""
                 record_event(
                     event_type="delegation",
                     session_id=_sid,
                     task_id=_tid,
                     tool_name="delegate_task",
-                    inputs={"goal": task_labels[_t_idx] if _t_idx < len(task_labels) else "", "summary": _entry.get("summary")},
+                    inputs={"goal": _goal_text, "summary": _entry.get("summary")},
                     artifact_refs=_art_refs,
                     status=_st,
                     metadata={
+                        "goal": _goal_text,
                         "duration_seconds": _entry.get("duration_seconds", 0),
                         "api_calls": _entry.get("api_calls", 0),
                         "error": _entry.get("error"),


### PR DESCRIPTION
## Summary
Hardens and polishes the structured audit trail implementation:
- **Flock Concurrency**: Added `fcntl.flock` file locking in `append()` and `prune()` to protect the SHA-256 hash chain from race conditions under heavy concurrent subagent / thread writes.
- **Secret Redaction**: Added `sanitize_metadata()` to strip sensitive credentials (api_key, token, secret, password, bearer headers) and bound metadata output to prevent long-lived secret leaks in logs.
- **Accurate Reference Extraction**: Narrowed artifact extraction strictly to file-writing tools (preventing `read_file` artifact inflation) and improved test/linter extraction (avoiding `xfailed` or `0 failed` false positives).
- **Tool Loop Instrumentation**: Cleanly wired audit trail recording into `model_tools.py:handle_function_call` to automatically capture tool executions when audit is enabled.
- **CLI Suite Polish**: Supported `--path` across all commands (`verify`, `show`, `list`, `prune`), added `--days` retention override to `prune`, improved delegation goal formatting, and registered `audit` in CLI test suites.

## Testing
- 17 unit tests in `tests/agent/test_audit_trail.py`, `tests/tools/test_delegate_audit_trail.py`, and `tests/hermes_cli/test_subcommands_batch.py` passing cleanly.