### PR TITLE
feat(memory): per-tier memory-tool injection dosage (Closes #75)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import inspect
 import threading
@@ -105,7 +106,10 @@ def memory_provider_tools_enabled(
 
         return any("memory" in resolve_toolset(name) for name in enabled_toolsets)
     except Exception:
-        logger.debug("Failed to resolve enabled toolsets for memory-provider tools", exc_info=True)
+        logger.debug(
+            "Failed to resolve enabled toolsets for memory-provider tools",
+            exc_info=True,
+        )
         return False
 
 
@@ -117,9 +121,7 @@ def inject_memory_provider_tools(agent: Any) -> int:
         return 0
 
     existing_tool_names = {
-        tool.get("function", {}).get("name")
-        for tool in tools
-        if isinstance(tool, dict)
+        tool.get("function", {}).get("name") for tool in tools if isinstance(tool, dict)
     }
     if not memory_provider_tools_enabled(
         getattr(agent, "enabled_toolsets", None),
@@ -138,6 +140,25 @@ def inject_memory_provider_tools(agent: Any) -> int:
         agent.valid_tool_names = valid_tool_names
 
     added = 0
+    # Memory dosage slices 1+2 (#75): per-tier injection profile. Cap how many
+    # memory-provider tool schemas are appended to the tool surface, tiered by
+    # model capability so small models are not flooded (slice 1: per-tier
+    # profile; slice 2: tiered caps rather than one global number). Override
+    # via EVOLUTION_MEMORY_TOOL_CAP.
+    _model = str(getattr(agent, "model", "") or "").lower()
+    try:
+        _cap = int(os.environ.get("EVOLUTION_MEMORY_TOOL_CAP", "") or 0)
+    except ValueError:
+        _cap = 0
+    if _cap <= 0:
+        if any(k in _model for k in ("mini", "flash", "small", "lite", "nano")):
+            _cap = 3
+        elif any(
+            k in _model for k in ("pro", "large", "sonnet", "opus", "turbo", "max")
+        ):
+            _cap = 8
+        else:
+            _cap = 6
     for raw_schema in get_schemas():
         schema = normalize_tool_schema(raw_schema)
         if schema is None:
@@ -154,6 +175,8 @@ def inject_memory_provider_tools(agent: Any) -> int:
         valid_tool_names.add(tool_name)
         existing_tool_names.add(tool_name)
         added += 1
+        if added >= _cap:  # (#75) per-tier injection cap
+            break
 
     return added
 
@@ -162,22 +185,22 @@ def inject_memory_provider_tools(agent: Any) -> int:
 # Context fencing helpers
 # ---------------------------------------------------------------------------
 
-_FENCE_TAG_RE = re.compile(r'</?\s*memory-context\s*>', re.IGNORECASE)
+_FENCE_TAG_RE = re.compile(r"</?\s*memory-context\s*>", re.IGNORECASE)
 _INTERNAL_CONTEXT_RE = re.compile(
-    r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
+    r"<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>",
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*|advisory context[^\]]*)\]\.\s*',
+    r"\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*|advisory context[^\]]*)\]\.\s*",
     re.IGNORECASE,
 )
 
 
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
-    text = _INTERNAL_CONTEXT_RE.sub('', text)
-    text = _INTERNAL_NOTE_RE.sub('', text)
-    text = _FENCE_TAG_RE.sub('', text)
+    text = _INTERNAL_CONTEXT_RE.sub("", text)
+    text = _INTERNAL_NOTE_RE.sub("", text)
+    text = _FENCE_TAG_RE.sub("", text)
     return text
 
 
@@ -242,16 +265,15 @@ class StreamingContextScrubber:
                     self._buf = buf[-held:] if held else ""
                     return "".join(out)
                 # Found close — skip span content + tag, continue
-                buf = buf[idx + len(self._CLOSE_TAG):]
+                buf = buf[idx + len(self._CLOSE_TAG) :]
                 self._in_span = False
             else:
                 idx = self._find_boundary_open_tag(buf)
                 if idx == -1:
                     # No open tag — hold back a potential partial open tag
-                    held = (
-                        self._max_pending_open_suffix(buf)
-                        or self._max_partial_suffix(buf, self._OPEN_TAG)
-                    )
+                    held = self._max_pending_open_suffix(
+                        buf
+                    ) or self._max_partial_suffix(buf, self._OPEN_TAG)
                     if held:
                         self._append_visible(out, buf[:-held])
                         self._buf = buf[-held:]
@@ -261,7 +283,7 @@ class StreamingContextScrubber:
                 # Emit text before the tag, enter span
                 if idx > 0:
                     self._append_visible(out, buf[:idx])
-                buf = buf[idx + len(self._OPEN_TAG):]
+                buf = buf[idx + len(self._OPEN_TAG) :]
                 self._in_span = True
 
         return "".join(out)
@@ -304,7 +326,9 @@ class StreamingContextScrubber:
             idx = buf_lower.find(self._OPEN_TAG, search_start)
             if idx == -1:
                 return -1
-            if self._is_block_boundary(buf, idx) and self._has_block_opener_suffix(buf, idx):
+            if self._is_block_boundary(buf, idx) and self._has_block_opener_suffix(
+                buf, idx
+            ):
                 return idx
             search_start = idx + 1
 
@@ -330,7 +354,7 @@ class StreamingContextScrubber:
         last_newline = preceding.rfind("\n")
         if last_newline == -1:
             return self._at_block_boundary and preceding.strip() == ""
-        return preceding[last_newline + 1:].strip() == ""
+        return preceding[last_newline + 1 :].strip() == ""
 
     def _append_visible(self, out: list[str], text: str) -> None:
         if not text:
@@ -341,7 +365,7 @@ class StreamingContextScrubber:
     def _update_block_boundary(self, text: str) -> None:
         last_newline = text.rfind("\n")
         if last_newline != -1:
-            self._at_block_boundary = text[last_newline + 1:].strip() == ""
+            self._at_block_boundary = text[last_newline + 1 :].strip() == ""
         else:
             self._at_block_boundary = self._at_block_boundary and text.strip() == ""
 
@@ -431,7 +455,8 @@ class MemoryManager:
                     "already registered. Only one external memory provider is "
                     "allowed at a time. Configure which one via memory.provider "
                     "in config.yaml.",
-                    provider.name, existing,
+                    provider.name,
+                    existing,
                 )
                 return
             self._has_external = True
@@ -460,7 +485,8 @@ class MemoryManager:
                     "Memory provider '%s' tool '%s' shadows a reserved core "
                     "tool name; registration ignored. Core tools always win — "
                     "rename the provider's tool to something unique.",
-                    provider.name, tool_name,
+                    provider.name,
+                    tool_name,
                 )
                 continue
             if tool_name and tool_name not in self._tool_to_provider:
@@ -509,7 +535,8 @@ class MemoryManager:
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' system_prompt_block() failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
         return "\n\n".join(blocks)
 
@@ -554,7 +581,9 @@ class MemoryManager:
 
             record_id = f"memory:{provider_name}"
             self._pending_retrievals.append((record_id, session_id))
-            record_retrieval(record_id, retrieval_context=query[:200], session_id=session_id)
+            record_retrieval(
+                record_id, retrieval_context=query[:200], session_id=session_id
+            )
         except Exception as e:
             logger.debug("retrieval-utility logging failed (non-fatal): %s", e)
 
@@ -580,9 +609,13 @@ class MemoryManager:
                 friction_signals = event.friction_signals or {}
             outcome = derive_outcome(friction_signals)
             for record_id, _session_id in self._pending_retrievals:
-                record_outcome(record_id, outcome=outcome, friction_signals=friction_signals)
+                record_outcome(
+                    record_id, outcome=outcome, friction_signals=friction_signals
+                )
         except Exception as e:
-            logger.debug("retrieval-utility outcome recording failed (non-fatal): %s", e)
+            logger.debug(
+                "retrieval-utility outcome recording failed (non-fatal): %s", e
+            )
         finally:
             self._pending_retrievals.clear()
 
@@ -623,7 +656,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' recall_status failed (non-fatal): %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
                 continue
             if status is None:
@@ -649,7 +683,9 @@ class MemoryManager:
         parts = []
         for provider in self._providers:
             try:
-                result = self._prefetch_provider(provider, clean_query, session_id=session_id)
+                result = self._prefetch_provider(
+                    provider, clean_query, session_id=session_id
+                )
                 if result and result.strip():
                     parts.append(result)
                     # Retrieval-utility logging (#1480): record that this
@@ -661,7 +697,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
         return "\n\n".join(parts)
 
@@ -676,7 +713,9 @@ class MemoryManager:
 
         def _run() -> None:
             try:
-                result_box["value"] = provider.prefetch(query, session_id=session_id) or ""
+                result_box["value"] = (
+                    provider.prefetch(query, session_id=session_id) or ""
+                )
             except Exception as exc:  # pragma: no cover - re-raised by caller
                 error_box["value"] = exc
 
@@ -737,7 +776,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' recall_status failed (non-fatal): %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
                 continue
             if status is None:
@@ -774,7 +814,8 @@ class MemoryManager:
                 except Exception as e:
                     logger.debug(
                         "Memory provider '%s' queue_prefetch failed (non-fatal): %s",
-                        provider.name, e,
+                        provider.name,
+                        e,
                     )
 
         self._submit_background(_run, kind="prefetch")
@@ -827,14 +868,28 @@ class MemoryManager:
         # human_corrections: correction-like user phrasing.
         if user_content:
             u = user_content.lower()
-            correction_markers = ("no,", "wrong", "actually", "instead", "not that", "redo")
+            correction_markers = (
+                "no,",
+                "wrong",
+                "actually",
+                "instead",
+                "not that",
+                "redo",
+            )
             if any(m in u for m in correction_markers):
                 signals["human_corrections"] = 1
 
         # task_failures: assistant output that looks like a failure.
         if assistant_content:
             a = assistant_content.lower()
-            failure_markers = ("sorry", "i can't", "i cannot", "failed", "error", "unable to")
+            failure_markers = (
+                "sorry",
+                "i can't",
+                "i cannot",
+                "failed",
+                "error",
+                "unable to",
+            )
             if any(m in a for m in failure_markers):
                 signals["task_failures"] = 1
 
@@ -850,9 +905,11 @@ class MemoryManager:
                     for tc in msg["tool_calls"]:
                         if not isinstance(tc, dict):
                             continue
-                        fn = (tc.get("function") or {}).get("name", "") if isinstance(
-                            tc.get("function"), dict
-                        ) else ""
+                        fn = (
+                            (tc.get("function") or {}).get("name", "")
+                            if isinstance(tc.get("function"), dict)
+                            else ""
+                        )
                         if fn == "memory":
                             saves += 1
                 if role == "tool":
@@ -1003,9 +1060,7 @@ class MemoryManager:
                 messages=messages,
             )
         except Exception as e:
-            logger.debug(
-                "score_memories() failed during sync (non-fatal): %s", e
-            )
+            logger.debug("score_memories() failed during sync (non-fatal): %s", e)
             event = None
 
         # Retrieval-utility outcome recording (#1480): if any retrievals
@@ -1020,7 +1075,9 @@ class MemoryManager:
         def _run() -> None:
             for provider in providers:
                 try:
-                    if messages is not None and self._provider_sync_accepts_messages(provider):
+                    if messages is not None and self._provider_sync_accepts_messages(
+                        provider
+                    ):
                         provider.sync_turn(
                             user_content,
                             assistant_content,
@@ -1036,7 +1093,8 @@ class MemoryManager:
                 except Exception as e:
                     logger.warning(
                         "Memory provider '%s' sync_turn failed: %s",
-                        provider.name, e,
+                        provider.name,
+                        e,
                     )
 
         self._submit_background(_run)
@@ -1061,7 +1119,9 @@ class MemoryManager:
         executor = self._get_sync_executor()
         if executor is None:
             if self._shutting_down:
-                logger.warning("Memory manager is shutting down; rejecting late %s task", kind)
+                logger.warning(
+                    "Memory manager is shutting down; rejecting late %s task", kind
+                )
                 return
             # Creation failure outside shutdown: preserve the historical
             # fail-safe behavior and run the operation inline.
@@ -1076,14 +1136,18 @@ class MemoryManager:
             # completed future invokes callbacks synchronously.
             with self._sync_executor_lock:
                 if self._shutting_down:
-                    logger.warning("Memory manager is shutting down; rejecting late %s task", kind)
+                    logger.warning(
+                        "Memory manager is shutting down; rejecting late %s task", kind
+                    )
                     return
                 future = executor.submit(fn)
                 self._background_futures[future] = kind
             future.add_done_callback(self._forget_background_future)
         except RuntimeError:
             if self._shutting_down:
-                logger.warning("Memory manager shut down during %s submission; task rejected", kind)
+                logger.warning(
+                    "Memory manager shut down during %s submission; task rejected", kind
+                )
                 return
             try:
                 fn()
@@ -1108,6 +1172,7 @@ class MemoryManager:
                     # Daemon workers (see tools.daemon_pool): a provider wedged
                     # on a network call must never block interpreter exit.
                     from tools.daemon_pool import DaemonThreadPoolExecutor
+
                     self._sync_executor = DaemonThreadPoolExecutor(
                         max_workers=1,
                         thread_name_prefix="mem-sync",
@@ -1163,7 +1228,8 @@ class MemoryManager:
                         logger.warning(
                             "Memory provider '%s' returned a tool schema with "
                             "no resolvable name; skipping (%r)",
-                            provider.name, raw_schema,
+                            provider.name,
+                            raw_schema,
                         )
                         continue
                     name = schema["name"]
@@ -1175,7 +1241,8 @@ class MemoryManager:
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' get_tool_schemas() failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
         return schemas
 
@@ -1187,9 +1254,7 @@ class MemoryManager:
         """Check if any provider handles this tool."""
         return tool_name in self._tool_to_provider
 
-    def handle_tool_call(
-        self, tool_name: str, args: Dict[str, Any], **kwargs
-    ) -> str:
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         """Route a tool call to the correct provider.
 
         Returns JSON string result. Raises ValueError if no provider
@@ -1203,7 +1268,9 @@ class MemoryManager:
         except Exception as e:
             logger.error(
                 "Memory provider '%s' handle_tool_call(%s) failed: %s",
-                provider.name, tool_name, e,
+                provider.name,
+                tool_name,
+                e,
             )
             return tool_error(f"Memory tool '{tool_name}' failed: {e}")
 
@@ -1220,7 +1287,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_turn_start failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
@@ -1231,7 +1299,8 @@ class MemoryManager:
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' on_session_end failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                     exc_info=True,
                 )
 
@@ -1270,7 +1339,9 @@ class MemoryManager:
         def _run() -> None:
             try:
                 self.on_session_end(snapshot)
-            except Exception as e:  # pragma: no cover - on_session_end guards per-provider
+            except (
+                Exception
+            ) as e:  # pragma: no cover - on_session_end guards per-provider
                 logger.warning("Session-boundary extraction failed: %s", e)
             try:
                 self.on_session_switch(
@@ -1279,7 +1350,9 @@ class MemoryManager:
                     reset=True,
                     reason=reason,
                 )
-            except Exception as e:  # pragma: no cover - on_session_switch guards per-provider
+            except (
+                Exception
+            ) as e:  # pragma: no cover - on_session_switch guards per-provider
                 logger.warning("Session-boundary switch failed: %s", e)
 
         self._submit_background(_run)
@@ -1329,7 +1402,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_session_switch failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
 
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
@@ -1347,7 +1421,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_pre_compress failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
         return "\n\n".join(parts)
 
@@ -1366,8 +1441,10 @@ class MemoryManager:
             return "keyword"
 
         accepted = [
-            p for p in params
-            if p.kind in {
+            p
+            for p in params
+            if p.kind
+            in {
                 inspect.Parameter.POSITIONAL_ONLY,
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 inspect.Parameter.KEYWORD_ONLY,
@@ -1398,13 +1475,16 @@ class MemoryManager:
                         action, target, content, metadata=dict(metadata or {})
                     )
                 elif metadata_mode == "positional":
-                    provider.on_memory_write(action, target, content, dict(metadata or {}))
+                    provider.on_memory_write(
+                        action, target, content, dict(metadata or {})
+                    )
                 else:
                     provider.on_memory_write(action, target, content)
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_memory_write failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
 
     # Actions the bridge mirrors to external providers. The built-in memory
@@ -1462,11 +1542,13 @@ class MemoryManager:
         if isinstance(operations, list) and operations:
             raw_operations = operations
         else:
-            raw_operations = [{
-                "action": tool_args.get("action"),
-                "content": tool_args.get("content"),
-                "old_text": tool_args.get("old_text"),
-            }]
+            raw_operations = [
+                {
+                    "action": tool_args.get("action"),
+                    "content": tool_args.get("content"),
+                    "old_text": tool_args.get("old_text"),
+                }
+            ]
 
         for op in raw_operations:
             if not isinstance(op, dict):
@@ -1545,7 +1627,9 @@ class MemoryManager:
         notes.extend(self._entries_to_notes(store.user_entries, target="user"))
         return notes
 
-    def check_staleness(self, *, config: Optional[Dict[str, Any]] = None) -> "StalenessReport":
+    def check_staleness(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> "StalenessReport":
         """Run staleness detection over the current memory corpus (#797).
 
         This is the real consumer of :func:`agent.memory_staleness.analyze`:
@@ -1563,7 +1647,9 @@ class MemoryManager:
         notes = self.collect_notes()
         return analyze(notes, config=config)
 
-    def render_staleness_report(self, *, config: Optional[Dict[str, Any]] = None) -> str:
+    def render_staleness_report(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> str:
         """Run :meth:`check_staleness` and render the result as markdown.
 
         Convenience wrapper for the CLI ``hermes memory stale`` subcommand and
@@ -1610,8 +1696,9 @@ class MemoryManager:
 
         return render_conflict_report(self.detect_memory_conflicts(config=config))
 
-    def on_delegation(self, task: str, result: str, *,
-                      child_session_id: str = "", **kwargs) -> None:
+    def on_delegation(
+        self, task: str, result: str, *, child_session_id: str = "", **kwargs
+    ) -> None:
         """Notify all providers that a subagent completed."""
         for provider in self._providers:
             try:
@@ -1621,7 +1708,8 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_delegation failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
 
     def shutdown_all(self) -> None:
@@ -1640,7 +1728,8 @@ class MemoryManager:
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' shutdown failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
 
     @property
@@ -1713,6 +1802,7 @@ class MemoryManager:
         """
         if "hermes_home" not in kwargs:
             from hermes_constants import get_hermes_home
+
             kwargs["hermes_home"] = str(get_hermes_home())
         for provider in self._providers:
             try:
@@ -1720,5 +1810,6 @@ class MemoryManager:
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )


### PR DESCRIPTION
Automated evolution PR for #75 (rework r4 — memory dosage slices 1+2).

**Rework decision (documented):** the previous review brief demanded fixing a
config key-path mismatch (`memory_injection` read at top level in
`agent/agent_init.py` vs defined under `agent` in `config_defaults.py`). That
target is MOOT on current main: `git log -S memory_injection` shows the
config-based dosage feature **never landed on main** — the key does not exist
anywhere in `agent/` or `hermes_cli/`. There is no config path to fix.

**This PR implements the issue's decomposition slices 1+2 at the real
injection site** (`inject_memory_provider_tools`, called at session start from
`agent/agent_init.py:1978`):
- Per-tier injection profile: how many memory-provider tool schemas get
  appended to the tool surface is capped by model capability (mini/flash/small
  = 3, default = 6, pro/large = 8).
- Tiered caps rather than one global number; operator override via
  `EVOLUTION_MEMORY_TOOL_CAP` (internal escape hatch, precedent:
  `SKILL_TRUSTED_SOURCES` in tools/skills_tool.py).
- Prompt-cache safe: cap is computed once at session start, does not mutate
  mid-conversation.

Validation: `ruff check` clean, `ruff format --check` clean,
`tests/agent/test_memory_provider.py` 67 passed.
