### PR TITLE
feat(agent): adaptive memory injection dosage by model tier (Closes Da-Mikey/hermes-agent-evolution#75)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2034,6 +2034,17 @@ def init_agent(
                 from plugins.memory import load_memory_provider as _load_mem
 
                 agent._memory_manager = _MemoryManager()
+                # Adaptive memory dosage (#75): config-gated, default off
+                # (agent.memory_injection.enabled: false). The policy only
+                # ever SHORTENS injected prefetch context — it never touches
+                # the static MEMORY_GUIDANCE prefix (prompt caching is
+                # sacred); see agent/memory_dosage.py.
+                try:
+                    agent._memory_manager.configure_dosage(
+                        _agent_cfg.get("memory_injection") or {}
+                    )
+                except Exception:
+                    pass  # dosage is optional — never break memory init
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/agent/memory_dosage.py
+++ b/agent/memory_dosage.py
@@ -1,0 +1,206 @@
+"""Adaptive memory injection — calibrate memory "dosage" to model capability (#75).
+
+Slices 1+2 of the #75 decomposition: per-tier injection profiles as CONFIG
+DATA plus the retrieval policy that selects a profile by model tier. The
+policy only ever SHORTENS the injected context — it never rewrites a byte of
+what a provider returned, and it never touches the static guidance prefix
+(``MEMORY_GUIDANCE`` in ``agent/prompt_builder.py``). That byte-stability is
+the HARD gate for this feature (per-conversation prompt caching is sacred):
+the dosage path removes provider blocks from the END of the merged prefetch
+text and truncates the tail at the profile's char budget, so the retained
+head is byte-identical to the undosed join. See
+``tests/agent/test_memory_dosage.py::TestByteStabilityHardGate``.
+
+Config (``agent.memory_injection`` in ``config.yaml`` /
+``hermes_cli.config_defaults``), default OFF until calibration shows cost
+savings without accuracy loss:
+
+.. code-block:: yaml
+
+   agent:
+     memory_injection:
+       enabled: false
+       profiles:
+         full:    {max_items: 8, max_chars: 6000}
+         curated: {max_items: 4, max_chars: 3000}
+         minimal: {max_items: 1, max_chars: 1000}
+       tier_patterns:
+         - [frontier, ["(?i)claude-opus", "(?i)gpt-4o", "(?i)gpt-5", "(?i)o[1-4]"]]
+         - [compact,  ["(?i)flash", "(?i)mini", "(?i)nano"]]
+       default_profile: curated
+
+Tier semantics: *frontier* models get the FULL dosage (they can absorb the
+context), *compact* models get MINIMAL (small windows, and weaker models are
+distracted by excess memory), everything else gets CURATED. The wiring lives
+in ``agent/memory_manager.py`` (``configure_dosage`` +
+``prefetch_all(..., model_id=...)``) and ``agent/turn_context.py``.
+
+Pure functions + explicit config boundary; import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+# Per-tier injection profiles (config data). ``max_items`` = how many
+# provider blocks may be injected; ``max_chars`` = total char budget for the
+# merged injection (the tail is truncated at this boundary).
+DEFAULT_PROFILES: Dict[str, Dict[str, int]] = {
+    "full": {"max_items": 8, "max_chars": 6000},
+    "curated": {"max_items": 4, "max_chars": 3000},
+    "minimal": {"max_items": 1, "max_chars": 1000},
+}
+
+# Ordered (tier, [regex patterns]) list — FIRST match wins. Regexes are
+# matched against the model id (case-insensitive, partial match). The
+# elements are tuples here (code) but plain lists when parsed from YAML.
+DEFAULT_TIER_PATTERNS: List[Any] = [
+    (
+        "frontier",
+        [
+            r"(?i)claude-opus",
+            r"(?i)gpt-4o",
+            r"(?i)gpt-5",
+            r"(?i)o[1-4](?:\b|-)",
+            r"(?i)gemini-2\.5-pro",
+            r"(?i)deepseek-reasoner",
+            r"(?i)sonnet",
+        ],
+    ),
+    (
+        "compact",
+        [
+            r"(?i)flash",
+            r"(?i)mini",
+            r"(?i)nano",
+            r"(?i)tiny",
+            r"(?i)(?:^|[^0-9])(?:1|3|7|8|9)b",
+            r"(?i)small",
+        ],
+    ),
+]
+
+DEFAULT_DEFAULT_PROFILE = "curated"
+
+# Tier name -> injection profile name. ``resolve_profile`` classifies a model
+# into a TIER (frontier / compact); ``profile_for`` maps that tier to a
+# PROFILE (full / curated / minimal) via this table. Tiers with no entry fall
+# through to the profile of the same name, then to ``default_profile``.
+DEFAULT_TIER_PROFILES: Dict[str, str] = {
+    "frontier": "full",
+    "compact": "minimal",
+}
+
+_SEP = "\n\n"
+
+
+def resolve_profile(
+    model_id: Optional[str],
+    tier_patterns: Optional[List[Any]] = None,
+    default_profile: str = DEFAULT_DEFAULT_PROFILE,
+) -> str:
+    """Classify a model id into an injection profile name.
+
+    First tier whose pattern matches the (lowercased) model id wins. An
+    unknown or empty model id falls back to ``default_profile`` — the dosage
+    policy must never crash or refuse on an unclassifiable model.
+    """
+    patterns = tier_patterns if tier_patterns is not None else DEFAULT_TIER_PATTERNS
+    model = (model_id or "").lower()
+    for tier, regexes in patterns:
+        for regex in regexes or []:
+            try:
+                if re.search(str(regex), model):
+                    return str(tier)
+            except re.error:
+                continue
+    return default_profile
+
+
+def load_dosage_config(cfg: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Normalize an ``agent.memory_injection`` config section.
+
+    Returns ``None`` when disabled or malformed (the dosage path is then a
+    no-op — default-off is the calibrated-rollout stance of #75). A valid
+    config is returned as ``{"enabled": True, "profiles": {...},
+    "tier_patterns": [[tier, [regexes]], ...], "default_profile": str}``.
+    """
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
+        return None
+    profiles = cfg.get("profiles") or {}
+    normalized_profiles: Dict[str, Dict[str, int]] = {}
+    for name, spec in profiles.items():
+        if not isinstance(spec, dict):
+            continue
+        try:
+            normalized_profiles[str(name)] = {
+                "max_items": max(0, int(spec.get("max_items") or 0)),
+                "max_chars": max(0, int(spec.get("max_chars") or 0)),
+            }
+        except (TypeError, ValueError):
+            continue
+    if not normalized_profiles:
+        return None
+    tier_patterns = cfg.get("tier_patterns") or DEFAULT_TIER_PATTERNS
+    if not isinstance(tier_patterns, list) or not tier_patterns:
+        tier_patterns = DEFAULT_TIER_PATTERNS
+    tier_profiles = cfg.get("tier_profiles") or DEFAULT_TIER_PROFILES
+    if not isinstance(tier_profiles, dict) or not tier_profiles:
+        tier_profiles = DEFAULT_TIER_PROFILES
+    default_profile = str(cfg.get("default_profile") or DEFAULT_DEFAULT_PROFILE)
+    return {
+        "enabled": True,
+        "profiles": normalized_profiles,
+        "tier_patterns": tier_patterns,
+        "tier_profiles": {str(k): str(v) for k, v in tier_profiles.items()},
+        "default_profile": default_profile,
+    }
+
+
+def profile_for(
+    model_id: Optional[str], config: Dict[str, Any]
+) -> Optional[Dict[str, int]]:
+    """The injection profile dict for ``model_id`` under ``config``."""
+    if not config:
+        return None
+    profiles = config.get("profiles") or {}
+    tier = resolve_profile(
+        model_id,
+        tier_patterns=config.get("tier_patterns"),
+        default_profile=config.get("default_profile", DEFAULT_DEFAULT_PROFILE),
+    )
+    # Tier -> profile mapping: explicit tier_profiles table, falling through
+    # to a profile sharing the tier's name, then to the default profile.
+    tier_profiles = config.get("tier_profiles") or {}
+    profile_name = tier_profiles.get(tier, tier)
+    return (
+        profiles.get(profile_name)
+        or profiles.get(tier)
+        or profiles.get(DEFAULT_DEFAULT_PROFILE)
+    )
+
+
+def apply_profile(profile: Dict[str, int], parts: List[str]) -> str:
+    """Apply a dosage profile to merged prefetch blocks.
+
+    BYTE-STABILITY CONTRACT (the hard gate): this only ever removes — keeps
+    the first ``max_items`` non-empty blocks in order, joins with ``"\\n\\n"``
+    and truncates the tail at ``max_chars``. The result is therefore a byte
+    PREFIX of the undosed join: every retained byte is identical to the
+    baseline, so the static guidance prefix (``MEMORY_GUIDANCE``) can never
+    be altered by dosage. Empty blocks are dropped before counting items so
+    providers that return blank text cannot waste an item slot.
+    """
+    blocks = [p for p in (parts or []) if p and p.strip()]
+    if not blocks:
+        return ""
+    kept = blocks[: int(profile.get("max_items") or len(blocks))]
+    joined = _SEP.join(kept)
+    max_chars = int(profile.get("max_chars") or 0)
+    if max_chars and len(joined) > max_chars:
+        # Never truncate INSIDE the first block: the head must stay
+        # byte-identical (the hard gate — see TestByteStabilityHardGate), so
+        # the char budget only ever applies to the tail beyond block 1.
+        return joined[: max(max_chars, len(kept[0]))]
+    return joined

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -35,6 +35,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_importance import EpisodicMemoryStore, MemoryEvent, score_importance
 from agent.memory_contradiction import ContradictionFlag, detect_contradictions
+from agent.memory_dosage import apply_profile, load_dosage_config, profile_for
 from agent.memory_provider import MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
@@ -409,6 +410,23 @@ class MemoryManager:
         # session_id) pairs logged during prefetch_all. Cleared after
         # outcomes are recorded in sync_all.
         self._pending_retrievals: List[tuple[str, str]] = []
+        # Adaptive memory dosage (#75): normalized ``agent.memory_injection``
+        # config, or None (default) = policy off, injection unchanged. Set
+        # via configure_dosage() by the agent init path. When active it only
+        # ever SHORTENS merged prefetch context (byte-stable head).
+        self._dosage_config: Optional[Dict[str, Any]] = None
+
+    def configure_dosage(self, config: Optional[Dict[str, Any]]) -> None:
+        """Enable/disable adaptive memory injection (#75).
+
+        ``config`` is an ``agent.memory_injection`` section (see
+        ``agent/memory_dosage.py``). Invalid or disabled configs are stored
+        as ``None`` — dosage stays off. Never raises.
+        """
+        try:
+            self._dosage_config = load_dosage_config(config)
+        except Exception:
+            self._dosage_config = None
 
     # -- Registration --------------------------------------------------------
 
@@ -637,11 +655,19 @@ class MemoryManager:
             segments.append(f"{status.glyph} {status.provider_label} — {detail}")
         return "  ".join(segments)
 
-    def prefetch_all(self, query: str, *, session_id: str = "") -> str:
+    def prefetch_all(
+        self, query: str, *, session_id: str = "", model_id: Optional[str] = None
+    ) -> str:
         """Collect prefetch context from all providers.
 
         Returns merged context text labeled by provider. Empty providers
         are skipped. Failures in one provider don't block others.
+
+        ``model_id`` feeds adaptive memory dosage (#75): when the manager has
+        a dosage config (configure_dosage) and a model id is supplied, the
+        merged context is capped per the resolved model tier's profile. The
+        filter only SHORTENS (byte-stable head) and is non-fatal — any
+        dosage failure falls back to the undosed merge.
         """
         clean_query = self._strip_skill_scaffolding(query)
         if not clean_query:
@@ -663,7 +689,22 @@ class MemoryManager:
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
                     provider.name, e,
                 )
-        return "\n\n".join(parts)
+        merged = "\n\n".join(parts)
+        if self._dosage_config and model_id and merged:
+            try:
+                profile = profile_for(model_id, self._dosage_config)
+                if profile:
+                    # Dosage operates on the \n\n-separated segments of the
+                    # merged text (a provider may itself return several
+                    # sections), so max_items/truncation never cut a provider
+                    # block mid-way — the byte-stable head is preserved.
+                    segments = [s for s in merged.split("\n\n") if s.strip()]
+                    dosed = apply_profile(profile, segments or [merged])
+                    if dosed:
+                        return dosed
+            except Exception as e:
+                logger.debug("Memory dosage filter skipped (non-fatal): %s", e)
+        return merged
 
     def _prefetch_provider(
         self, provider: MemoryProvider, query: str, *, session_id: str = ""

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1294,7 +1294,15 @@ def build_turn_context(
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             if not is_trivial_prompt(_query):
-                ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+                # model_id feeds adaptive memory dosage (#75) — config-gated
+                # in agent_init, default off; when active it only ever
+                # shortens the injected prefetch context.
+                ext_prefetch_cache = (
+                    agent._memory_manager.prefetch_all(
+                        _query, model_id=getattr(agent, "model", None)
+                    )
+                    or ""
+                )
         except Exception:
             pass
         # Deterministic, model-independent recall indicator: when memory was

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -333,6 +333,53 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Adaptive memory dosage (#75): calibrate injected memory volume to
+        # model capability. Default OFF until calibration shows cost savings
+        # without accuracy loss. When enabled, the merged prefetch context is
+        # capped per the model tier's profile — the policy only ever SHORTENS
+        # the injected context and never touches the byte-stable guidance
+        # prefix (prompt caching is sacred). See agent/memory_dosage.py.
+        "memory_injection": {
+            "enabled": False,
+            "profiles": {
+                "full": {"max_items": 8, "max_chars": 6000},
+                "curated": {"max_items": 4, "max_chars": 3000},
+                "minimal": {"max_items": 1, "max_chars": 1000},
+            },
+            # Ordered (tier, [regex patterns]) — first match wins against the
+            # model id. Frontier models absorb full context; compact models
+            # get minimal (small windows, weaker models distract easier);
+            # unknown models get the default_profile. tier_profiles maps a
+            # tier to an injection profile (fallback: same-name profile).
+            "tier_patterns": [
+                [
+                    "frontier",
+                    [
+                        "(?i)claude-opus",
+                        "(?i)gpt-4o",
+                        "(?i)gpt-5",
+                        "(?i)o[1-4](?:\\b|-)",
+                        "(?i)gemini-2\\.5-pro",
+                        "(?i)deepseek-reasoner",
+                        "(?i)sonnet",
+                    ],
+                ],
+                [
+                    "compact",
+                    [
+                        "(?i)flash",
+                        "(?i)mini",
+                        "(?i)nano",
+                        "(?i)tiny",
+                        "(?i)(?:^|[^0-9])(?:1|3|7|8|9)b",
+                        "(?i)small",
+                    ],
+                ],
+            ],
+            "tier_profiles": {"frontier": "full", "compact": "minimal"},
+            "default_profile": "curated",
+        },
     },
 
     "terminal": {

--- a/tests/agent/test_memory_dosage.py
+++ b/tests/agent/test_memory_dosage.py
@@ -1,0 +1,201 @@
+"""Adaptive memory injection (#75, slices 1+2) — unit tests + HARD gate.
+
+The byte-stability HARD gate (TestByteStabilityHardGate) is the load-bearing
+part: per-conversation prompt caching is sacred, so the dosage policy must
+never alter a single byte of the static guidance prefix (MEMORY_GUIDANCE) or
+of any retained memory block. The contract, asserted here: the dosed output
+is a byte PREFIX of the undosed merge — dosage only ever removes from the
+end. A regression in that invariant fails CI and blocks merge.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent.memory_dosage import (  # noqa: E402
+    DEFAULT_DEFAULT_PROFILE,
+    DEFAULT_PROFILES,
+    DEFAULT_TIER_PATTERNS,
+    apply_profile,
+    load_dosage_config,
+    profile_for,
+    resolve_profile,
+)
+from agent.memory_manager import MemoryManager  # noqa: E402
+from agent.prompt_builder import MEMORY_GUIDANCE  # noqa: E402
+
+MINIMAL_CFG = {
+    "enabled": True,
+    "profiles": {
+        "full": {"max_items": 8, "max_chars": 6000},
+        "curated": {"max_items": 4, "max_chars": 3000},
+        "minimal": {"max_items": 1, "max_chars": 1000},
+    },
+    "tier_patterns": DEFAULT_TIER_PATTERNS,
+    "tier_profiles": {"frontier": "full", "compact": "minimal"},
+    "default_profile": DEFAULT_DEFAULT_PROFILE,
+}
+
+
+class TestResolveProfile:
+    def test_frontier_model(self):
+        assert resolve_profile("anthropic/claude-opus-4-1") == "frontier"
+        assert resolve_profile("openai/gpt-4o") == "frontier"
+        assert resolve_profile("openai/o3") == "frontier"
+
+    def test_compact_model(self):
+        assert resolve_profile("google/gemini-3-flash-preview") == "compact"
+        assert resolve_profile("deepseek/deepseek-chat-mini") == "compact"
+
+    def test_unknown_falls_back_to_default(self):
+        assert resolve_profile("some/new-model-x") == "curated"
+
+    def test_empty_model_falls_back(self):
+        assert resolve_profile(None) == "curated"
+        assert resolve_profile("") == "curated"
+
+    def test_first_match_wins(self):
+        # a model matching BOTH frontier and compact patterns -> frontier
+        assert resolve_profile("claude-opus-mini") == "frontier"
+
+
+class TestLoadDosageConfig:
+    def test_disabled_is_none(self):
+        assert load_dosage_config({"enabled": False}) is None
+        assert load_dosage_config(None) is None
+        assert load_dosage_config({}) is None
+
+    def test_valid_config_normalized(self):
+        cfg = load_dosage_config(MINIMAL_CFG)
+        assert cfg is not None
+        assert cfg["enabled"] is True
+        assert cfg["profiles"]["minimal"]["max_items"] == 1
+
+    def test_malformed_profiles_degrade_to_none(self):
+        assert load_dosage_config({"enabled": True, "profiles": {}}) is None
+        assert (
+            load_dosage_config({"enabled": True, "profiles": {"bad": "not-a-dict"}})
+            is None
+        )
+
+
+class TestProfileFor:
+    def test_returns_profile_for_tier(self):
+        cfg = load_dosage_config(MINIMAL_CFG)
+        assert cfg is not None
+        assert profile_for("claude-opus-4", cfg) == cfg["profiles"]["full"]
+        assert profile_for("gemini-flash", cfg) == cfg["profiles"]["minimal"]
+        assert profile_for("unknown-model", cfg) == cfg["profiles"]["curated"]
+
+    def test_none_config_returns_none(self):
+        assert profile_for("anything", None) is None
+
+
+class TestApplyProfile:
+    def test_keeps_first_items_only(self):
+        parts = ["a", "b", "c", "d"]
+        out = apply_profile({"max_items": 2, "max_chars": 0}, parts)
+        assert out == "a\n\nb"
+
+    def test_truncates_tail_at_char_budget(self):
+        parts = ["head", "y" * 3000]
+        out = apply_profile({"max_items": 8, "max_chars": 1000}, parts)
+        assert len(out) == 1000
+        assert out == ("head\n\n" + "y" * 3000)[:1000]
+
+    def test_char_budget_never_cuts_first_block(self):
+        # The hard gate: max_chars applies only to the tail beyond block 1 —
+        # truncating inside the first block would break the byte-stable head.
+        parts = ["x" * 3000, "y" * 3000]
+        out = apply_profile({"max_items": 8, "max_chars": 1000}, parts)
+        assert out == "x" * 3000  # first block intact, tail dropped entirely
+
+    def test_empty_blocks_do_not_consume_items(self):
+        parts = ["", "   ", "real", ""]
+        out = apply_profile({"max_items": 1, "max_chars": 0}, parts)
+        assert out == "real"
+
+    def test_no_parts_is_empty(self):
+        assert apply_profile({"max_items": 8, "max_chars": 1000}, []) == ""
+
+
+class TestByteStabilityHardGate:
+    """THE hard gate for #75: dosage must never alter retained bytes."""
+
+    def test_memory_guidance_prefix_byte_stable(self):
+        baseline = MEMORY_GUIDANCE.encode()
+        parts = [MEMORY_GUIDANCE, "user prefers terse replies", "project uses pytest"]
+        for profile in DEFAULT_PROFILES.values():
+            out = apply_profile(profile, parts)
+            assert MEMORY_GUIDANCE.encode() == baseline  # constant untouched
+            assert out.startswith(MEMORY_GUIDANCE)  # retained head byte-identical
+
+    def test_dosed_is_byte_prefix_of_undosed(self):
+        parts = ["alpha " + "x" * 400, "beta " + "y" * 400, "gamma " + "z" * 400]
+        undosed = "\n\n".join(parts)
+        for profile in DEFAULT_PROFILES.values():
+            dosed = apply_profile(profile, parts)
+            assert dosed == "" or undosed.startswith(dosed), profile
+
+
+class TestWiring:
+    """prefetch_all honors dosage only when configured (default off)."""
+
+    class _FakeBuiltin:
+        name = "builtin"
+
+        def __init__(self, *blocks):
+            self._blocks = blocks
+
+        def get_tool_schemas(self):
+            return []  # current main add_provider indexes tool schemas
+
+        def prefetch(self, query, session_id=""):
+            return "\n\n".join(self._blocks)
+
+    def _manager_with_fake(self):
+        mgr = MemoryManager()
+        mgr.add_provider(  # type: ignore[arg-type] — duck-typed test double
+            self._FakeBuiltin(
+                "alpha " + "x" * 400, "beta " + "y" * 400, "gamma " + "z" * 400
+            )
+        )
+        return mgr
+
+    def test_default_off_returns_undosed_merge(self):
+        mgr = self._manager_with_fake()
+        out = mgr.prefetch_all("query", model_id="claude-opus-4")
+        assert (
+            out
+            == "alpha " + "x" * 400 + "\n\nbeta " + "y" * 400 + "\n\ngamma " + "z" * 400
+        )
+
+    def test_enabled_doses_and_preserves_prefix(self):
+        mgr = self._manager_with_fake()
+        undosed = mgr.prefetch_all("query", model_id="claude-opus-4")
+        mgr.configure_dosage(MINIMAL_CFG)
+        dosed = mgr.prefetch_all("query", model_id="claude-opus-4")
+        # frontier tier -> full profile (8 items / 6000 chars): merge is 3
+        # blocks ~1240 chars, so full profile caps only on items? No —
+        # full keeps everything here; use the compact tier to force the cap.
+        assert undosed.startswith(dosed)
+
+    def test_compact_tier_gets_minimal_profile(self):
+        mgr = self._manager_with_fake()
+        mgr.configure_dosage(MINIMAL_CFG)
+        out = mgr.prefetch_all("query", model_id="gemini-flash")
+        # compact tier -> minimal profile: 1 item, 1000 chars.
+        assert out == ("alpha " + "x" * 400)[:1000]
+
+    def test_invalid_config_disables_dosage(self):
+        mgr = self._manager_with_fake()
+        mgr.configure_dosage({"enabled": True, "profiles": {}})
+        out = mgr.prefetch_all("query", model_id="gemini-flash")
+        assert "gamma" in out  # undosed merge
+
+    def test_no_model_id_skips_dosage(self):
+        mgr = self._manager_with_fake()
+        mgr.configure_dosage(MINIMAL_CFG)
+        out = mgr.prefetch_all("query")  # model_id=None -> no dosage
+        assert "gamma" in out

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -246,7 +246,7 @@ def test_prefetch_runs_for_substantive_user_message():
     agent, mm = _agent_with_memory_manager()
     query = "what did we decide about the deploy pipeline?"
     ctx = _build(agent, user_message=query)
-    mm.prefetch_all.assert_called_once_with(query)
+    mm.prefetch_all.assert_called_once_with(query, model_id="test/model")
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 

--- a/tests/scripts/test_evolution_trace_replay.py
+++ b/tests/scripts/test_evolution_trace_replay.py
@@ -56,8 +56,7 @@ class TestIterTrajectories:
         assert [e.tool for e in logs[0].entries] == ["tool_0", "tool_1"]
 
     def test_jsonl_append_format_multi_turn(self, tmp_path):
-        p = tmp_path / "2026-08-23_s1.jsonl"
-        _make_log("success", session_id="s1").append(tmp_path)
+        p = _make_log("success", session_id="s1").append(tmp_path)
         _make_log("failure", session_id="s1").append(tmp_path)
         logs = iter_trajectories(p)
         assert len(logs) == 2


### PR DESCRIPTION
Automated evolution PR for issue Da-Mikey/hermes-agent-evolution#75 — slices 1+2 (the core, per the implementation decomposition).

**What ships:**
- `agent/memory_dosage.py` — per-tier injection profiles as config data (full / curated / minimal with `max_items` + `max_chars`), model-tier classification (ordered regex patterns over the model id, first match wins), tier→profile mapping, and `apply_profile`. Pure + import-safe.
- Wiring: `MemoryManager.configure_dosage()` and `prefetch_all(..., model_id=...)` — configured from `agent.memory_injection` in `agent_init`, model id passed from `turn_context`. **Default OFF** (calibrated-rollout stance).
- Config: `memory_injection` block in `config_defaults.py` (frontier→full, compact→minimal, default curated).

**The hard gate (prompt caching is sacred):** dosage only ever REMOVES from the end of the merged prefetch text, never truncates inside the first segment, and never touches the static `MEMORY_GUIDANCE` prefix. Enforced by `TestByteStabilityHardGate` (dosed output is a byte-prefix of the undosed merge; guidance prefix retained in full under every profile) — a regression here fails CI.

**Validation:** 22/22 dosage tests pass (unit + wiring + hard gate); 75 adjacent memory-manager tests pass; `ruff check` green on all touched files.

**Scope note:** slices 3 (outcome-signal tracking, needs the opt-in gate) and 4 (cache-hit verification) remain independent future work per the 2026-08-19 decomposition comment.