### PR TITLE
fix(state): atomic state.db backup, disk-exhaustion guard, and repair loop hardening

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1858,12 +1858,27 @@ _MAX_MALFORMED_BACKUPS = 3
 # header on any real recovery), while staying O(1) on a multi-GB file.
 _FINGERPRINT_SAMPLE_BYTES = 65536
 
-# Free-space floor for the pre-repair forensic backup. The backup is a full
-# raw copy of the damaged DB, so a repair loop on a large state.db is a disk
-# amplifier: the reported incident wrote 98MB every ~10s until the volume was
-# nearly full, which would have taken down every agent on the host. Refuse
-# the copy unless the volume would still hold this much afterwards.
-_REPAIR_BACKUP_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+# Free-space headroom for the pre-repair forensic backup. The backup is a
+# full raw copy of the damaged DB (plus its -wal/-shm sidecars), so a repair
+# loop on a large state.db is a disk amplifier: the reporting incident wrote
+# ~98MB every ~10s until the volume was nearly full, which would have taken
+# down every agent on the host.
+#
+# Proportional, not a flat floor: an absolute multi-GB reserve would refuse
+# backups that fit comfortably on small container/VM volumes, and because a
+# refused backup is a HARD STOP (#69603) that would silently convert "repair
+# loops" into "repair never runs" for those deployments. Require the copy
+# itself plus a small slice of the volume, clamped to a modest floor.
+_REPAIR_BACKUP_MIN_FREE_BYTES = 256 * 1024 * 1024  # 256 MiB absolute floor
+_REPAIR_BACKUP_FREE_FRACTION = 0.02  # plus 2% of the volume
+
+
+def _repair_backup_headroom_bytes(total_bytes: int) -> int:
+    """Free space required *beyond* the copy itself, for a volume of *total_bytes*."""
+    return max(
+        _REPAIR_BACKUP_MIN_FREE_BYTES,
+        int(total_bytes * _REPAIR_BACKUP_FREE_FRACTION),
+    )
 
 
 def _repair_ledger_path(db_path: Path) -> Path:
@@ -2069,31 +2084,70 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                     return existing, None
         except OSError:
             pass
-        # Disk guard: this is a full raw copy of a possibly multi-GB DB. On a
-        # host whose volume is already nearly full — which a preceding repair
-        # loop may itself have caused — taking it can finish off the disk and
-        # take down every process on the machine. Refuse while there is still
-        # room to refuse in.
+        # Disk guard: this is a full raw copy of a possibly multi-GB DB plus
+        # its sidecars. On a host whose volume is already nearly full — which
+        # a preceding repair loop may itself have caused — taking it can
+        # finish off the disk and take down every process on the machine.
+        # Refuse while there is still room to refuse in.
         try:
-            src_size = db_path.stat().st_size
-            free = shutil.disk_usage(db_path.parent).free
-            if free - src_size < _REPAIR_BACKUP_MIN_FREE_BYTES:
+            need = db_path.stat().st_size
+            for suffix in ("-wal", "-shm"):
+                sidecar = db_path.with_name(db_path.name + suffix)
+                if sidecar.exists():
+                    need += sidecar.stat().st_size
+            usage = shutil.disk_usage(db_path.parent)
+            headroom = _repair_backup_headroom_bytes(usage.total)
+            if usage.free - need < headroom:
                 reason = (
-                    f"only {free / 1e9:.1f}GB free on {db_path.parent}; copying "
-                    f"the {src_size / 1e9:.1f}GB damaged DB would leave less than "
-                    f"{_REPAIR_BACKUP_MIN_FREE_BYTES / 1e9:.1f}GB. Free disk space, "
-                    "then retry (or recover manually with `sqlite3 "
-                    f"{db_path} \".recover\"`)."
+                    f"only {usage.free / 1e9:.2f}GB free on {db_path.parent}; "
+                    f"copying the damaged DB needs {need / 1e9:.2f}GB and must "
+                    f"leave {headroom / 1e9:.2f}GB headroom. Free disk space, "
+                    f"then retry (or recover manually with `sqlite3 {db_path} "
+                    '".recover"`).'
                 )
                 logger.error("Refusing forensic backup of %s: %s", db_path, reason)
                 return None, reason
         except OSError:
             pass
-        shutil.copy2(db_path, backup_path)
-        for suffix in ("-wal", "-shm"):
-            sidecar = db_path.with_name(db_path.name + suffix)
-            if sidecar.exists():
-                shutil.copy2(sidecar, backup_path.with_name(backup_path.name + suffix))
+        # Copy to a staging name that does NOT match the backup prefix, then
+        # rename into place only once every copy has succeeded. A copy that
+        # fails partway (ENOSPC, kill) would otherwise leave a prefix-matching
+        # partial that `_prune_malformed_backups` never reaches — prune runs
+        # only on the success path — so debris accumulated unbounded and, on a
+        # later successful pass, the newest-by-name partials were KEPT while
+        # intact forensic copies were pruned away.
+        staging = db_path.with_name(f"{backup_path.name}.incomplete")
+        staged: "List[Tuple[Path, Path]]" = []
+        try:
+            # Clear debris from an earlier interrupted pass (kill mid-copy).
+            # Matches sidecar staging names (``.incomplete-wal``) too.
+            for old in db_path.parent.glob(
+                f"{db_path.name}.malformed-backup-*.incomplete*"
+            ):
+                old.unlink(missing_ok=True)
+            shutil.copy2(db_path, staging)
+            staged.append((staging, backup_path))
+            for suffix in ("-wal", "-shm"):
+                sidecar = db_path.with_name(db_path.name + suffix)
+                if sidecar.exists():
+                    side_staging = staging.with_name(staging.name + suffix)
+                    shutil.copy2(sidecar, side_staging)
+                    staged.append(
+                        (side_staging, backup_path.with_name(backup_path.name + suffix))
+                    )
+            for src, dst in staged:
+                os.replace(src, dst)
+        except Exception:
+            for src, _ in staged:
+                try:
+                    src.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            try:
+                staging.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
         # Retention cap (#86747): keep only the newest few forensic copies.
         _prune_malformed_backups(db_path)
         return backup_path, None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1853,6 +1853,14 @@ def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
 _MAX_PERSISTENT_REPAIR_ATTEMPTS = 3
 _MAX_MALFORMED_BACKUPS = 3
 
+# Sidecars copied alongside a damaged DB and pruned with it. ``-journal`` is
+# included because rollback-journal (DELETE) mode — Hermes's fallback on
+# NFS/SMB/FUSE/ZFS and on WAL-reset-vulnerable SQLite builds — leaves a hot
+# journal on disk whenever a transaction was open, and that file is what
+# interprets the damaged bytes. Omitting it from the forensic copy means the
+# backup cannot be rolled back to a consistent state by hand.
+_DB_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
 # Head/tail bytes sampled by ``_db_fingerprint``. Enough to change whenever
 # the DB is genuinely repaired, truncated or restored (SQLite rewrites the
 # header on any real recovery), while staying O(1) on a multi-GB file.
@@ -2079,7 +2087,7 @@ def _existing_malformed_backups(db_path: Path) -> "List[Path]":
             p
             for p in db_path.parent.iterdir()
             if p.name.startswith(prefix)
-            and not p.name.endswith(("-wal", "-shm"))
+            and not p.name.endswith(_DB_SIDECAR_SUFFIXES)
         ]
     except OSError:
         return []
@@ -2091,8 +2099,7 @@ def _prune_malformed_backups(db_path: Path, keep: int = _MAX_MALFORMED_BACKUPS) 
     for stale in _existing_malformed_backups(db_path)[keep:]:
         for victim in (
             stale,
-            stale.with_name(stale.name + "-wal"),
-            stale.with_name(stale.name + "-shm"),
+            *(stale.with_name(stale.name + suffix) for suffix in _DB_SIDECAR_SUFFIXES),
         ):
             try:
                 victim.unlink(missing_ok=True)
@@ -2190,7 +2197,7 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         # Refuse while there is still room to refuse in.
         try:
             need = db_path.stat().st_size
-            for suffix in ("-wal", "-shm"):
+            for suffix in _DB_SIDECAR_SUFFIXES:
                 sidecar = db_path.with_name(db_path.name + suffix)
                 if sidecar.exists():
                     need += sidecar.stat().st_size
@@ -2235,7 +2242,7 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         try:
             shutil.copy2(db_path, staging)
             staged.append((staging, backup_path))
-            for suffix in ("-wal", "-shm"):
+            for suffix in _DB_SIDECAR_SUFFIXES:
                 sidecar = db_path.with_name(db_path.name + suffix)
                 if sidecar.exists():
                     side_staging = staging.with_name(staging.name + suffix)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1844,8 +1844,8 @@ def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
 #
 # * a sidecar attempt ledger (``<db>.repair-attempts.json``) that refuses
 #   further surgery after ``_MAX_PERSISTENT_REPAIR_ATTEMPTS`` failures on
-#   the SAME damaged file (fingerprint = size + mtime; any successful repair
-#   or replacement changes it and resets the count);
+#   the SAME damaged file (fingerprint = size + a bounded content sample; any
+#   successful repair or replacement changes it and resets the count);
 # * backup dedupe + a retention cap in ``_backup_db_file`` — an identical
 #   damaged file is never copied twice, and only the newest
 #   ``_MAX_MALFORMED_BACKUPS`` forensic copies are kept.
@@ -1905,16 +1905,47 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
     size plus the head/tail slices that any real repair, truncation or
     restore necessarily changes. Stable across passes that merely touch
     mtime; still resets the attempt count after genuine recovery.
+
+    The content read runs under ``offline_file_access`` because it takes a raw
+    descriptor, and ``close()`` on ANY descriptor cancels every POSIX advisory
+    lock this process holds on the file — including a peer connection's
+    RESERVED lock (see ``hermes_cli.sqlite_safe_read`` rule 1). This function
+    is reached from ``repair_state_db_schema``'s exhaustion probe BEFORE
+    ``_backup_db_file``'s ``has_live_connection`` guard, and the repair path is
+    entered by one SessionDB while the gateway holds others, so a live peer is
+    the expected case rather than a theoretical one. When one exists we fall
+    back to ``size:mtime_ns``: a live connection means the backup is refused
+    and repair HARD STOPs (#69603), so no surgery runs and nothing moves mtime
+    behind our back — the content key is only load-bearing on the offline
+    repair path, which is exactly where the guard lets it through.
     """
     try:
         st = db_path.stat()
-        with open(db_path, "rb") as fh:
-            head = fh.read(_FINGERPRINT_SAMPLE_BYTES)
-            if st.st_size > _FINGERPRINT_SAMPLE_BYTES:
-                fh.seek(max(0, st.st_size - _FINGERPRINT_SAMPLE_BYTES))
-                tail = fh.read(_FINGERPRINT_SAMPLE_BYTES)
-            else:
-                tail = b""
+        try:
+            from hermes_cli.sqlite_safe_read import (
+                LiveConnectionError,
+                offline_file_access,
+            )
+        except ImportError:
+            # Scaffold/embed installs ship hermes_state without hermes_cli. No
+            # tracked connections exist there, so the raw read is safe.
+            LiveConnectionError = ()  # type: ignore[assignment]
+            offline_file_access = None  # type: ignore[assignment]
+        try:
+            with (
+                contextlib.nullcontext()
+                if offline_file_access is None
+                else offline_file_access(db_path, what="fingerprint")
+            ):
+                with open(db_path, "rb") as fh:
+                    head = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+                    if st.st_size > _FINGERPRINT_SAMPLE_BYTES:
+                        fh.seek(max(0, st.st_size - _FINGERPRINT_SAMPLE_BYTES))
+                        tail = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+                    else:
+                        tail = b""
+        except LiveConnectionError:
+            return f"{st.st_size}:{st.st_mtime_ns}"
         digest = hashlib.sha256(head + tail).hexdigest()[:32]
         return f"{st.st_size}:{digest}"
     except OSError:
@@ -2107,8 +2138,20 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                 )
                 logger.error("Refusing forensic backup of %s: %s", db_path, reason)
                 return None, reason
-        except OSError:
-            pass
+        except OSError as exc:
+            # Fail CLOSED. This guard exists for the nearly-full volume, which
+            # is exactly where stat()/disk_usage() is most likely to fail — and
+            # proceeding would take the multi-GB copy that finishes off the
+            # disk. A refused backup is a HARD STOP (#69603), so repair simply
+            # does not run until a human frees space, which is the safe side.
+            reason = (
+                f"could not determine free space on {db_path.parent} ({exc}); "
+                "refusing the forensic copy rather than risk filling the "
+                f"volume. Free disk space, then retry (or recover manually "
+                f'with `sqlite3 {db_path} ".recover"`).'
+            )
+            logger.error("Refusing forensic backup of %s: %s", db_path, reason)
+            return None, reason
         # Copy to a staging name that does NOT match the backup prefix, then
         # rename into place only once every copy has succeeded. A copy that
         # fails partway (ENOSPC, kill) would otherwise leave a prefix-matching

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1853,22 +1853,55 @@ def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
 _MAX_PERSISTENT_REPAIR_ATTEMPTS = 3
 _MAX_MALFORMED_BACKUPS = 3
 
+# Head/tail bytes sampled by ``_db_fingerprint``. Enough to change whenever
+# the DB is genuinely repaired, truncated or restored (SQLite rewrites the
+# header on any real recovery), while staying O(1) on a multi-GB file.
+_FINGERPRINT_SAMPLE_BYTES = 65536
+
+# Free-space floor for the pre-repair forensic backup. The backup is a full
+# raw copy of the damaged DB, so a repair loop on a large state.db is a disk
+# amplifier: the reported incident wrote 98MB every ~10s until the volume was
+# nearly full, which would have taken down every agent on the host. Refuse
+# the copy unless the volume would still hold this much afterwards.
+_REPAIR_BACKUP_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
 
 def _repair_ledger_path(db_path: Path) -> Path:
     return db_path.with_name(db_path.name + ".repair-attempts.json")
 
 
 def _db_fingerprint(db_path: Path) -> "Optional[str]":
-    """Cheap identity for a damaged DB file: size + mtime_ns.
+    """Cheap identity for a damaged DB file: size + a bounded content sample.
 
-    Hashing a multi-GB corrupt file on every open is exactly the kind of
-    repeated cost this ledger exists to avoid; size+mtime is stable for a
-    file nothing can successfully write to, and any successful repair,
-    truncation or manual restore changes it (resetting the attempt count).
+    Deliberately EXCLUDES mtime. The original ledger keyed on
+    ``size:mtime_ns`` on the assumption that "nothing can successfully write
+    to a damaged file", but that does not hold for the malformed-schema
+    class: the DB still opens and accepts writes (only ``sqlite_master`` is
+    unreadable), so live writers, WAL checkpoints and the in-place repair
+    strategies themselves all move mtime between passes. Every pass then
+    looked like a NEW file — the attempt counter reset to 1 forever, never
+    reaching ``_MAX_PERSISTENT_REPAIR_ATTEMPTS``, and the ``_backup_db_file``
+    dedupe (which compares mtime too) never matched, so each pass wrote
+    another full-size forensic copy. Observed: a repair every ~10s, a fresh
+    98MB copy each time, 2.3GB in 20 minutes, disk heading to zero.
+
+    Hashing a multi-GB corrupt file on every open is the repeated cost this
+    ledger exists to avoid, so sample instead of digesting the whole file:
+    size plus the head/tail slices that any real repair, truncation or
+    restore necessarily changes. Stable across passes that merely touch
+    mtime; still resets the attempt count after genuine recovery.
     """
     try:
         st = db_path.stat()
-        return f"{st.st_size}:{st.st_mtime_ns}"
+        with open(db_path, "rb") as fh:
+            head = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+            if st.st_size > _FINGERPRINT_SAMPLE_BYTES:
+                fh.seek(max(0, st.st_size - _FINGERPRINT_SAMPLE_BYTES))
+                tail = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+            else:
+                tail = b""
+        digest = hashlib.sha256(head + tail).hexdigest()[:32]
+        return f"{st.st_size}:{digest}"
     except OSError:
         return None
 
@@ -2017,20 +2050,43 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         # Dedupe (#86747): a repair loop used to copy the SAME damaged bytes
         # on every restart — ~900MB a pass, 89GB over 11 days in the
         # reporting install. If the newest existing backup already matches
-        # this file (size + mtime preserved by copy2), reuse it.
+        # this file, reuse it.
+        #
+        # Matching on mtime made this dedupe miss exactly when it mattered
+        # most: the malformed-SCHEMA class still accepts writes, so live
+        # writers and the in-place repair strategies move mtime between
+        # passes and every pass wrote another full-size copy (2.3GB in 20
+        # minutes). Compare the content fingerprint instead, which is stable
+        # while the damaged bytes are.
         try:
-            src_stat = db_path.stat()
+            src_fp = _db_fingerprint(db_path)
             for existing in _existing_malformed_backups(db_path)[:1]:
-                est = existing.stat()
-                if (
-                    est.st_size == src_stat.st_size
-                    and est.st_mtime_ns == src_stat.st_mtime_ns
-                ):
+                if src_fp is not None and _db_fingerprint(existing) == src_fp:
                     logger.info(
                         "Reusing existing forensic backup %s (identical to the "
                         "damaged DB).", existing,
                     )
                     return existing, None
+        except OSError:
+            pass
+        # Disk guard: this is a full raw copy of a possibly multi-GB DB. On a
+        # host whose volume is already nearly full — which a preceding repair
+        # loop may itself have caused — taking it can finish off the disk and
+        # take down every process on the machine. Refuse while there is still
+        # room to refuse in.
+        try:
+            src_size = db_path.stat().st_size
+            free = shutil.disk_usage(db_path.parent).free
+            if free - src_size < _REPAIR_BACKUP_MIN_FREE_BYTES:
+                reason = (
+                    f"only {free / 1e9:.1f}GB free on {db_path.parent}; copying "
+                    f"the {src_size / 1e9:.1f}GB damaged DB would leave less than "
+                    f"{_REPAIR_BACKUP_MIN_FREE_BYTES / 1e9:.1f}GB. Free disk space, "
+                    "then retry (or recover manually with `sqlite3 "
+                    f"{db_path} \".recover\"`)."
+                )
+                logger.error("Refusing forensic backup of %s: %s", db_path, reason)
+                return None, reason
         except OSError:
             pass
         shutil.copy2(db_path, backup_path)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2093,6 +2093,23 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         )
         seq += 1
     try:
+        # Sweep staging debris from an earlier interrupted pass (kill mid-copy)
+        # BEFORE the dedupe below. A leftover staging file is a byte-identical
+        # copy of the damaged DB, so its fingerprint MATCHES and the dedupe
+        # would otherwise hand it back as a legitimate forensic backup.
+        # Matches sidecar staging names (``.backup-staging-<stamp>-wal``) too.
+        # The second pattern is the pre-merge ``.incomplete`` spelling, swept so
+        # a host that ran that build does not keep prefix-matching debris that
+        # sorts NEWEST and survives prune forever.
+        for pattern in (
+            f"{db_path.name}.backup-staging-*",
+            f"{db_path.name}.malformed-backup-*.incomplete*",
+        ):
+            for old in db_path.parent.glob(pattern):
+                try:
+                    old.unlink(missing_ok=True)
+                except OSError:  # pragma: no cover - best effort
+                    pass
         # Dedupe (#86747): a repair loop used to copy the SAME damaged bytes
         # on every restart — ~900MB a pass, 89GB over 11 days in the
         # reporting install. If the newest existing backup already matches
@@ -2152,22 +2169,19 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
             )
             logger.error("Refusing forensic backup of %s: %s", db_path, reason)
             return None, reason
-        # Copy to a staging name that does NOT match the backup prefix, then
-        # rename into place only once every copy has succeeded. A copy that
-        # fails partway (ENOSPC, kill) would otherwise leave a prefix-matching
-        # partial that `_prune_malformed_backups` never reaches — prune runs
-        # only on the success path — so debris accumulated unbounded and, on a
-        # later successful pass, the newest-by-name partials were KEPT while
-        # intact forensic copies were pruned away.
-        staging = db_path.with_name(f"{backup_path.name}.incomplete")
+        # Copy to a staging name OUTSIDE the ``.malformed-backup-`` prefix, then
+        # rename into place only once every copy has succeeded. The prefix
+        # matters: ``_existing_malformed_backups`` matches on
+        # ``startswith(f"{db}.malformed-backup-")`` and excludes only ``-wal``/
+        # ``-shm`` suffixes, so a staging name derived from the backup name (e.g.
+        # ``…malformed-backup-<stamp>.incomplete``) still counts as a backup —
+        # it sorts NEWEST (``.incomplete`` > the bare stamp), so prune's
+        # keep-3-newest slice retained partials and deleted intact copies, and
+        # the dedupe could hand a partial back as the official ``backup_path``,
+        # passing the #69603 hard-stop gate with no real forensic copy on disk.
+        staging = db_path.with_name(f"{db_path.name}.backup-staging-{stamp}")
         staged: "List[Tuple[Path, Path]]" = []
         try:
-            # Clear debris from an earlier interrupted pass (kill mid-copy).
-            # Matches sidecar staging names (``.incomplete-wal``) too.
-            for old in db_path.parent.glob(
-                f"{db_path.name}.malformed-backup-*.incomplete*"
-            ):
-                old.unlink(missing_ok=True)
             shutil.copy2(db_path, staging)
             staged.append((staging, backup_path))
             for suffix in ("-wal", "-shm"):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1913,11 +1913,15 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
     is reached from ``repair_state_db_schema``'s exhaustion probe BEFORE
     ``_backup_db_file``'s ``has_live_connection`` guard, and the repair path is
     entered by one SessionDB while the gateway holds others, so a live peer is
-    the expected case rather than a theoretical one. When one exists we fall
-    back to ``size:mtime_ns``: a live connection means the backup is refused
-    and repair HARD STOPs (#69603), so no surgery runs and nothing moves mtime
-    behind our back — the content key is only load-bearing on the offline
-    repair path, which is exactly where the guard lets it through.
+    the expected case rather than a theoretical one.
+
+    Returns ``None`` when a live connection makes the read unsafe. Callers MUST
+    NOT substitute a differently-shaped key (an earlier revision fell back to
+    ``size:mtime_ns``): the ledger compares keys for equality, so alternating
+    between a content key and an mtime key across passes never matches, the
+    counter resets to 1 every time and the unbounded repair loop this ledger
+    exists to stop comes straight back. ``None`` means "identity unavailable",
+    and the ledger helpers below keep using the key already on record.
     """
     try:
         st = db_path.stat()
@@ -1929,14 +1933,15 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
         except ImportError:
             # Scaffold/embed installs ship hermes_state without hermes_cli. No
             # tracked connections exist there, so the raw read is safe.
-            LiveConnectionError = ()  # type: ignore[assignment]
-            offline_file_access = None  # type: ignore[assignment]
+            @contextmanager
+            def offline_file_access(_path, **_kw):
+                yield
+
+            class LiveConnectionError(Exception):
+                pass
+
         try:
-            with (
-                contextlib.nullcontext()
-                if offline_file_access is None
-                else offline_file_access(db_path, what="fingerprint")
-            ):
+            with offline_file_access(db_path, what="fingerprint"):
                 with open(db_path, "rb") as fh:
                     head = fh.read(_FINGERPRINT_SAMPLE_BYTES)
                     if st.st_size > _FINGERPRINT_SAMPLE_BYTES:
@@ -1945,7 +1950,7 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
                     else:
                         tail = b""
         except LiveConnectionError:
-            return f"{st.st_size}:{st.st_mtime_ns}"
+            return None
         digest = hashlib.sha256(head + tail).hexdigest()[:32]
         return f"{st.st_size}:{digest}"
     except OSError:
@@ -1969,15 +1974,28 @@ def _persistent_repair_attempts_exhausted(db_path: Path) -> bool:
     failed attempts against the CURRENT file fingerprint. Never raises; a
     missing/corrupt ledger or unstatable DB reads as "not exhausted" (the
     in-process claim and cross-process lock still bound a single run).
+
+    When the fingerprint is unavailable because a live connection makes the
+    content read unsafe, fall back to the SIZE the ledger recorded rather than
+    reading as "not exhausted". Otherwise a peer connection is enough to hide
+    an exhausted budget on every pass, which is the unbounded loop again.
     """
+    ledger = _read_repair_ledger(db_path)
+    recorded = ledger.get("fingerprint")
     fp = _db_fingerprint(db_path)
     if fp is None:
+        # Size is the one component both key shapes share and that a raw read
+        # is not needed for; an unchanged size means the damaged file is very
+        # likely the same one the budget was burned on.
+        try:
+            size_prefix = f"{db_path.stat().st_size}:"
+        except OSError:
+            return False
+        if not isinstance(recorded, str) or not recorded.startswith(size_prefix):
+            return False
+    elif recorded != fp:
         return False
-    ledger = _read_repair_ledger(db_path)
-    return (
-        ledger.get("fingerprint") == fp
-        and int(ledger.get("failed_attempts", 0)) >= _MAX_PERSISTENT_REPAIR_ATTEMPTS
-    )
+    return int(ledger.get("failed_attempts", 0)) >= _MAX_PERSISTENT_REPAIR_ATTEMPTS
 
 
 def _record_repair_outcome(
@@ -1987,20 +2005,30 @@ def _record_repair_outcome(
 
     Defaults to the post-attempt fingerprint — the file state the NEXT
     attempt's exhaustion probe will observe.
+
+    When the fingerprint is unavailable (a live connection makes the content
+    read unsafe), keep the key already on record and still increment: dropping
+    the pass would let a peer connection reset the budget every time, which is
+    the unbounded loop this ledger exists to stop. Never write a differently
+    shaped key — the probe compares for equality, so mixing key shapes across
+    passes never matches.
     """
     ledger_path = _repair_ledger_path(db_path)
     try:
         if repaired:
             ledger_path.unlink(missing_ok=True)
             return
+        ledger = _read_repair_ledger(db_path)
+        recorded = ledger.get("fingerprint")
         fp = fingerprint if fingerprint is not None else _db_fingerprint(db_path)
         if fp is None:
-            return
-        ledger = _read_repair_ledger(db_path)
+            if not isinstance(recorded, str):
+                # No prior key to extend and no way to mint one safely: the
+                # in-process claim and cross-process lock still bound this run.
+                return
+            fp = recorded
         attempts = (
-            int(ledger.get("failed_attempts", 0)) + 1
-            if ledger.get("fingerprint") == fp
-            else 1
+            int(ledger.get("failed_attempts", 0)) + 1 if recorded == fp else 1
         )
         import datetime
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1988,6 +1988,71 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
         return None
 
 
+def _backup_content_identity(db_path: Path) -> "Optional[str]":
+    """Recovery-image identity for forensic-backup dedupe: whole-file + sidecars.
+
+    This is a DIFFERENT equivalence relation from :func:`_db_fingerprint`, and
+    the two MUST NOT be conflated. ``_db_fingerprint`` answers "same repair
+    epoch?" — it masks SQLite's commit counters and samples only the head/tail
+    so an ordinary write does not mint a fresh repair budget. That is exactly
+    the wrong predicate for "may I reuse an existing forensic copy?": a live
+    writer can commit new transcript/session rows into an *interior* page while
+    preserving file size and leaving the first/last 64 KiB untouched, so two
+    materially different recovery images share one ``_db_fingerprint``. Reusing
+    a backup on that basis hands the operator a snapshot that predates real
+    user data (and #87409 shows a failed in-place repair can still VACUUM
+    canonical tables away), so the forensic copy must claim byte identity, not
+    epoch identity.
+
+    So this digests the ENTIRE main file plus every present sidecar
+    (``-wal``/``-shm``/``-journal``) — the WAL can hold committed frames not yet
+    checkpointed, so it is part of the recovery image. The cost is an O(n) read;
+    on a miss the caller is about to do an O(n) *write* (the full raw copy), so
+    the read is the cheaper half and never the dominant cost. Runs under
+    ``offline_file_access`` for the same POSIX-advisory-lock reason as
+    ``_db_fingerprint``; returns ``None`` when a live connection makes the read
+    unsafe (caller then declines to dedupe and takes a fresh backup — the safe
+    side, never a false reuse).
+    """
+    try:
+        from hermes_cli.sqlite_safe_read import (
+            LiveConnectionError,
+            offline_file_access,
+        )
+    except ImportError:
+        @contextmanager
+        def offline_file_access(_path, **_kw):
+            yield
+
+        class LiveConnectionError(Exception):
+            pass
+
+    def _hash_whole(path: Path, hasher: "Any") -> None:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                hasher.update(chunk)
+
+    try:
+        hasher = hashlib.sha256()
+        with offline_file_access(db_path, what="backup-identity"):
+            # Length-delimit every member (main file included) so the
+            # concatenation is prefix-free — otherwise a main-file tail could
+            # coincide with a main+sidecar split and dedupe two different
+            # recovery images together.
+            hasher.update(f"\0main:{db_path.stat().st_size}\0".encode())
+            _hash_whole(db_path, hasher)
+            for suffix in _DB_SIDECAR_SUFFIXES:
+                sidecar = db_path.with_name(db_path.name + suffix)
+                if sidecar.exists():
+                    hasher.update(f"\0{suffix}:{sidecar.stat().st_size}\0".encode())
+                    _hash_whole(sidecar, hasher)
+        return hasher.hexdigest()
+    except LiveConnectionError:
+        return None
+    except OSError:
+        return None
+
+
 def _read_repair_ledger(db_path: Path) -> "Dict[str, Any]":
     try:
         raw = json.loads(_repair_ledger_path(db_path).read_text(encoding="utf-8"))
@@ -2170,24 +2235,38 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                     pass
         # Dedupe (#86747): a repair loop used to copy the SAME damaged bytes
         # on every restart — ~900MB a pass, 89GB over 11 days in the
-        # reporting install. If the newest existing backup already matches
-        # this file, reuse it.
+        # reporting install. If the newest existing backup is byte-identical to
+        # the current recovery image, reuse it.
         #
         # Matching on mtime made this dedupe miss exactly when it mattered
         # most: the malformed-SCHEMA class still accepts writes, so live
         # writers and the in-place repair strategies move mtime between
         # passes and every pass wrote another full-size copy (2.3GB in 20
-        # minutes). Compare the content fingerprint instead, which is stable
-        # while the damaged bytes are.
+        # minutes).
+        #
+        # Use ``_backup_content_identity`` (whole file + sidecars), NOT the
+        # repair-epoch ``_db_fingerprint``. They are different equivalence
+        # relations: the fingerprint masks commit counters and samples only
+        # head/tail so an ordinary interior-page write does not re-key the
+        # repair budget — but that same write DOES change the recovery image,
+        # and deduping on the fingerprint would hand back a stale backup that
+        # predates the write. A forensic copy must prove byte identity, so it
+        # pays the O(n) read (cheaper than the O(n) write it avoids on a hit).
         try:
-            src_fp = _db_fingerprint(db_path)
-            for existing in _existing_malformed_backups(db_path)[:1]:
-                if src_fp is not None and _db_fingerprint(existing) == src_fp:
-                    logger.info(
-                        "Reusing existing forensic backup %s (identical to the "
-                        "damaged DB).", existing,
-                    )
-                    return existing, None
+            # Only hash the source when there is actually a candidate to dedupe
+            # against — on the common first-corruption pass there is no prior
+            # backup, and hashing the (possibly multi-GB) source then would be
+            # pure waste right before the copy reads it again anyway.
+            existing_backups = _existing_malformed_backups(db_path)[:1]
+            if existing_backups:
+                src_id = _backup_content_identity(db_path)
+                for existing in existing_backups:
+                    if src_id is not None and _backup_content_identity(existing) == src_id:
+                        logger.info(
+                            "Reusing existing forensic backup %s (identical to the "
+                            "damaged DB).", existing,
+                        )
+                        return existing, None
         except OSError:
             pass
         # Disk guard: this is a full raw copy of a possibly multi-GB DB plus
@@ -2238,24 +2317,49 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         # the dedupe could hand a partial back as the official ``backup_path``,
         # passing the #69603 hard-stop gate with no real forensic copy on disk.
         staging = db_path.with_name(f"{db_path.name}.backup-staging-{stamp}")
-        staged: "List[Tuple[Path, Path]]" = []
+        # (staging_src, final_dst) pairs. ORDER MATTERS for publication: the
+        # main-DB backup name is the bundle's commit marker —
+        # ``_existing_malformed_backups`` matches ``{db}.malformed-backup-*``
+        # and excludes only the ``-wal``/``-shm``/``-journal`` suffixes, so the
+        # main file appearing is what makes the bundle "count". Sidecars are
+        # therefore staged/published FIRST and the main DB LAST, so a failure
+        # partway through never leaves a countable main backup standing over a
+        # missing sidecar (an incomplete recovery image that would pass the
+        # #69603 hard stop and dedupe as legitimate on the next pass).
+        staged_sidecars: "List[Tuple[Path, Path, Path]]" = []
+        for suffix in _DB_SIDECAR_SUFFIXES:
+            sidecar = db_path.with_name(db_path.name + suffix)
+            if sidecar.exists():
+                side_staging = staging.with_name(staging.name + suffix)
+                side_dst = backup_path.with_name(backup_path.name + suffix)
+                staged_sidecars.append((sidecar, side_staging, side_dst))
+        main_pair = (staging, backup_path)
+        published: "List[Path]" = []
+        all_staging_srcs = [staging] + [s for _src, s, _d in staged_sidecars]
         try:
             shutil.copy2(db_path, staging)
-            staged.append((staging, backup_path))
-            for suffix in _DB_SIDECAR_SUFFIXES:
-                sidecar = db_path.with_name(db_path.name + suffix)
-                if sidecar.exists():
-                    side_staging = staging.with_name(staging.name + suffix)
-                    shutil.copy2(sidecar, side_staging)
-                    staged.append(
-                        (side_staging, backup_path.with_name(backup_path.name + suffix))
-                    )
-            for src, dst in staged:
+            for sidecar, side_staging, _side_dst in staged_sidecars:
+                shutil.copy2(sidecar, side_staging)
+            # Publish sidecars first, main DB LAST (the commit marker), so a
+            # mid-publish failure never leaves a countable-but-incomplete bundle.
+            publish_order = [
+                (s, d) for _src, s, d in staged_sidecars
+            ] + [main_pair]
+            for src, dst in publish_order:
                 os.replace(src, dst)
+                published.append(dst)
         except Exception:
-            for src, _ in staged:
+            # Roll back BOTH unpublished staging files AND anything already
+            # promoted — the old code unlinked only staging srcs, so a failure
+            # after the main os.replace left the official backup_path on disk.
+            for src in all_staging_srcs:
                 try:
                     src.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            for dst in published:
+                try:
+                    dst.unlink(missing_ok=True)
                 except OSError:
                     pass
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1858,6 +1858,29 @@ _MAX_MALFORMED_BACKUPS = 3
 # header on any real recovery), while staying O(1) on a multi-GB file.
 _FINGERPRINT_SAMPLE_BYTES = 65536
 
+# Byte ranges inside SQLite's 100-byte database header that move on ordinary
+# commits rather than on repair, and are therefore masked out of the content
+# sample. In rollback-journal (DELETE) mode a commit writes the main file
+# directly, bumping the file change counter (24-27) and version-valid-for
+# (92-95); a malformed-SCHEMA DB still accepts those writes, so without the
+# mask any live session write re-keys the ledger and the repair budget resets
+# to 1 forever — the exact unbounded loop this ledger exists to stop. (WAL mode
+# routes commits to the -wal sidecar, so the main file's header only moves on
+# checkpoint; masking is harmless there and correct for both.) Everything that
+# matters for repair identity — the page-1 sqlite_master b-tree — sits after
+# byte 100 and stays in the sample.
+_FINGERPRINT_VOLATILE_HEADER_RANGES = ((24, 28), (92, 96))
+
+
+def _mask_volatile_header(head: bytes) -> bytes:
+    """Zero the commit-counter fields so ordinary writes don't re-key the ledger."""
+    if len(head) < 96:
+        return head
+    buf = bytearray(head)
+    for start, end in _FINGERPRINT_VOLATILE_HEADER_RANGES:
+        buf[start:end] = b"\x00" * (end - start)
+    return bytes(buf)
+
 # Free-space headroom for the pre-repair forensic backup. The backup is a
 # full raw copy of the damaged DB (plus its -wal/-shm sidecars), so a repair
 # loop on a large state.db is a disk amplifier: the reporting incident wrote
@@ -1951,7 +1974,7 @@ def _db_fingerprint(db_path: Path) -> "Optional[str]":
                         tail = b""
         except LiveConnectionError:
             return None
-        digest = hashlib.sha256(head + tail).hexdigest()[:32]
+        digest = hashlib.sha256(_mask_volatile_header(head) + tail).hexdigest()[:32]
         return f"{st.st_size}:{digest}"
     except OSError:
         return None

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -22,6 +22,7 @@ missing free-space refusal.
 from __future__ import annotations
 
 import os
+import shutil
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -36,6 +37,7 @@ from hermes_state import (
     _existing_malformed_backups,
     _persistent_repair_attempts_exhausted,
     _record_repair_outcome,
+    _repair_backup_headroom_bytes,
 )
 
 
@@ -137,13 +139,88 @@ def test_backup_refused_when_disk_would_be_exhausted(tmp_path):
     """A nearly-full volume must not be finished off by the forensic copy."""
     db = _damaged_db(tmp_path)
     tight = type(
-        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+        "Usage",
+        (),
+        {"total": 10_000_000_000, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2},
     )()
     with patch("shutil.disk_usage", return_value=tight):
         path, reason = _backup_db_file(db)
     assert path is None
     assert reason is not None and "free" in reason.lower()
     assert not _existing_malformed_backups(db)
+
+
+def test_backup_allowed_on_small_volume_with_room(tmp_path):
+    """A flat multi-GB floor would disable repair on small VMs/containers.
+
+    50MB DB on a 10GB volume with 1.5GB free fits with ~30x headroom; the
+    guard must allow it rather than hard-stopping repair forever.
+    """
+    db = _damaged_db(tmp_path, size=50_000_000)
+    small_vm = type(
+        "Usage", (), {"total": 10_000_000_000, "used": 8_500_000_000, "free": 1_500_000_000}
+    )()
+    with patch("shutil.disk_usage", return_value=small_vm):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+
+
+def test_headroom_scales_with_volume_size():
+    """Big volumes reserve proportionally; small ones keep a modest floor."""
+    assert _repair_backup_headroom_bytes(1_000_000_000) == _REPAIR_BACKUP_MIN_FREE_BYTES
+    assert _repair_backup_headroom_bytes(1_000_000_000_000) > _REPAIR_BACKUP_MIN_FREE_BYTES
+
+
+def test_disk_guard_accounts_for_sidecars(tmp_path):
+    """The copy includes -wal/-shm, so the space check must count them."""
+    db = _damaged_db(tmp_path, size=1_000_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(400_000_000))
+    usage = type(
+        "Usage",
+        (),
+        {"total": 10_000_000_000, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES + 300_000_000},
+    )()
+    with patch("shutil.disk_usage", return_value=usage):
+        path, reason = _backup_db_file(db)
+    assert path is None, "sidecar bytes were ignored by the free-space check"
+    assert reason is not None
+
+
+def test_failed_copy_leaves_no_countable_debris(tmp_path):
+    """Prune only runs on success, so a failed copy must self-clean.
+
+    Otherwise partials matching the backup prefix accumulate unbounded and,
+    on a later successful pass, are KEPT (newest by name) while intact
+    forensic copies get pruned away.
+    """
+    db = _damaged_db(tmp_path, size=1_000_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(1_000_000))
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+    real_copy2 = shutil.copy2
+
+    def sidecar_fails(src, dst, *a, **kw):
+        if str(src).endswith("-wal"):
+            Path(dst).write_bytes(b"PARTIAL" * 100)
+            raise OSError(28, "No space left on device")
+        return real_copy2(src, dst, *a, **kw)
+
+    with patch("shutil.disk_usage", return_value=roomy), \
+            patch("shutil.copy2", sidecar_fails):
+        for _ in range(6):
+            _backup_db_file(db)
+            time.sleep(0.01)
+            os.utime(db, None)
+
+    assert len(_existing_malformed_backups(db)) <= _MAX_MALFORMED_BACKUPS
+
+    # a later successful pass must sweep any staging debris
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+    strays = list(tmp_path.glob("*.incomplete*"))
+    assert not strays, f"staging debris survived: {strays}"
 
 
 def test_backup_allowed_with_ample_disk(tmp_path):

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -1,0 +1,168 @@
+"""Regression: the state.db repair-loop guards must survive an mtime change.
+
+Incident (2026-08-17): a malformed-SCHEMA state.db sent Hermes into an
+unbounded repair loop that wrote a fresh 98MB forensic copy every ~10s —
+2.3GB in 20 minutes, disk heading to zero, whole agent fleet at risk.
+
+The #86747 guards were already present and did NOT hold, because both keyed
+on ``size:mtime_ns``:
+
+* ``_db_fingerprint`` -> the ledger's attempt counter reset to 1 on every
+  pass, so ``_MAX_PERSISTENT_REPAIR_ATTEMPTS`` was never reached;
+* ``_backup_db_file``'s dedupe compared mtime, so it never matched and each
+  pass wrote another full-size copy.
+
+Unlike the b-tree damage of #86747, the malformed-SCHEMA class still opens
+and accepts writes (only ``sqlite_master`` is unreadable), so live writers,
+WAL checkpoints and the in-place repair strategies all move mtime between
+passes. These tests pin the guards to content, not mtime, and add the
+missing free-space refusal.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import hermes_state
+from hermes_state import (
+    _MAX_MALFORMED_BACKUPS,
+    _MAX_PERSISTENT_REPAIR_ATTEMPTS,
+    _REPAIR_BACKUP_MIN_FREE_BYTES,
+    _backup_db_file,
+    _db_fingerprint,
+    _existing_malformed_backups,
+    _persistent_repair_attempts_exhausted,
+    _record_repair_outcome,
+)
+
+
+def _damaged_db(tmp_path: Path, size: int = 200_000) -> Path:
+    db = tmp_path / "state.db"
+    db.write_bytes(b"SQLite format 3\x00" + os.urandom(size))
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint stability
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_survives_mtime_change(tmp_path):
+    """A touched-but-unchanged file keeps its identity (the incident's core)."""
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    time.sleep(0.01)
+    os.utime(db, None)  # live writer / WAL checkpoint / in-place repair pass
+    assert _db_fingerprint(db) == before
+
+
+def test_fingerprint_changes_when_contents_change(tmp_path):
+    """Genuine recovery must still reset the attempt budget."""
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    db.write_bytes(b"SQLite format 3\x00" + os.urandom(200_000))
+    assert _db_fingerprint(db) != before
+
+
+def test_fingerprint_changes_on_truncation(tmp_path):
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    with open(db, "r+b") as fh:
+        fh.truncate(1024)
+    assert _db_fingerprint(db) != before
+
+
+# ---------------------------------------------------------------------------
+# Attempt ledger
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_budget_exhausts_despite_mtime_churn(tmp_path):
+    """The loop must terminate even when every pass touches the file."""
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        assert not _persistent_repair_attempts_exhausted(db)
+        _record_repair_outcome(db, repaired=False)
+        time.sleep(0.01)
+        os.utime(db, None)
+    assert _persistent_repair_attempts_exhausted(db)
+
+
+def test_successful_repair_clears_budget(tmp_path):
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        _record_repair_outcome(db, repaired=False)
+    assert _persistent_repair_attempts_exhausted(db)
+    _record_repair_outcome(db, repaired=True)
+    assert not _persistent_repair_attempts_exhausted(db)
+
+
+# ---------------------------------------------------------------------------
+# Backup dedupe
+# ---------------------------------------------------------------------------
+
+
+def test_backup_dedupes_across_mtime_change(tmp_path):
+    """Repeated passes over identical bytes must not each write a new copy."""
+    db = _damaged_db(tmp_path)
+    first, err = _backup_db_file(db)
+    assert err is None and first is not None
+    for _ in range(5):
+        time.sleep(0.01)
+        os.utime(db, None)
+        again, err = _backup_db_file(db)
+        assert err is None
+        assert again == first, "a touched-but-identical DB was copied again"
+    assert len(_existing_malformed_backups(db)) == 1
+
+
+def test_backup_retention_cap_still_holds(tmp_path):
+    """Genuinely different damaged states are kept, but bounded."""
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_MALFORMED_BACKUPS + 3):
+        db.write_bytes(b"SQLite format 3\x00" + os.urandom(200_000))
+        _backup_db_file(db)
+    assert len(_existing_malformed_backups(db)) <= _MAX_MALFORMED_BACKUPS
+
+
+# ---------------------------------------------------------------------------
+# Free-space guard
+# ---------------------------------------------------------------------------
+
+
+def test_backup_refused_when_disk_would_be_exhausted(tmp_path):
+    """A nearly-full volume must not be finished off by the forensic copy."""
+    db = _damaged_db(tmp_path)
+    tight = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+    )()
+    with patch("shutil.disk_usage", return_value=tight):
+        path, reason = _backup_db_file(db)
+    assert path is None
+    assert reason is not None and "free" in reason.lower()
+    assert not _existing_malformed_backups(db)
+
+
+def test_backup_allowed_with_ample_disk(tmp_path):
+    db = _damaged_db(tmp_path)
+    roomy = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES * 10}
+    )()
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+
+
+def test_repair_aborts_when_backup_refused_for_disk(tmp_path):
+    """Refused backup is a HARD STOP — never mutate the only damaged copy."""
+    db = _damaged_db(tmp_path)
+    tight = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+    )()
+    with patch("shutil.disk_usage", return_value=tight):
+        report = hermes_state.repair_state_db_schema(db)
+    assert not report.get("repaired")
+    assert "free" in (report.get("error") or "").lower()

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -618,3 +618,62 @@ def test_genuine_recovery_still_resets_the_budget(tmp_path):
     with open(db, "r+b") as handle:
         handle.truncate(4096)
     assert _db_fingerprint(db) != before, "truncation left the fingerprint unchanged"
+
+
+def test_forensic_backup_includes_the_rollback_journal(tmp_path):
+    """DELETE mode leaves a hot -journal, and that file interprets the damage.
+
+    Rollback-journal mode is Hermes's fallback on NFS/SMB/FUSE/ZFS and on
+    WAL-reset-vulnerable SQLite builds. A forensic copy without the journal
+    cannot be rolled back to a consistent state by hand.
+    """
+    db = _damaged_db(tmp_path, size=20_000)
+    for suffix, payload in (("-wal", b"WALDATA"), ("-journal", b"JOURNALDATA")):
+        db.with_name(db.name + suffix).write_bytes(payload)
+
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+
+    journal_copy = path.with_name(path.name + "-journal")
+    assert journal_copy.exists(), "the rollback journal was left out of the backup"
+    assert journal_copy.read_bytes() == b"JOURNALDATA"
+    assert path.with_name(path.name + "-wal").read_bytes() == b"WALDATA"
+
+    # Sidecar copies must not inflate the retention count.
+    assert len(_existing_malformed_backups(db)) == 1
+
+
+def test_prune_removes_journal_sidecars_too(tmp_path):
+    """Otherwise the retention cap leaks one -journal per pruned backup."""
+    db = _damaged_db(tmp_path, size=20_000)
+    db.with_name(db.name + "-journal").write_bytes(b"J")
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+    for _ in range(_MAX_MALFORMED_BACKUPS + 2):
+        db.write_bytes(b"SQLite format 3\x00" + os.urandom(20_000))
+        with patch("shutil.disk_usage", return_value=roomy):
+            _backup_db_file(db)
+
+    kept = _existing_malformed_backups(db)
+    assert len(kept) <= _MAX_MALFORMED_BACKUPS
+
+    # Assert on what is ON DISK rather than on the paths returned earlier: a
+    # same-second stamp collision means an earlier return value can name a file
+    # a later pass legitimately recreated.
+    kept_names = {p.name for p in kept}
+    orphans = [
+        p.name
+        for p in tmp_path.iterdir()
+        if p.name.endswith("-journal")
+        and ".malformed-backup-" in p.name
+        and p.name[: -len("-journal")] not in kept_names
+    ]
+    assert not orphans, f"pruned backups left journals behind: {orphans}"
+    # And every surviving backup keeps its journal.
+    for survivor in kept:
+        assert survivor.with_name(survivor.name + "-journal").exists()

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -287,9 +287,11 @@ def test_fingerprint_takes_no_raw_fd_while_a_connection_is_live(tmp_path):
             fp = _db_fingerprint(db)
 
         assert not opened, f"raw fd taken on a live DB: {opened}"
-        # Must still return an identity, or the attempt ledger silently stops
-        # counting (fp None => "not exhausted" => the loop never terminates).
-        assert fp is not None
+        # None is the correct answer here — see
+        # test_budget_exhausts_when_liveness_alternates_across_passes for why a
+        # substitute key shape would be worse than no key at all. The ledger
+        # keeps counting against the key already on record.
+        assert fp is None
     finally:
         live.close()
 
@@ -455,3 +457,64 @@ def test_backup_refused_when_free_space_cannot_be_determined(tmp_path):
     assert path is None
     assert reason is not None and "free space" in reason.lower()
     assert not _existing_malformed_backups(db)
+
+
+def test_budget_exhausts_when_liveness_alternates_across_passes(tmp_path):
+    """A peer connection must not reset the attempt budget.
+
+    ``_db_fingerprint`` returns None when a live connection makes the content
+    read unsafe. If the ledger treated that as "no identity" (skip the record)
+    or substituted a differently-shaped key (``size:mtime_ns``), then a gateway
+    peer connecting and disconnecting between passes would reset the counter to
+    1 forever — the exact unbounded loop this whole ledger exists to stop.
+    """
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE t(a)")
+    conn.commit()
+    conn.close()
+
+    for index in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        live = None
+        if index % 2 == 1:  # a peer holds the DB on alternate passes
+            live = connect_tracked(db, isolation_level=None, check_same_thread=False)
+        try:
+            assert not _persistent_repair_attempts_exhausted(db)
+            _record_repair_outcome(db, repaired=False)
+        finally:
+            if live is not None:
+                live.close()
+
+    assert _persistent_repair_attempts_exhausted(db), (
+        "alternating live/offline passes reset the repair budget"
+    )
+    # And an exhausted budget must stay visible even while a peer is connected.
+    live = connect_tracked(db, isolation_level=None, check_same_thread=False)
+    try:
+        assert _persistent_repair_attempts_exhausted(db)
+    finally:
+        live.close()
+
+
+def test_fingerprint_returns_none_rather_than_a_mtime_shaped_key(tmp_path):
+    """Never mint a second key SHAPE — the ledger compares for equality."""
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE t(a)")
+    conn.commit()
+    conn.close()
+
+    offline = _db_fingerprint(db)
+    assert offline is not None
+    live = connect_tracked(db, isolation_level=None, check_same_thread=False)
+    try:
+        assert _db_fingerprint(db) is None, (
+            "a live connection produced a fingerprint; if its shape differs "
+            "from the offline key the ledger can never match across passes"
+        )
+    finally:
+        live.close()

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sqlite3
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -243,3 +244,129 @@ def test_repair_aborts_when_backup_refused_for_disk(tmp_path):
         report = hermes_state.repair_state_db_schema(db)
     assert not report.get("repaired")
     assert "free" in (report.get("error") or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Lock safety: the content fingerprint must not cancel POSIX advisory locks
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_takes_no_raw_fd_while_a_connection_is_live(tmp_path):
+    """The content read must not ``open()`` a DB that has a live connection.
+
+    ``close()`` on ANY descriptor cancels every POSIX advisory lock this
+    process holds on the file (https://sqlite.org/howtocorrupt.html), so a
+    peer connection's RESERVED lock is silently dropped and another process
+    can write into a file the holder still believes it owns. The exhaustion
+    probe runs BEFORE ``_backup_db_file``'s ``has_live_connection`` guard, so
+    the fingerprint has to guard itself.
+    """
+    import builtins
+
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE t(a)")
+    conn.commit()
+    conn.close()
+
+    live = connect_tracked(db, isolation_level=None, check_same_thread=False)
+    try:
+        opened: list[str] = []
+        real_open = builtins.open
+
+        def spy(target, *a, **kw):
+            if str(target).endswith("state.db"):
+                opened.append(str(target))
+            return real_open(target, *a, **kw)
+
+        with patch.object(builtins, "open", spy):
+            fp = _db_fingerprint(db)
+
+        assert not opened, f"raw fd taken on a live DB: {opened}"
+        # Must still return an identity, or the attempt ledger silently stops
+        # counting (fp None => "not exhausted" => the loop never terminates).
+        assert fp is not None
+    finally:
+        live.close()
+
+
+def test_live_connection_keeps_its_write_lock_across_a_repair_pass(tmp_path):
+    """End-to-end: a peer must not be able to steal the holder's write lock.
+
+    The peer runs in a SUBPROCESS on purpose. POSIX advisory locks are owned
+    per-process, so a same-process peer shares the holder's lock ownership and
+    cannot demonstrate the cancellation — it stays blocked either way, which
+    makes the test vacuous.
+
+    Rollback-journal mode only — WAL coordinates through ``-shm`` rather than
+    POSIX advisory locks, so it is immune. DELETE mode is what Hermes falls
+    back to on NFS/SMB/FUSE/ZFS and on SQLite builds vulnerable to the
+    WAL-reset bug, so it is a real deployment shape, not a corner case.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.execute("CREATE TABLE sessions(id TEXT)")
+    conn.commit()
+    conn.close()
+
+    peer_script = tmp_path / "peer.py"
+    peer_script.write_text(
+        textwrap.dedent(
+            """
+            import sqlite3, sys
+            con = sqlite3.connect(sys.argv[1], timeout=0.3, isolation_level=None)
+            try:
+                con.execute("BEGIN IMMEDIATE")
+                con.execute("INSERT INTO sessions VALUES('peer')")
+                con.execute("COMMIT")
+                print("WROTE")
+            except sqlite3.OperationalError:
+                print("BLOCKED")
+            """
+        )
+    )
+
+    def _peer_can_write() -> bool:
+        out = subprocess.run(
+            [sys.executable, str(peer_script), str(db)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        ).stdout.strip()
+        assert out in {"WROTE", "BLOCKED"}, f"unexpected peer output: {out!r}"
+        return out == "WROTE"
+
+    live = connect_tracked(db, isolation_level=None, check_same_thread=False)
+    try:
+        live.execute("BEGIN IMMEDIATE")
+        live.execute("INSERT INTO sessions VALUES('holder')")
+        assert not _peer_can_write(), "peer wrote before the fingerprint (bad fixture)"
+
+        _db_fingerprint(db)
+
+        assert not _peer_can_write(), (
+            "the fingerprint cancelled the holder's POSIX advisory lock"
+        )
+        live.execute("COMMIT")
+    finally:
+        live.close()
+
+
+def test_backup_refused_when_free_space_cannot_be_determined(tmp_path):
+    """Fail CLOSED: a nearly-full volume is where disk_usage is likeliest to
+    fail, and proceeding is the multi-GB copy that finishes off the disk."""
+    db = _damaged_db(tmp_path)
+    with patch("shutil.disk_usage", side_effect=OSError("statvfs failed")):
+        path, reason = _backup_db_file(db)
+    assert path is None
+    assert reason is not None and "free space" in reason.lower()
+    assert not _existing_malformed_backups(db)

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -33,6 +33,7 @@ from hermes_state import (
     _MAX_MALFORMED_BACKUPS,
     _MAX_PERSISTENT_REPAIR_ATTEMPTS,
     _REPAIR_BACKUP_MIN_FREE_BYTES,
+    _backup_content_identity,
     _backup_db_file,
     _db_fingerprint,
     _existing_malformed_backups,
@@ -677,3 +678,107 @@ def test_prune_removes_journal_sidecars_too(tmp_path):
     # And every surviving backup keeps its journal.
     for survivor in kept:
         assert survivor.with_name(survivor.name + "-journal").exists()
+
+
+# ---------------------------------------------------------------------------
+# Backup identity vs repair-epoch fingerprint are different equivalence
+# relations (the forensic dedupe must NOT reuse _db_fingerprint).
+# ---------------------------------------------------------------------------
+
+
+def test_backup_not_deduped_after_interior_page_write(tmp_path):
+    """An interior-page write must force a fresh forensic backup.
+
+    ``_db_fingerprint`` deliberately samples only head/tail and masks commit
+    counters so an ordinary write does not re-key the repair budget. If the
+    forensic dedupe reused THAT identity, a live writer committing new rows
+    into an interior page (size preserved, first/last 64KiB untouched) would
+    be handed the STALE earlier backup as "identical" — a recovery point that
+    predates real user data. The dedupe must use ``_backup_content_identity``
+    (whole file), which detects the interior change.
+    """
+    # Larger than 2x the 64KiB head/tail sample so a middle region exists
+    # outside the sampled windows.
+    db = tmp_path / "state.db"
+    db.write_bytes(b"SQLite format 3\x00" + os.urandom(300_000))
+    size = db.stat().st_size
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        first, err = _backup_db_file(db)
+    assert err is None and first is not None
+
+    # Mutate an interior byte far from both sampled windows; keep size + mtime.
+    raw = bytearray(db.read_bytes())
+    mid = len(raw) // 2
+    raw[mid] ^= 0xFF
+    st = db.stat()
+    db.write_bytes(bytes(raw))
+    os.utime(db, ns=(st.st_atime_ns, st.st_mtime_ns))
+    assert db.stat().st_size == size
+
+    # Guard the test's own premise: the repair-epoch fingerprint is BLIND to
+    # this change (that is why it must not be the dedupe key), while the
+    # backup-content identity SEES it.
+    assert _backup_content_identity(db) != _backup_content_identity(first)
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        second, err = _backup_db_file(db)
+    assert err is None and second is not None
+    assert second != first, "an interior-page write was wrongly deduped to a stale backup"
+    assert len(_existing_malformed_backups(db)) == 2
+
+
+def test_publication_failure_leaves_no_countable_partial_bundle(tmp_path):
+    """A mid-publish os.replace failure must not leave a countable main backup.
+
+    The bundle is published sidecars-first, main-DB-last (the main name is the
+    commit marker ``_existing_malformed_backups`` counts). If a promotion after
+    the first fails, cleanup must roll back every already-published
+    destination — otherwise an incomplete bundle (main present, a sidecar
+    missing) survives, passes the #69603 hard stop, and is deduped/reused as a
+    legitimate forensic copy on the next pass.
+
+    Distinct from ``test_failed_copy_leaves_no_countable_debris``, which fails
+    during ``copy2`` (before any ``os.replace``); this exercises the
+    publication window.
+    """
+    db = _damaged_db(tmp_path, size=200_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(50_000))
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def replace_fails_after_first(src, dst, *a, **kw):
+        # Let the first promotion (a sidecar) land, fail the next one.
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError(28, "No space left on device")
+        return real_replace(src, dst, *a, **kw)
+
+    with patch("shutil.disk_usage", return_value=roomy), \
+            patch("os.replace", replace_fails_after_first):
+        try:
+            _backup_db_file(db)
+        except OSError:
+            pass  # the failure is re-raised by design; we assert on-disk state
+
+    # No countable main backup, and no orphaned promoted sidecar, may survive.
+    assert not _existing_malformed_backups(db), "a partial bundle was left countable"
+    promoted = [
+        p for p in tmp_path.iterdir()
+        if ".malformed-backup-" in p.name and p.name != "state.db"
+    ]
+    assert not promoted, f"partial promoted files survived: {promoted}"
+
+    # A later clean pass must still succeed and must not dedupe onto debris.
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+    strays = list(tmp_path.glob("*.backup-staging-*"))
+    assert not strays, f"staging debris survived: {strays}"

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -220,7 +220,9 @@ def test_failed_copy_leaves_no_countable_debris(tmp_path):
     with patch("shutil.disk_usage", return_value=roomy):
         path, reason = _backup_db_file(db)
     assert reason is None and path is not None
-    strays = list(tmp_path.glob("*.incomplete*"))
+    strays = list(tmp_path.glob("*.backup-staging-*")) + list(
+        tmp_path.glob("*.incomplete*")
+    )
     assert not strays, f"staging debris survived: {strays}"
 
 
@@ -359,6 +361,89 @@ def test_live_connection_keeps_its_write_lock_across_a_repair_pass(tmp_path):
         live.execute("COMMIT")
     finally:
         live.close()
+
+
+# ---------------------------------------------------------------------------
+# Staging must never be mistaken for a forensic backup
+# ---------------------------------------------------------------------------
+
+
+def test_staging_name_is_outside_the_backup_prefix(tmp_path):
+    """Whatever staging name the code picks must not be counted as a backup.
+
+    Observes the REAL staging path (captured from the copy call) rather than
+    hardcoding it, so the assertion binds to the invariant instead of to
+    today's spelling. ``_existing_malformed_backups`` matches
+    ``startswith(f"{db}.malformed-backup-")`` and excludes only ``-wal``/
+    ``-shm``, so a staging name derived from the backup name sorts NEWEST and
+    prune keeps partials while deleting intact copies.
+    """
+    db = _damaged_db(tmp_path, size=20_000)
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+    real_copy2 = shutil.copy2
+    staging_names: list[str] = []
+
+    def capture(src, dst, *a, **kw):
+        staging_names.append(Path(dst).name)
+        return real_copy2(src, dst, *a, **kw)
+
+    with patch("shutil.disk_usage", return_value=roomy), \
+            patch("shutil.copy2", capture):
+        path, reason = _backup_db_file(db)
+
+    assert reason is None and path is not None
+    assert staging_names, "no copy was made (fixture problem)"
+    prefix = f"{db.name}.malformed-backup-"
+    for name in staging_names:
+        assert not name.startswith(prefix), (
+            f"staging name {name!r} matches the backup prefix — it would be "
+            "counted by _existing_malformed_backups, sort NEWEST, and let "
+            "prune keep partials while deleting intact forensic copies"
+        )
+
+
+def test_orphaned_staging_is_never_returned_as_the_backup_path(tmp_path):
+    """A kill mid-copy leaves a byte-identical staging file; the dedupe must
+    not hand it back as the official ``backup_path``.
+
+    It would pass the #69603 hard-stop gate — repair then runs destructive
+    surgery believing a forensic copy exists — and the next pass's sweep
+    deletes that very file.
+    """
+    db = _damaged_db(tmp_path, size=20_000)
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    # Discover the staging name the implementation actually uses, then plant an
+    # orphan under it — so this binds to the code's scheme, not to a literal.
+    real_copy2 = shutil.copy2
+    seen: list[Path] = []
+
+    def capture(src, dst, *a, **kw):
+        seen.append(Path(dst))
+        return real_copy2(src, dst, *a, **kw)
+
+    with patch("shutil.disk_usage", return_value=roomy), \
+            patch("shutil.copy2", capture):
+        first, _ = _backup_db_file(db)
+    assert first is not None
+    Path(first).unlink(missing_ok=True)
+    orphan = seen[0]
+    shutil.copy2(db, orphan)  # identical bytes => fingerprint matches
+    assert orphan.exists()
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+
+    assert reason is None and path is not None
+    assert Path(path) != orphan, f"staging returned as the backup: {path}"
+    assert not str(path).endswith(".incomplete")
+    assert "staging" not in Path(path).name
+    assert Path(path).exists()
+    assert not orphan.exists(), "stale staging debris was not swept"
 
 
 def test_backup_refused_when_free_space_cannot_be_determined(tmp_path):

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -157,7 +157,13 @@ def test_backup_allowed_on_small_volume_with_room(tmp_path):
     50MB DB on a 10GB volume with 1.5GB free fits with ~30x headroom; the
     guard must allow it rather than hard-stopping repair forever.
     """
-    db = _damaged_db(tmp_path, size=50_000_000)
+    # Sparse: this test DOES copy the file, but the guard and copy both care
+    # about st_size, not content — 50MB of os.urandom would only cost CI time.
+    db = tmp_path / "state.db"
+    with open(db, "wb") as handle:
+        handle.write(b"SQLite format 3\x00")
+        handle.truncate(50_000_000)
+    assert db.stat().st_size == 50_000_000
     small_vm = type(
         "Usage", (), {"total": 10_000_000_000, "used": 8_500_000_000, "free": 1_500_000_000}
     )()
@@ -175,7 +181,12 @@ def test_headroom_scales_with_volume_size():
 def test_disk_guard_accounts_for_sidecars(tmp_path):
     """The copy includes -wal/-shm, so the space check must count them."""
     db = _damaged_db(tmp_path, size=1_000_000)
-    db.with_name(db.name + "-wal").write_bytes(os.urandom(400_000_000))
+    # Sparse: the guard reads st_size, so allocating 400MB of real bytes would
+    # only buy CI cost (and an ENOSPC risk on tmpfs runners).
+    wal = db.with_name(db.name + "-wal")
+    with open(wal, "wb") as handle:
+        handle.truncate(400_000_000)
+    assert wal.stat().st_size == 400_000_000
     usage = type(
         "Usage",
         (),
@@ -518,3 +529,92 @@ def test_fingerprint_returns_none_rather_than_a_mtime_shaped_key(tmp_path):
         )
     finally:
         live.close()
+
+
+# ---------------------------------------------------------------------------
+# The content sample must exclude SQLite's commit counters
+# ---------------------------------------------------------------------------
+
+
+def _populated_db(path: Path, journal_mode: str, rows: int = 600) -> None:
+    """A DB comfortably larger than the fingerprint sample window (~270KB)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(f"PRAGMA journal_mode={journal_mode}")
+    conn.execute("CREATE TABLE sessions(id TEXT, blob TEXT)")
+    conn.executemany(
+        "INSERT INTO sessions VALUES(?,?)",
+        [(str(i), "x" * 400) for i in range(rows)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_ordinary_commit_does_not_rekey_the_fingerprint(tmp_path):
+    """A malformed-SCHEMA DB still accepts writes, so commits must not re-key.
+
+    In rollback-journal (DELETE) mode a commit writes the main file directly and
+    bumps the header's file change counter (bytes 24-27) and version-valid-for
+    (92-95). Those live inside the head sample, so an unmasked fingerprint
+    changed on every ordinary session write — resetting the repair budget to 1
+    forever, which is exactly the unbounded loop this suite exists to pin.
+    """
+    for journal_mode in ("DELETE", "WAL"):
+        db = tmp_path / f"state_{journal_mode}.db"
+        _populated_db(db, journal_mode)
+        before = _db_fingerprint(db)
+
+        writer = sqlite3.connect(str(db), isolation_level=None)
+        try:
+            writer.execute("UPDATE sessions SET blob='peer' WHERE id='20000'")
+        finally:
+            writer.close()
+
+        assert _db_fingerprint(db) == before, (
+            f"{journal_mode} mode: an ordinary commit re-keyed the ledger"
+        )
+
+
+def test_budget_exhausts_while_a_writer_commits_between_passes(tmp_path):
+    """End-to-end shape of the original incident, in DELETE mode."""
+    db = tmp_path / "state.db"
+    _populated_db(db, "DELETE")
+
+    for index in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        assert not _persistent_repair_attempts_exhausted(db)
+        _record_repair_outcome(db, repaired=False)
+        writer = sqlite3.connect(str(db), isolation_level=None)
+        try:
+            writer.execute("UPDATE sessions SET blob=? WHERE id='20000'", (f"v{index}",))
+        finally:
+            writer.close()
+
+    assert _persistent_repair_attempts_exhausted(db), (
+        "a live writer's commits reset the repair budget every pass"
+    )
+
+
+def test_genuine_recovery_still_resets_the_budget(tmp_path):
+    """Masking the commit counters must not blind us to real repair."""
+    db = tmp_path / "state.db"
+    _populated_db(db, "DELETE")
+
+    def _mutate(sql: str) -> None:
+        conn = sqlite3.connect(str(db), isolation_level=None)
+        try:
+            conn.execute(sql)
+        finally:
+            conn.close()
+
+    for label, sql in (
+        ("sqlite_master rewrite", "CREATE TABLE healed(x)"),
+        ("index rebuild", "CREATE INDEX ix_sessions_id ON sessions(id)"),
+        ("VACUUM", "VACUUM"),
+    ):
+        before = _db_fingerprint(db)
+        _mutate(sql)
+        assert _db_fingerprint(db) != before, f"{label} left the fingerprint unchanged"
+
+    before = _db_fingerprint(db)
+    with open(db, "r+b") as handle:
+        handle.truncate(4096)
+    assert _db_fingerprint(db) != before, "truncation left the fingerprint unchanged"


### PR DESCRIPTION
## Description
Syncs Cluster 1: State DB Resilience & Repair Loop Hardening from upstream (`hermes_state.py`):

1. **Unbounded Repair Loop & Disk Exhaustion Defense**:
   - Prevent infinite repair iterations from exhausting disk space under corrupted DB state.
   - Proportional disk space guards and rollback journal inclusion in forensic snapshots.

2. **Atomic Backup Publishing & Fingerprint Isolation**:
   - Split forensic-backup identity from repair-epoch fingerprint.
   - Publish backup bundles atomically via staging.
   - Exclude volatile SQLite commit counters from the repair fingerprint so POSIX advisory locks remain intact.

3. **Validation**:
   - 28 regression tests in `tests/test_state_db_repair_loop_mtime.py` + 422 evolution tests passing 100%.