### PR TITLE
fix(agent): fast failover and negative caching on empty completions (Closes #3144)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2499,6 +2499,7 @@ def try_activate_fallback(
         FailoverReason.rate_limit,
         FailoverReason.billing,
         FailoverReason.upstream_rate_limit,
+        FailoverReason.server_error,
     }:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
@@ -2533,6 +2534,8 @@ def try_activate_fallback(
             # stays blocked and subsequent calls go to the fallback chain.
             if reason == FailoverReason.billing:
                 _cooldown = 3600.0
+            elif reason == FailoverReason.server_error:
+                _cooldown = 300.0
             if _retry_after_raw:
                 _parsed = extract_retry_after_seconds(_retry_after_raw)
                 if _parsed is not None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8299,7 +8299,7 @@ def _run_conversation_impl(
                             "⚠️ Model returning empty responses — "
                             "switching to fallback provider..."
                         )
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(reason=FailoverReason.server_error):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             agent._empty_content_retries = 0

--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -252,14 +252,23 @@ def deterministic_empty(agent: Any) -> bool:
 
 
 def empty_retry_budget(agent: Any, response: Any) -> int:
-    """Empty-retry budget for the current streak (3, or 1 when a single
-    attempt is estimated to cost more than the configured threshold)."""
+    """Empty-retry budget for the current streak.
+
+    Returns 1 (REDUCED_EMPTY_RETRY_BUDGET) when:
+    - Running in a cron / subagent autonomous execution context (#3144), or
+    - A single attempt is estimated to cost more than the configured threshold (NS-503).
+    Otherwise returns 3 (DEFAULT_EMPTY_RETRY_BUDGET).
+    """
     if not guard_enabled(agent):
         return DEFAULT_EMPTY_RETRY_BUDGET
+    if (
+        getattr(agent, "platform", None) == "cron"
+        or getattr(agent, "_is_cron_subagent", False)
+        or getattr(agent, "_is_cron_context", False)
+    ):
+        return REDUCED_EMPTY_RETRY_BUDGET
     cost = _estimate_attempt_cost(agent, response)
-    if cost is None:
-        return DEFAULT_EMPTY_RETRY_BUDGET
-    if cost >= _cost_threshold_usd(agent):
+    if cost is not None and cost >= _cost_threshold_usd(agent):
         return REDUCED_EMPTY_RETRY_BUDGET
     return DEFAULT_EMPTY_RETRY_BUDGET
 

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -232,6 +232,22 @@ class TestEmptyRetryBudget:
             == guard.DEFAULT_EMPTY_RETRY_BUDGET
         )
 
+    def test_cron_platform_uses_reduced_retry_budget(self):
+        """Issue #3144: cron jobs should only retry once before failover."""
+        agent = _agent(platform="cron")
+        assert (
+            guard.empty_retry_budget(agent, _response())
+            == guard.REDUCED_EMPTY_RETRY_BUDGET
+        )
+
+    def test_cron_subagent_uses_reduced_retry_budget(self):
+        """Issue #3144: cron subagents should only retry once before failover."""
+        agent = _agent(_is_cron_subagent=True)
+        assert (
+            guard.empty_retry_budget(agent, _response())
+            == guard.REDUCED_EMPTY_RETRY_BUDGET
+        )
+
 
 class TestStreakCost:
     def test_streak_cost_accumulates(self, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5693,7 +5693,7 @@ class TestRunConversation:
 
         fallback_called = {"called": False}
 
-        def _mock_fallback():
+        def _mock_fallback(*args, **kwargs):
             fallback_called["called"] = True
             # Simulate what _try_activate_fallback does: just advance the
             # index and set the flag (the client is already mocked).
@@ -5738,7 +5738,7 @@ class TestRunConversation:
             empty_resp,  # fallback exhausted
         ]
 
-        def _mock_fallback():
+        def _mock_fallback(*args, **kwargs):
             if agent._fallback_index >= len(agent._fallback_chain):
                 return False
             agent._fallback_index += 1


### PR DESCRIPTION
Fixes #3144

## Problem
When upstream inference providers returned empty streams (HTTP 200 with no content or reasoning tokens), cron jobs and agent loops executed 3 full retries with exponential backoffs per turn before attempting fallback. In addition, fallback activation did not bench the degraded provider for subsequent turns in the same window, causing repeat loops across scheduled jobs.

## Fix
1. In `empty_response_guard.py`, reduce empty retry budget to 1 in cron and subagent contexts (`_is_cron_subagent`, `platform == 'cron'`).
2. In `conversation_loop.py`, pass `reason=FailoverReason.server_error` when activating fallback after empty responses.
3. In `chat_completion_helpers.py:try_activate_fallback`, record a 300s cooldown for `server_error` failovers so the degraded primary provider stays benched for subsequent turns in the same window.
4. Added unit tests in `tests/agent/test_empty_response_guard.py`.

## Validation
- `ruff check`: PASS
- `pytest tests/agent/test_empty_response_guard.py`: 35/35 PASS
- `pytest tests/run_agent/test_empty_response_recovery_persistence.py tests/test_empty_model_fallback.py tests/test_empty_session_hygiene.py tests/agent/test_empty_tool_name_loop_dampening.py`: 28/28 PASS