### PR TITLE
feat(delegate): consecutive-failure loop-guard for delegate_task (#3224)

### DIFF
--- a/tests/tools/test_delegate_loop_guard.py
+++ b/tests/tools/test_delegate_loop_guard.py
@@ -1,0 +1,159 @@
+"""Tests for delegate_task consecutive-failure loop guard (#3224 slice 2)."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.delegate_loop_guard import (
+    DEFAULT_DELEGATE_MAX_LOOP_FAILURES,
+    DELEGATE_LOOP_GUARD,
+    _compute_goal_signature,
+)
+from tools.delegate_tool import delegate_task
+
+
+@pytest.fixture(autouse=True)
+def clean_guard():
+    DELEGATE_LOOP_GUARD.reset("test-session")
+    DELEGATE_LOOP_GUARD.reset("test-session-2")
+    yield
+    DELEGATE_LOOP_GUARD.reset("test-session")
+    DELEGATE_LOOP_GUARD.reset("test-session-2")
+
+
+def test_goal_signature_normalization():
+    sig1 = _compute_goal_signature([{"task": "Run tests on branch"}])
+    sig2 = _compute_goal_signature([{"task": "  run   tests  on  branch  "}])
+    sig3 = _compute_goal_signature([{"task": "Run tests on main"}])
+
+    assert sig1 == sig2
+    assert sig1 != sig3
+
+
+def test_first_failure_does_not_trip():
+    tasks = [{"task": "fix bug"}]
+    results = [{"status": "failed", "error": "something exploded"}]
+
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks, results, budget=3
+    )
+    assert not tripped
+    assert count == 1
+    assert diag is None
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session") == 1
+
+
+def test_consecutive_identical_failures_trip_at_budget():
+    tasks = [{"task": "fix bug"}]
+    results = [{"status": "failed", "error": "something exploded"}]
+
+    # 1st failure
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks, results, budget=3
+    )
+    assert not tripped
+    assert count == 1
+
+    # 2nd failure
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks, results, budget=3
+    )
+    assert not tripped
+    assert count == 2
+
+    # 3rd failure (trips)
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks, results, budget=3
+    )
+    assert tripped
+    assert count == 3
+    assert diag is not None
+    assert "Delegate loop guard tripped" in diag
+    assert "Change strategy" in diag
+
+
+def test_changed_goal_resets_consecutive_count():
+    tasks1 = [{"task": "fix bug A"}]
+    tasks2 = [{"task": "fix bug B"}]
+    fail = [{"status": "failed", "error": "err"}]
+
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks1, fail, budget=3)
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks1, fail, budget=3)
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session") == 2
+
+    # Different task resets count to 1
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks2, fail, budget=3
+    )
+    assert not tripped
+    assert count == 1
+    assert diag is None
+
+
+def test_success_resets_consecutive_failures():
+    tasks = [{"task": "fix bug"}]
+    fail = [{"status": "failed", "error": "err"}]
+    ok = [{"status": "completed", "result": "done"}]
+
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks, fail, budget=3)
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks, fail, budget=3)
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session") == 2
+
+    # Success resets counter
+    tripped, count, diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+        "test-session", tasks, ok, budget=3
+    )
+    assert not tripped
+    assert count == 0
+    assert diag is None
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session") == 0
+
+
+def test_session_isolation():
+    tasks = [{"task": "fix bug"}]
+    fail = [{"status": "failed", "error": "err"}]
+
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks, fail, budget=3)
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session", tasks, fail, budget=3)
+    DELEGATE_LOOP_GUARD.record_and_evaluate("test-session-2", tasks, fail, budget=3)
+
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session") == 2
+    assert DELEGATE_LOOP_GUARD.get_consecutive_failures("test-session-2") == 1
+
+
+def test_empty_children_early_return_triggers_guard():
+    from unittest.mock import patch
+
+    parent = MagicMock()
+    parent.session_id = "test-session"
+    parent._delegate_depth = 0
+    parent.enabled_toolsets = ["terminal"]
+
+    mock_child = MagicMock()
+    mock_child.valid_tool_names = set()
+    mock_child._delegate_resolved_toolsets = []
+    mock_child._delegate_requested_toolsets = []
+    mock_child._delegate_denied_toolsets = []
+    mock_child.run_conversation.return_value = {
+        "completed": False,
+        "status": "failed",
+        "error": "child failure",
+        "final_response": "error",
+    }
+
+    tasks = [
+        {"goal": "task 1 with empty tools"},
+        {"goal": "task 2 with empty tools"},
+    ]
+
+    with patch("tools.delegate_tool._build_child_agent", return_value=mock_child):
+        for _ in range(DEFAULT_DELEGATE_MAX_LOOP_FAILURES - 1):
+            res = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+            assert "delegate_loop_guard_tripped" not in res
+
+        # Nth attempt trips guard
+        res = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+        assert res.get("delegate_loop_guard_tripped") is True
+        assert res.get("consecutive_delegate_failures") == DEFAULT_DELEGATE_MAX_LOOP_FAILURES
+        assert "strategy_recommendation" in res

--- a/tools/delegate_loop_guard.py
+++ b/tools/delegate_loop_guard.py
@@ -1,0 +1,142 @@
+"""Consecutive-failure loop-guard for delegate_task (#3224 slice 2).
+
+Mirrors the tool spiral guard (tools/terminal_tool.py, tools/file_tools.py)
+for delegation: after N consecutive delegate_task failures with near-identical
+goal signatures, forces a strategy change (different toolset, direct
+execution, or explicit fallback) instead of re-dispatching the same shape.
+
+Thread-safe: delegate_task dispatches can happen across threads, so all
+internal counter state is guarded by a lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+DEFAULT_DELEGATE_MAX_LOOP_FAILURES = 3
+_DELEGATE_MAX_LOOP_FAILURES_CEILING = 20
+_delegate_max_loop_failures_cached: Optional[int] = None
+
+
+def _get_delegate_max_loop_failures() -> int:
+    """Return the configured delegate loop-guard failure budget."""
+    global _delegate_max_loop_failures_cached
+    if _delegate_max_loop_failures_cached is not None:
+        return _delegate_max_loop_failures_cached
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        val = cfg.get("delegate", {}).get(
+            "max_loop_failures", DEFAULT_DELEGATE_MAX_LOOP_FAILURES
+        )
+        if isinstance(val, int) and val > 0:
+            _delegate_max_loop_failures_cached = min(
+                val, _DELEGATE_MAX_LOOP_FAILURES_CEILING
+            )
+            return _delegate_max_loop_failures_cached
+    except Exception:
+        pass
+    _delegate_max_loop_failures_cached = DEFAULT_DELEGATE_MAX_LOOP_FAILURES
+    return _delegate_max_loop_failures_cached
+
+
+def _compute_goal_signature(tasks: List[Dict[str, Any]]) -> str:
+    """Compute a compact, normalized hash for a batch of delegation tasks."""
+    normalized_parts = []
+    for t in tasks:
+        if isinstance(t, dict):
+            task_str = str(t.get("task") or t.get("goal") or t.get("description") or "")
+        else:
+            task_str = str(t)
+        # Normalize whitespace and case
+        cleaned = re.sub(r"\s+", " ", task_str.strip().lower())
+        normalized_parts.append(cleaned)
+
+    h = hashlib.sha1()
+    for part in normalized_parts:
+        h.update(part.encode("utf-8", "replace"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _is_task_failure(result: Dict[str, Any]) -> bool:
+    """Check if an individual child task result represents a failure."""
+    if not isinstance(result, dict):
+        return True
+    status = result.get("status")
+    if status == "completed":
+        return False
+    if status == "failed" or status == "error":
+        return True
+    if result.get("error") is not None:
+        return True
+    return False
+
+
+class _DelegateLoopGuardTracker:
+    """Thread-safe per-session tracker for consecutive delegate_task failures."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: Dict[str, Tuple[str, int]] = {}
+
+    def record_and_evaluate(
+        self,
+        session_id: Optional[str],
+        tasks: List[Dict[str, Any]],
+        results: List[Dict[str, Any]],
+        budget: Optional[int] = None,
+    ) -> Tuple[bool, int, Optional[str]]:
+        """Record batch outcomes and evaluate if loop guard is tripped.
+
+        Returns (tripped: bool, consecutive_failures: int, diagnostic: Optional[str]).
+        """
+        if not session_id:
+            return False, 0, None
+
+        has_success = any(not _is_task_failure(r) for r in results) if results else False
+
+        with self._lock:
+            if has_success:
+                # Any successful child in the batch resets the consecutive failure spiral
+                self._sessions.pop(session_id, None)
+                return False, 0, None
+
+            sig = _compute_goal_signature(tasks)
+            last_sig, count = self._sessions.get(session_id, ("", 0))
+            count = count + 1 if sig == last_sig else 1
+            self._sessions[session_id] = (sig, count)
+
+            effective_budget = budget or _get_delegate_max_loop_failures()
+            tripped = count >= effective_budget
+            diagnostic = None
+            if tripped:
+                diagnostic = (
+                    f"Delegate loop guard tripped: identical delegation goal has failed "
+                    f"{count} consecutive times in this session (budget={effective_budget}). "
+                    f"Do NOT retry identical delegate_task dispatches. Change strategy: "
+                    f"execute tasks directly in the primary session, modify subagent "
+                    f"instructions/toolsets, or report blocker to user."
+                )
+            return tripped, count, diagnostic
+
+    def get_consecutive_failures(self, session_id: Optional[str]) -> int:
+        """Return the current consecutive identical failure count for session."""
+        if not session_id:
+            return 0
+        with self._lock:
+            return self._sessions.get(session_id, ("", 0))[1]
+
+    def reset(self, session_id: Optional[str]) -> bool:
+        """Clear state for the given session."""
+        if not session_id:
+            return False
+        with self._lock:
+            return self._sessions.pop(session_id, None) is not None
+
+
+DELEGATE_LOOP_GUARD = _DelegateLoopGuardTracker()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5486,17 +5486,31 @@ def delegate_task(
     # return the error results immediately — _execute_and_aggregate would
     # IndexError on an empty children list.
     if not children:
-        # Record the skipped batch as all-failed for per-session stats (#3225).
+        # Record the skipped batch as all-failed for per-session stats (#3225)
+        # and loop guard evaluation (#3224).
+        _empty_sid = str(
+            getattr(parent_agent, "session_id", "") or _origin_ui_session_id or ""
+        )
+        res_dict: Dict[str, Any] = {"results": results}
         try:
             from tools.delegate_session_stats import DELEGATE_SESSION_STATS
 
-            _empty_sid = str(
-                getattr(parent_agent, "session_id", "") or _origin_ui_session_id or ""
-            )
             DELEGATE_SESSION_STATS.record(_empty_sid, results)
         except Exception:
             logger.debug("delegate session stats recording failed", exc_info=True)
-        return json.dumps({"results": results})
+        try:
+            from tools.delegate_loop_guard import DELEGATE_LOOP_GUARD
+
+            _tripped, _cnt, _diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+                _empty_sid, tasks, results
+            )
+            if _tripped:
+                res_dict["delegate_loop_guard_tripped"] = True
+                res_dict["consecutive_delegate_failures"] = _cnt
+                res_dict["strategy_recommendation"] = _diag
+        except Exception:
+            logger.debug("delegate loop guard recording failed", exc_info=True)
+        return json.dumps(res_dict)
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
@@ -5745,6 +5759,24 @@ def delegate_task(
                 combined["session_delegate_stats"] = _stats
         except Exception:
             logger.debug("delegate session stats recording failed", exc_info=True)
+
+        # Consecutive-failure loop-guard (#3224): evaluate identical-goal failure spirals
+        try:
+            from tools.delegate_loop_guard import DELEGATE_LOOP_GUARD
+
+            _guard_sid = str(
+                getattr(parent_agent, "session_id", "") or _origin_ui_session_id or ""
+            )
+            _tripped, _cnt, _diag = DELEGATE_LOOP_GUARD.record_and_evaluate(
+                _guard_sid, tasks, results
+            )
+            if _tripped:
+                combined["delegate_loop_guard_tripped"] = True
+                combined["consecutive_delegate_failures"] = _cnt
+                combined["strategy_recommendation"] = _diag
+        except Exception:
+            logger.debug("delegate loop guard recording failed", exc_info=True)
+
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----


### PR DESCRIPTION
Implements #3224 (slice 2 of #3220).

Adds tools/delegate_loop_guard.py, a thread-safe tracker that monitors consecutive delegate_task failures with near-identical goal signatures per session.
After N consecutive failures (default 3, configurable via delegate.max_loop_failures in config.yaml), the guard trips and surfaces:
- delegate_loop_guard_tripped: True
- consecutive_delegate_failures: count
- strategy_recommendation: diagnostic guidance

Success or changed goals reset the consecutive failure counter.

Closes #3224.