### PR TITLE
feat(terminal): deterministic preflight guard for missing executable and workdir (Closes #3243)

### DIFF
--- a/tests/tools/test_terminal_preflight.py
+++ b/tests/tools/test_terminal_preflight.py
@@ -1,0 +1,60 @@
+"""Tests for the terminal preflight guard (#3243)."""
+
+import json
+
+import pytest
+
+from tools.terminal_tool import _first_command_token, _preflight_check, terminal_tool
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("ls -la /tmp", "ls"),
+        ("'ls' -la", "ls"),
+        ("cd /tmp && ls", None),
+        ("cat file | grep x", None),
+        ("echo hi > file", None),
+        ("echo $(date)", None),
+        ("FOO=bar python script.py", None),
+    ],
+)
+def test_first_command_token(command, expected):
+    assert _first_command_token(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command,workdir,timeout,should_fail",
+    [
+        ("ls", "/nonexistent_dir_3243", None, True),
+        ("definitely_not_a_command_3243", None, None, True),
+        ("ls", None, 0, True),
+        ("cd /tmp", None, None, False),
+        ("cd /tmp && ls", None, None, False),
+    ],
+)
+def test_preflight_check(command, workdir, timeout, should_fail):
+    assert (_preflight_check(command, workdir, timeout) is not None) == should_fail
+
+
+def test_terminal_tool_preflight_missing_bin():
+    result = json.loads(
+        terminal_tool("definitely_not_a_command_3243", task_id="t-preflight-1")
+    )
+    assert result["exit_code"] == -1
+    assert "was not found in PATH" in result["error"]
+
+
+def test_terminal_tool_preflight_missing_workdir(tmp_path):
+    result = json.loads(
+        terminal_tool("ls", workdir=str(tmp_path / "missing"), task_id="t-preflight-2")
+    )
+    assert result["exit_code"] == -1
+    assert "does not exist or is not a directory" in result["error"]
+
+
+def test_terminal_tool_preflight_existing_workdir_ok(tmp_path):
+    result = json.loads(
+        terminal_tool("pwd", workdir=str(tmp_path), task_id="t-preflight-3")
+    )
+    assert result["exit_code"] == 0

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -43,7 +43,7 @@ def test_foreground_command_uses_registered_task_cwd_for_existing_environment(mo
     assert calls == [("pwd", {"timeout": 60, "cwd": "/workspace/acp", "bounded_capture": True})]
 
 
-def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
+def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch, tmp_path):
     calls = []
 
     class FakeEnv:
@@ -64,19 +64,22 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
         lambda command, env_type, **kwargs: {"approved": True},
     )
 
+    explicit_path = tmp_path / "explicit"
+    explicit_path.mkdir()
+    explicit = str(explicit_path)
     result = json.loads(
         terminal_tool.terminal_tool(
             command="pwd",
             task_id=task_id,
-            workdir="/explicit/workdir",
+            workdir=explicit,
         )
     )
 
     assert result["exit_code"] == 0
-    assert calls == [{"timeout": 60, "cwd": "/explicit/workdir", "bounded_capture": True}]
+    assert calls == [{"timeout": 60, "cwd": explicit, "bounded_capture": True}]
 
 
-def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch):
+def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch, tmp_path):
     """A per-command ``workdir`` must not hijack the durable session cwd.
 
     Regression: the post-command dual-write recorded ``env.cwd`` (stamped to
@@ -110,10 +113,11 @@ def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch):
         lambda session_key, cwd: recorded.append((session_key, cwd)),
     )
 
-    terminal_tool.terminal_tool(command="pwd", task_id=task_id, workdir="/one/off/dir")
+    one_off = str(tmp_path / "one-off")
+    terminal_tool.terminal_tool(command="pwd", task_id=task_id, workdir=one_off)
 
     # The transient workdir must NOT have been recorded as the session cwd.
-    assert all(cwd != "/one/off/dir" for _, cwd in recorded), recorded
+    assert all(cwd != one_off for _, cwd in recorded), recorded
 
 
 def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -516,24 +516,30 @@ def _preflight_check(
     command: str,
     workdir: Optional[str],
     timeout: Optional[int],
+    env_type: str = "local",
+    is_mock_env: bool = False,
 ) -> str | None:
     """Return an error string if the command fails a preflight check, else None.
 
     Checks, in order:
-      1. An explicitly provided ``workdir`` exists and is a directory.
-      2. The first command token resolves to an executable in PATH (or is an
-         absolute path that exists and is executable). Only checked for
-         simple single commands; compound commands are left to the shell.
-      3. Timeout realism: reject a sub-second timeout (non-positive values
+      1. Timeout realism: reject a sub-second timeout (non-positive values
          are already rejected by the caller).
+      2. For local, non-mocked environments: an explicitly provided ``workdir``
+         exists and is a directory on the local host.
+      3. For local, non-mocked environments: the first command token resolves
+         to an executable in PATH (or is an absolute path that exists and is
+         executable). Only checked for simple single commands; compound commands
+         are left to the shell.
     """
+    if timeout is not None and timeout < 1:
+        return f"Preflight: timeout must be at least 1 second (got {timeout})."
+    if env_type != "local" or is_mock_env:
+        return None
     if workdir and not os.path.isdir(workdir):
         return (
             f"Preflight: workdir {workdir!r} does not exist or is not a "
             "directory. Create it first or pass an existing directory."
         )
-    if timeout is not None and timeout < 1:
-        return f"Preflight: timeout must be at least 1 second (got {timeout})."
     first = _first_command_token(command)
     if first is None or _is_shell_builtin(first):
         return None
@@ -3128,20 +3134,6 @@ def terminal_tool(
                 ensure_ascii=False,
             )
 
-        # Lightweight preflight guard: fail fast on common, deterministic mistakes
-        # before paying for environment setup / shell execution (#3243).
-        preflight_error = _preflight_check(command, workdir, timeout)
-        if preflight_error:
-            return json.dumps(
-                {
-                    "output": "",
-                    "exit_code": -1,
-                    "error": preflight_error,
-                    "status": "error",
-                },
-                ensure_ascii=False,
-            )
-
         # Check active verification scope (issue #2458 / #2436)
         from agent.file_safety import get_active_verification_scope
 
@@ -3171,6 +3163,26 @@ def terminal_tool(
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
         effective_task_id = _resolve_container_task_id(task_id)
+
+        from tools.environments.local import LocalEnvironment
+        active_env = _active_environments.get(effective_task_id) or _active_environments.get("default")
+        is_mock_env = active_env is not None and not isinstance(active_env, LocalEnvironment)
+
+        # Lightweight preflight guard: fail fast on common, deterministic mistakes
+        # before paying for environment setup / shell execution (#3243).
+        preflight_error = _preflight_check(
+            command, workdir, timeout, env_type=env_type, is_mock_env=is_mock_env
+        )
+        if preflight_error:
+            return json.dumps(
+                {
+                    "output": "",
+                    "exit_code": -1,
+                    "error": preflight_error,
+                    "status": "error",
+                },
+                ensure_ascii=False,
+            )
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -532,7 +532,7 @@ def _preflight_check(
          are left to the shell.
     """
     if timeout is not None and timeout < 1:
-        return f"Preflight: timeout must be at least 1 second (got {timeout})."
+        return f"Preflight: timeout must be a positive integer in seconds (must be at least 1 second, got {timeout})."
     if env_type != "local" or is_mock_env:
         return None
     if workdir and not os.path.isdir(workdir):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -449,6 +449,108 @@ def _validate_workdir(workdir: str) -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Preflight guard (#3243): catch the most common terminal failure classes
+# BEFORE the shell runs, so the model gets a clear, actionable error instead
+# of a runtime failure. Deliberately conservative — only flags unambiguous
+# cases and never blocks shell builtins, pipelines, or compound commands.
+# Dangerous-command patterns are intentionally NOT duplicated here: they are
+# already enforced by tools/approval.py's check_all_command_guards.
+# ---------------------------------------------------------------------------
+_SHELL_BUILTINS = frozenset({
+    "cd",
+    "pwd",
+    "echo",
+    "printf",
+    "export",
+    "unset",
+    "source",
+    ".",
+    "test",
+    "[",
+    "[[",
+    "true",
+    "false",
+    "exec",
+    "exit",
+    "command",
+    "builtin",
+    "type",
+    "alias",
+    "unalias",
+})
+
+
+def _first_command_token(command: str) -> str | None:
+    """Return the first executable token of a simple command, or None.
+
+    Returns None for compound commands (pipes, ``&&``/``||``, ``;``,
+    redirection, background ``&``, command substitution) and for commands
+    that begin with env-var assignments — those are left to the shell.
+    """
+    if not command or not command.strip():
+        return None
+    stripped = command.strip()
+    if any(ch in stripped for ch in "|&;<>`"):
+        return None
+    if "$(" in stripped:
+        return None
+    try:
+        parts = shlex.split(stripped)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    first = parts[0]
+    # Skip leading env-var assignments (FOO=bar cmd ...).
+    if "=" in first and not first.startswith("/"):
+        return None
+    return first
+
+
+def _is_shell_builtin(token: str) -> bool:
+    return token in _SHELL_BUILTINS
+
+
+def _preflight_check(
+    command: str,
+    workdir: Optional[str],
+    timeout: Optional[int],
+) -> str | None:
+    """Return an error string if the command fails a preflight check, else None.
+
+    Checks, in order:
+      1. An explicitly provided ``workdir`` exists and is a directory.
+      2. The first command token resolves to an executable in PATH (or is an
+         absolute path that exists and is executable). Only checked for
+         simple single commands; compound commands are left to the shell.
+      3. Timeout realism: reject a sub-second timeout (non-positive values
+         are already rejected by the caller).
+    """
+    if workdir and not os.path.isdir(workdir):
+        return (
+            f"Preflight: workdir {workdir!r} does not exist or is not a "
+            "directory. Create it first or pass an existing directory."
+        )
+    if timeout is not None and timeout < 1:
+        return f"Preflight: timeout must be at least 1 second (got {timeout})."
+    first = _first_command_token(command)
+    if first is None or _is_shell_builtin(first):
+        return None
+    if os.path.sep in first:
+        if not os.path.exists(first) or not os.access(first, os.X_OK):
+            return (
+                f"Preflight: {first!r} does not exist or is not executable. "
+                "Check the path or install the tool."
+            )
+    elif shutil.which(first) is None:
+        return (
+            f"Preflight: {first!r} was not found in PATH. Install it or use "
+            "an absolute path."
+        )
+    return None
+
+
 def _handle_sudo_failure(output: str, env_type: str) -> str:
     """
     Check for sudo failure and add helpful message for messaging contexts.
@@ -3021,6 +3123,20 @@ def terminal_tool(
                     "output": "",
                     "exit_code": -1,
                     "error": f"Invalid command: expected string, got {type(command).__name__}",
+                    "status": "error",
+                },
+                ensure_ascii=False,
+            )
+
+        # Lightweight preflight guard: fail fast on common, deterministic mistakes
+        # before paying for environment setup / shell execution (#3243).
+        preflight_error = _preflight_check(command, workdir, timeout)
+        if preflight_error:
+            return json.dumps(
+                {
+                    "output": "",
+                    "exit_code": -1,
+                    "error": preflight_error,
                     "status": "error",
                 },
                 ensure_ascii=False,


### PR DESCRIPTION
Adds a lightweight preflight check to `terminal_tool()` that fails fast on missing executables, missing explicit workdirs, and sub-second timeouts before invoking the shell. Compound commands and shell builtins are skipped; dangerous-command checks remain owned by `tools/approval.py`.

Closes #3243