### PR TITLE
feat(evolution): triggered-skill outcome logging and auto-demotion (#3218)

### DIFF
--- a/evolution/lib/skill_outcome_logger.py
+++ b/evolution/lib/skill_outcome_logger.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""Triggered-skill outcome logging and auto-demotion (#3218, child of #3210).
+
+Closes the feedback loop for triggered skills:
+- Logs (skill_id, trigger_confidence, success, revision) per triggered use.
+- Tracks triggered_use_count and triggered_success_count.
+- Demotes skills whose triggered success rate falls below 50% over >= 5 uses.
+- Supports re-promotion and stats inspection.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_MIN_USES = 5
+DEFAULT_MIN_SUCCESS_RATE = 0.5
+
+
+class _SkillOutcomeStore:
+    """Thread-safe in-memory and persistent store for skill execution outcomes."""
+
+    def __init__(self, storage_file: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._storage_file = storage_file
+        self._stats: Dict[str, Dict[str, Any]] = {}
+        self._events: List[Dict[str, Any]] = []
+        if storage_file and storage_file.is_file():
+            self._load()
+
+    def _load(self) -> None:
+        try:
+            if self._storage_file and self._storage_file.is_file():
+                data = json.loads(self._storage_file.read_text(encoding="utf-8"))
+                self._stats = data.get("stats", {})
+                self._events = data.get("events", [])
+        except Exception:
+            pass
+
+    def _save(self) -> None:
+        if not self._storage_file:
+            return
+        try:
+            self._storage_file.parent.mkdir(parents=True, exist_ok=True)
+            self._storage_file.write_text(
+                json.dumps({"stats": self._stats, "events": self._events[-500:]}, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    def record_outcome(
+        self,
+        skill_id: str,
+        trigger_confidence: float,
+        success: bool,
+        revision: str = "",
+    ) -> Dict[str, Any]:
+        with self._lock:
+            sid = str(skill_id).strip()
+            if not sid:
+                return {}
+            rec = self._stats.setdefault(
+                sid,
+                {
+                    "skill_id": sid,
+                    "triggered_use_count": 0,
+                    "triggered_success_count": 0,
+                    "demoted": False,
+                    "revision": revision,
+                },
+            )
+            rec["triggered_use_count"] += 1
+            if success:
+                rec["triggered_success_count"] += 1
+            if revision:
+                rec["revision"] = revision
+
+            uses = rec["triggered_use_count"]
+            succ = rec["triggered_success_count"]
+            rate = succ / uses if uses > 0 else 0.0
+            rec["success_rate"] = rate
+
+            # Demotion rule: rate < 0.5 over >= 5 uses
+            if uses >= DEFAULT_MIN_USES and rate < DEFAULT_MIN_SUCCESS_RATE:
+                rec["demoted"] = True
+            elif uses >= DEFAULT_MIN_USES and rate >= DEFAULT_MIN_SUCCESS_RATE:
+                rec["demoted"] = False
+
+            self._events.append({
+                "skill_id": sid,
+                "trigger_confidence": float(trigger_confidence),
+                "success": bool(success),
+                "revision": revision,
+            })
+            self._save()
+            return dict(rec)
+
+    def is_demoted(
+        self,
+        skill_id: str,
+        min_uses: int = DEFAULT_MIN_USES,
+        min_success_rate: float = DEFAULT_MIN_SUCCESS_RATE,
+    ) -> bool:
+        with self._lock:
+            sid = str(skill_id).strip()
+            rec = self._stats.get(sid)
+            if not rec:
+                return False
+            uses = rec.get("triggered_use_count", 0)
+            succ = rec.get("triggered_success_count", 0)
+            if uses < min_uses:
+                return False
+            rate = succ / uses if uses > 0 else 0.0
+            return rate < min_success_rate or bool(rec.get("demoted", False))
+
+    def get_stats(self, skill_id: Optional[str] = None) -> Dict[str, Any]:
+        with self._lock:
+            if skill_id:
+                sid = str(skill_id).strip()
+                return dict(self._stats.get(sid, {}))
+            return {k: dict(v) for k, v in self._stats.items()}
+
+    def promote_skill(self, skill_id: str) -> Dict[str, Any]:
+        """Re-promote a skill, clearing its demotion state."""
+        with self._lock:
+            sid = str(skill_id).strip()
+            rec = self._stats.setdefault(
+                sid,
+                {
+                    "skill_id": sid,
+                    "triggered_use_count": 0,
+                    "triggered_success_count": 0,
+                    "demoted": False,
+                },
+            )
+            rec["demoted"] = False
+            rec["triggered_use_count"] = 0
+            rec["triggered_success_count"] = 0
+            rec["success_rate"] = 1.0
+            self._save()
+            return dict(rec)
+
+
+_GLOBAL_STORE = _SkillOutcomeStore()
+
+
+def record_skill_outcome(
+    skill_id: str,
+    trigger_confidence: float,
+    success: bool,
+    revision: str = "",
+) -> Dict[str, Any]:
+    """Record execution outcome for a triggered skill."""
+    return _GLOBAL_STORE.record_outcome(
+        skill_id=skill_id,
+        trigger_confidence=trigger_confidence,
+        success=success,
+        revision=revision,
+    )
+
+
+def is_skill_demoted(skill_id: str) -> bool:
+    """Return True if skill has been demoted due to poor triggered success rate."""
+    return _GLOBAL_STORE.is_demoted(skill_id=skill_id)
+
+
+def get_skill_stats(skill_id: Optional[str] = None) -> Dict[str, Any]:
+    """Get outcome stats for a specific skill or all skills."""
+    return _GLOBAL_STORE.get_stats(skill_id=skill_id)
+
+
+def promote_skill(skill_id: str) -> Dict[str, Any]:
+    """Manually re-promote a demoted skill."""
+    return _GLOBAL_STORE.promote_skill(skill_id=skill_id)

--- a/evolution/lib/trigger_matcher.py
+++ b/evolution/lib/trigger_matcher.py
@@ -206,9 +206,18 @@ def get_matching_skills(
     top_k: int = 3,
 ) -> list[tuple[dict[str, Any], float]]:
     """Retrieve top matching skills whose trigger scores meet or exceed threshold."""
+    try:
+        from evolution.lib.skill_outcome_logger import is_skill_demoted
+    except ImportError:
+        def is_skill_demoted(name: str) -> bool:
+            return False
+
     scored: list[tuple[dict[str, Any], float]] = []
     for skill in skills:
         if not isinstance(skill, dict):
+            continue
+        name = str(skill.get("name", ""))
+        if skill.get("demoted") or (name and is_skill_demoted(name)):
             continue
         score = score_state_against_skill(state, skill)
         if score >= threshold:

--- a/tests/evolution/test_skill_outcome_logger.py
+++ b/tests/evolution/test_skill_outcome_logger.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for evolution.lib.skill_outcome_logger (#3218)."""
+
+import pytest
+from evolution.lib.skill_outcome_logger import (
+    _SkillOutcomeStore,
+    get_skill_stats,
+    is_skill_demoted,
+    promote_skill,
+    record_skill_outcome,
+)
+from evolution.lib.trigger_matcher import get_matching_skills
+
+
+class TestSkillOutcomeLogger:
+    def test_record_single_outcome(self):
+        store = _SkillOutcomeStore()
+        rec = store.record_outcome("deploy-app", 0.9, True, revision="v1")
+        assert rec["triggered_use_count"] == 1
+        assert rec["triggered_success_count"] == 1
+        assert rec["success_rate"] == 1.0
+        assert not store.is_demoted("deploy-app")
+
+    def test_demotion_after_5_uses_under_half_success(self):
+        store = _SkillOutcomeStore()
+        # 1 success, 4 failures = 20% success rate over 5 uses
+        store.record_outcome("flake-skill", 0.8, True)
+        store.record_outcome("flake-skill", 0.8, False)
+        store.record_outcome("flake-skill", 0.8, False)
+        store.record_outcome("flake-skill", 0.8, False)
+        assert not store.is_demoted("flake-skill")  # 4 uses, not yet demoted (needs 5)
+        rec = store.record_outcome("flake-skill", 0.8, False)
+        assert rec["triggered_use_count"] == 5
+        assert rec["success_rate"] == pytest.approx(0.2)
+        assert rec["demoted"] is True
+        assert store.is_demoted("flake-skill") is True
+
+    def test_re_promotion_clears_demotion(self):
+        store = _SkillOutcomeStore()
+        for _ in range(5):
+            store.record_outcome("flake-skill", 0.8, False)
+        assert store.is_demoted("flake-skill") is True
+
+        promoted = store.promote_skill("flake-skill")
+        assert promoted["demoted"] is False
+        assert store.is_demoted("flake-skill") is False
+
+    def test_persistence_roundtrip(self, tmp_path):
+        f = tmp_path / "outcomes.json"
+        store1 = _SkillOutcomeStore(f)
+        store1.record_outcome("test-skill", 0.95, True, revision="r1")
+        assert f.is_file()
+
+        store2 = _SkillOutcomeStore(f)
+        stats = store2.get_stats("test-skill")
+        assert stats["triggered_use_count"] == 1
+        assert stats["triggered_success_count"] == 1
+        assert stats["revision"] == "r1"
+
+
+class TestTriggerMatcherDemotionIntegration:
+    def test_demoted_skills_excluded_from_matches(self):
+        # Mark flaky-skill as demoted
+        for _ in range(5):
+            record_skill_outcome("flaky-skill", 0.9, False)
+        assert is_skill_demoted("flaky-skill") is True
+
+        skills = [
+            {"name": "flaky-skill", "triggers": [{"type": "goal_contains", "values": ["test"], "weight": 1.0}]},
+            {"name": "good-skill", "triggers": [{"type": "goal_contains", "values": ["test"], "weight": 1.0}]},
+        ]
+        matches = get_matching_skills({"goal": "run test workflow"}, skills, threshold=0.7)
+        assert len(matches) == 1
+        assert matches[0][0]["name"] == "good-skill"


### PR DESCRIPTION
Implements #3218 (increment 3 of #3210).

Adds evolution/lib/skill_outcome_logger.py and connects it with trigger matching:
- Records execution outcome (skill_id, trigger_confidence, success/failure, revision) for triggered skills.
- Tracks triggered_use_count, triggered_success_count, and success rate.
- Automatically demotes skills whose success rate falls below 50% over >= 5 triggered uses.
- Excludes demoted skills from runtime trigger matching.
- Supports manual re-promotion and stats inspection.
- Unit tests in tests/evolution/test_skill_outcome_logger.py.

Closes #3218.