### PR TITLE
feat: AutoSaddler-style diagnosis skeleton + component-scoped proposals (increment 1 of #3209)

### DIFF
--- a/scripts/evolution_harness_proposer.py
+++ b/scripts/evolution_harness_proposer.py
@@ -102,11 +102,12 @@ def _evidence_of(weakness: Dict[str, Any]) -> Dict[str, Any]:
     """Carry the trace evidence forward VERBATIM from the weakness record.
 
     Only the anonymized fields the miner already emits (counts / classes /
-    labels / tool names) — never raw trace content, because the miner never had
-    any. Subset is whitelisted so nothing unexpected leaks into a filed issue."""
+    labels / tool names) plus the deterministic diagnosis skeleton — never raw
+    trace content, because the miner never had any. Subset is whitelisted so
+    nothing unexpected leaks into a filed issue."""
     allowed = (
         "kind", "tool", "signature", "occurrences", "severity", "label",
-        "max_consecutive", "sessions",
+        "max_consecutive", "sessions", "diagnosis",
     )
     return {k: weakness[k] for k in allowed if k in weakness}
 
@@ -114,15 +115,36 @@ def _evidence_of(weakness: Dict[str, Any]) -> Dict[str, Any]:
 def _default_title(weakness: Dict[str, Any], ptype: str) -> str:
     """Deterministic fallback title used when no LLM seam authors one.
 
-    Concrete and de-dup-friendly (names the subject + the proposal type) so the
-    issues stage's exact-title idempotency guard behaves predictably."""
+    Concrete and de-dup-friendly (names the subject + the proposal type +
+    component scope) so the issues stage's exact-title idempotency guard behaves
+    predictably."""
     subject = weakness.get("tool") or weakness.get("signature") or "agent harness"
+    diag = weakness.get("diagnosis") or {}
+    scope = diag.get("component_scope") or "agent"
     label = {
         "system_prompt_delta": "system-prompt guard",
         "retry_policy_change": "retry-policy change",
         "tool_guard": "tool guard",
     }[ptype]
-    return f"[HARNESS] {label} for `{subject}`"
+    return f"[HARNESS] {label} ({scope}) for `{subject}`"
+
+
+def _default_rationale(weakness: Dict[str, Any], ptype: str) -> str:
+    """Offline rationale that cites the diagnosis skeleton when available.
+
+    Falls back to the miner's free-form label when no deterministic diagnosis
+    exists, preserving the previous behavior."""
+    diag = weakness.get("diagnosis") or {}
+    if diag:
+        root = diag.get("likely_root_cause", "recurring failure")
+        mode = diag.get("failure_mode", "")
+        surface = diag.get("recommended_harness_surface", ptype)
+        return (
+            f"Diagnosed root cause: {root}. "
+            f"Failure mode: {mode}. "
+            f"Recommended harness surface: {surface}."
+        )
+    return _coerce_str(weakness.get("label"))
 
 
 def _coerce_str(value: Any) -> str:
@@ -162,10 +184,12 @@ def build_proposal(
         return None
 
     evidence = _evidence_of(weakness)
+    diag = weakness.get("diagnosis") or {}
     proposal: Dict[str, Any] = {
         "type": ptype,
         "source": "self-harness",  # distinguishes from research-generated proposals
         "evidence": evidence,
+        "component_scope": diag.get("component_scope") or "agent",
         # --- HARD human-gating invariant: inert, never auto-applied. ---
         "status": "proposed",
         "requires_human_review": True,
@@ -188,12 +212,12 @@ def build_proposal(
         title = _coerce_str(authored.get("title")) or _default_title(weakness, ptype)
         proposal["title"] = title
         proposal["delta"] = _coerce_str(authored.get("delta"))
-        proposal["rationale"] = _coerce_str(authored.get("rationale"))
+        proposal["rationale"] = _coerce_str(authored.get("rationale")) or _default_rationale(weakness, ptype)
         proposal["llm_authored"] = bool(authored)
     else:
         proposal["title"] = _default_title(weakness, ptype)
         proposal["delta"] = ""
-        proposal["rationale"] = _coerce_str(weakness.get("label"))
+        proposal["rationale"] = _default_rationale(weakness, ptype)
         proposal["llm_authored"] = False
 
     # Attach a structured code diff for the retry-policy surface (#2613).

--- a/scripts/evolution_trace_miner.py
+++ b/scripts/evolution_trace_miner.py
@@ -34,6 +34,50 @@ except Exception:  # pragma: no cover - keep import path explicit on failure
 
 DEFAULT_MIN_COUNT = 5  # a cluster must recur this often to become a weakness
 
+# Per-kind diagnosis skeleton for the AutoSaddler-style harness optimization slice
+# (#3209 increment 1).  Each weakness is mapped to a component scope and a likely
+# root cause so the downstream proposer can generate typed, scoped edits rather
+# than broad prose rewrites.  This layer is deterministic and uses only the
+# anonymized fields already emitted by the miner.
+DIAGNOSIS_TEMPLATES: Dict[str, Dict[str, str]] = {
+    "tool_failure": {
+        "component_scope": "tool_wrapper",
+        "likely_root_cause": "argument validation or result-shape mismatch",
+        "failure_mode": "tool results look like failures across multiple sessions",
+        "recommended_harness_surface": "tool_guard",
+    },
+    "provider_error": {
+        "component_scope": "retry_policy",
+        "likely_root_cause": "retry/fallback policy not tuned for this error class",
+        "failure_mode": "provider-layer error recurs before recovery succeeds",
+        "recommended_harness_surface": "retry_policy_change",
+    },
+    "retry_spiral": {
+        "component_scope": "retry_policy",
+        "likely_root_cause": "uncapped consecutive retries on a failing tool",
+        "failure_mode": "same tool invoked many times in a row without recovery",
+        "recommended_harness_surface": "retry_policy_change",
+    },
+}
+
+
+def diagnose_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach a deterministic, component-scoped diagnosis skeleton to a weakness
+    record.  The diagnosis never uses raw trace content; it only reflects the
+    anonymized kind + counts already present.  Returns a fresh dict so the input
+    record is not mutated in place."""
+    out = dict(record)
+    tmpl = DIAGNOSIS_TEMPLATES.get(out.get("kind"), {})
+    if tmpl:
+        out["diagnosis"] = {
+            "component_scope": tmpl["component_scope"],
+            "likely_root_cause": tmpl["likely_root_cause"],
+            "failure_mode": tmpl["failure_mode"],
+            "recommended_harness_surface": tmpl["recommended_harness_surface"],
+            "severity": out.get("severity", 0),
+        }
+    return out
+
 
 def mine_weaknesses(digest: Dict[str, Any], min_count: int = DEFAULT_MIN_COUNT) -> List[Dict[str, Any]]:
     """Turn an introspection digest's aggregated signals into structured weakness
@@ -84,9 +128,8 @@ def mine_weaknesses(digest: Dict[str, Any], min_count: int = DEFAULT_MIN_COUNT) 
                          f"diagnostic or a fallback path.",
             })
 
-    # Highest-severity first so the issues stage triages the worst clusters early.
     records.sort(key=lambda r: -int(r.get("severity") or 0))
-    return records
+    return [diagnose_record(r) for r in records]
 
 
 def format_weaknesses(records: List[Dict[str, Any]], window_days: int = 0) -> str:

--- a/tests/scripts/test_evolution_harness_proposer.py
+++ b/tests/scripts/test_evolution_harness_proposer.py
@@ -103,8 +103,27 @@ class TestBuildProposal:
         assert p["llm_authored"] is False
         assert p["delta"] == ""  # no model -> no authored delta
         assert p["title"].startswith("[HARNESS]")
-        # rationale falls back to the miner's label (no model).
-        assert "harden" in p["rationale"]
+        # Fixture has no diagnosis -> component scope falls back to "agent"
+        # (backward-compat with records the miner emitted before #3209).
+        assert p["component_scope"] == "agent"
+
+    def test_component_scope_propagates_from_diagnosis(self):
+        # A weakness that carries the new diagnosis skeleton propagates its
+        # component scope into the proposal (the realistic post-#3209 path).
+        w = dict(_tool_failure())
+        w["diagnosis"] = {
+            "component_scope": "tool_wrapper",
+            "likely_root_cause": "argument validation or result-shape mismatch",
+            "failure_mode": "tool results look like failures across sessions",
+            "recommended_harness_surface": "tool_guard",
+            "severity": 9,
+        }
+        p = build_proposal(w)
+        assert p is not None
+        assert p["component_scope"] == "tool_wrapper"
+        assert "tool_wrapper" in p["title"]
+        # offline rationale cites the deterministic diagnosis skeleton.
+        assert "Diagnosed root cause" in p["rationale"]
 
     def test_llm_seam_authors_fields_and_is_called(self):
         calls = []

--- a/tests/scripts/test_evolution_trace_miner.py
+++ b/tests/scripts/test_evolution_trace_miner.py
@@ -64,7 +64,8 @@ class TestMineWeaknesses:
         assert len(recs) == 1 and recs[0]["tool"] == "browser"
 
     def test_no_raw_content_only_counts_and_labels(self):
-        # mined records carry only tool names, counts, and our labels.
+        # mined records carry only tool names, counts, our labels, and the
+        # deterministic diagnosis skeleton — never raw trace content.
         d = _digest(tool_failures={"terminal": 9}, provider_errors={"429:rate_limit": 9})
         blob = json.dumps(mine_weaknesses(d, min_count=5))
         assert "rate_limit" in blob  # the class label is fine
@@ -72,8 +73,22 @@ class TestMineWeaknesses:
         for r in mine_weaknesses(d, min_count=5):
             assert set(r).issubset(
                 {"kind", "tool", "occurrences", "severity", "label", "signature",
-                 "max_consecutive", "sessions"}
+                 "max_consecutive", "sessions", "diagnosis"}
             )
+
+    def test_diagnosis_skeleton_attached_per_kind(self):
+        # Each weakness carries a typed, component-scoped diagnosis skeleton.
+        d = _digest(
+            tool_failures={"terminal": 9},
+            provider_errors={"429:rate_limit": 9},
+            repeated={"browser_navigate": {"max_consecutive": 9, "sessions": 1}},
+        )
+        by_kind = {r["kind"]: r["diagnosis"] for r in mine_weaknesses(d, min_count=5)}
+        assert by_kind["tool_failure"]["component_scope"] == "tool_wrapper"
+        assert by_kind["provider_error"]["component_scope"] == "retry_policy"
+        assert by_kind["retry_spiral"]["component_scope"] == "retry_policy"
+        assert by_kind["retry_spiral"]["recommended_harness_surface"] == "retry_policy_change"
+        assert by_kind["tool_failure"]["severity"] == 9
 
 
 class TestFormat:


### PR DESCRIPTION
First coherent slice of #3209.

Adds a deterministic, component-scoped diagnosis skeleton to `evolution_trace_miner.py` and teaches `evolution_harness_proposer.py` to propagate that component scope and diagnosis-aware rationale into typed harness proposals (tool_guard, retry_policy_change).

Deferred (next increment):
- Trace-based validation harness: hold back a mini-batch of sessions and score each candidate harness update against it.
- Select only updates that generalize across sessions.
- Measure reduction in the target failure cluster over a 7-day window after a proposal lands.
