### PR TITLE
fix(whatsapp-bridge): Node>=20 guard + exponential reconnect backoff (Closes #118)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -48,6 +48,19 @@ import {
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
 
+// #118: Baileys 7 requires global WebCrypto ('subtle'), which is only
+// stable on Node >= 20. Fail fast with an actionable message instead of
+// the cryptic "Cannot destructure property 'subtle'" startup TypeError
+// that currently crash-loops the bridge on older Node runtimes.
+const NODE_MAJOR = parseInt(process.versions.node.split('.')[0], 10);
+if (Number.isFinite(NODE_MAJOR) && NODE_MAJOR < 20) {
+  console.error(
+    `❌ hermes-whatsapp-bridge requires Node >= 20 (found ${process.versions.node}). ` +
+    'Install Node 20+ (or run with --experimental-global-webcrypto on Node 18).'
+  );
+  process.exit(1);
+}
+
 // Parse CLI args
 const args = process.argv.slice(2);
 function getArg(name, defaultVal) {
@@ -419,6 +432,9 @@ async function startSocket() {
     },
   });
 
+  // #118: consecutive-close counter for flap backoff (resets on open).
+  let consecutiveReconnects = 0;
+
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 
   sock.ev.on('connection.update', (update) => {
@@ -454,10 +470,20 @@ async function startSocket() {
             console.log(`⚠️  Connection closed (reason: ${reason}). Reconnecting in 3s...`);
           }
         }
-        scheduleReconnect(reason === 515 ? 1000 : 3000);
+        // #118: exponential backoff on repeated closes (428/503 flap) so the
+        // reconnect loop stops hammering the WhatsApp servers; capped at 60s.
+        // 515 (restart requested) always reconnects fast.
+        if (reason === 515) {
+          scheduleReconnect(1000);
+        } else {
+          consecutiveReconnects += 1;
+          const backoffMs = Math.min(3000 * 2 ** (consecutiveReconnects - 1), 60000);
+          scheduleReconnect(backoffMs);
+        }
       }
     } else if (connection === 'open') {
       connectionState = 'connected';
+      consecutiveReconnects = 0;  // #118: flap backoff resets on a stable connection
       const connectedUser = sock?.user
         ? {
             id: sock.user.id || null,

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "start": "node bridge.js"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",
     "express": "^4.21.0",


### PR DESCRIPTION

---

## Implementation (round 1, 2026-08-26)

- package.json declares engines.node >= 20; bridge.js fails fast with an
  actionable message on older Node (fixes the 'Cannot destructure property
  subtle' startup crash loop).
- The 428/503 reconnect flap now backs off exponentially (3s..60s cap) and
  resets on a stable connection, instead of reconnecting every 3s forever.
- Selected by analysis phase 2-github-aware-merged (2026-08-26).

Closes #
