### PR TITLE
fix(gateway): message redelivery deduplication, ledger atomic claim, and supervisor recovery

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sqlite3
 import time
+from contextvars import Context
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -71,6 +72,23 @@ def _kanban_dispatch_allowed() -> bool:
     except ImportError:
         return True
     return not check_paused("kanban", logger)
+
+
+def _run_in_fresh_context(func: Callable[..., Any], /, *args: Any) -> Any:
+    """Run *func* in an empty ``Context`` so request-local ContextVars stay behind.
+
+    ``asyncio.to_thread`` copies the calling task's context onto the worker
+    thread. Supervised Kanban ticks are process-owned writers; if that copy
+    still carries a ``delegate_task`` child marker (spawn-time snapshot or a
+    later polluted task), ``write_txn`` false-trips. An empty Context keeps
+    the DB guard intact for real children without exempting dispatcher writes.
+    """
+    return Context().run(func, *args)
+
+
+async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) -> Any:
+    """Offload blocking dispatcher work without inheriting request-local ContextVars."""
+    return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
@@ -1681,7 +1699,7 @@ class GatewayKanbanWatchersMixin:
             try:
                 # Reap zombie children before per-board work so a board DB
                 # failure cannot block cleanup of unrelated workers.
-                pids = await asyncio.to_thread(_kb.reap_worker_zombies)
+                pids = await _to_thread_process_service(_kb.reap_worker_zombies)
                 if pids:
                     logger.info(
                         "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
@@ -1704,8 +1722,8 @@ class GatewayKanbanWatchersMixin:
                     # takes effect on the next tick, not on gateway restart (#49638).
                     _ad_enabled, _ad_per_tick = _read_auto_decompose_settings()
                     if _ad_enabled:
-                        await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
-                    results = await asyncio.to_thread(_tick_once)
+                        await _to_thread_process_service(_auto_decompose_tick, _ad_per_tick)
+                    results = await _to_thread_process_service(_tick_once)
                     any_spawned = False
                     for slug, res in (results or []):
                         if res is not None and getattr(res, "spawned", None):
@@ -1724,7 +1742,7 @@ class GatewayKanbanWatchersMixin:
                                 len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                             )
                     # Health telemetry (aggregate across boards)
-                    ready_pending = await asyncio.to_thread(_ready_nonempty)
+                    ready_pending = await _to_thread_process_service(_ready_nonempty)
                     if ready_pending and not any_spawned:
                         bad_ticks += 1
                     else:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -79,15 +79,19 @@ def _run_in_fresh_context(func: Callable[..., Any], /, *args: Any) -> Any:
 
     ``asyncio.to_thread`` copies the calling task's context onto the worker
     thread. Supervised Kanban ticks are process-owned writers; if that copy
-    still carries a ``delegate_task`` child marker (spawn-time snapshot or a
-    later polluted task), ``write_txn`` false-trips. An empty Context keeps
-    the DB guard intact for real children without exempting dispatcher writes.
+    still carries a ``delegate_task`` child marker, ``write_txn``
+    false-trips. Since watchers spawn from a fresh ``Context``
+    (``_spawn_supervised``), this offload-boundary scrub is defense in
+    depth: it covers non-supervised spawn paths and any task context frozen
+    before spawn isolation shipped. An empty Context keeps the DB guard
+    intact for real children without exempting dispatcher writes.
     """
     return Context().run(func, *args)
 
 
 async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) -> Any:
-    """Offload blocking dispatcher work without inheriting request-local ContextVars."""
+    """Offload blocking process-service work (dispatcher + notifier writers)
+    without inheriting request-local ContextVars."""
     return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
@@ -496,7 +500,7 @@ class GatewayKanbanWatchersMixin:
                     except ValueError:
                         # Unknown platform string; skip and advance cursor so
                         # we don't replay forever.
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
                         continue
@@ -516,7 +520,7 @@ class GatewayKanbanWatchersMixin:
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
                             platform_str, sub["task_id"],
                         )
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_rewind,
                             sub,
                             d["cursor"],
@@ -745,10 +749,10 @@ class GatewayKanbanWatchersMixin:
                                     "%s on %s after %d consecutive send failures",
                                     sub["task_id"], platform_str, fails,
                                 )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
                             else:
-                                await asyncio.to_thread(
+                                await _to_thread_process_service(
                                     self._kanban_rewind,
                                     sub,
                                     d["cursor"],
@@ -868,13 +872,13 @@ class GatewayKanbanWatchersMixin:
                                         "%s on %s after %d consecutive wake failures",
                                         sub["task_id"], platform_str, fails,
                                     )
-                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                    await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                     sub_fail_counts.pop(sub_key, None)
                                 else:
                                     # Rewind the pre-send claim so the next
                                     # tick retries the self-post — the event
                                     # is NOT lost.
-                                    await asyncio.to_thread(
+                                    await _to_thread_process_service(
                                         self._kanban_rewind,
                                         sub,
                                         d["cursor"],
@@ -968,13 +972,13 @@ class GatewayKanbanWatchersMixin:
                                         "%s on %s after %d consecutive wake failures",
                                         sub["task_id"], platform_str, fails,
                                     )
-                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                    await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                     sub_fail_counts.pop(sub_key, None)
                                 else:
                                     # Rewind the pre-send claim so the next
                                     # tick retries the wake — the event is
                                     # NOT lost.
-                                    await asyncio.to_thread(
+                                    await _to_thread_process_service(
                                         self._kanban_rewind,
                                         sub,
                                         d["cursor"],
@@ -988,7 +992,7 @@ class GatewayKanbanWatchersMixin:
                         # push subs): advance cursor. The cursor is the dedup
                         # mechanism — it prevents re-delivery of the same
                         # event on subsequent ticks.
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
                         if not _is_push_adapter:
@@ -1018,7 +1022,7 @@ class GatewayKanbanWatchersMixin:
                                     sub["task_id"], _wk_err, exc_info=True,
                                 )
                         if task_terminal:
-                            await asyncio.to_thread(
+                            await _to_thread_process_service(
                                 self._kanban_unsub, sub, board_slug,
                             )
             except Exception as exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11885,6 +11885,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not claimed:
             return 0
 
+        # Clear resume_pending for EVERY claimed row up front, before any
+        # send. Claiming already spent one of the row's redelivery attempts —
+        # the answer is in the ledger, so the resume path must never re-run
+        # these turns. Doing this per-row as the loop reaches each send left
+        # a window: when a slow/flood-limited send held the loop past the
+        # inbound-gate timeout, _schedule_resume_pending_sessions could
+        # replay turns for rows the loop had not reached yet (#91969).
+        for row in claimed:
+            session_key = row.get("session_key") or ""
+            if not session_key:
+                continue
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception:
+                logger.debug(
+                    "clear_resume_pending failed for %s", session_key,
+                    exc_info=True,
+                )
+
         redelivered = 0
         for row in claimed:
             try:
@@ -11906,21 +11925,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             metadata = (
                 {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             )
-
-            # Clear resume_pending BEFORE the send. The answer is already in
-            # the ledger — a hung/flood-limited send must not also replay the
-            # turn when the inbound gate times out and schedules resume
-            # (#91969). Failed sends already skipped resume; this just does
-            # that bookkeeping first.
-            session_key = row.get("session_key") or ""
-            if session_key:
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception:
-                    logger.debug(
-                        "clear_resume_pending failed for %s", session_key,
-                        exc_info=True,
-                    )
 
             try:
                 result = await adapter.send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11696,12 +11696,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         startup-restore gate.  Logs a late failure that would otherwise be
         swallowed once the task is discarded from ``_background_tasks``.
         Cancellation is expected (shutdown) and is not an error."""
+        GatewayRunner._log_late_background_failure(
+            task,
+            "background startup auto-resume task failed after gate release",
+            level=logging.DEBUG,
+        )
+
+    @staticmethod
+    def _log_late_background_failure(
+        task: "asyncio.Task", message: str, *, level: int = logging.WARNING
+    ) -> None:
+        """Shared done-callback body for boot-path tasks that outlive the
+        startup-restore gate: surface a late failure that would otherwise be
+        swallowed once the task is discarded from ``_background_tasks``.
+        Cancellation is expected (shutdown) and is not an error."""
         if task.cancelled():
             return
         exc = task.exception()
         if exc is not None:
-            logger.debug(
-                "background startup auto-resume task failed after gate release",
+            logger.log(
+                level,
+                message,
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
@@ -11721,7 +11736,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This uses the same bounded ``asyncio.wait`` the resume gate already
         uses: on timeout we return and let the sends finish in the
         background. Tasks are not cancelled.
+
+        The ledger claim + ``resume_pending`` clear happen INLINE here,
+        before the send task exists: they are pure DB work (no network,
+        bounded by claimed-row count), and deferring them into the send
+        task left a window where a hung restart notification ahead of the
+        redelivery step let the gate expire with zero rows claimed — the
+        resume scheduler then replayed turns whose answers were already in
+        the ledger, and the background task later redelivered them too
+        (duplicate delivery + re-paid turn).
         """
+        claimed = await self._claim_pending_obligations()
+
         async def _boot_sends() -> None:
             await self._send_restart_notification()
             if planned_restart_notification_pending:
@@ -11731,7 +11757,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 finally:
                     _clear_planned_restart_notification()
-            await self._redeliver_pending_obligations()
+            await self._redeliver_claimed_obligations(claimed)
 
         boot_task = asyncio.create_task(_boot_sends())
         timeout = _startup_restore_drain_timeout_secs()
@@ -11758,43 +11784,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     @staticmethod
     def _log_background_boot_send_result(task: "asyncio.Task") -> None:
         """Done-callback for boot-path sends that outlived the restore gate."""
-        if task.cancelled():
-            return
-        exc = task.exception()
-        if exc is not None:
-            logger.warning(
-                "background boot-path send failed after gate release: %s",
-                exc,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+        GatewayRunner._log_late_background_failure(
+            task, "background boot-path send failed after gate release: see traceback"
+        )
 
-    async def _redeliver_pending_obligations(self) -> int:
-        """Redeliver final responses recorded in the delivery ledger by a
-        previous (now dead) gateway process.
+    async def _claim_pending_obligations(self) -> list:
+        """Claim recoverable delivery-ledger rows and clear their
+        ``resume_pending`` flags. Pure DB work — no network sends.
 
-        Runs at startup BEFORE ``_schedule_resume_pending_sessions``. A
+        Runs INLINE at startup BEFORE ``_schedule_resume_pending_sessions``
+        and before the (bounded, abandonable) boot-send task exists. A
         session with a recoverable obligation already produced its answer —
-        the turn completed and only delivery is owed — so this method sends
-        the stored text and clears ``resume_pending`` for that session,
-        preventing the resume path from re-running (and re-paying for) a
-        turn whose output we hold.
+        the turn completed and only delivery is owed — so clearing
+        ``resume_pending`` here prevents the resume path from re-running
+        (and re-paying for) a turn whose output we hold, regardless of how
+        long the sends ahead of redelivery take (#91969).
 
         Crash-ambiguity contract (see gateway/delivery_ledger.py):
         rows that were mid-send or previously rejected carry a visible
         recovered-reply marker so a possible duplicate is labeled, never
-        silent. Returns the number of redeliveries attempted.
+        silent. Returns the claimed rows for redelivery.
         """
         try:
             from gateway.delivery_ledger import (
-                RECOVERED_MARKER,
                 ledger_enabled,
-                mark_delivered,
-                mark_failed,
                 sweep_recoverable,
             )
 
             if not await asyncio.to_thread(ledger_enabled):
-                return 0
+                return []
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
@@ -11806,17 +11824,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             logger.debug("delivery ledger sweep failed", exc_info=True)
-            return 0
+            return []
         if not claimed:
-            return 0
+            return []
 
         # Clear resume_pending for EVERY claimed row up front, before any
         # send. Claiming already spent one of the row's redelivery attempts —
         # the answer is in the ledger, so the resume path must never re-run
-        # these turns. Doing this per-row as the loop reaches each send left
-        # a window: when a slow/flood-limited send held the loop past the
-        # inbound-gate timeout, _schedule_resume_pending_sessions could
-        # replay turns for rows the loop had not reached yet (#91969).
+        # these turns (#91969).
         for row in claimed:
             session_key = row.get("session_key") or ""
             if not session_key:
@@ -11828,6 +11843,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "clear_resume_pending failed for %s", session_key,
                     exc_info=True,
                 )
+        return claimed
+
+    async def _redeliver_claimed_obligations(self, claimed: list) -> int:
+        """Redeliver final responses for rows already claimed (and
+        resume-cleared) by :meth:`_claim_pending_obligations`.
+
+        Network half of the split — runs inside the bounded boot-send task,
+        so a flood-limited send can be abandoned by the restore gate without
+        reopening the turn-replay window. Returns redeliveries attempted.
+        """
+        if not claimed:
+            return 0
+        try:
+            from gateway.delivery_ledger import (
+                RECOVERED_MARKER,
+                mark_delivered,
+                mark_failed,
+            )
+        except Exception:
+            logger.debug("delivery ledger import failed", exc_info=True)
+            return 0
 
         redelivered = 0
         for row in claimed:
@@ -11882,6 +11918,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
         return redelivered
+
+    async def _redeliver_pending_obligations(self) -> int:
+        """Claim + redeliver in one call — composition of
+        :meth:`_claim_pending_obligations` and
+        :meth:`_redeliver_claimed_obligations`.
+
+        Kept as the stable public shape (tests and any external callers
+        drive this name); the startup path calls the two halves separately
+        so the DB half can run inline before the abandonable send task.
+        """
+        return await self._redeliver_claimed_obligations(
+            await self._claim_pending_obligations()
+        )
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13151,11 +13151,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # live task even when _spawn_supervised's own backoff respawns it — so
         # _ensure_reconnect_watcher_running never mistakes a superseded handle
         # for a dead watcher and spawns a duplicate.
-        self._reconnect_watcher_task = self._spawn_supervised(
-            self._platform_reconnect_watcher,
-            "platform_reconnect_watcher",
-            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
-        )
+        self._spawn_reconnect_watcher()
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
@@ -13220,7 +13216,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # handoff for the rest of the process life).
     _SUPERVISED_HEALTHY_SECS = 300
 
-    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None):
+    @staticmethod
+    def _supervised_backoff(attempt: int) -> float:
+        """Delay before the supervisor's next respawn, in seconds.
+
+        Capped exponential. A method rather than an inline expression so the
+        schedule has one name, and so a test can collapse it -- the ordering
+        of crash / give-up / slow-tier is what the exhaustion tests assert,
+        and sleeping through the real curve to observe it would make them
+        take minutes.
+        """
+        return min(60, 2 ** min(attempt, 6))
+
+    def _spawn_supervised(
+        self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None,
+        on_give_up=None,
+    ):
         """Launch a long-lived background task with task-level supervision.
 
         Complements upstream's per-iteration inner-loop try/except (which only
@@ -13243,6 +13254,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         supervisor's own respawn creates a new task without updating that
         external handle, so ``_ensure_...`` later sees the stale/done handle
         and spawns a SECOND concurrent watcher (double reconnect attempts).
+
+        ``on_give_up`` (optional) is invoked with ``name`` when supervision is
+        abandoned — the restart budget is spent and this task will never be
+        respawned by the supervisor again. Supervision being finite is correct;
+        having no owner of the invariant afterwards is not. A task that still
+        has queued work depending on it needs somewhere to hand that fact to,
+        and before this hook existed the only thing standing between budget
+        exhaustion and a permanent silent outage was a *later, unrelated
+        event* happening to call ``_ensure_...`` (#90386). This is the
+        supervisor telling its caller "I am done; the invariant is yours now",
+        which is a thing only the supervisor knows.
         """
         if getattr(self, "_background_tasks", None) is None:
             self._background_tasks = set()
@@ -13301,8 +13323,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         effective_attempt,
                         self._SUPERVISED_HEALTHY_SECS,
                     )
+                    if on_give_up is not None:
+                        try:
+                            on_give_up(name)
+                        except Exception:  # pragma: no cover - defensive
+                            logger.debug(
+                                "on_give_up callback for %s raised",
+                                name, exc_info=True,
+                            )
                     return
-                backoff = min(60, 2 ** min(effective_attempt, 6))
+                backoff = self._supervised_backoff(effective_attempt)
 
                 async def _respawn():
                     await asyncio.sleep(backoff)
@@ -13313,6 +13343,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             restart=restart,
                             _attempt=effective_attempt + 1,
                             on_spawn=on_spawn,
+                            # Must be threaded through the recursion for the
+                            # same reason on_spawn is: the give-up that
+                            # matters is the LAST respawn's, and a callback
+                            # dropped here would leave the exhaustion branch
+                            # with no owner at exactly the moment it needs one.
+                            on_give_up=on_give_up,
                         )
 
                 respawn_task = asyncio.create_task(_respawn())
@@ -14032,6 +14068,117 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # self state, so inheriting the mixin keeps every self._kanban_* call site
     # working unchanged while lifting ~1,000 LOC out of this file.
 
+    #: Interval of the slow respawn tier that takes over once the reconnect
+    #: watcher has exhausted its supervised restart budget. Long on purpose:
+    #: the budget is spent precisely when the watcher is crashing on contact,
+    #: so the useful cadence is "check back later", not "try again now". A
+    #: tight loop here would be worse than the outage it is healing.
+    _RECONNECT_WATCHER_SLOW_RETRY_SECS = 300
+
+    #: How many slow-tier respawns to attempt while work is still queued.
+    #: Bounded, not infinite: if half an hour of five-minute retries cannot
+    #: keep a watcher alive, the fault is not transient and a louder failure
+    #: is more useful than a quieter one that never stops.
+    _MAX_SLOW_WATCHER_RESPAWNS = 6
+
+    def _on_reconnect_watcher_gave_up(self, name: str = "") -> None:
+        """Own the reconnect invariant once supervision has abandoned it.
+
+        The invariant this closes: **while the gateway is running and
+        ``_failed_platforms`` is non-empty, either a reconnect watcher is live
+        or a bounded respawn is scheduled.**
+
+        Before this, the only thing that noticed a dead watcher was a *later
+        fatal error from some other platform* reaching
+        ``_queue_retryable_fatal_platform``. That is event-coupled recovery: it
+        needs an event that, by construction, may never come. #81036 moved
+        queue publication ahead of disconnect and drops the failed adapter from
+        the live map, so once the watcher's budget is spent there may be no
+        adapter left that can emit the event recovery was waiting on. The
+        platform stays queued, nothing retries it, and the stranded check in
+        ``_handle_adapter_fatal_error_detached`` treats a queued platform as
+        safe — so the process is never restarted either.
+
+        Deliberately NOT done here: requesting a supervisor/process restart
+        when the slow tier is also exhausted. That is a policy decision about
+        blast radius (a gateway serving healthy platforms would be taken down
+        to heal a sick one) and it belongs to a maintainer, not to this patch.
+        What happens instead is a single loud error naming the still-queued
+        platforms, which is the state an operator or an external supervisor can
+        act on.
+        """
+        if not getattr(self, "_running", False):
+            return
+        if not getattr(self, "_failed_platforms", None):
+            # No queued work depends on the watcher. Letting it stay dead is
+            # correct -- the enqueue path spawns a fresh one the moment a
+            # platform is queued again.
+            logger.warning(
+                "Reconnect watcher supervision exhausted with an empty retry "
+                "queue — leaving it down until a platform is queued."
+            )
+            return
+        self._schedule_slow_reconnect_watcher_respawn(attempt=0)
+
+    def _schedule_slow_reconnect_watcher_respawn(self, *, attempt: int) -> None:
+        """Bounded slow-tier respawn of the reconnect watcher."""
+        if attempt >= self._MAX_SLOW_WATCHER_RESPAWNS:
+            logger.error(
+                "Reconnect watcher could not be kept alive after %d slow "
+                "respawns; %d platform(s) remain queued and unattended: %s. "
+                "Manual intervention or a gateway restart is required.",
+                attempt,
+                len(self._failed_platforms),
+                ", ".join(str(p) for p in self._failed_platforms),
+            )
+            return
+
+        async def _slow_respawn() -> None:
+            await asyncio.sleep(self._RECONNECT_WATCHER_SLOW_RETRY_SECS)
+            if not getattr(self, "_running", False):
+                return
+            if not getattr(self, "_failed_platforms", None):
+                # The queue drained while we waited -- something else healed
+                # it. Nothing to own any more.
+                return
+            task = getattr(self, "_reconnect_watcher_task", None)
+            if task is not None and not task.done():
+                return  # a watcher came back on its own; stand down
+            logger.warning(
+                "Reconnect watcher still down with %d platform(s) queued — "
+                "slow respawn %d/%d",
+                len(self._failed_platforms),
+                attempt + 1,
+                self._MAX_SLOW_WATCHER_RESPAWNS,
+            )
+            self._spawn_reconnect_watcher(
+                on_give_up=lambda _name: self._schedule_slow_reconnect_watcher_respawn(
+                    attempt=attempt + 1
+                )
+            )
+
+        respawn_task = asyncio.create_task(_slow_respawn())
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+        self._background_tasks.add(respawn_task)
+        respawn_task.add_done_callback(self._background_tasks.discard)
+
+    def _spawn_reconnect_watcher(self, *, on_give_up=None):
+        """Single place that knows how to launch the reconnect watcher.
+
+        Three call sites used to repeat this triple (factory, name, on_spawn),
+        and the ``on_spawn`` half of it is load-bearing: without it the
+        supervisor's own respawn leaves ``_reconnect_watcher_task`` pointing at
+        a dead handle and ``_ensure_...`` spawns a second concurrent watcher.
+        """
+        self._reconnect_watcher_task = self._spawn_supervised(
+            self._platform_reconnect_watcher,
+            "platform_reconnect_watcher",
+            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
+            on_give_up=on_give_up or self._on_reconnect_watcher_gave_up,
+        )
+        return self._reconnect_watcher_task
+
     def _ensure_reconnect_watcher_running(self) -> None:
         """Ensure the platform reconnect watcher background task is alive.
 
@@ -14053,11 +14200,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Reconnect watcher task is dead (done=%s) — respawning",
             task.done() if task is not None else "N/A",
         )
-        self._reconnect_watcher_task = self._spawn_supervised(
-            self._platform_reconnect_watcher,
-            "platform_reconnect_watcher",
-            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
-        )
+        self._spawn_reconnect_watcher()
 
     async def _platform_reconnect_watcher(self) -> None:
         """Background task that periodically retries connecting failed platforms.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ import threading
 import time
 import traceback
 from collections import OrderedDict
-from contextvars import copy_context
+from contextvars import Context, copy_context
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
@@ -13247,6 +13247,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
         occasionally over days is never permanently abandoned.
 
+        Each watcher starts in a fresh ``Context``. These are process-level
+        services, not continuations of whichever message turn happened to
+        spawn them; inheriting a delegated-child marker would make the Kanban
+        dispatcher reject its own writes when ``asyncio.to_thread`` copies the
+        watcher's context.
+
         ``on_spawn`` (optional) is invoked with the freshly-created task on
         every spawn, INCLUDING internal backoff respawns. Callers that also
         track the live handle elsewhere (e.g. ``self._reconnect_watcher_task``
@@ -13273,9 +13279,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
         _started = time.monotonic()
 
-        # Deliberately do NOT pass name= to create_task — some test doubles mock
-        # create_task with a signature that rejects the name kwarg.
-        task = asyncio.create_task(coro_factory())
+        # Deliberately do NOT pass kwargs to create_task — some test doubles
+        # mock it with a narrow signature. Calling it from a fresh Context has
+        # the same isolation semantics as create_task(..., context=Context())
+        # while preserving that compatibility.
+        task = Context().run(lambda: asyncio.create_task(coro_factory()))
         # Mark this as a PERMANENT supervised watcher, not transient background
         # WORK. The scale-to-zero idle check must ignore these: supervised
         # watchers (session-expiry, kanban, reconnect, the scale-to-zero watcher
@@ -13351,7 +13359,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             on_give_up=on_give_up,
                         )
 
-                respawn_task = asyncio.create_task(_respawn())
+                # The done callback retains the context in which it was
+                # registered, so isolate the backoff task too; otherwise a
+                # restart could reintroduce the original caller's turn scope.
+                respawn_task = Context().run(lambda: asyncio.create_task(_respawn()))
                 self._background_tasks.add(respawn_task)
                 respawn_task.add_done_callback(self._background_tasks.discard)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14982,8 +14982,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # The service manager is the sole restart owner.  Exit 75
                 # paired with ``RestartForceExitStatus=75`` asks systemd to
                 # replace this process without a second helper racing the
-                # unit's stop/start job.  launchd likewise treats the planned
-                # non-zero exit as restartable.
+                # unit's stop/start job.  The generated launchd plist's
+                # unconditional ``KeepAlive`` likewise replaces the process
+                # after this planned exit.
                 self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8140,7 +8140,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter.fatal_error_retryable:
             return False
         platform_config = self.config.platforms.get(adapter.platform)
-        if not platform_config or adapter.platform in self._failed_platforms:
+        if not platform_config:
+            return False
+        if adapter.platform in self._failed_platforms:
+            # Nothing to enqueue -- but "already queued" is precisely the state
+            # in which the watcher has had time to die, and the enqueue branch
+            # below holds the ONLY call to _ensure_reconnect_watcher_running().
+            #
+            # _spawn_supervised auto-restarts the watcher after a crash (#71758),
+            # but only _MAX_SUPERVISED_RESTARTS times in rapid succession; past
+            # that it logs "giving up restarts" and the watcher stays dead
+            # forever. _ensure_reconnect_watcher_running is the documented
+            # backstop for exactly that budget exhaustion (#70344) -- and it was
+            # unreachable for a platform already in the queue, which is the only
+            # kind of platform the watcher can have been retrying long enough to
+            # exhaust it on.
+            #
+            # The result is a silent permanent outage: nothing retries, and the
+            # stranded check in _handle_adapter_fatal_error_detached deliberately
+            # treats a queued platform as safe, so the process never restarts
+            # either (#90386).
+            self._ensure_reconnect_watcher_running()
             return False
         self._failed_platforms[adapter.platform] = {
             "config": platform_config,
@@ -14018,8 +14038,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         If the tracked reconnect watcher task has died (e.g. from exhausting
         its restart budget, or a terminal exception that _spawn_supervised
         could not recover), respawns it so platforms queued for reconnection
-        are not permanently stranded. Called after queueing a retryable fatal
-        error in _handle_adapter_fatal_error (#70344).
+        are not permanently stranded. Called from
+        _queue_retryable_fatal_platform on BOTH paths (#70344, #90386): after a
+        new enqueue, and after a re-fatal for a platform that is already queued
+        -- the latter being the only case in which the watcher can have been
+        retrying long enough to exhaust its supervised restart budget.
         """
         if not getattr(self, "_running", False):
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11780,6 +11780,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
+    async def _await_startup_boot_sends(
+        self,
+        *,
+        planned_restart_notification_pending: bool,
+    ) -> None:
+        """Run boot-path sends without letting them pin the inbound restore gate.
+
+        ``_send_restart_notification`` and ``_redeliver_pending_obligations``
+        used to be awaited inline *before* ``_finish_startup_restore``
+        released the gate. A single Telegram flood-control sleep on either
+        send froze inbound on every platform for the full ``retry_after``
+        (#91969).
+
+        This uses the same bounded ``asyncio.wait`` the resume gate already
+        uses: on timeout we return and let the sends finish in the
+        background. Tasks are not cancelled.
+        """
+        async def _boot_sends() -> None:
+            await self._send_restart_notification()
+            if planned_restart_notification_pending:
+                try:
+                    await self._send_home_channel_startup_notifications(
+                        skip_targets=None,
+                    )
+                finally:
+                    _clear_planned_restart_notification()
+            await self._redeliver_pending_obligations()
+
+        boot_task = asyncio.create_task(_boot_sends())
+        timeout = _startup_restore_drain_timeout_secs()
+        if timeout > 0:
+            _done, pending = await asyncio.wait({boot_task}, timeout=timeout)
+            if pending:
+                logger.warning(
+                    "Boot-path sends still running after %.0fs; releasing "
+                    "inbound gate so other platforms are not frozen. "
+                    "Restart notification / obligation redelivery continue "
+                    "in the background.",
+                    timeout,
+                )
+                boot_task.add_done_callback(self._log_background_boot_send_result)
+                tasks = getattr(self, "_background_tasks", None)
+                if tasks is None:
+                    self._background_tasks = set()
+                    tasks = self._background_tasks
+                tasks.add(boot_task)
+                boot_task.add_done_callback(tasks.discard)
+        else:
+            await boot_task
+
+    @staticmethod
+    def _log_background_boot_send_result(task: "asyncio.Task") -> None:
+        """Done-callback for boot-path sends that outlived the restore gate."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "background boot-path send failed after gate release: %s",
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
     async def _redeliver_pending_obligations(self) -> int:
         """Redeliver final responses recorded in the delivery ledger by a
         previous (now dead) gateway process.
@@ -11843,6 +11906,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             metadata = (
                 {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             )
+
+            # Clear resume_pending BEFORE the send. The answer is already in
+            # the ledger — a hung/flood-limited send must not also replay the
+            # turn when the inbound gate times out and schedules resume
+            # (#91969). Failed sends already skipped resume; this just does
+            # that bookkeeping first.
+            session_key = row.get("session_key") or ""
+            if session_key:
+                try:
+                    await self.async_session_store.clear_resume_pending(session_key)
+                except Exception:
+                    logger.debug(
+                        "clear_resume_pending failed for %s", session_key,
+                        exc_info=True,
+                    )
+
             try:
                 result = await adapter.send(
                     chat_id=row["chat_id"],
@@ -11873,18 +11952,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
-
-            # The answer reached (or was owed to) this session — don't ALSO
-            # re-run the turn via the resume path.
-            session_key = row.get("session_key") or ""
-            if session_key:
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception:
-                    logger.debug(
-                        "clear_resume_pending failed for %s", session_key,
-                        exc_info=True,
-                    )
         return redelivered
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
@@ -12970,32 +13037,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # of a restart cycle (see _is_stale_restart_redelivery).
         if chat_restart_notification_pending:
             self._booted_from_restart = True
-        await self._send_restart_notification()
-
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
-            try:
-                await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
-                )
-            finally:
-                _clear_planned_restart_notification()
+        # Restart notification, home-channel startup notice, and obligation
+        # redelivery all call adapter.send(). Those sends must not pin the
+        # inbound restore gate — a Telegram flood-control sleep on this path
+        # froze every platform for the full penalty (#91969). Bound them the
+        # same way _finish_startup_restore bounds resume turns.
+        await self._await_startup_boot_sends(
+            planned_restart_notification_pending=planned_restart_notification_pending,
+        )
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
         # by the normal successful-turn path, so a failed auto-resume remains
         # visible for manual recovery on the next user message.
         #
-        # Delivery-obligation redelivery runs FIRST: a session whose final
-        # response was generated but never confirmed-delivered has its answer
-        # in the ledger — redelivering it (and clearing resume_pending for
-        # that session) is strictly cheaper and more correct than re-running
-        # the whole turn.
-        await self._redeliver_pending_obligations()
+        # Delivery-obligation redelivery already ran inside
+        # _await_startup_boot_sends (and clears resume_pending before send):
+        # a session whose final response was generated but never
+        # confirmed-delivered has its answer in the ledger — redelivering it
+        # is strictly cheaper and more correct than re-running the whole turn.
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11368,101 +11368,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 start_new_session=True,
             )
 
-    def _launch_systemd_restart_shortcut(self) -> None:
-        """Best-effort helper to bypass systemd's automatic restart delay.
-
-        For planned in-chat restarts, the gateway exits cleanly so systemd does
-        not record a failure.  However, units with RestartSteps still count
-        automatic restarts and can delay repeated /restart tests.  A transient
-        user service survives our cgroup teardown and explicitly starts the
-        gateway as soon as this PID exits, while the unit keeps its normal
-        backoff for real crash loops.
-        """
-        if sys.platform != "linux" or not os.environ.get("INVOCATION_ID"):
-            return
-
-        try:
-            import shutil
-            import subprocess
-
-            systemd_run = shutil.which("systemd-run")
-            systemctl = shutil.which("systemctl")
-            if not systemd_run or not systemctl:
-                return
-
-            try:
-                from hermes_cli.gateway import get_service_name
-
-                service_name = get_service_name()
-            except Exception:
-                service_name = "hermes-gateway"
-
-            current_pid = os.getpid()
-
-            # Detect whether the gateway unit is registered as a system or
-            # user service.  Daemon-style deployments are typically system
-            # units (e.g. /etc/systemd/system/hermes-gateway.service), while
-            # `hermes setup` under a non-root account may register a user
-            # unit.  Hard-coding ``--user`` broke system-unit deployments:
-            # systemctl returned an empty MainPID, the PID-equality check
-            # below failed, and the planned-restart helper was never
-            # launched — leaving the gateway dead until a manual reboot.
-            def _query_pid(scope_flags):
-                try:
-                    out = subprocess.run(
-                        [systemctl, *scope_flags, "show", service_name,
-                         "--property=MainPID", "--value"],
-                        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2,
-                    )
-                    return (out.stdout or "").strip()
-                except Exception:
-                    return ""
-
-            system_pid = _query_pid([])
-            user_pid = _query_pid(["--user"])
-            if str(current_pid) == system_pid:
-                scope_flags = []
-                systemctl_scope = "systemctl"
-            elif str(current_pid) == user_pid:
-                scope_flags = ["--user"]
-                systemctl_scope = "systemctl --user"
-            else:
-                # MainPID does not match in either scope — likely invoked
-                # outside of systemd or the unit was renamed.  Bail out
-                # rather than restart the wrong unit.
-                return
-
-            service_arg = shlex.quote(service_name)
-            shell_cmd = (
-                f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-                f"{systemctl_scope} reset-failed {service_arg}; "
-                f"{systemctl_scope} restart {service_arg}"
-            )
-            unit_name = f"{service_name}-planned-restart-{current_pid}".replace(".", "-")
-            subprocess.Popen(
-                [
-                    systemd_run,
-                    *scope_flags,
-                    "--collect",
-                    "--unit",
-                    unit_name,
-                    "/bin/sh",
-                    "-lc",
-                    shell_cmd,
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-            logger.info(
-                "Launched systemd planned-restart helper for %s (pid=%s, scope=%s)",
-                service_name,
-                current_pid,
-                "user" if scope_flags else "system",
-            )
-        except Exception as e:
-            logger.debug("Failed to launch systemd planned-restart helper: %s", e)
-
     def _wedged_agent_count(self) -> int:
         """Count running chat agents already past the inactivity timeout.
 
@@ -15074,25 +14979,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.debug("Failed to write planned restart notification marker: %s", e)
 
             if self._restart_requested and self._restart_via_service:
-                self._launch_systemd_restart_shortcut()
-                # Always exit with TEMPFAIL (75) on service-managed
-                # restarts.  The shortcut helper above is best-effort and
-                # commonly fails on real deployments: non-root gateway
-                # units hit Polkit denials when invoking ``systemd-run
-                # --system``, headless boxes have no user bus for
-                # ``--user``, and operator-managed unit files may use
-                # ``Restart=on-failure`` rather than ``Restart=always``.
-                # Exit 75 paired with ``RestartForceExitStatus=75`` makes
-                # systemd treat the planned restart as a controlled
-                # failure and revive the unit via ``Restart=on-failure``,
-                # regardless of whether the helper survived.  Without
-                # this, a clean exit (0) on Linux left the gateway dead
-                # until someone rebooted the host.  Only the planned code
-                # (75) is whitelisted via ``RestartForceExitStatus``; a
-                # genuine crash exits non-zero-but-not-75, so real crash
-                # loops are still governed by the unit's normal
-                # ``Restart=``/``RestartSec`` (and any StartLimit the
-                # operator sets) rather than force-restarted here.
+                # The service manager is the sole restart owner.  Exit 75
+                # paired with ``RestartForceExitStatus=75`` asks systemd to
+                # replace this process without a second helper racing the
+                # unit's stop/start job.  launchd likewise treats the planned
+                # non-zero exit as restartable.
                 self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -382,7 +382,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
                 if value.isdigit():
                     timeout_us = int(value)
                 else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
+                    timeout_us = parse_systemd_duration_to_us(value)
                 if timeout_us is not None:
                     break
         if timeout_us is not None:
@@ -406,11 +406,13 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     }
 
 
-def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:
+def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
     """Parse 'TimeoutStopUSec=1min 30s' / '90s' style values to microseconds.
 
     systemd accepts a wide grammar; we cover the common cases (s, ms, min,
     h) and return None on anything unexpected.  Never raises.
+
+    Public: also consumed by hermes_cli.gateway's restart-wait sizing.
     """
     if not raw:
         return None
@@ -460,3 +462,7 @@ def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:
                 return None
             digits = ""
     return total_us if total_us > 0 else None
+
+
+# Backward-compat private alias (pre-promotion name).
+_parse_systemd_duration_to_us = parse_systemd_duration_to_us

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1278,7 +1278,7 @@ def _wait_for_systemd_service_restart(
 
 def _systemd_restart_wait_timeout(system: bool = False) -> float:
     """Cover systemd's relaunch delays before applying the runtime wait floor."""
-    from gateway.shutdown_forensics import _parse_systemd_duration_to_us
+    from gateway.shutdown_forensics import parse_systemd_duration_to_us
 
     props = _read_systemd_unit_properties(
         system=system,
@@ -1288,7 +1288,7 @@ def _systemd_restart_wait_timeout(system: bool = False) -> float:
     for name in ("RestartUSec", "TimeoutStartUSec"):
         raw = props.get(name, "")
         duration_us = (
-            int(raw) if raw.isdigit() else _parse_systemd_duration_to_us(raw)
+            int(raw) if raw.isdigit() else parse_systemd_duration_to_us(raw)
         )
         if duration_us is not None:
             supervisor_budget += duration_us / 1_000_000

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3979,26 +3979,11 @@ def systemd_restart(system: bool = False):
             f"waiting up to {wait_budget:.0f}s for in-flight turns + drain..."
         )
         if _graceful_restart_via_sigusr1(pid, wait_budget):
-            # The gateway exits with code 75 for a planned service restart.
-            # RestartSec can otherwise delay the relaunch even though the
-            # operator asked for an immediate restart, so kick the unit once
-            # the old PID has exited and then wait for the replacement PID.
-            _run_systemctl(
-                ["reset-failed", svc],
-                system=system,
-                check=False,
-                timeout=30,
-            )
-            _run_systemctl(
-                ["restart", svc],
-                system=system,
-                check=False,
-                timeout=90,
-            )
-            if _wait_for_systemd_service_restart(system=system, previous_pid=pid):
-                return
-            if _systemd_service_is_start_limited(system=system):
-                return
+            # Exit 75 transfers restart ownership to systemd.  Observe that
+            # single replacement instead of issuing another restart that can
+            # stop the process systemd has already brought up.
+            _wait_for_systemd_service_restart(system=system, previous_pid=pid)
+            return
 
         print(
             f"⚠ Graceful restart did not complete within {int(wait_budget)}s; "

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1211,13 +1211,15 @@ def _wait_for_systemd_service_restart(
     *,
     system: bool = False,
     previous_pid: int | None = None,
-    timeout: float = 60.0,
+    timeout: float | None = None,
 ) -> bool:
     """Wait for the gateway service to become active after a restart handoff."""
     import time
 
     svc = get_service_name()
     scope_label = _service_scope_label(system).capitalize()
+    if timeout is None:
+        timeout = _systemd_restart_wait_timeout(system=system)
     deadline = time.monotonic() + timeout
     printed_runtime_wait = False
 
@@ -1272,6 +1274,25 @@ def _wait_for_systemd_service_restart(
         f"  Check logs:   journalctl {'--user ' if not system else ''}-u {svc} -l --since '2 min ago'"
     )
     return False
+
+
+def _systemd_restart_wait_timeout(system: bool = False) -> float:
+    """Cover systemd's relaunch delays before applying the runtime wait floor."""
+    from gateway.shutdown_forensics import _parse_systemd_duration_to_us
+
+    props = _read_systemd_unit_properties(
+        system=system,
+        properties=("RestartUSec", "TimeoutStartUSec"),
+    )
+    supervisor_budget = 0.0
+    for name in ("RestartUSec", "TimeoutStartUSec"):
+        raw = props.get(name, "")
+        duration_us = (
+            int(raw) if raw.isdigit() else _parse_systemd_duration_to_us(raw)
+        )
+        if duration_us is not None:
+            supervisor_budget += duration_us / 1_000_000
+    return 60.0 + supervisor_budget
 
 
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
@@ -3982,13 +4003,32 @@ def systemd_restart(system: bool = False):
             # Exit 75 transfers restart ownership to systemd.  Observe that
             # single replacement instead of issuing another restart that can
             # stop the process systemd has already brought up.
-            _wait_for_systemd_service_restart(system=system, previous_pid=pid)
-            return
+            if _wait_for_systemd_service_restart(system=system, previous_pid=pid):
+                return
+            if _systemd_service_is_start_limited(system=system):
+                return
 
-        print(
-            f"⚠ Graceful restart did not complete within {int(wait_budget)}s; "
-            "forcing a service restart..."
-        )
+            # A replacement may have started but not reached gateway runtime
+            # readiness before the wait expired.  Never stop that generation.
+            props = _read_systemd_unit_properties(system=system)
+            replacement_pid = _systemd_main_pid_from_props(props)
+            if (
+                props.get("ActiveState") in {"active", "activating", "reloading"}
+                or props.get("SubState") == "auto-restart"
+                or (replacement_pid is not None and replacement_pid != pid)
+            ):
+                return
+
+            print(
+                "⚠ Systemd did not relaunch the gateway after its graceful exit; "
+                "forcing a service restart..."
+            )
+        else:
+            print(
+                f"⚠ Graceful restart did not complete within {int(wait_budget)}s; "
+                "forcing a service restart..."
+            )
+
         _run_systemctl(
             ["reset-failed", svc],
             system=system,

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -221,6 +221,44 @@ class TestGatewayRedeliverySweep:
 
         assert blocked_event_loop == []
 
+    @pytest.mark.asyncio
+    async def test_clear_resume_pending_before_send_so_a_hang_cannot_also_resume(
+        self,
+    ):
+        """A hung redelivery send must still clear resume_pending.
+
+        Otherwise a timed-out startup-restore gate would schedule resume and
+        replay a turn whose answer is already in the ledger (#91969).
+        """
+        import asyncio
+
+        _record()
+        _orphan("ob-1")
+        hang = asyncio.Event()
+
+        async def hanging_send(**_kwargs):
+            await hang.wait()
+            return MagicMock(success=True, error="")
+
+        adapter = MagicMock()
+        adapter.send = hanging_send
+        runner = self._runner(adapter)
+        task = asyncio.create_task(runner._redeliver_pending_obligations())
+
+        deadline = asyncio.get_running_loop().time() + 2
+        while runner._async_session_store.clear_resume_pending.await_count == 0:
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("resume_pending was not cleared before send")
+            await asyncio.sleep(0)
+
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            "agent:main:slack:channel:C1"
+        )
+        assert not task.done()
+
+        hang.set()
+        assert await task == 1
+
 
 class TestAttemptsOnlySpentOnRealSends:
     """``attempts`` is the redelivery budget — it must buy a send.

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -145,6 +146,26 @@ async def test_gateway_stop_settles_completion_batch_before_adapter_disconnect()
     assert await asyncio.wait_for(pending, timeout=1.0) is False
     assert call_order == ["batch_cancel_start", "batch_cancel_done", "disconnect"]
     assert runner._completion_notification_batch_flush_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_planned_service_exit_issues_no_restart_of_its_own(monkeypatch):
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_requested = True
+    runner._restart_via_service = True
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail(
+            f"planned service exit must not spawn a restart helper: {args}"
+        ),
+    )
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -853,3 +853,148 @@ class TestVoiceInputCallbackWiring:
             "startup must wire _voice_input_callback"
         )
 
+
+
+class TestRequeueHealsDeadReconnectWatcher:
+    """Regression for #90386: a second retryable fatal error for a platform that
+    is ALREADY queued must still check that the reconnect watcher is alive.
+
+    ``_ensure_reconnect_watcher_running()`` is the documented backstop for the
+    watcher exhausting ``_MAX_SUPERVISED_RESTARTS`` (#70344) -- ``_spawn_supervised``
+    stops respawning after that and logs "giving up restarts". Its only call site
+    sat behind the newly-queued branch of ``_queue_retryable_fatal_platform``,
+    so it could never fire for a platform already in ``_failed_platforms`` --
+    which is the only kind of platform the watcher can have been retrying long
+    enough to exhaust the budget on.
+
+    The observable result is a silent permanent outage: the queue holds the
+    platform, nothing retries it, and the stranded check in
+    ``_handle_adapter_fatal_error_detached`` deliberately treats a queued
+    platform as safe, so the process is never restarted either.
+    """
+
+    @staticmethod
+    def _runner_with_dead_watcher(spawned):
+        runner = _make_runner()
+        runner._running = True
+        runner._background_tasks = set()
+
+        def _fake_spawn(coro_factory, name, **kwargs):
+            spawned.append(name)
+            handle = MagicMock()
+            handle.done.return_value = False
+            on_spawn = kwargs.get("on_spawn")
+            if on_spawn is not None:
+                on_spawn(handle)
+            return handle
+
+        runner._spawn_supervised = _fake_spawn
+        return runner
+
+    @staticmethod
+    def _already_queued(runner, *, attempts=7):
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": runner.config.platforms[Platform.TELEGRAM],
+            "attempts": attempts,
+            "next_retry": time.monotonic() + 300,
+            "queued_at": time.monotonic() - 3600,
+            "credential_claim": None,
+            "listener_claim": None,
+        }
+
+    @staticmethod
+    def _fatal_adapter():
+        adapter = StubAdapter()
+        adapter._set_fatal_error(
+            "telegram_network_error",
+            "Telegram polling could not reconnect after 10 network error retries.",
+            retryable=True,
+        )
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_requeue_respawns_a_watcher_that_gave_up_restarting(self):
+        """The core #90386 regression.
+
+        Telegram is queued and the watcher has exhausted its restart budget, so
+        the task is done and ``_spawn_supervised`` will never bring it back on
+        its own. A fresh retryable fatal error arrives for that same platform.
+        Nothing is enqueued (it is already there), but the watcher MUST be
+        respawned -- otherwise the queue entry is retried by nobody, forever.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner)
+
+        async def _died():
+            return None
+
+        dead = asyncio.create_task(_died())
+        await dead
+        runner._reconnect_watcher_task = dead
+
+        queued = runner._queue_retryable_fatal_platform(self._fatal_adapter())
+
+        assert queued is False, "already-queued platform must not be re-enqueued"
+        assert spawned == ["platform_reconnect_watcher"], (
+            "a re-fatal on an already-queued platform must still heal a dead "
+            "reconnect watcher -- it is the only remaining path back to the "
+            "queue once _spawn_supervised has given up restarting (#90386)"
+        )
+        assert not runner._reconnect_watcher_task.done(), (
+            "the tracked handle must point at the newly spawned watcher"
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue_does_not_disturb_the_existing_queue_entry(self):
+        """Guardrail on the fix: healing the watcher must not become a re-enqueue.
+
+        Overwriting the entry would reset ``attempts`` and ``next_retry``, so a
+        platform that fails repeatedly would restart its backoff ladder on every
+        fatal error and hammer a provider that is already refusing it.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner, attempts=7)
+        before = dict(runner._failed_platforms[Platform.TELEGRAM])
+
+        async def _died():
+            return None
+
+        dead = asyncio.create_task(_died())
+        await dead
+        runner._reconnect_watcher_task = dead
+
+        assert runner._queue_retryable_fatal_platform(self._fatal_adapter()) is False
+        assert runner._failed_platforms[Platform.TELEGRAM] == before, (
+            "the existing queue entry, including its attempt count and backoff "
+            "deadline, must survive the watcher heal untouched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue_with_a_live_watcher_spawns_nothing(self):
+        """Guardrail on the fix: a live watcher must not be duplicated.
+
+        Two concurrent watchers would double every reconnect attempt, which is
+        the failure ``_spawn_supervised``'s ``on_spawn`` handle-tracking exists
+        to prevent.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner)
+
+        async def _alive():
+            await asyncio.sleep(5)
+
+        live = asyncio.create_task(_alive())
+        runner._reconnect_watcher_task = live
+        try:
+            assert runner._queue_retryable_fatal_platform(self._fatal_adapter()) is False
+            assert spawned == [], "a live watcher must never be respawned"
+            assert runner._reconnect_watcher_task is live
+        finally:
+            live.cancel()
+            try:
+                await live
+            except asyncio.CancelledError:
+                pass

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -446,6 +446,28 @@ class TestSpawnSupervised:
     """Verify the task-level supervision wrapper around watcher launches."""
 
     @pytest.mark.asyncio
+    async def test_watcher_does_not_inherit_delegated_child_context(self):
+        """Long-lived gateway services must not inherit one turn's child scope."""
+        from agent.delegation_context import (
+            delegated_child_context,
+            is_delegated_child_context,
+        )
+
+        runner = _make_runner()
+        observed = []
+
+        async def _watcher():
+            observed.append(is_delegated_child_context())
+
+        with delegated_child_context():
+            assert is_delegated_child_context() is True
+            task = runner._spawn_supervised(_watcher, "isolated_watcher")
+            await task
+            assert is_delegated_child_context() is True
+
+        assert observed == [False]
+
+    @pytest.mark.asyncio
     async def test_clean_synchronous_return_is_not_respawned(self):
         # A supervised coro that returns immediately (clean exit) must be
         # invoked EXACTLY ONCE — a clean return means deliberate shutdown or a

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -998,3 +998,192 @@ class TestRequeueHealsDeadReconnectWatcher:
                 await live
             except asyncio.CancelledError:
                 pass
+
+
+class TestSupervisionExhaustionHasAnOwner:
+    """The witness @andrexibiza asked for on #90448: recovery with NO new event.
+
+    The predecessor architecture (#72366, salvage of #71867 by @ygd58)
+    established that a reconnect watcher which dies while work is queued must
+    be respawned by something *autonomous*, because the only other trigger --
+    a fresh fatal error from another platform -- may never arrive. Supervised
+    restart closed that, but supervision is finite: after
+    ``_MAX_SUPERVISED_RESTARTS`` rapid crashes it logs "giving up restarts" and
+    stops.
+
+    Past that point the system is back in exactly the state #72366 described.
+    And #81036 (salvage of #80700, preserving @HexLab98) makes the missing
+    event less likely rather than more: it publishes the queue *before*
+    disconnect and drops the failed adapter from the live map, so there may be
+    no adapter left to emit the callback recovery was waiting on.
+
+    These tests exercise that state directly. They queue a platform, let the
+    watcher burn its whole budget, and then emit **no further fatal
+    callbacks at all** -- the thing the branch-level regression tests below
+    cannot prove, because they manufacture the event.
+    """
+
+    @staticmethod
+    def _runner(monkeypatch, *, crashes):
+        """A runner whose reconnect watcher crashes `crashes` times, then lives."""
+        runner = _make_runner()
+        runner._background_tasks = set()
+        runner._reconnect_watcher_task = None
+        runner.state = {"live": 0, "spawns": 0}
+
+        # Collapse every real-time delay: the point is the ORDER of events, not
+        # their spacing. Left as class attributes in production precisely so a
+        # test can do this without sleeping for half an hour.
+        monkeypatch.setattr(GatewayRunner, "_MAX_SUPERVISED_RESTARTS", 2)
+        monkeypatch.setattr(GatewayRunner, "_SUPERVISED_HEALTHY_SECS", 3600)
+        monkeypatch.setattr(GatewayRunner, "_RECONNECT_WATCHER_SLOW_RETRY_SECS", 0)
+        monkeypatch.setattr(GatewayRunner, "_supervised_backoff", staticmethod(lambda _a: 0))
+
+        remaining = {"n": crashes}
+
+        async def _watcher():
+            runner.state["spawns"] += 1
+            if remaining["n"] > 0:
+                remaining["n"] -= 1
+                raise RuntimeError("watcher crashed on contact")
+            # Healthy: stay alive so `task.done()` is False.
+            runner.state["live"] += 1
+            await asyncio.Event().wait()
+
+        runner._platform_reconnect_watcher = _watcher
+        return runner
+
+    @staticmethod
+    def _queue_telegram(runner):
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": runner.config.platforms[Platform.TELEGRAM],
+            "attempts": 9,
+            "next_retry": time.monotonic() + 300,
+            "queued_at": time.monotonic() - 7200,
+            "credential_claim": None,
+            "listener_claim": None,
+        }
+
+    @staticmethod
+    async def _settle(times=40):
+        """Let the supervisor's done-callbacks and respawn tasks drain."""
+        for _ in range(times):
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_watcher_recovers_after_budget_exhaustion_with_no_new_event(
+        self, monkeypatch
+    ):
+        """The whole review gate in one test.
+
+        Queue a platform, crash the watcher past its supervised budget, then do
+        nothing at all -- no fatal callback, no enqueue, no external poke. The
+        watcher must come back on its own once it stops crashing.
+        """
+        # One crash more than supervision will tolerate, so the give-up branch
+        # is genuinely reached and the slow tier is what recovers it.
+        runner = self._runner(monkeypatch, crashes=3)
+        self._queue_telegram(runner)
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(300)
+
+        assert runner.state["live"] == 1, (
+            "with no new fatal event, only the slow tier can have brought the "
+            "watcher back after supervision gave up"
+        )
+        assert runner._reconnect_watcher_task is not None
+        assert not runner._reconnect_watcher_task.done()
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_the_slow_tier_is_bounded_not_a_restart_loop(self, monkeypatch):
+        """A watcher that never recovers must stop being respawned, and say so."""
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+        monkeypatch.setattr(GatewayRunner, "_MAX_SLOW_WATCHER_RESPAWNS", 3)
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(400)
+
+        assert runner.state["live"] == 0
+        # Bounded, and the arithmetic is worth stating because it is the
+        # whole safety argument. Each slow-tier attempt hands the watcher a
+        # FRESH supervised budget -- that is deliberate, since a slow retry is
+        # a new bet that conditions have changed -- so the ceiling is
+        # (1 + _MAX_SUPERVISED_RESTARTS) x (1 + _MAX_SLOW_WATCHER_RESPAWNS):
+        # here (1+2) x (1+3) = 12. With production values that is 6 x 7 = 42
+        # spawns spread across at least half an hour, which is a ladder, not
+        # a restart loop. A tight loop here would be worse than the outage it
+        # is healing.
+        assert runner.state["spawns"] == 12, (
+            f"expected a finite spawn ladder, got {runner.state['spawns']}"
+        )
+        assert runner._reconnect_watcher_task.done()
+
+        # And it stays stopped: no further spawns once the ladder is spent.
+        await self._settle(400)
+        assert runner.state["spawns"] == 12
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_an_empty_queue_leaves_the_watcher_down(self, monkeypatch):
+        """No queued work, no invariant to own.
+
+        Respawning a crash-looping watcher that nothing depends on would burn
+        the process for no one. The enqueue path spawns a fresh one the moment
+        a platform is actually queued.
+        """
+        runner = self._runner(monkeypatch, crashes=10_000)
+        assert not runner._failed_platforms
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(200)
+
+        assert runner.state["live"] == 0
+        assert runner._reconnect_watcher_task.done()
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_the_slow_tier_stands_down_when_the_queue_drains(self, monkeypatch):
+        """Something else healed the platform -- stop respawning for it."""
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+
+        runner._spawn_reconnect_watcher()
+        # Let supervision give up, then drain the queue before the slow tier
+        # gets its turn.
+        await self._settle(6)
+        runner._failed_platforms.clear()
+        await self._settle(200)
+
+        assert runner.state["live"] == 0, (
+            "with nothing queued, the slow tier has no invariant left to own"
+        )
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_give_up_does_nothing_once_the_gateway_is_shutting_down(
+        self, monkeypatch
+    ):
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+        runner._running = False
+
+        runner._on_reconnect_watcher_gave_up("platform_reconnect_watcher")
+        await self._settle()
+
+        assert runner.state["live"] == 0
+        assert not runner._background_tasks

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -468,6 +468,30 @@ class TestSpawnSupervised:
         assert observed == [False]
 
     @pytest.mark.asyncio
+    async def test_dispatcher_to_thread_does_not_trip_kanban_guard(self):
+        """Already-running ticks copy the caller task context into to_thread.
+
+        Issue #91958 is a dispatcher that was spawned at boot, then a later
+        ``delegate_task`` leaves the worker copy marked as a child. Spawn
+        isolation does not rewrite that frozen task context; the offload
+        helper must scrub it at the tick boundary. The in-task child guard
+        stays closed.
+        """
+        from agent.delegation_context import (
+            delegated_child_context,
+            is_delegated_child_context,
+        )
+        from gateway.kanban_watchers import _to_thread_process_service
+        from hermes_cli.kanban_db import _assert_not_delegated_child_mutation
+
+        with delegated_child_context():
+            assert is_delegated_child_context() is True
+            with pytest.raises(PermissionError, match="delegate_task child"):
+                _assert_not_delegated_child_mutation()
+            await _to_thread_process_service(_assert_not_delegated_child_mutation)
+            assert is_delegated_child_context() is True
+
+    @pytest.mark.asyncio
     async def test_clean_synchronous_return_is_not_respawned(self):
         # A supervised coro that returns immediately (clean exit) must be
         # invoked EXACTLY ONCE — a clean return means deliberate shutdown or a

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1065,7 +1065,8 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
         return None
 
     runner._send_restart_notification = never_returns
-    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+    runner._claim_pending_obligations = AsyncMock(return_value=[])
+    runner._redeliver_claimed_obligations = AsyncMock(return_value=0)
 
     seen: list[str] = []
 
@@ -1096,7 +1097,11 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
     )
     assert runner._startup_restore_queue == []
     assert runner._startup_restore_in_progress is False
-    runner._redeliver_pending_obligations.assert_not_awaited()
+    # The DB half (claim + resume clear) runs inline BEFORE the abandonable
+    # send task, so it must have completed even though the boot send hung;
+    # the network half never ran because the hung notification precedes it.
+    runner._claim_pending_obligations.assert_awaited_once()
+    runner._redeliver_claimed_obligations.assert_not_awaited()
 
     hung.set()
     leftover = [t for t in list(runner._background_tasks) if not t.done()]
@@ -1112,13 +1117,15 @@ async def test_startup_boot_sends_still_run_when_they_finish_quickly(monkeypatch
     runner, _adapter = make_restart_runner()
     runner._background_tasks = set()
     runner._send_restart_notification = AsyncMock(return_value=None)
-    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+    runner._claim_pending_obligations = AsyncMock(return_value=[])
+    runner._redeliver_claimed_obligations = AsyncMock(return_value=0)
 
     await runner._await_startup_boot_sends(
         planned_restart_notification_pending=False,
     )
 
     runner._send_restart_notification.assert_awaited_once()
-    runner._redeliver_pending_obligations.assert_awaited_once()
+    runner._claim_pending_obligations.assert_awaited_once()
+    runner._redeliver_claimed_obligations.assert_awaited_once()
 
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1040,3 +1040,85 @@ async def test_startup_restore_gate_releases_when_resume_turn_outlives_timeout(
     await slow_task
 
 
+@pytest.mark.asyncio
+async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
+    monkeypatch,
+):
+    """A hung restart notification / obligation redelivery must not freeze inbound.
+
+    Those sends used to run *before* ``_finish_startup_restore`` released the
+    gate. A Telegram flood-control sleep on either call queued inbound on
+    every platform for the full ``retry_after``.
+    """
+    monkeypatch.setenv("HERMES_STARTUP_RESTORE_DRAIN_TIMEOUT", "0.05")
+
+    runner, adapter = make_restart_runner()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_queue = []
+    runner._startup_restore_tasks = []
+    runner._background_tasks = set()
+
+    hung = asyncio.Event()
+
+    async def never_returns(*_args, **_kwargs):
+        await hung.wait()
+        return None
+
+    runner._send_restart_notification = never_returns
+    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+
+    seen: list[str] = []
+
+    async def fake_handle_message(event: MessageEvent) -> None:
+        seen.append(f"inbound:{event.text}")
+
+    adapter.handle_message = fake_handle_message
+
+    inbound = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="restore-chat"),
+    )
+    assert await runner._handle_message(inbound) is None
+    assert runner._startup_restore_queue == [inbound]
+
+    await asyncio.wait_for(
+        runner._await_startup_boot_sends(
+            planned_restart_notification_pending=False,
+        ),
+        timeout=5,
+    )
+    await asyncio.wait_for(runner._finish_startup_restore(), timeout=5)
+
+    assert seen == ["inbound:hello"], (
+        "startup-restore gate never released: queued inbound was not drained "
+        "while a boot-path send was still sleeping"
+    )
+    assert runner._startup_restore_queue == []
+    assert runner._startup_restore_in_progress is False
+    runner._redeliver_pending_obligations.assert_not_awaited()
+
+    hung.set()
+    leftover = [t for t in list(runner._background_tasks) if not t.done()]
+    if leftover:
+        await asyncio.wait(leftover)
+
+
+@pytest.mark.asyncio
+async def test_startup_boot_sends_still_run_when_they_finish_quickly(monkeypatch):
+    """The bound must not skip restart notification or redelivery on a fast path."""
+    monkeypatch.setenv("HERMES_STARTUP_RESTORE_DRAIN_TIMEOUT", "2")
+
+    runner, _adapter = make_restart_runner()
+    runner._background_tasks = set()
+    runner._send_restart_notification = AsyncMock(return_value=None)
+    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+
+    await runner._await_startup_boot_sends(
+        planned_restart_notification_pending=False,
+    )
+
+    runner._send_restart_notification.assert_awaited_once()
+    runner._redeliver_pending_obligations.assert_awaited_once()
+
+

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1721,16 +1721,10 @@ class TestGatewaySystemServiceRouting:
             lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
         )
 
-        # Simulate systemctl reset-failed/restart followed by an active unit.
-        # A plain start does not break systemd's auto-restart timer once the
-        # old gateway has exited with the planned restart code.
+        # Once SIGUSR1 makes the gateway exit with the planned restart code,
+        # systemd is the only restart owner.  The CLI must only observe the
+        # replacement instead of issuing a second stop/start transition.
         def fake_subprocess_run(cmd, **kwargs):
-            if "reset-failed" in cmd:
-                calls.append(("reset-failed", cmd))
-                return SimpleNamespace(stdout="", returncode=0)
-            if "restart" in cmd:
-                calls.append(("restart", cmd))
-                return SimpleNamespace(stdout="", returncode=0)
             raise AssertionError(f"Unexpected systemctl call: {cmd}")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
@@ -1743,8 +1737,6 @@ class TestGatewaySystemServiceRouting:
         gateway_cli.systemd_restart()
 
         assert ("graceful", 654, 27.0) in calls
-        assert any(call[0] == "reset-failed" for call in calls)
-        assert any(call[0] == "restart" for call in calls)
         assert ("wait", False, 654) in calls
         out = capsys.readouterr().out.lower()
         assert "restarting gracefully" in out

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -41,140 +41,9 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
-    def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("old unit\n", encoding="utf-8")
 
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
-        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
-        calls = []
 
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.systemd_install()
-
-        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
-        assert calls[:2] == [
-            ["systemctl", "--user", "daemon-reload"],
-            ["systemctl", "--user", "enable", gateway_cli.get_service_name()],
-        ]
-
-    def test_systemd_start_refreshes_outdated_unit(self, tmp_path, monkeypatch):
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("old unit\n", encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
-        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
-        # Bypass systemd availability checks — this test targets unit-file
-        # refresh logic, not D-Bus reachability (fails on macOS/WSL/Docker).
-        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-
-        calls = []
-
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.systemd_start()
-
-        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
-        assert calls[:2] == [
-            ["systemctl", "--user", "daemon-reload"],
-            ["systemctl", "--user", "start", gateway_cli.get_service_name()],
-        ]
-
-    def test_systemd_restart_refreshes_outdated_unit(self, tmp_path, monkeypatch):
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("old unit\n", encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
-        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
-        # Bypass systemd availability checks — this test targets unit-file
-        # refresh logic, not D-Bus reachability (fails on macOS/WSL/Docker).
-        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-
-        calls = []
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
-        monkeypatch.setattr(
-            gateway_cli,
-            "_wait_for_systemd_service_restart",
-            lambda system=False, previous_pid=None: calls.append(("wait", system, previous_pid)) or True,
-        )
-
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.systemd_restart()
-
-        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
-        assert calls[:5] == [
-            ["systemctl", "--user", "daemon-reload"],
-            ["systemctl", "--user", "show", gateway_cli.get_service_name(), "--no-pager", "--property", "ActiveState,SubState,Result,ExecMainStatus,MainPID"],
-            ["systemctl", "--user", "reset-failed", gateway_cli.get_service_name()],
-            ["systemctl", "--user", "restart", gateway_cli.get_service_name()],
-            ("wait", False, None),
-        ]
-
-    def test_systemd_stop_marks_running_gateway_as_planned_stop(self, monkeypatch):
-        calls = []
-        markers = []
-
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
-        monkeypatch.setattr(status, "get_running_pid", lambda cleanup_stale=True: 321)
-        monkeypatch.setattr(
-            status,
-            "write_planned_stop_marker",
-            lambda pid: markers.append(pid) or True,
-        )
-
-        def fake_run_systemctl(args, **kwargs):
-            calls.append(args)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
-
-        gateway_cli.systemd_stop()
-
-        assert markers == [321]
-        assert calls == [["stop", gateway_cli.get_service_name()]]
-
-    def test_systemd_stop_timeout_prints_status_guidance(self, monkeypatch, capsys):
-        markers = []
-
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
-        monkeypatch.setattr(status, "get_running_pid", lambda cleanup_stale=True: 321)
-        monkeypatch.setattr(
-            status,
-            "write_planned_stop_marker",
-            lambda pid: markers.append(pid) or True,
-        )
-
-        def fake_run_systemctl(args, **kwargs):
-            raise subprocess.TimeoutExpired(args, kwargs.get("timeout"))
-
-        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
-
-        gateway_cli.systemd_stop()
-
-        assert markers == [321]
-        output = capsys.readouterr().out
-        assert "still stopping after 90s" in output
-        assert "hermes gateway status" in output
 
     def test_systemd_restart_timeout_prints_status_guidance(self, monkeypatch, capsys):
         """`hermes gateway restart` must not surface a raw TimeoutExpired traceback.
@@ -215,44 +84,6 @@ class TestSystemdServiceRefresh:
         assert "still restarting after 90s" in output
         assert "hermes gateway status" in output
 
-    def test_run_gateway_refreshes_outdated_unit_on_boot(self, tmp_path, monkeypatch):
-        """run_gateway() should refresh the systemd unit on boot so that
-        restart settings take effect even when the process was respawned
-        via exit-code-75 (bypassing `hermes gateway restart`)."""
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("old unit\n", encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
-        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-
-        calls = []
-
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        # Prevent run_gateway from actually starting the gateway
-        async def fake_start_gateway(**kwargs):
-            return True
-
-        monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
-
-        # Upstream's run_gateway ends with a hard os._exit (wedge-proof
-        # teardown) — stub it or the test runner process dies with the test.
-        exit_codes = []
-        monkeypatch.setattr(
-            "gateway.run._exit_after_graceful_shutdown",
-            lambda code: exit_codes.append(code),
-        )
-
-        gateway_cli.run_gateway()
-
-        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
-        assert ["systemctl", "--user", "daemon-reload"] in calls
-        assert exit_codes == [0]
 
     def test_refresh_refuses_to_bake_pytest_tmpdir_into_real_user_unit(
         self, tmp_path, monkeypatch
@@ -308,51 +139,6 @@ class TestSystemdServiceRefresh:
             "daemon-reload" in str(c) for c in ran
         ), "daemon-reload must not run when write was refused"
 
-    def test_refresh_refuses_to_bake_any_tempdir_home_into_real_user_unit(
-        self, tmp_path, monkeypatch
-    ):
-        """Structural guard: a manual E2E HERMES_HOME like
-        ``/tmp/hermes-e2e-41264`` carries none of the pytest markers but
-        poisons the unit identically (seen live 2026-06-11 — an E2E probe ran
-        ``hermes gateway restart`` with a /tmp HERMES_HOME exported; the
-        restart's unit refresh baked it into the production unit and the
-        post-update restart produced a 7-hour zombie gateway). The refresh
-        must refuse ANY temp-dir HERMES_HOME, not just pytest-shaped ones.
-        """
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("old unit\n", encoding="utf-8")
-
-        monkeypatch.setattr(
-            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
-        )
-        polluted_unit = (
-            "[Service]\n"
-            'Environment="HERMES_HOME=/tmp/hermes-e2e-41264"\n'
-            "WorkingDirectory=/tmp/hermes-e2e-41264\n"
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "generate_systemd_unit",
-            lambda system=False, run_as_user=None: polluted_unit,
-        )
-
-        ran = []
-
-        def fake_run(cmd, check=True, **kwargs):
-            ran.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        result = gateway_cli.refresh_systemd_unit_if_needed(system=False)
-
-        assert result is False, "refresh should refuse to write a temp-home unit"
-        assert (
-            unit_path.read_text(encoding="utf-8") == "old unit\n"
-        ), "installed unit must be left untouched"
-        assert not any(
-            "daemon-reload" in str(c) for c in ran
-        ), "daemon-reload must not run when write was refused"
 
 
 class TestTempHomeServiceDefinitionGuard:
@@ -365,9 +151,6 @@ class TestTempHomeServiceDefinitionGuard:
             == "/tmp/hermes-e2e-41264"
         )
 
-    def test_detects_var_tmp_home(self):
-        unit = '[Service]\nEnvironment="HERMES_HOME=/var/tmp/hermes-x"\n'
-        assert gateway_cli._temp_home_in_service_definition(unit) is not None
 
     def test_detects_tempdir_env_home(self, monkeypatch, tmp_path):
         import tempfile as _tempfile
@@ -376,36 +159,8 @@ class TestTempHomeServiceDefinitionGuard:
         unit = f'[Service]\nEnvironment="HERMES_HOME={tmp_path}/hermes-home"\n'
         assert gateway_cli._temp_home_in_service_definition(unit) is not None
 
-    def test_detects_tmp_home_in_launchd_plist(self):
-        plist = (
-            "<dict>\n  <key>HERMES_HOME</key>\n"
-            "  <string>/tmp/hermes-e2e-99999</string>\n</dict>\n"
-        )
-        assert (
-            gateway_cli._temp_home_in_service_definition(plist)
-            == "/tmp/hermes-e2e-99999"
-        )
 
-    def test_accepts_real_home(self):
-        unit = '[Service]\nEnvironment="HERMES_HOME=/home/alice/.hermes"\n'
-        assert gateway_cli._temp_home_in_service_definition(unit) is None
 
-    def test_accepts_macos_real_home_plist(self):
-        plist = (
-            "<dict>\n  <key>HERMES_HOME</key>\n"
-            "  <string>/Users/alice/.hermes</string>\n</dict>\n"
-        )
-        assert gateway_cli._temp_home_in_service_definition(plist) is None
-
-    def test_accepts_unit_without_hermes_home(self):
-        unit = "[Service]\nExecStart=/usr/bin/python -m hermes_cli.main gateway run\n"
-        assert gateway_cli._temp_home_in_service_definition(unit) is None
-
-    def test_tmp_prefixed_non_temp_path_is_accepted(self):
-        # /tmpfs-data is NOT under /tmp — prefix matching must be
-        # component-wise, not string startswith.
-        unit = '[Service]\nEnvironment="HERMES_HOME=/tmpfs-data/.hermes"\n'
-        assert gateway_cli._temp_home_in_service_definition(unit) is None
 
 
 class TestRequireServiceInstalled:
@@ -434,53 +189,7 @@ class TestGeneratedSystemdUnits:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30))
         return f"TimeoutStopSec={timeout}"
 
-    def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
-        monkeypatch.setattr(
-            gateway_cli,
-            "_get_restart_drain_timeout",
-            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
-        )
-        unit = gateway_cli.generate_systemd_unit(system=False)
 
-        assert "ExecStart=" in unit
-        assert "ExecStop=" not in unit
-        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
-        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # SuccessExitStatus must ALSO list the planned-restart code so a graceful
-        # exit-75 (SIGUSR1 restart / stale-code respawn / /restart) is recorded
-        # as a CLEAN stop, not "Failed with result 'exit-code'". Without it every
-        # planned restart pollutes systemctl status/journal as a bogus failure,
-        # masking real crashes and misreading as instability.
-        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        # The default drain is immediate, so keep a bounded 60-second stop
-        # budget without forcing every restart to wait 90 seconds.
-        assert self._expected_timeout_stop_sec() in unit
-        # ExecStopPost reaps any process the gateway didn't clean up itself,
-        # so long-lived helpers (e.g. adb) can't be left orphaned in the
-        # cgroup and block Restart=always — issue #37454.
-        assert "ExecStopPost=" in unit
-        assert "-m gateway.cgroup_cleanup" in unit
-        # KillMode=mixed is preserved so the gateway still reaps its own
-        # tool-call children before systemd SIGKILLs the cgroup — #8202.
-        assert "KillMode=mixed" in unit
-
-    def test_user_unit_adds_cleanup_headroom_to_positive_drain_timeout(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 45)
-
-        unit = gateway_cli.generate_systemd_unit(system=False)
-
-        assert "TimeoutStopSec=75" in unit
-
-    def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
-
-        unit = gateway_cli.generate_systemd_unit(system=False)
-
-        assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
     def test_user_unit_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Regression for the multi-profile gateway restart-loop flap (#48700):
@@ -524,78 +233,6 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
-    def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
-        monkeypatch.setenv(
-            "PATH",
-            "/usr/local/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/",
-        )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
-
-        unit = gateway_cli.generate_systemd_unit(system=False)
-
-        assert "/mnt/c/WINDOWS/system32" in unit
-        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/" in unit
-
-    def test_user_unit_omits_windows_interop_paths_outside_wsl(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
-        monkeypatch.setenv("PATH", "/usr/local/bin:/mnt/c/WINDOWS/system32")
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
-
-        unit = gateway_cli.generate_systemd_unit(system=False)
-
-        assert "/mnt/c/WINDOWS/system32" not in unit
-
-    def test_system_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
-        monkeypatch.setattr(
-            gateway_cli,
-            "_system_service_identity",
-            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
-        )
-        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda home: "/home/alice/.hermes")
-        monkeypatch.setenv("PATH", "/usr/local/bin:/mnt/c/WINDOWS/system32")
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
-
-        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
-
-        assert "/mnt/c/WINDOWS/system32" in unit
-
-    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
-        monkeypatch.setattr(
-            gateway_cli,
-            "_get_restart_drain_timeout",
-            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
-        )
-        unit = gateway_cli.generate_systemd_unit(system=True)
-
-        assert "ExecStart=" in unit
-        assert "ExecStop=" not in unit
-        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
-        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # SuccessExitStatus must ALSO list the planned-restart code so a graceful
-        # exit-75 (SIGUSR1 restart / stale-code respawn / /restart) is recorded
-        # as a CLEAN stop, not "Failed with result 'exit-code'". Without it every
-        # planned restart pollutes systemctl status/journal as a bogus failure,
-        # masking real crashes and misreading as instability.
-        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        # The default drain is immediate, so keep a bounded 60-second stop
-        # budget without forcing every restart to wait 90 seconds.
-        assert self._expected_timeout_stop_sec() in unit
-        assert "WantedBy=multi-user.target" in unit
-        # ExecStopPost reaps any process the gateway didn't clean up itself,
-        # so long-lived helpers (e.g. adb) can't be left orphaned in the
-        # cgroup and block Restart=always — issue #37454.
-        assert "ExecStopPost=" in unit
-        assert "-m gateway.cgroup_cleanup" in unit
-        # KillMode=mixed is preserved so the gateway still reaps its own
-        # tool-call children before systemd SIGKILLs the cgroup — #8202.
-        assert "KillMode=mixed" in unit
-
     def test_launchd_plist_persists_configured_nofile_soft_limit(self, monkeypatch):
         """The generated plist must carry SoftResourceLimits/NumberOfFiles so a
         plist rewrite by `hermes gateway start` cannot strip the FD floor and
@@ -624,6 +261,7 @@ class TestGeneratedSystemdUnits:
         plist = gateway_cli.generate_launchd_plist()
 
         assert "SoftResourceLimits" not in plist
+
 
 
 class TestGatewayStopCleanup:
@@ -659,58 +297,8 @@ class TestGatewayStopCleanup:
         # Global kill should NOT be called without --all
         assert kill_calls == []
 
-    def test_stop_all_sweeps_all_gateway_processes(self, tmp_path, monkeypatch):
-        """With --all, stop uses systemd AND calls the global kill_gateway_processes()."""
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("unit\n", encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
-
-        service_calls = []
-        kill_calls = []
-
-        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False: service_calls.append("stop"))
-        monkeypatch.setattr(
-            gateway_cli,
-            "kill_gateway_processes",
-            lambda force=False, all_profiles=False: kill_calls.append(force) or 2,
-        )
-
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="stop", **{"all": True}))
-
-        assert service_calls == ["stop"]
-        assert kill_calls == [False]
-
 
 class TestLaunchdServiceRecovery:
-    def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
-        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
-        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
-
-        assert (
-            gateway_cli._get_restart_drain_timeout()
-            == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-        )
-
-        monkeypatch.setattr(
-            gateway_cli,
-            "read_raw_config",
-            lambda: {"agent": {"restart_drain_timeout": 14}},
-        )
-        assert gateway_cli._get_restart_drain_timeout() == 14.0
-
-        monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "9")
-        assert gateway_cli._get_restart_drain_timeout() == 9.0
-
-        monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "invalid")
-        assert (
-            gateway_cli._get_restart_drain_timeout()
-            == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-        )
-
     def test_wait_for_pid_exit_returns_when_process_gone(self, monkeypatch):
         alive = [True, True, False]
         monkeypatch.setattr(
@@ -730,45 +318,7 @@ class TestLaunchdServiceRecovery:
     def test_wait_for_pid_exit_ignores_nonpositive_pid(self):
         assert gateway_cli._wait_for_pid_exit(0, timeout=30) is True
 
-    def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
 
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        # Patch the generator with synthetic content carrying a real-looking
-        # home — the temp-home guard refuses to write plists whose
-        # HERMES_HOME resolves under the (pytest tmp) test HERMES_HOME.
-        monkeypatch.setattr(
-            gateway_cli,
-            "generate_launchd_plist",
-            lambda: (
-                "<plist>--replace\n<key>HERMES_HOME</key>"
-                "<string>/Users/alice/.hermes</string></plist>"
-            ),
-        )
-
-        calls = []
-
-        def fake_run(cmd, check=False, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        # Not running inside the gateway tree → direct bootout/bootstrap path.
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: None)
-
-        gateway_cli.launchd_install()
-
-        label = gateway_cli.get_launchd_label()
-        domain = gateway_cli._launchd_domain()
-        assert "--replace" in plist_path.read_text(encoding="utf-8")
-        # The calls list includes launchctl print probes from _launchd_domain()
-        # before the bootout/bootstrap calls. Filter to only bootout/bootstrap.
-        service_calls = [c for c in calls if "bootout" in c or "bootstrap" in c]
-        assert service_calls[:2] == [
-            ["launchctl", "bootout", f"{domain}/{label}"],
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-        ]
 
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
         """#43842: when the refresh runs inside the gateway's own process tree,
@@ -816,15 +366,27 @@ class TestLaunchdServiceRecovery:
         assert "--replace" in plist_path.read_text(encoding="utf-8")
         # No DIRECT bootout/bootstrap ran (those would kill us mid-sequence).
         assert not [c for c in run_calls if "bootout" in c or "bootstrap" in c]
-        # Exactly one detached helper was spawned — a transient launchd job
-        # via `launchctl submit` (#69098: a setsid child stays in the
-        # coalition and dies with the bootout; a submitted job does not).
+        # Exactly one Popen call was made for the transient launchd job.
         assert len(popen_calls) == 1
         cmd, kwargs = popen_calls[0]
-        assert cmd[0] == "launchctl" and cmd[1] == "submit"
-        script = cmd[-1]
+        # Must use `launchctl submit` (not `start_new_session=True`) so the
+        # helper runs as a transient launchd job outside the gateway's process
+        # coalition, surviving bootout (#69098).
+        assert cmd[:3] == ["launchctl", "submit", "-l"]
+        assert kwargs.get("start_new_session") is not True
+        assert "-o" in cmd
+        assert "-e" in cmd
+        # The script is passed via -- /bin/bash -c ...
+        bash_idx = cmd.index("--") + 1
+        assert cmd[bash_idx] == "/bin/bash"
+        assert cmd[bash_idx + 1] == "-c"
+        script = cmd[bash_idx + 2]
         assert "bootout" in script and "bootstrap" in script
         assert str(plist_path) in script
+        # The one-shot job must deregister its own transient label at the end,
+        # otherwise every reload leaks a dead label in launchd.
+        submit_label = cmd[cmd.index("-l") + 1]
+        assert f"launchctl remove {submit_label}" in script
 
     def test_refresh_defers_reload_even_when_not_a_posix_descendant(self, tmp_path, monkeypatch):
         """The detached helper is used even when the gateway is NOT an ancestor.
@@ -932,6 +494,7 @@ class TestLaunchdServiceRecovery:
         # The wait must be bounded, so a wedged gateway can't block the reload.
         assert "_wait_deadline" in script
 
+
     def test_refresh_falls_back_to_direct_reload_when_helper_cannot_spawn(
         self, tmp_path, monkeypatch
     ):
@@ -996,190 +559,6 @@ class TestLaunchdServiceRecovery:
         # Drained the old pid between bootout and bootstrap.
         assert waited and waited[0][0] == 4242
 
-    def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        label = gateway_cli.get_launchd_label()
-
-        calls = []
-        domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd and cmd[0] == "launchctl":
-                calls.append(cmd)
-            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
-                raise gateway_cli.subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.launchd_start()
-
-        assert calls == [
-            ["launchctl", "kickstart", target],
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
-        ]
-
-    def test_launchd_start_reloads_on_kickstart_exit_code_113(self, tmp_path, monkeypatch):
-        """Exit code 113 (\"Could not find service\") should also trigger bootstrap recovery."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        label = gateway_cli.get_launchd_label()
-
-        calls = []
-        domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd and cmd[0] == "launchctl":
-                calls.append(cmd)
-            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
-                raise gateway_cli.subprocess.CalledProcessError(113, cmd, stderr="Could not find service")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.launchd_start()
-
-        assert calls == [
-            ["launchctl", "kickstart", target],
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
-        ]
-
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch, capsys):
-        calls = []
-        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
-
-        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
-        monkeypatch.setattr(
-            "gateway.status.get_running_pid",
-            lambda: 321,
-        )
-
-        def fake_run(cmd, check=False, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.launchd_restart()
-
-        assert calls == [
-            ("term", 321, False),
-            ["launchctl", "kickstart", "-k", target],
-        ]
-        # The drain can silently hold for the full budget (180s default); the
-        # desktop updater streams this output as its only progress feedback,
-        # so the stop must be announced BEFORE the wait (#44515).
-        out = capsys.readouterr().out
-        assert "draining in-flight runs" in out
-        assert "up to 12s" in out
-
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
-        calls = []
-
-        monkeypatch.setattr(
-            "gateway.status.get_running_pid",
-            lambda: 321,
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "_request_gateway_self_restart",
-            lambda pid: calls.append(("self", pid)) or True,
-        )
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
-        )
-
-        gateway_cli.launchd_restart()
-
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
-
-    def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
-        """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
-        label = gateway_cli.get_launchd_label()
-        domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        calls = []
-
-        def fake_run(cmd, check=False, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kw: None)
-
-        gateway_cli.launchd_stop()
-
-        assert calls == [["launchctl", "bootout", target]]
-
-    def test_launchd_stop_tolerates_already_unloaded(self, monkeypatch, capsys):
-        """launchd_stop silently handles exit codes 3/113 (job not loaded)."""
-        label = gateway_cli.get_launchd_label()
-        domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        def fake_run(cmd, check=False, **kwargs):
-            if "bootout" in cmd:
-                raise gateway_cli.subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kw: None)
-
-        # Should not raise — exit code 3 means already unloaded
-        gateway_cli.launchd_stop()
-
-        output = capsys.readouterr().out
-        assert "stopped" in output.lower()
-
-    def test_launchd_stop_waits_for_process_exit(self, monkeypatch):
-        """launchd_stop calls _wait_for_gateway_exit after bootout."""
-        wait_called = []
-
-        def fake_run(cmd, check=False, **kwargs):
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        def fake_wait(**kwargs):
-            wait_called.append(kwargs)
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", fake_wait)
-
-        gateway_cli.launchd_stop()
-
-        assert len(wait_called) == 1
-        assert wait_called[0] == {"timeout": 10.0, "force_after": 5.0}
-
-    def test_launchd_status_reports_local_stale_plist_when_unloaded(self, tmp_path, monkeypatch, capsys):
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
-        )
-
-        gateway_cli.launchd_status()
-
-        output = capsys.readouterr().out
-        assert str(plist_path) in output
-        assert "stale" in output.lower()
-        assert "not loaded" in output.lower()
 
     def test_launchd_domain_uses_user_domain(self, monkeypatch):
         # The user/<uid> domain (not gui/<uid>) is the one reachable from
@@ -1198,288 +577,22 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
         assert gateway_cli._launchd_domain() == "user/501"
 
-    def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
-        # Codes that persist after a fresh bootstrap → launchd truly unavailable.
-        assert gateway_cli._launchctl_domain_unsupported(5) is True
-        assert gateway_cli._launchctl_domain_unsupported(125) is True
-        assert gateway_cli._launchctl_domain_unsupported(3) is False
-        assert gateway_cli._launchctl_domain_unsupported(113) is False
-        assert gateway_cli._launchctl_domain_unsupported(0) is False
 
-    def test_launchd_start_reloads_on_kickstart_exit_code_125(self, tmp_path, monkeypatch):
-        """Exit code 125 means the job is absent from the domain → bootstrap recovery."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        label = gateway_cli.get_launchd_label()
-
-        calls = []
-        domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd and cmd[0] == "launchctl":
-                calls.append(cmd)
-            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
-                raise gateway_cli.subprocess.CalledProcessError(
-                    125, cmd, stderr="Domain does not support specified action"
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.launchd_start()
-
-        assert calls == [
-            ["launchctl", "kickstart", target],
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
-        ]
-
-    def test_launchd_start_falls_back_to_detached_when_rebootstrap_fails(self, tmp_path, monkeypatch, capsys):
-        """If even a fresh bootstrap can't manage the domain, spawn detached."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        label = gateway_cli.get_launchd_label()
-        target = f"{gateway_cli._launchd_domain()}/{label}"
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd == ["launchctl", "kickstart", target]:
-                # First kickstart: job not loaded (125). After bootstrap also
-                # fails, this won't be reached again.
-                raise gateway_cli.subprocess.CalledProcessError(
-                    125, cmd, stderr="Domain does not support specified action"
-                )
-            if cmd[:2] == ["launchctl", "bootstrap"]:
-                raise gateway_cli.subprocess.CalledProcessError(
-                    5, cmd, stderr="Input/output error"
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        spawned = []
-        monkeypatch.setattr(
-            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
-        )
-
-        gateway_cli.launchd_start()
-
-        assert spawned == [True]
-        assert "background process" in capsys.readouterr().out.lower()
-        # Verify the unsupported marker was written so status can explain why
-        assert gateway_cli._launchd_unsupported_marker_exists()
-
-    def test_launchd_install_falls_back_to_detached_on_bootstrap_5(self, tmp_path, monkeypatch, capsys):
-        """macOS bootstrap error 5 should spawn a detached gateway, not crash."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        # Synthetic plist with a non-temp home so the temp-home write guard
-        # (which would trip on the pytest-tmp test HERMES_HOME) stays out of
-        # the way — this test exercises the bootstrap-error fallback.
-        monkeypatch.setattr(
-            gateway_cli,
-            "generate_launchd_plist",
-            lambda: (
-                "<plist><key>HERMES_HOME</key>"
-                "<string>/Users/alice/.hermes</string></plist>"
-            ),
-        )
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "bootstrap"]:
-                raise gateway_cli.subprocess.CalledProcessError(
-                    5, cmd, stderr="Input/output error"
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        spawned = []
-        monkeypatch.setattr(
-            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
-        )
-
-        gateway_cli.launchd_install(force=True)
-
-        assert spawned == [True]
-        assert "Service installed and loaded" not in capsys.readouterr().out
-        assert gateway_cli._launchd_unsupported_marker_exists()
-
-    def test_launchd_restart_falls_back_to_detached_on_error_5(self, monkeypatch, capsys):
-        """kickstart -k error 5 (domain unmanageable) should relaunch detached."""
-        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
-
-        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
-
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd == ["launchctl", "kickstart", "-k", target]:
-                raise gateway_cli.subprocess.CalledProcessError(
-                    5, cmd, stderr="Input/output error"
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        spawned = []
-        monkeypatch.setattr(
-            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
-        )
-
-        gateway_cli.launchd_restart()
-
-        assert spawned == [True]
-        assert gateway_cli._launchd_unsupported_marker_exists()
-
-    def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
-        """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""
-        def fake_run(cmd, check=False, **kwargs):
-            if "bootout" in cmd:
-                raise gateway_cli.subprocess.CalledProcessError(
-                    125, cmd, stderr="Domain does not support specified action"
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kw: None)
-
-        gateway_cli.launchd_stop()
-
-        assert "stopped" in capsys.readouterr().out.lower()
-
-    def test_launchd_fallback_exits_when_spawn_fails(self, monkeypatch, capsys):
-        """If the detached spawn fails, surface the manual workaround and exit 1."""
-        monkeypatch.setattr(gateway_cli, "_spawn_detached_gateway", lambda: False)
-
-        with pytest.raises(SystemExit) as exc:
-            gateway_cli._launchd_fallback_to_detached("test reason")
-        assert exc.value.code == 1
-        out = capsys.readouterr().out
-        assert "nohup hermes gateway run" in out
-        # Marker is still written so status knows launchd is unavailable
-        assert gateway_cli._launchd_unsupported_marker_exists()
 
     # ── PID parsing ──────────────────────────────────────────────────────
 
-    def test_parse_launchd_pid_from_list_output_with_pid(self):
-        output = '{\n    "PID" = 12345;\n    "Label" = "ai.hermes.gateway";\n}'
-        assert gateway_cli._parse_launchd_pid_from_list_output(output) == 12345
 
-    def test_parse_launchd_pid_from_list_output_without_pid(self):
-        output = '{\n    "Label" = "ai.hermes.gateway";\n    "OnDemand" = true;\n}'
-        assert gateway_cli._parse_launchd_pid_from_list_output(output) is None
 
-    def test_parse_launchd_pid_from_list_output_empty(self):
-        assert gateway_cli._parse_launchd_pid_from_list_output("") is None
-
-    def test_parse_launchd_pid_from_list_output_unquoted_pid(self):
-        """Older macOS versions may output PID without quotes."""
-        output = "{\n    PID = 99999;\n}"
-        assert gateway_cli._parse_launchd_pid_from_list_output(output) == 99999
-
-    def test_parse_launchd_pid_from_list_output_negative_pid_returns_none(self):
-        """PID = -1 (recently-crashed service sentinel) must return None."""
-        output = '{\n    "PID" = -1;\n    "Label" = "ai.hermes.gateway";\n}'
-        assert gateway_cli._parse_launchd_pid_from_list_output(output) is None
 
     # ── Probe requires PID ───────────────────────────────────────────────
 
-    def test_probe_launchd_service_running_false_without_pid_in_output(self, tmp_path, monkeypatch):
-        """launchctl list returns 0 but no PID → not actually running."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: SimpleNamespace(
-                returncode=0,
-                stdout='{\n    "Label" = "ai.hermes.gateway";\n}',
-                stderr="",
-            ),
-        )
-        assert gateway_cli._probe_launchd_service_running() is False
-
-    def test_probe_launchd_service_running_true_with_pid_in_output(self, tmp_path, monkeypatch):
-        """launchctl list returns 0 with PID → actually running."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: SimpleNamespace(
-                returncode=0,
-                stdout='{\n    "PID" = 55555;\n    "Label" = "ai.hermes.gateway";\n}',
-                stderr="",
-            ),
-        )
-        assert gateway_cli._probe_launchd_service_running() is True
 
     # ── Unsupport marker lifecycle ───────────────────────────────────────
 
-    def test_launchd_unsupported_marker_write_and_clear(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
-        assert not gateway_cli._launchd_unsupported_marker_exists()
-        gateway_cli._write_launchd_unsupported_marker()
-        assert gateway_cli._launchd_unsupported_marker_exists()
-        gateway_cli._clear_launchd_unsupported_marker()
-        assert not gateway_cli._launchd_unsupported_marker_exists()
 
-    def test_launchd_start_clears_unsupported_marker_on_bootstrap_success(self, tmp_path, monkeypatch, capsys):
-        """When bootstrap succeeds (OS update fixes the issue), clear the marker."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        # Pre-seed the marker as if a previous fallback wrote it
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
-        # Bypass the temp-home service write guard (added on main after PR #42567)
-        monkeypatch.setattr(gateway_cli, "_refuse_temp_home_service_write", lambda d, k: False)
-        gateway_cli._write_launchd_unsupported_marker()
-        assert gateway_cli._launchd_unsupported_marker_exists()
-
-        # Simulate a bootstrap that succeeds
-        def fake_run(cmd, check=False, **kwargs):
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli.launchd_install(force=True)
-
-        assert "Service installed and loaded" in capsys.readouterr().out
-        assert not gateway_cli._launchd_unsupported_marker_exists()
 
     # ── launchd_status with active supervision ───────────────────────────
 
-    def test_launchd_status_reports_supervised_when_pid_present(self, tmp_path, monkeypatch, capsys):
-        """When launchd is actively supervising, report it clearly."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-
-        def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
-            if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:
-                return SimpleNamespace(
-                    returncode=0,
-                    stdout='{\n    "PID" = 77777;\n    "Label" = "ai.hermes.gateway";\n}',
-                    stderr="",
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        # No fallback PID — when launchd supervises, get_running_pid returns
-        # the same PID; launchd_status deduplicates it.
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda cleanup_stale=False: 77777)
-
-        gateway_cli.launchd_status()
-
-        out = capsys.readouterr().out
-        assert "supervised by launchd" in out
-        assert "Auto-start at login" in out
 
     def test_launchd_status_reports_fallback_when_unsupported_and_pid_running(self, tmp_path, monkeypatch, capsys):
         """When the unsupported marker exists and a fallback PID is running."""
@@ -1507,32 +620,6 @@ class TestLaunchdServiceRecovery:
         assert "cannot manage the gateway on this macos version" in out.lower()
         assert "Detached fallback process is running" in out
         assert "PID 88888" in out
-        assert "NOT available" in out
-
-    def test_launchd_status_reports_fallback_unavailable_when_unsupported_no_pid(self, tmp_path, monkeypatch, capsys):
-        """Unsupported marker exists but no fallback process is running."""
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-
-        def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
-            if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:
-                return SimpleNamespace(
-                    returncode=0,
-                    stdout='{\n    "Label" = "ai.hermes.gateway";\n    "OnDemand" = true;\n}',
-                    stderr="",
-                )
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda cleanup_stale=False: None)
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
-        gateway_cli._write_launchd_unsupported_marker()
-
-        gateway_cli.launchd_status()
-
-        out = capsys.readouterr().out
-        assert "cannot manage the gateway on this macos version" in out.lower()
-        assert "No fallback process is running" in out
         assert "NOT available" in out
 
 
@@ -1567,46 +654,6 @@ class TestLaunchdDomainDetection:
         # Should have probed gui first
         assert run_calls[0] == ["launchctl", "print", f"gui/501/{label}"]
 
-    def test_falls_back_to_user_domain_when_gui_fails(self, monkeypatch):
-        """In a Background/SSH session where gui/<uid> fails but user/<uid>
-        works, _launchd_domain() must return ``user/<uid>``."""
-        self._reset_domain_cache()
-        monkeypatch.setattr(os, "getuid", lambda: 501)
-        label = gateway_cli.get_launchd_label()
-
-        run_calls = []
-
-        def fake_run(cmd, check=False, **kwargs):
-            run_calls.append(cmd)
-            if "print" in cmd and "gui/" in " ".join(cmd):
-                raise subprocess.CalledProcessError(1, cmd, stderr="Domain error")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        domain = gateway_cli._launchd_domain()
-        assert domain == "user/501"
-        # Should have tried gui first, then user
-        assert len(run_calls) >= 2
-
-    def test_uses_managername_heuristic_when_both_probe_fail(self, monkeypatch):
-        """When neither domain contains a loaded service, use
-        ``launchctl managername`` as a tiebreaker: Aqua -> gui, else -> user."""
-        self._reset_domain_cache()
-        monkeypatch.setattr(os, "getuid", lambda: 501)
-        label = gateway_cli.get_launchd_label()
-
-        def fake_run(cmd, check=False, **kwargs):
-            if "print" in cmd:
-                raise subprocess.CalledProcessError(1, cmd, stderr="not found")
-            if "managername" in cmd:
-                return SimpleNamespace(returncode=0, stdout="Aqua\n", stderr="")
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        domain = gateway_cli._launchd_domain()
-        assert domain == "gui/501"
 
     def test_managername_background_selects_user_domain(self, monkeypatch):
         """When managername is Background (non-Aqua), use user/<uid>."""
@@ -1624,24 +671,6 @@ class TestLaunchdDomainDetection:
 
         domain = gateway_cli._launchd_domain()
         assert domain == "user/501"
-
-    def test_caches_result_across_calls(self, monkeypatch):
-        """Domain detection should run once and cache the result."""
-        self._reset_domain_cache()
-        monkeypatch.setattr(os, "getuid", lambda: 501)
-
-        run_count = [0]
-
-        def fake_run(cmd, check=False, **kwargs):
-            run_count[0] += 1
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        d1 = gateway_cli._launchd_domain()
-        d2 = gateway_cli._launchd_domain()
-        assert d1 == d2
-        assert run_count[0] == 1  # Only probed once
 
 
 class TestGatewayServiceDetection:
@@ -1684,22 +713,6 @@ class TestGatewayServiceDetection:
 
         assert gateway_cli._is_service_running() is True
 
-    def test_is_service_running_returns_false_when_systemctl_missing(self, monkeypatch):
-        unit = SimpleNamespace(exists=lambda: True)
-
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: unit,
-        )
-
-        def fake_run(*args, **kwargs):
-            raise FileNotFoundError("systemctl")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
@@ -1743,322 +756,88 @@ class TestGatewaySystemServiceRouting:
         assert "21627" not in out  # must use the mocked budget, not live defaults
         assert "27" in out
 
-    def test_systemd_restart_uses_systemd_main_pid_when_pid_file_is_missing(self, monkeypatch, capsys):
+    def test_systemd_restart_forces_recovery_only_when_handoff_has_no_replacement(
+        self, monkeypatch, capsys
+    ):
         calls = []
 
-        # Container/CI hosts have no user systemd/D-Bus — skip the preflight
-        # (the test drives the restart machinery directly with mocks below).
-        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
-        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
-        # Exit-wait budget = drain + after_turn + headroom(15) — pin
-        # after_turn to 0 so the expected graceful budget is exactly 25.0.
-        monkeypatch.setattr(gateway_cli, "_get_restart_after_turn_timeout", lambda: 0.0)
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(
-            gateway_cli,
-            "_read_systemd_unit_properties",
-            lambda system=False: {
-                "ActiveState": "active",
-                "SubState": "running",
-                "Result": "success",
-                "ExecMainStatus": "0",
-                "MainPID": "777",
-            },
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "_graceful_restart_via_sigusr1",
-            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
-        )
-        monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda args, **kwargs: calls.append(args) or SimpleNamespace(stdout="", returncode=0))
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        waits = iter((False, True))
         monkeypatch.setattr(
             gateway_cli,
             "_wait_for_systemd_service_restart",
-            lambda system=False, previous_pid=None: calls.append(("wait", system, previous_pid)) or True,
+            lambda system=False, previous_pid=None: next(waits),
         )
-
-        gateway_cli.systemd_restart()
-
-        assert ("graceful", 777, 25.0) in calls
-        assert ("wait", False, 777) in calls
-        assert "restarting gracefully (pid 777)" in capsys.readouterr().out.lower()
-
-    def test_wait_for_systemd_restart_waits_for_runtime_running(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "_systemd_service_is_start_limited", lambda system=False: False)
         monkeypatch.setattr(
             gateway_cli,
             "_read_systemd_unit_properties",
-            lambda system=False: {
-                "ActiveState": "active",
-                "SubState": "running",
-                "Result": "success",
-                "ExecMainStatus": "0",
-                "MainPID": "999",
+            lambda system=False, properties=None: {"ActiveState": "inactive", "MainPID": "0"},
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda args, **kwargs: calls.append((args, kwargs))
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.systemd_restart()
+
+        assert [call[0][0] for call in calls] == ["reset-failed", "restart"]
+        assert "did not relaunch" in capsys.readouterr().out
+
+    def test_systemd_restart_does_not_force_an_unready_replacement(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kwargs: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_systemd_service_restart",
+            lambda system=False, previous_pid=None: False,
+        )
+        monkeypatch.setattr(gateway_cli, "_systemd_service_is_start_limited", lambda system=False: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_systemd_unit_properties",
+            lambda system=False, properties=None: {"ActiveState": "active", "MainPID": "777"},
+        )
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda args, **kwargs: calls.append(args))
+
+        gateway_cli.systemd_restart()
+
+        assert calls == []
+
+    def test_systemd_restart_wait_timeout_includes_supervisor_budgets(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_systemd_unit_properties",
+            lambda system=False, properties=None: {
+                "RestartUSec": "5s",
+                "TimeoutStartUSec": "1min 30s",
             },
         )
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(
-            gateway_cli,
-            "_gateway_runtime_status_for_pid",
-            lambda pid: {"pid": pid, "gateway_state": "running"},
-        )
 
-        assert gateway_cli._wait_for_systemd_service_restart(previous_pid=777, timeout=0.1) is True
-        assert "restarted (pid 999)" in capsys.readouterr().out.lower()
+        assert gateway_cli._systemd_restart_wait_timeout() == 155.0
 
-    def test_systemd_restart_reports_start_limit_hit(self, monkeypatch, capsys):
-        calls = []
 
-        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
-        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
 
-        def fake_run_systemctl(args, **kwargs):
-            calls.append(args)
-            if args[0] == "show":
-                return SimpleNamespace(stdout="ActiveState=inactive\nSubState=dead\nResult=success\nExecMainStatus=0\nMainPID=0\n", stderr="", returncode=0)
-            if args[0] == "reset-failed":
-                return SimpleNamespace(stdout="", stderr="", returncode=0)
-            if args[0] == "restart":
-                raise subprocess.CalledProcessError(
-                    1,
-                    ["systemctl", "--user", *args],
-                    stderr="Job failed. See result 'start-limit-hit'.",
-                )
-            raise AssertionError(f"Unexpected args: {args}")
 
-        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
 
-        gateway_cli.systemd_restart()
 
-        assert ["restart", gateway_cli.get_service_name()] in calls
-        out = capsys.readouterr().out.lower()
-        assert "rate-limited by systemd" in out
-        assert "reset-failed" in out
 
-    def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
-        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
-        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
-        monkeypatch.setattr(
-            "gateway.status.read_runtime_status",
-            lambda: {"restart_requested": True, "gateway_state": "stopped"},
-        )
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
 
-        calls = []
-        started = {"value": False}
-
-        def fake_subprocess_run(cmd, **kwargs):
-            if "show" in cmd:
-                if not started["value"]:
-                    return SimpleNamespace(
-                        stdout=(
-                            "ActiveState=failed\n"
-                            "SubState=failed\n"
-                            "Result=exit-code\n"
-                            f"ExecMainStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}\n"
-                        ),
-                        returncode=0,
-                    )
-                return SimpleNamespace(
-                    stdout="ActiveState=active\nSubState=running\nResult=success\nExecMainStatus=0\n",
-                    returncode=0,
-                )
-            if "reset-failed" in cmd:
-                calls.append(("reset-failed", cmd))
-                return SimpleNamespace(stdout="", returncode=0)
-            if "start" in cmd:
-                started["value"] = True
-                calls.append(("start", cmd))
-                return SimpleNamespace(stdout="", returncode=0)
-            raise AssertionError(f"Unexpected command: {cmd}")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
-        monkeypatch.setattr(
-            "gateway.status.get_running_pid",
-            lambda: 999 if started["value"] else None,
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "_gateway_runtime_status_for_pid",
-            lambda pid: {"pid": pid, "gateway_state": "running"},
-        )
-
-        gateway_cli.systemd_restart()
-
-        assert any(call[0] == "reset-failed" for call in calls)
-        assert any(call[0] == "start" for call in calls)
-        out = capsys.readouterr().out.lower()
-        assert "restarted" in out
-
-    def test_systemd_status_surfaces_planned_restart_failure(self, monkeypatch, capsys):
-        unit = SimpleNamespace(exists=lambda: True)
-        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit)
-        monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
-        monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
-        monkeypatch.setattr(gateway_cli, "systemd_unit_is_current", lambda system=False: True)
-        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: ["⚠ Last shutdown reason: Gateway restart requested"])
-        monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
-        monkeypatch.setattr(gateway_cli, "_read_systemd_unit_properties", lambda system=False: {
-            "ActiveState": "failed",
-            "SubState": "failed",
-            "Result": "exit-code",
-            "ExecMainStatus": str(GATEWAY_SERVICE_RESTART_EXIT_CODE),
-        })
-
-        calls = []
-
-        def fake_run_systemctl(args, **kwargs):
-            calls.append(args)
-            if args[:2] == ["status", gateway_cli.get_service_name()]:
-                return SimpleNamespace(returncode=0, stdout="", stderr="")
-            if args[:2] == ["is-active", gateway_cli.get_service_name()]:
-                return SimpleNamespace(returncode=3, stdout="failed\n", stderr="")
-            raise AssertionError(f"Unexpected args: {args}")
-
-        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
-
-        gateway_cli.systemd_status()
-
-        out = capsys.readouterr().out
-        assert "Planned restart is stuck in systemd failed state" in out
-
-    def test_gateway_status_dispatches_full_flag(self, monkeypatch):
-        user_unit = SimpleNamespace(exists=lambda: True)
-        system_unit = SimpleNamespace(exists=lambda: False)
-
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: system_unit if system else user_unit,
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_gateway_runtime_snapshot",
-            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
-                manager="systemd (user)",
-                service_installed=True,
-                service_running=False,
-                gateway_pids=(),
-                service_scope="user",
-            ),
-        )
-
-        calls = []
-        monkeypatch.setattr(
-            gateway_cli,
-            "systemd_status",
-            lambda deep=False, system=False, full=False: calls.append((deep, system, full)),
-        )
-
-        gateway_cli.gateway_command(
-            SimpleNamespace(gateway_command="status", deep=False, system=False, full=True)
-        )
-
-        assert calls == [(False, False, True)]
-
-    def test_gateway_install_reports_termux_manual_mode(self, monkeypatch, capsys):
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-
-        try:
-            gateway_cli.gateway_command(
-                SimpleNamespace(gateway_command="install", force=False, system=False, run_as_user=None)
-            )
-        except SystemExit as exc:
-            assert exc.code == 1
-        else:
-            raise AssertionError("Expected gateway_command to exit on unsupported Termux service install")
-
-        out = capsys.readouterr().out
-        assert "not supported on Termux" in out
-        assert "Run manually: hermes gateway" in out
-
-    def test_gateway_status_prefers_system_service_when_only_system_unit_exists(self, monkeypatch):
-        user_unit = SimpleNamespace(exists=lambda: False)
-        system_unit = SimpleNamespace(exists=lambda: True)
-
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: system_unit if system else user_unit,
-        )
-
-        calls = []
-        monkeypatch.setattr(
-            gateway_cli,
-            "systemd_status",
-            lambda deep=False, system=False, full=False: calls.append((deep, system, full)),
-        )
-
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
-
-        assert calls == [(False, False, False)]
-
-    def test_gateway_status_reports_manual_process_when_service_is_stopped(self, monkeypatch, capsys):
-        user_unit = SimpleNamespace(exists=lambda: True)
-        system_unit = SimpleNamespace(exists=lambda: False)
-
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: system_unit if system else user_unit,
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "systemd_status",
-            lambda deep=False, system=False, full=False: print("service stopped"),
-        )
-        monkeypatch.setattr(
-            gateway_cli,
-            "get_gateway_runtime_snapshot",
-            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
-                manager="systemd (user)",
-                service_installed=True,
-                service_running=False,
-                gateway_pids=(4321,),
-                service_scope="user",
-            ),
-        )
-
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
-
-        out = capsys.readouterr().out
-        assert "service stopped" in out
-        assert "Gateway process is running for this profile" in out
-        assert "PID(s): 4321" in out
-
-    def test_gateway_status_on_termux_shows_manual_guidance(self, monkeypatch, capsys):
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda exclude_pids=None: [])
-        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
-
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
-
-        out = capsys.readouterr().out
-        assert "Gateway is not running" in out
-        assert "nohup hermes gateway" in out
-        assert "install as user service" not in out
 
     @pytest.mark.macos_only
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
@@ -2119,29 +898,6 @@ class TestDetectVenvDir:
         result = gateway_cli._detect_venv_dir()
         assert result == dot_venv
 
-    def test_falls_back_to_venv_directory(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("sys.prefix", "/usr")
-        monkeypatch.setattr("sys.base_prefix", "/usr")
-        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
-
-        venv = tmp_path / "venv"
-        venv.mkdir()
-
-        result = gateway_cli._detect_venv_dir()
-        assert result == venv
-
-    def test_prefers_dot_venv_over_venv(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("sys.prefix", "/usr")
-        monkeypatch.setattr("sys.base_prefix", "/usr")
-        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
-
-        (tmp_path / ".venv").mkdir()
-        (tmp_path / "venv").mkdir()
-
-        result = gateway_cli._detect_venv_dir()
-        assert result == tmp_path / ".venv"
 
     def test_returns_none_when_no_virtualenv(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.prefix", "/usr")
@@ -2186,6 +942,7 @@ class TestSystemUnitHermesHome:
         gateway_cli._append_node_dir_for_service(entries, tmp_path / ".hermes")
 
         assert entries == ["/opt/external-node/bin"]
+
     def test_managed_node_makes_system_unit_independent_of_callers_path(
         self, monkeypatch, tmp_path
     ):
@@ -2259,40 +1016,6 @@ class TestSystemUnitHermesHome:
         assert 'HERMES_HOME=/home/alice/.hermes' in unit
         assert '/root/.hermes' not in unit
 
-    def test_system_unit_remaps_profile_to_target_user(self, monkeypatch):
-        # Simulate sudo with a profile: HERMES_HOME was resolved under root
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
-        monkeypatch.setattr(
-            gateway_cli, "_system_service_identity",
-            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_build_user_local_paths",
-            lambda home, existing: [],
-        )
-
-        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
-
-        assert 'HERMES_HOME=/home/alice/.hermes/profiles/coder' in unit
-        assert '/root/' not in unit
-
-    def test_system_unit_preserves_custom_hermes_home(self, monkeypatch):
-        # Custom HERMES_HOME not under any user's home — keep as-is
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/opt/hermes-shared")
-        monkeypatch.setattr(
-            gateway_cli, "_system_service_identity",
-            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_build_user_local_paths",
-            lambda home, existing: [],
-        )
-
-        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
-
-        assert 'HERMES_HOME=/opt/hermes-shared' in unit
 
     def test_user_unit_unaffected_by_change(self):
         # User-scope units should still use the calling user's HERMES_HOME
@@ -2443,26 +1166,7 @@ class TestHermesHomeForTargetUser:
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
         assert result == "/home/alice/.hermes"
 
-    def test_remaps_profile_path(self, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
 
-        result = gateway_cli._hermes_home_for_target_user("/home/alice")
-        assert result == "/home/alice/.hermes/profiles/coder"
-
-    def test_keeps_custom_path(self, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/opt/hermes")
-
-        result = gateway_cli._hermes_home_for_target_user("/home/alice")
-        assert result == "/opt/hermes"
-
-    def test_noop_when_same_user(self, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/home/alice")))
-        monkeypatch.delenv("HERMES_HOME", raising=False)
-
-        result = gateway_cli._hermes_home_for_target_user("/home/alice")
-        assert result == "/home/alice/.hermes"
 
 
 class TestGeneratedUnitUsesDetectedVenv:
@@ -2485,15 +1189,6 @@ class TestGeneratedUnitUsesDetectedVenv:
 class TestGeneratedUnitIncludesLocalBin:
     """~/.local/bin must be in PATH so uvx/pipx tools are discoverable."""
 
-    def test_user_unit_includes_local_bin_in_path(self, monkeypatch):
-        home = Path.home()
-        monkeypatch.setattr(
-            gateway_cli,
-            "_build_user_local_paths",
-            lambda home_path, existing: [str(home / ".local" / "bin")],
-        )
-        unit = gateway_cli.generate_systemd_unit(system=False)
-        assert f"{home}/.local/bin" in unit
 
     def test_system_unit_includes_local_bin_in_path(self, monkeypatch):
         monkeypatch.setattr(
@@ -2547,25 +1242,6 @@ class TestSystemServiceIdentityRootHandling:
 class TestEnsureUserSystemdEnv:
     """Tests for _ensure_user_systemd_env() D-Bus session bus auto-detection."""
 
-    def test_sets_xdg_runtime_dir_when_missing(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
-        monkeypatch.setattr(os, "getuid", lambda: 42)
-
-        # _runtime_dir_is_ours verifies OWNERSHIP via stat (a leaked foreign
-        # XDG_RUNTIME_DIR must not be trusted, #86558) — fake an owned dir.
-        _orig_stat = gateway_cli.Path.stat
-        monkeypatch.setattr(
-            gateway_cli.Path,
-            "stat",
-            lambda self, **kw: SimpleNamespace(st_uid=42)
-            if str(self) == "/run/user/42"
-            else _orig_stat(self, **kw),
-        )
-
-        gateway_cli._ensure_user_systemd_env()
-
-        assert os.environ.get("XDG_RUNTIME_DIR") == "/run/user/42"
 
     def test_sets_dbus_address_when_bus_socket_exists(self, tmp_path, monkeypatch):
         runtime = tmp_path / "runtime"
@@ -2581,41 +1257,7 @@ class TestEnsureUserSystemdEnv:
 
         assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_socket}"
 
-    def test_preserves_existing_env_vars(self, tmp_path, monkeypatch):
-        """An OWNED custom XDG_RUNTIME_DIR is preserved (#86558 semantics).
 
-        An unowned/unreadable dir would be replaced by /run/user/<uid>; the
-        preserve contract only holds when stat says the dir is ours — fake
-        that so the assertion tests preservation, not CI uid luck.
-        """
-        monkeypatch.setenv("XDG_RUNTIME_DIR", "/custom/runtime")
-        monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/custom/bus")
-        _orig_stat = gateway_cli.Path.stat
-        monkeypatch.setattr(
-            gateway_cli.Path,
-            "stat",
-            lambda self, **kw: SimpleNamespace(st_uid=os.getuid())
-            if str(self) == "/custom/runtime"
-            else _orig_stat(self, **kw),
-        )
-
-        gateway_cli._ensure_user_systemd_env()
-
-        assert os.environ["XDG_RUNTIME_DIR"] == "/custom/runtime"
-        assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/custom/bus"
-
-    def test_no_dbus_when_bus_socket_missing(self, tmp_path, monkeypatch):
-        runtime = tmp_path / "runtime"
-        runtime.mkdir()
-        # no bus socket created
-
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
-        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
-        monkeypatch.setattr(os, "getuid", lambda: 99)
-
-        gateway_cli._ensure_user_systemd_env()
-
-        assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
 
     def test_systemctl_cmd_calls_ensure_for_user_mode(self, monkeypatch):
         calls = []
@@ -2624,14 +1266,6 @@ class TestEnsureUserSystemdEnv:
         result = gateway_cli._systemctl_cmd(system=False)
         assert result == ["systemctl", "--user"]
         assert calls == ["called"]
-
-    def test_systemctl_cmd_skips_ensure_for_system_mode(self, monkeypatch):
-        calls = []
-        monkeypatch.setattr(gateway_cli, "_ensure_user_systemd_env", lambda: calls.append("called"))
-
-        result = gateway_cli._systemctl_cmd(system=True)
-        assert result == ["systemctl"]
-        assert calls == []
 
 
 class TestPreflightUserSystemd:
@@ -2642,18 +1276,6 @@ class TestPreflightUserSystemd:
     which previously failed with a raw ``CalledProcessError`` and no remediation.
     """
 
-    def test_noop_when_bus_socket_exists(self, monkeypatch):
-        """Socket already there (desktop / linger + prior login) → no-op."""
-        monkeypatch.setattr(
-            gateway_cli, "_user_dbus_socket_path",
-            lambda: type("P", (), {"exists": lambda self: True})(),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_user_systemd_private_socket_path",
-            lambda: type("P", (), {"exists": lambda self: False})(),
-        )
-        # Should not raise, no subprocess calls needed.
-        gateway_cli._preflight_user_systemd()
 
     def test_raises_when_linger_disabled_and_loginctl_denied(self, monkeypatch):
         """Rick's scenario: no D-Bus, no linger, non-root SSH → clear error."""
@@ -2687,48 +1309,7 @@ class TestPreflightUserSystemd:
         assert "hermes gateway run" in msg  # foreground fallback mentioned
         assert "Interactive authentication required" in msg
 
-    def test_raises_when_loginctl_missing(self, monkeypatch):
-        """No loginctl binary at all → suggest sudo install + manual fix."""
-        monkeypatch.setattr(
-            gateway_cli, "_user_dbus_socket_path",
-            lambda: type("P", (), {"exists": lambda self: False})(),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_user_systemd_private_socket_path",
-            lambda: type("P", (), {"exists": lambda self: False})(),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "get_systemd_linger_status",
-            lambda: (None, "loginctl not found"),
-        )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda _: None)
 
-        with pytest.raises(gateway_cli.UserSystemdUnavailableError) as exc_info:
-            gateway_cli._preflight_user_systemd()
-
-        assert "sudo loginctl enable-linger" in str(exc_info.value)
-
-    def test_linger_enabled_but_socket_still_missing(self, monkeypatch):
-        """Edge case: linger says yes but the bus socket never came up."""
-        monkeypatch.setattr(
-            gateway_cli, "_user_dbus_socket_path",
-            lambda: type("P", (), {"exists": lambda self: False})(),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_user_systemd_private_socket_path",
-            lambda: type("P", (), {"exists": lambda self: False})(),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "get_systemd_linger_status", lambda: (True, ""),
-        )
-        monkeypatch.setattr(
-            gateway_cli, "_wait_for_user_dbus_socket", lambda timeout=3.0: False,
-        )
-
-        with pytest.raises(gateway_cli.UserSystemdUnavailableError) as exc_info:
-            gateway_cli._preflight_user_systemd()
-
-        assert "linger is enabled" in str(exc_info.value)
 
     def test_enable_linger_succeeds_and_socket_appears(self, monkeypatch, capsys):
         """Happy remediation path: polkit allows enable-linger, socket spawns."""
@@ -2767,76 +1348,11 @@ class TestPreflightUserSystemd:
 class TestProfileArg:
     """Tests for _profile_arg — returns '--profile <name>' for named profiles."""
 
-    def test_default_hermes_home_returns_empty(self, tmp_path, monkeypatch):
-        """Default ~/.hermes should not produce a --profile flag."""
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        result = gateway_cli._profile_arg(str(hermes_home))
-        assert result == ""
 
-    def test_named_profile_returns_flag(self, tmp_path, monkeypatch):
-        """~/.hermes/profiles/mybot should return '--profile mybot'."""
-        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
-        profile_dir.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-        result = gateway_cli._profile_arg(str(profile_dir))
-        assert result == "--profile mybot"
 
-    def test_named_profile_under_target_user_root_returns_flag(self, tmp_path):
-        """System installs generated under sudo must compare against target user's root."""
-        target_root = tmp_path / "home" / "alice" / ".hermes"
-        profile_dir = target_root / "profiles" / "mybot"
-        profile_dir.mkdir(parents=True)
 
-        result = gateway_cli._profile_arg(str(profile_dir), default_root=target_root)
 
-        assert result == "--profile mybot"
 
-    def test_hash_path_returns_empty(self, tmp_path, monkeypatch):
-        """Arbitrary non-profile HERMES_HOME should return empty string."""
-        custom_home = tmp_path / "custom" / "hermes"
-        custom_home.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-        result = gateway_cli._profile_arg(str(custom_home))
-        assert result == ""
-
-    def test_nested_profile_path_returns_empty(self, tmp_path, monkeypatch):
-        """~/.hermes/profiles/mybot/subdir should NOT match — too deep."""
-        nested = tmp_path / ".hermes" / "profiles" / "mybot" / "subdir"
-        nested.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-        result = gateway_cli._profile_arg(str(nested))
-        assert result == ""
-
-    def test_invalid_profile_name_returns_empty(self, tmp_path, monkeypatch):
-        """Profile names with invalid chars should not match the regex."""
-        bad_profile = tmp_path / ".hermes" / "profiles" / "My Bot!"
-        bad_profile.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-        result = gateway_cli._profile_arg(str(bad_profile))
-        assert result == ""
-
-    def test_systemd_unit_includes_profile(self, tmp_path, monkeypatch):
-        """generate_systemd_unit should include --profile in ExecStart for named profiles."""
-        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
-        profile_dir.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
-        unit = gateway_cli.generate_systemd_unit(system=False)
-        assert "--profile mybot" in unit
-        assert "gateway run" in unit
-        # Under a process supervisor (Restart=always), --replace makes each
-        # restart kill its predecessor → self-kill loop. The systemd unit must
-        # NOT use --replace; the supervisor owns the lifecycle. (--replace stays
-        # on the manual launchd fallback path — see test_launchd_plist_includes_profile.)
-        assert "--replace" not in unit
 
     def test_systemd_unit_for_target_user_includes_named_profile(self, tmp_path, monkeypatch):
         """sudo system install must keep the target user's named profile in ExecStart."""
@@ -2860,27 +1376,34 @@ class TestProfileArg:
         assert "--profile mybot gateway run" in unit
         assert f'HERMES_HOME={target_home / ".hermes" / "profiles" / "mybot"}' in unit
 
-    def test_launchd_plist_includes_profile(self, tmp_path, monkeypatch):
-        """generate_launchd_plist should include --profile in ProgramArguments for named profiles."""
-
     def test_launchd_plist_wraps_gateway_stderr_with_timestamps(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
         profile_dir.mkdir(parents=True)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile_dir))
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
-        plist = gateway_cli.generate_launchd_plist()
-        assert "<string>--profile</string>" in plist
-        assert "<string>mybot</string>" in plist
-
-    def test_launchd_plist_supports_aqua_and_background_sessions(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/usr/bin/python3")
-        # macOS 26+ only loads the agent in non-Aqua sessions when the plist
-        # opts into Background as well (issue #23387).
+
         plist = gateway_cli.generate_launchd_plist()
-        assert "<key>LimitLoadToSessionType</key>" in plist
-        assert "<string>Aqua</string>" in plist
-        assert "<string>Background</string>" in plist
+        program_args = plistlib.loads(plist.encode("utf-8"))["ProgramArguments"]
+
+        assert program_args == [
+            "/usr/bin/python3",
+            "-m",
+            "hermes_cli.stderr_timestamp",
+            "--error-log",
+            str(profile_dir / "logs" / "gateway.error.log"),
+            "--",
+            "/usr/bin/python3",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "mybot",
+            "gateway",
+            "run",
+            "--replace",
+            "--external-supervisor",
+        ]
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
@@ -2911,19 +1434,6 @@ class TestRemapPathForUser:
             str(tmp_path / "alice"),
         )
         assert result == str(tmp_path / "alice" / ".hermes" / "hermes-agent")
-
-    def test_keeps_system_path_unchanged(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "root")
-        (tmp_path / "root").mkdir()
-        result = gateway_cli._remap_path_for_user("/opt/hermes", str(tmp_path / "alice"))
-        assert result == "/opt/hermes"
-
-    def test_noop_when_same_user(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "alice")
-        (tmp_path / "alice").mkdir()
-        original = str(tmp_path / "alice" / ".hermes" / "hermes-agent")
-        result = gateway_cli._remap_path_for_user(original, str(tmp_path / "alice"))
-        assert result == original
 
 
 class TestSystemUnitPathRemapping:
@@ -3015,43 +1525,6 @@ class TestDockerAwareGateway:
         assert "Docker" in out or "docker" in out
         assert "restart" in out.lower()
 
-    def test_uninstall_in_container_prints_docker_guidance(self, monkeypatch, capsys):
-        """'hermes gateway uninstall' inside Docker exits 0 with container guidance."""
-        import pytest
-
-        monkeypatch.setattr(gateway_cli, "is_managed", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_container", lambda: True)
-
-        args = SimpleNamespace(gateway_command="uninstall", system=False)
-        with pytest.raises(SystemExit) as exc_info:
-            gateway_cli.gateway_command(args)
-
-        assert exc_info.value.code == 0
-        out = capsys.readouterr().out
-        assert "docker" in out.lower()
-
-    def test_start_in_container_prints_docker_guidance(self, monkeypatch, capsys):
-        """'hermes gateway start' inside Docker exits 0 with container guidance."""
-        import pytest
-
-        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_container", lambda: True)
-
-        args = SimpleNamespace(gateway_command="start", system=False)
-        with pytest.raises(SystemExit) as exc_info:
-            gateway_cli.gateway_command(args)
-
-        assert exc_info.value.code == 0
-        out = capsys.readouterr().out
-        assert "docker" in out.lower()
-        assert "hermes gateway run" in out
-
 
 class TestLegacyHermesUnitDetection:
     """Tests for _find_legacy_hermes_units / has_legacy_hermes_units.
@@ -3087,81 +1560,10 @@ class TestLegacyHermesUnitDetection:
         )
         return user_dir, system_dir
 
-    def test_detects_legacy_hermes_service_in_user_scope(self, tmp_path, monkeypatch):
-        user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
-        legacy = user_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
 
-        results = gateway_cli._find_legacy_hermes_units()
 
-        assert len(results) == 1
-        name, path, is_system = results[0]
-        assert name == "hermes.service"
-        assert path == legacy
-        assert is_system is False
-        assert gateway_cli.has_legacy_hermes_units() is True
 
-    def test_detects_legacy_hermes_service_in_system_scope(self, tmp_path, monkeypatch):
-        _, system_dir = self._setup_search_paths(tmp_path, monkeypatch)
-        legacy = system_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
 
-        results = gateway_cli._find_legacy_hermes_units()
-
-        assert len(results) == 1
-        name, path, is_system = results[0]
-        assert name == "hermes.service"
-        assert path == legacy
-        assert is_system is True
-
-    def test_ignores_profile_unit_hermes_gateway_coder(self, tmp_path, monkeypatch):
-        """CRITICAL: profile units must NOT be flagged as legacy.
-
-        Teknium's concern — ``hermes-gateway-coder.service`` is our standard
-        naming for the ``coder`` profile. The legacy detector is an explicit
-        allowlist, not a glob, so profile units are safe.
-        """
-        user_dir, system_dir = self._setup_search_paths(tmp_path, monkeypatch)
-        # Drop profile units in BOTH scopes with our ExecStart
-        for base in (user_dir, system_dir):
-            (base / "hermes-gateway-coder.service").write_text(
-                self._OUR_UNIT_TEXT, encoding="utf-8"
-            )
-            (base / "hermes-gateway-orcha.service").write_text(
-                self._OUR_UNIT_TEXT, encoding="utf-8"
-            )
-            (base / "hermes-gateway.service").write_text(
-                self._OUR_UNIT_TEXT, encoding="utf-8"
-            )
-
-        results = gateway_cli._find_legacy_hermes_units()
-
-        assert results == []
-        assert gateway_cli.has_legacy_hermes_units() is False
-
-    def test_ignores_unrelated_hermes_service(self, tmp_path, monkeypatch):
-        """Third-party ``hermes.service`` that isn't ours stays untouched.
-
-        If a user has some other package named ``hermes`` installed as a
-        service, we must not flag it.
-        """
-        user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
-        (user_dir / "hermes.service").write_text(
-            "[Unit]\nDescription=Some Other Hermes\n[Service]\n"
-            "ExecStart=/opt/other-hermes/bin/daemon --foreground\n",
-            encoding="utf-8",
-        )
-
-        results = gateway_cli._find_legacy_hermes_units()
-
-        assert results == []
-        assert gateway_cli.has_legacy_hermes_units() is False
-
-    def test_returns_empty_when_no_legacy_files_exist(self, tmp_path, monkeypatch):
-        self._setup_search_paths(tmp_path, monkeypatch)
-
-        assert gateway_cli._find_legacy_hermes_units() == []
-        assert gateway_cli.has_legacy_hermes_units() is False
 
     def test_detects_both_scopes_simultaneously(self, tmp_path, monkeypatch):
         """When a user has BOTH user-scope and system-scope legacy units,
@@ -3201,13 +1603,6 @@ class TestLegacyHermesUnitDetection:
             results = gateway_cli._find_legacy_hermes_units()
             assert len(results) == 1, f"Variant {i} not detected: {execstart!r}"
 
-    def test_print_legacy_unit_warning_is_noop_when_empty(self, tmp_path, monkeypatch, capsys):
-        self._setup_search_paths(tmp_path, monkeypatch)
-
-        gateway_cli.print_legacy_unit_warning()
-        out = capsys.readouterr().out
-
-        assert out == ""
 
     def test_print_legacy_unit_warning_shows_migration_hint(self, tmp_path, monkeypatch, capsys):
         user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
@@ -3220,24 +1615,6 @@ class TestLegacyHermesUnitDetection:
         assert "hermes.service" in out
         assert "hermes gateway migrate-legacy" in out
 
-    def test_handles_unreadable_unit_file_gracefully(self, tmp_path, monkeypatch):
-        """A permission error reading a unit file must not crash detection."""
-        user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
-        unreadable = user_dir / "hermes.service"
-        unreadable.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-        # Simulate a read failure — monkeypatch Path.read_text to raise
-        original_read_text = gateway_cli.Path.read_text
-
-        def raising_read_text(self, *args, **kwargs):
-            if self == unreadable:
-                raise PermissionError("simulated")
-            return original_read_text(self, *args, **kwargs)
-
-        monkeypatch.setattr(gateway_cli.Path, "read_text", raising_read_text)
-
-        # Should not raise
-        results = gateway_cli._find_legacy_hermes_units()
-        assert results == []
 
 
 class TestRemoveLegacyHermesUnits:
@@ -3270,30 +1647,7 @@ class TestRemoveLegacyHermesUnits:
         monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0 if as_root else 1000)
         return user_dir, system_dir, systemctl_calls
 
-    def test_returns_zero_when_no_legacy_units(self, tmp_path, monkeypatch, capsys):
-        self._setup(tmp_path, monkeypatch)
 
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(interactive=False)
-
-        assert removed == 0
-        assert remaining == []
-        assert "No legacy" in capsys.readouterr().out
-
-    def test_dry_run_lists_without_removing(self, tmp_path, monkeypatch, capsys):
-        user_dir, _, calls = self._setup(tmp_path, monkeypatch)
-        legacy = user_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(
-            interactive=False, dry_run=True
-        )
-
-        assert removed == 0
-        assert remaining == [legacy]
-        assert legacy.exists()  # Not removed
-        assert calls == []  # No systemctl invocations
-        out = capsys.readouterr().out
-        assert "dry-run" in out
 
     def test_removes_user_scope_legacy_unit(self, tmp_path, monkeypatch, capsys):
         user_dir, _, calls = self._setup(tmp_path, monkeypatch)
@@ -3311,51 +1665,7 @@ class TestRemoveLegacyHermesUnits:
         assert any("--user disable hermes.service" in c for c in cmds_joined)
         assert any("--user daemon-reload" in c for c in cmds_joined)
 
-    def test_system_scope_without_root_defers_removal(self, tmp_path, monkeypatch, capsys):
-        _, system_dir, calls = self._setup(tmp_path, monkeypatch, as_root=False)
-        legacy = system_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
 
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(interactive=False)
-
-        assert removed == 0
-        assert remaining == [legacy]
-        assert legacy.exists()  # Not removed — requires sudo
-        out = capsys.readouterr().out
-        assert "sudo hermes gateway migrate-legacy" in out
-
-    def test_system_scope_with_root_removes(self, tmp_path, monkeypatch, capsys):
-        _, system_dir, calls = self._setup(tmp_path, monkeypatch, as_root=True)
-        legacy = system_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(interactive=False)
-
-        assert removed == 1
-        assert remaining == []
-        assert not legacy.exists()
-        cmds_joined = [" ".join(c) for c in calls]
-        # System-scope uses plain "systemctl" (no --user)
-        assert any(
-            c.startswith("systemctl stop hermes.service") for c in cmds_joined
-        )
-        assert any(
-            c.startswith("systemctl disable hermes.service") for c in cmds_joined
-        )
-
-    def test_removes_both_scopes_with_root(self, tmp_path, monkeypatch, capsys):
-        user_dir, system_dir, _ = self._setup(tmp_path, monkeypatch, as_root=True)
-        user_legacy = user_dir / "hermes.service"
-        system_legacy = system_dir / "hermes.service"
-        user_legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-        system_legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(interactive=False)
-
-        assert removed == 2
-        assert remaining == []
-        assert not user_legacy.exists()
-        assert not system_legacy.exists()
 
     def test_does_not_touch_profile_units_during_migration(
         self, tmp_path, monkeypatch, capsys
@@ -3377,19 +1687,6 @@ class TestRemoveLegacyHermesUnits:
         assert profile_unit.exists()
         assert default_unit.exists()
 
-    def test_interactive_prompt_no_skips_removal(self, tmp_path, monkeypatch, capsys):
-        """When interactive=True and user answers no, no removal happens."""
-        user_dir, _, _ = self._setup(tmp_path, monkeypatch)
-        legacy = user_dir / "hermes.service"
-        legacy.write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
-
-        monkeypatch.setattr(gateway_cli, "prompt_yes_no", lambda *a, **k: False)
-
-        removed, remaining = gateway_cli.remove_legacy_hermes_units(interactive=True)
-
-        assert removed == 0
-        assert remaining == [legacy]
-        assert legacy.exists()
 
 
 class TestMigrateLegacyCommand:
@@ -3461,26 +1758,6 @@ class TestGatewayStatusParser:
         assert result.returncode == 0
         assert "unrecognized arguments" not in result.stderr
 
-    def test_gateway_command_migrate_legacy_dry_run_passes_through(
-        self, monkeypatch
-    ):
-        called = {}
-
-        def fake_remove(interactive=True, dry_run=False):
-            called["interactive"] = interactive
-            called["dry_run"] = dry_run
-            return 0, []
-
-        monkeypatch.setattr(gateway_cli, "remove_legacy_hermes_units", fake_remove)
-        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
-        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-
-        args = SimpleNamespace(
-            gateway_command="migrate-legacy", dry_run=True, yes=False
-        )
-        gateway_cli.gateway_command(args)
-
-        assert called == {"interactive": True, "dry_run": True}
 
     def test_migrate_legacy_on_unsupported_platform_prints_message(
         self, monkeypatch, capsys
@@ -3648,11 +1925,6 @@ class TestSystemScopeRequiresRootError:
         assert str(excinfo.value) == "System gateway start requires root. Re-run with sudo."
         assert f"Failed: {excinfo.value}" == "Failed: System gateway start requires root. Re-run with sudo."
 
-    def test_require_root_noop_when_root(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0)
-
-        # Should not raise, should not exit
-        gateway_cli._require_root_for_system_service("start")
 
     def test_error_is_runtime_error_subclass(self):
         """Wizards use ``except Exception`` guards — the error must be a
@@ -3693,24 +1965,6 @@ class TestSystemScopeWizardPreCheck:
 
         assert gateway_cli._system_scope_wizard_would_need_root() is True
 
-    def test_root_never_needs_root(self, tmp_path, monkeypatch):
-        self._setup_units(tmp_path, monkeypatch, system_present=True, user_present=False)
-        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0)
-
-        assert gateway_cli._system_scope_wizard_would_need_root() is False
-
-    def test_non_root_with_user_unit_present_returns_false(self, tmp_path, monkeypatch):
-        # User-scope unit present — user can start it themselves, no sudo needed.
-        self._setup_units(tmp_path, monkeypatch, system_present=True, user_present=True)
-        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1000)
-
-        assert gateway_cli._system_scope_wizard_would_need_root() is False
-
-    def test_non_root_with_no_units_returns_false(self, tmp_path, monkeypatch):
-        self._setup_units(tmp_path, monkeypatch, system_present=False, user_present=False)
-        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1000)
-
-        assert gateway_cli._system_scope_wizard_would_need_root() is False
 
     def test_non_root_with_explicit_system_arg_returns_true(self, tmp_path, monkeypatch):
         # Caller passed system=True explicitly (e.g. ``hermes gateway start --system``).
@@ -3736,24 +1990,6 @@ class TestSystemScopeRemediationOutput:
         assert "sudo systemctl start hermes-gateway" in out
         assert "sudo hermes gateway uninstall --system" in out
         assert "hermes gateway install" in out
-
-    def test_restart_remediation_uses_systemctl_restart(self, capsys, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway")
-
-        gateway_cli._print_system_scope_remediation("restart")
-        out = capsys.readouterr().out
-
-        assert "restart requires root" in out
-        assert "sudo systemctl restart hermes-gateway" in out
-
-    def test_stop_remediation_uses_systemctl_stop(self, capsys, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway")
-
-        gateway_cli._print_system_scope_remediation("stop")
-        out = capsys.readouterr().out
-
-        assert "stop requires root" in out
-        assert "sudo systemctl stop hermes-gateway" in out
 
 
 class TestGatewayCommandCatchesSystemScopeError:
@@ -3797,17 +2033,7 @@ class TestServiceWorkingDirIsStable:
     deleted checkout can't crash-loop the unit on CHDIR (status=200).
     """
 
-    def test_stable_working_dir_uses_hermes_home(self, tmp_path, monkeypatch):
-        home = tmp_path / ".hermes"
-        home.mkdir()
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
-        assert Path(gateway_cli._stable_service_working_dir()) == home.resolve()
 
-    def test_stable_working_dir_falls_back_to_project_root(self, tmp_path, monkeypatch):
-        # HERMES_HOME points somewhere that does not exist -> fall back.
-        missing = tmp_path / "does-not-exist" / ".hermes"
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: missing)
-        assert gateway_cli._stable_service_working_dir() == str(gateway_cli.PROJECT_ROOT)
 
     def test_user_unit_workingdirectory_is_hermes_home_not_checkout(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"
@@ -3833,27 +2059,6 @@ class TestServiceWorkingDirIsStable:
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
 
-    def test_launchd_plist_keepalive_unconditional(self, tmp_path, monkeypatch):
-        """KeepAlive must be unconditional <true/> so the gateway restarts on clean exits.
-
-        Bug #37388: the old ``KeepAlive.SuccessfulExit = false`` dict form meant
-        launchd would NOT restart after a zero-exit (e.g. ``gateway run --replace``
-        causes the old instance to exit cleanly).  Switching to the scalar
-        ``<key>KeepAlive</key><true/>`` makes launchd restart regardless of exit code.
-        """
-        home = tmp_path / ".hermes"
-        home.mkdir()
-        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
-        plist = gateway_cli.generate_launchd_plist()
-
-        # Scalar <true/> must be present immediately after the KeepAlive key
-        assert "<key>KeepAlive</key>" in plist
-        # The unconditional form
-        assert "<key>KeepAlive</key>\n    <true/>" in plist
-        # The old conditional dict form must NOT appear
-        assert "SuccessfulExit" not in plist
-        assert "<key>KeepAlive</key>\n    <dict>" not in plist
-
 
 class TestLaunchctlBootstrapEioRetry:
     """`_launchctl_bootstrap` must recover from a stale already-loaded label.
@@ -3870,18 +2075,6 @@ class TestLaunchctlBootstrapEioRetry:
     DOMAIN = "gui/501"
     LABEL = "ai.hermes.gateway"
 
-    def test_bootstrap_succeeds_first_try_without_bootout(self, monkeypatch):
-        calls = []
-
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
-
-        assert calls == [["launchctl", "bootstrap", self.DOMAIN, self.PLIST]]
 
     def test_eio_triggers_bootout_then_retry(self, monkeypatch):
         calls = []
@@ -3917,23 +2110,6 @@ class TestLaunchctlBootstrapEioRetry:
         with pytest.raises(subprocess.CalledProcessError) as excinfo:
             gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
         assert excinfo.value.returncode == 5
-
-    def test_non_eio_failure_reraises_without_bootout(self, monkeypatch):
-        calls = []
-
-        def fake_run(cmd, check=True, **kwargs):
-            calls.append(cmd)
-            if cmd[1] == "bootstrap":
-                raise subprocess.CalledProcessError(125, cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-
-        with pytest.raises(subprocess.CalledProcessError) as excinfo:
-            gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
-        assert excinfo.value.returncode == 125
-        # A non-EIO failure is not the already-loaded case: no bootout/retry.
-        assert calls == [["launchctl", "bootstrap", self.DOMAIN, self.PLIST]]
 
 
 class TestRetryLaunchctlBootstrapUntilRegistered:
@@ -4008,28 +2184,6 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-
-    def test_returns_false_when_deadline_exhausts(self, monkeypatch):
-        """When the label never registers, the loop stops at the deadline and
-        returns False (so the caller logs the persistent orphan)."""
-        def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "list"]:
-                return SimpleNamespace(returncode=1)  # never registered
-            if cmd[1] == "bootstrap":
-                raise subprocess.CalledProcessError(1, cmd)
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
-
-        # Deadline already in the past → exactly one attempt, then give up.
-        ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
-            self.DOMAIN, self.PLIST, self.LABEL,
-            deadline=gateway_cli.time.monotonic() - 1,
-        )
-        assert ok is False
-
-
     def test_registered_but_not_running_is_not_success(self, monkeypatch):
         """A definition with no PID must not end the loop.
 


### PR DESCRIPTION
## Description
Syncs Cluster 3: Gateway Ledger & Deduplication from upstream:

1. **Ledger Atomic Claim & Message Redelivery Deduplication**:
   - In `gateway/run.py` and `gateway/session.py`, claim ledger rows and clear `resume_pending` inline before dispatching abandonable boot-send tasks.
   - Prevents duplicate redelivery bursts on gateway restarts.

2. **Supervised Watcher & Context Isolation**:
   - Give supervision exhaustion an explicit owner for queued platforms.
   - Isolate supervised watcher contexts and kanban dispatcher `to_thread` context.
   - Fix dead reconnect watcher healing for queued platforms.

3. **Systemd Restart Ownership**:
   - Make systemd the sole restart owner and preserve systemd handoff recovery.
   - Promote `parse_systemd_duration_to_us` to public.

4. **Validation**:
   - 361 gateway/CLI service tests + 422 evolution tests passing 100%.