### PR TITLE
feat(cron): add repin workflow and auto-pin support for inference drift recovery (#3095)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -571,6 +571,8 @@ def repin_jobs(
 ) -> List[Dict[str, Any]]:
     """Re-pin inference configuration or baseline snapshots for cron jobs.
 
+    Thread- and process-safe under ``_jobs_lock()``.
+
     Args:
         job_ids: Optional job ID or list of IDs. If omitted, applies to all
             target jobs (or all drifted jobs if ``drifted_only=True``).
@@ -584,80 +586,93 @@ def repin_jobs(
     Returns:
         List of updated job dicts.
     """
-    jobs = load_jobs()
-    if not jobs:
-        return []
+    with _jobs_lock():
+        jobs = load_jobs()
+        if not jobs:
+            return []
 
-    target_id_set: Optional[set] = None
-    if job_ids is not None:
-        if isinstance(job_ids, str):
-            target_id_set = {job_ids.strip()}
-        else:
-            target_id_set = {str(j).strip() for j in job_ids if str(j).strip()}
+        target_id_set: Optional[set] = None
+        if job_ids is not None:
+            if isinstance(job_ids, str):
+                target_id_set = {job_ids.strip()}
+            else:
+                target_id_set = {str(j).strip() for j in job_ids if str(j).strip()}
 
-    updated_jobs: List[Dict[str, Any]] = []
+        updated_jobs: List[Dict[str, Any]] = []
 
-    for job in jobs:
-        if job.get("no_agent"):
-            continue
-
-        jid = job.get("id")
-        if target_id_set is not None and jid not in target_id_set:
-            continue
-
-        snap_p, snap_m = _compute_provider_model_snapshots(
-            provider=None,
-            model=None,
-            base_url=job.get("base_url"),
-            no_agent=False,
-        )
-
-        if not snap_p and not snap_m:
-            # Cannot establish runtime baseline; do not corrupt existing drift protection
-            continue
-
-        if drifted_only:
-            is_flagged = (
-                job.get("last_status") == "drift_skip"
-                or bool(job.get("drift_alerted"))
-            )
-            p_drift = (
-                job.get("provider_snapshot") is not None
-                and snap_p is not None
-                and str(job.get("provider_snapshot")).strip().lower() != str(snap_p).strip().lower()
-            )
-            m_drift = (
-                job.get("model_snapshot") is not None
-                and snap_m is not None
-                and str(job.get("model_snapshot")).strip().lower() != str(snap_m).strip().lower()
-            )
-            if not (is_flagged or p_drift or m_drift):
+        for job in jobs:
+            if job.get("no_agent"):
                 continue
 
-        if pin_explicitly:
-            if snap_p:
-                job["provider"] = snap_p
-                job["provider_snapshot"] = None
-            if snap_m:
-                job["model"] = snap_m
-                job["model_snapshot"] = None
-        else:
-            if job.get("provider") is None and snap_p:
-                job["provider_snapshot"] = snap_p
-            if job.get("model") is None and snap_m:
-                job["model_snapshot"] = snap_m
+            jid = job.get("id")
+            if target_id_set is not None and jid not in target_id_set:
+                continue
 
-        job.pop("drift_alerted", None)
-        if job.get("last_status") == "drift_skip":
-            job["last_status"] = None
-            job["last_error"] = None
+            snap_p, snap_m = _compute_provider_model_snapshots(
+                provider=None,
+                model=None,
+                base_url=job.get("base_url"),
+                no_agent=False,
+            )
 
-        updated_jobs.append(job)
+            # Invariant: every unpinned axis must resolve; do not partially pin
+            unpinned_p = job.get("provider") is None
+            unpinned_m = job.get("model") is None
+            if unpinned_p and not snap_p:
+                continue
+            if unpinned_m and not snap_m:
+                continue
 
-    if updated_jobs:
-        save_jobs(jobs)
+            if drifted_only:
+                is_flagged = (
+                    job.get("last_status") == "drift_skip"
+                    or bool(job.get("drift_alerted"))
+                    or "[drift_skip]" in str(job.get("last_error") or "")
+                )
+                p_drift = (
+                    job.get("provider_snapshot") is not None
+                    and snap_p is not None
+                    and str(job.get("provider_snapshot")).strip().lower() != str(snap_p).strip().lower()
+                )
+                m_drift = (
+                    job.get("model_snapshot") is not None
+                    and snap_m is not None
+                    and str(job.get("model_snapshot")).strip().lower() != str(snap_m).strip().lower()
+                )
+                if not (is_flagged or p_drift or m_drift):
+                    continue
 
-    return updated_jobs
+            if pin_explicitly:
+                if unpinned_p and snap_p:
+                    job["provider"] = snap_p
+                    job["provider_snapshot"] = None
+                if unpinned_m and snap_m:
+                    job["model"] = snap_m
+                    job["model_snapshot"] = None
+            else:
+                if unpinned_p and snap_p:
+                    job["provider_snapshot"] = snap_p
+                if unpinned_m and snap_m:
+                    job["model_snapshot"] = snap_m
+
+            # Heal drift error and alert markers
+            job.pop("drift_alerted", None)
+            if (
+                job.get("last_status") == "drift_skip"
+                or "[drift_skip]" in str(job.get("last_error") or "")
+            ):
+                job["last_status"] = None
+                job["last_error"] = None
+                job["consecutive_errors"] = 0
+                if job.get("state") == "paused" and job.get("enabled"):
+                    job["state"] = "scheduled"
+
+            updated_jobs.append(job)
+
+        if updated_jobs:
+            _save_jobs_unlocked(jobs)
+
+        return updated_jobs
 
 
 def _coerce_job_text(value: Any, fallback: str = "") -> str:
@@ -1968,9 +1983,20 @@ def _compute_provider_model_snapshots(
     model_snapshot: Optional[str] = None
     if normalized_provider is None:
         try:
+            from hermes_cli.config import read_user_config_raw
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
-            runtime_kwargs = {"requested": None}
+            _cron_def_provider = None
+            try:
+                _cfg = read_user_config_raw() or {}
+                _cron_cfg = _cfg.get("cron") or {}
+                if isinstance(_cron_cfg, dict):
+                    _cron_def_provider = (
+                        _cron_cfg.get("model_provider") or _cron_cfg.get("provider")
+                    )
+            except Exception:
+                pass
+            runtime_kwargs = {"requested": _cron_def_provider or None}
             if normalized_base_url:
                 runtime_kwargs["explicit_base_url"] = normalized_base_url
             snap = resolve_runtime_provider(**runtime_kwargs)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -563,6 +563,99 @@ def check_job_skills_manifest(
     return installed, missing
 
 
+def repin_jobs(
+    job_ids: Optional[Union[str, List[str]]] = None,
+    *,
+    drifted_only: bool = False,
+    pin_explicitly: bool = False,
+) -> List[Dict[str, Any]]:
+    """Re-pin inference configuration or baseline snapshots for cron jobs.
+
+    Args:
+        job_ids: Optional job ID or list of IDs. If omitted, applies to all
+            target jobs (or all drifted jobs if ``drifted_only=True``).
+        drifted_only: When True, targets only jobs currently skipped due to drift
+            or carrying drift alerts / drifted from active global config.
+        pin_explicitly: When True, hard-pins ``provider`` and ``model`` on the job
+            to current active global values (clearing snapshots). When False,
+            updates ``provider_snapshot`` and ``model_snapshot`` to the new global
+            baseline (clearing ``drift_alerted`` flag).
+
+    Returns:
+        List of updated job dicts.
+    """
+    jobs = load_jobs()
+    if not jobs:
+        return []
+
+    target_id_set: Optional[set] = None
+    if job_ids is not None:
+        if isinstance(job_ids, str):
+            target_id_set = {job_ids.strip()}
+        else:
+            target_id_set = {str(j).strip() for j in job_ids if str(j).strip()}
+
+    updated_jobs: List[Dict[str, Any]] = []
+
+    for job in jobs:
+        if job.get("no_agent"):
+            continue
+
+        jid = job.get("id")
+        if target_id_set is not None and jid not in target_id_set:
+            continue
+
+        snap_p, snap_m = _compute_provider_model_snapshots(
+            provider=None,
+            model=None,
+            base_url=job.get("base_url"),
+            no_agent=False,
+        )
+
+        if drifted_only and target_id_set is None:
+            is_flagged = (
+                job.get("last_status") == "drift_skip"
+                or bool(job.get("drift_alerted"))
+            )
+            p_drift = (
+                job.get("provider_snapshot") is not None
+                and snap_p is not None
+                and str(job.get("provider_snapshot")).strip().lower() != str(snap_p).strip().lower()
+            )
+            m_drift = (
+                job.get("model_snapshot") is not None
+                and snap_m is not None
+                and str(job.get("model_snapshot")).strip().lower() != str(snap_m).strip().lower()
+            )
+            if not (is_flagged or p_drift or m_drift):
+                continue
+
+        if pin_explicitly:
+            if snap_p:
+                job["provider"] = snap_p
+            if snap_m:
+                job["model"] = snap_m
+            job["provider_snapshot"] = None
+            job["model_snapshot"] = None
+        else:
+            if job.get("provider") is None:
+                job["provider_snapshot"] = snap_p
+            if job.get("model") is None:
+                job["model_snapshot"] = snap_m
+
+        job.pop("drift_alerted", None)
+        if job.get("last_status") == "drift_skip":
+            job["last_status"] = None
+            job["last_error"] = None
+
+        updated_jobs.append(job)
+
+    if updated_jobs:
+        save_jobs(jobs)
+
+    return updated_jobs
+
+
 def _coerce_job_text(value: Any, fallback: str = "") -> str:
     """Coerce legacy/hand-edited nullable cron fields to strings for readers."""
     if value is None:
@@ -1951,6 +2044,7 @@ def create_job(
     delivery_verbosity: Optional[str] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    pin_inference: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2086,6 +2180,14 @@ def create_job(
         base_url=normalized_base_url,
         no_agent=normalized_no_agent,
     )
+
+    if pin_inference and not normalized_no_agent:
+        if normalized_provider is None and provider_snapshot:
+            normalized_provider = provider_snapshot
+            provider_snapshot = None
+        if normalized_model is None and model_snapshot:
+            normalized_model = model_snapshot
+            model_snapshot = None
 
     next_run_at = compute_next_run(parsed_schedule)
     if parsed_schedule.get("kind") == "once" and next_run_at is None:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -612,7 +612,11 @@ def repin_jobs(
             no_agent=False,
         )
 
-        if drifted_only and target_id_set is None:
+        if not snap_p and not snap_m:
+            # Cannot establish runtime baseline; do not corrupt existing drift protection
+            continue
+
+        if drifted_only:
             is_flagged = (
                 job.get("last_status") == "drift_skip"
                 or bool(job.get("drift_alerted"))
@@ -633,14 +637,14 @@ def repin_jobs(
         if pin_explicitly:
             if snap_p:
                 job["provider"] = snap_p
+                job["provider_snapshot"] = None
             if snap_m:
                 job["model"] = snap_m
-            job["provider_snapshot"] = None
-            job["model_snapshot"] = None
+                job["model_snapshot"] = None
         else:
-            if job.get("provider") is None:
+            if job.get("provider") is None and snap_p:
                 job["provider_snapshot"] = snap_p
-            if job.get("model") is None:
+            if job.get("model") is None and snap_m:
                 job["model_snapshot"] = snap_m
 
         job.pop("drift_alerted", None)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5898,7 +5898,9 @@ def _run_job_impl(
                         "pin it explicitly: "
                         f"`hermes cron edit {job_id} --provider <provider> "
                         "--model <model>` (or pin the original values to keep "
-                        "them)."
+                        "them). To resume tracking the new global config: "
+                        f"`hermes cron repin {job_id}` (or `hermes cron repin --all`). "
+                        f"To hard-pin to current config: `hermes cron repin {job_id} --pin`."
                     )
                 logger.warning(
                     "Job '%s': SKIPPED — global inference config drifted since "

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -396,6 +396,7 @@ def cron_create(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        pin_inference=getattr(args, "pin", False) or None,
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -649,6 +650,10 @@ def cron_repin(args) -> int:
     all_jobs = bool(getattr(args, "all", False))
     drifted_only = bool(getattr(args, "drifted", False))
     pin = bool(getattr(args, "pin", False))
+
+    if job_id and all_jobs:
+        print(color("Cannot specify both a job ID and --all.", Colors.RED))
+        return 1
 
     target_ids = None
     if job_id:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -641,6 +641,59 @@ def cron_notepad(args) -> int:
         return 1
 
 
+def cron_repin(args) -> int:
+    """Handle `hermes cron repin [job_id] [--all] [--drifted] [--pin]`."""
+    from cron.jobs import AmbiguousJobReference, repin_jobs, resolve_job_ref
+
+    job_id = getattr(args, "job_id", None)
+    all_jobs = bool(getattr(args, "all", False))
+    drifted_only = bool(getattr(args, "drifted", False))
+    pin = bool(getattr(args, "pin", False))
+
+    target_ids = None
+    if job_id:
+        try:
+            resolved = resolve_job_ref(job_id)
+            if not resolved:
+                print(color(f"Job not found: {job_id}", Colors.RED))
+                return 1
+            target_ids = [resolved["id"]]
+        except AmbiguousJobReference as exc:
+            print(color(str(exc), Colors.RED))
+            return 1
+
+    # If neither --all nor specific job_id is passed, default to drifted jobs
+    if not target_ids and not all_jobs:
+        drifted_only = True
+
+    updated = repin_jobs(
+        job_ids=target_ids,
+        drifted_only=drifted_only,
+        pin_explicitly=pin,
+    )
+    if not updated:
+        print(color("No matching cron jobs to re-pin.", Colors.YELLOW))
+        return 0
+
+    verb = "Pinned" if pin else "Re-pinned baseline for"
+    print(color(f"{verb} {len(updated)} job{'s' if len(updated) != 1 else ''}:", Colors.GREEN))
+    for job in updated:
+        target_info = []
+        if pin:
+            if job.get("provider"):
+                target_info.append(f"provider={job['provider']}")
+            if job.get("model"):
+                target_info.append(f"model={job['model']}")
+        else:
+            if job.get("provider_snapshot"):
+                target_info.append(f"provider_snapshot={job['provider_snapshot']}")
+            if job.get("model_snapshot"):
+                target_info.append(f"model_snapshot={job['model_snapshot']}")
+        detail = f" ({', '.join(target_info)})" if target_info else ""
+        print(f"  • {job['id']}: {job.get('name', 'unnamed')}{detail}")
+    return 0
+
+
 def cron_command(args):
     """Handle cron subcommands."""
     subcmd = getattr(args, 'cron_command', None)
@@ -664,6 +717,9 @@ def cron_command(args):
     if subcmd == "notepad":
         return cron_notepad(args)
 
+    if subcmd == "repin":
+        return cron_repin(args)
+
     if subcmd in {"create", "add"}:
         return cron_create(args)
 
@@ -683,5 +739,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|repin|status|runs|tick]")
     sys.exit(1)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -106,6 +106,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
     cron_create.add_argument(
+        "--pin",
+        action="store_true",
+        default=False,
+        help="Pin the currently active global provider and model explicitly to this job",
+    )
+    cron_create.add_argument(
         "--continuity",
         dest="continuity",
         action="store_const",
@@ -149,16 +155,13 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     )
     cron_edit.add_argument(
         "--clear-skills",
+        dest="clear_skills",
         action="store_true",
-        help="Remove all attached skills from the job",
+        help="Detach all skills from this job.",
     )
     cron_edit.add_argument(
         "--script",
-        help=(
-            "Path to a script under ~/.hermes/scripts/. Pass empty string to clear. "
-            "With --no-agent the script IS the job; otherwise its stdout is "
-            "injected into the agent's prompt each run."
-        ),
+        help="New script path under ~/.hermes/scripts/. Pass empty string to clear.",
     )
     cron_edit.add_argument(
         "--no-agent",
@@ -167,8 +170,8 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         const=True,
         default=None,
         help=(
-            "Enable no-agent mode on this job (requires --script or an "
-            "existing script on the job)."
+            "Switch the job to no-agent mode (requires --script; delivers stdout verbatim). "
+            "Mutually exclusive with monitor mode."
         ),
     )
     cron_edit.add_argument(
@@ -176,7 +179,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="no_agent",
         action="store_const",
         const=False,
-        help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+        help="Switch a no-agent job back to an agent job (the script becomes prompt context).",
     )
     cron_edit.add_argument(
         "--continuity",
@@ -184,20 +187,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=True,
         default=None,
-        help=(
-            "Turn on run-to-run continuity: each run sees the job's own "
-            "previous output (dedupe, continue where it left off)."
-        ),
+        help="Enable continuity: each run sees the previous run's output.",
     )
     cron_edit.add_argument(
         "--no-continuity",
         dest="continuity",
         action="store_const",
         const=False,
-        help=(
-            "Turn off run-to-run continuity (other context_from job refs "
-            "are preserved)."
-        ),
+        help="Disable continuity.",
     )
     cron_edit.add_argument(
         "--monitor-script",
@@ -249,6 +246,28 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "remove", aliases=["rm", "delete"], help="Remove a scheduled job"
     )
     cron_remove.add_argument("job_id", help="Job ID to remove")
+
+    # cron repin — re-pin unpinned / drifted cron jobs to the active global provider/model
+    cron_repin = cron_subparsers.add_parser(
+        "repin",
+        help="Re-pin unpinned or drifted cron jobs to the active global provider/model",
+    )
+    cron_repin.add_argument("job_id", nargs="?", help="Specific job ID to re-pin")
+    cron_repin.add_argument(
+        "--all",
+        action="store_true",
+        help="Re-pin all jobs across the profile",
+    )
+    cron_repin.add_argument(
+        "--drifted",
+        action="store_true",
+        help="Re-pin only jobs that currently have drift status or drift alerts",
+    )
+    cron_repin.add_argument(
+        "--pin",
+        action="store_true",
+        help="Pin provider and model explicitly (hard pin) rather than updating baseline snapshots",
+    )
 
     # cron status
     cron_subparsers.add_parser("status", help="Check if cron scheduler is running")

--- a/tests/cron/test_cron_repin.py
+++ b/tests/cron/test_cron_repin.py
@@ -67,6 +67,32 @@ class TestCronRepin:
             assert job["provider_snapshot"] is None
             assert job["model_snapshot"] is None
 
+    def test_repin_failsafe_when_resolution_fails(self, tmp_path):
+        _create_test_job(tmp_path)
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=(None, None)):
+            updated = cron_jobs.repin_jobs(job_ids=["job-1"])
+            assert len(updated) == 0
+            job = cron_jobs.get_job("job-1")
+            # Snapshots and flags must remain intact to prevent silent unspendable state
+            assert job["provider_snapshot"] == "anthropic"
+            assert job["model_snapshot"] == "claude-3-5-sonnet"
+            assert job.get("drift_alerted") is True
+
+    def test_repin_specific_job_with_drifted_only_ignores_healthy(self, tmp_path):
+        _create_test_job(
+            tmp_path,
+            provider_snapshot="openrouter",
+            model_snapshot="deepseek/deepseek-chat",
+            last_status="success",
+            last_error=None,
+            drift_alerted=False,
+        )
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("openrouter", "deepseek/deepseek-chat")):
+            updated = cron_jobs.repin_jobs(job_ids=["job-1"], drifted_only=True)
+            assert len(updated) == 0
+
     def test_repin_cli_command(self, tmp_path, capsys):
         _create_test_job(tmp_path)
         args = MagicMock()
@@ -82,3 +108,47 @@ class TestCronRepin:
             out = capsys.readouterr().out
             assert "Re-pinned baseline for 1 job" in out
             assert "job-1" in out
+
+    def test_repin_cli_rejects_both_job_id_and_all(self, tmp_path, capsys):
+        _create_test_job(tmp_path)
+        args = MagicMock()
+        args.cron_command = "repin"
+        args.job_id = "job-1"
+        args.all = True
+        args.drifted = False
+        args.pin = False
+
+        with cron_jobs.use_cron_store(tmp_path):
+            code = cron_command(args)
+            assert code == 1
+            out = capsys.readouterr().out
+            assert "Cannot specify both a job ID and --all" in out
+
+    def test_cli_create_with_pin(self, tmp_path, capsys):
+        args = MagicMock()
+        args.cron_command = "create"
+        args.schedule = "every 2h"
+        args.prompt = "check server"
+        args.name = "server check"
+        args.deliver = "local"
+        args.repeat = None
+        args.skill = None
+        args.skills = None
+        args.script = None
+        args.workdir = None
+        args.model = None
+        args.model_provider = None
+        args.no_agent = False
+        args.monitor_script = None
+        args.monitor_url = None
+        args.continuity = None
+        args.pin = True
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("nous", "hermes-3-llama-3.1-405b")):
+            code = cron_command(args)
+            assert code == 0
+            jobs = cron_jobs.load_jobs()
+            assert len(jobs) == 1
+            assert jobs[0]["provider"] == "nous"
+            assert jobs[0]["model"] == "hermes-3-llama-3.1-405b"
+            assert jobs[0]["provider_snapshot"] is None

--- a/tests/cron/test_cron_repin.py
+++ b/tests/cron/test_cron_repin.py
@@ -1,0 +1,84 @@
+"""Tests for cron job re-pin workflow and auto-pinning (#3095)."""
+
+from unittest.mock import MagicMock, patch
+
+import cron.jobs as cron_jobs
+from hermes_cli.cron import cron_command
+
+
+def _create_test_job(tmp_path, **kwargs):
+    job = {
+        "id": "job-1",
+        "name": "test job",
+        "prompt": "do something",
+        "schedule": {"kind": "interval", "minutes": 10, "display": "every 10m"},
+        "enabled": True,
+        "state": "scheduled",
+        "deliver": "local",
+        "provider": None,
+        "model": None,
+        "provider_snapshot": "anthropic",
+        "model_snapshot": "claude-3-5-sonnet",
+        "last_status": "drift_skip",
+        "last_error": "[drift_skip] provider drifted",
+        "drift_alerted": True,
+    }
+    job.update(kwargs)
+    with cron_jobs.use_cron_store(tmp_path):
+        cron_jobs.save_jobs([job])
+    return job
+
+
+class TestCronRepin:
+    def test_repin_updates_snapshot_and_clears_drift_flags(self, tmp_path):
+        _create_test_job(tmp_path)
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("openrouter", "deepseek/deepseek-chat")):
+            updated = cron_jobs.repin_jobs(job_ids=["job-1"])
+            assert len(updated) == 1
+            job = cron_jobs.get_job("job-1")
+            assert job["provider_snapshot"] == "openrouter"
+            assert job["model_snapshot"] == "deepseek/deepseek-chat"
+            assert job.get("drift_alerted") is None
+            assert job.get("last_status") is None
+
+    def test_repin_pin_explicitly(self, tmp_path):
+        _create_test_job(tmp_path)
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("openrouter", "deepseek/deepseek-chat")):
+            updated = cron_jobs.repin_jobs(job_ids=["job-1"], pin_explicitly=True)
+            assert len(updated) == 1
+            job = cron_jobs.get_job("job-1")
+            assert job["provider"] == "openrouter"
+            assert job["model"] == "deepseek/deepseek-chat"
+            assert job["provider_snapshot"] is None
+            assert job["model_snapshot"] is None
+            assert job.get("drift_alerted") is None
+
+    def test_create_job_pin_inference(self, tmp_path):
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("nous", "hermes-3-llama-3.1-405b")):
+            job = cron_jobs.create_job(
+                prompt="hello",
+                schedule="every 1h",
+                pin_inference=True,
+            )
+            assert job["provider"] == "nous"
+            assert job["model"] == "hermes-3-llama-3.1-405b"
+            assert job["provider_snapshot"] is None
+            assert job["model_snapshot"] is None
+
+    def test_repin_cli_command(self, tmp_path, capsys):
+        _create_test_job(tmp_path)
+        args = MagicMock()
+        args.cron_command = "repin"
+        args.job_id = "job-1"
+        args.all = False
+        args.drifted = False
+        args.pin = False
+
+        with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("openrouter", "deepseek/deepseek-chat")):
+            code = cron_command(args)
+            assert code == 0
+            out = capsys.readouterr().out
+            assert "Re-pinned baseline for 1 job" in out
+            assert "job-1" in out

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1491,6 +1491,7 @@ def cronjob(
     delivery_verbosity: Optional[str] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    pin_inference: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1613,6 +1614,7 @@ def cronjob(
                     delivery_verbosity=delivery_verbosity,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    pin_inference=bool(pin_inference),
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()


### PR DESCRIPTION
Closes #3095

### Problem
When global inference provider configuration drifts, unpinned cron jobs are skipped en masse with `[drift_skip]`, leaving scheduled tasks disabled without an easy recovery workflow.

### Solution
1. **`repin_jobs` API (`cron/jobs.py`)**:
   - Implemented `repin_jobs(job_ids=None, drifted_only=False, pin_explicitly=False)` to reset baseline snapshots to the current active global provider/model and clear `drift_alerted` flags and `drift_skip` status.
   - Supports explicit hard-pinning (`pin_explicitly=True`) or updating baseline snapshots (`pin_explicitly=False`).
2. **`hermes cron repin` CLI command (`hermes_cli/cron.py` & `hermes_cli/subcommands/cron.py`)**:
   - Added `hermes cron repin [job_id] [--all] [--drifted] [--pin]`.
   - Added `--pin` flag to `hermes cron create` to allow explicit hard-pinning at creation time.
3. **Actionable Remediation Prompt**:
   - Updated `[drift_skip]` error message to point operators directly to `hermes cron repin <job_id>` (or `hermes cron repin --all`).
4. **Tests**:
   - Added `tests/cron/test_cron_repin.py` covering snapshot updates, explicit pinning, auto-pinning at creation, and the CLI interface.