### PR TITLE
feat(evolution): runtime trigger monitor for crystallized skills (#3217)

### DIFF
--- a/evolution/lib/trigger_matcher.py
+++ b/evolution/lib/trigger_matcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Any, List, Sequence, Tuple
 
-TYPES = ("goal_contains", "tool_used")
+TYPES = ("goal_contains", "tool_used", "error_class", "task_kind", "intent")
 DEFAULT_WEIGHT = 1.0
 _STOP = frozenset({
     "the",
@@ -146,6 +146,7 @@ def render_triggers(triggers: Sequence[dict[str, Any]]) -> str:
 
 
 def score_trigger(state: dict[str, Any], trigger: dict[str, Any]) -> float:
+    """Score a single trigger condition against current execution state."""
     if not isinstance(state, dict) or not isinstance(trigger, dict):
         return 0.0
     tt, vals = trigger.get("type"), trigger.get("values")
@@ -155,35 +156,74 @@ def score_trigger(state: dict[str, Any], trigger: dict[str, Any]) -> float:
         w = float(trigger.get("weight", DEFAULT_WEIGHT))
     except (TypeError, ValueError):
         w = DEFAULT_WEIGHT
-    if tt == "goal_contains":
-        g = state.get("goal")
-        if not isinstance(g, str):
+
+    if tt in ("goal_contains", "intent"):
+        g = str(state.get("goal") or state.get("intent") or "").lower()
+        if not g:
             return 0.0
-        g = g.lower()
         return w if any(isinstance(v, str) and v.lower() in g for v in vals) else 0.0
-    tools = state.get("tools_used")
-    if not isinstance(tools, list):
+
+    if tt == "tool_used":
+        tools = state.get("tools_used") or state.get("tool_constellation")
+        if not isinstance(tools, (list, tuple, set)):
+            return 0.0
+        tset = {str(t).lower() for t in tools}
+        return w if any(isinstance(v, str) and v.lower() in tset for v in vals) else 0.0
+
+    if tt == "error_class":
+        err = str(state.get("error_class") or state.get("last_error") or "").lower()
+        if not err:
+            return 0.0
+        return w if any(isinstance(v, str) and v.lower() in err for v in vals) else 0.0
+
+    if tt == "task_kind":
+        kind = str(state.get("task_kind") or state.get("kind") or "").lower()
+        if not kind:
+            return 0.0
+        return w if any(isinstance(v, str) and v.lower() in kind for v in vals) else 0.0
+
+    return 0.0
+
+
+def score_state_against_skill(state: dict[str, Any], skill: dict[str, Any]) -> float:
+    """Score execution state against a skill's triggers, returning relevance 0.0..1.0."""
+    if not isinstance(state, dict) or not isinstance(skill, dict):
         return 0.0
-    tset = {str(t).lower() for t in tools}
-    return w if any(isinstance(v, str) and v.lower() in tset for v in vals) else 0.0
+    triggers = skill.get("triggers")
+    if not isinstance(triggers, list):
+        md = skill.get("skill_markdown")
+        triggers = parse_triggers(md) if isinstance(md, str) else []
+    if not triggers:
+        return 0.0
+    scores = [score_trigger(state, t) for t in triggers]
+    return max(scores, default=0.0)
+
+
+def get_matching_skills(
+    state: dict[str, Any],
+    skills: Sequence[dict[str, Any]],
+    threshold: float = 0.7,
+    top_k: int = 3,
+) -> list[tuple[dict[str, Any], float]]:
+    """Retrieve top matching skills whose trigger scores meet or exceed threshold."""
+    scored: list[tuple[dict[str, Any], float]] = []
+    for skill in skills:
+        if not isinstance(skill, dict):
+            continue
+        score = score_state_against_skill(state, skill)
+        if score >= threshold:
+            scored.append((skill, score))
+    scored.sort(key=lambda item: (-item[1], str(item[0].get("name", ""))))
+    return scored[:top_k]
 
 
 def best_matches(
     state: dict[str, Any], skills: Sequence[dict[str, Any]], threshold: float = 0.7
 ) -> list[tuple[str, float]]:
+    """Legacy helper returning name, score tuples."""
     ranked: list[tuple[str, float]] = []
-    for skill in skills:
-        if not isinstance(skill, dict):
-            continue
-        name = skill.get("name")
-        if not isinstance(name, str) or not name:
-            continue
-        triggers = skill.get("triggers")
-        if not isinstance(triggers, list):
-            md = skill.get("skill_markdown")
-            triggers = parse_triggers(md) if isinstance(md, str) else []
-        best = max((score_trigger(state, t) for t in triggers), default=0.0)
-        if best >= threshold:
-            ranked.append((name, best))
-    ranked.sort(key=lambda p: (-p[1], p[0]))
+    for skill, score in get_matching_skills(state, skills, threshold=threshold, top_k=100):
+        name = str(skill.get("name", ""))
+        if name:
+            ranked.append((name, score))
     return ranked

--- a/tests/evolution/test_trigger_matcher.py
+++ b/tests/evolution/test_trigger_matcher.py
@@ -5,8 +5,10 @@ import pytest
 from evolution.lib.trigger_matcher import (
     best_matches,
     extract_triggers,
+    get_matching_skills,
     parse_triggers,
     render_triggers,
+    score_state_against_skill,
     score_trigger,
 )
 
@@ -105,6 +107,69 @@ class TestScoreTrigger:
             == 0.0
         )
 
+    def test_error_class_matching(self):
+        assert (
+            score_trigger(
+                {"error_class": "database_connection_timeout"},
+                _trig("error_class", ["database_connection", "timeout"]),
+            )
+            == 1.0
+        )
+        assert (
+            score_trigger(
+                {"last_error": "ConnectionRefusedError: port 5432"},
+                _trig("error_class", ["ConnectionRefusedError"]),
+            )
+            == 1.0
+        )
+
+    def test_task_kind_matching(self):
+        assert (
+            score_trigger(
+                {"task_kind": "database_migration"},
+                _trig("task_kind", ["database_migration"]),
+            )
+            == 1.0
+        )
+
+    def test_intent_matching(self):
+        assert (
+            score_trigger(
+                {"intent": "fix broken tests in CI"},
+                _trig("intent", ["tests", "ci"]),
+            )
+            == 1.0
+        )
+
+    def test_tool_constellation_matching(self):
+        assert (
+            score_trigger(
+                {"tool_constellation": ["terminal", "browser_navigate", "read_file"]},
+                _trig("tool_used", ["browser_navigate"]),
+            )
+            == 1.0
+        )
+
+
+class TestStateAndMatchingSkills:
+    def test_score_state_against_skill(self):
+        skill = _skill("db-ops", [_trig("goal_contains", ["database"])])
+        state = {"goal": "Optimize the database query"}
+        assert score_state_against_skill(state, skill) == 1.0
+        assert score_state_against_skill({}, skill) == 0.0
+
+    def test_get_matching_skills_top_k(self):
+        skills = [
+            _skill("db-1", [_trig("goal_contains", ["db"], 0.8)]),
+            _skill("db-2", [_trig("goal_contains", ["db"], 0.95)]),
+            _skill("db-3", [_trig("goal_contains", ["db"], 0.9)]),
+            _skill("other", [_trig("goal_contains", ["other"], 0.9)]),
+        ]
+        matches = get_matching_skills({"goal": "fix db index"}, skills, threshold=0.7, top_k=2)
+        assert len(matches) == 2
+        assert matches[0][0]["name"] == "db-2"
+        assert matches[1][0]["name"] == "db-3"
+
 
 class TestBestMatches:
     def test_ranks_by_best_trigger(self):
@@ -135,3 +200,4 @@ class TestBestMatches:
             "apple",
             "zebra",
         ]
+


### PR DESCRIPTION
Implements #3217 (increment 2 of #3210).

Enhances evolution/lib/trigger_matcher.py:
- Adds multi-signal trigger scoring against task-kind, tool constellation, error class, and user intent.
- Implements score_state_against_skill(state, skill) returning 0..1 relevance.
- Implements get_matching_skills(state, skills, threshold=0.7, top_k=3) for calibrated skill retrieval.
- Comprehensive unit tests in tests/evolution/test_trigger_matcher.py covering all signal types.

Closes #3217.