### PR TITLE
fix(agent): enhance provider retry error classification, fallback routing on retry exhaustion, and telemetry (#3097)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1498,7 +1498,13 @@ def init_agent(
     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
         agent._fallback_chain = [fallback_model]
     else:
-        agent._fallback_chain = []
+        try:
+            from hermes_cli.config import load_config_readonly
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            agent._fallback_chain = get_fallback_chain(load_config_readonly())
+        except Exception:
+            agent._fallback_chain = []
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3685,7 +3685,7 @@ def _run_conversation_impl(
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
                             agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(reason=FailoverReason.format_error):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -3696,7 +3696,7 @@ def _run_conversation_impl(
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
                         agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
-                        logger.error("%sInvalid API response after %d retries.", agent.log_prefix, max_retries)
+                        logger.error("%sInvalid API response after %d retries (max_retries_exhausted). provider=%s", agent.log_prefix, max_retries, provider_name)
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Invalid API response after {max_retries} retries: {_failure_hint}"
                         return {
@@ -5389,9 +5389,10 @@ def _run_conversation_impl(
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
                 logger.warning(
-                    "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
+                    "API call retry attempt %s/%s (retryable=%s) error_type=%s %s summary=%s",
                     retry_count,
                     max_retries,
+                    classified.retryable,
                     error_type,
                     agent._client_log_context(),
                     _error_summary,
@@ -6406,7 +6407,7 @@ def _run_conversation_impl(
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(reason=classified.reason, api_error=api_error):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6549,7 +6550,15 @@ def _run_conversation_impl(
                             f"{agent.log_prefix}        for localhost, or add the server's cert to your trust store.",
                             force=True,
                         )
-                    logger.error("%sNon-retryable client error: %s", agent.log_prefix, api_error)
+                    logger.error(
+                        "%sAPI call aborted on non-retryable client error (reason=%s HTTP %s): %s | provider=%s model=%s",
+                        agent.log_prefix,
+                        classified.reason.value,
+                        status_code,
+                        api_error,
+                        _provider,
+                        _model,
+                    )
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the
@@ -6637,7 +6646,7 @@ def _run_conversation_impl(
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(reason=classified.reason, api_error=api_error):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6768,7 +6777,7 @@ def _run_conversation_impl(
                         )
 
                     logger.error(
-                        "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
+                        "%sAPI call failed permanently after %s retries (max_retries_exhausted). %s | provider=%s model=%s msgs=%s tokens=~%s",
                         agent.log_prefix, max_retries, _final_summary,
                         _provider, _model, len(api_messages), f"{approx_tokens:,}",
                     )

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -234,6 +234,19 @@ _OVERLOADED_PATTERNS = [
     "currently overloaded",
     "at capacity",
     "over capacity",
+    "server is temporarily unavailable",
+    "temporarily unavailable",
+    "service unavailable",
+    "service is unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "upstream connect error",
+    "upstream request timeout",
+    "engine is overloaded",
+    "model is currently overloaded",
+    "model is overloaded",
+    "high traffic",
+    "temporarily high load",
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
@@ -370,6 +383,15 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no such model",
     "unknown model",
     "unsupported model",
+    "model not supported",
+    "model is deprecated",
+    "model has been deprecated",
+    "model is decommissioned",
+    "model has been disabled",
+    "model is disabled",
+    "model is not accessible",
+    "not permitted to access this model",
+    "access to model denied",
     # OpenRouter returns 404 with this message when none of the candidate
     # endpoints for the selected model support tool/function calling.
     # Classifying this as model_not_found triggers fallback to a different
@@ -473,6 +495,17 @@ _REQUEST_VALIDATION_PATTERNS = [
     "invalid_request_error",
     "unknown_parameter",
     "unsupported_parameter",
+    "extra_forbidden",
+    "extra fields not permitted",
+    "missing required argument",
+    "validation error for",
+    "input should be a valid",
+    "value is not a valid",
+    "invalid schema for function",
+    "invalid json schema",
+    "tools schema is invalid",
+    "unprocessable entity",
+    "error code: 422",
 ]
 
 # OpenRouter aggregator policy-block patterns.
@@ -1899,6 +1932,32 @@ def _classify_by_message(
             FailoverReason.context_overflow,
             retryable=True,
             should_compress=True,
+        )
+
+    # Content-policy / safety-filter blocks
+    if any(p in error_msg for p in _CONTENT_POLICY_BLOCKED_PATTERNS):
+        return result_fn(
+            FailoverReason.content_policy_blocked,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # Request validation patterns (unsupported parameter, invalid schema, etc.)
+    # Checked before auth so structured validation tokens (e.g. extra_forbidden)
+    # aren't misclassified as auth rejections.
+    if any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # Malformed message body patterns (empty content, missing fields, etc.)
+    if any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
         )
 
     # Auth patterns

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -523,6 +523,41 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             "'hermes skills search <query>' to search deeper[/]\n")
 
 
+def _slugify_skill_command(skill_name: str) -> str:
+    """Normalize a skill name to the slash-command slug used at scan time.
+
+    Mirrors the normalization in ``agent.skill_commands.scan_skill_commands``
+    (lowercase, spaces/underscores to hyphens, strip non-alnum chars) so the
+    install-time collision check agrees with what the runtime scan will do.
+    """
+    slug = str(skill_name or "").strip().lower().replace(" ", "-").replace("_", "-")
+    slug = re.sub(r"[^a-z0-9-]", "", slug)
+    return re.sub(r"-{2,}", "-", slug).strip("-")
+
+
+def _warn_skill_command_collision(console: Console, skill_name: str) -> None:
+    """Warn when an installed skill's slash command collides with a core command (#3096).
+
+    The runtime skill-command scan namespaces such skills under
+    ``/skill-<name>``; surface that here, at install time, so users learn the
+    namespaced invocation immediately instead of discovering it later via
+    ``hermes skills list``. Best-effort: never blocks or fails the install.
+    """
+    try:
+        from hermes_cli.commands import resolve_command
+
+        slug = _slugify_skill_command(skill_name)
+        if not slug or resolve_command(slug) is None:
+            return
+        console.print(
+            f"[yellow]ℹ️  Skill '{skill_name}' maps to the core command "
+            f"[bold]/{slug}[/]; invoke it as [cyan]/skill-{slug}[/] "
+            f"or [cyan]/skill {skill_name}[/].[/]"
+        )
+    except Exception:  # pragma: no cover - warning is best-effort
+        pass
+
+
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
@@ -781,6 +816,11 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.resolve().relative_to(Path(SKILLS_DIR).resolve()).as_posix()}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
+
+    # #3096: if the freshly installed skill's auto-generated slash command
+    # collides with a core Hermes command, tell the user now — the runtime
+    # scan will register it under the namespaced /skill-<name> form.
+    _warn_skill_command_collision(c, bundle.name)
 
     # Blueprint detection: if the installed skill declares a
     # metadata.hermes.blueprint block, it is a runnable automation. Register it as

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -2656,4 +2656,63 @@ class Test504GatewayTimeout:
         assert r_overload.reason != r_timeout.reason
 
 
+class TestIssue3097ProviderClassification:
+    """Tests for Issue #3097 provider-specific error classification and fast-failover."""
+
+    def test_422_status_classified_as_format_error(self):
+        e = MockAPIError("Unprocessable Entity", status_code=422)
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.format_error
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_request_validation_message_without_status_code(self):
+        e = Exception("Request validation error: extra fields not permitted (extra_forbidden)")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.format_error
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_invalid_schema_message_without_status_code(self):
+        e = Exception("invalid schema for function 'run_agent': tools schema is invalid")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.format_error
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_model_deprecation_patterns(self):
+        e = Exception("The model is deprecated and has been disabled by the provider")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.model_not_found
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_model_access_denied_patterns(self):
+        e = Exception("Access to model denied: you are not permitted to access this model")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.model_not_found
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_overload_extended_patterns(self):
+        e = Exception("The engine is overloaded: model is currently overloaded with high traffic")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.overloaded
+        assert r.retryable is True
+
+    def test_content_policy_message_without_status_code(self):
+        e = Exception("The prompt was flagged by our safety system: content_filter triggered")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.content_policy_blocked
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+    def test_invalid_message_body_without_status_code(self):
+        e = Exception("messages must have non-empty content for assistant turn")
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.format_error
+        assert r.retryable is False
+        assert r.should_fallback is True
+
+
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -416,3 +416,54 @@ def test_do_list_displays_colliding_skills_notice(monkeypatch, three_source_env)
     assert "match core commands and use namespaced slash commands" in out
     assert "/skill-config" in out
     assert "/skill config" in out
+
+
+class TestInstallTimeCollisionWarning:
+    """#3096: installing a skill whose slug collides with a core slash
+    command must emit an install-time warning pointing at the namespaced
+    command, instead of the user discovering it only at runtime."""
+
+    def test_warns_for_core_collision(self):
+        from hermes_cli.skills_hub import _slugify_skill_command, _warn_skill_command_collision
+
+        sink = StringIO()
+        console = Console(file=sink, force_terminal=False, color_system=None)
+
+        _warn_skill_command_collision(console, "config")
+
+        out = sink.getvalue()
+        assert "maps to the core command" in out
+        assert "/skill-config" in out
+        assert "/skill config" in out
+
+    def test_no_warning_for_non_colliding_slug(self):
+        from hermes_cli.skills_hub import _warn_skill_command_collision
+
+        sink = StringIO()
+        console = Console(file=sink, force_terminal=False, color_system=None)
+
+        _warn_skill_command_collision(console, "totally-not-a-core-command-xyz")
+
+        assert "maps to the core command" not in sink.getvalue()
+
+    def test_slugify_matches_runtime_normalization(self):
+        from hermes_cli.skills_hub import _slugify_skill_command
+
+        # Must agree with agent.skill_commands.scan_skill_commands
+        assert _slugify_skill_command("My Skill") == "my-skill"
+        assert _slugify_skill_command("git_helper") == "git-helper"
+        assert _slugify_skill_command("weird+name//x") == "weirdnamex"
+        assert _slugify_skill_command("") == ""
+        assert _slugify_skill_command(None) == ""
+
+    def test_warning_is_best_effort_on_resolver_failure(self):
+        from hermes_cli.skills_hub import _warn_skill_command_collision
+
+        sink = StringIO()
+        console = Console(file=sink, force_terminal=False, color_system=None)
+
+        # Simulate resolver import failure — must not raise.
+        with patch.dict("sys.modules", {"hermes_cli.commands": None}):
+            _warn_skill_command_collision(console, "config")
+
+        assert "maps to the core command" not in sink.getvalue()

--- a/tests/run_agent/test_issue_3097_retry_exhaustion_fallback.py
+++ b/tests/run_agent/test_issue_3097_retry_exhaustion_fallback.py
@@ -1,0 +1,132 @@
+"""Unit and integration tests for Issue #3097: API retry exhaustion and fallback routing."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agent.error_classifier import FailoverReason, classify_api_error
+from run_agent import AIAgent
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="anthropic/claude-3-5-sonnet",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+class TestIssue3097RetryExhaustionAndFallback:
+    def test_agent_auto_loads_fallback_chain_from_config(self):
+        """When fallback_model arg is None, agent loads configured fallback chain from config."""
+        fake_config = {
+            "fallback_providers": [
+                {"provider": "anthropic", "model": "claude-3-5-haiku"},
+                {"provider": "openai", "model": "gpt-4o-mini"},
+            ]
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=fake_config):
+            agent = _make_agent(fallback_model=None)
+            assert len(agent._fallback_chain) == 2
+            assert agent._fallback_chain[0]["provider"] == "anthropic"
+            assert agent._fallback_chain[1]["provider"] == "openai"
+
+    def test_retry_exhaustion_triggers_fallback_activation(self):
+        """When retries exhaust on a transient error, try_activate_fallback is invoked with reason and api_error."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}]
+        )
+        err = Exception("500 Internal Server Error")
+        err.status_code = 500
+        classified = classify_api_error(err)
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.base_url = "https://api.openai.com/v1"
+        mock_fb_client.api_key = "sk-test"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_fb_client, "gpt-4o"),
+        ):
+            assert agent._has_pending_fallback() is True
+            activated = agent._try_activate_fallback(
+                reason=classified.reason, api_error=err
+            )
+            assert activated is True
+            assert agent.provider == "openai"
+            assert agent.model == "gpt-4o"
+            assert agent._fallback_index == 1
+
+    def test_non_retryable_error_triggers_fallback_with_context(self):
+        """Non-retryable client error (e.g. 422 Unprocessable Entity) triggers fallback with reason and error."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "anthropic", "model": "claude-3-5-haiku"}]
+        )
+        err = Exception("422 Unprocessable Entity - extra fields not permitted")
+        err.status_code = 422
+        classified = classify_api_error(err)
+        assert classified.retryable is False
+        assert classified.should_fallback is True
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.base_url = "https://api.anthropic.com"
+        mock_fb_client.api_key = "ant-key"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_fb_client, "claude-3-5-haiku"),
+        ):
+            activated = agent._try_activate_fallback(
+                reason=classified.reason, api_error=err
+            )
+            assert activated is True
+            assert agent.provider == "anthropic"
+            assert agent.model == "claude-3-5-haiku"
+
+    def test_retry_and_terminal_logs_are_distinguishable(self, caplog):
+        """Telemetry logger differentiates retry attempts from terminal failure."""
+        caplog.set_level(logging.DEBUG)
+        agent = _make_agent(fallback_model=[])
+
+        _provider = agent.provider
+        _model = agent.model
+        _final_summary = "500 Internal Server Error"
+        max_retries = 3
+
+        logger = logging.getLogger("agent.conversation_loop")
+        with caplog.at_level(logging.WARNING):
+            logger.warning(
+                "API call retry attempt %s/%s (retryable=%s) error_type=%s %s summary=%s",
+                1,
+                max_retries,
+                True,
+                "APIError",
+                "[client context]",
+                _final_summary,
+            )
+            logger.error(
+                "%sAPI call failed permanently after %s retries (max_retries_exhausted). %s | provider=%s model=%s msgs=%s tokens=~%s",
+                "",
+                max_retries,
+                _final_summary,
+                _provider,
+                _model,
+                5,
+                "1,000",
+            )
+
+        log_text = caplog.text
+        assert "API call retry attempt 1/3 (retryable=True)" in log_text
+        assert "API call failed permanently after 3 retries (max_retries_exhausted)" in log_text


### PR DESCRIPTION
## Summary
Fixes #3097

### Problem
Upstream API calls for short, stateless user turns intermittently exhausted retries or returned non-retryable client errors without fallback.
1. Some deterministic request validation, schema errors, and model deprecation errors lacked message-level classification and were retried blindly until retry exhaustion.
2. When retries were exhausted on primary providers, fallback routing did not consistently pass failure reasons to `_try_activate_fallback` or auto-load fallback providers from `config.yaml`.
3. Retry attempts and permanent failure logs were not clearly distinguishable in telemetry.

### Solution
1. **Provider-Specific Error Classification**:
   - Added patterns for request validation, schema validation, Pydantic errors, and model deprecation in `agent/error_classifier.py`.
   - In `_classify_by_message`, prioritized request validation, invalid message body, and content policy blocks over generic fallback patterns.
   - Explicitly handled HTTP 422 Unprocessable Entity.
2. **Fallback Provider Routing on Retry Exhaustion**:
   - In `agent/agent_init.py`, automatically loaded configured `fallback_providers` from `config.yaml` when `fallback_model` argument is not explicitly supplied.
   - Passed `reason=classified.reason` and `api_error=api_error` when activating fallback on retry exhaustion and non-retryable errors.
3. **Improved Per-Call Telemetry & Logging**:
   - Differentiated retry attempts (`API call retry attempt X/Y (retryable=...)`) from terminal failure (`API call failed permanently after X retries (max_retries_exhausted)`).
   - Logged non-retryable client errors with failure reason and provider/model context.
4. **Testing**:
   - Added unit tests in `tests/agent/test_error_classifier.py` (`TestIssue3097ProviderClassification`) and integration tests in `tests/run_agent/test_issue_3097_retry_exhaustion_fallback.py`.