### PR TITLE
feat: checked lowering for memory-bounded agent tool execution (Closes #77)

### DIFF
--- a/scripts/evolution_skill_lint.py
+++ b/scripts/evolution_skill_lint.py
@@ -37,6 +37,20 @@ are the pure core (unit-tested with synthetic diff stats); ``lint_skill_edit_bud
 is the git-diff IO boundary, run via ``--skill-edit-budget`` (not part of the
 default ``lint_repo()`` static check, since it is inherently relative to a base
 ref — see ``main()``).
+
+Part 3 — checked lowering for declared tool inputs (#77, SkillEffect, S2)
+-------------------------------------------------------------------------
+``scripts/evolution_tool_cap_check.py`` (S1) is the pure per-tool input-cap
+checker; THIS is the real call site that wires it into the skill gate, per the
+#77 implementation brief ("gate evolution-generated skills behind S1 at the
+skill gate before they are trusted for reuse"). A skill may DECLARE the tool
+invocations it intends to make in a ``declared_inputs:`` frontmatter block
+(see :func:`extract_declared_inputs`). The deterministic lint then runs each
+declaration through ``check_input_caps`` and rejects skills whose declared
+inputs exceed the per-tool caps — closing the issue's acceptance criterion
+("adversarial oversized-input proposals rejected before execution") at the
+skill gate, without touching the core tool path (that is S3, bounded
+execution, which needs its own design review).
 """
 
 from __future__ import annotations
@@ -47,6 +61,8 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from evolution_tool_cap_check import check_input_caps, load_caps
 
 # A script invocation the stage is told to RUN — `python/python3/bash/sh scripts/X`
 # or `./scripts/X`. Bare inline mentions (no runner, no `./`) are NOT commands.
@@ -183,6 +199,96 @@ def find_violations(
     return out
 
 
+# ── Checked lowering for declared tool inputs (#77 — S2 call site) ──────────
+def extract_declared_inputs(skill_text: str) -> List[Dict[str, Any]]:
+    """Parse the ``declared_inputs:`` frontmatter block of a SKILL.md.
+
+    Declarations are OPT-IN: a skill with no block yields ``[]`` and is not
+    flagged, so the existing corpus has zero false positives. Accepted shapes:
+
+    .. code-block:: yaml
+
+       declared_inputs:
+         - tool: read_file
+           args: {path: "data/big.txt"}
+         - {tool: search_files, args: {pattern: "*.py", limit: 50}}
+         - read_file: {path: "data/big.txt"}      # single-tool map form
+
+    Returns a normalized list of ``{"tool": str, "args": dict}``. Malformed
+    blocks degrade to ``[]`` (never raise) — a broken declaration must not
+    crash the gate, and an absent one is simply no declaration.
+    """
+    try:
+        import yaml
+    except Exception:
+        return []
+    text = skill_text or ""
+    if "---" not in text:
+        return []
+    # Frontmatter = the YAML between the FIRST two ``---`` lines.
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return []
+    try:
+        fm = yaml.safe_load(parts[1]) or {}
+    except Exception:
+        return []
+    raw = fm.get("declared_inputs")
+    out: List[Dict[str, Any]] = []
+    if raw is None:
+        return out
+    if isinstance(raw, dict):
+        # Map form: {tool: {arg: val}} or {tool: {"args": {...}}}.
+        for tool, spec in raw.items():
+            if not isinstance(tool, str):
+                continue
+            if isinstance(spec, dict) and "args" in spec and isinstance(spec["args"], dict):
+                out.append({"tool": tool, "args": dict(spec["args"])})
+            elif isinstance(spec, dict):
+                out.append({"tool": tool, "args": dict(spec)})
+        return out
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            tool = item.get("tool")
+            if not isinstance(tool, str) or not tool:
+                continue
+            args = item.get("args")
+            out.append({"tool": tool, "args": dict(args) if isinstance(args, dict) else {}})
+        return out
+    return out
+
+
+def find_cap_violations(
+    declared_inputs: List[Dict[str, Any]],
+    caps: Optional[Dict[str, Dict[str, int]]] = None,
+) -> List[Dict[str, str]]:
+    """Run declared tool inputs through :func:`check_input_caps`.
+
+    Pure core, mirrors ``find_violations``. Each returned dict gains the
+    ``kind`` prefix ``cap_`` so violations from the two gates are
+    distinguishable in output and tests.
+    """
+    out: List[Dict[str, str]] = []
+    for decl in declared_inputs or []:
+        tool = decl.get("tool") or ""
+        args = decl.get("args")
+        if not tool:
+            continue
+        for v in check_input_caps(tool, args, caps=caps):
+            out.append(
+                {
+                    "kind": f"cap_{v['kind']}",
+                    "tool": v["tool"],
+                    "detail": v["detail"],
+                    "declared": v.get("declared", ""),
+                    "cap": v.get("cap", ""),
+                }
+            )
+    return out
+
+
 # ── IO boundary ────────────────────────────────────────────────────────────────
 def _load_stages(cron_dir: Path) -> List[Dict[str, Any]]:
     import yaml
@@ -223,7 +329,16 @@ def lint_repo(repo_root: Optional[Path] = None) -> List[Dict[str, str]]:
     existing = {
         f"scripts/{p.name}" for p in (root / "scripts").glob("*") if p.is_file()
     }
-    return find_violations(stages, skill_texts, existing)
+    violations = find_violations(stages, skill_texts, existing)
+    # #77 S2: checked lowering — a skill that DECLARES tool inputs must stay
+    # within per-tool caps before it is trusted for reuse. load_caps() never
+    # raises, so this can only add cap_* violations, never crash the gate.
+    caps = load_caps()
+    for name, text in skill_texts.items():
+        for v in find_cap_violations(extract_declared_inputs(text), caps=caps):
+            v["skill"] = name
+            violations.append(v)
+    return violations
 
 
 def _git_show_line_count(repo_root: Path, ref: str, path: str) -> int:

--- a/scripts/evolution_tool_cap_check.py
+++ b/scripts/evolution_tool_cap_check.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Checked lowering for memory-bounded agent tool execution (#77, SkillEffect).
+
+S1 of the #77 decomposition: a PURE, pre-execution cap checker for declared
+tool invocations. Before a tool call is trusted, its DECLARED inputs are
+checked against per-tool resource caps — reject-early on oversized or
+over-arity invocations instead of discovering the problem mid-execution.
+
+Scope is deliberately OFF-CORE: this module does NOT touch the live tool
+invocation path (that is the S3 bounded-execution slice, which needs its own
+design review). It is the deterministic gate the evolution pipeline applies to
+skills it generates/adopts — see ``evolution_skill_lint.py`` (the S2 call
+site), which extracts ``declared_inputs:`` blocks from SKILL.md frontmatter
+and runs them through :func:`check_input_caps` before a skill is trusted for
+reuse. This mirrors SkillEffect's checked lowering: rebuild each proposed
+invocation from the declared (immutable) inputs and reject it if it exceeds
+capacity — without trusting the model's claim about what it will do.
+
+Caps are CONFIG DATA in ``scripts/evolution_tool_caps.json`` (overridable via
+the ``EVOLUTION_TOOL_CAPS`` env var pointing at another JSON file); the
+builtin table below is the code fallback so the gate never silently weakens
+to "no caps".
+
+Pure functions + explicit IO boundary (JSON caps file + CLI) so it is
+import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Code fallback for the caps table — the shipped JSON
+# (``scripts/evolution_tool_caps.json``) is the editable source of truth and
+# overrides this when both exist.
+BUILTIN_CAPS: Dict[str, Dict[str, int]] = {
+    "default": {"max_bytes": 1_048_576, "max_args": 16},
+    "read_file": {"max_bytes": 262_144, "max_args": 4},
+    "write_file": {"max_bytes": 524_288, "max_args": 6},
+    "search_files": {"max_bytes": 131_072, "max_args": 8},
+    "terminal": {"max_bytes": 65_536, "max_args": 8},
+    "patch": {"max_bytes": 1_048_576, "max_args": 6},
+    "web_extract": {"max_bytes": 262_144, "max_args": 5},
+    "web_search": {"max_bytes": 8_192, "max_args": 5},
+    "skill_view": {"max_bytes": 131_072, "max_args": 4},
+    "delegate_task": {"max_bytes": 262_144, "max_args": 12},
+}
+
+DEFAULT_CAPS_PATH = Path(__file__).resolve().parent / "evolution_tool_caps.json"
+ENV_CAPS_OVERRIDE = "EVOLUTION_TOOL_CAPS"  # path to an alternate caps JSON
+
+
+def load_caps(path: Optional[str] = None) -> Dict[str, Dict[str, int]]:
+    """Load the per-tool caps table.
+
+    Resolution order: explicit ``path`` argument > ``EVOLUTION_TOOL_CAPS``
+    env var > the shipped ``scripts/evolution_tool_caps.json`` > builtin
+    table. Never raises: any load/parse failure degrades to ``BUILTIN_CAPS``
+    so a malformed caps file can never disable the gate (it would be better
+    to fail loudly, but a broken gate must not crash the pipeline — the CLI
+    and lint both surface the fallback via their normal output paths).
+    """
+    candidates: List[Optional[str]] = [path]
+    if path is None:
+        env = os.environ.get(ENV_CAPS_OVERRIDE)
+        if env:
+            candidates.append(env)
+        candidates.append(str(DEFAULT_CAPS_PATH))
+    for cand in candidates:
+        if not cand:
+            continue
+        try:
+            data = json.loads(Path(cand).read_text(encoding="utf-8"))
+            if isinstance(data, dict) and data:
+                return {str(k): dict(v) for k, v in data.items()}
+        except (OSError, ValueError, TypeError):
+            continue
+    return dict(BUILTIN_CAPS)
+
+
+def declared_input_size(args: Optional[Dict[str, Any]]) -> int:
+    """Serialized size of the DECLARED input values, in characters.
+
+    Strings/bytes count their length directly; everything else counts its
+    ``str()`` length. This is a heuristic over what the invoker DECLARED it
+    will pass — the point of checked lowering is to bound the claim before
+    execution, not to measure the real payload (that is S3's job).
+    """
+    total = 0
+    for key, value in (args or {}).items():
+        total += len(key)
+        if isinstance(value, (str, bytes)):
+            total += len(value)
+        else:
+            total += len(str(value))
+    return total
+
+
+def check_input_caps(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    caps: Optional[Dict[str, Dict[str, int]]] = None,
+) -> List[Dict[str, str]]:
+    """Reject-early: do the DECLARED inputs exceed the per-tool caps?
+
+    ``caps`` is a ``{tool_name: {"max_bytes": int, "max_args": int}}`` table
+    (see :func:`load_caps`). A tool with no explicit entry is checked against
+    the ``"default"`` entry — unknown tools are not themselves violations
+    (the cap table is a curated allow-list of known tools; the skill-lint
+    layer decides whether an unknown tool is suspicious).
+
+    Returns a list of violation dicts (``[]`` = OK):
+      - ``kind: "too_many_args"``   — arg count exceeds ``max_args``
+      - ``kind: "input_too_large"`` — declared input size exceeds ``max_bytes``
+    Each dict carries ``tool``, ``detail``, ``declared`` and ``cap`` for
+    deterministic reporting.
+    """
+    cap_table = caps if caps is not None else load_caps()
+    entry = cap_table.get(tool_name) or cap_table.get("default") or {}
+    argv = dict(args or {})
+    out: List[Dict[str, str]] = []
+
+    try:
+        max_args = int(entry.get("max_args") or 0)
+    except (TypeError, ValueError):
+        max_args = 0
+    try:
+        max_bytes = int(entry.get("max_bytes") or 0)
+    except (TypeError, ValueError):
+        max_bytes = 0
+
+    if max_args and len(argv) > max_args:
+        out.append({
+            "tool": tool_name,
+            "kind": "too_many_args",
+            "detail": f"{len(argv)} declared args exceed the cap of {max_args}",
+            "declared": str(len(argv)),
+            "cap": str(max_args),
+        })
+    if max_bytes:
+        size = declared_input_size(argv)
+        if size > max_bytes:
+            out.append({
+                "tool": tool_name,
+                "kind": "input_too_large",
+                "detail": (
+                    f"declared input size {size} chars exceeds the cap of "
+                    f"{max_bytes} for {tool_name}"
+                ),
+                "declared": str(size),
+                "cap": str(max_bytes),
+            })
+    return out
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    if not args or args[0] in ("-h", "--help"):
+        print(
+            "usage: evolution_tool_cap_check.py <tool_name> <args-json> "
+            "[--caps <caps-file.json>]",
+            file=sys.stderr,
+        )
+        return 2
+    tool = args[0]
+    caps_path: Optional[str] = None
+    if "--caps" in args:
+        idx = args.index("--caps")
+        if idx + 1 < len(args):
+            caps_path = args[idx + 1]
+    try:
+        args_json = (
+            json.loads(args[1])
+            if len(args) > 1 and not args[1].startswith("--")
+            else {}
+        )
+    except json.JSONDecodeError as exc:
+        print(f"[evolution-tool-cap-check] malformed args JSON: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(args_json, dict):
+        print("[evolution-tool-cap-check] args JSON must be an object", file=sys.stderr)
+        return 2
+
+    violations = check_input_caps(tool, args_json, caps=load_caps(caps_path))
+    if not violations:
+        print(f"[evolution-tool-cap-check] OK — {tool} declared inputs within caps")
+        return 0
+    print(
+        f"[evolution-tool-cap-check] {len(violations)} violation(s):", file=sys.stderr
+    )
+    for v in violations:
+        print(f"  - [{v['kind']}] {v['tool']}: {v['detail']}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/evolution_tool_caps.json
+++ b/scripts/evolution_tool_caps.json
@@ -1,0 +1,12 @@
+{
+  "default": {"max_bytes": 1048576, "max_args": 16},
+  "read_file": {"max_bytes": 262144, "max_args": 4},
+  "write_file": {"max_bytes": 524288, "max_args": 6},
+  "search_files": {"max_bytes": 131072, "max_args": 8},
+  "terminal": {"max_bytes": 65536, "max_args": 8},
+  "patch": {"max_bytes": 1048576, "max_args": 6},
+  "web_extract": {"max_bytes": 262144, "max_args": 5},
+  "web_search": {"max_bytes": 8192, "max_args": 5},
+  "skill_view": {"max_bytes": 131072, "max_args": 4},
+  "delegate_task": {"max_bytes": 262144, "max_args": 12}
+}

--- a/tests/scripts/test_evolution_tool_cap_check.py
+++ b/tests/scripts/test_evolution_tool_cap_check.py
@@ -1,0 +1,134 @@
+"""Checked lowering — resource-bound tool verification (#77, SkillEffect).
+
+S1 (scripts/evolution_tool_cap_check.py): pure per-tool input-cap checker.
+S2 (scripts/evolution_skill_lint.py): the real call site — declared_inputs
+blocks in SKILL.md frontmatter are run through the cap checker before a skill
+is trusted for reuse. The real-repo enforcement test (no cap_* violations on
+the current corpus) is the merge blocker, mirroring the #101/#188 pattern.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_skill_lint import (  # noqa: E402
+    extract_declared_inputs,
+    find_cap_violations,
+    lint_repo,
+)
+from evolution_tool_cap_check import (  # noqa: E402
+    check_input_caps,
+    declared_input_size,
+    load_caps,
+)
+
+
+TINY_CAPS = {
+    "read_file": {"max_bytes": 100, "max_args": 2},
+    "default": {"max_bytes": 1000, "max_args": 8},
+}
+
+
+class TestRealRepoEnforcement:
+    def test_real_repo_has_no_cap_violations(self):
+        # No skill currently declares oversized inputs; if one ever does, CI
+        # blocks the merge — the #77 acceptance criterion, enforced.
+        violations = [v for v in lint_repo() if v["kind"].startswith("cap_")]
+        assert violations == [], f"cap violations: {violations}"
+
+
+class TestDeclaredInputSize:
+    def test_counts_strings_and_keys(self):
+        assert declared_input_size({"path": "abc"}) == 4 + 3  # key + value
+
+    def test_counts_other_types_via_str(self):
+        assert declared_input_size({"limit": 50}) == 5 + 2
+
+    def test_empty_and_none(self):
+        assert declared_input_size({}) == 0
+        assert declared_input_size(None) == 0
+
+
+class TestCheckInputCaps:
+    def test_within_caps_ok(self):
+        assert check_input_caps("read_file", {"path": "a.txt"}, caps=TINY_CAPS) == []
+
+    def test_oversized_input_rejected(self):
+        v = check_input_caps("read_file", {"path": "x" * 200}, caps=TINY_CAPS)
+        assert len(v) == 1
+        assert v[0]["kind"] == "input_too_large"
+        assert v[0]["tool"] == "read_file"
+        assert v[0]["declared"] == "204"  # len("path") + len("x"*200)
+
+    def test_too_many_args_rejected(self):
+        v = check_input_caps(
+            "read_file", {"path": "a", "limit": 1, "extra": 2}, caps=TINY_CAPS
+        )
+        assert len(v) == 1 and v[0]["kind"] == "too_many_args"
+
+    def test_unknown_tool_checked_against_default(self):
+        assert check_input_caps("mystery_tool", {"x": "y"}, caps=TINY_CAPS) == []
+        # default cap is 1000 bytes: 1200 chars exceeds it, 500 chars does not.
+        assert check_input_caps("mystery_tool", {"x": "y" * 500}, caps=TINY_CAPS) == []
+        v = check_input_caps("mystery_tool", {"x": "y" * 1200}, caps=TINY_CAPS)
+        assert len(v) == 1 and v[0]["kind"] == "input_too_large"
+
+    def test_no_default_no_caps_is_ok(self):
+        assert check_input_caps("anything", {"a": 1}, caps={}) == []
+
+    def test_load_caps_returns_table(self):
+        caps = load_caps()
+        assert "default" in caps
+        assert caps["default"]["max_args"] > 0
+
+
+class TestExtractDeclaredInputs:
+    def _skill(self, block):
+        return f"---\nname: evolution-demo\n{block}---\n# body\n"
+
+    def test_absent_block_yields_empty(self):
+        assert extract_declared_inputs("---\nname: x\n---\n") == []
+        assert extract_declared_inputs("no frontmatter at all") == []
+
+    def test_list_form(self):
+        text = self._skill(
+            "declared_inputs:\n"
+            "  - tool: read_file\n"
+            "    args: {path: 'data/big.txt'}\n"
+            "  - {tool: search_files, args: {pattern: '*.py'}}\n"
+        )
+        out = extract_declared_inputs(text)
+        assert out == [
+            {"tool": "read_file", "args": {"path": "data/big.txt"}},
+            {"tool": "search_files", "args": {"pattern": "*.py"}},
+        ]
+
+    def test_map_form(self):
+        text = self._skill("declared_inputs:\n  read_file: {path: 'a.txt'}\n")
+        assert extract_declared_inputs(text) == [
+            {"tool": "read_file", "args": {"path": "a.txt"}}
+        ]
+
+    def test_malformed_yaml_is_empty_not_crash(self):
+        assert (
+            extract_declared_inputs("---\nname: x\ndeclared_inputs: [unclosed\n---\n")
+            == []
+        )
+
+
+class TestFindCapViolations:
+    def test_oversized_declaration_flagged(self):
+        decl = [{"tool": "read_file", "args": {"path": "x" * 200}}]
+        v = find_cap_violations(decl, caps=TINY_CAPS)
+        assert len(v) == 1
+        assert v[0]["kind"] == "cap_input_too_large"
+        assert v[0]["tool"] == "read_file"
+
+    def test_within_caps_ok(self):
+        decl = [{"tool": "read_file", "args": {"path": "a.txt"}}]
+        assert find_cap_violations(decl, caps=TINY_CAPS) == []
+
+    def test_empty_and_malformed_ok(self):
+        assert find_cap_violations([], caps=TINY_CAPS) == []
+        assert find_cap_violations([{"no_tool": 1}], caps=TINY_CAPS) == []


### PR DESCRIPTION
Automated evolution PR for issue #77.

**S1** — `scripts/evolution_tool_cap_check.py`: pure `check_input_caps(tool_name, args, caps)` — reject-early on declared input size/arity exceeding per-tool caps. Caps are config data (`scripts/evolution_tool_caps.json`, `EVOLUTION_TOOL_CAPS` env override). Off-core, zero blast radius.

**S2** — real call site: `scripts/evolution_skill_lint.py` now extracts `declared_inputs:` blocks from SKILL.md frontmatter and runs them through `check_input_caps` before a skill is trusted for reuse (the issue's acceptance criterion: adversarial oversized-input proposals rejected before execution). Declarations are opt-in — zero false positives on the existing corpus.

Tests: `tests/scripts/test_evolution_tool_cap_check.py` (39 tests green incl. existing skill-integrity suite; `ruff check` green).