### PR TITLE
fix(cron): opt-in model_drift_auto_repin warn-and-repin for drift guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4446,6 +4446,58 @@ def _cron_preflight_enabled(cfg: dict) -> bool:
     return cron_cfg.get("preflight", True) is not False
 
 
+def _cron_drift_auto_repin_enabled(cfg: dict) -> bool:
+    """Whether drifted unpinned jobs auto-repin to the new baseline.
+
+    Default OFF — the #44585 spend-safety guard stays fail-closed unless the
+    user opts in with the literal YAML boolean ``true`` under
+    ``cron.model_drift_auto_repin``. Missing or malformed values stay off
+    (inverse of ``cron_model_drift_guard_enabled`` semantics).
+    """
+    cron_cfg = (cfg or {}).get("cron")
+    if not isinstance(cron_cfg, dict):
+        return False
+    return cron_cfg.get("model_drift_auto_repin", False) is True
+
+
+def _auto_repin_drifted_job(job_id: str, changes: str) -> bool:
+    """Best-effort baseline re-pin of a drifted job (warn-and-repin).
+
+    Refreshes the job's provider/model snapshots to the current global
+    baseline via ``repin_jobs`` so it tracks the new config and runs this
+    tick instead of staying skipped. Returns True only when the job was
+    actually updated; on any failure the caller falls back to the default
+    drift skip so a broken repin can never silently enable spend.
+    """
+    try:
+        from cron.jobs import repin_jobs
+
+        repinned = repin_jobs(job_id)
+    except Exception as exc:
+        logger.warning(
+            "Job '%s': drift auto-repin failed (%s); falling back to the "
+            "default drift skip.",
+            job_id,
+            exc,
+        )
+        return False
+    if not repinned:
+        logger.warning(
+            "Job '%s': drift auto-repin did not update the job (unresolvable "
+            "axis); falling back to the default drift skip.",
+            job_id,
+        )
+        return False
+    logger.warning(
+        "Job '%s': global inference config drifted since creation (%s); "
+        "cron.model_drift_auto_repin is enabled — snapshots re-pinned to "
+        "the new baseline and the job runs this tick instead of skipping.",
+        job_id,
+        changes,
+    )
+    return True
+
+
 def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     """READ-ONLY probe: would provider resolution fail for lack of a key?
 
@@ -5876,63 +5928,70 @@ def _run_job_impl(
                 _drift.append(f"{_axis} '{_snapshot}' -> '{_current}'")
             if _drift:
                 _changes = "; ".join(_drift)
-                # Lifecycle-aware remediation (#72056, @sashmatash): a finite
-                # one-shot is consumed by this attempted dispatch — telling an
-                # operator to edit a spent job is a dead end. Recurring and
-                # repeatable jobs get the pin command instead.
-                _repeat = job.get("repeat") if isinstance(job.get("repeat"), dict) else {}
-                _finite_oneshot = (
-                    isinstance(job.get("schedule"), dict)
-                    and job["schedule"].get("kind") == "once"
-                    and _repeat.get("times") == 1
-                )
-                if _finite_oneshot:
-                    _remediation = (
-                        "This finite one-shot job is consumed by this attempted run; "
-                        "create a new one-shot job at a future time with an explicit "
-                        "provider and model."
+                # Opt-in warn-and-repin (#drift-auto-repin): when enabled, a
+                # drifted unpinned job is re-pinned to the new baseline and
+                # runs this tick. Default stays the fail-closed skip below.
+                _auto_repin_done = False
+                if _cron_drift_auto_repin_enabled(_cfg):
+                    _auto_repin_done = _auto_repin_drifted_job(job_id, _changes)
+                if not _auto_repin_done:
+                    # Lifecycle-aware remediation (#72056, @sashmatash): a finite
+                    # one-shot is consumed by this attempted dispatch — telling an
+                    # operator to edit a spent job is a dead end. Recurring and
+                    # repeatable jobs get the pin command instead.
+                    _repeat = job.get("repeat") if isinstance(job.get("repeat"), dict) else {}
+                    _finite_oneshot = (
+                        isinstance(job.get("schedule"), dict)
+                        and job["schedule"].get("kind") == "once"
+                        and _repeat.get("times") == 1
                     )
-                else:
-                    _remediation = (
-                        "To run on the new config, on the host running Hermes "
-                        "pin it explicitly: "
-                        f"`hermes cron edit {job_id} --provider <provider> "
-                        "--model <model>` (or pin the original values to keep "
-                        "them). To resume tracking the new global config: "
-                        f"`hermes cron repin {job_id}` (or `hermes cron repin --all`). "
-                        f"To hard-pin to current config: `hermes cron repin {job_id} --pin`."
+                    if _finite_oneshot:
+                        _remediation = (
+                            "This finite one-shot job is consumed by this attempted run; "
+                            "create a new one-shot job at a future time with an explicit "
+                            "provider and model."
+                        )
+                    else:
+                        _remediation = (
+                            "To run on the new config, on the host running Hermes "
+                            "pin it explicitly: "
+                            f"`hermes cron edit {job_id} --provider <provider> "
+                            "--model <model>` (or pin the original values to keep "
+                            "them). To resume tracking the new global config: "
+                            f"`hermes cron repin {job_id}` (or `hermes cron repin --all`). "
+                            f"To hard-pin to current config: `hermes cron repin {job_id} --pin`."
+                        )
+                    logger.warning(
+                        "Job '%s': SKIPPED — global inference config drifted since "
+                        "creation (%s) and this job is unpinned. Skipped to prevent "
+                        "unintended spend. %s",
+                        job_id,
+                        _changes,
+                        _remediation,
                     )
-                logger.warning(
-                    "Job '%s': SKIPPED — global inference config drifted since "
-                    "creation (%s) and this job is unpinned. Skipped to prevent "
-                    "unintended spend. %s",
-                    job_id,
-                    _changes,
-                    _remediation,
-                )
-                # Alert-once (#73506 shape): persist the drift_alerted bit so
-                # only the FIRST drifted tick delivers; run_one_job suppresses
-                # delivery on the silent marker. mark_job_run clears the bit
-                # when a run succeeds (drift healed), re-arming the alert.
-                _drift_already_alerted = False
-                try:
-                    from cron.jobs import mark_drift_alerted
+                    # Alert-once (#73506 shape): persist the drift_alerted bit so
+                    # only the FIRST drifted tick delivers; run_one_job suppresses
+                    # delivery on the silent marker. mark_job_run clears the bit
+                    # when a run succeeds (drift healed), re-arming the alert.
+                    _drift_already_alerted = False
+                    try:
+                        from cron.jobs import mark_drift_alerted
 
-                    _drift_already_alerted = mark_drift_alerted(job_id)
-                except Exception:
-                    pass  # fail open: better a duplicate alert than none
-                _drift_marker = (
-                    DRIFT_SKIP_SILENT_MARKER if _drift_already_alerted
-                    else DRIFT_SKIP_MARKER
-                )
-                raise RuntimeError(
-                    f"{_drift_marker} Skipped to prevent unintended spend: global "
-                    f"inference config drifted since this job was created "
-                    f"({_changes}), and this job is unpinned. No inference call "
-                    f"was made. {_remediation} "
-                    f"This alert is sent once; the job stays skipped until the "
-                    f"config is pinned or restored. See #44585."
-                )
+                        _drift_already_alerted = mark_drift_alerted(job_id)
+                    except Exception:
+                        pass  # fail open: better a duplicate alert than none
+                    _drift_marker = (
+                        DRIFT_SKIP_SILENT_MARKER if _drift_already_alerted
+                        else DRIFT_SKIP_MARKER
+                    )
+                    raise RuntimeError(
+                        f"{_drift_marker} Skipped to prevent unintended spend: global "
+                        f"inference config drifted since this job was created "
+                        f"({_changes}), and this job is unpinned. No inference call "
+                        f"was made. {_remediation} "
+                        f"This alert is sent once; the job stays skipped until the "
+                        f"config is pinned or restored. See #44585."
+                    )
 
         fallback_model = get_fallback_chain(_cfg) or None
         credential_pool = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2427,6 +2427,13 @@ DEFAULT_CONFIG = {
         # jobs from silently inheriting a paid default. Set to false only when
         # jobs should deliberately track changing global inference defaults.
         "model_drift_guard": True,
+        # Opt-in companion to model_drift_guard: when true, a drifted unpinned
+        # job is automatically re-pinned to the new global baseline (snapshots
+        # refreshed, drift alert cleared) and runs on schedule instead of
+        # being skipped. Default false preserves the fail-closed spend safety:
+        # drift keeps skipping the job until an operator pins or repins it.
+        # Only the literal YAML boolean ``true`` enables this.
+        "model_drift_auto_repin": False,
         # Default inference model for cron jobs (Axis A — WHAT model an
         # agent job runs on). Resolution at fire time: per-job user pin >
         # cron.model > global model.default. When set, unpinned jobs follow

--- a/tests/cron/test_cron_drift_auto_repin.py
+++ b/tests/cron/test_cron_drift_auto_repin.py
@@ -1,0 +1,166 @@
+"""Opt-in warn-and-repin for the cron model-drift guard (cron.model_drift_auto_repin).
+
+Field report (2026-08-23): a global provider switch (bedrock→nous) mass-skipped
+13 unpinned tc-* cron jobs in a single scheduler pass. The #44585 fail-closed
+guard is the right default for interactive installs, but headless fleets want
+unpinned jobs to track the new baseline and keep running.
+
+Contract:
+- Default (option missing) → guard behaves exactly as before: skip + alert once.
+- Literal ``true`` → the drifted job is re-pinned to the new baseline (snapshots
+  refreshed on disk, drift alert bit cleared) and RUNS this tick.
+- Malformed values (e.g. the string "yes") stay OFF — strict opt-in.
+- Repin failure (exception or unresolvable axis) → falls back to the skip path;
+  a broken repin can never silently enable spend.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import cron.jobs as cron_jobs
+import cron.scheduler as sched
+
+
+def _job(**overrides):
+    job = {
+        "id": "auto-repin-test",
+        "name": "auto repin test",
+        "prompt": "hello",
+        "enabled": True,
+        "state": "scheduled",
+        "schedule": {"kind": "interval", "minutes": 5, "display": "every 5m"},
+        "deliver": "local",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": "openrouter",
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _write_config(tmp_path, auto_repin):
+    """Write a config.yaml enabling/disabling cron.model_drift_auto_repin."""
+    lines = ["model:", "  default: test-model"]
+    if auto_repin is not None:
+        lines += ["cron:", f"  model_drift_auto_repin: {auto_repin}"]
+    (tmp_path / "config.yaml").write_text("\n".join(lines) + "\n")
+
+
+def _tick(job, tmp_path, current_provider, deliveries):
+    """Run one run_one_job tick with the provider resolution pinned."""
+    fake_db = MagicMock()
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        deliveries.append(content)
+        return None
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               return_value={
+                   "api_key": "test-key",
+                   "base_url": "https://example.invalid/v1",
+                   "provider": current_provider,
+                   "api_mode": "chat_completions",
+               }), \
+         patch("cron.jobs._compute_provider_model_snapshots",
+               return_value=(current_provider, "test-model")), \
+         patch.object(sched, "_deliver_result", side_effect=fake_deliver), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        ok = sched.run_one_job(job)
+    return ok, mock_agent_cls.called
+
+
+def _stored(tmp_path, job_id="auto-repin-test"):
+    return [j for j in cron_jobs.load_jobs() if j["id"] == job_id][0]
+
+
+class TestDriftAutoRepin:
+    def test_default_off_preserves_fail_closed_skip(self, tmp_path):
+        """No opt-in → the #44585 skip + alert-once behavior is untouched."""
+        _write_config(tmp_path, None)
+        job = _job()
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = _stored(tmp_path)
+            ok, agent_called = _tick(fresh, tmp_path, "nous", deliveries)
+            assert agent_called is False, "default must not spend on drift"
+
+            stored = _stored(tmp_path)
+            assert stored.get("drift_alerted") is True
+        assert len(deliveries) == 1
+        assert "drift" in deliveries[0].lower()
+
+    def test_enabled_repins_and_runs(self, tmp_path):
+        """Literal true → drifted job re-pins to the new baseline and runs."""
+        _write_config(tmp_path, "true")
+        job = _job()
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = _stored(tmp_path)
+            ok, agent_called = _tick(fresh, tmp_path, "nous", deliveries)
+            assert agent_called is True, "opted-in drifted job must run"
+
+            stored = _stored(tmp_path)
+            assert stored.get("provider_snapshot") == "nous", (
+                "snapshots must be refreshed to the new baseline"
+            )
+            assert not stored.get("drift_alerted"), "repin clears the alert bit"
+
+    def test_malformed_value_stays_off(self, tmp_path):
+        """Only the literal YAML boolean true opts in."""
+        _write_config(tmp_path, '"yes"')
+        job = _job()
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = _stored(tmp_path)
+            ok, agent_called = _tick(fresh, tmp_path, "nous", deliveries)
+            assert agent_called is False, "malformed value must stay fail-closed"
+            assert _stored(tmp_path).get("drift_alerted") is True
+
+    def test_repin_failure_falls_back_to_skip(self, tmp_path):
+        """A repin exception must fall back to the default skip, never run."""
+        _write_config(tmp_path, "true")
+        job = _job()
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = _stored(tmp_path)
+            with patch("cron.jobs.repin_jobs", side_effect=RuntimeError("lock lost")):
+                ok, agent_called = _tick(fresh, tmp_path, "nous", deliveries)
+            assert agent_called is False, "failed repin must not spend"
+
+            stored = _stored(tmp_path)
+            assert stored.get("drift_alerted") is True, (
+                "skip path must re-arm the alert"
+            )
+
+    def test_flag_helper_semantics(self):
+        assert sched._cron_drift_auto_repin_enabled({}) is False
+        assert sched._cron_drift_auto_repin_enabled({"cron": {}}) is False
+        assert sched._cron_drift_auto_repin_enabled(
+            {"cron": {"model_drift_auto_repin": True}}
+        ) is True
+        assert sched._cron_drift_auto_repin_enabled(
+            {"cron": {"model_drift_auto_repin": "true"}}
+        ) is False
+        assert sched._cron_drift_auto_repin_enabled(
+            {"cron": {"model_drift_auto_repin": False}}
+        ) is False
+        assert sched._cron_drift_auto_repin_enabled({"cron": "garbage"}) is False
+        assert sched._cron_drift_auto_repin_enabled(None) is False


### PR DESCRIPTION
Closes #3111.

## Problem
On every global provider change, the #44585 drift guard skips **every** unpinned cron job. On 2026-08-23 a bedrock→nous switch mass-skipped 13 tc-* jobs in one scheduler pass. The fail-closed default is correct spend safety, but headless fleets have no way to say "track the new baseline and keep running" — every change demands a manual `hermes cron repin --all`.

## Change
New config option `cron.model_drift_auto_repin` (default **false**):

- Only the literal YAML boolean `true` opts in (missing/malformed stays fail-closed — inverse of `model_drift_guard` semantics).
- When enabled and drift is detected: snapshots are refreshed to the current baseline via the existing `repin_jobs()` (which also clears `drift_alerted`), a prominent warning is logged, and the job runs this tick.
- Repin failure (exception or unresolvable axis) falls back to the existing skip + alert-once path — a broken repin can never silently enable spend.
- Default-off behavior is byte-for-byte unchanged (skip → remediation text → alert-once → raise).

## Docs
Documented in `hermes_cli/config_defaults.py` alongside `model_drift_guard` (that block is the user-facing doc surface for cron options).

## Tests
New `tests/cron/test_cron_drift_auto_repin.py` (5 tests): default-off preserves fail-closed skip + alert-once; literal true re-pins (snapshot persisted to disk, alert bit cleared) and runs; malformed value stays off; repin exception falls back to skip; flag-helper semantics table. All 16 tests in `test_cron_drift_auto_repin.py` + `test_cron_drift_alert_once.py` + `test_cron_repin.py` pass locally against `.venv`.

## Rollback
Single commit on this branch; revert merge commit or `git revert b54f33492c`.