### PR TITLE
fix(cron): preflight validation for missing attached skills and manifest checks (#3094)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -517,16 +517,40 @@ def check_job_skills_manifest(
     if not skill_list:
         return [], []
 
-    from agent.skill_bundles import resolve_bundle_command_key
+    from agent.skill_bundles import get_skill_bundles, resolve_bundle_command_key
     from agent.skill_utils import normalize_skill_lookup_name
     from tools.skills_tool import skill_view
 
     installed: List[str] = []
     missing: List[str] = []
+    bundles = None
+
     for skill_name in skill_list:
-        if resolve_bundle_command_key(skill_name.lstrip("/")):
-            installed.append(skill_name)
+        bundle_key = resolve_bundle_command_key(skill_name.lstrip("/"))
+        if bundle_key:
+            if bundles is None:
+                bundles = get_skill_bundles()
+            bundle = bundles.get(bundle_key)
+            if not bundle or not bundle.get("skills"):
+                missing.append(skill_name)
+                continue
+            all_members_installed = True
+            for member in bundle.get("skills", []):
+                try:
+                    raw = skill_view(normalize_skill_lookup_name(str(member).strip()))
+                    payload = json.loads(raw)
+                    if not (isinstance(payload, dict) and payload.get("success")):
+                        all_members_installed = False
+                        break
+                except Exception:
+                    all_members_installed = False
+                    break
+            if all_members_installed:
+                installed.append(skill_name)
+            else:
+                missing.append(skill_name)
             continue
+
         try:
             raw = skill_view(normalize_skill_lookup_name(skill_name))
             payload = json.loads(raw)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -505,6 +505,40 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+def check_job_skills_manifest(
+    skills: Optional[Union[str, List[str]]],
+) -> Tuple[List[str], List[str]]:
+    """Check a list of skill names against installed skills in the active profile.
+
+    Returns:
+        Tuple of (installed_skills, missing_skills)
+    """
+    skill_list = _normalize_skill_list(skills=skills)
+    if not skill_list:
+        return [], []
+
+    from agent.skill_bundles import resolve_bundle_command_key
+    from agent.skill_utils import normalize_skill_lookup_name
+    from tools.skills_tool import skill_view
+
+    installed: List[str] = []
+    missing: List[str] = []
+    for skill_name in skill_list:
+        if resolve_bundle_command_key(skill_name.lstrip("/")):
+            installed.append(skill_name)
+            continue
+        try:
+            raw = skill_view(normalize_skill_lookup_name(skill_name))
+            payload = json.loads(raw)
+            if isinstance(payload, dict) and payload.get("success"):
+                installed.append(skill_name)
+            else:
+                missing.append(skill_name)
+        except Exception:
+            missing.append(skill_name)
+    return installed, missing
+
+
 def _coerce_job_text(value: Any, fallback: str = "") -> str:
     """Coerce legacy/hand-edited nullable cron fields to strings for readers."""
     if value is None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4604,14 +4604,13 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
 
 
 def _preflight_check_skills(job: dict) -> Optional[str]:
-    """Check attached skills report ready (no missing required env/commands).
+    """Check attached skills exist and report ready (installed and no missing required env/commands).
 
     Consults the same ``readiness_status`` payload ``skill_view`` computes
-    for interactive use. Skills that fail to load at all are left to the
-    existing skipped-skill handling in ``_build_job_prompt`` (fail-open):
-    this check only blocks on an affirmative "setup needed" verdict, i.e.
-    the skill exists but its required environment is missing — a run that
-    is guaranteed to misfire.
+    for interactive use. If an attached skill is missing/uninstalled in the active
+    profile or its required environment is missing, preflight blocks the run
+    before constructing the agent so no tokens are burned and the operator is
+    alerted (same fail-before-spend spirit as the #44585 drift guard and #27948).
     """
     skills = job.get("skills")
     if skills is None:
@@ -4623,15 +4622,44 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     if not skill_names:
         return None
 
+    from agent.skill_bundles import (
+        build_bundle_invocation_message,
+        resolve_bundle_command_key,
+    )
+    from agent.skill_utils import normalize_skill_lookup_name
     from tools.skills_tool import skill_view
 
     for skill_name in skill_names:
-        try:
-            payload = json.loads(skill_view(skill_name))
-        except Exception:
-            continue  # unreadable/missing skill → existing skip handling
-        if not isinstance(payload, dict) or not payload.get("success"):
+        bundle_key = resolve_bundle_command_key(skill_name.lstrip("/"))
+        if bundle_key:
+            bundle_payload = build_bundle_invocation_message(
+                bundle_key,
+                user_instruction="",
+                task_id=str(job.get("id") or "") or None,
+            )
+            if not bundle_payload or not bundle_payload[1]:
+                return (
+                    f"attached skill bundle '{skill_name}' could not load any member skills. "
+                    "Install the required skills or detach the bundle from this job."
+                )
             continue
+
+        try:
+            payload = json.loads(skill_view(normalize_skill_lookup_name(skill_name)))
+        except Exception as exc:
+            return (
+                f"attached skill '{skill_name}' failed to load: {exc}. "
+                "Install the missing skill or detach it from this job."
+            )
+        if not isinstance(payload, dict) or not payload.get("success"):
+            error_msg = (
+                (payload.get("error") if isinstance(payload, dict) else None)
+                or "skill not found in active profile"
+            )
+            return (
+                f"attached skill '{skill_name}' is not installed in the active profile ({error_msg}). "
+                "Install the missing skill or detach it from this job."
+            )
         if (
             payload.get("setup_needed")
             or payload.get("readiness_status") == "setup_needed"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4607,8 +4607,8 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     """Check attached skills exist and report ready (installed and no missing required env/commands).
 
     Consults the same ``readiness_status`` payload ``skill_view`` computes
-    for interactive use. If an attached skill is missing/uninstalled in the active
-    profile or its required environment is missing, preflight blocks the run
+    for interactive use. If an attached skill or bundle member is missing/uninstalled
+    in the active profile or its required environment is missing, preflight blocks the run
     before constructing the agent so no tokens are burned and the operator is
     alerted (same fail-before-spend spirit as the #44585 drift guard and #27948).
     """
@@ -4623,67 +4623,82 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
         return None
 
     from agent.skill_bundles import (
-        build_bundle_invocation_message,
+        get_skill_bundles,
         resolve_bundle_command_key,
     )
     from agent.skill_utils import normalize_skill_lookup_name
     from tools.skills_tool import skill_view
 
-    for skill_name in skill_names:
-        bundle_key = resolve_bundle_command_key(skill_name.lstrip("/"))
-        if bundle_key:
-            bundle_payload = build_bundle_invocation_message(
-                bundle_key,
-                user_instruction="",
-                task_id=str(job.get("id") or "") or None,
-            )
-            if not bundle_payload or not bundle_payload[1]:
-                return (
-                    f"attached skill bundle '{skill_name}' could not load any member skills. "
-                    "Install the required skills or detach the bundle from this job."
-                )
-            continue
-
+    def _check_single_skill(name: str, context_label: str) -> Optional[str]:
+        lookup_name = normalize_skill_lookup_name(name)
         try:
-            payload = json.loads(skill_view(normalize_skill_lookup_name(skill_name)))
+            raw = skill_view(lookup_name)
+            payload = json.loads(raw)
         except Exception as exc:
+            logger.debug("Cron preflight: could not inspect skill '%s': %s", name, exc)
+            return None  # fail-open on transient I/O or JSON decode errors
+
+        if isinstance(payload, dict) and not payload.get("success"):
+            error_msg = payload.get("error") or "skill not found in active profile"
             return (
-                f"attached skill '{skill_name}' failed to load: {exc}. "
+                f"{context_label} '{name}' is not installed in the active profile ({error_msg}). "
                 "Install the missing skill or detach it from this job."
             )
-        if not isinstance(payload, dict) or not payload.get("success"):
-            error_msg = (
-                (payload.get("error") if isinstance(payload, dict) else None)
-                or "skill not found in active profile"
-            )
-            return (
-                f"attached skill '{skill_name}' is not installed in the active profile ({error_msg}). "
-                "Install the missing skill or detach it from this job."
-            )
-        if (
+        if isinstance(payload, dict) and (
             payload.get("setup_needed")
             or payload.get("readiness_status") == "setup_needed"
         ):
             missing = [
-                f"env ${name}"
-                for name in payload.get(
+                f"env ${env_var}"
+                for env_var in payload.get(
                     "missing_required_environment_variables"
                 ) or []
             ]
             missing += [
-                f"command '{name}'"
-                for name in payload.get("missing_required_commands") or []
+                f"command '{cmd}'"
+                for cmd in payload.get("missing_required_commands") or []
             ]
             missing += [
-                f"credential file {name}"
-                for name in payload.get("missing_credential_files") or []
+                f"credential file {path}"
+                for path in payload.get("missing_credential_files") or []
             ]
             detail = ", ".join(missing) or "required setup incomplete"
             return (
-                f"attached skill '{skill_name}' is not ready: missing "
+                f"{context_label} '{name}' is not ready: missing "
                 f"{detail}. Provide the missing prerequisites or detach the "
                 "skill from this job."
             )
+        return None
+
+    for skill_name in skill_names:
+        bundle_key = resolve_bundle_command_key(skill_name.lstrip("/"))
+        if bundle_key:
+            bundles = get_skill_bundles()
+            bundle = bundles.get(bundle_key)
+            if not bundle:
+                return (
+                    f"attached skill bundle '{skill_name}' is not found in the active profile. "
+                    "Install the bundle or detach it from this job."
+                )
+            member_skills = bundle.get("skills") or []
+            if not member_skills:
+                return (
+                    f"attached skill bundle '{skill_name}' has no member skills defined. "
+                    "Add member skills or detach the bundle from this job."
+                )
+            for member in member_skills:
+                member_err = _check_single_skill(
+                    str(member).strip(),
+                    f"attached bundle '{skill_name}' member skill",
+                )
+                if member_err:
+                    return member_err
+            continue
+
+        err = _check_single_skill(skill_name, "attached skill")
+        if err:
+            return err
+
     return None
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -405,6 +405,16 @@ def cron_create(args):
     print(f"  Schedule: {result['schedule']}")
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
+        from cron.jobs import check_job_skills_manifest
+
+        _, missing = check_job_skills_manifest(result["skills"])
+        if missing:
+            print(
+                color(
+                    f"  ⚠️ Warning: Attached skill(s) not installed in active profile: {', '.join(missing)}",
+                    Colors.YELLOW,
+                )
+            )
     job_data = result.get("job", {})
     if job_data.get("script"):
         print(f"  Script: {job_data['script']}")
@@ -481,6 +491,16 @@ def cron_edit(args):
     print(f"  Schedule: {updated['schedule']}")
     if updated.get("skills"):
         print(f"  Skills: {', '.join(updated['skills'])}")
+        from cron.jobs import check_job_skills_manifest
+
+        _, missing = check_job_skills_manifest(updated["skills"])
+        if missing:
+            print(
+                color(
+                    f"  ⚠️ Warning: Attached skill(s) not installed in active profile: {', '.join(missing)}",
+                    Colors.YELLOW,
+                )
+            )
     else:
         print("  Skills: none")
     if updated.get("script"):

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -344,6 +344,33 @@ class TestSkillReadiness:
         assert installed == ["installed-one"]
         assert missing == ["missing-two"]
 
+    def test_bundle_with_missing_member_blocks(self, tmp_path):
+        """A skill bundle whose member skill is missing blocks preflight."""
+        fake_bundles = {
+            "my-bundle": {
+                "name": "my-bundle",
+                "skills": ["member-one", "missing-member"],
+            }
+        }
+
+        def fake_skill_view(name, *args, **kwargs):
+            if name == "member-one":
+                return json.dumps({"success": True, "content": "hi"})
+            return json.dumps({"success": False, "error": "not found"})
+
+        job = _job(skills=["/my-bundle"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch("agent.skill_bundles.resolve_bundle_command_key", return_value="my-bundle"), \
+                 patch("agent.skill_bundles.get_skill_bundles", return_value=fake_bundles):
+                success, output, final_response, error, agent_constructed = \
+                    _run_job_patched(job, tmp_path, skill_view=fake_skill_view)
+
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None and "[blocked_config]" in error
+        assert "missing-member" in f"{error} {output}"
+
 
 class TestDeliveryPlatform:
     def test_unknown_delivery_platform_blocks(self, tmp_path):

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -313,6 +313,37 @@ class TestSkillReadiness:
         assert success is True
         assert agent_constructed is True
 
+    def test_missing_skill_blocks(self, tmp_path):
+        """An attached skill that is not installed in the active profile blocks the run."""
+        payload = json.dumps({"success": False, "error": "Skill 'ghost-skill' not found"})
+
+        def fake_skill_view(name, *args, **kwargs):
+            return payload
+
+        job = _job(skills=["ghost-skill"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            success, output, final_response, error, agent_constructed = \
+                _run_job_patched(job, tmp_path, skill_view=fake_skill_view)
+
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None and "[blocked_config]" in error
+        assert "ghost-skill" in f"{error} {output}"
+
+    def test_check_job_skills_manifest(self):
+        """check_job_skills_manifest correctly partitions installed vs missing skills."""
+        def fake_skill_view(name, *args, **kwargs):
+            if name == "installed-one":
+                return json.dumps({"success": True, "content": "hi"})
+            return json.dumps({"success": False, "error": "not found"})
+
+        with patch("tools.skills_tool.skill_view", side_effect=fake_skill_view):
+            installed, missing = cron_jobs.check_job_skills_manifest(["installed-one", "missing-two"])
+
+        assert installed == ["installed-one"]
+        assert missing == ["missing-two"]
+
 
 class TestDeliveryPlatform:
     def test_unknown_delivery_platform_blocks(self, tmp_path):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,7 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            await resp.text()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None


### PR DESCRIPTION
Closes #3094

### Problem
Cron jobs referencing skills not installed in the active profile were silently skipped at runtime, falling back to autonomous reasoning without the skill's validation, rules, and output schemas.

### Solution
1. **Pre-dispatch skill check (`_preflight_check_skills`)**:
   - Validates that attached skills or skill bundles are installed and ready in the active profile before constructing the agent.
   - If an attached skill is missing or failed to load, blocks execution with `last_status='blocked_config'` and alerts the operator once (same fail-before-spend spirit as `drift_guard`).
2. **Skill Manifest Check (`check_job_skills_manifest`)**:
   - Adds `check_job_skills_manifest` helper to inspect skills against the active profile.
   - Warns at job creation/update time in CLI (`hermes cron create` / `hermes cron edit`) if any attached skills are not installed.
3. **Tests**:
   - Added unit tests for missing skill preflight blocking and manifest partition checks in `tests/cron/test_preflight_config.py`.