### PR TITLE
fix(loop_guard): implement structured refusal and access-denied recovery policy (#3106)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1965,6 +1965,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_dropped_toolcall_nudge",
+    "_refusal_recovery_synthetic",
 )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7308,6 +7308,12 @@ def _run_conversation_impl(
             
             # Check for tool calls
             if assistant_message.tool_calls:
+                try:
+                    from agent import refusal_telemetry
+                    refusal_telemetry.record_transition_if_pending(agent, category_after="", took_action=True)
+                    agent._refusal_recovery_nudges = 0
+                except Exception:
+                    pass
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
                 
@@ -8468,6 +8474,7 @@ def _run_conversation_impl(
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
                         or messages[-1].get("_dropped_toolcall_nudge")
+                        or messages[-1].get("_refusal_recovery_synthetic")
                     )
                 ):
                     messages.pop()
@@ -8636,6 +8643,85 @@ def _run_conversation_impl(
                     # final_response while continuing so a later budget
                     # exhaustion path does not treat the narrated stop as
                     # a completed answer.
+                    _pending_verification_response = final_response
+                    _pending_verification_response_previewed = (
+                        agent._interim_content_was_streamed(final_response or "")
+                    )
+                    final_response = None
+                    continue
+
+                # ── Refusal / Access-denied recovery guard (#3106) ───
+                # When the model produces a text-only refusal without tool calls,
+                # give it a structured 2-stage opportunity to course-correct:
+                # 1st nudge (advisory): taxonomy-specific recovery guidance.
+                # 2nd nudge (directive): alternative tool / narrow scope / escalate.
+                # Capped at 2 nudges per turn to prevent refusal loops.
+                _refusal_nudge = None
+                try:
+                    from agent import refusal_telemetry
+                    from agent.loop_guard import (
+                        detect_refusal_category,
+                        maybe_refusal_nudge,
+                    )
+
+                    _refusal_cat = detect_refusal_category(final_response)
+                    if _refusal_cat and bool(agent.valid_tool_names):
+                        _refusal_attempts = getattr(
+                            agent, "_refusal_recovery_nudges", 0
+                        )
+                        if _refusal_attempts < 2:
+                            _nudge_tier = (
+                                "advisory" if _refusal_attempts == 0 else "directive"
+                            )
+                            _refusal_nudge = maybe_refusal_nudge(
+                                [*messages, final_msg],
+                                already_nudged=(_refusal_attempts > 0),
+                                nudge_count=(_refusal_attempts + 1),
+                            )
+                            if _refusal_nudge:
+                                refusal_telemetry.record_nudge_and_set_pending(
+                                    agent,
+                                    _refusal_cat,
+                                    _nudge_tier,
+                                    _refusal_attempts + 1,
+                                )
+                        else:
+                            # Max refusal attempts reached — record final unrecovered transition
+                            refusal_telemetry.record_transition_if_pending(
+                                agent, _refusal_cat, took_action=False
+                            )
+                            agent._refusal_recovery_nudges = 0
+                    else:
+                        # No refusal detected in text — record transition if a nudge was pending
+                        refusal_telemetry.record_transition_if_pending(
+                            agent, "", took_action=False
+                        )
+                        agent._refusal_recovery_nudges = 0
+                except Exception:
+                    logger.debug("refusal recovery check failed", exc_info=True)
+                    _refusal_nudge = None
+
+                if _refusal_nudge:
+                    agent._refusal_recovery_nudges = (
+                        getattr(agent, "_refusal_recovery_nudges", 0) + 1
+                    )
+                    final_msg["finish_reason"] = "refusal_recovery_required"
+                    final_msg["_refusal_recovery_synthetic"] = True
+                    append_message(messages, final_msg)
+                    append_message(messages, {
+                        "role": "user",
+                        "content": _refusal_nudge,
+                        "_refusal_recovery_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.info(
+                        "refusal recovery nudge issued (attempt %d, category=%s)",
+                        agent._refusal_recovery_nudges,
+                        _refusal_cat,
+                    )
+                    agent._emit_status(
+                        f"⚠️ Refusal detected ({_refusal_cat}) — nudging recovery ({agent._refusal_recovery_nudges}/2)"
+                    )
                     _pending_verification_response = final_response
                     _pending_verification_response_previewed = (
                         agent._interim_content_was_streamed(final_response or "")

--- a/agent/loop_guard.py
+++ b/agent/loop_guard.py
@@ -1297,13 +1297,13 @@ def run_warrants_cron_hard_stop(messages: List[Dict[str, Any]]) -> bool:
 
 _REFUSAL_PAT = re.compile(
     "|".join([  # fmt: skip
-        r"i can'?t",
-        r"i can not",
+        r"i can'?t\b",
+        r"i can not\b",
+        r"i cannot\b",
         r"i don'?t have (?:access|permission)",
         r"no access",
         r"i'?m unable to",
         r"i don'?t have (?:a |the )?(?:tool|skill|feature|plugin|ability|capability)",
-        r"i cannot (?:help|assist|do|provide|access)",
         r"not (?:able|allowed) to",
     ]),
     re.IGNORECASE,
@@ -1315,25 +1315,46 @@ _FP_REFUSAL_PAT = re.compile(
 )
 
 _REFUSAL_CATEGORIES = {
+    "safety_refusal": (
+        r"safety|policy|content filter|harmful|restricted|guidelines|terms of service|unacceptable",
+        "A safety or policy boundary was cited. Verify if the request can "
+        "be fulfilled safely by rephrasing, focusing on technical/"
+        "educational aspects, or exploring permitted alternatives. If "
+        "truly unsafe, explain the exact boundary concisely.",
+    ),
+    "rate_limit": (
+        r"rate limit|too many requests|quota|429|throttl",
+        "A rate limit or quota boundary was encountered. Do not retry "
+        "identically — switch to an alternative local source or cached "
+        "data, or chunk the request into smaller batches.",
+    ),
+    "unsupported_parameter": (
+        r"invalid (?:argument|parameter|schema|option)|unknown (?:flag|parameter|argument)|unsupported (?:parameter|argument|format)",
+        "An unsupported parameter or invalid argument was cited. Check the "
+        "tool schema or documentation, simplify the arguments, or use a "
+        "standard alternative approach.",
+    ),
+    "permission_boundary": (
+        r"permission|security|unauthorized|forbidden|access denied|403",
+        "An access-denied or permission boundary was cited. Check if the "
+        "action is achievable with alternative available tools (e.g. "
+        "`read_file` vs `terminal`, local commands vs remote APIs). If "
+        "essential access is missing, name the exact credential or "
+        "permission needed.",
+    ),
     "true_capability_gap": (
-        r"don'?t have (?:a |the )?(?:tool|skill|plugin|feature)",
+        r"don'?t have (?:a |the )?(?:tool|skill|plugin|feature|ability)|cannot (?:browse|run|execute|access the web)",
         "A capability gap was cited. Check whether the capability exists "
         "locally (use `hermes tools` or check skills) before accepting the "
         "refusal. If a tool/skill is available, use it directly. If genuinely "
         "missing, suggest how to install or configure it rather than stopping.",
     ),
-    "permission_boundary": (
-        r"permission|security|unauthorized|forbidden",
-        "A permission/security boundary was cited. Verify this is a genuine "
-        "security boundary and not an over-refusal — check whether the "
-        "action is safe and permitted in the current context. If legitimate, "
-        "explain the boundary and suggest an alternative approach.",
-    ),
     "over_refusal": (
         r"",
         "The capability likely exists locally. Before accepting this refusal, "
         "re-check available tools and skills — the requested action may be "
-        "achievable with the tools already configured. Use them directly.",
+        "achievable with the tools already configured. Break down the task into "
+        "concrete steps and execute them directly.",
     ),
 }
 
@@ -1378,6 +1399,7 @@ def maybe_refusal_nudge(
     messages: List[Dict[str, Any]],
     *,
     already_nudged: bool = False,
+    nudge_count: int = 1,
 ) -> Optional[str]:
     """Return a recovery directive if the last assistant message contains
     refusal language, else None.
@@ -1388,14 +1410,9 @@ def maybe_refusal_nudge(
     message — giving the model a chance to course-correct before the
     refusal is accepted as the final answer.
 
-    #1243 — ``already_nudged`` no longer suppresses the nudge entirely.
-    The caller now passes ``already_nudged=True`` on the 2nd refusal to
-    get the same detection (the caller handles escalation language).
+    Stage 1 (nudge_count=1, already_nudged=False): advisory category directive.
+    Stage 2 (nudge_count>=2, already_nudged=True): escalated alternative/escalate directive.
     """
-    if already_nudged:
-        # #1243 — Still detect; the caller builds the escalated directive.
-        # We just need to confirm the last message is still a refusal.
-        pass
     # Find the last assistant message with text content
     last_assistant_text = None
     for msg in reversed(messages):
@@ -1426,7 +1443,17 @@ def maybe_refusal_nudge(
     category = _classify_refusal(snippet)
     if not category:
         return None
-    # Build recovery directive
+
+    if already_nudged or nudge_count >= 2:
+        return (
+            f"[loop-guard] Second refusal detected ({category}). If an alternative "
+            f"approach, narrower scope, or alternative tool can satisfy the request, "
+            f"take action now. Otherwise, explain clearly and factually what is needed "
+            f"(e.g. missing credentials, exact permissions, or specific user clarification) "
+            f"so the turn can conclude cleanly."
+        )
+
+    # Build 1st-stage advisory recovery directive
     _, recovery = _REFUSAL_CATEGORIES.get(category, _REFUSAL_CATEGORIES["over_refusal"])
     return (
         f"[loop-guard] Refusal detected ({category}). {recovery} "

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -53,6 +53,7 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_refusal_recovery_synthetic",
 )
 
 

--- a/tests/agent/test_issue_3106_refusal_recovery.py
+++ b/tests/agent/test_issue_3106_refusal_recovery.py
@@ -1,0 +1,162 @@
+"""Tests for Issue #3106: Structured Refusal & Access-Denied Recovery Policy.
+
+Verifies:
+1. Category classification across safety_refusal, rate_limit, unsupported_parameter,
+   permission_boundary, true_capability_gap, and over_refusal.
+2. 2-stage recovery retry ladder (advisory -> directive).
+3. Telemetry tracking (record_nudge, record_transition, record_transition_if_pending).
+4. Turn finalization and synthetic scaffolding cleanup.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent.loop_guard import (
+    detect_refusal_category,
+    maybe_refusal_nudge,
+    _REFUSAL_CATEGORIES,
+)
+from agent import refusal_telemetry
+from agent.turn_finalizer import _drop_verification_continuation_scaffolding
+
+
+class TestRefusalTaxonomyClassification:
+    """Test classification across all structured refusal categories."""
+
+    def test_safety_refusal_detection(self):
+        text = "I cannot fulfill this request as it violates safety guidelines and policy."
+        cat = detect_refusal_category(text)
+        assert cat == "safety_refusal"
+
+    def test_rate_limit_detection(self):
+        text = "I'm unable to proceed because we hit a 429 rate limit on the endpoint."
+        cat = detect_refusal_category(text)
+        assert cat == "rate_limit"
+
+    def test_unsupported_parameter_detection(self):
+        text = "I cannot run this tool because of an invalid parameter schema in the call."
+        cat = detect_refusal_category(text)
+        assert cat == "unsupported_parameter"
+
+    def test_permission_boundary_detection(self):
+        text = "I don't have access to /etc/shadow due to permission denied (403 forbidden)."
+        cat = detect_refusal_category(text)
+        assert cat == "permission_boundary"
+
+    def test_true_capability_gap_detection(self):
+        text = "I don't have a tool to search the live web or browse URLs."
+        cat = detect_refusal_category(text)
+        assert cat == "true_capability_gap"
+
+    def test_over_refusal_detection(self):
+        text = "I'm unable to do that for you right now."
+        cat = detect_refusal_category(text)
+        assert cat == "over_refusal"
+
+    def test_false_positive_ignored(self):
+        text = "I can't imagine how fast this algorithm runs on large datasets!"
+        cat = detect_refusal_category(text)
+        assert cat == ""
+
+
+class TestTwoStageRefusalNudgeLadder:
+    """Test 1st stage advisory nudge vs 2nd stage directive nudge."""
+
+    def test_stage_1_advisory_nudge(self):
+        messages = [
+            {"role": "user", "content": "Fetch the report"},
+            {"role": "assistant", "content": "I don't have permission to access that API."},
+        ]
+        nudge = maybe_refusal_nudge(messages, already_nudged=False, nudge_count=1)
+        assert nudge is not None
+        assert "Refusal detected (permission_boundary)" in nudge
+        assert "Do not simply repeat the refusal" in nudge
+
+    def test_stage_2_directive_nudge(self):
+        messages = [
+            {"role": "user", "content": "Fetch the report"},
+            {"role": "assistant", "content": "I don't have permission to access that API."},
+        ]
+        nudge = maybe_refusal_nudge(messages, already_nudged=True, nudge_count=2)
+        assert nudge is not None
+        assert "Second refusal detected (permission_boundary)" in nudge
+        assert "alternative approach" in nudge
+        assert "missing credentials, exact permissions" in nudge
+
+    def test_no_nudge_for_non_refusal_text(self):
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "The answer is 4."},
+        ]
+        nudge = maybe_refusal_nudge(messages)
+        assert nudge is None
+
+
+class TestRefusalTelemetryIntegration:
+    """Test refusal telemetry recording and transition tracking."""
+
+    def test_record_nudge_and_transition(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("agent.refusal_telemetry.get_hermes_home", lambda: tmp_path)
+        agent = SimpleNamespace(
+            session_id="test-session-3106",
+            _session_refusal_count=1,
+            _pending_nudge_telemetry=None,
+        )
+
+        # Stage 1: Record nudge
+        refusal_telemetry.record_nudge_and_set_pending(
+            agent,
+            refusal_category="permission_boundary",
+            nudge_tier="advisory",
+            nudge_count=1,
+        )
+        assert agent._pending_nudge_telemetry == {
+            "tier": "advisory",
+            "category": "permission_boundary",
+        }
+
+        # Stage 2: Successful action recovery (tool call)
+        refusal_telemetry.record_transition_if_pending(
+            agent,
+            category_after="",
+            took_action=True,
+        )
+        assert agent._pending_nudge_telemetry is None
+
+        events = refusal_telemetry.load_events()
+        assert len(events) == 2
+        assert events[0]["type"] == "nudge"
+        assert events[0]["refusal_category"] == "permission_boundary"
+        assert events[1]["type"] == "transition"
+        assert events[1]["category_before"] == "permission_boundary"
+        assert events[1]["recovered"] is True
+        assert events[1]["took_action"] is True
+
+
+class TestSyntheticScaffoldingCleanup:
+    """Test that _refusal_recovery_synthetic flags are cleaned up on turn finalization."""
+
+    def test_drop_refusal_recovery_synthetic_messages(self):
+        messages = [
+            {"role": "user", "content": "Deploy the app"},
+            {
+                "role": "assistant",
+                "content": "I cannot deploy without credentials.",
+                "_refusal_recovery_synthetic": True,
+            },
+            {
+                "role": "user",
+                "content": "[loop-guard] Refusal detected...",
+                "_refusal_recovery_synthetic": True,
+            },
+            {"role": "assistant", "content": "I have created the deployment script instead."},
+        ]
+
+        _drop_verification_continuation_scaffolding(messages)
+
+        assert len(messages) == 2
+        assert messages[0]["content"] == "Deploy the app"
+        assert messages[1]["content"] == "I have created the deployment script instead."


### PR DESCRIPTION
Resolves #3106.

### Summary of Changes
1. **Refusal Taxonomy Expansion ()**:
   - Added comprehensive structured categories: `safety_refusal`, `rate_limit`, `unsupported_parameter`, `permission_boundary`, `true_capability_gap`, and `over_refusal`.
   - Updated `_REFUSAL_PAT` to accurately match all refusal forms across boundaries.

2. **Two-Stage Recovery Retry Ladder ()**:
   - Stage 1 (advisory): Provides category-matched recovery guidance (rephrase, substitute tool, decompose, reduce scope).
   - Stage 2 (directive): Steers toward immediate alternative tool execution or concise factual escalation.
   - Capped at 2 nudges per turn to prevent infinite loops while maintaining high recovery rates.

3. **Conversation Loop Integration ()**:
   - Evaluates assistant text responses for refusal language before turn completion.
   - Injects structured recovery nudges when tools are available in the session.
   - Hooks tool-call execution to automatically record recovery transitions in telemetry sidecar (`agent/refusal_telemetry.py`).

4. **Scaffolding Cleanup & Invariants (, )**:
   - Marked refusal nudges with `_refusal_recovery_synthetic` to strip them from durable history on turn completion.
   - Preserves strict prompt cache byte-stability and message role alternation.

5. **Test Coverage**:
   - Added 12 new tests in `tests/agent/test_issue_3106_refusal_recovery.py` covering classification, 2-stage ladder, telemetry transitions, and scaffolding cleanup.
   - All 66 refusal test suites pass cleanly.