### PR TITLE
fix(process): accept 'stop' as an alias for 'kill' (Closes #3221)

### DIFF
--- a/tests/tools/test_process_schema_confusion.py
+++ b/tests/tools/test_process_schema_confusion.py
@@ -21,7 +21,6 @@ class TestSuggestProcessAction:
         ("run", "list"),
         ("status", "poll"),
         ("check", "poll"),
-        ("stop", "kill"),
         ("tail", "log"),
         ("read", "log"),
         ("send", "submit"),
@@ -40,7 +39,7 @@ class TestSuggestProcessAction:
 
     def test_valid_action_returns_none(self):
         """Valid actions don't need a suggestion."""
-        for action in ["list", "poll", "log", "wait", "kill", "write", "submit", "close"]:
+        for action in ["list", "poll", "log", "wait", "kill", "stop", "write", "submit", "close"]:
             # Valid actions may or may not return a suggestion — the
             # handler only calls _suggest_process_action for INVALID actions
             pass  # no assertion needed, just verify no crash
@@ -75,11 +74,26 @@ class TestHandleProcessInvalidAction:
 
     def test_invalid_action_synonym_mapped(self):
         """An invalid action synonym gets the right suggestion."""
-        result = _handle_process({"action": "stop"}, task_id="test")
+        result = _handle_process({"action": "delete"}, task_id="test")
         data = json.loads(result)
         assert "error" in data
         assert "kill" in data["error"]
         assert "Did you mean" in data["error"]
+
+    def test_stop_action_maps_to_kill(self):
+        """'stop' is now a valid alias for 'kill' (issue #3221)."""
+        with patch("tools.process_registry.process_registry") as mock_reg:
+            mock_reg.get.return_value = MagicMock(id="proc_abc")
+            mock_reg.kill_process.return_value = {"status": "ok", "session_id": "proc_abc"}
+            result = _handle_process(
+                {"action": "stop", "session_id": "proc_abc"},
+                task_id="test",
+            )
+            data = json.loads(result)
+            # Should dispatch to kill_process, not return an error
+            mock_reg.kill_process.assert_called_once_with("proc_abc")
+            assert "error" not in data
+            assert data.get("status") == "ok"
 
     def test_completely_unknown_action_lists_valid(self):
         """A completely unknown action still lists valid actions."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -3064,7 +3064,7 @@ PROCESS_SCHEMA = {
         "Manage background processes started with terminal(background=true). "
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
-        "'kill' (terminate), 'write' (send raw stdin data without newline), "
+        "'kill' (terminate), 'stop' (alias for kill), 'write' (send raw stdin data without newline), "
         "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
     ),
     "parameters": {
@@ -3072,7 +3072,7 @@ PROCESS_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close"],
+                "enum": ["list", "poll", "log", "wait", "kill", "stop", "write", "submit", "close"],
                 "description": "Action to perform on background processes"
             },
             "session_id": {
@@ -3134,7 +3134,7 @@ def _handle_process(args, **kw):
     # Coerce to string — some models send session_id as an integer
     session_id = str(args.get("session_id", "")) if args.get("session_id") is not None else ""
 
-    valid_actions = {"list", "poll", "log", "wait", "kill", "write", "submit", "close"}
+    valid_actions = {"list", "poll", "log", "wait", "kill", "stop", "write", "submit", "close"}
 
     if action == "list":
         # Surface session-scoped background processes (e.g. a forgotten
@@ -3214,7 +3214,7 @@ def _handle_process(args, **kw):
                 session_id, offset=args.get("offset"), limit=args.get("limit", 200))), ensure_ascii=False)
         elif action == "wait":
             return json.dumps(_redact_process_result(process_registry.wait(session_id, timeout=args.get("timeout"))), ensure_ascii=False)
-        elif action == "kill":
+        elif action in ("kill", "stop"):
             return json.dumps(
                 _redact_process_result(process_registry.kill_process(session_id)),
                 ensure_ascii=False,


### PR DESCRIPTION
Closes #3221

Models frequently invoke the process tool with action='stop' when they want to terminate a background process. The schema only allowed 'kill', so every 'stop' call produced an argument-validation error and wasted a turn before retrying.

This PR adds 'stop' to the process tool schema enum and dispatches it to the same handler as 'kill'.

Checks (local):
- Targeted tests: pytest tests/tools/test_process_schema_confusion.py tests/tools/test_process_registry.py (119 passed, 4 skipped)
- Blocking lint: ruff check . passed
- Pre-PR runner: python scripts/evolution_pre_pr_test_runner.py --changed-files tools/process_registry.py,tests/tools/test_process_schema_confusion.py passed
- Diff size: 28 changed lines (≤ 200 self-merge cap)