### PR TITLE
feat: quarantine redacted issue bodies with metadata (Closes #3236)

### DIFF
--- a/scripts/redact_pii.py
+++ b/scripts/redact_pii.py
@@ -11,12 +11,23 @@ Usage::
     # exit 0  → clean, safe to publish
     # exit 1  → blocked; stderr shows the redaction reason(s)
 
+With quarantine (evolution pipeline mode)::
+
+    $ printf '%s' "$BODY" | python scripts/redact_pii.py \
+    $     --quarantine-dir ~/.hermes/evolution/quarantine \
+    $     --slug "issue-123-proposal"
+    # exit 0 → clean, stdout = redacted body (unchanged if clean)
+    # exit 1 → blocked, stdout = redacted body, quarantine file written,
+    #          stderr = JSON with path and reasons
+
 Exit codes
 ----------
 0  Clean — no sensitive patterns found.
 1  Blocked — one or more sensitive patterns were detected. The filtered text
    is written to stdout and the reasons to stderr, so a wrapper can abort the
-   ``gh issue create`` call.
+   ``gh issue create`` call. When ``--quarantine-dir`` is given, a blocked
+   input is also written to a quarantine file for human review.
+2  Usage / IO error (e.g. cannot read file or write quarantine).
 
 Patterns
 --------
@@ -35,8 +46,13 @@ Author: Hermes Evolution
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
 
 # Redacted replacement token — deterministic, so diffs remain stable.
 _REDACTED = "[REDACTED]"
@@ -122,15 +138,80 @@ def redact(text: str) -> tuple[str, list[str]]:
     return out, reasons
 
 
+def _safe_slug(raw: str) -> str:
+    """Collapse a title into a filesystem-safe slug."""
+    out = re.sub(r"[^\w._-]+", "-", raw)
+    out = re.sub(r"-+", "-", out).strip("-.")
+    if not out:
+        out = "blocked"
+    # Keep length bounded; quarantine filenames are human-readable, not DB keys.
+    return out[:80]
+
+
+def _write_quarantine(
+    quarantine_dir: Path,
+    slug: str,
+    cleaned: str,
+    reasons: list[str],
+) -> Optional[Path]:
+    """Write a blocked body to quarantine and return the path, or None on failure.
+
+    The file contains the redacted body plus a YAML-ish metadata header so a
+    human reviewer can see what triggered the gate without re-running the
+    detector. Returns ``None`` if the directory cannot be created or written.
+    """
+    try:
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+        path = quarantine_dir / f"{timestamp}_{slug}.md"
+        header_lines = [
+            "# Quarantined evolution issue body",
+            "",
+            f"**slug:** {slug}",
+            f"**timestamp:** {timestamp}Z",
+            f"**matched_patterns:** {len(reasons)}",
+            "**redaction_reasons:**",
+        ]
+        for reason in reasons:
+            header_lines.append(f"  - {reason}")
+        header_lines.extend(["", "---", ""])
+        path.write_text("\n".join(header_lines) + cleaned, encoding="utf-8")
+        return path
+    except OSError:
+        return None
+
+
 def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Mechanical PII/secret redaction gate.",
+        usage=(
+            "%(prog)s [--quarantine-dir DIR --slug SLUG] [FILE]\n"
+            "       %(prog)s < input.txt"
+        ),
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Optional file to read; otherwise stdin is read.",
+    )
+    parser.add_argument(
+        "--quarantine-dir",
+        dest="quarantine_dir",
+        help="Directory where blocked inputs are written for human review.",
+    )
+    parser.add_argument(
+        "--slug",
+        help="Human-readable slug for the quarantine filename (default: blocked).",
+    )
+    args = parser.parse_args(argv[1:])
+
     src = sys.stdin.read()
-    if argv[1:]:
-        path = argv[1]
+    if args.path:
         try:
-            with open(path, "r", encoding="utf-8") as fh:
+            with open(args.path, "r", encoding="utf-8") as fh:
                 src = fh.read()
         except OSError as exc:
-            print(f"[redact-pii] error reading {path}: {exc}", file=sys.stderr)
+            print(f"[redact-pii] error reading {args.path}: {exc}", file=sys.stderr)
             return 2
 
     cleaned, reasons = redact(src)
@@ -143,6 +224,22 @@ def main(argv: list[str]) -> int:
         )
         for r in reasons:
             print(f"  • {r}", file=sys.stderr)
+
+        qpath: Optional[Path] = None
+        if args.quarantine_dir:
+            qdir = Path(args.quarantine_dir).expanduser()
+            slug = _safe_slug(args.slug or "blocked")
+            qpath = _write_quarantine(qdir, slug, cleaned, reasons)
+            if qpath is None:
+                print(
+                    "[redact-pii] ERROR: could not write quarantine file",
+                    file=sys.stderr,
+                )
+                return 2
+            print(
+                json.dumps({"quarantine_path": str(qpath), "reasons": reasons}),
+                file=sys.stderr,
+            )
         return 1
     return 0
 

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -170,10 +170,17 @@ if [ -z "$RPII" ]; then
   exit 1
 fi
 
+# Ensure a quarantine directory exists so blocked issues are preserved for review.
+QUARANTINE_DIR="${HERMES_HOME:-$HOME/.hermes}/evolution/quarantine"
+mkdir -p "$QUARANTINE_DIR"
+
 BODY="<issue body markdown>"
-CLEANED=$(printf '%s' "$BODY" | python3 "$RPII")
-if [ $? -ne 0 ]; then
-  echo "BLOCKED by PII gate — issue body contained sensitive data"
+SLUG="$(printf '%s' "$TITLE" | tr -cs '[:alnum:]._' '-')"
+CLEANED=$(printf '%s' "$BODY" | python3 "$RPII" --quarantine-dir "$QUARANTINE_DIR" --slug "$SLUG")
+RPII_RC=$?
+if [ $RPII_RC -ne 0 ]; then
+  echo "BLOCKED by PII gate — issue body contained sensitive data (quarantine: $QUARANTINE_DIR)"
+  # Do NOT file the issue. The quarantine file is written; a human can review it.
   continue
 fi
 BODY="$CLEANED"

--- a/skills/evolution/evolution-issues/SKILL.md
+++ b/skills/evolution/evolution-issues/SKILL.md
@@ -170,17 +170,10 @@ if [ -z "$RPII" ]; then
   exit 1
 fi
 
-# Ensure a quarantine directory exists so blocked issues are preserved for review.
-QUARANTINE_DIR="${HERMES_HOME:-$HOME/.hermes}/evolution/quarantine"
-mkdir -p "$QUARANTINE_DIR"
-
 BODY="<issue body markdown>"
-SLUG="$(printf '%s' "$TITLE" | tr -cs '[:alnum:]._' '-')"
-CLEANED=$(printf '%s' "$BODY" | python3 "$RPII" --quarantine-dir "$QUARANTINE_DIR" --slug "$SLUG")
-RPII_RC=$?
-if [ $RPII_RC -ne 0 ]; then
-  echo "BLOCKED by PII gate — issue body contained sensitive data (quarantine: $QUARANTINE_DIR)"
-  # Do NOT file the issue. The quarantine file is written; a human can review it.
+CLEANED=$(printf '%s' "$BODY" | python3 "$RPII")
+if [ $? -ne 0 ]; then
+  echo "BLOCKED by PII gate — issue body contained sensitive data"
   continue
 fi
 BODY="$CLEANED"

--- a/tests/scripts/test_redact_pii.py
+++ b/tests/scripts/test_redact_pii.py
@@ -13,15 +13,18 @@ SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "redact_pii.py"
 # The concatenated results still match redact_pii's detection regexes.
 FAKE_SK_TOKEN = "sk-" + "abcdefghijklmnopqrstuvwxyz"
 FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE"  # AWS docs example key id
-FAKE_HEX_BLOB = "aabbccdd112233445566778899" + "aabbccddeeff00112233445566778899aabbccdd"
+FAKE_HEX_BLOB = (
+    "aabbccdd112233445566778899" + "aabbccddeeff00112233445566778899aabbccdd"
+)
 FAKE_GHP_TOKEN = "ghp_" + "x" * 36
 FAKE_HEX_SHORT = "deadbeef" + "0123456789abcdef" * 2
 
 
-def _run(text: str) -> tuple[int, str, str]:
+def _run(text: str, extra_args: list[str] | None = None) -> tuple[int, str, str]:
     assert SCRIPT.exists()
+    cmd = [sys.executable, str(SCRIPT), *(extra_args or [])]
     proc = subprocess.run(
-        [sys.executable, str(SCRIPT)],
+        cmd,
         input=text,
         capture_output=True,
         text=True,
@@ -99,3 +102,101 @@ class TestRedactPiiViaStdin:
         assert lines[0] == "line1"
         assert "[REDACTED]" in lines[1]
         assert lines[2] == "line3"
+
+
+class TestRedactPiiQuarantine:
+    def test_blocked_body_is_quarantined(self, tmp_path: Path):
+        qdir = tmp_path / "quarantine"
+        slug = "proposal-test-feature"
+        body = (
+            "Contact me at alice@example.com, my token is sk-"
+            + "x" * 32
+            + ", and my home is /home/bob/projects."
+        )
+        rc, out, err = _run(
+            body, extra_args=["--quarantine-dir", str(qdir), "--slug", slug]
+        )
+        assert rc == 1
+        # stdout is the redacted body
+        assert "alice@example.com" not in out
+        assert "[REDACTED]" in out
+        # quarantine file was created
+        files = list(qdir.iterdir())
+        assert len(files) == 1
+        qfile = files[0]
+        assert qfile.suffix == ".md"
+        assert slug in qfile.name
+        content = qfile.read_text(encoding="utf-8")
+        assert "# Quarantined evolution issue body" in content
+        # Reasons are recorded in the file (non-empty).
+        assert "redaction_reasons:" in content
+        # Raw secrets and home path do not leak into the quarantine file either.
+        assert "alice@example.com" not in content
+        assert "/home/bob/projects" not in content
+        assert "sk-" + "x" * 32 not in content
+        # stderr carries structured metadata for logging.
+        assert "quarantine_path" in err
+        assert qfile.name in err
+
+    def test_clean_body_does_not_create_quarantine(self, tmp_path: Path):
+        qdir = tmp_path / "quarantine"
+        rc, out, err = _run(
+            "A plain description of a memory handling bug.",
+            extra_args=["--quarantine-dir", str(qdir), "--slug", "clean"],
+        )
+        assert rc == 0
+        # Clean bodies never create the quarantine dir — assert non-existence,
+        # not "dir exists but is empty" (iterdir() would raise FileNotFoundError).
+        assert not qdir.exists()
+        assert "quarantine_path" not in err
+
+    def test_missing_slug_uses_default(self, tmp_path: Path):
+        qdir = tmp_path / "quarantine"
+        rc, out, err = _run(
+            "Internal IP 192.168.1.1",
+            extra_args=["--quarantine-dir", str(qdir)],
+        )
+        assert rc == 1
+        files = list(qdir.iterdir())
+        assert len(files) == 1
+        assert "blocked" in files[0].name
+
+    def test_quarantine_dir_is_created(self, tmp_path: Path):
+        qdir = tmp_path / "deep" / "quarantine"
+        rc, out, err = _run(
+            "email here dave@example.org",
+            extra_args=["--quarantine-dir", str(qdir), "--slug", "nested"],
+        )
+        assert rc == 1
+        assert qdir.exists()
+        assert len(list(qdir.iterdir())) == 1
+
+    def test_quarantine_covers_acceptance_patterns(self, tmp_path: Path):
+        """Regression for the PII gate acceptance criteria (#3236)."""
+        qdir = tmp_path / "quarantine"
+        samples = [
+            ("email@example.com", "Email"),
+            ("/home/alice/config.yaml", "Absolute home path"),
+            ("server at 10.0.0.1", "Private IPv4"),
+            ("github token gho_" + "1" * 36, "GitHub token"),
+            ("secretKey=" + "a" * 48, "Generic secret"),
+        ]
+        for sample, expected_reason in samples:
+            rc, out, err = _run(
+                sample,
+                extra_args=[
+                    "--quarantine-dir",
+                    str(qdir),
+                    "--slug",
+                    expected_reason.lower().replace(" ", "-"),
+                ],
+            )
+            assert rc == 1, f"{sample} should be blocked"
+            files = list(qdir.iterdir())
+            assert files, f"{sample} should be quarantined"
+            content = files[-1].read_text(encoding="utf-8")
+            assert expected_reason in content, f"{sample}: expected {expected_reason}"
+            # raw sample must not survive in the quarantine file
+            assert sample not in content
+            # remove the file for the next sample to keep directory clean
+            files[-1].unlink()

--- a/tests/scripts/test_redact_pii.py
+++ b/tests/scripts/test_redact_pii.py
@@ -161,16 +161,6 @@ class TestRedactPiiQuarantine:
         assert len(files) == 1
         assert "blocked" in files[0].name
 
-    def test_quarantine_dir_is_created(self, tmp_path: Path):
-        qdir = tmp_path / "deep" / "quarantine"
-        rc, out, err = _run(
-            "email here dave@example.org",
-            extra_args=["--quarantine-dir", str(qdir), "--slug", "nested"],
-        )
-        assert rc == 1
-        assert qdir.exists()
-        assert len(list(qdir.iterdir())) == 1
-
     def test_quarantine_covers_acceptance_patterns(self, tmp_path: Path):
         """Regression for the PII gate acceptance criteria (#3236)."""
         qdir = tmp_path / "quarantine"
@@ -184,19 +174,14 @@ class TestRedactPiiQuarantine:
         for sample, expected_reason in samples:
             rc, out, err = _run(
                 sample,
-                extra_args=[
-                    "--quarantine-dir",
-                    str(qdir),
-                    "--slug",
-                    expected_reason.lower().replace(" ", "-"),
-                ],
+                extra_args=["--quarantine-dir", str(qdir), "--slug", "pattern"],
             )
             assert rc == 1, f"{sample} should be blocked"
             files = list(qdir.iterdir())
             assert files, f"{sample} should be quarantined"
             content = files[-1].read_text(encoding="utf-8")
             assert expected_reason in content, f"{sample}: expected {expected_reason}"
-            # raw sample must not survive in the quarantine file
+            # raw sample must not survive into the quarantine file
             assert sample not in content
             # remove the file for the next sample to keep directory clean
             files[-1].unlink()


### PR DESCRIPTION
Automated evolution PR for issue #3236.

- Extend `scripts/redact_pii.py` with `--quarantine-dir` and `--slug` options.
- On block, write a quarantine `.md` file containing the redacted body plus redaction reasons.
- Add regression tests covering blocked quarantine, clean bodies, and all five PII pattern categories.

Deferred (next increment):
- Update `skills/evolution/evolution-issues/SKILL.md` to use `--quarantine-dir` and surface the quarantine path to the reviewer.