### PR TITLE
feat: typed failure classification on delegate_task dispatch (#3223 slice 1)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9386,7 +9386,7 @@ class AIAgent:
         #     gateway session the async result would route back to.
         # The schema-level `background` param is intentionally ignored here.
         _is_subagent = getattr(self, "_delegate_depth", 0) > 0
-        return _delegate_task(
+        result = _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=function_args.get("tasks"),
@@ -9399,6 +9399,24 @@ class AIAgent:
             message=function_args.get("message"),
             parent_agent=self,
         )
+        # #3223 slice 1 — attach a typed failure_class to failed dispatches so
+        # the parent sees a deterministic category (capability-blocked |
+        # provider-error | timeout) instead of only free-text error summaries.
+        # Background handles carry no result to classify here; their per-child
+        # results are surfaced on the completion path (follow-up #3225).
+        try:
+            from tools.delegate_failure_classifier import (
+                inject_delegate_failure_class,
+            )
+
+            payload = json.loads(result)
+            if isinstance(payload, dict) and inject_delegate_failure_class(payload):
+                result = json.dumps(payload, ensure_ascii=False)
+        except Exception:
+            # Never break dispatch on a classification failure — the raw result
+            # is still valid and the parent can act on it.
+            pass
+        return result
 
     def _invoke_tool(
         self,

--- a/tests/tools/test_delegate_failure_classifier.py
+++ b/tests/tools/test_delegate_failure_classifier.py
@@ -1,0 +1,78 @@
+"""Tests for the delegate_task failure classifier (#3223 slice 1)."""
+
+import json
+import unittest
+
+from tools.delegate_failure_classifier import (
+    DelegateFailureClass,
+    classify_delegate_failure,
+    inject_delegate_failure_class,
+)
+
+
+class TestClassifyDelegateFailure(unittest.TestCase):
+    def test_capability_blocked(self):
+        self.assertEqual(
+            classify_delegate_failure(error_text="Tool 'foo' is blocked by policy"),
+            DelegateFailureClass.capability_blocked,
+        )
+        self.assertEqual(
+            classify_delegate_failure(error_text="permission denied on resource"),
+            DelegateFailureClass.capability_blocked,
+        )
+
+    def test_provider_error(self):
+        self.assertEqual(
+            classify_delegate_failure(error_text="API provider returned 503"),
+            DelegateFailureClass.provider_error,
+        )
+        self.assertEqual(
+            classify_delegate_failure(error_text="rate limit hit"),
+            DelegateFailureClass.provider_error,
+        )
+
+    def test_timeout(self):
+        self.assertEqual(
+            classify_delegate_failure(error_text="Subagent timed out after 60s"),
+            DelegateFailureClass.timeout,
+        )
+
+    def test_unrecognised_returns_none(self):
+        self.assertIsNone(
+            classify_delegate_failure(error_text="Something weird happened")
+        )
+
+    def test_parses_json_string(self):
+        self.assertEqual(
+            classify_delegate_failure('{"error": "not installed"}'),
+            DelegateFailureClass.capability_blocked,
+        )
+
+
+class TestInjectDelegateFailureClass(unittest.TestCase):
+    def test_top_level_error(self):
+        payload = json.loads('{"error": "blocked by hardline policy"}')
+        self.assertTrue(inject_delegate_failure_class(payload))
+        self.assertEqual(payload["failure_class"], "capability-blocked")
+
+    def test_per_task_results(self):
+        payload = {
+            "results": [
+                {"task_index": 0, "status": "completed", "summary": "done"},
+                {"task_index": 1, "status": "error", "error": "provider 503"},
+                {"task_index": 2, "status": "error", "error": "timed out"},
+            ],
+            "total_duration_seconds": 5.0,
+        }
+        self.assertTrue(inject_delegate_failure_class(payload))
+        self.assertNotIn("failure_class", payload["results"][0])
+        self.assertEqual(payload["results"][1]["failure_class"], "provider-error")
+        self.assertEqual(payload["results"][2]["failure_class"], "timeout")
+
+    def test_noop_when_no_errors(self):
+        payload = {"results": [{"status": "completed"}]}
+        self.assertFalse(inject_delegate_failure_class(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_failure_classifier.py
+++ b/tools/delegate_failure_classifier.py
@@ -1,0 +1,137 @@
+"""Typed failure classification for delegate_task child dispatches (#3223 slice 1).
+
+This module mirrors the cross-tool ``tools/tool_failure_classifier.py`` but
+specialises on the *dispatch* layer: when a ``delegate_task`` child fails
+before or during execution, the parent receives a structured
+``failure_class`` drawn from a small, action-oriented vocabulary:
+
+- ``capability-blocked`` — child rejected pre-execution on environment /
+  capability grounds (missing tool, blocked tool, permission denied,
+  unconfigured dependency).
+- ``provider-error`` — upstream provider / API failure (rate limit, quota,
+  transient provider/network fault).
+- ``timeout`` — child exceeded its execution budget.
+
+The classifier is intentionally conservative.  A failure that does not match any
+class stays unclassified; successful dispatches are left untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class DelegateFailureClass(str, Enum):
+    """Structured failure classes for delegate_task dispatches."""
+
+    capability_blocked = "capability-blocked"
+    provider_error = "provider-error"
+    timeout = "timeout"
+
+
+# Ordered: more specific signals win over generic ones.
+_CAPABILITY_MARKERS = [
+    r"\bcapability\b",
+    r"\bblocked\b",
+    r"\bpermission denied\b",
+    r"\baccess denied\b",
+    r"\bforbidden\b",
+    r"\bnot available\b",
+    r"\bnot installed\b",
+    r"\bnot configured\b",
+    r"\bnot registered\b",
+    r"\bunknown command\b",
+    r"\bcommand not found\b",
+    r"\bno module named\b",
+    r"\btool_unavailable\b",
+]
+_PROVIDER_MARKERS = [
+    r"\bprovider\b",
+    r"\bapi error\b",
+    r"\brat(?:e[ _-])?limit\b",
+    r"\bquota\b",
+    r"\bbilling\b",
+    r"\btransient network\b",
+    r"\bconnection refused\b",
+    r"\bconnection reset\b",
+    r"\b429\b",
+    r"\b50[0-3]\b",
+    r"\b503\b",
+]
+_TIMEOUT_MARKERS = [
+    r"\btimed out\b",
+    r"\btimeout\b",
+]
+
+
+def _extract_error_text(data: Dict[str, Any]) -> str:
+    """Best-effort extraction of an error string from a delegate result payload."""
+    if isinstance(data, dict):
+        return str(data.get("error") or data.get("message") or "")
+    return ""
+
+
+def classify_delegate_failure(
+    result: Optional[str | Dict[str, Any]] = None,
+    *,
+    error_text: Optional[str] = None,
+) -> Optional[DelegateFailureClass]:
+    """Classify a failed delegate_task dispatch.
+
+    Accepts either the raw JSON result, a parsed payload, or an explicit error
+    text.  Returns ``None`` for unrecognised or empty input.
+    """
+    text = ""
+    if error_text is not None:
+        text = str(error_text)
+    elif isinstance(result, str):
+        try:
+            text = _extract_error_text(json.loads(result))
+        except Exception:
+            text = result
+    elif isinstance(result, dict):
+        text = _extract_error_text(result)
+
+    text = text.lower().strip()
+    if not text:
+        return None
+
+    if any(re.search(p, text) for p in _TIMEOUT_MARKERS):
+        return DelegateFailureClass.timeout
+    if any(re.search(p, text) for p in _CAPABILITY_MARKERS):
+        return DelegateFailureClass.capability_blocked
+    if any(re.search(p, text) for p in _PROVIDER_MARKERS):
+        return DelegateFailureClass.provider_error
+    return None
+
+
+def inject_delegate_failure_class(payload: Dict[str, Any]) -> bool:
+    """Mutate a parsed delegate_task result payload in place.
+
+    Adds ``failure_class`` to the top-level result for tool_error-style
+    failures and to each per-task ``results`` entry whose status is not
+    ``completed``.  Returns ``True`` if any classification was added.
+    """
+    changed = False
+    top_error = payload.get("error")
+    if top_error:
+        cls = classify_delegate_failure(error_text=top_error)
+        if cls is not None:
+            payload["failure_class"] = cls.value
+            changed = True
+
+    for entry in payload.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("status") == "completed":
+            continue
+        err = entry.get("error")
+        if err:
+            cls = classify_delegate_failure(error_text=err)
+            if cls is not None:
+                entry["failure_class"] = cls.value
+                changed = True
+    return changed


### PR DESCRIPTION
Adds a deterministic `failure_class` to failed `delegate_task` dispatches so the parent sees a structured category instead of only free-text error summaries.

### What changed
- New `tools/delegate_failure_classifier.py` with `DelegateFailureClass` enum and `classify_delegate_failure` / `inject_delegate_failure_class` helpers.
- `run_agent.py::_dispatch_delegate_task` now parses the returned JSON, injects `failure_class` into top-level error results and per-task `results[]` entries whose status is not `completed`, then re-serializes.
- Tests in `tests/tools/test_delegate_failure_classifier.py` (8 cases, all passing).

### Scope
- This is **slice 1** of issue #3223 (typed failure classification on `delegate_task`).
- Background dispatch handles carry no result to classify here; their per-child results are surfaced on the completion path in follow-up #3225.

### Risk / rollback
- No runtime schema or tool contract changes for successful dispatches.
- Classification is wrapped in a try/except so a classification failure never masks the raw result.
- Easy revert: remove the injected block in `_dispatch_delegate_task` and delete the classifier module.

Closes #3223.