### PR TITLE
docs(evolution): harness-over-backbone tie-break in analysis selection

### DIFF
--- a/skills/evolution/evolution-analysis/SKILL.md
+++ b/skills/evolution/evolution-analysis/SKILL.md
@@ -287,6 +287,13 @@ final_priority = base_priority + community*0.1 + age*0.15 + compatibility*0.2 + 
      in step 5a — **3.0** by default, **1.5** when throttled; never a middle value.
      Stop adding issues once their summed `effort_score` reaches this budget; under
      the throttled 1.5 budget, fill it with the highest-land-confidence issues first.
+   - **Harness-over-backbone tie-break:** when two candidates score within 0.1 of
+     each other, prefer the harness/pipeline/tooling improvement over the
+     model-upgrade proposal. Rationale: task-specific harness refinement beats
+     backbone upgrades at comparable or better gains and up to ~60% lower cost
+     (arXiv:2608.08466), and this pipeline runs under sustained provider
+     cost/rate-limit pressure. Record the tie-break in the entry's
+     `selected_reason` as `"harness-first"` so the preference stays measurable.
 
 6a. **Anti-starvation slot — guarantee no valid issue rots for days.** Scoring
     alone lets a sound-but-modest issue lose every single night. To prevent that,


### PR DESCRIPTION
Implements local proposal evo-2026-08-26-04 (no GitHub issue — local_only proposal).

## What
Adds an explicit selection rule to `skills/evolution/evolution-analysis/SKILL.md`: on near-tie scores (Δ ≤ 0.1), prefer harness/pipeline/tooling proposals over model-upgrade proposals, tagged `selected_reason: "harness-first"` so the preference is measurable in funnel metrics.

Rationale: arXiv:2608.08466 shows task-specific harness refinement beats backbone upgrades at comparable gains and up to ~60% lower cost; the pipeline currently runs under provider cost/rate-limit pressure.

## Validation
- skill-edit budget lint ✓ (7-line addition to a 485-line skill)

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>