### PR TITLE
fix(introspection): apply --days cutoff to SessionDB state.db sessions (Closes #3145)

### DIFF
--- a/scripts/introspection_extract.py
+++ b/scripts/introspection_extract.py
@@ -370,8 +370,8 @@ _MESSAGE_ROW_ID_KEY = "_db_id"
 
 def _message_row_to_dict(row: sqlite3.Row) -> Optional[Dict[str, Any]]:
     """Convert a SessionDB messages row into the role-tagged dict scan_messages
-    consumes (#399).  Drops DB-only columns (session_id, timestamp) but keeps
-    the original id for ordering."""
+    consumes (#399). Drops DB-only columns (session_id) but keeps
+    the original id for ordering and timestamp for cutoff filtering (#3145)."""
     obj: Dict[str, Any] = {_MESSAGE_ROW_ID_KEY: row["id"]}
     if "role" in row.keys():
         obj["role"] = row["role"]
@@ -388,6 +388,11 @@ def _message_row_to_dict(row: sqlite3.Row) -> Optional[Dict[str, Any]]:
             pass
     if "tool_name" in row.keys():
         obj["tool_name"] = row["tool_name"]
+    if "timestamp" in row.keys() and row["timestamp"] is not None:
+        try:
+            obj["timestamp"] = float(row["timestamp"])
+        except (ValueError, TypeError):
+            pass
     return obj if obj.get("role") else None
 
 
@@ -405,12 +410,20 @@ def _iter_state_db(db_path: Path) -> Iterable[tuple[str, List[Dict[str, Any]]]]:
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
         # Probe schema; the expected columns are id, session_id, role, content,
-        # tool_call_id, tool_calls, tool_name, timestamp.  Any subset is fine.
+        # tool_call_id, tool_calls, tool_name, timestamp. Any subset is fine.
         try:
             cur.execute(
                 "SELECT session_id, id, role, content, tool_call_id, tool_calls, "
-                "tool_name FROM messages ORDER BY session_id, id"
+                "tool_name, timestamp FROM messages ORDER BY session_id, id"
             )
+        except sqlite3.OperationalError:
+            try:
+                cur.execute(
+                    "SELECT session_id, id, role, content, tool_call_id, tool_calls, "
+                    "tool_name FROM messages ORDER BY session_id, id"
+                )
+            except sqlite3.Error:
+                return
         except sqlite3.Error:
             return
         current_session: Optional[str] = None
@@ -437,11 +450,12 @@ def _state_db_session_signals(msgs: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     The caller gives us messages already grouped by session_id and ordered by
     id, but we also carry the original id on each dict so we can re-sort here
-    as a defense-in-depth step.  The id key is stripped before scanning so it
-    never leaks into the digest."""
+    as a defense-in-depth step. The id and timestamp keys are stripped before
+    scanning so they never leak into the digest."""
     ordered = sorted(msgs, key=lambda m: m.get(_MESSAGE_ROW_ID_KEY, 0))
     for m in ordered:
         m.pop(_MESSAGE_ROW_ID_KEY, None)
+        m.pop("timestamp", None)
     return scan_messages(ordered)
 
 
@@ -667,6 +681,16 @@ def build_digest(
             if db_path.is_file():
                 for _sid, msgs in _iter_state_db(db_path):
                     if not msgs:
+                        continue
+                    # Issue #3145: Filter by --days cutoff so 7-day digest
+                    # doesn't aggregate all historical SessionDB sessions.
+                    # A session is fresh if any message timestamp >= cutoff,
+                    # or if no messages carry timestamps, fall back to file mtime.
+                    has_ts = any("timestamp" in m for m in msgs)
+                    if has_ts:
+                        if not any(m.get("timestamp", 0) >= cutoff for m in msgs):
+                            continue
+                    elif not _fresh(db_path, cutoff):
                         continue
                     scanned += 1
                     _aggregate(_state_db_session_signals(msgs))

--- a/tests/scripts/test_introspection_extract.py
+++ b/tests/scripts/test_introspection_extract.py
@@ -686,7 +686,7 @@ def _state_db(tmp_path, rows):
                 r.get("tool_call_id"),
                 json.dumps(r["tool_calls"]) if r.get("tool_calls") else None,
                 r.get("tool_name"),
-                time.time(),
+                r.get("timestamp", time.time()),
             )
             if "id" in r:
                 conn.execute(
@@ -721,8 +721,9 @@ def _db_tool(cid, content):
 
 
 class TestStateDB:
-    """#399 — scripts/introspection_extract.py must scan the SQLite SessionDB
-    (state.db messages table) in addition to JSONL and request_dump files."""
+    """#399 / #3145 — scripts/introspection_extract.py must scan the SQLite SessionDB
+    (state.db messages table) in addition to JSONL and request_dump files, respecting
+    the --days cutoff."""
 
     def test_state_db_counts_sessions_and_signals(self, tmp_path):
         _state_db(
@@ -743,6 +744,43 @@ class TestStateDB:
         d = build_digest(tmp_path, window_days=7)
         assert d["sessions_scanned"] == 2
         assert d["signals"]["tool_failures"] == {"terminal": 1, "read_file": 1}
+
+    def test_state_db_respects_cutoff_window(self, tmp_path):
+        """Issue #3145: SessionDB messages older than cutoff must not be aggregated."""
+        now = time.time()
+        old_ts = now - 30 * 86400  # 30 days ago
+        fresh_ts = now - 2 * 86400  # 2 days ago
+
+        _state_db(
+            tmp_path,
+            [
+                # Old session (30 days ago) — should be excluded from 7-day digest
+                {
+                    "session_id": "old-sess",
+                    "timestamp": old_ts,
+                    **_db_asst("terminal", "c1"),
+                },
+                {
+                    "session_id": "old-sess",
+                    "timestamp": old_ts,
+                    **_db_tool("c1", _term("bash: old: not found", exit_code=127)),
+                },
+                # Fresh session (2 days ago) — should be included
+                {
+                    "session_id": "fresh-sess",
+                    "timestamp": fresh_ts,
+                    **_db_asst("read_file", "c2"),
+                },
+                {
+                    "session_id": "fresh-sess",
+                    "timestamp": fresh_ts,
+                    **_db_tool("c2", _fail("no such file")),
+                },
+            ],
+        )
+        d = build_digest(tmp_path, window_days=7, now=now)
+        assert d["sessions_scanned"] == 1
+        assert d["signals"]["tool_failures"] == {"read_file": 1}
 
     def test_state_db_at_hermes_home_root(self, tmp_path, monkeypatch):
         """#623 — state.db can live at HERMES_HOME root, not under sessions_dir."""


### PR DESCRIPTION
Fixes #3145

## Problem
The evolution-introspection extractor (`scripts/introspection_extract.py`) applied the `--days` cutoff to `*.jsonl` and `request_dump_*.json` files via `_fresh(path, cutoff)`, but the SQLite SessionDB path (`state.db`) iterated every session without filtering by timestamp. As a result, `--days=7` aggregated all historical sessions.

## Fix
1. Include `timestamp` column in `_iter_state_db` and `_message_row_to_dict`.
2. In `build_digest`, filter SessionDB sessions to require at least one message with `timestamp >= cutoff` (or fresh DB mtime if timestamps are missing).
3. Strip `timestamp` in `_state_db_session_signals` so it doesn't leak into message dicts.
4. Added regression test `test_state_db_respects_cutoff_window` in `tests/scripts/test_introspection_extract.py`.

## Validation
- `ruff check`: PASS
- `pytest tests/scripts/test_introspection_extract.py`: 65/65 PASS