### PR TITLE
feat: TrACE-style adaptive compute — disagreement-driven budget allocation (Closes #86)

### DIFF
--- a/scripts/evolution_disagreement.py
+++ b/scripts/evolution_disagreement.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""TrACE-style adaptive compute — disagreement-driven budget allocation (#86).
+
+S1 of the #86 decomposition: the pure disagreement metric and budget rule from
+TrACE ("Don't Overthink It", arXiv:2604.08369), plus a CLI that computes
+per-step budgets from a JSONL of candidate actions. Off-core, zero blast
+radius — S2 (instrumentation), S3 (config-gated wiring into the decision
+layer) and S4 (calibration harness) follow as separate slices.
+
+The idea: reasoning effort is currently static per task (#78). TrACE spends
+compute only where rollouts DISAGREE on the next action — routine steps where
+every sampled rollout picks the same action get a small budget; genuinely
+ambiguous steps (split votes) get the full budget.
+
+- :func:`disagreement_index` — how much the sampled rollouts disagree on the
+  next action: ``1 - max vote fraction`` (0.0 when unanimous, approaching 1.0
+  as the vote splits evenly).
+- :func:`budget_rule` — linear ramp: ``base_budget * min_multiplier`` at full
+  agreement, ramping to ``base_budget * max_multiplier`` at full
+  disagreement, capped so no step ever exceeds the maximum.
+
+Pure functions + explicit IO boundary (JSONL reader + CLI) so it is
+import-safe and unit-testable. The CLI's JSONL schema (one JSON object per
+line) is the S2 instrumentation contract:
+
+    {"step": 3, "actions": ["search_files", "search_files", "read_file"]}
+    {"actions": ["read_file", "read_file"]}      # step defaults to line number
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _action_key(action: Any) -> str:
+    """Canonical label for one candidate action.
+
+    Strings label themselves. Dicts prefer a ``tool`` / ``name`` / ``action``
+    key (tool-call shaped), falling back to the whole dict. Anything else is
+    ``str()``-ed. Only the LABEL participates in disagreement — args do not.
+    """
+    if isinstance(action, str):
+        return action
+    if isinstance(action, dict):
+        for key in ("tool", "name", "action"):
+            if key in action:
+                return str(action[key])
+        return str(action)
+    return str(action)
+
+
+def disagreement_index(actions: Iterable[Any]) -> float:
+    """Disagreement over the next action: ``1 - max vote fraction``.
+
+    0.0 when all rollouts agree on the same action; approaches 1.0 as the
+    vote splits evenly (e.g. two actions each getting half the votes → 0.5).
+    Raises ``ValueError`` on an empty sequence — no votes means no signal.
+    """
+    labels = [_action_key(a) for a in actions]
+    if not labels:
+        raise ValueError("disagreement_index requires at least one action")
+    counts = Counter(labels)
+    max_fraction = max(counts.values()) / len(labels)
+    return 1.0 - max_fraction
+
+
+def budget_rule(
+    disagreement: float,
+    base_budget: float,
+    min_multiplier: float = 1.0,
+    max_multiplier: float = 3.0,
+) -> float:
+    """Allocate a compute budget for a step from its disagreement index.
+
+    Linear ramp: ``base_budget * min_multiplier`` when the rollouts fully
+    agree (disagreement 0), ``base_budget * max_multiplier`` at full
+    disagreement (1.0), capped so no step exceeds the maximum. The index is
+    clamped to ``[0, 1]`` defensively. If ``max_multiplier <= min_multiplier``
+    the budget is flat at ``base_budget * min_multiplier`` (no ramp).
+    """
+    d = max(0.0, min(1.0, float(disagreement)))
+    if max_multiplier <= min_multiplier:
+        multiplier = float(min_multiplier)
+    else:
+        multiplier = min_multiplier + (max_multiplier - min_multiplier) * d
+    return float(base_budget) * multiplier
+
+
+def iter_steps(path: str) -> Iterable[Dict[str, Any]]:
+    """Yield ``{"step": int, "actions": list}`` records from a JSONL file.
+
+    ``step`` is taken from the record if present, else 1-based line order.
+    Blank lines are skipped. Malformed JSON raises ``ValueError`` with the
+    line number so the CLI can fail loudly instead of silently dropping data.
+    """
+    with open(path, encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {line_no}: malformed JSON — {exc}") from exc
+            if not isinstance(record, dict) or not isinstance(
+                record.get("actions"), list
+            ):
+                raise ValueError(
+                    f"line {line_no}: expected {{'actions': [...]}} record, got {line[:80]!r}"
+                )
+            step = record.get("step", line_no)
+            try:
+                step = int(step)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"line {line_no}: 'step' must be an int, got {step!r}"
+                ) from None
+            yield {"step": step, "actions": record["actions"]}
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    positional = [a for a in args if not a.startswith("--")]
+    flags = {
+        args[i]: args[i + 1] for i in range(len(args) - 1) if args[i].startswith("--")
+    }
+
+    if not positional or "--help" in args or "-h" in args:
+        print(
+            "usage: evolution_disagreement.py <steps.jsonl> [--base-budget N] "
+            "[--min-multiplier N] [--max-multiplier N] [--json]",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        base_budget = float(flags.get("--base-budget", 4.0))
+        min_multiplier = float(flags.get("--min-multiplier", 1.0))
+        max_multiplier = float(flags.get("--max-multiplier", 3.0))
+    except ValueError as exc:
+        print(f"[evolution-disagreement] bad flag value: {exc}", file=sys.stderr)
+        return 2
+    if base_budget < 0 or min_multiplier < 0 or max_multiplier < 0:
+        print(
+            "[evolution-disagreement] budgets/multipliers must be >= 0", file=sys.stderr
+        )
+        return 2
+
+    try:
+        steps = list(iter_steps(positional[0]))
+    except (OSError, ValueError) as exc:
+        print(f"[evolution-disagreement] {exc}", file=sys.stderr)
+        return 2
+    if not steps:
+        print("[evolution-disagreement] no records found in input", file=sys.stderr)
+        return 2
+
+    rows = []
+    total_budget = 0.0
+    indices = []
+    for record in steps:
+        index = disagreement_index(record["actions"])
+        budget = budget_rule(index, base_budget, min_multiplier, max_multiplier)
+        rows.append({
+            "step": record["step"],
+            "index": round(index, 6),
+            "budget": round(budget, 6),
+        })
+        total_budget += budget
+        indices.append(index)
+
+    if "--json" in args:
+        print(
+            json.dumps(
+                {
+                    "steps": rows,
+                    "summary": {
+                        "count": len(rows),
+                        "mean_index": round(sum(indices) / len(indices), 6),
+                        "total_budget": round(total_budget, 6),
+                        "base_budget": base_budget,
+                    },
+                },
+                indent=2,
+            )
+        )
+    else:
+        for row in rows:
+            print(
+                f"step={row['step']} disagreement={row['index']:.3f} budget={row['budget']:.3f}"
+            )
+        print(
+            f"summary: {len(rows)} steps, mean disagreement "
+            f"{sum(indices) / len(indices):.3f}, total budget {total_budget:.3f}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_evolution_disagreement.py
+++ b/tests/scripts/test_evolution_disagreement.py
@@ -1,0 +1,152 @@
+"""TrACE-style adaptive compute — disagreement metric + budget rule (#86, S1).
+
+Pure metric and rule from scripts/evolution_disagreement.py, exercised with
+synthetic per-step candidate-action sets. The JSONL IO boundary (iter_steps)
+is tested with a temp file; the CLI's exit paths are tested via main(argv).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from evolution_disagreement import (  # noqa: E402
+    _action_key,
+    budget_rule,
+    disagreement_index,
+    iter_steps,
+    main,
+)
+
+
+class TestActionKey:
+    def test_string_passes_through(self):
+        assert _action_key("read_file") == "read_file"
+
+    def test_dict_prefers_tool_then_name(self):
+        assert _action_key({"tool": "read_file", "path": "a"}) == "read_file"
+        assert _action_key({"name": "search_files"}) == "search_files"
+        assert _action_key({"action": "x"}) == "x"
+
+    def test_dict_without_keys_falls_back_to_str(self):
+        assert _action_key({"a": 1}) == "{'a': 1}"
+
+    def test_other_types_str_ed(self):
+        assert _action_key(42) == "42"
+
+
+class TestDisagreementIndex:
+    def test_unanimous_is_zero(self):
+        assert disagreement_index(["read_file", "read_file", "read_file"]) == 0.0
+
+    def test_single_action_is_zero(self):
+        assert disagreement_index(["read_file"]) == 0.0
+
+    def test_even_split(self):
+        assert disagreement_index(["a", "b"]) == 0.5
+
+    def test_two_thirds_majority(self):
+        assert disagreement_index(["a", "a", "b"]) == 1.0 - 2.0 / 3.0
+
+    def test_dict_actions_labeled_by_tool(self):
+        actions = [
+            {"tool": "search_files", "pattern": "x"},
+            {"tool": "search_files", "pattern": "y"},
+            {"tool": "read_file", "path": "z"},
+        ]
+        assert disagreement_index(actions) == 1.0 - 2.0 / 3.0
+
+    def test_empty_raises(self):
+        try:
+            disagreement_index([])
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for empty actions")
+
+
+class TestBudgetRule:
+    def test_agreement_gets_base_budget(self):
+        assert budget_rule(0.0, 4.0) == 4.0
+
+    def test_full_disagreement_gets_capped_budget(self):
+        assert budget_rule(1.0, 4.0, max_multiplier=3.0) == 12.0
+
+    def test_linear_ramp_midpoint(self):
+        # d=0.5 -> multiplier 2.0 -> budget 8.0
+        assert budget_rule(0.5, 4.0, min_multiplier=1.0, max_multiplier=3.0) == 8.0
+
+    def test_flat_when_no_ramp(self):
+        assert budget_rule(1.0, 4.0, min_multiplier=2.0, max_multiplier=2.0) == 8.0
+
+    def test_clamps_out_of_range(self):
+        assert budget_rule(-1.0, 4.0) == 4.0
+        assert budget_rule(2.0, 4.0, max_multiplier=3.0) == 12.0
+
+    def test_custom_multipliers(self):
+        assert budget_rule(0.0, 4.0, min_multiplier=2.0, max_multiplier=5.0) == 8.0
+        assert budget_rule(1.0, 4.0, min_multiplier=2.0, max_multiplier=5.0) == 20.0
+
+
+class TestIterSteps:
+    def test_reads_records_with_step(self, tmp_path):
+        p = tmp_path / "steps.jsonl"
+        p.write_text(
+            '{"step": 3, "actions": ["a", "a", "b"]}\n{"actions": ["a", "a"]}\n',
+            encoding="utf-8",
+        )
+        out = list(iter_steps(str(p)))
+        assert out == [
+            {"step": 3, "actions": ["a", "a", "b"]},
+            {"step": 2, "actions": ["a", "a"]},  # line number fallback
+        ]
+
+    def test_skips_blank_lines(self, tmp_path):
+        p = tmp_path / "steps.jsonl"
+        p.write_text('\n{"actions": ["a"]}\n\n', encoding="utf-8")
+        assert list(iter_steps(str(p))) == [{"step": 2, "actions": ["a"]}]
+
+    def test_malformed_json_raises_with_line(self, tmp_path):
+        p = tmp_path / "steps.jsonl"
+        p.write_text('{"actions": ["a"]}\nnot json\n', encoding="utf-8")
+        try:
+            list(iter_steps(str(p)))
+        except ValueError as exc:
+            assert "line 2" in str(exc)
+            return
+        raise AssertionError("expected ValueError on malformed line")
+
+
+class TestCli:
+    def test_runs_and_reports_budgets(self, tmp_path, capsys):
+        p = tmp_path / "steps.jsonl"
+        p.write_text(
+            '{"step": 1, "actions": ["a", "a"]}\n{"step": 2, "actions": ["a", "b"]}\n',
+            encoding="utf-8",
+        )
+        assert main(["prog", str(p), "--base-budget", "4"]) == 0
+        captured = capsys.readouterr().out
+        assert "step=1 disagreement=0.000 budget=4.000" in captured
+        assert "step=2 disagreement=0.500 budget=8.000" in captured
+
+    def test_json_output_shape(self, tmp_path, capsys):
+        p = tmp_path / "steps.jsonl"
+        p.write_text('{"actions": ["a", "b"]}\n', encoding="utf-8")
+        assert main(["prog", str(p), "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["steps"][0]["index"] == 0.5
+        assert data["summary"]["count"] == 1
+        assert data["summary"]["total_budget"] == 8.0  # 4.0 * 2.0 at d=0.5
+
+    def test_malformed_input_exits_2(self, tmp_path, capsys):
+        p = tmp_path / "steps.jsonl"
+        p.write_text("garbage\n", encoding="utf-8")
+        assert main(["prog", str(p)]) == 2
+
+    def test_missing_arg_exits_2(self, capsys):
+        assert main(["prog"]) == 2
+
+    def test_empty_input_exits_2(self, tmp_path, capsys):
+        p = tmp_path / "steps.jsonl"
+        p.write_text("", encoding="utf-8")
+        assert main(["prog", str(p)]) == 2

--- a/tests/scripts/test_evolution_trace_replay.py
+++ b/tests/scripts/test_evolution_trace_replay.py
@@ -56,8 +56,7 @@ class TestIterTrajectories:
         assert [e.tool for e in logs[0].entries] == ["tool_0", "tool_1"]
 
     def test_jsonl_append_format_multi_turn(self, tmp_path):
-        p = tmp_path / "2026-08-23_s1.jsonl"
-        _make_log("success", session_id="s1").append(tmp_path)
+        p = _make_log("success", session_id="s1").append(tmp_path)
         _make_log("failure", session_id="s1").append(tmp_path)
         logs = iter_trajectories(p)
         assert len(logs) == 2


### PR DESCRIPTION
Automated evolution PR for issue #86 (S1).

`scripts/evolution_disagreement.py` — pure, off-core:
- `disagreement_index(actions)`: 1 - max vote fraction (0.0 unanimous → ~1.0 split); dict actions labeled by tool/name/action key.
- `budget_rule(disagreement, base_budget, min_multiplier, max_multiplier)`: linear ramp capped; flat when max<=min; index clamped.
- CLI over a JSONL of per-step candidate actions (the S2 instrumentation contract): `{"step": n, "actions": [...]}`, with `--json` output and strict malformed-input handling.

Tests: `tests/scripts/test_evolution_disagreement.py` (24 green; `ruff check` green). S2 (instrumentation), S3 (config-gated wiring, default off) and S4 (calibration) remain split.