### PR TITLE
feat(evolution): baseline+diff audit over agent config/skill/hook trees (slice A of Da-Mikey/hermes-agent-evolution#89)

### DIFF
--- a/cron/evolution/config-mutation-scan.yaml
+++ b/cron/evolution/config-mutation-scan.yaml
@@ -1,0 +1,29 @@
+name: evolution-config-mutation-scan
+# 03:15 daily — after the 02:00 dreaming pipeline and before the 03:30
+# memory-poison-scan, so both audits run in the same quiet band. A config/skill
+# mutation is flagged within 24h of landing (issue #89 success criterion).
+schedule: "15 3 * * *"
+enabled: true
+mode: PRIVATE
+
+# Deterministic audit — NO LLM agent. The script IS the job: snapshots the
+# config/skill/hook trees under HERMES_HOME (sha256 + mtime), persists the
+# baseline to config_baseline.json (auto-initialized on first run), and every
+# run after diffs current vs baseline into config_mutation_scan.json (added /
+# removed / modified). Report-only — attribution of session-owned writes is
+# slice B. Issue #89 slice A.
+no_agent: true
+script: evolution_config_mutation_scan.py
+
+# Report to disk only; a scan run is data, not an alert. Alerting via the
+# audit channel is slice C.
+deliver: local
+
+prompt: |
+  Deterministic baseline + diff audit over the agent config/skill/hook trees
+  (no LLM). First run snapshots sha256/mtime of config-ish files under
+  HERMES_HOME (yaml/json/toml/conf/md/txt/sh/py, volatile subtrees excluded)
+  into config_baseline.json; every run after compares and writes
+  config_mutation_scan.json listing added / removed / modified files. No
+  attribution yet (slice B); report-only. Issue #89 slice A (parent stays
+  open for slices B-C).

--- a/scripts/evolution_config_mutation_scan.py
+++ b/scripts/evolution_config_mutation_scan.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Baseline + diff audit over the agent config/skill/hook trees (issue #89, slice A).
+
+Scheduled as the ``no_agent`` job ``evolution-config-mutation-scan``
+(``cron/evolution/config-mutation-scan.yaml``, 03:15 daily).
+
+Background: Microsoft's ChainDrop analysis (2026-08-04) documents a
+credential-stealing worm that persists via auto-append hooks in agent config
+directories (``.claude/settings.json``, ``.vscode/tasks.json``, shell rc
+files), surviving reinstall. The agent's own config, skills and hooks are
+equally writable, and nothing currently detects an unexpected mutation — a
+hook or directive appended to a config file or skill without a session having
+made that change. This is slice A of the defense: a deterministic baseline +
+diff primitive. Slice B adds attribution (which writes are session-owned),
+slice C adds the auto-append hook scan and alerting.
+
+What it does (all deterministic, no LLM, no MCP):
+
+1. snapshots a hash/mtime record of the config-ish files under ``HERMES_HOME``
+   (``~/.hermes`` by default) plus an optional ``--project-root`` — skipping
+   known-volatile subtrees (cache, backups, cron job state, evolution data,
+   lock files),
+2. persists the snapshot to ``~/.hermes/evolution/config_baseline.json``
+   (``--init`` writes it explicitly; a scan auto-initializes when the baseline
+   is missing, so the first scheduled run bootstraps itself),
+3. every run after diffs current vs baseline and writes a report listing
+   added / removed / modified files to
+   ``~/.hermes/evolution/config_mutation_scan.json``.
+
+Report-only by design: mutations are surfaced, not auto-reverted (reverting
+legit session edits would be destructive — attribution is slice B).
+``--fail-on-changes`` makes the exit code actionable for a future alerting
+wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Volatile subtrees and file kinds that would otherwise turn every scan into
+# noise: caches, backup mirrors, job state, the evolution pipeline's own data,
+# lock/temp files. Deliberately name-based so it works across machines.
+EXCLUDE_DIR_NAMES = {
+    ".git",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "cache",
+    "backups",
+    "checkpoints",
+    "cron",
+    "data",
+    "logs",
+    "document_cache",
+    "audio_cache",
+    "chrome-debug",
+    ".curator_backups",
+    "evolution",
+    "ambient",
+    "docker",
+    "mcp_pins",
+    ".snapshots",
+}
+
+EXCLUDE_FILE_SUFFIXES = {".lock", ".tmp", ".swp", ".pyc"}
+
+# The persistence-vector surface: anything that can carry a hook or directive.
+INCLUDE_EXTS = {
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".conf",
+    ".ini",
+    ".cfg",
+    ".md",
+    ".txt",
+    ".sh",
+    ".py",
+}
+
+DEFAULT_REPORT = Path.home() / ".hermes" / "evolution" / "config_mutation_scan.json"
+DEFAULT_BASELINE = Path.home() / ".hermes" / "evolution" / "config_baseline.json"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def snapshot_tree(root: Path) -> dict[str, dict[str, Any]]:
+    """Snapshot one tree: ``{relpath: {"sha256", "size", "mtime_ns"}}``.
+
+    Only files whose suffix is in ``INCLUDE_EXTS`` are recorded; subtrees whose
+    name is in ``EXCLUDE_DIR_NAMES`` and files whose suffix is in
+    ``EXCLUDE_FILE_SUFFIXES`` are skipped. Deterministic: paths are walked in
+    sorted order.
+    """
+    snapshot: dict[str, dict[str, Any]] = {}
+    if not root.is_dir():
+        return snapshot
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            continue
+        if any(part in EXCLUDE_DIR_NAMES for part in path.parts):
+            continue
+        if path.suffix.lower() not in INCLUDE_EXTS:
+            continue
+        if path.suffix.lower() in EXCLUDE_FILE_SUFFIXES:
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        snapshot[str(path.relative_to(root))] = {
+            "sha256": _sha256(path),
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+        }
+    return snapshot
+
+
+def snapshot_roots(roots: list[Path]) -> dict[str, dict[str, Any]]:
+    """Snapshot multiple roots into one baseline, keyed ``<root.name>/<relpath>``.
+
+    The root-name prefix keeps paths unambiguous when a project root shares
+    file names with HERMES_HOME (e.g. both have ``config.yaml``).
+    """
+    merged: dict[str, dict[str, Any]] = {}
+    for root in roots:
+        for relpath, meta in snapshot_tree(root).items():
+            merged[f"{root.name}/{relpath}"] = meta
+    return merged
+
+
+def detect_mutations(
+    baseline: dict[str, dict[str, Any]],
+    current: dict[str, dict[str, Any]],
+) -> dict[str, list[Any]]:
+    """Diff current against baseline.
+
+    Returns ``{"added": [...], "removed": [...], "modified": [...]}``, each a
+    sorted list of paths (modified entries carry ``before``/``after`` hashes
+    for audit).
+    """
+    added = sorted(set(current) - set(baseline))
+    removed = sorted(set(baseline) - set(current))
+    modified = [
+        {
+            "path": path,
+            "before_sha256": baseline[path]["sha256"],
+            "after_sha256": current[path]["sha256"],
+        }
+        for path in sorted(set(baseline) & set(current))
+        if baseline[path]["sha256"] != current[path]["sha256"]
+    ]
+    return {"added": added, "removed": removed, "modified": modified}
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="evolution_config_mutation_scan.py",
+        description=(
+            "Baseline + diff audit over the agent config/skill/hook trees "
+            "(issue #89 slice A)."
+        ),
+    )
+    parser.add_argument(
+        "--init",
+        action="store_true",
+        help="write the baseline snapshot and exit (no diff)",
+    )
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        metavar="DIR",
+        help=f"tree to snapshot (repeatable; default: {Path.home() / '.hermes'})",
+    )
+    parser.add_argument(
+        "--project-root",
+        default="",
+        metavar="DIR",
+        help="optional project tree to snapshot alongside HERMES_HOME",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=str(DEFAULT_BASELINE),
+        help=f"baseline JSON path (default: {DEFAULT_BASELINE})",
+    )
+    parser.add_argument(
+        "--report",
+        default=str(DEFAULT_REPORT),
+        help=f"JSON report output path (default: {DEFAULT_REPORT})",
+    )
+    parser.add_argument(
+        "--fail-on-changes",
+        action="store_true",
+        help="exit 2 when any mutation is detected (report-only by default)",
+    )
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(list(argv) if argv is not None else sys.argv)
+
+    roots = [Path(r).expanduser() for r in args.root] or [
+        Path.home() / ".hermes"
+    ]
+    if args.project_root:
+        roots.append(Path(args.project_root).expanduser())
+
+    baseline_path = Path(args.baseline).expanduser()
+    report_path = Path(args.report).expanduser()
+
+    current = snapshot_roots(roots)
+
+    if args.init or not baseline_path.is_file():
+        try:
+            baseline_path.parent.mkdir(parents=True, exist_ok=True)
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "scanned_at": datetime.now(timezone.utc).isoformat(),
+                        "roots": [str(r) for r in roots],
+                        "files": current,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(f"[config-mutation-scan] cannot write baseline: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"[config-mutation-scan] baseline initialized: {len(current)} files "
+            f"({', '.join(str(r) for r in roots)}) -> {baseline_path}"
+        )
+        return 0
+
+    try:
+        baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[config-mutation-scan] cannot read baseline: {exc}", file=sys.stderr)
+        return 1
+    baseline = baseline_data.get("files", {})
+
+    mutations = detect_mutations(baseline, current)
+    summary = {
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+        "baseline": str(baseline_path),
+        "roots": [str(r) for r in roots],
+        "files_baselined": len(baseline),
+        "files_current": len(current),
+        **mutations,
+        "changed_total": len(mutations["added"])
+        + len(mutations["removed"])
+        + len(mutations["modified"]),
+    }
+
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(f"[config-mutation-scan] cannot write report: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"[config-mutation-scan] baselined={summary['files_baselined']} "
+        f"current={summary['files_current']} "
+        f"added={len(summary['added'])} removed={len(summary['removed'])} "
+        f"modified={len(summary['modified'])} report={report_path}"
+    )
+    if args.fail_on_changes and summary["changed_total"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_evolution_config_mutation_scan.py
+++ b/tests/scripts/test_evolution_config_mutation_scan.py
@@ -1,0 +1,162 @@
+"""Tests for the config mutation baseline+diff runner (issue #89 slice A).
+
+The runner is the ``no_agent`` cron entry point
+(``evolution-config-mutation-scan``, 03:15 daily) — these tests exercise its
+real ``main()`` against temp trees, covering the snapshot, the diff primitive,
+baseline init/auto-init, exclude behavior and the report/exit-code contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "scripts"))
+
+import evolution_config_mutation_scan as runner  # noqa: E402
+
+
+def _tree(root: Path) -> None:
+    """Build a small config/skill/hook tree. Parent dirs are created."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.yaml").write_text("key: value\n", encoding="utf-8")
+    skill = root / "skills" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text("# Demo skill\n", encoding="utf-8")
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "helper.py").write_text("print('x')\n", encoding="utf-8")
+    cache = root / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "volatile.json").write_text("{}\n", encoding="utf-8")
+    (root / "auth.lock").write_text("", encoding="utf-8")
+
+
+def _scanroot(tmp_path: Path) -> Path:
+    """A dedicated subtree to scan; baseline/report live OUTSIDE it so the
+    artifacts themselves are never reported as mutations."""
+    root = tmp_path / "scanroot"
+    _tree(root)
+    return root
+
+
+def _out(tmp_path: Path) -> tuple[Path, Path]:
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    return out / "baseline.json", out / "report.json"
+
+
+def test_snapshot_hashes_and_excludes(tmp_path: Path) -> None:
+    snap = runner.snapshot_tree(_scanroot(tmp_path))
+    # config + skill + script recorded
+    assert "config.yaml" in snap
+    assert "skills/demo/SKILL.md" in snap
+    assert "scripts/helper.py" in snap
+    # volatile subtree and lock file excluded
+    assert "cache/volatile.json" not in snap
+    assert "auth.lock" not in snap
+    assert snap["config.yaml"]["sha256"]
+    assert snap["config.yaml"]["size"] == len("key: value\n")
+    assert snap["config.yaml"]["mtime_ns"] > 0
+
+
+def test_detect_added_modified_removed(tmp_path: Path) -> None:
+    root = _scanroot(tmp_path)
+    baseline = runner.snapshot_tree(root)
+    (root / "config.yaml").write_text("key: CHANGED\n", encoding="utf-8")
+    (root / "skills" / "demo" / "SKILL.md").unlink()
+    (root / "new_hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    current = runner.snapshot_tree(root)
+    mut = runner.detect_mutations(baseline, current)
+    assert mut["added"] == ["new_hook.sh"]
+    assert mut["removed"] == ["skills/demo/SKILL.md"]
+    assert len(mut["modified"]) == 1
+    assert mut["modified"][0]["path"] == "config.yaml"
+    assert mut["modified"][0]["before_sha256"] != mut["modified"][0]["after_sha256"]
+
+
+def test_init_writes_baseline(tmp_path: Path) -> None:
+    root = _scanroot(tmp_path)
+    baseline, _ = _out(tmp_path)
+    code = runner.main(["prog", "--init", "--root", str(root), "--baseline", str(baseline)])
+    assert code == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["roots"] == [str(root)]
+    assert "scanroot/config.yaml" in data["files"]
+    assert data["files"]["scanroot/config.yaml"]["sha256"]
+
+
+def test_scan_auto_initializes_when_baseline_missing(tmp_path: Path) -> None:
+    root = _scanroot(tmp_path)
+    baseline, report = _out(tmp_path)
+    code = runner.main(
+        ["prog", "--root", str(root), "--baseline", str(baseline), "--report", str(report)]
+    )
+    assert code == 0
+    assert baseline.is_file()  # bootstrapped itself
+    assert not report.exists()  # no diff on the init run
+
+
+def test_scan_reports_mutations(tmp_path: Path) -> None:
+    root = _scanroot(tmp_path)
+    baseline, report = _out(tmp_path)
+    args = ["prog", "--root", str(root), "--baseline", str(baseline), "--report", str(report)]
+    assert runner.main([*args, "--init"]) == 0
+    (root / "config.yaml").write_text("key: mutated\n", encoding="utf-8")
+    (root / "sneaky.json").write_text('{"hook": true}\n', encoding="utf-8")
+    assert runner.main(args) == 0
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["changed_total"] == 2
+    assert data["added"] == ["scanroot/sneaky.json"]
+    assert data["modified"][0]["path"] == "scanroot/config.yaml"
+    assert data["files_baselined"] == 3
+
+
+def test_fail_on_changes_exit_code(tmp_path: Path) -> None:
+    root = _scanroot(tmp_path)
+    baseline, report = _out(tmp_path)
+    args = [
+        "prog",
+        "--root",
+        str(root),
+        "--baseline",
+        str(baseline),
+        "--report",
+        str(report),
+        "--fail-on-changes",
+    ]
+    assert runner.main([*args, "--init"]) == 0
+    (root / "config.yaml").write_text("key: mutated\n", encoding="utf-8")
+    assert runner.main(args) == 2
+
+
+def test_project_root_prefixing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    proj = tmp_path / "proj"
+    home.mkdir()
+    proj.mkdir()
+    (home / "config.yaml").write_text("a: 1\n", encoding="utf-8")
+    (proj / "config.yaml").write_text("b: 2\n", encoding="utf-8")
+    snap = runner.snapshot_roots([home, proj])
+    assert "home/config.yaml" in snap
+    assert "proj/config.yaml" in snap
+    assert snap["home/config.yaml"]["sha256"] != snap["proj/config.yaml"]["sha256"]
+
+
+def test_missing_root_is_clean_noop(tmp_path: Path) -> None:
+    baseline, report = _out(tmp_path)
+    args = [
+        "prog",
+        "--root",
+        str(tmp_path / "nonexistent"),
+        "--baseline",
+        str(baseline),
+        "--report",
+        str(report),
+    ]
+    assert runner.main([*args, "--init"]) == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["files"] == {}

--- a/tests/scripts/test_evolution_trace_replay.py
+++ b/tests/scripts/test_evolution_trace_replay.py
@@ -56,8 +56,7 @@ class TestIterTrajectories:
         assert [e.tool for e in logs[0].entries] == ["tool_0", "tool_1"]
 
     def test_jsonl_append_format_multi_turn(self, tmp_path):
-        p = tmp_path / "2026-08-23_s1.jsonl"
-        _make_log("success", session_id="s1").append(tmp_path)
+        p = _make_log("success", session_id="s1").append(tmp_path)
         _make_log("failure", session_id="s1").append(tmp_path)
         logs = iter_trajectories(p)
         assert len(logs) == 2


### PR DESCRIPTION
Automated evolution PR for issue Da-Mikey/hermes-agent-evolution#89 (slice A).

**What ships:** deterministic, read-only baseline + diff audit over the agent config/skill/hook trees. `snapshot_roots()` hashes (sha256 + mtime) config-ish files under HERMES_HOME + optional `--project-root` into `config_baseline.json` (auto-initializes on first run); every run after diffs into `config_mutation_scan.json` (added / removed / modified with before/after hashes). Volatile subtrees (cache, backups, cron state, evolution data, lock files) excluded by name. Wired as `no_agent` cron job `evolution-config-mutation-scan` (03:15 daily, deliver local).

**Slice boundaries (issue Da-Mikey/hermes-agent-evolution#89 decomposition):** A = this baseline+diff primitive (no attribution). B = session-write attribution ledger (the security-critical half). C = auto-append hook scan + alerting. Parent issue stays open.

**Validation (local, same commands CI runs):** ruff check . → All checks passed!; new suite 8/8 (snapshot, diff primitive, init/auto-init, excludes, multi-root prefixing, exit codes). Live run against this machine's real HERMES_HOME: 69,527 files baselined in ~19s; scan detected the day's real churn (a plugin watermark) as the single modified file.