### PR TITLE
feat: sub-skill schema for cross-task skill transfer (Closes #3070)

### DIFF
--- a/evolution/lib/subskill_schema.py
+++ b/evolution/lib/subskill_schema.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""Sub-skill schema for cross-task skill transfer (issue #3070).
+
+A sub-skill is a reusable primitive extracted from a completed task.  It is
+coarser than a single tool call and finer than a full SKILL.md bundle.  The
+schema is intentionally minimal so it can be round-tripped through the
+existing skill-hub install/uninstall flow and written to the audit log
+without inventing a new storage layer.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "SubSkill",
+    "CapabilityFragment",
+    "Precondition",
+    "SubSkillProvenance",
+    "SubSkillStatus",
+    "validate_subskill",
+    "subskill_to_bundle_meta",
+]
+
+
+class SubSkillStatus:
+    """Lifecycle states for a sub-skill promotion."""
+
+    EXTRACTED = "extracted"  # candidate produced by the extractor
+    PENDING_REVIEW = "pending_review"  # awaiting human approval
+    APPROVED = "approved"  # cleared for reuse
+    REJECTED = "rejected"  # explicitly turned down
+    RETIRED = "retired"  # no longer offered for reuse
+
+
+@dataclass
+class Precondition:
+    """A simple structured matcher for when a sub-skill applies."""
+
+    intent_keywords: List[str] = field(default_factory=list)
+    required_tool_names: List[str] = field(default_factory=list)
+    required_state_keys: List[str] = field(default_factory=list)
+    description: str = ""
+
+    def match_score(
+        self, intent: str, tool_names: List[str], state_keys: List[str]
+    ) -> float:
+        """Return a 0..1 overlap score against a planning context."""
+        intent = intent.lower()
+        scores: List[float] = []
+        if self.intent_keywords:
+            hits = sum(1 for kw in self.intent_keywords if kw.lower() in intent)
+            scores.append(hits / len(self.intent_keywords))
+        if self.required_tool_names:
+            hits = len(set(self.required_tool_names) & set(tool_names))
+            scores.append(hits / len(self.required_tool_names))
+        if self.required_state_keys:
+            hits = len(set(self.required_state_keys) & set(state_keys))
+            scores.append(hits / len(self.required_state_keys))
+        if not scores:
+            return 0.0
+        return sum(scores) / len(scores)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CapabilityFragment:
+    """The reusable 'how' of a sub-skill: a tool sequence plus parameters."""
+
+    description: str = ""
+    tool_sequence: List[str] = field(default_factory=list)
+    parameter_schema: Dict[str, Any] = field(default_factory=dict)
+    example_usage: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SubSkillProvenance:
+    """Where a sub-skill came from and when it changed."""
+
+    source_task_id: str = ""
+    source_session_id: str = ""
+    extracted_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    extractor_version: str = "1.0"
+    human_reviewer: Optional[str] = None
+    reviewed_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SubSkill:
+    """A reusable primitive extracted from a successful task trace."""
+
+    name: str
+    description: str
+    precondition: Precondition = field(default_factory=Precondition)
+    capability: CapabilityFragment = field(default_factory=CapabilityFragment)
+    provenance: SubSkillProvenance = field(default_factory=SubSkillProvenance)
+    status: str = SubSkillStatus.EXTRACTED
+    review_required: bool = True
+    tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    subskill_id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("sub-skill name is required")
+        # Normalize to a filesystem- and URL-friendly identifier.
+        self._id_slug = re.sub(r"[^a-z0-9_-]+", "-", self.name.lower()).strip("-")
+
+    @property
+    def id_slug(self) -> str:
+        return getattr(self, "_id_slug", "")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SubSkill":
+        """Deserialize from a plain dict; ignores unknown fields."""
+        data = dict(data)
+        data.pop("_id_slug", None)
+        data["precondition"] = Precondition(**data.get("precondition", {}))
+        data["capability"] = CapabilityFragment(**data.get("capability", {}))
+        data["provenance"] = SubSkillProvenance(**data.get("provenance", {}))
+        return cls(**{
+            k: v
+            for k, v in data.items()
+            if k in {f.name for f in cls.__dataclass_fields__.values()}
+        })
+
+    def approve(self, reviewer: str) -> None:
+        """Promote the sub-skill to approved status after human review."""
+        self.status = SubSkillStatus.APPROVED
+        self.review_required = False
+        self.provenance.human_reviewer = reviewer
+        self.provenance.reviewed_at = datetime.now(timezone.utc).isoformat()
+
+    def reject(self, reviewer: str) -> None:
+        """Mark the sub-skill as rejected by human review."""
+        self.status = SubSkillStatus.REJECTED
+        self.review_required = False
+        self.provenance.human_reviewer = reviewer
+        self.provenance.reviewed_at = datetime.now(timezone.utc).isoformat()
+
+
+def validate_subskill(skill: SubSkill) -> Dict[str, Any]:
+    """Return a validation report with ``valid`` and a list of errors."""
+    errors: List[str] = []
+    if not skill.name or not skill.name.strip():
+        errors.append("name is empty")
+    if not skill.description or not skill.description.strip():
+        errors.append("description is empty")
+    if (
+        not skill.precondition.intent_keywords
+        and not skill.precondition.required_tool_names
+    ):
+        errors.append("precondition has no intent keywords or required tools")
+    if not skill.capability.tool_sequence:
+        errors.append("capability.tool_sequence is empty")
+    if skill.status not in {
+        SubSkillStatus.EXTRACTED,
+        SubSkillStatus.PENDING_REVIEW,
+        SubSkillStatus.APPROVED,
+        SubSkillStatus.REJECTED,
+        SubSkillStatus.RETIRED,
+    }:
+        errors.append(f"unknown status {skill.status!r}")
+    return {"valid": not errors, "errors": errors}
+
+
+def subskill_to_bundle_meta(skill: SubSkill) -> Dict[str, Any]:
+    """Convert a sub-skill into the metadata shape used by ``tools.skills_hub.SkillBundle``.
+
+    This keeps the sub-skill compatible with the existing skill-hub install and
+    uninstall paths: it can be stored as a single SKILL.md-less bundle entry or
+    promoted into a full skill card later.
+    """
+    return {
+        "name": skill.name,
+        "description": skill.description,
+        "source": "subskill",
+        "identifier": f"subskill/{skill.subskill_id}/{skill.id_slug}",
+        "trust_level": "agent",
+        "tags": list(skill.tags),
+        "extra": {
+            "subskill_id": skill.subskill_id,
+            "status": skill.status,
+            "review_required": skill.review_required,
+            "precondition": skill.precondition.to_dict(),
+            "capability": skill.capability.to_dict(),
+            "provenance": skill.provenance.to_dict(),
+        },
+    }

--- a/tests/evolution/test_subskill_schema.py
+++ b/tests/evolution/test_subskill_schema.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the sub-skill schema (issue #3070).
+
+Covers serialization round-trips, validation, provenance tagging, the
+human-review approval gate, and compatibility with the skill-hub bundle
+metadata shape used by ``tools.skills_hub``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evolution.lib.subskill_schema import (
+    CapabilityFragment,
+    Precondition,
+    SubSkill,
+    SubSkillProvenance,
+    SubSkillStatus,
+    subskill_to_bundle_meta,
+    validate_subskill,
+)
+
+
+def _sample_subskill(**overrides) -> SubSkill:
+    base = SubSkill(
+        name="git-commit-and-push",
+        description="Commit staged changes and push to the current branch.",
+        precondition=Precondition(
+            intent_keywords=["commit", "push"],
+            required_tool_names=["terminal"],
+            required_state_keys=["git_repo"],
+        ),
+        capability=CapabilityFragment(
+            description="Run git add/commit/push in sequence.",
+            tool_sequence=["terminal", "terminal", "terminal"],
+            parameter_schema={"commit_message": {"type": "string"}},
+        ),
+        provenance=SubSkillProvenance(
+            source_task_id="task-42",
+            source_session_id="sess-7",
+        ),
+        tags=["git", "vcs"],
+    )
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+# --- Serialization ---------------------------------------------------------
+
+
+def test_round_trip_preserves_all_fields():
+    skill = _sample_subskill()
+    restored = SubSkill.from_dict(skill.to_dict())
+    assert restored.to_dict() == skill.to_dict()
+    assert restored.name == "git-commit-and-push"
+    assert restored.precondition.intent_keywords == ["commit", "push"]
+    assert restored.capability.tool_sequence == ["terminal", "terminal", "terminal"]
+    assert restored.provenance.source_task_id == "task-42"
+
+
+def test_from_dict_ignores_unknown_fields():
+    data = _sample_subskill().to_dict()
+    data["bogus_field"] = "ignored"
+    restored = SubSkill.from_dict(data)
+    assert not hasattr(restored, "bogus_field")
+    assert restored.name == "git-commit-and-push"
+
+
+def test_id_slug_is_normalized():
+    skill = SubSkill(name="My Sub Skill: v2!", description="d")
+    assert skill.id_slug == "my-sub-skill-v2"
+
+
+# --- Validation ------------------------------------------------------------
+
+
+def test_valid_subskill_passes_validation():
+    report = validate_subskill(_sample_subskill())
+    assert report["valid"] is True
+    assert report["errors"] == []
+
+
+def test_missing_name_fails_validation():
+    report = validate_subskill(_sample_subskill(name=""))
+    assert report["valid"] is False
+    assert "name is empty" in report["errors"]
+
+
+def test_empty_precondition_fails_validation():
+    skill = _sample_subskill()
+    skill.precondition = Precondition()
+    report = validate_subskill(skill)
+    assert report["valid"] is False
+    assert any("precondition" in e for e in report["errors"])
+
+
+def test_empty_capability_sequence_fails_validation():
+    skill = _sample_subskill()
+    skill.capability = CapabilityFragment(description="no tools")
+    report = validate_subskill(skill)
+    assert report["valid"] is False
+    assert any("tool_sequence" in e for e in report["errors"])
+
+
+def test_unknown_status_fails_validation():
+    skill = _sample_subskill(status="bogus")
+    report = validate_subskill(skill)
+    assert report["valid"] is False
+    assert any("status" in e for e in report["errors"])
+
+
+# --- Provenance tagging ----------------------------------------------------
+
+
+def test_provenance_records_source_and_timestamp():
+    skill = _sample_subskill()
+    assert skill.provenance.source_task_id == "task-42"
+    assert skill.provenance.source_session_id == "sess-7"
+    assert skill.provenance.extracted_at  # non-empty ISO timestamp
+
+
+def test_approve_tags_human_reviewer_and_flips_status():
+    skill = _sample_subskill()
+    assert skill.status == SubSkillStatus.EXTRACTED
+    assert skill.review_required is True
+    skill.approve("alice")
+    assert skill.status == SubSkillStatus.APPROVED
+    assert skill.review_required is False
+    assert skill.provenance.human_reviewer == "alice"
+    assert skill.provenance.reviewed_at
+
+
+def test_reject_tags_human_reviewer_and_flips_status():
+    skill = _sample_subskill()
+    skill.reject("bob")
+    assert skill.status == SubSkillStatus.REJECTED
+    assert skill.review_required is False
+    assert skill.provenance.human_reviewer == "bob"
+
+
+# --- Precondition match scoring --------------------------------------------
+
+
+def test_match_score_returns_one_for_full_overlap():
+    skill = _sample_subskill()
+    score = skill.precondition.match_score(
+        "please commit and push", ["terminal"], ["git_repo"]
+    )
+    assert score == pytest.approx(1.0)
+
+
+def test_match_score_returns_zero_for_no_overlap():
+    skill = _sample_subskill()
+    score = skill.precondition.match_score("deploy to prod", ["web"], ["cluster"])
+    assert score == pytest.approx(0.0)
+
+
+def test_match_score_is_partial_for_partial_overlap():
+    skill = _sample_subskill()
+    score = skill.precondition.match_score("commit", ["terminal"], ["git_repo"])
+    # intent keywords: 1/2 hit; tools: 1/1; state: 1/1 -> mean of 0.5, 1.0, 1.0
+    assert score == pytest.approx((0.5 + 1.0 + 1.0) / 3.0)
+
+
+# --- Skill-hub bundle meta compatibility -----------------------------------
+
+
+def test_bundle_meta_round_trips_through_skill_hub_shape():
+    skill = _sample_subskill()
+    meta = subskill_to_bundle_meta(skill)
+    # Shape expected by tools.skills_hub.SkillBundle / SkillMeta.
+    assert meta["name"] == "git-commit-and-push"
+    assert meta["source"] == "subskill"
+    assert meta["trust_level"] == "agent"
+    assert meta["identifier"].startswith("subskill/")
+    assert meta["extra"]["subskill_id"] == skill.subskill_id
+    assert meta["extra"]["status"] == SubSkillStatus.EXTRACTED
+    assert meta["extra"]["precondition"]["intent_keywords"] == ["commit", "push"]
+    assert meta["extra"]["capability"]["tool_sequence"] == [
+        "terminal",
+        "terminal",
+        "terminal",
+    ]
+    assert meta["extra"]["provenance"]["source_task_id"] == "task-42"
+
+
+def test_bundle_meta_is_json_serializable():
+    import json
+
+    meta = subskill_to_bundle_meta(_sample_subskill())
+    # Must survive a JSON round-trip (audit log / hub persistence).
+    dumped = json.dumps(meta)
+    assert json.loads(dumped) == meta


### PR DESCRIPTION
Implements the sub-skill schema requested in #3070.

**What changed**
- New evolution/lib/subskill_schema.py defining SubSkill, Precondition, CapabilityFragment, SubSkillProvenance plus validation, approval/rejection gates, and a converter to the tools.skills_hub.SkillBundle metadata shape.
- New tests/evolution/test_subskill_schema.py covering serialization round-trips, validation, provenance tagging, precondition matching, and skill-hub bundle compatibility.

**Local validation**
- pytest tests/evolution/test_subskill_schema.py: 16 passed
- ruff check evolution/lib/subskill_schema.py tests/evolution/test_subskill_schema.py: passed
- ruff format --check evolution/lib/subskill_schema.py tests/evolution/test_subskill_schema.py: passed

**Merge-gate note**: the diff is ~402 insertions, which exceeds the 200-line autonomous-landing cap. This PR should land via human review.

Closes #3070