### PR TITLE
feat(evolution): co-evolve agent-critic feedback and advantage shaping (#3244)

### DIFF
--- a/scripts/evolution_evaluator.py
+++ b/scripts/evolution_evaluator.py
@@ -275,6 +275,41 @@ def _exit_code(verdict: str) -> int:
     }.get(verdict, EXIT_BAD_INPUT)
 
 
+def update_rubric_weights_from_outcome(
+    dimension_scores: Dict[str, float],
+    outcome_success: bool,
+    *,
+    current_weights: Optional[Dict[str, float]] = None,
+    learning_rate: float = 0.05,
+    skip_gap_advantage: Optional[float] = None,
+    min_weight: float = 0.2,
+    max_weight: float = 3.0,
+) -> Dict[str, float]:
+    """Co-evolve rubric weights based on post-merge outcome feedback (#3244, CAFE pattern).
+
+    Dimensions where high scores aligned with success (or low scores with failure)
+    receive positive advantage reinforcement. Mispredicted dimensions are adjusted
+    proportionally with advantage shaping. All weights are bounded in [min_weight, max_weight].
+    """
+    weights = dict(current_weights or DEFAULT_RUBRIC)
+    multiplier = 1.0
+    if skip_gap_advantage is not None:
+        multiplier = max(0.1, min(3.0, 1.0 + float(skip_gap_advantage)))
+
+    target_delta_sign = 1.0 if outcome_success else -1.0
+
+    for dim, score in dimension_scores.items():
+        if dim not in weights:
+            continue
+        sc = _clamp01(score)
+        advantage = (sc - 0.5) * 2.0
+        delta = learning_rate * multiplier * target_delta_sign * advantage
+        new_w = max(min_weight, min(max_weight, weights[dim] + delta))
+        weights[dim] = round(new_w, 4)
+
+    return weights
+
+
 def _parse_args(argv: List[str]) -> Tuple[Dict[str, Any], Optional[str]]:
     """Tiny hand-rolled arg parse (matches the other evolution_* CLIs' style).
 

--- a/tests/scripts/test_evolution_evaluator.py
+++ b/tests/scripts/test_evolution_evaluator.py
@@ -20,6 +20,7 @@ from evolution_evaluator import (  # noqa: E402
     evaluate_candidates,
     main,
     score_candidate,
+    update_rubric_weights_from_outcome,
 )
 
 
@@ -300,3 +301,38 @@ class TestCli:
     def test_bad_numeric_flag_exit_2(self, capsys):
         rc = main(["evolution_evaluator.py", "--threshold", "high"])
         assert rc == EXIT_BAD_INPUT
+
+
+class TestCoEvolveCriticFeedback:
+    def test_success_outcome_increases_high_scoring_dimensions(self):
+        initial = {"relevance": 1.0, "correctness": 1.2}
+        updated = update_rubric_weights_from_outcome(
+            {"relevance": 0.9, "correctness": 0.3},
+            outcome_success=True,
+            current_weights=initial,
+            learning_rate=0.1,
+        )
+        assert updated["relevance"] > 1.0
+        assert updated["correctness"] < 1.2
+
+    def test_failure_outcome_penalizes_high_scoring_dimensions(self):
+        initial = {"relevance": 1.0, "correctness": 1.2}
+        updated = update_rubric_weights_from_outcome(
+            {"relevance": 0.9, "correctness": 0.3},
+            outcome_success=False,
+            current_weights=initial,
+            learning_rate=0.1,
+        )
+        assert updated["relevance"] < 1.0
+        assert updated["correctness"] > 1.2
+
+    def test_weights_stay_bounded(self):
+        initial = {"relevance": 2.95}
+        updated = update_rubric_weights_from_outcome(
+            {"relevance": 1.0},
+            outcome_success=True,
+            current_weights=initial,
+            learning_rate=0.5,
+            max_weight=3.0,
+        )
+        assert updated["relevance"] <= 3.0


### PR DESCRIPTION
Implements #3244.

Adds update_rubric_weights_from_outcome to scripts/evolution_evaluator.py (CAFE co-evolving feedback pattern):
- Updates rubric weights based on post-merge outcome feedback.
- Reweights scoring advantages with feedback-aware advantage shaping and skip-gap signal.
- Enforces strict deterministic bounds [min_weight, max_weight] on all weight updates.
- Unit tests in tests/scripts/test_evolution_evaluator.py.

Closes #3244.