### PR TITLE
fix(toolsets): resolve toolset mismatch, add restricted toolset guidance, and auto-inherit file toolset in delegation (#3093)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -573,9 +573,7 @@ TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm",
 #      the blocker.  (Observed on DeepSeek v4-flash on the same task:
 #      pushed through PEP-668 wall, then returned fabricated listings.)
 #
-# Short on purpose.  This block is shipped to every user, every session,
-# in the cached system prompt — token cost is paid once at install and
-# then amortised across all sessions via prefix caching.  Keep it tight.
+# Universal task-completion guidance. Short on purpose: shipped in cached prompt.
 TASK_COMPLETION_GUIDANCE = (
     "# Finishing the job\n"
     "When the user asks you to build, run, or verify something, the deliverable is "
@@ -589,6 +587,25 @@ TASK_COMPLETION_GUIDANCE = (
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
     "is always better than inventing a result."
+)
+
+# Scoped / restricted toolset guidance (#3093).
+# Injected when the session has tools loaded but lacks execution and file-write
+# capabilities (e.g. web-only, safe mode, webhook safe toolset). Tells the model
+# upfront that it cannot run commands or edit files directly, so it declines local
+# execution immediately and provides complete runnable code snippets/artifacts for
+# the user instead of attempting non-existent tools or promising execution.
+RESTRICTED_TOOLSET_GUIDANCE = (
+    "# Scoped / Read-only toolset boundaries\n"
+    "This session is operating with a scoped toolset without local command execution "
+    "or filesystem write tools (no `terminal`, `write_file`, or `patch`).\n"
+    "When the user requests tasks that require local builds, command execution, "
+    "or file modifications:\n"
+    "1. Decline action execution upfront and clearly: state that this session is "
+    "configured in a scoped / read-only mode without local execution or file-writing tools.\n"
+    "2. Do NOT attempt to invoke missing execution tools or promise background execution.\n"
+    "3. Provide complete, verified, self-contained code snippets, commands, or "
+    "artifacts directly in your response so the user can execute them directly."
 )
 
 # Universal anti-fixation guidance.  A behavioural instruction the model itself
@@ -656,6 +673,7 @@ RECOVERY_BEFORE_REFUSAL_GUIDANCE = (
     "- No `grep` tool → use `search_files` with a regex pattern.\n"
     "- No direct database access → write a script via `terminal` that queries it.\n"
     "- No image editor → use `terminal` to invoke ImageMagick or Python PIL.\n"
+    "- Scoped toolset without terminal/write access → state the restriction upfront and provide complete, runnable code/commands for the user.\n"
     "The goal is to exhaust available capabilities before declining a request."
 )
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -44,6 +44,7 @@ from agent.prompt_builder import (
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
     RECOVERY_BEFORE_REFUSAL_GUIDANCE,
+    RESTRICTED_TOOLSET_GUIDANCE,
     SELFCOMPACT_RUBRIC_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
@@ -399,14 +400,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
 
-    # Universal task-completion / no-fabrication guidance.  Applied to ALL
-    # models regardless of tool_use_enforcement gating — the failure modes
-    # this targets (stopping after a stub; fabricating output when a real
-    # path is blocked) are not model-family specific.  Gated only by
-    # config.yaml ``agent.task_completion_guidance`` (default True) so
-    # users who want a leaner prompt can turn it off.
+    # Universal task-completion / no-fabrication guidance (#3093).
+    # When the session has execution/write capabilities (terminal, process,
+    # write_file, patch, execute_code), enforce finishing the job with real tool output.
+    # When the session has tools loaded but is intentionally scoped/read-only (e.g.
+    # web-only, safe, webhook safe), inject RESTRICTED_TOOLSET_GUIDANCE to decline
+    # execution upfront and provide complete runnable artifacts directly.
+    # Gated by config.yaml ``agent.task_completion_guidance`` (default True).
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
-        stable_parts.append(TASK_COMPLETION_GUIDANCE)
+        _has_execution_or_write = any(
+            t in agent.valid_tool_names
+            for t in ("terminal", "process", "write_file", "patch", "execute_code")
+        )
+        if _has_execution_or_write:
+            stable_parts.append(TASK_COMPLETION_GUIDANCE)
+        else:
+            stable_parts.append(RESTRICTED_TOOLSET_GUIDANCE)
 
     # Universal anti-fixation guidance (issue #45): a reset the model performs
     # itself to break tunnel vision. Always on — cheap, static text, helps every

--- a/tests/run_agent/test_issue_3093_toolset_mismatch.py
+++ b/tests/run_agent/test_issue_3093_toolset_mismatch.py
@@ -1,0 +1,109 @@
+"""Unit and integration tests for Issue #3093: Toolset mismatch and capability awareness."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agent.prompt_builder import (
+    RECOVERY_BEFORE_REFUSAL_GUIDANCE,
+    RESTRICTED_TOOLSET_GUIDANCE,
+    TASK_COMPLETION_GUIDANCE,
+)
+from agent.system_prompt import build_system_prompt_parts
+from run_agent import AIAgent
+from toolsets import resolve_toolset, TOOLSETS
+from tools.delegate_tool import _goal_needs_file, _build_child_agent
+
+
+def _make_agent(valid_tool_names=None, platform="cli"):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="anthropic/claude-3-5-sonnet",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform=platform,
+        )
+        agent.client = MagicMock()
+        if valid_tool_names is not None:
+            agent.valid_tool_names = set(valid_tool_names)
+        return agent
+
+
+class TestIssue3093ToolsetGuidance:
+    def test_api_server_toolset_includes_repo_map(self):
+        """hermes-api-server toolset includes repo_map tool."""
+        tools = resolve_toolset("hermes-api-server")
+        assert "repo_map" in tools
+        assert "read_file" in tools
+        assert "write_file" in tools
+
+    def test_full_session_injects_task_completion_guidance(self):
+        """When agent has terminal or write tools, TASK_COMPLETION_GUIDANCE is injected."""
+        agent = _make_agent(
+            valid_tool_names={"terminal", "read_file", "write_file", "web_search"}
+        )
+        parts = build_system_prompt_parts(agent)
+        stable = parts["stable"]
+        assert TASK_COMPLETION_GUIDANCE in stable
+        assert RESTRICTED_TOOLSET_GUIDANCE not in stable
+
+    def test_restricted_session_injects_restricted_toolset_guidance(self):
+        """When agent has tools but lacks terminal/write tools (e.g. web-only/safe), RESTRICTED_TOOLSET_GUIDANCE is injected."""
+        agent = _make_agent(
+            valid_tool_names={"web_search", "web_extract", "vision_analyze", "clarify"}
+        )
+        parts = build_system_prompt_parts(agent)
+        stable = parts["stable"]
+        assert RESTRICTED_TOOLSET_GUIDANCE in stable
+        assert TASK_COMPLETION_GUIDANCE not in stable
+
+    def test_recovery_before_refusal_includes_scoped_boundaries(self):
+        """RECOVERY_BEFORE_REFUSAL_GUIDANCE includes guidance on scoped toolset boundaries."""
+        assert "Scoped toolset without terminal/write access" in RECOVERY_BEFORE_REFUSAL_GUIDANCE
+
+
+class TestIssue3093DelegationToolsetInheritance:
+    def test_goal_needs_file_heuristics(self):
+        """_goal_needs_file detects filesystem-oriented goals."""
+        assert _goal_needs_file("Create a new Python file src/main.py") is True
+        assert _goal_needs_file("Patch the auth handler in auth.py") is True
+        assert _goal_needs_file("Edit the config file") is True
+        assert _goal_needs_file("Search for information about neural networks") is False
+
+    def test_child_agent_auto_inherits_file_toolset(self):
+        """Child subagent auto-adds 'file' toolset when goal needs filesystem and parent has file access."""
+        parent_agent = _make_agent(
+            valid_tool_names={"read_file", "write_file", "web_search", "delegate_task"}
+        )
+        parent_agent.enabled_toolsets = ["web", "file", "delegation"]
+        parent_agent.disabled_toolsets = []
+
+        with (
+            patch("run_agent.AIAgent") as mock_child_cls,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
+            mock_child = MagicMock()
+            mock_child_cls.return_value = mock_child
+
+            _build_child_agent(
+                task_index=1,
+                goal="Write and patch the test files in tests/",
+                context="",
+                toolsets=["web"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent_agent,
+            )
+
+            # Assert mock_child_cls was called with enabled_toolsets containing 'file'
+            call_kwargs = mock_child_cls.call_args.kwargs
+            enabled = call_kwargs.get("enabled_toolsets", [])
+            assert "file" in enabled

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1786,6 +1786,25 @@ _SHELL_DEPENDENT_VERBS = frozenset({
     "check",
 })
 
+# Verbs that strongly indicate the task requires filesystem access (#3093).
+_FILESYSTEM_DEPENDENT_VERBS = frozenset({
+    "file",
+    "files",
+    "write",
+    "patch",
+    "edit",
+    "create",
+    "modify",
+    "read_file",
+    "write_file",
+    "save",
+    "update_file",
+    "overwrite",
+    "append",
+    "search_files",
+    "repo_map",
+})
+
 
 def _goal_needs_terminal(goal: str, context: Optional[str] = None) -> bool:
     """Return True if the task goal/context text references shell-dependent work.
@@ -1808,6 +1827,22 @@ def _goal_needs_terminal(goal: str, context: Optional[str] = None) -> bool:
     # Word-boundary match so "git" doesn't match "digit" / "fidget".
     pattern = re.compile(
         r"\b(" + "|".join(re.escape(v) for v in _SHELL_DEPENDENT_VERBS) + r")\b",
+        re.IGNORECASE,
+    )
+    return bool(pattern.search(text))
+
+
+def _goal_needs_file(goal: str, context: Optional[str] = None) -> bool:
+    """Return True if the task goal/context text references filesystem-dependent work (#3093)."""
+    import re
+
+    text = goal or ""
+    if context:
+        text = f"{text}\n{context}"
+    if not text:
+        return False
+    pattern = re.compile(
+        r"\b(" + "|".join(re.escape(v) for v in _FILESYSTEM_DEPENDENT_VERBS) + r")\b",
         re.IGNORECASE,
     )
     return bool(pattern.search(text))
@@ -2187,6 +2222,17 @@ def _build_child_agent(
                 "delegate_task: auto-added 'terminal' toolset for task %d "
                 "(goal references shell-dependent verbs but resolved toolset "
                 "omitted it) — #1369 regression fix",
+                task_index,
+            )
+    if _goal_needs_file(goal, context) and "file" not in child_toolsets:
+        expanded_parent = _expand_parent_toolsets(parent_toolsets)
+        if "file" in expanded_parent:
+            child_toolsets.append("file")
+            _toolset_adjusted = True
+            logger.info(
+                "delegate_task: auto-added 'file' toolset for task %d "
+                "(goal references filesystem-dependent verbs but resolved toolset "
+                "omitted it) — #3093",
                 task_index,
             )
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -468,7 +468,7 @@ TOOLSETS = {
             # Terminal + process management
             "terminal", "process",
             # File manipulation
-            "read_file", "write_file", "patch", "search_files",
+            "read_file", "write_file", "patch", "search_files", "repo_map",
             # Vision + image generation
             "vision_analyze", "image_generate",
             # BFL FLUX 3 video generation


### PR DESCRIPTION
## Summary
Fixes #3093

### Problem
Sessions launched with restricted/scoped toolsets (e.g. web-only, safe mode, webhook safe toolset) received build/run/verify requests and encountered capability dead-ends:
1. `TASK_COMPLETION_GUIDANCE` instructed models to only deliver working artifacts backed by real tool output even when the session lacked filesystem write or terminal tools.
2. In `delegate_task`, subagents whose goals referenced filesystem actions (creating, modifying, patching files) were not auto-inheriting the `file` toolset from the parent.
3. `hermes-api-server` toolset was missing `repo_map`.

### Solution
1. **Restricted Toolset Guidance & Capability Awareness**:
   - Added `RESTRICTED_TOOLSET_GUIDANCE` in `agent/prompt_builder.py`.
   - In `agent/system_prompt.py`, when a session has tools but lacks execution/write capabilities (`terminal`, `process`, `write_file`, `patch`, `execute_code`), injected `RESTRICTED_TOOLSET_GUIDANCE` instead of `TASK_COMPLETION_GUIDANCE`, instructing the model to decline local execution upfront and provide complete runnable code/artifacts for the user.
   - Enhanced `RECOVERY_BEFORE_REFUSAL_GUIDANCE` to cover scoped toolset boundaries.
2. **Subagent Delegation Toolset Auto-Inheritance**:
   - Added `_goal_needs_file` heuristic in `tools/delegate_tool.py` alongside `_goal_needs_terminal` so delegated subagents with file-oriented goals auto-inherit the `file` toolset when available in the parent.
3. **Toolset Alignment**:
   - Added `"repo_map"` to `hermes-api-server` toolset in `toolsets.py`.
4. **Testing**:
   - Added unit and integration tests in `tests/run_agent/test_issue_3093_toolset_mismatch.py`.