### PR TITLE
fix(memory): contradiction detector generic-token stopwords (Closes #121)

### DIFF
--- a/agent/memory_contradiction.py
+++ b/agent/memory_contradiction.py
@@ -294,12 +294,15 @@ def detect_contradictions(
         if stored_negated == obs_negated:
             continue
         shared = obs_tokens & _content_tokens(stored_text)
-        # Require at least THREE shared content tokens (#121). A single token
-        # is usually a common predicate; two still fires on unrelated
-        # observations sharing a generic subject + common predicate (the
-        # over-fire that produced 1,090 warnings in 3 days). Three shared
-        # tokens means subject AND claim overlap on distinctive content.
-        if len(shared) < 3:
+        # Require at least TWO shared content tokens. A single shared token is
+        # usually a common predicate ("sleeping") with different subjects —
+        # "the cat is sleeping" vs "the dog is not sleeping" is NOT a
+        # contradiction. Two+ shared tokens means subject AND claim overlap.
+        # (Generic context tokens that co-occur across unrelated observations
+        # are handled by the #121 stopword list above, NOT by raising this bar —
+        # subject+claim pairs like "nas healthy" vs "nas not healthy" are
+        # genuine contradictions and must still fire with two shared tokens.)
+        if len(shared) < 2:
             continue
         if obs_negated:
             reason = (
@@ -311,7 +314,7 @@ def detect_contradictions(
                 "new observation conflicts with a negated claim in stored memory "
                 f"(shared subject: {', '.join(sorted(shared))})"
             )
-        confidence = min(0.9, 0.55 + 0.05 * min(len(shared), 6))
+        confidence = min(0.9, 0.6 + 0.05 * min(len(shared), 6))
         flags.append(
             ContradictionFlag(
                 event_id=event.event_id,

--- a/agent/memory_contradiction.py
+++ b/agent/memory_contradiction.py
@@ -146,6 +146,28 @@ _STOPWORDS = frozenset({
     "not",
     "no",
     "never",
+    # Generic entity/context tokens (#121): co-occur across unrelated
+    # observations (system state lines, pipeline logs) and make the shared
+    # token bar fire on noise. Treated as polarity-neutral.
+    "system",
+    "pipeline",
+    "memory",
+    "data",
+    "user",
+    "agent",
+    "time",
+    "day",
+    "morning",
+    "evening",
+    "yesterday",
+    "today",
+    "job",
+    "task",
+    "message",
+    "session",
+    "log",
+    "status",
+    "error",
 })
 
 #: Tokens that look like negation fragments even after tokenize() mangling
@@ -272,11 +294,12 @@ def detect_contradictions(
         if stored_negated == obs_negated:
             continue
         shared = obs_tokens & _content_tokens(stored_text)
-        # Require at least TWO shared content tokens. A single shared token is
-        # usually a common predicate ("sleeping") with different subjects —
-        # "the cat is sleeping" vs "the dog is not sleeping" is NOT a
-        # contradiction. Two+ shared tokens means subject AND claim overlap.
-        if len(shared) < 2:
+        # Require at least THREE shared content tokens (#121). A single token
+        # is usually a common predicate; two still fires on unrelated
+        # observations sharing a generic subject + common predicate (the
+        # over-fire that produced 1,090 warnings in 3 days). Three shared
+        # tokens means subject AND claim overlap on distinctive content.
+        if len(shared) < 3:
             continue
         if obs_negated:
             reason = (
@@ -288,7 +311,7 @@ def detect_contradictions(
                 "new observation conflicts with a negated claim in stored memory "
                 f"(shared subject: {', '.join(sorted(shared))})"
             )
-        confidence = min(0.9, 0.6 + 0.05 * min(len(shared), 6))
+        confidence = min(0.9, 0.55 + 0.05 * min(len(shared), 6))
         flags.append(
             ContradictionFlag(
                 event_id=event.event_id,


### PR DESCRIPTION
Automated evolution PR for #121.

**Problem:** the contradiction detector over-fires on unrelated observations
that share generic context tokens — 903 warnings in one day (1,090 per the
analysis window), risking wrong memory rewrites and flooding logs.

**Root cause:** the generic-token stopword list was too thin. Tokens like
`system`, `pipeline`, `memory`, `data`, `user`, `agent`, `time`, `job`,
`task`, `session`, `log`, `status`, `error` co-occur across unrelated system
state / pipeline log lines, so unrelated observations pass the shared-token
bar and get flagged as contradictions.

**Fix:** 19 new polarity-neutral stopwords. The shared-token bar stays at 2 —
subject+claim pairs like "nas healthy" vs "nas not healthy" are *genuine*
contradictions and must keep firing (the analysis-stage draft raised the bar
to 3; tests showed that suppresses real detection, so this PR deliberately
keeps the bar and fixes the noise at the token level instead).

Validation: `tests/agent/test_memory_contradiction.py` +
`test_memory_conflicts.py` 47 passed; `ruff check` + `ruff format --check` clean.
