### PR TITLE
feat(delegate): per-session success-rate tracking for delegate_task (#3225)

### DIFF
--- a/tests/tools/test_delegate_session_stats.py
+++ b/tests/tools/test_delegate_session_stats.py
@@ -1,0 +1,67 @@
+"""Tests for tools/delegate_session_stats.py (#3225)."""
+
+from tools.delegate_session_stats import DELEGATE_SESSION_STATS, _DelegateSessionStats
+
+
+def test_record_empty_results_is_noop():
+    stats = _DelegateSessionStats()
+    bucket = stats.record("sid", [])
+    assert bucket == {"dispatches": 0, "completed": 0, "failed": 0}
+
+
+def test_record_completed_and_failed_tasks():
+    stats = _DelegateSessionStats()
+    results = [
+        {"status": "completed"},
+        {"status": "completed"},
+        {"status": "error", "error": "boom"},
+    ]
+    bucket = stats.record("sid", results)
+    assert bucket == {"dispatches": 3, "completed": 2, "failed": 1}
+
+
+def test_record_accumulates_across_calls():
+    stats = _DelegateSessionStats()
+    stats.record("sid", [{"status": "completed"}, {"status": "error"}])
+    bucket = stats.record("sid", [{"status": "completed"}])
+    assert bucket == {"dispatches": 3, "completed": 2, "failed": 1}
+
+
+def test_get_snapshot_isolation():
+    stats = _DelegateSessionStats()
+    stats.record("sid", [{"status": "completed"}])
+    snapshot = stats.get("sid")
+    assert snapshot is not None
+    snapshot["completed"] = 99
+    assert stats.get("sid") == {"dispatches": 1, "completed": 1, "failed": 0}
+
+
+def test_record_with_no_session_returns_none():
+    stats = _DelegateSessionStats()
+    assert stats.record(None, [{"status": "completed"}]) is None
+    assert stats.record("", [{"status": "completed"}]) is None
+
+
+def test_reset_session_clears_bucket():
+    stats = _DelegateSessionStats()
+    stats.record("sid", [{"status": "completed"}])
+    assert stats.reset("sid") is True
+    assert stats.get("sid") is None
+    assert stats.reset("sid") is False
+
+
+def test_global_instance_record_and_get():
+    DELEGATE_SESSION_STATS.reset("global-test-sid")
+    assert DELEGATE_SESSION_STATS.record(
+        "global-test-sid", [{"status": "completed"}]
+    ) == {
+        "dispatches": 1,
+        "completed": 1,
+        "failed": 0,
+    }
+    assert DELEGATE_SESSION_STATS.get("global-test-sid") == {
+        "dispatches": 1,
+        "completed": 1,
+        "failed": 0,
+    }
+    DELEGATE_SESSION_STATS.reset("global-test-sid")

--- a/tools/delegate_session_stats.py
+++ b/tools/delegate_session_stats.py
@@ -1,0 +1,67 @@
+"""Per-session success-rate counters for delegate_task (#3225 slice 1).
+
+A small observability hook that records completed vs failed child dispatches
+keyed by the parent agent's durable ``session_id``. It does NOT persist across
+process restarts and does NOT make decisions — it only exposes counts so
+downstream logic (e.g. the #3224 loop-guard) can act on them.
+
+Thread-safe: delegate_task can be invoked from tool-worker threads, so all
+mutation happens under a lock.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional
+
+
+class _DelegateSessionStats:
+    """In-memory per-session counters for delegate_task outcomes."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: Dict[str, Dict[str, int]] = {}
+
+    def record(
+        self, session_id: Optional[str], results: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, int]]:
+        """Accumulate completed/failed counts for one dispatch batch.
+
+        ``results`` is the per-task results array from a delegate_task return.
+        A task counts as completed when its entry has ``status == "completed"``
+        (or carries no error); anything else counts as failed. Returns the
+        updated bucket for the session, or ``None`` when no session id is given.
+        """
+        if not session_id:
+            return None
+        total = len(results)
+        completed = sum(
+            1 for r in results if isinstance(r, dict) and r.get("status") == "completed"
+        )
+        failed = total - completed
+        with self._lock:
+            bucket = self._sessions.setdefault(
+                session_id, {"dispatches": 0, "completed": 0, "failed": 0}
+            )
+            bucket["dispatches"] += total
+            bucket["completed"] += completed
+            bucket["failed"] += failed
+            return dict(bucket)
+
+    def get(self, session_id: Optional[str]) -> Optional[Dict[str, int]]:
+        """Return a snapshot of the session's counters, or ``None`` if absent."""
+        if not session_id:
+            return None
+        with self._lock:
+            bucket = self._sessions.get(session_id)
+            return dict(bucket) if bucket is not None else None
+
+    def reset(self, session_id: Optional[str]) -> bool:
+        """Drop the session's counters. Returns ``True`` if they existed."""
+        if not session_id:
+            return False
+        with self._lock:
+            return self._sessions.pop(session_id, None) is not None
+
+
+DELEGATE_SESSION_STATS = _DelegateSessionStats()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5486,6 +5486,16 @@ def delegate_task(
     # return the error results immediately — _execute_and_aggregate would
     # IndexError on an empty children list.
     if not children:
+        # Record the skipped batch as all-failed for per-session stats (#3225).
+        try:
+            from tools.delegate_session_stats import DELEGATE_SESSION_STATS
+
+            _empty_sid = str(
+                getattr(parent_agent, "session_id", "") or _origin_ui_session_id or ""
+            )
+            DELEGATE_SESSION_STATS.record(_empty_sid, results)
+        except Exception:
+            logger.debug("delegate session stats recording failed", exc_info=True)
         return json.dumps({"results": results})
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
@@ -5719,6 +5729,22 @@ def delegate_task(
         }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
+        # Per-session success-rate tracking (#3225): record this batch's
+        # completed/failed counts keyed by the parent's durable session id and
+        # attach a snapshot to the result so callers can observe the running
+        # rate without a separate lookup. Best-effort — never break the
+        # delegate path on a stats failure.
+        try:
+            from tools.delegate_session_stats import DELEGATE_SESSION_STATS
+
+            _stats_sid = str(
+                getattr(parent_agent, "session_id", "") or _origin_ui_session_id or ""
+            )
+            _stats = DELEGATE_SESSION_STATS.record(_stats_sid, results)
+            if _stats is not None:
+                combined["session_delegate_stats"] = _stats
+        except Exception:
+            logger.debug("delegate session stats recording failed", exc_info=True)
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----


### PR DESCRIPTION
Implements #3225.

Adds `tools/delegate_session_stats.py`, a thread-safe in-memory counter keyed by the parent agent's durable `session_id`, and wires it into the `delegate_task` result path. Each batch's completed/failed counts are recorded and surfaced as `session_delegate_stats` on the result payload.

- Best-effort: a stats failure never breaks the delegate path.
- Records at aggregation time for the background (async) path.
- Records the empty-children early return as all-failed.
- Diff is under the 200-line autonomous-merge cap.

Closes #3225.
