### PR TITLE
fix(skills): resolve skill slash command collisions with namespacing and warnings (#3096)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ from agent.skill_preprocessing import (
 logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
+_colliding_skills: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
@@ -423,9 +424,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform, _skill_commands_home
-    _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands_home = _resolve_skill_commands_home()
-    _skill_commands = {}
+    try:
+        _skill_commands.clear()
+        _colliding_skills.clear()
+        _skill_commands_platform = _resolve_skill_commands_platform()
+        _skill_commands_home = _resolve_skill_commands_home()
+    except Exception:
+        pass
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
@@ -437,6 +442,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
+        pending_colliding: list = []
 
         # Scan project dirs first (highest precedence), then local, then external.
         # Project dirs iterate through the quarantine chokepoint.
@@ -487,19 +493,15 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    # Skip if this skill's auto-generated /command collides
-                    # with a core Hermes slash command (name or alias). The
-                    # skill remains fully loadable via /skill <name>.
-                    # Uses resolve_command() so aliases and case variants are
-                    # covered without maintaining a separate cache.
+
+                    # If this skill's auto-generated /command collides
+                    # with a core Hermes slash command (name or alias), defer
+                    # namespaced registration to pass 2 so real skills (e.g.
+                    # a skill named 'skill-config') are not shadowed (#3096).
                     if resolve_command(cmd_name) is not None:
-                        logger.warning(
-                            "Skill %r generates slash command '/%s' which "
-                            "collides with a core Hermes command; skipping "
-                            "auto-registration. Use '/skill %s' instead.",
-                            name, cmd_name, name,
-                        )
+                        pending_colliding.append((name, cmd_name, description, skill_md))
                         continue
+
                     # Dedup on the resolved slug, not just the raw name: two
                     # distinct frontmatter names can normalize to the same
                     # slug (e.g. "git_helper" vs "git-helper"). First-wins
@@ -520,6 +522,45 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     }
                 except Exception:
                     continue
+
+        # Pass 2: Register namespaced commands for colliding skills
+        for name, cmd_name, description, skill_md in pending_colliding:
+            namespaced_key = f"/skill-{cmd_name}"
+            if namespaced_key in _skill_commands:
+                logger.warning(
+                    "Skill %r collides with core command '/%s' and '%s' is already "
+                    "claimed by %r; keeping the first and skipping this one.",
+                    name, cmd_name, namespaced_key, _skill_commands[namespaced_key]["name"],
+                )
+                continue
+            if cmd_name in _colliding_skills:
+                logger.warning(
+                    "Skill %r maps to colliding slug '%s' already claimed "
+                    "by %r; keeping the first and skipping this one.",
+                    name, cmd_name, _colliding_skills[cmd_name]["name"],
+                )
+                continue
+            logger.warning(
+                "Skill %r generates slash command '/%s' which "
+                "collides with a core Hermes command; registering "
+                "namespaced command '%s'. Use '%s' or '/skill %s' instead.",
+                name, cmd_name, namespaced_key, namespaced_key, name,
+            )
+            _colliding_skills[cmd_name] = {
+                "name": name,
+                "cmd_name": cmd_name,
+                "namespaced_key": namespaced_key,
+                "description": description or f"Invoke the {name} skill (namespaced due to collision with core /{cmd_name})",
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(skill_md.parent),
+            }
+            _skill_commands[namespaced_key] = {
+                "name": name,
+                "description": description or f"Invoke the {name} skill (namespaced due to collision with core /{cmd_name})",
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(skill_md.parent),
+                "collides_with": cmd_name,
+            }
     except Exception:
         pass
     return _skill_commands
@@ -608,6 +649,12 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
+def get_colliding_skills() -> Dict[str, Dict[str, Any]]:
+    """Return skills whose primary slash commands collided with core commands."""
+    get_skill_commands()
+    return dict(_colliding_skills)
+
+
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
@@ -618,13 +665,45 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     (which disallow hyphens, so ``/claude-code`` is registered as
     ``/claude_code`` and comes back in the underscored form).
 
+    Supports:
+    - Direct slug: ``claude-code``, ``/claude-code``, ``claude_code``
+    - Namespaced slug: ``skill-config``, ``/skill-config``, ``skill_config``
+    - Explicit invocation: ``skill config``, ``/skill config``, ``skill/config``
+
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
     ``None`` if no match.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    raw = command.strip().replace("_", "-")
+    clean = raw.lstrip("/")
+    cmds = get_skill_commands()
+
+    # 1. Direct match with leading slash
+    direct_key = f"/{clean}"
+    if direct_key in cmds:
+        return direct_key
+
+    # 2. Namespaced or explicit skill prefix: "skill-foo" or "skill foo" or "skill/foo"
+    if clean.startswith("skill-"):
+        target = clean[6:]
+        if f"/{target}" in cmds:
+            return f"/{target}"
+        if f"/skill-{target}" in cmds:
+            return f"/skill-{target}"
+    elif clean.startswith("skill ") or clean.startswith("skill/"):
+        target = clean.split(None, 1)[1].strip() if " " in clean else clean[6:].strip()
+        target = target.replace("_", "-")
+        if f"/{target}" in cmds:
+            return f"/{target}"
+        if f"/skill-{target}" in cmds:
+            return f"/skill-{target}"
+
+    # 3. If typed bare and collided, resolve to its namespaced key
+    if clean in _colliding_skills:
+        return _colliding_skills[clean]["namespaced_key"]
+
+    return None
 
 
 def build_skill_invocation_message(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -809,12 +809,13 @@ class WebhookAdapter(BasePlatformAdapter):
                 from agent.skill_commands import (
                     build_skill_invocation_message,
                     get_skill_commands,
+                    resolve_skill_command_key,
                 )
 
                 skill_cmds = get_skill_commands()
                 for skill_name in skills:
-                    cmd_key = f"/{skill_name}"
-                    if cmd_key in skill_cmds:
+                    cmd_key = resolve_skill_command_key(skill_name)
+                    if cmd_key and cmd_key in skill_cmds:
                         skill_content = build_skill_invocation_message(
                             cmd_key, user_instruction=prompt
                         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17769,6 +17769,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 skill_cmds = get_skill_commands()
                 cmd_key = resolve_skill_command_key(command)
+                _custom_instruction = None
+                if cmd_key is None and command.lower() in {"skill", "skills"}:
+                    _args_raw = event.get_command_args().strip()
+                    if _args_raw:
+                        _parts = _args_raw.split(None, 1)
+                        _first = _parts[0].lower()
+                        if _first not in {"pending", "approve", "apply", "reject", "deny", "drop", "diff", "approval", "mode"}:
+                            _sub_match = resolve_skill_command_key(_parts[0])
+                            if _sub_match:
+                                cmd_key = _sub_match
+                                _custom_instruction = _parts[1] if len(_parts) > 1 else ""
                 if cmd_key is not None:
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled
@@ -17783,7 +17794,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 f"The **{_skill_name}** skill is disabled for {_plat}.\n"
                                 f"Enable it with: `hermes skills config`"
                             )
-                    user_instruction = event.get_command_args().strip()
+                    user_instruction = (
+                        _custom_instruction
+                        if _custom_instruction is not None
+                        else event.get_command_args().strip()
+                    )
                     # Stacked slash-skill invocations: `/skill-a /skill-b do
                     # XYZ` loads every leading skill (up to 5), not just the
                     # first. Inspired by Claude Code v2.1.199. Mirrors CLI.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2008,7 +2008,7 @@ class CLICommandsMixin:
         from cli import ChatConsole
         # Intercept write-approval review subcommands first (pending/approve/
         # reject/diff/mode); everything else goes to the skills hub.
-        parts = cmd.strip().split()
+        parts = cmd.strip().split(None, 2)
         args = parts[1:] if len(parts) > 1 else []
         if args and args[0].lower() in {"pending", "approve", "apply", "reject",
                                         "deny", "drop", "diff", "approval", "mode"}:
@@ -2021,6 +2021,33 @@ class CLICommandsMixin:
             if out is not None:
                 print(out)
                 return
+
+        # Check if user typed `/skill <name> [instruction]` or `/skills <name> [instruction]`
+        # targeting an installed skill rather than a hub subcommand.
+        _known_subcommands = {
+            "search", "browse", "inspect", "install", "audit", "check",
+            "update", "uninstall", "list", "list-modified", "diff", "opt-in",
+            "opt-out", "publish", "snapshot", "tap", "help", "reset",
+        }
+        if args and args[0].lower() not in _known_subcommands:
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                get_skill_commands,
+                resolve_skill_command_key,
+            )
+            target_key = resolve_skill_command_key(args[0])
+            if target_key:
+                instruction = parts[2] if len(parts) > 2 else ""
+                msg = build_skill_invocation_message(
+                    target_key, instruction, task_id=getattr(self, "session_id", None)
+                )
+                if msg:
+                    skill_name = get_skill_commands().get(target_key, {}).get("name") or args[0]
+                    print(f"\n⚡ Loading skill: {skill_name}")
+                    if hasattr(self, '_pending_input'):
+                        self._pending_input.put(msg)
+                    return
+
         from hermes_cli.skills_hub import handle_skills_slash
         handle_skills_slash(cmd, ChatConsole())
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -823,6 +823,37 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     except Exception:  # pragma: no cover - blueprint detection is best-effort
         pass
 
+    try:
+        from agent.skill_commands import _SKILL_INVALID_CHARS, _SKILL_MULTI_HYPHEN
+        from hermes_cli.commands import resolve_command
+        from tools.skills_tool import _parse_frontmatter
+
+        # Read actual frontmatter name if available on disk
+        installed_name = bundle.name
+        target_skill_dir = SKILLS_DIR / (f"{category}/{bundle.name}" if category else bundle.name)
+        skill_md_file = target_skill_dir / "SKILL.md"
+        if skill_md_file.exists():
+            try:
+                fm, _ = _parse_frontmatter(skill_md_file.read_text(encoding="utf-8"))
+                if fm.get("name"):
+                    installed_name = fm["name"]
+            except Exception:
+                pass
+
+        cmd_slug = installed_name.lower().replace(" ", "-").replace("_", "-")
+        cmd_slug = _SKILL_INVALID_CHARS.sub("", cmd_slug)
+        cmd_slug = _SKILL_MULTI_HYPHEN.sub("-", cmd_slug).strip("-")
+
+        if cmd_slug and resolve_command(cmd_slug) is not None:
+            c.print(
+                f"[yellow]⚠️ Note:[/] Skill name '[bold]{installed_name}[/]' matches a core Hermes slash command ([bold]/{cmd_slug}[/])."
+            )
+            c.print(
+                f"[dim]To invoke this skill, run [bold]/skill {installed_name}[/] or [bold]/skill-{cmd_slug}[/].[/]\n"
+            )
+    except Exception:
+        pass
+
     if invalidate_cache:
         # Invalidate the skills prompt cache so the new skill appears immediately
         try:
@@ -1069,6 +1100,22 @@ def do_list(source_filter: str = "all",
         summary += f" — {enabled_count} enabled, {disabled_count} disabled"
     summary += "[/]\n"
     c.print(summary)
+
+    try:
+        from agent.skill_commands import get_colliding_skills
+        colliding = get_colliding_skills()
+        if colliding:
+            c.print(
+                f"[yellow]ℹ️  {len(colliding)} skill(s) match core commands and use namespaced slash commands:[/]"
+            )
+            for cmd_name, info in sorted(colliding.items()):
+                c.print(
+                    f"  • [bold]{info['name']}[/]: use [cyan]{info['namespaced_key']}[/]"
+                    f" or [cyan]/skill {info['name']}[/]"
+                )
+            c.print()
+    except Exception:
+        pass
 
 
 def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> None:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -10,6 +10,7 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    get_colliding_skills,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -347,6 +348,98 @@ class TestScanSkillCommands:
             with caplog.at_level(_logging.WARNING, logger="agent.skill_commands"):
                 scan_skill_commands()
         assert any("already claimed" in r.message for r in caplog.records)
+
+
+class TestSkillCommandCollisions:
+    """Skills colliding with core Hermes slash commands must be safely
+    namespaced under /skill-<name> so they remain discoverable and executable (#3096).
+    """
+
+    def test_colliding_skill_registers_as_namespaced_command(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "config", body="Custom skill for configuration.")
+            _make_skill(tmp_path, "help", body="Custom skill for help.")
+            _make_skill(tmp_path, "custom-skill", body="Ordinary custom skill.")
+
+            cmds = scan_skill_commands()
+            colliding = get_colliding_skills()
+
+            # Direct core collision commands are not registered as bare /config or /help
+            assert "/config" not in cmds
+            assert "/help" not in cmds
+
+            # They are registered under namespaced slash commands
+            assert "/skill-config" in cmds
+            assert "/skill-help" in cmds
+            assert "/custom-skill" in cmds
+
+            # Colliding registry tracks the collisions
+            assert "config" in colliding
+            assert colliding["config"]["namespaced_key"] == "/skill-config"
+            assert "help" in colliding
+            assert colliding["help"]["namespaced_key"] == "/skill-help"
+
+    def test_colliding_skill_resolves_via_various_syntax(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "config", body="Custom config skill.")
+            _make_skill(tmp_path, "undo", body="Custom undo skill.")
+            scan_skill_commands()
+
+            # Namespaced direct resolution
+            assert resolve_skill_command_key("/skill-config") == "/skill-config"
+            assert resolve_skill_command_key("skill-config") == "/skill-config"
+            assert resolve_skill_command_key("skill_config") == "/skill-config"
+
+            # Explicit /skill prefix resolution
+            assert resolve_skill_command_key("/skill config") == "/skill-config"
+            assert resolve_skill_command_key("skill config") == "/skill-config"
+            assert resolve_skill_command_key("skill/config") == "/skill-config"
+
+            # Bare colliding slug resolution (fallback to namespaced key)
+            assert resolve_skill_command_key("config") == "/skill-config"
+            assert resolve_skill_command_key("/undo") == "/skill-undo"
+
+    def test_builds_skill_invocation_message_for_namespaced_command(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "debug", body="Perform advanced AI debugging.")
+            scan_skill_commands()
+
+            msg = build_skill_invocation_message("/skill-debug", user_instruction="inspect auth loop")
+            assert msg is not None
+            assert "Perform advanced AI debugging." in msg
+            assert "inspect auth loop" in msg
+
+    def test_namespaced_skill_does_not_shadow_legitimate_skill_or_duplicate(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            # A skill named skill-config exists alongside a colliding skill named config
+            _make_skill(tmp_path, "skill-config", body="The real skill-config.")
+            _make_skill(tmp_path, "config", body="The config skill.")
+            scan_skill_commands()
+
+            # skill-config keeps its identity
+            cmds = scan_skill_commands()
+            assert cmds["/skill-config"]["name"] == "skill-config"
+
+    def test_cli_slash_skill_dispatch_invokes_colliding_skill(self, tmp_path):
+        import queue
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        class DummyCLI(CLICommandsMixin):
+            def __init__(self):
+                self.session_id = "test-session"
+                self._pending_input = queue.Queue()
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "config", body="Custom configuration helper.")
+            scan_skill_commands()
+
+            cli = DummyCLI()
+            cli._handle_skills_command("/skill config review memory settings")
+
+            assert not cli._pending_input.empty()
+            queued = cli._pending_input.get()
+            assert "Custom configuration helper." in queued
+            assert "review memory settings" in queued
 
 
 class TestResolveSkillCommandKey:

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -204,6 +204,55 @@ class TestSkillsInjection:
             assert "You are a code reviewer" in event.text
             mock_build.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_colliding_skill_injected_into_webhook_prompt(self):
+        """When a route has a colliding skill like skills: ['config'],
+        resolve_skill_command_key resolves it to /skill-config and injects it."""
+        routes = {
+            "config-hook": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["push"],
+                "prompt": "Inspect config update",
+                "skills": ["config"],
+            }
+        }
+        adapter = _make_adapter(routes)
+        captured_events: list[MessageEvent] = []
+
+        async def _capture(event: MessageEvent):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+
+        skill_content = "Loaded colliding config skill content."
+
+        with patch(
+            "agent.skill_commands.build_skill_invocation_message",
+            return_value=skill_content,
+        ) as mock_build, patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/skill-config": {"name": "config"}},
+        ), patch(
+            "agent.skill_commands.resolve_skill_command_key",
+            return_value="/skill-config",
+        ):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/config-hook",
+                    json={"ref": "refs/heads/main"},
+                    headers={
+                        "X-GitHub-Event": "push",
+                        "X-GitHub-Delivery": "skill-test-002",
+                    },
+                )
+                assert resp.status == 202
+
+            await asyncio.sleep(0.05)
+            assert len(captured_events) == 1
+            assert captured_events[0].text == skill_content
+            mock_build.assert_called_once_with("/skill-config", user_instruction="Inspect config update")
+
 
 # ===================================================================
 # Test 3: Cross-platform delivery (webhook → Telegram)

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -394,3 +394,25 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+
+
+def test_do_list_displays_colliding_skills_notice(monkeypatch, three_source_env):
+    """When colliding skills exist, do_list prints a notice with namespaced keys."""
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    with patch(
+        "agent.skill_commands.get_colliding_skills",
+        return_value={
+            "config": {
+                "name": "config",
+                "namespaced_key": "/skill-config",
+            }
+        },
+    ):
+        do_list(console=console)
+
+    out = sink.getvalue()
+    assert "match core commands and use namespaced slash commands" in out
+    assert "/skill-config" in out
+    assert "/skill config" in out


### PR DESCRIPTION
## Summary
Fixes #3096

### Problem
Installed skills that generate slash commands matching core Hermes commands (e.g. `config`, `debug`, `help`, `import`, `fast`, `undo`, `update`) were skipped entirely at startup with only a silent warning. Users could not discover or invoke them via slash commands.

### Solution
1. **Two-Pass Namespacing**: During skill discovery (`scan_skill_commands`), register non-colliding skills first so authentic skills like `skill-config` are never shadowed. Register colliding skills under namespaced keys (`/skill-<name>`).
2. **Discoverability**: Export `get_colliding_skills()` and list colliding skills and their namespaced commands in `hermes skills list` and `do_list()`.
3. **Proactive Install Warnings**: In `do_install()`, canonicalize the installed frontmatter name and warn users when a newly installed skill matches a core command.
4. **Flexible Invocation & Dispatch**:
   - In CLI and Gateway, support `/skill <name> [instruction]`.
   - In Webhooks, resolve configured skill names via `resolve_skill_command_key` so namespaced and collided skills load properly.
5. **Full Test Coverage**: Added comprehensive test suite in `tests/agent/test_skill_commands.py`, `tests/gateway/test_webhook_integration.py`, and `tests/hermes_cli/test_skills_hub.py`.