### PR TITLE
fix: search_files missing-pattern preflight with correction hint (Closes #3237)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -139,7 +139,7 @@ class _BatchAbandoned(BaseException):
     """
 
 def _parse_tool_arguments(
-    raw_arguments: Any, function_name: str = ""
+    raw_arguments: Any, function_name: str = "", agent: Any = None
 ) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them.
 
@@ -151,6 +151,10 @@ def _parse_tool_arguments(
     (a common model failure mode — emitting ``ls -la`` instead of
     ``{"command": "ls -la"}``), we extract it as the ``command`` argument
     so the command executes instead of producing a parse error.
+
+    For search_files, if the required ``pattern`` argument is missing, we
+    return a structured correction hint instead of letting the tool fail
+    with an opaque parameter error (issue #3237 — repeated cron noise).
     """
     if raw_arguments is None:
         return {}, json.dumps(
@@ -210,6 +214,35 @@ def _parse_tool_arguments(
         )
 
     if isinstance(arguments, dict):
+        # search_files preflight: a missing `pattern` argument is a frequent
+        # model failure mode. Return a correction hint immediately so the agent
+        # fixes the call on the same turn instead of blind-retrying.
+        if function_name == "search_files" and "pattern" not in arguments:
+            count = 0
+            if agent is not None:
+                count = getattr(agent, "_search_files_missing_pattern_count", 0) + 1
+                agent._search_files_missing_pattern_count = count
+            return {}, json.dumps(
+                {
+                    "error": "Missing required argument: pattern",
+                    "tool": "search_files",
+                    "missing": ["pattern"],
+                    "correction": {
+                        "pattern": "function_name_or_regex",
+                        "target": "content",
+                        "path": ".",
+                    },
+                    "message": (
+                        "`search_files` requires a `pattern` argument. "
+                        "Provide a regex/glob pattern and optionally "
+                        "`target='files'` for filename searches. "
+                        "Example: `search_files(pattern='*.py', target='files', path='.')`."
+                    ),
+                    "search_files_missing_pattern_count": count,
+                    "argument_shape_spiral": count >= 3,
+                },
+                ensure_ascii=False,
+            )
         return arguments, None
 
     # Parsed successfully but not a dict (e.g. a JSON list or scalar).
@@ -1224,7 +1257,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments, function_name=function_name
+            tool_call.function.arguments, function_name=function_name, agent=agent
         )
 
         if malformed_args_result is not None:
@@ -2082,7 +2115,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments, function_name=function_name
+            tool_call.function.arguments, function_name=function_name, agent=agent
         )
         if malformed_args_result is not None:
             _emit_terminal_post_tool_call(

--- a/tests/agent/test_search_files_argument_preflight.py
+++ b/tests/agent/test_search_files_argument_preflight.py
@@ -1,0 +1,101 @@
+"""Regression tests for the search_files missing-pattern preflight (#3237)."""
+
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parents[2]))
+
+from agent.tool_executor import _parse_tool_arguments
+
+
+def _make_agent():
+    """Return a bare object that can store counter attributes."""
+    return SimpleNamespace()
+
+
+class TestSearchFilesArgumentPreflight:
+    def test_search_files_missing_pattern_returns_correction(self):
+        agent = _make_agent()
+        args, err = _parse_tool_arguments(
+            '{"target": "content", "path": "."}',
+            function_name="search_files",
+            agent=agent,
+        )
+        assert args == {}
+        assert err is not None
+        assert isinstance(err, str)
+        payload = json.loads(err)
+        assert payload["error"] == "Missing required argument: pattern"
+        assert payload["tool"] == "search_files"
+        assert payload["missing"] == ["pattern"]
+        assert "correction" in payload
+        assert "Example:" in payload["message"]
+        assert agent._search_files_missing_pattern_count == 1
+        assert payload["search_files_missing_pattern_count"] == 1
+        assert payload["argument_shape_spiral"] is False
+
+    def test_search_files_with_pattern_is_clean(self):
+        agent = _make_agent()
+        args, err = _parse_tool_arguments(
+            '{"pattern": "*.py", "target": "files", "path": "."}',
+            function_name="search_files",
+            agent=agent,
+        )
+        assert err is None
+        assert args == {"pattern": "*.py", "target": "files", "path": "."}
+        assert not hasattr(agent, "_search_files_missing_pattern_count")
+
+    def test_missing_pattern_counter_increments_per_call(self):
+        agent = _make_agent()
+        for i in range(1, 5):
+            args, err = _parse_tool_arguments(
+                "{}",
+                function_name="search_files",
+                agent=agent,
+            )
+            assert args == {}
+            assert err is not None
+            payload = json.loads(err)
+            assert payload["search_files_missing_pattern_count"] == i
+            expected_spiral = i >= 3
+            assert payload["argument_shape_spiral"] is expected_spiral
+        assert agent._search_files_missing_pattern_count == 4
+
+    def test_no_agent_still_returns_hint(self):
+        args, err = _parse_tool_arguments(
+            '{"target": "content"}',
+            function_name="search_files",
+            agent=None,
+        )
+        assert args == {}
+        payload = json.loads(err)
+        assert payload["error"] == "Missing required argument: pattern"
+        assert payload["search_files_missing_pattern_count"] == 0
+        assert payload["argument_shape_spiral"] is False
+
+    def test_other_tools_not_affected(self):
+        agent = _make_agent()
+        args, err = _parse_tool_arguments(
+            '{"command": "echo hello"}',
+            function_name="terminal",
+            agent=agent,
+        )
+        assert err is None
+        assert args == {"command": "echo hello"}
+        assert not hasattr(agent, "_search_files_missing_pattern_count")
+
+    def test_no_blind_retry_path(self):
+        """Malformed args result is returned to the model, not retried."""
+        agent = _make_agent()
+        args, err = _parse_tool_arguments(
+            '{"target": "content"}',
+            function_name="search_files",
+            agent=agent,
+        )
+        assert err is not None
+        # The executor uses this result as the tool result, so no dispatch occurs.
+        assert "pattern" in err.lower()


### PR DESCRIPTION
Automated evolution PR for issue #3237.

- Add a preflight check in `agent/tool_executor._parse_tool_arguments()` for `search_files` calls missing the required `pattern` argument.
- Return a structured correction hint (missing field, example, spiral counter) so the model can fix the call on the same turn.
- Track `_search_files_missing_pattern_count` per session and set `argument_shape_spiral=True` once it recurs 3+ times.
- Add regression tests in `tests/agent/test_search_files_argument_preflight.py`.

Deferred (next increment):
- Wire `argument_shape_spiral` signal into `agent/loop_guard.py` for hard-stop action.