### PR TITLE
feat: deterministic trigger matcher for skill ranking (#3229, #3210 slice 2)

### DIFF
--- a/evolution/lib/trigger_matcher.py
+++ b/evolution/lib/trigger_matcher.py
@@ -1,0 +1,189 @@
+"""Deterministic trigger matching for the skill library (#3229)."""
+
+from __future__ import annotations
+import re
+from typing import Any, List, Sequence, Tuple
+
+TYPES = ("goal_contains", "tool_used")
+DEFAULT_WEIGHT = 1.0
+_STOP = frozenset({
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "of",
+    "to",
+    "for",
+    "in",
+    "on",
+    "with",
+    "this",
+    "that",
+    "it",
+    "is",
+    "are",
+    "be",
+    "do",
+    "does",
+    "please",
+    "can",
+    "i",
+    "you",
+    "we",
+    "my",
+    "your",
+    "me",
+    "help",
+    "need",
+    "want",
+    "using",
+    "use",
+    "from",
+    "by",
+    "at",
+    "as",
+    "into",
+    "about",
+    "how",
+    "what",
+    "when",
+})
+
+
+def _tokens(text: str) -> List[str]:
+    return [w for w in re.split(r"[^a-zA-Z0-9]+", text.lower()) if w and w not in _STOP]
+
+
+def extract_triggers(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(trace, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    if (
+        isinstance(trace.get("goal"), str)
+        and (g := trace["goal"]).strip()
+        and (kw := _tokens(g))
+    ):
+        out.append({"type": "goal_contains", "values": kw, "weight": DEFAULT_WEIGHT})
+    calls = trace.get("tool_calls")
+    if isinstance(calls, list):
+        tools: list[str] = []
+        for c in calls:
+            n = c.get("name") if isinstance(c, dict) else None
+            if isinstance(n, str) and n and n not in tools:
+                tools.append(n)
+        if tools:
+            out.append({"type": "tool_used", "values": tools, "weight": 0.8})
+    return out
+
+
+def parse_triggers(skill_markdown: str) -> list[dict[str, Any]]:
+    if not isinstance(skill_markdown, str):
+        return []
+    lines = skill_markdown.splitlines()
+    fm = ""
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                fm = "\n".join(lines[1:i])
+                break
+    if not fm:
+        fm = skill_markdown
+    triggers: list[dict[str, Any]] = []
+    cur: dict[str, Any] | None = None
+    inside = False
+    for line in fm.splitlines():
+        s = line.strip()
+        if not inside:
+            if s.startswith("triggers:"):
+                inside = True
+            continue
+        if s.startswith("- "):
+            if cur is not None:
+                triggers.append(cur)
+            cur, s = (
+                {"type": None, "values": [], "weight": DEFAULT_WEIGHT},
+                s[2:].strip(),
+            )
+        if cur is None:
+            break
+        if ":" not in s:
+            continue
+        k, _, v = s.partition(":")
+        k, v = k.strip(), v.strip()
+        if k == "type":
+            cur["type"] = v.strip("'\"")
+        elif k == "weight":
+            try:
+                cur["weight"] = float(v)
+            except ValueError:
+                pass
+        elif k == "values":
+            cur["values"] = [
+                x.strip().strip("'\"") for x in v.strip("[]").split(",") if x.strip()
+            ]
+    if cur is not None:
+        triggers.append(cur)
+    return [t for t in triggers if t.get("type") in TYPES and t.get("values")]
+
+
+def render_triggers(triggers: Sequence[dict[str, Any]]) -> str:
+    if not triggers:
+        return ""
+    lines = ["triggers:"]
+    for t in triggers:
+        if (
+            not isinstance(t, dict)
+            or (tt := t.get("type")) not in TYPES
+            or not isinstance((vals := t.get("values")), list)
+            or not vals
+        ):
+            continue
+        lines.append(f"  - type: {tt}")
+        lines.append(f"    values: [{', '.join(str(v) for v in vals)}]")
+        lines.append(f"    weight: {float(t.get('weight', DEFAULT_WEIGHT)):g}")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def score_trigger(state: dict[str, Any], trigger: dict[str, Any]) -> float:
+    if not isinstance(state, dict) or not isinstance(trigger, dict):
+        return 0.0
+    tt, vals = trigger.get("type"), trigger.get("values")
+    if tt not in TYPES or not isinstance(vals, list) or not vals:
+        return 0.0
+    try:
+        w = float(trigger.get("weight", DEFAULT_WEIGHT))
+    except (TypeError, ValueError):
+        w = DEFAULT_WEIGHT
+    if tt == "goal_contains":
+        g = state.get("goal")
+        if not isinstance(g, str):
+            return 0.0
+        g = g.lower()
+        return w if any(isinstance(v, str) and v.lower() in g for v in vals) else 0.0
+    tools = state.get("tools_used")
+    if not isinstance(tools, list):
+        return 0.0
+    tset = {str(t).lower() for t in tools}
+    return w if any(isinstance(v, str) and v.lower() in tset for v in vals) else 0.0
+
+
+def best_matches(
+    state: dict[str, Any], skills: Sequence[dict[str, Any]], threshold: float = 0.7
+) -> list[tuple[str, float]]:
+    ranked: list[tuple[str, float]] = []
+    for skill in skills:
+        if not isinstance(skill, dict):
+            continue
+        name = skill.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        triggers = skill.get("triggers")
+        if not isinstance(triggers, list):
+            md = skill.get("skill_markdown")
+            triggers = parse_triggers(md) if isinstance(md, str) else []
+        best = max((score_trigger(state, t) for t in triggers), default=0.0)
+        if best >= threshold:
+            ranked.append((name, best))
+    ranked.sort(key=lambda p: (-p[1], p[0]))
+    return ranked

--- a/tests/evolution/test_trigger_matcher.py
+++ b/tests/evolution/test_trigger_matcher.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for evolution.lib.trigger_matcher (#3229)."""
+
+import pytest
+from evolution.lib.trigger_matcher import (
+    best_matches,
+    extract_triggers,
+    parse_triggers,
+    render_triggers,
+    score_trigger,
+)
+
+
+def _skill(name, triggers=None, md=None):
+    s = {"name": name}
+    if triggers is not None:
+        s["triggers"] = triggers
+    if md is not None:
+        s["skill_markdown"] = md
+    return s
+
+
+def _trig(ttype, values, weight=1.0):
+    return {"type": ttype, "values": values, "weight": weight}
+
+
+class TestExtractTriggers:
+    def test_extracts_goal_and_tools(self):
+        ts = extract_triggers({
+            "goal": "Run the database migration and verify indexes",
+            "tool_calls": [
+                {"name": "read_file"},
+                {"name": "terminal"},
+                {"name": "terminal"},
+            ],
+        })
+        assert any(t["type"] == "goal_contains" for t in ts)
+        tool_t = next(t for t in ts if t["type"] == "tool_used")
+        assert sorted(tool_t["values"]) == ["read_file", "terminal"]
+
+    def test_ignores_malformed_trace(self):
+        assert extract_triggers("not a dict") == []  # type: ignore[arg-type]
+        assert extract_triggers({"tool_calls": None}) == []
+        assert (
+            extract_triggers({
+                "goal": "The and of to in on a an can please help me with this"
+            })
+            == []
+        )
+
+
+class TestParseAndRenderTriggers:
+    def test_round_trip(self):
+        ts = [
+            _trig("goal_contains", ["migration", "index"]),
+            _trig("tool_used", ["terminal", "read_file"], 0.8),
+        ]
+        rendered = render_triggers(ts)
+        assert "triggers:" in rendered and "goal_contains" in rendered
+        assert parse_triggers(rendered) == ts
+
+    def test_parse_from_full_skill_markdown(self):
+        md = "---\nname: migrate-db\ntriggers:\n  - type: goal_contains\n    values: [migration, database]\n    weight: 1\n  - type: tool_used\n    values: [terminal, read_file]\n    weight: 0.8\n---\n# DB migration\n"
+        ts = parse_triggers(md)
+        assert len(ts) == 2
+        assert ts[0]["type"] == "goal_contains" and ts[0]["values"] == [
+            "migration",
+            "database",
+        ]
+        assert ts[1]["type"] == "tool_used"
+
+    def test_parse_empty_and_render_skips_invalid(self):
+        assert parse_triggers("no frontmatter") == []
+        assert parse_triggers("---\nname: x\n---\n") == []
+        rendered = render_triggers([
+            _trig("goal_contains", ["ok"]),
+            _trig("unknown_type", ["x"]),
+            _trig("goal_contains", []),
+        ])
+        assert "unknown_type" not in rendered and "ok" in rendered
+
+
+class TestScoreTrigger:
+    def test_goal_contains_fires(self):
+        assert (
+            score_trigger(
+                {"goal": "Migrate the database schema", "tools_used": []},
+                _trig("goal_contains", ["migrate", "schema"]),
+            )
+            == 1.0
+        )
+        assert score_trigger(
+            {"goal": "Migrate the database schema", "tools_used": []},
+            _trig("goal_contains", ["MIGRATE"], 0.9),
+        ) == pytest.approx(0.9)
+        assert score_trigger(
+            {"goal": "", "tools_used": ["terminal", "read_file"]},
+            _trig("tool_used", ["terminal"], 0.8),
+        ) == pytest.approx(0.8)
+        assert (
+            score_trigger(
+                {"goal": "Deploy web app", "tools_used": ["terminal"]},
+                _trig("goal_contains", ["migration"]),
+            )
+            == 0.0
+        )
+
+
+class TestBestMatches:
+    def test_ranks_by_best_trigger(self):
+        state = {"goal": "Migrate the database", "tools_used": ["terminal"]}
+        skills = [
+            _skill("db-migrate", [_trig("goal_contains", ["migrate"])]),
+            _skill("web-deploy", [_trig("goal_contains", ["deploy"])]),
+            _skill(
+                "db-verify",
+                md="---\ntriggers:\n  - type: goal_contains\n    values: [database]\n    weight: 0.9\n---\n# DB verify\n",
+            ),
+        ]
+        result = best_matches(state, skills, threshold=0.7)
+        assert [r[0] for r in result] == ["db-migrate", "db-verify"]
+        assert result[0][1] == 1.0 and result[1][1] == pytest.approx(0.9)
+        state2 = {"goal": "Migrate", "tools_used": []}
+        skills2 = [
+            _skill("exact", [_trig("goal_contains", ["migrate"])]),
+            _skill("weak", [_trig("goal_contains", ["not-here"], 0.6)]),
+        ]
+        assert best_matches(state2, skills2, threshold=0.7) == [("exact", 1.0)]
+        state3 = {"goal": "abc", "tools_used": []}
+        skills3 = [
+            _skill("zebra", [_trig("goal_contains", ["abc"])]),
+            _skill("apple", [_trig("goal_contains", ["abc"])]),
+        ]
+        assert [r[0] for r in best_matches(state3, skills3, threshold=0.7)] == [
+            "apple",
+            "zebra",
+        ]


### PR DESCRIPTION
- Implements standalone `evolution/lib/trigger_matcher.py` for deterministic skill matching.
- Adds dependency-free frontmatter parsing for `triggers:` blocks, including round-trip with `render_triggers`.
- Supports `goal_contains` and `tool_used` triggers with weighted scoring.
- Adds unit tests in `tests/evolution/test_trigger_matcher.py` (7 passing).
- No LLM/network usage; no raw trace content emitted.
- Module file is 189 lines, within the requested ≤200-line slice cap.
- Does not wire into `skill_crystallizer.py` per the rework brief.

Closes #3229
cc #3210