### PR TITLE
fix: patch preflight blocks empty old_string with re_read_file instruction (Closes #3238)

### DIFF
--- a/tests/tools/test_patch_preflight.py
+++ b/tests/tools/test_patch_preflight.py
@@ -1,0 +1,99 @@
+"""Regression tests for the patch preflight guard (#3238)."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from tools.file_tools import patch_tool
+
+
+class TestPatchPreflight:
+    def test_empty_old_string_returns_re_read_action(self, tmp_path):
+        target = tmp_path / "sample.py"
+        target.write_text("print('hello')\n")
+
+        result = patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="",
+            new_string="pass",
+            task_id="test-empty",
+        )
+
+        payload = json.loads(result)
+        assert payload["action"] == "re_read_file"
+        assert payload["reason"] == "empty old_string"
+        assert payload["path"] == str(target)
+        assert payload["patch_preflight_blocked"] == 1
+        assert payload["argument_shape_spiral"] is False
+        assert "read_file" in payload["message"]
+
+    def test_counter_increments_per_block(self, tmp_path):
+        target = tmp_path / "sample.py"
+        target.write_text("abc def ghi\n")
+        for i in range(1, 5):
+            result = patch_tool(
+                mode="replace",
+                path=str(target),
+                old_string="",
+                new_string="x",
+                task_id="test-counter",
+            )
+            payload = json.loads(result)
+            assert payload["patch_preflight_blocked"] == i
+            assert payload["argument_shape_spiral"] is (i >= 3)
+
+    def test_valid_old_string_is_not_blocked(self, tmp_path):
+        target = tmp_path / "sample.py"
+        target.write_text("def hello():\n    return 42\n")
+
+        result = patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="def hello():\n    return 42\n",
+            new_string="def hello():\n    return 43\n",
+            task_id="test-valid",
+        )
+
+        # Valid patch should succeed (returned as JSON with success flag).
+        payload = json.loads(result)
+        assert payload.get("success") is True
+        assert target.read_text() == "def hello():\n    return 43\n"
+
+    def test_short_old_string_still_allowed(self, tmp_path):
+        """Short old_strings are deferred to the fuzzy matcher; not blocked."""
+        target = tmp_path / "sample.py"
+        target.write_text("x\n")
+
+        result = patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="x",
+            new_string="y",
+            task_id="test-short-allowed",
+        )
+
+        payload = json.loads(result)
+        assert payload.get("success") is True
+        assert target.read_text() == "y\n"
+
+    def test_no_blind_retry(self, tmp_path):
+        """Blocked preflight returns immediately, no file mutation."""
+        original = "unchanged\n"
+        target = tmp_path / "sample.py"
+        target.write_text(original)
+
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="",
+            new_string="mutated",
+            task_id="test-no-retry",
+        )
+
+        assert target.read_text() == original

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1644,6 +1644,50 @@ def _empty_old_string_error(path: str, task_id: str) -> str:
 # is never referenced again (only the most recent reads matter for dedup,
 # loop detection, and external-edit warnings).  Hard caps bound the
 # accretion to a few hundred KB regardless of session length.
+
+# #3238 — patch preflight counter: every replace-mode call blocked for an
+# empty/short/ambiguous old_string increments this per-task counter.  It is
+# surfaced in the structured error so the spiral guard can act on it.
+_patch_preflight_blocked_lock = threading.Lock()
+_patch_preflight_blocked_counter: dict[str, int] = {}
+
+
+def _record_patch_preflight_blocked(task_id: str) -> int:
+    """Increment and return the per-task patch-preflight block count."""
+    with _patch_preflight_blocked_lock:
+        _patch_preflight_blocked_counter[task_id] = (
+            _patch_preflight_blocked_counter.get(task_id, 0) + 1
+        )
+        return _patch_preflight_blocked_counter[task_id]
+
+
+def _patch_preflight_blocked_structured(
+    path: str, reason: str, task_id: str, extra_message: str = ""
+) -> str:
+    """Return a structured re_read_file instruction for a blocked patch.
+
+    The payload is a non-retryable correction request that tells the model to
+    re-read the target file and try again with a more precise old_string.
+    """
+    count = _record_patch_preflight_blocked(task_id)
+    message = (
+        f"Patch blocked by preflight: {reason}. "
+        f"Re-read {path!r} with read_file, copy the exact text you want to replace, "
+        f"and retry with a longer, unambiguous old_string."
+    )
+    if extra_message:
+        message += " " + extra_message
+    return json.dumps(
+        {
+            "action": "re_read_file",
+            "path": path,
+            "reason": reason,
+            "message": message,
+            "patch_preflight_blocked": count,
+            "argument_shape_spiral": count >= 3,
+        },
+        ensure_ascii=False,
+    )
 _READ_HISTORY_CAP = 500  # set; used only by get_read_files_summary
 _DEDUP_CAP = 1000  # dict; skip-identical-reread guard
 _READ_TIMESTAMPS_CAP = 1000  # dict; external-edit detection for write/patch
@@ -3025,14 +3069,14 @@ def patch_tool(
             if mode == "replace":
                 if not path:
                     return tool_error("path required")
-                # #1703 — a replace-mode call with an EMPTY (falsy) old_string is
-                # a usage error, not a match failure. Return a targeted,
-                # non-retryable diagnostic at the boundary instead of letting
-                # the generic error below feed a 5-8 call retry spiral. A
-                # non-empty old_string clears any prior empty-string counter for
-                # this path (the model moved past the bad shape).
-                if not old_string:
-                    return _empty_old_string_error(path, task_id)
+                # #1703/#3238 — Preflight: reject empty old_string before
+                # attempting the patch. Return a structured re_read_file
+                # instruction so the model fixes the shape instead of blind-retrying.
+                _old = (old_string or "").strip()
+                if not _old:
+                    return _patch_preflight_blocked_structured(
+                        path, "empty old_string", task_id
+                    )
                 _reset_empty_old_string(task_id, path)
                 if new_string is None:
                     return tool_error("old_string and new_string required")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1669,7 +1669,22 @@ def _patch_preflight_blocked_structured(
     The payload is a non-retryable correction request that tells the model to
     re-read the target file and try again with a more precise old_string.
     """
-    count = _record_patch_preflight_blocked(task_id)
+    count = _record_empty_old_string(task_id, path)
+    preflight_count = _record_patch_preflight_blocked(task_id)
+    msg = (
+        "replace mode requires a non-empty old_string. The old_string is the "
+        "exact text to find and replace in the file; an empty string cannot be "
+        "matched. Either supply the text to replace, or use mode=patch (V4A "
+        "format) for insertions."
+    )
+    if count >= 2:
+        suffix = {2: "nd", 3: "rd"}.get(count % 10, "th")
+        msg += (
+            f" STOP: this is the {count}{suffix} consecutive replace-mode call with an "
+            f"empty old_string on {path!r}. Do not retry this shape — re-read the "
+            f"file to see the exact text, then supply a real old_string, or use "
+            f"mode=patch / write_file instead."
+        )
     message = (
         f"Patch blocked by preflight: {reason}. "
         f"Re-read {path!r} with read_file, copy the exact text you want to replace, "
@@ -1679,12 +1694,13 @@ def _patch_preflight_blocked_structured(
         message += " " + extra_message
     return json.dumps(
         {
+            "error": msg,
             "action": "re_read_file",
             "path": path,
             "reason": reason,
             "message": message,
-            "patch_preflight_blocked": count,
-            "argument_shape_spiral": count >= 3,
+            "patch_preflight_blocked": preflight_count,
+            "argument_shape_spiral": preflight_count >= 3,
         },
         ensure_ascii=False,
     )


### PR DESCRIPTION
Automated evolution PR for issue #3238.

- Replace the legacy `_empty_old_string_error` in `tools/file_tools.py` with a structured `_patch_preflight_blocked_structured` response.
- Empty `old_string` in replace-mode now returns `{"action": "re_read_file", ...}` instead of a generic error, so the model can self-correct on the same turn.
- Track `patch_preflight_blocked` per task and surface `argument_shape_spiral=True` once it recurs 3+ times.
- Add regression tests in `tests/tools/test_patch_preflight.py`.

Deferred (next increment):
- Extend preflight to very short/ambiguous `old_string` (needs updating existing `test_file_tools.py` expectations).
- Wire `argument_shape_spiral` into `agent/loop_guard.py` for hard-stop action.