### PR TITLE
feat(dream): add contradiction scanner to the dream pass (Closes #48)

### DIFF
--- a/scripts/evolution_dream_pass.py
+++ b/scripts/evolution_dream_pass.py
@@ -4,7 +4,13 @@
 Phase 1 of grade-weighted memory retention ("dreaming"): reads recent cycle
 outcomes from ``metrics.jsonl`` and adjusts a file-backed note store so
 high-grade runs get promoted (weight raised) and revision-needed runs get a
-failure-mode tag. Pure file-based — no LLM, no MCP dependency.
+failure-mode tag.
+
+Also hosts slice 1 of issue #48 (Oracular Dream upgrade): a deterministic
+contradiction scanner over the same note store. Notes sharing a topic whose
+lifecycle signals disagree (one promoted, one failure-tagged) are paired into
+a prune/promote proposal — the newer note is authoritative and the older is
+deprecation-linked for audit. Pure file-based — no LLM, no MCP dependency.
 """
 
 from __future__ import annotations
@@ -15,6 +21,15 @@ from typing import Any
 
 PROMOTE_BUMP = 0.5  # weight increment for high-grade cycles
 WEIGHT_CAP = 2.0
+
+#: Lifecycle signals the dream pass itself writes. A note tagged ``promoted``
+#: or carrying weight > 1.0 asserts "this worked"; ``failure:unmerged``
+#: asserts "this did not". Two notes about the same topic carrying opposite
+#: signals are a contradiction candidate.
+POSITIVE_SIGNAL_TAGS = ("promoted",)
+NEGATIVE_SIGNAL_TAGS = ("failure:unmerged",)
+POSITIVE_WEIGHT = 1.0  # weight strictly above this counts as positive signal
+NEGATIVE_WEIGHT = 1.0  # weight strictly below this counts as negative signal
 
 
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -103,8 +118,162 @@ def dream_pass(
     return summary
 
 
+def _topic_of(note: dict[str, Any]) -> str | None:
+    """The grouping key for contradiction detection.
+
+    Prefers an explicit ``topic`` field; falls back to ``title`` when present.
+    Notes with neither cannot be grouped and are skipped.
+    """
+    for key in ("topic", "title"):
+        val = note.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip().lower()
+    return None
+
+
+def _signal(note: dict[str, Any]) -> str:
+    """Lifecycle signal of a note: ``positive``, ``negative`` or ``neutral``.
+
+    Positive: tagged ``promoted`` (written by the dream pass) or weight > 1.0.
+    Negative: tagged ``failure:unmerged`` (written by the dream pass) or
+    weight < 1.0.  Anything else is neutral — no contradiction is asserted.
+    """
+    tags = note.get("tags") or []
+    try:
+        weight = float(note.get("weight", 1.0))
+    except (TypeError, ValueError):
+        weight = 1.0
+    if any(t in POSITIVE_SIGNAL_TAGS for t in tags) or weight > POSITIVE_WEIGHT:
+        return "positive"
+    if any(t in NEGATIVE_SIGNAL_TAGS for t in tags) or weight < NEGATIVE_WEIGHT:
+        return "negative"
+    return "neutral"
+
+
+def scan_contradictions(
+    notes_file: Path, notes: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
+    """Slice 1 of #48: detect contradictory notes in the file-backed store.
+
+    Two notes about the same topic with opposite lifecycle signals (one
+    positive, one negative) form a contradiction.  For each pair the newer
+    note (by ``cycle``) is authoritative: the proposal says the newer
+    observation overrides the older one, and the older should be
+    deprecation-linked for audit.  Deterministic, read-only — callers decide
+    whether to apply the proposals (see :func:`apply_deprecations`).
+
+    Returns a list of proposal dicts::
+
+        {
+          "topic": "...",
+          "older_id": "...", "older_cycle": "...",
+          "newer_id": "...", "newer_cycle": "...",
+          "resolution": "newer-overrides-older",
+          "action": "deprecate-older",
+        }
+
+    Notes without a topic/title are never grouped and are silently skipped.
+    Cycles compare as strings; if either note lacks a comparable cycle the
+    pair is skipped — conservatism beats a false positive here.
+    """
+    if notes is None:
+        notes = load_notes(notes_file)
+    by_topic: dict[str, list[dict[str, Any]]] = {}
+    for n in notes:
+        topic = _topic_of(n)
+        if topic is None:
+            continue
+        by_topic.setdefault(topic, []).append(n)
+    proposals: list[dict[str, Any]] = []
+    for topic, group in by_topic.items():
+        for i, older in enumerate(group):
+            for newer in group[i + 1 :]:
+                o_cycle, n_cycle = older.get("cycle"), newer.get("cycle")
+                if not isinstance(o_cycle, str) or not isinstance(n_cycle, str):
+                    continue  # cannot determine recency — skip
+                if o_cycle == n_cycle:
+                    continue  # same cycle: no ordering to adjudicate
+                o_sig, n_sig = _signal(older), _signal(newer)
+                if o_sig == "neutral" or n_sig == "neutral" or o_sig == n_sig:
+                    continue
+                if n_cycle > o_cycle:
+                    older_note, newer_note = older, newer
+                else:
+                    older_note, newer_note = newer, older
+                proposals.append({
+                    "topic": topic,
+                    "older_id": older_note.get("id"),
+                    "older_cycle": older_note.get("cycle"),
+                    "newer_id": newer_note.get("id"),
+                    "newer_cycle": newer_note.get("cycle"),
+                    "resolution": "newer-overrides-older",
+                    "action": "deprecate-older",
+                })
+    return proposals
+
+
+def apply_deprecations(notes_file: Path, proposals: list[dict[str, Any]]) -> int:
+    """Apply deprecation links for contradiction proposals (issue #48).
+
+    For each proposal, the older note is tagged ``deprecated:by=<newer_id>``
+    and marked ``deprecated: true`` — the entry stays for audit, but is
+    flagged so downstream readers treat the newer note as authoritative.
+    Idempotent: notes already deprecated are left untouched.
+
+    Returns the number of notes newly deprecated.
+    """
+    notes = load_notes(notes_file)
+    applied = 0
+    for prop in proposals:
+        older_id = prop.get("older_id")
+        for n in notes:
+            if n.get("id") != older_id or n.get("deprecated"):
+                continue
+            tags = n.setdefault("tags", [])
+            tag = f"deprecated:by={prop.get('newer_id')}"
+            if tag not in tags:
+                tags.append(tag)
+            n["deprecated"] = True
+            applied += 1
+            break
+    if applied and notes:
+        txt = "".join(json.dumps(n) + "\n" for n in notes)
+        notes_file.write_text(txt, encoding="utf-8")
+    return applied
+
+
+def dream_pass_with_contradictions(
+    metrics_file: Path,
+    notes_file: Path,
+    *,
+    recent: int = 7,
+) -> dict[str, Any]:
+    """Full dream pass: grade-weighted retention + contradiction scan (slice 1
+    of #48).
+
+    Runs the existing :func:`dream_pass`, then scans the (post-promotion)
+    note store for same-topic contradictions, applies deprecation links, and
+    writes ``contradiction_proposals.json`` next to the notes file.  The
+    returned summary extends the base summary with ``contradictions_found``
+    and ``deprecations_applied``.
+    """
+    summary = dream_pass(metrics_file, notes_file, recent=recent)
+    proposals = scan_contradictions(notes_file)
+    deprecated = apply_deprecations(notes_file, proposals)
+    (notes_file.parent / "contradiction_proposals.json").write_text(
+        json.dumps(proposals, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    summary["contradictions_found"] = len(proposals)
+    summary["deprecations_applied"] = deprecated
+    (metrics_file.parent / "dream_pass.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return summary
+
+
 if __name__ == "__main__":  # pragma: no cover
     import sys
 
     evo = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("evolution")
-    dream_pass(evo / "metrics.jsonl", evo / "notes.jsonl")
+    dream_pass_with_contradictions(evo / "metrics.jsonl", evo / "notes.jsonl")

--- a/tests/scripts/test_evolution_dream_pass.py
+++ b/tests/scripts/test_evolution_dream_pass.py
@@ -10,7 +10,15 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT / "scripts") not in sys.path:
     sys.path.insert(0, str(ROOT / "scripts"))
 
-from evolution_dream_pass import classify_cycle, dream_pass, load_notes, load_records  # noqa: E402
+from evolution_dream_pass import (  # noqa: E402
+    apply_deprecations,
+    classify_cycle,
+    dream_pass,
+    dream_pass_with_contradictions,
+    load_notes,
+    load_records,
+    scan_contradictions,
+)
 
 
 def _jl(path: Path, rows: list[dict]) -> None:
@@ -85,3 +93,131 @@ def test_load_records_skips_malformed(tmp_path: Path) -> None:
         '{"date":"x","merged":1}\nnot-json\n\n{"date":"y"}\n', encoding="utf-8"
     )
     assert [r["date"] for r in load_records(f)] == ["x", "y"]
+
+
+# --- Contradiction scanner (issue #48, slice 1) ---
+
+
+def _tn(i: str, c: str, topic: str, tags: list | None = None, w: float = 1.0) -> dict:
+    n = _note(i, c, w)
+    n["topic"] = topic
+    if tags:
+        n["tags"] = tags
+    return n
+
+
+def test_scan_detects_newer_overrides_older(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.jsonl"
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x", ["failure:unmerged"]),
+            _tn("n2", "2026-08-02", "tool-x", ["promoted"], 1.5),
+        ],
+    )
+    props = scan_contradictions(notes)
+    assert len(props) == 1
+    p = props[0]
+    assert p["older_id"] == "n1" and p["newer_id"] == "n2"
+    assert p["topic"] == "tool-x"
+    assert p["resolution"] == "newer-overrides-older"
+    assert p["action"] == "deprecate-older"
+
+
+def test_scan_reversed_cycles_flips_roles(tmp_path: Path) -> None:
+    # Positive signal is OLDER, negative is NEWER → the newer (negative) is
+    # authoritative, the older (positive) is deprecated.
+    notes = tmp_path / "notes.jsonl"
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x", ["promoted"], 1.5),
+            _tn("n2", "2026-08-02", "tool-x", ["failure:unmerged"]),
+        ],
+    )
+    props = scan_contradictions(notes)
+    assert len(props) == 1
+    assert props[0]["older_id"] == "n1" and props[0]["newer_id"] == "n2"
+
+
+def test_scan_same_signal_is_not_a_contradiction(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.jsonl"
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x", ["failure:unmerged"]),
+            _tn("n2", "2026-08-02", "tool-x", ["failure:unmerged"]),
+        ],
+    )
+    assert scan_contradictions(notes) == []
+
+
+def test_scan_neutral_or_missing_topic_skipped(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.jsonl"
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x"),  # neutral (no tags, weight 1.0)
+            _note("n2", "2026-08-02"),  # no topic
+            _tn("n3", "2026-08-03", "tool-y", ["promoted"], 1.5),
+            _tn("n4", "2026-08-04", "tool-y", ["failure:unmerged"]),
+        ],
+    )
+    props = scan_contradictions(notes)
+    # Only the n3/n4 pair qualifies: n1 is neutral, n2 has no topic.
+    assert len(props) == 1
+    assert {props[0]["older_id"], props[0]["newer_id"]} == {"n3", "n4"}
+
+
+def test_scan_requires_comparable_cycles(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.jsonl"
+    n1 = _tn("n1", "2026-08-01", "tool-x", ["promoted"], 1.5)
+    n2 = _tn("n2", "2026-08-02", "tool-x", ["failure:unmerged"])
+    n2["cycle"] = None  # not orderable → pair must be skipped
+    _jl(notes, [n1, n2])
+    assert scan_contradictions(notes) == []
+
+
+def test_apply_deprecations_tags_and_is_idempotent(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.jsonl"
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x", ["failure:unmerged"]),
+            _tn("n2", "2026-08-02", "tool-x", ["promoted"], 1.5),
+        ],
+    )
+    props = scan_contradictions(notes)
+    assert apply_deprecations(notes, props) == 1
+    up = {n["id"]: n for n in load_notes(notes)}
+    assert up["n1"]["deprecated"] is True
+    assert "deprecated:by=n2" in up["n1"]["tags"]
+    assert "deprecated" not in up["n2"]
+    # Second run: nothing left to deprecate.
+    assert apply_deprecations(notes, props) == 0
+
+
+def test_dream_pass_with_contradictions_end_to_end(tmp_path: Path) -> None:
+    metrics, notes = tmp_path / "metrics.jsonl", tmp_path / "notes.jsonl"
+    _jl(
+        metrics,
+        [
+            _cy("2026-08-01", 0, 1, 2),  # revision-needed → failure tag
+            _cy("2026-08-02", 2, 3, 1),  # high-grade → promote
+        ],
+    )
+    _jl(
+        notes,
+        [
+            _tn("n1", "2026-08-01", "tool-x"),
+            _tn("n2", "2026-08-02", "tool-x"),
+        ],
+    )
+    s = dream_pass_with_contradictions(metrics, notes)
+    assert s["contradictions_found"] == 1
+    assert s["deprecations_applied"] == 1
+    up = {n["id"]: n for n in load_notes(notes)}
+    assert up["n1"]["deprecated"] is True  # older failure note deprecation-linked
+    assert up["n2"]["weight"] == 1.5  # newer promoted note is authoritative
+    assert (tmp_path / "contradiction_proposals.json").exists()
+    assert (tmp_path / "dream_pass.json").exists()


### PR DESCRIPTION
Automated evolution PR for issue #48 (slice 1 of the needs-split decomposition).

**What:** deterministic contradiction scanner for the file-backed note store the dream pass maintains. Notes sharing a topic whose lifecycle signals disagree (one `promoted`, one `failure:unmerged`) are paired into prune/promote proposals; the newer note is authoritative and the older is deprecation-linked for audit.

**Wired into:** `scripts/evolution_dream_pass.py` (existing entry point now runs `dream_pass_with_contradictions`), writes `contradiction_proposals.json`, extends the `dream_pass.json` summary with `contradictions_found` / `deprecations_applied`.

**Design:** pure file-based, no LLM, no MCP dependency — matches the existing pass. Conservative: notes without a comparable cycle are skipped; same-signal pairs are not flagged.

**Validation:** ruff check + format green; 12/12 tests in `test_evolution_dream_pass.py` pass (7 new).