### PR TITLE
feat(agent): opt-in read-only tool tier for exploratory subagents

### DIFF
--- a/agent/read_only_tier.py
+++ b/agent/read_only_tier.py
@@ -1,0 +1,124 @@
+# Read-only tool tier for exploratory subagent tool calls.
+#
+# HERMES-SUBAGENT-ATTRIBUTION subagent_id=sa-0-5295fac9 parent=root task_index=0 spawned_at=2026-08-26T00:06:28+00:00
+#
+# Implements evo-2026-08-26-01: a typed least-privilege execution mode so
+# exploratory subagents can probe tools without destructive operations or
+# human approval round-trips (mirrors NemoClaw's `call-read-only TOOL --json`).
+#
+# Design:
+# - An allowlist of read-only tool names (READ_ONLY_TOOLS) plus argument-level
+#   guards for dual-mode tools (terminal/read_file variants).
+# - Enforcement is opt-in per process/agent: either the environment variable
+#   ``HERMES_SUBAGENT_READ_ONLY=1`` or an agent attribute ``read_only_mode``
+#   set by the delegation layer when spawning an exploratory subagent.
+# - Fail-closed for explicitly non-read-only calls; fail-open on internal
+#   errors of the classifier itself would defeat the tier, so unknown tools
+#   are DENIED (the subagent can still use the known read-only surface).
+"""Read-only tool-tier enforcement helpers."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Optional
+
+ENV_READ_ONLY = "HERMES_SUBAGENT_READ_ONLY"
+
+#: Tools whose whole surface is observational and side-effect free.
+READ_ONLY_TOOLS = frozenset({
+    "read_file",
+    "search_files",
+    "repo_map",
+    "list_directory",
+    "list_dir",
+    "glob",
+    "grep",
+    "web_search",
+    "web_fetch",
+    "browser_navigate",
+    "get_tweet",
+    "get_user_by_username",
+    "list_issues",
+    "get_repo",
+    "get_issue",
+    "tool_describe",
+    "tool_search",
+})
+
+#: Dual-mode tools allowed only when the arguments are purely observational.
+_DUAL_MODE = {
+    "terminal",
+    "shell",
+    "bash",
+    "execute_command",
+    "run_command",
+    "execute_code",
+}
+
+# Commands that mutate state even inside a dual-mode tool.
+_WRITE_CMD_PATTERNS = (
+    r"\brm\b",
+    r"\bmv\b",
+    r"\bcp\b",
+    r"\bmkdir\b",
+    r"\btouch\b",
+    r"\bchmod\b",
+    r"\bchown\b",
+    r"\btee\b",
+    # Any shell redirection ('>' covers '>', ' >', '2>', and '>>') writes state.
+    r">",
+    r"\bgit\s+(commit|push|reset|rebase|merge|checkout|clean|apply|stash)\b",
+    r"\bpip\s+install\b",
+    r"\bnpm\s+(install|i)\b",
+    r"\bcurl\b",
+    r"\bwget\b",
+    r"\bkill\b",
+    r"\bsudo\b",
+    r"\bdocker\s+(run|rm|rmi|build)\b",
+    r"\bsystemctl\b",
+)
+_WRITE_RE = re.compile("|".join(_WRITE_CMD_PATTERNS))
+
+
+def read_only_mode_enabled(agent: Any = None) -> bool:
+    """Return True when this agent/process runs under the read-only tier."""
+    if getattr(agent, "read_only_mode", False):
+        return True
+    return os.environ.get(ENV_READ_ONLY, "").strip().lower() in ("1", "true", "yes")
+
+
+def block_reason(function_name: str, function_args: Any) -> Optional[str]:
+    """Return a denial reason when the call is not read-only-safe, else None."""
+    name = str(function_name or "").strip().lower()
+    args = function_args if isinstance(function_args, dict) else {}
+
+    if name in READ_ONLY_TOOLS:
+        return None
+
+    if name in _DUAL_MODE:
+        cmd = str(args.get("command") or args.get("cmd") or "")
+        if cmd and not _WRITE_RE.search(cmd):
+            return None
+        return (
+            f"tool '{name}' is not permitted in read-only mode "
+            "(mutating command); re-run the subagent without the read-only "
+            "tier to execute state-changing commands"
+        )
+
+    # Unknown / unclassified tool: fail closed.
+    return f"tool '{name}' is not on the read-only allowlist"
+
+
+def blocked_tool_result(reason: str) -> str:
+    """JSON tool-result payload used when the tier denies a call."""
+    import json
+
+    return json.dumps(
+        {
+            "error": f"Tool execution blocked by read-only tier: {reason}",
+            "status": "blocked",
+            "tier": "read_only",
+        },
+        ensure_ascii=False,
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -413,6 +413,39 @@ def _harm_gate_block_reason(function_name: str, function_args: Any) -> Optional[
         return None
 
 
+def _read_only_block_reason(agent: Any, function_name: str, function_args: Any) -> Optional[str]:
+    """Read-only tier (evo-2026-08-26-01): deny non-observational calls.
+
+    Active only when the agent runs under the read-only tier
+    (``HERMES_SUBAGENT_READ_ONLY=1`` or ``agent.read_only_mode``); inert for
+    normal sessions.
+    """
+    try:
+        from agent.read_only_tier import block_reason, read_only_mode_enabled
+
+        if not read_only_mode_enabled(agent):
+            return None
+        return block_reason(function_name, function_args)
+    except Exception:
+        # Enforcement must never break normal execution; fail open here and
+        # let the harm gate / approval layer apply its own rules.
+        return None
+
+
+def _read_only_blocked_tool_result(reason: str) -> str:
+    try:
+        from agent.read_only_tier import blocked_tool_result
+
+        return blocked_tool_result(reason)
+    except Exception:
+        import json
+
+        return json.dumps(
+            {"error": f"Tool execution blocked by read-only tier: {reason}", "status": "blocked"},
+            ensure_ascii=False,
+        )
+
+
 def _harm_blocked_tool_result(reason: str) -> str:
     return json.dumps(
         {
@@ -1440,6 +1473,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             try:
                 def _execute(next_args: dict[str, Any]) -> Any:
                     _emit_execute_tool_event(agent, function_name)
+                    # Read-only tier (evo-2026-08-26-01): exploratory subagents
+                    # running under HERMES_SUBAGENT_READ_ONLY / agent
+                    # .read_only_mode may only invoke observational tools.
+                    ro_block = _read_only_block_reason(agent, function_name, next_args)
+                    if ro_block is not None:
+                        logger.warning(
+                            "tool %s blocked by read-only tier: %s",
+                            function_name,
+                            ro_block,
+                        )
+                        return _read_only_blocked_tool_result(ro_block)
                     # AgentProcessBench harm gate (#2662): reject high-impact
                     # calls (delete/overwrite/credential access) pre-execution.
                     block_reason = _harm_gate_block_reason(function_name, next_args)

--- a/tests/test_read_only_tier.py
+++ b/tests/test_read_only_tier.py
@@ -1,0 +1,62 @@
+"""Tests for the read-only tool tier (evo-2026-08-26-01).
+
+HERMES-SUBAGENT-ATTRIBUTION subagent_id=sa-0-5295fac9 parent=root task_index=0 spawned_at=2026-08-26T00:06:28+00:00
+"""
+
+import os
+
+import pytest
+
+from agent.read_only_tier import (
+    ENV_READ_ONLY,
+    block_reason,
+    read_only_mode_enabled,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(ENV_READ_ONLY, raising=False)
+
+
+def test_disabled_by_default():
+    # Enforcement gating lives in tool_executor (read_only_mode_enabled);
+    # block_reason is a pure classifier and always classifies.
+    assert read_only_mode_enabled(None) is False
+    assert read_only_mode_enabled(object()) is False
+
+
+def test_env_enables_mode():
+    os.environ[ENV_READ_ONLY] = "1"
+    assert read_only_mode_enabled(None) is True
+
+
+def test_agent_attr_enables_mode():
+    class A:
+        read_only_mode = True
+
+    assert read_only_mode_enabled(A()) is True
+
+
+def test_read_only_tools_allowed():
+    os.environ[ENV_READ_ONLY] = "1"
+    assert block_reason("read_file", {"path": "/etc/hosts"}) is None
+    assert block_reason("search_files", {"pattern": "x"}) is None
+
+
+def test_mutating_terminal_blocked():
+    os.environ[ENV_READ_ONLY] = "1"
+    assert block_reason("terminal", {"command": "rm -rf /tmp/x"}) is not None
+    assert block_reason("terminal", {"command": "git push origin main"}) is not None
+    assert block_reason("shell", {"command": "echo hi > /etc/passwd"}) is not None
+
+
+def test_observe_terminal_allowed():
+    os.environ[ENV_READ_ONLY] = "1"
+    assert block_reason("terminal", {"command": "ls -la"}) is None
+    assert block_reason("terminal", {"command": "git status && git log -1"}) is None
+
+
+def test_unknown_tool_fails_closed():
+    os.environ[ENV_READ_ONLY] = "1"
+    assert block_reason("deploy_to_prod", {}) is not None


### PR DESCRIPTION
Implements local proposal evo-2026-08-26-01 (no GitHub issue — local_only proposal).

## What
A typed least-privilege execution mode so exploratory subagents can probe tools without destructive operations or human-approval round-trips (mirrors NemoClaw's `call-read-only TOOL --json`).

- new `agent/read_only_tier.py`: observational-tool allowlist + argument-level guards for dual-mode tools (terminal/shell/execute_code); unknown tools fail closed
- enforcement wired into `execute_tool_calls_concurrent` ahead of the harm gate; inert unless `HERMES_SUBAGENT_READ_ONLY=1` (internal bridge env var) or `agent.read_only_mode` is set
- unit tests for allow/deny/fail-closed paths (`tests/test_read_only_tier.py`, 7 cases)

## Validation
- ruff check + format ✓; targeted unit tests 7/7 ✓
- pre-PR runner shard `tests/agent`: 751 passed; single remaining failure (`test_auxiliary_main_first`) reproduced identically on a pristine `origin/main` worktree — pre-existing test-order pollution, unrelated to this change

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>