### PR TITLE
feat(tools): retry-spiral circuit breaker and diagnostic fallback (#3241)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1963,6 +1963,30 @@ def handle_function_call(
         except Exception:
             logger.debug("Audit trail tool call record failed", exc_info=True)
 
+        # Retry-spiral circuit breaker check (#3241)
+        try:
+            from tools.tool_circuit_breaker import TOOL_CIRCUIT_BREAKER
+            _st, _err_type, _err_msg = _tool_result_observer_fields(function_name, result)
+            _eff_sid = session_id or task_id or "default"
+            _breaker_event = TOOL_CIRCUIT_BREAKER.record_result(
+                session_id=_eff_sid,
+                tool_name=function_name,
+                status=_st,
+                error_message=_err_msg,
+            )
+            if _breaker_event and _breaker_event.get("circuit_breaker_tripped"):
+                if isinstance(result, str) and "[CIRCUIT_BREAKER]" not in result:
+                    _diag = (
+                        f"\n\n[CIRCUIT_BREAKER] Tool '{function_name}' has failed "
+                        f"{_breaker_event['consecutive_failures']} consecutive times "
+                        f"(budget: {_breaker_event['budget']}). "
+                        f"Class: {_breaker_event['failure_class']}. "
+                        f"Recommendation: {_breaker_event['strategy_recommendation']}"
+                    )
+                    result += _diag
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:

--- a/tests/tools/test_tool_circuit_breaker.py
+++ b/tests/tools/test_tool_circuit_breaker.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for tools.tool_circuit_breaker (#3241)."""
+
+import pytest
+from tools.tool_circuit_breaker import (
+    _ToolCircuitBreakerTracker,
+    classify_tool_error,
+    get_strategy_recommendation,
+    FAILURE_CLASS_NOT_FOUND,
+    FAILURE_CLASS_PERMISSION,
+    FAILURE_CLASS_INVALID_ARG,
+    FAILURE_CLASS_TIMEOUT,
+    FAILURE_CLASS_PROVIDER,
+    FAILURE_CLASS_TRANSIENT,
+)
+
+
+class TestClassifyToolError:
+    def test_not_found(self):
+        assert classify_tool_error("FileNotFoundError: [Errno 2] No such file or directory: 'foo.txt'") == FAILURE_CLASS_NOT_FOUND
+        assert classify_tool_error("Cannot find path /bar") == FAILURE_CLASS_NOT_FOUND
+
+    def test_permission_denied(self):
+        assert classify_tool_error("PermissionError: [Errno 13] Permission denied") == FAILURE_CLASS_PERMISSION
+
+    def test_invalid_arg(self):
+        assert classify_tool_error("ValueError: invalid literal for int()") == FAILURE_CLASS_INVALID_ARG
+
+    def test_timeout(self):
+        assert classify_tool_error("TimeoutError: command timed out after 30s") == FAILURE_CLASS_TIMEOUT
+
+    def test_provider_error(self):
+        assert classify_tool_error("API rate limit exceeded (429)") == FAILURE_CLASS_PROVIDER
+
+    def test_transient_fallback(self):
+        assert classify_tool_error("Unexpected unknown anomaly") == FAILURE_CLASS_TRANSIENT
+        assert classify_tool_error(None) == FAILURE_CLASS_TRANSIENT
+
+
+class TestStrategyRecommendation:
+    def test_patch_recommendation(self):
+        rec = get_strategy_recommendation("patch", FAILURE_CLASS_NOT_FOUND)
+        assert "read_file" in rec
+
+    def test_read_file_recommendation(self):
+        rec = get_strategy_recommendation("read_file", FAILURE_CLASS_NOT_FOUND)
+        assert "target path exists" in rec
+
+    def test_terminal_recommendation(self):
+        rec = get_strategy_recommendation("terminal", FAILURE_CLASS_TIMEOUT)
+        assert "background task" in rec or "prerequisites" in rec
+
+
+class TestToolCircuitBreakerTracker:
+    def test_single_failure_does_not_trip(self):
+        tracker = _ToolCircuitBreakerTracker()
+        event = tracker.record_result("sess1", "read_file", "error", "file not found", budget=3)
+        assert event is None
+
+    def test_exhausted_budget_trips_circuit_breaker(self):
+        tracker = _ToolCircuitBreakerTracker()
+        tracker.record_result("sess1", "read_file", "error", "file not found", budget=3)
+        tracker.record_result("sess1", "read_file", "error", "file not found", budget=3)
+        event = tracker.record_result("sess1", "read_file", "error", "file not found", budget=3)
+        assert event is not None
+        assert event["circuit_breaker_tripped"] is True
+        assert event["consecutive_failures"] == 3
+        assert event["failure_class"] == FAILURE_CLASS_NOT_FOUND
+        assert "target path exists" in event["strategy_recommendation"]
+
+    def test_success_resets_consecutive_failures(self):
+        tracker = _ToolCircuitBreakerTracker()
+        tracker.record_result("sess1", "patch", "error", "patch reject", budget=3)
+        tracker.record_result("sess1", "patch", "error", "patch reject", budget=3)
+        # Success resets
+        tracker.record_result("sess1", "patch", "ok")
+        event = tracker.record_result("sess1", "patch", "error", "patch reject", budget=3)
+        assert event is None  # Only 1 consecutive failure now
+
+    def test_session_isolation(self):
+        tracker = _ToolCircuitBreakerTracker()
+        for _ in range(3):
+            tracker.record_result("sess1", "terminal", "error", "command failed", budget=3)
+        stats1 = tracker.get_session_stats("sess1")
+        stats2 = tracker.get_session_stats("sess2")
+        assert stats1["terminal"]["consecutive_failures"] == 3
+        assert "terminal" not in stats2

--- a/tools/tool_circuit_breaker.py
+++ b/tools/tool_circuit_breaker.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Retry-spiral circuit breaker and diagnostic fallback for core tool invocations (#3241).
+
+Prevents infinite retry spirals on core tools (read_file, patch, terminal, search_files)
+by tracking consecutive failures per session, classifying the failure mode, and
+tripping with structured diagnostic guidance once the per-tool budget is exceeded.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TOOL_RETRY_BUDGETS = {
+    "read_file": 3,
+    "write_file": 3,
+    "patch": 3,
+    "search_files": 3,
+    "terminal": 5,
+}
+
+FAILURE_CLASS_NOT_FOUND = "not_found"
+FAILURE_CLASS_PERMISSION = "permission_denied"
+FAILURE_CLASS_INVALID_ARG = "invalid_argument"
+FAILURE_CLASS_TIMEOUT = "timeout"
+FAILURE_CLASS_PROVIDER = "provider_error"
+FAILURE_CLASS_TRANSIENT = "transient"
+
+
+def classify_tool_error(error_text: Optional[str]) -> str:
+    """Deterministically classify a tool error string into a standard failure class."""
+    if not error_text or not isinstance(error_text, str):
+        return FAILURE_CLASS_TRANSIENT
+    txt = error_text.lower()
+    if any(s in txt for s in ("not found", "no such file", "enoent", "404", "cannot find")):
+        return FAILURE_CLASS_NOT_FOUND
+    if any(s in txt for s in ("permission denied", "access denied", "eacces", "403", "unauthorized", "operation not permitted")):
+        return FAILURE_CLASS_PERMISSION
+    if any(s in txt for s in ("invalid argument", "valueerror", "typeerror", "schema", "required argument", "unexpected keyword")):
+        return FAILURE_CLASS_INVALID_ARG
+    if any(s in txt for s in ("timeout", "timed out", "deadline exceeded", "econnreset")):
+        return FAILURE_CLASS_TIMEOUT
+    if any(s in txt for s in ("rate limit", "429", "500", "502", "503", "service unavailable", "quota")):
+        return FAILURE_CLASS_PROVIDER
+    return FAILURE_CLASS_TRANSIENT
+
+
+def get_strategy_recommendation(tool_name: str, failure_class: str, last_error: Optional[str] = None) -> str:
+    """Return targeted diagnostic recommendations for exhausted tool retry budgets."""
+    t = (tool_name or "").lower()
+    if t == "patch":
+        return "Re-read the target file with read_file to inspect current line numbers and exact content before attempting another patch."
+    if t == "read_file":
+        return "Verify the target path exists and check permissions before reading again."
+    if t == "search_files":
+        return "Simplify search query or regex, or check the search directory path."
+    if t == "terminal":
+        return "For long-running or failing commands, verify prerequisites, arguments, or consider running as a background task."
+    return "Inspect tool arguments and preconditions before retrying."
+
+
+class _ToolCircuitBreakerTracker:
+    """Thread-safe tracker for tool invocation success rates and retry spirals."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+    def record_result(
+        self,
+        session_id: str,
+        tool_name: str,
+        status: str,
+        error_message: Optional[str] = None,
+        budget: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Record a tool result and return a diagnostic event if the circuit breaker trips."""
+        with self._lock:
+            sid = str(session_id or "default").strip()
+            tname = str(tool_name or "").strip()
+            if not sid or not tname:
+                return None
+
+            sess_map = self._state.setdefault(sid, {})
+            tool_rec = sess_map.setdefault(
+                tname,
+                {
+                    "consecutive_failures": 0,
+                    "total_calls": 0,
+                    "total_failures": 0,
+                    "last_error": None,
+                    "last_failure_class": None,
+                },
+            )
+
+            tool_rec["total_calls"] += 1
+
+            if status == "error":
+                tool_rec["consecutive_failures"] += 1
+                tool_rec["total_failures"] += 1
+                tool_rec["last_error"] = error_message
+                fclass = classify_tool_error(error_message)
+                tool_rec["last_failure_class"] = fclass
+
+                eff_budget = budget or DEFAULT_TOOL_RETRY_BUDGETS.get(tname, 3)
+                consecutive = tool_rec["consecutive_failures"]
+
+                if consecutive >= eff_budget:
+                    recommendation = get_strategy_recommendation(tname, fclass, error_message)
+                    return {
+                        "circuit_breaker_tripped": True,
+                        "consecutive_failures": consecutive,
+                        "budget": eff_budget,
+                        "failure_class": fclass,
+                        "tool_name": tname,
+                        "last_error": error_message,
+                        "strategy_recommendation": recommendation,
+                    }
+                return None
+            else:
+                tool_rec["consecutive_failures"] = 0
+                return None
+
+    def get_session_stats(self, session_id: str) -> Dict[str, Any]:
+        with self._lock:
+            sid = str(session_id or "default").strip()
+            return {k: dict(v) for k, v in self._state.get(sid, {}).items()}
+
+    def reset(self, session_id: Optional[str] = None) -> None:
+        with self._lock:
+            if session_id:
+                self._state.pop(str(session_id).strip(), None)
+            else:
+                self._state.clear()
+
+
+TOOL_CIRCUIT_BREAKER = _ToolCircuitBreakerTracker()


### PR DESCRIPTION
Implements #3241.

Adds tools/tool_circuit_breaker.py and integrates it into model_tools.py:
- Per-tool consecutive-failure budgets (e.g. 3 for read_file/write_file/patch/search_files, 5 for terminal).
- Deterministic error classification: not_found, permission_denied, invalid_argument, timeout, provider_error, transient.
- Emits structured diagnostic feedback with targeted recovery recommendations when a tool's retry budget is exhausted.
- Thread-safe per-session tracking and isolation.
- Unit tests in tests/tools/test_tool_circuit_breaker.py.

Closes #3241.