### PR TITLE
feat(traces): deterministic session-trace replay, resume and branch (Closes #85)

### DIFF
--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -54,6 +54,7 @@ import json
 import os
 import secrets
 import sys
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -71,6 +72,9 @@ __all__ = [
     "extract_model_calls",
     "build_trajectory_log",
     "capture_turn",
+    "replay_trajectory",
+    "resume_index",
+    "branch_trajectory",
 ]
 
 #: Result summaries are already truncated by the logger; this bounds the
@@ -98,7 +102,12 @@ _SALT_FILENAME = ".trajectory_key_salt"
 
 def capture_enabled() -> bool:
     """True when trajectory capture is switched on for this process."""
-    return os.environ.get(_CAPTURE_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+    return os.environ.get(_CAPTURE_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
 
 
 def _salt(trajectory_dir: Optional[Path] = None) -> bytes:
@@ -220,15 +229,13 @@ def extract_tool_calls(
             content = results.get(cid)
             if isinstance(content, str) and len(content) > _MAX_RESULT_CHARS:
                 content = content[:_MAX_RESULT_CHARS]
-            calls.append(
-                {
-                    "tool": str(name),
-                    "args": args if isinstance(args, dict) else {},
-                    "result": content,
-                    "status": _result_status(content) if has_result else "pending",
-                    "duration_ms": timings.get(cid) if cid else None,
-                }
-            )
+            calls.append({
+                "tool": str(name),
+                "args": args if isinstance(args, dict) else {},
+                "result": content,
+                "status": _result_status(content) if has_result else "pending",
+                "duration_ms": timings.get(cid) if cid else None,
+            })
     return calls
 
 
@@ -262,13 +269,11 @@ def extract_model_calls(
     for msg in messages:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
-        calls.append(
-            {
-                "model": str(msg.get("model") or ""),
-                "decision": _classify_model_decision(msg),
-                "tool_call_count": len(msg.get("tool_calls") or []),
-            }
-        )
+        calls.append({
+            "model": str(msg.get("model") or ""),
+            "decision": _classify_model_decision(msg),
+            "tool_call_count": len(msg.get("tool_calls") or []),
+        })
     return calls
 
 
@@ -340,3 +345,132 @@ def capture_turn(
         return log.append(trajectory_dir)
     except Exception:
         return None
+
+
+# --- Replay / resume / branch over recorded trajectories (#85) --------------
+#
+# Capture records *what happened*; these turn a record back into something
+# an optimizer can reason about deterministically. Moirai's trace-optimization
+# concept needs exactly this: replay a session to see where it went wrong,
+# branch from the first bad step with a corrected instruction, resume an
+# interrupted session from its first pending call. All three are pure
+# functions over a TrajectoryLog — no IO, no LLM, no mutation of the source.
+
+_FAILURE_STATUSES = ("failure", "error")
+_INCOMPLETE_STATUSES = ("pending", "unknown")
+
+
+def _window_entries(
+    log: "TrajectoryLog",
+    *,
+    start_at: int = 0,
+    stop_at: Optional[int] = None,
+) -> List[tuple[int, Any]]:
+    """Return ``(absolute_index, entry)`` pairs for the replay window.
+
+    Bounds are clamped to the entry list; negative or inverted windows yield
+    an empty list rather than an error — replay is analysis, not a crash."""
+    n = len(log.entries)
+    start = max(0, int(start_at))
+    stop = n if stop_at is None else min(n, max(0, int(stop_at)))
+    if start >= stop:
+        return []
+    return list(enumerate(log.entries))[start:stop]
+
+
+def replay_trajectory(
+    log: "TrajectoryLog",
+    *,
+    start_at: int = 0,
+    stop_at: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Deterministic replay summary of a recorded trajectory (#85).
+
+    Walks the (clamped) entry window and produces the action sequence an
+    optimizer reasons over — tool names, per-step statuses, durations — plus
+    a single task-level ``outcome``:
+
+    * ``success`` — every step succeeded (nothing to fix),
+    * ``failed`` — at least one step recorded a failure/error,
+    * ``incomplete`` — no hard failure, but a step is pending/unknown (the
+      session was interrupted; the trace is not a completed story),
+    * ``empty`` — no steps in the window.
+
+    ``first_failure_index`` is the absolute index of the first failed step
+    (None when the outcome is not ``failed``); ``stopped_at`` is the absolute
+    index one past the last replayed step, i.e. where a resume would continue.
+    """
+    window = _window_entries(log, start_at=start_at, stop_at=stop_at)
+    steps: List[Dict[str, Any]] = []
+    failure_idx: Optional[int] = None
+    for idx, entry in window:
+        status = str(getattr(entry, "result_status", "unknown"))
+        steps.append({
+            "index": idx,
+            "tool": str(getattr(entry, "tool", "unknown")),
+            "status": status,
+            "duration_ms": getattr(entry, "duration_ms", None),
+        })
+        if status in _FAILURE_STATUSES and failure_idx is None:
+            failure_idx = idx
+    if not steps:
+        outcome = "empty"
+    elif failure_idx is not None:
+        outcome = "failed"
+    elif any(s["status"] in _INCOMPLETE_STATUSES for s in steps):
+        outcome = "incomplete"
+    else:
+        outcome = "success"
+    return {
+        "outcome": outcome,
+        "steps": steps,
+        "step_count": len(steps),
+        "tool_sequence": [s["tool"] for s in steps],
+        "first_failure_index": failure_idx,
+        "started_at": start_at if steps else None,
+        "stopped_at": (steps[-1]["index"] + 1) if steps else None,
+    }
+
+
+def resume_index(log: "TrajectoryLog") -> Optional[int]:
+    """First step worth resuming/branching from, or None for a clean run.
+
+    The first entry whose status is not ``success`` is the point of interest:
+    for a failed run it is where the trace went wrong (branch here with a
+    corrected instruction); for an interrupted run it is the first call that
+    never completed (resume here). A fully successful trajectory has nothing
+    to resume from — None.
+    """
+    for idx, entry in enumerate(log.entries):
+        status = str(getattr(entry, "result_status", "unknown"))
+        if status != "success":
+            return idx
+    return None
+
+
+def branch_trajectory(
+    log: "TrajectoryLog",
+    up_to_index: int,
+) -> "TrajectoryLog":
+    """Copy the prefix of a trajectory up to (and including) a step.
+
+    The branch is a fresh :class:`TrajectoryLog` sharing the source's session
+    id, date, completion flag and task key, with deep-copied entries
+    ``[0 .. up_to_index]`` (clamped) and the same coordination edges. The
+    source log is never mutated — an optimizer can branch repeatedly from
+    different points without corrupting the record it is optimizing over.
+    """
+    n = len(log.entries)
+    stop = n if up_to_index is None else min(n, max(0, int(up_to_index) + 1))
+    branch = TrajectoryLog(
+        session_id=log.session_id,
+        date=log.date,
+        completed=log.completed,
+        task_key=log.task_key,
+    )
+    # Deep-copy the entries directly rather than round-tripping through
+    # add_tool_call: the source entries are ALREADY redacted/summarized, and
+    # re-running those transforms could distort the copy.
+    branch.entries = [deepcopy(e) for e in log.entries[:stop]]
+    branch.edges = list(log.edges)
+    return branch

--- a/scripts/evolution_trace_replay.py
+++ b/scripts/evolution_trace_replay.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""CLI for deterministic session-trace replay, resume and branch (issue #85).
+
+``agent/tool_call_capture.py`` records what the agent actually did, but until
+now a recorded trajectory was a dead file: nothing could replay it, resume an
+interrupted session from its first pending call, or branch from an arbitrary
+recorded point. That is exactly what Moirai's trace-optimization needs — and
+what the DeepSeek harness-style session recording pattern (the issue's
+namesake) provides.
+
+This CLI is the real call site that keeps the replay machinery from being dead
+code: it loads a recorded trajectory (either the single-object ``.json`` from
+:meth:`TrajectoryLog.save` or the per-turn ``.jsonl`` from
+:meth:`TrajectoryLog.append`), replays it deterministically, reports the
+resume point, or writes a branch prefix.
+
+Usage::
+
+    evolution_trace_replay.py replay <path> [--from N] [--to N] [--json]
+    evolution_trace_replay.py resume <path>
+    evolution_trace_replay.py branch <path> --to N [--out DIR]
+
+``replay`` prints a per-step action sequence + the task-level ``outcome``
+(success / failed / incomplete / empty). ``resume`` prints the index of the
+first step worth resuming from (exit 1 when the run is already clean).
+``branch`` writes a new trajectory containing steps ``[0 .. --to]`` and prints
+the output path. All output is deterministic — no LLM, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Make both scripts/ (trajectory logger) and agent/ (capture) importable.
+ROOT = Path(__file__).resolve().parent.parent
+for p in (str(ROOT / "scripts"), str(ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from agent.tool_call_capture import branch_trajectory, replay_trajectory, resume_index  # noqa: E402
+from evolution_trajectory_logger import iter_trajectories  # noqa: E402
+
+EXIT_OK = 0
+EXIT_BAD_INPUT = 2
+EXIT_CLEAN_RUN = 1  # resume: nothing to resume from
+
+
+def _load_single(path: Path) -> Optional[Any]:
+    """Load the (first) trajectory log in a file; None on unreadable input."""
+    logs = iter_trajectories(path)
+    return logs[0] if logs else None
+
+
+def _print_json(obj: Dict[str, Any]) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True))
+
+
+def cmd_replay(argv: List[str]) -> int:
+    path = argv[0]
+    start_at = 0
+    stop_at = None
+    as_json = False
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--from" and i + 1 < len(argv):
+            start_at = int(argv[i + 1])
+            i += 2
+        elif arg == "--to" and i + 1 < len(argv):
+            stop_at = int(argv[i + 1])
+            i += 2
+        elif arg == "--json":
+            as_json = True
+            i += 1
+        else:
+            return _err(f"unknown argument: {arg}")
+    log = _load_single(Path(path))
+    if log is None:
+        return _err(f"could not load trajectory: {path}")
+    result = replay_trajectory(log, start_at=start_at, stop_at=stop_at)
+    result["source"] = path
+    result["entries_total"] = len(log.entries)
+    if as_json:
+        _print_json(result)
+        return EXIT_OK
+    print(f"=== Replay: {path} ({len(log.entries)} recorded steps) ===")
+    print(f"Outcome: {result['outcome'].upper()}")
+    for s in result["steps"]:
+        dur = f" ({s['duration_ms']}ms)" if s["duration_ms"] is not None else ""
+        print(f"  [{s['index']}] {s['tool']}: {s['status']}{dur}")
+    return EXIT_OK
+
+
+def cmd_resume(argv: List[str]) -> int:
+    path = argv[0]
+    log = _load_single(Path(path))
+    if log is None:
+        return _err(f"could not load trajectory: {path}")
+    idx = resume_index(log)
+    if idx is None:
+        print(
+            f"clean run: no step to resume from ({len(log.entries)} steps all successful)"
+        )
+        return EXIT_CLEAN_RUN
+    print(
+        f"resume at index {idx} "
+        f"(step {idx}: {log.entries[idx].tool}, status {log.entries[idx].result_status})"
+    )
+    return EXIT_OK
+
+
+def cmd_branch(argv: List[str]) -> int:
+    path = argv[0]
+    up_to = None
+    out_dir: Optional[Path] = None
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--to" and i + 1 < len(argv):
+            up_to = int(argv[i + 1])
+            i += 2
+        elif arg == "--out" and i + 1 < len(argv):
+            out_dir = Path(argv[i + 1])
+            i += 2
+        else:
+            return _err(f"unknown argument: {arg}")
+    if up_to is None:
+        return _err("branch requires --to N")
+    log = _load_single(Path(path))
+    if log is None:
+        return _err(f"could not load trajectory: {path}")
+    branch = branch_trajectory(log, up_to)
+    if out_dir is None:
+        out_dir = Path(path).parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    name = Path(path).stem
+    out_path = out_dir / f"{name}.branch-{up_to}.json"
+    out_path.write_text(branch.to_json(), encoding="utf-8")
+    print(out_path)
+    return EXIT_OK
+
+
+def _err(msg: str) -> int:
+    print(f"[evolution-trace-replay] {msg}", file=sys.stderr)
+    return EXIT_BAD_INPUT
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: evolution_trace_replay.py <replay|resume|branch> <path> [opts]",
+            file=sys.stderr,
+        )
+        return EXIT_BAD_INPUT
+    sub, rest = argv[1], argv[2:]
+    if sub == "replay":
+        if not rest:
+            return _err("replay requires a path")
+        return cmd_replay(rest)
+    if sub == "resume":
+        if not rest:
+            return _err("resume requires a path")
+        return cmd_resume(rest)
+    if sub == "branch":
+        if not rest:
+            return _err("branch requires a path")
+        return cmd_branch(rest)
+    return _err(f"unknown subcommand: {sub}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -171,6 +171,22 @@ class TrajectoryEntry:
             duration_ms=duration_ms,
         )
 
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "TrajectoryEntry":
+        """Rebuild an entry from its ``to_dict()`` shape (tolerant of gaps).
+
+        Unknown statuses and missing fields are preserved as-is rather than
+        defaulted, so a replay sees exactly what was recorded — a recorded
+        ``"pending"`` must not silently become ``"unknown"``."""
+        return cls(
+            tool=str(d.get("tool", "unknown")),
+            args_summary=d.get("args_summary", {}) or {},
+            result_status=str(d.get("result_status", "unknown")),
+            result_summary=str(d.get("result_summary", "")),
+            timestamp=str(d.get("timestamp", "")),
+            duration_ms=d.get("duration_ms"),
+        )
+
 
 class TrajectoryLog:
     """In-memory trajectory log for a single cron session."""
@@ -216,9 +232,7 @@ class TrajectoryLog:
         Pure logging: measures delegation overhead (who talked to whom, via
         which channel, at what token cost) without changing behavior.
         """
-        self.edges.append(
-            CoordinationEdge(source, target, edge_type, cost_tokens)
-        )
+        self.edges.append(CoordinationEdge(source, target, edge_type, cost_tokens))
 
     def add_tool_call(
         self,
@@ -298,6 +312,29 @@ class TrajectoryLog:
     def tools_used(self) -> set[str]:
         return {e.tool for e in self.entries}
 
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "TrajectoryLog":
+        """Rebuild a log from its ``to_dict()`` shape.
+
+        Shared by ``load_trajectory`` and ``iter_trajectories`` so the
+        .json and .jsonl storage formats both round-trip through the same
+        reader. Absent optional fields (``completed``, ``task_key``, edges)
+        stay absent — a pre-#1363 cron-stage trajectory must read back
+        exactly as it was written."""
+        log = cls(
+            session_id=str(d.get("session_id", "")),
+            date=str(d.get("date", "")),
+            completed=d.get("completed"),
+            task_key=str(d.get("task_key", "")),
+        )
+        for ed in d.get("entries", []):
+            if isinstance(ed, dict):
+                log.entries.append(TrajectoryEntry.from_dict(ed))
+        for ed in d.get("edges", []):
+            if isinstance(ed, dict):
+                log.edges.append(CoordinationEdge.from_dict(ed))
+        return log
+
     def failure_count(self) -> int:
         return sum(1 for e in self.entries if e.result_status in ("failure", "error"))
 
@@ -321,31 +358,44 @@ def load_trajectory(path: Path) -> Optional[TrajectoryLog]:
         return None
     if not isinstance(data, dict):
         return None
-    log = TrajectoryLog(
-        session_id=data.get("session_id", ""),
-        date=data.get("date", ""),
-        # Absent on pre-#1363 cron-stage trajectories; None/"" there means
-        # "not recorded", which consumers must treat differently from a
-        # recorded failure.
-        completed=data.get("completed"),
-        task_key=data.get("task_key", ""),
-    )
-    for ed in data.get("entries", []):
-        if isinstance(ed, dict):
-            log.entries.append(
-                TrajectoryEntry(
-                    tool=ed.get("tool", "unknown"),
-                    args_summary=ed.get("args_summary", {}),
-                    result_status=ed.get("result_status", "unknown"),
-                    result_summary=ed.get("result_summary", ""),
-                    timestamp=ed.get("timestamp", ""),
-                    duration_ms=ed.get("duration_ms"),
-                )
-            )
-    for ed in data.get("edges", []):
-        if isinstance(ed, dict):
-            log.edges.append(CoordinationEdge.from_dict(ed))
-    return log
+    return TrajectoryLog.from_dict(data)
+
+
+def iter_trajectories(path: Path) -> List[TrajectoryLog]:
+    """Load every trajectory in a file, in order — both storage formats.
+
+    ``save()`` writes one pretty-printed JSON object (``.json``);
+    ``append()`` writes one compact JSON object per line (``.jsonl``) so a
+    multi-turn session keeps every turn. Whole-file parse is tried first
+    (covers the .json format), then line-by-line (covers .jsonl). Malformed
+    lines are skipped — a torn write must never take a replay down (#85)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    stripped = raw.strip()
+    if not stripped:
+        return []
+    # Single pretty-printed object (TrajectoryLog.save / load_trajectory).
+    try:
+        data = json.loads(stripped)
+        if isinstance(data, dict):
+            return [TrajectoryLog.from_dict(data)]
+    except ValueError:
+        pass
+    # JSONL append format: one compact object per line.
+    logs: List[TrajectoryLog] = []
+    for line in raw.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        try:
+            data = json.loads(s)
+        except ValueError:
+            continue
+        if isinstance(data, dict):
+            logs.append(TrajectoryLog.from_dict(data))
+    return logs
 
 
 def main(argv: List[str]) -> int:

--- a/tests/scripts/test_evolution_trace_replay.py
+++ b/tests/scripts/test_evolution_trace_replay.py
@@ -1,0 +1,216 @@
+"""Tests for session-trace replay / resume / branch (issue #85).
+
+Exercises the pure functions in agent/tool_call_capture.py and the CLI in
+scripts/evolution_trace_replay.py over both trajectory storage formats
+(single-object .json from save(), per-turn .jsonl from append())."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+for p in (str(ROOT / "scripts"), str(ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from agent.tool_call_capture import (  # noqa: E402
+    branch_trajectory,
+    replay_trajectory,
+    resume_index,
+)
+from evolution_trajectory_logger import TrajectoryLog, iter_trajectories  # noqa: E402
+
+
+def _make_log(*statuses: str, session_id: str = "s1") -> TrajectoryLog:
+    log = TrajectoryLog(session_id=session_id, completed=True)
+    for i, status in enumerate(statuses):
+        log.add_tool_call(
+            f"tool_{i}",
+            {"arg": i},
+            result=f"result {i}",
+            status=status,
+            duration_ms=i * 10,
+        )
+    return log
+
+
+def _write_json(path: Path, log: TrajectoryLog) -> Path:
+    """Write a trajectory in the single-object .json (save) format."""
+    path.write_text(log.to_json(), encoding="utf-8")
+    return path
+
+
+def _save_path(tmp_path: Path, log: TrajectoryLog) -> Path:
+    """Save a log and return its exact path (save() takes a directory and
+    derives the filename from date + session_id; tmp_path also receives
+    unrelated conftest artifacts, so never use iterdir())."""
+    log.save(tmp_path)
+    return tmp_path / f"{log.date}_{log.session_id}.json"
+
+
+class TestIterTrajectories:
+    def test_single_json_format(self, tmp_path):
+        p = _save_path(tmp_path, _make_log("success", "success"))
+        logs = iter_trajectories(p)
+        assert len(logs) == 1
+        assert [e.tool for e in logs[0].entries] == ["tool_0", "tool_1"]
+
+    def test_jsonl_append_format_multi_turn(self, tmp_path):
+        p = tmp_path / "2026-08-23_s1.jsonl"
+        _make_log("success", session_id="s1").append(tmp_path)
+        _make_log("failure", session_id="s1").append(tmp_path)
+        logs = iter_trajectories(p)
+        assert len(logs) == 2
+        assert logs[0].entries[0].result_status == "success"
+        assert logs[1].entries[0].result_status == "failure"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        p.write_text('{"session_id": "a", "entries": []}\nnot json\n', encoding="utf-8")
+        logs = iter_trajectories(p)
+        assert len(logs) == 1
+
+    def test_missing_file_empty(self, tmp_path):
+        assert iter_trajectories(tmp_path / "nope.json") == []
+
+    def test_roundtrip_preserves_fields(self, tmp_path):
+        p = _save_path(tmp_path, _make_log("success", "pending", session_id="s9"))
+        log = iter_trajectories(p)[0]
+        assert log.session_id == "s9"
+        assert log.entries[1].result_status == "pending"
+
+
+class TestReplayTrajectory:
+    def test_all_success(self):
+        r = replay_trajectory(_make_log("success", "success"))
+        assert r["outcome"] == "success"
+        assert r["step_count"] == 2
+        assert r["first_failure_index"] is None
+        assert r["stopped_at"] == 2
+
+    def test_failure_detected(self):
+        r = replay_trajectory(_make_log("success", "failure", "success"))
+        assert r["outcome"] == "failed"
+        assert r["first_failure_index"] == 1
+        assert r["tool_sequence"] == ["tool_0", "tool_1", "tool_2"]
+
+    def test_pending_is_incomplete(self):
+        r = replay_trajectory(_make_log("success", "pending"))
+        assert r["outcome"] == "incomplete"
+
+    def test_window_clamps(self):
+        r = replay_trajectory(_make_log("success", "failure"), start_at=1, stop_at=1)
+        assert r["outcome"] == "empty"
+        r2 = replay_trajectory(_make_log("success", "failure"), start_at=0, stop_at=1)
+        assert r2["outcome"] == "success"
+        assert r2["stopped_at"] == 1
+
+    def test_error_status_counts_as_failure(self):
+        r = replay_trajectory(_make_log("error"))
+        assert r["outcome"] == "failed"
+
+    def test_unknown_is_incomplete(self):
+        r = replay_trajectory(_make_log("success", "unknown"))
+        assert r["outcome"] == "incomplete"
+
+    def test_duration_recorded_per_step(self):
+        r = replay_trajectory(_make_log("success"))
+        assert r["steps"][0]["duration_ms"] == 0
+
+
+class TestResumeIndex:
+    def test_clean_run_returns_none(self):
+        assert resume_index(_make_log("success", "success")) is None
+
+    def test_failure_point(self):
+        assert resume_index(_make_log("success", "failure")) == 1
+
+    def test_pending_point(self):
+        assert resume_index(_make_log("pending", "success")) == 0
+
+    def test_empty_log_returns_none(self):
+        assert resume_index(TrajectoryLog(session_id="s")) is None
+
+
+class TestBranchTrajectory:
+    def test_prefix_inclusive(self):
+        src = _make_log("success", "failure", "success")
+        br = branch_trajectory(src, 1)
+        assert len(br.entries) == 2
+        assert [e.tool for e in br.entries] == ["tool_0", "tool_1"]
+        assert br.entries[1].result_status == "failure"
+
+    def test_source_not_mutated(self):
+        src = _make_log("success", "failure")
+        branch_trajectory(src, 0)
+        assert len(src.entries) == 2
+        assert src.entries[1].result_status == "failure"
+
+    def test_clamped_upper_bound(self):
+        src = _make_log("success", "success")
+        br = branch_trajectory(src, 99)
+        assert len(br.entries) == 2
+
+    def test_zero_index_branches_first_step_only(self):
+        src = _make_log("success", "failure")
+        br = branch_trajectory(src, 0)
+        assert len(br.entries) == 1
+
+    def test_metadata_carried(self):
+        src = _make_log("success", session_id="sx")
+        src.completed = False
+        br = branch_trajectory(src, 0)
+        assert br.session_id == "sx"
+        assert br.completed is False
+
+    def test_branch_roundtrips_through_loader(self, tmp_path):
+        src = _make_log("success", "failure", session_id="sb")
+        br = branch_trajectory(src, 1)
+        p = _save_path(tmp_path, br)
+        loaded = iter_trajectories(p)[0]
+        assert loaded.entries[1].result_status == "failure"
+
+
+class TestTraceReplayCli:
+    def _run(self, argv, capsys):
+        from evolution_trace_replay import main
+
+        code = main(["evolution_trace_replay.py", *argv])
+        return code, capsys.readouterr()
+
+    def test_replay_cli_json(self, tmp_path, capsys):
+        p = _save_path(tmp_path, _make_log("success", "failure"))
+        code, cap = self._run(["replay", str(p), "--json"], capsys)
+        assert code == 0
+        out = json.loads(cap.out)
+        assert out["outcome"] == "failed"
+        assert out["first_failure_index"] == 1
+
+    def test_resume_cli(self, tmp_path, capsys):
+        p = _save_path(tmp_path, _make_log("success", "pending"))
+        code, cap = self._run(["resume", str(p)], capsys)
+        assert code == 0
+        assert "resume at index 1" in cap.out
+
+    def test_resume_clean_run_exit_one(self, tmp_path, capsys):
+        p = _save_path(tmp_path, _make_log("success"))
+        code, cap = self._run(["resume", str(p)], capsys)
+        assert code == 1
+        assert "clean run" in cap.out
+
+    def test_branch_cli_writes_file(self, tmp_path, capsys):
+        p = _save_path(tmp_path, _make_log("success", "failure", "success"))
+        out_dir = tmp_path / "branches"
+        code, cap = self._run(
+            ["branch", str(p), "--to", "1", "--out", str(out_dir)], capsys
+        )
+        assert code == 0
+        written = Path(cap.out.strip())
+        assert written.exists()
+        loaded = iter_trajectories(written)[0]
+        assert len(loaded.entries) == 2
+
+    def test_bad_input_exit_two(self, tmp_path, capsys):
+        code, cap = self._run(["replay", str(tmp_path / "missing.json")], capsys)
+        assert code == 2
+        assert "could not load" in cap.err


### PR DESCRIPTION
Automated evolution PR for issue #85.

Recorded trajectories become actionable: deterministic replay (outcome: success/failed/incomplete), resume-point detection, and branching from any recorded step — the Moirai trace-optimization primitive. Pure functions in agent/tool_call_capture.py, from_dict/iter_trajectories in the trajectory logger, CLI call site in scripts/evolution_trace_replay.py. Tests included.