### PR TITLE
fix(checkpoint): survive unreadable dirs in git add -A

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -169,6 +169,56 @@ class TestTakeCheckpoint:
         (work_dir / "main.py").write_text("print('modified')\n")
         assert mgr.ensure_checkpoint(str(work_dir), "turn 2") is True
 
+    def test_unreadable_subdir_does_not_kill_checkpoint(self, mgr, work_dir):
+        """#127: a root-owned /tmp/systemd-private-* style dir (unreadable to
+        the agent) must not silently kill the whole checkpoint — the readable
+        content still lands in the snapshot."""
+        locked = work_dir / "locked"
+        locked.mkdir()
+        (locked / "secret.txt").write_text("nope\n")
+        locked.chmod(0o000)
+        try:
+            assert mgr.ensure_checkpoint(str(work_dir), "with locked dir") is True
+        finally:
+            locked.chmod(0o755)
+        snapshots = mgr.list_checkpoints(str(work_dir))
+        assert len(snapshots) == 1
+
+    def test_unreadable_subdir_retry_excludes_and_succeeds(
+        self, mgr, work_dir, monkeypatch,
+    ):
+        """#127: when `git add -A` fails (rc=128, unreadable dirs), the retry
+        excludes those paths from staging and still snapshots readable content."""
+        import tools.checkpoint_manager as ckm
+
+        locked = work_dir / "locked"
+        locked.mkdir()
+        (locked / "secret.txt").write_text("nope\n")
+        locked.chmod(0o000)
+
+        real_run_git = ckm._run_git
+        calls: list = []
+
+        def flaky_add(args, store, working_dir, **kw):
+            calls.append(list(args))
+            if args[:2] == ["add", "-A"] and "--ignore-errors" not in args:
+                return False, "", (
+                    "warning: could not open directory 'locked/': Permission denied"
+                )
+            return real_run_git(args, store, working_dir, **kw)
+
+        monkeypatch.setattr(ckm, "_run_git", flaky_add)
+        try:
+            assert mgr.ensure_checkpoint(str(work_dir), "with locked dir") is True
+        finally:
+            locked.chmod(0o755)
+
+        retry = [c for c in calls if "--ignore-errors" in c]
+        assert retry, "expected a retry add with --ignore-errors"
+        assert any(":(exclude,top)locked" in str(p) for p in retry[0])
+        snapshots = mgr.list_checkpoints(str(work_dir))
+        assert len(snapshots) == 1
+
 
 # =========================================================================
 # CheckpointManager — listing

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -420,6 +420,31 @@ def _run_git(
         return False, "", str(exc)
 
 
+def _unreadable_dirs(working_dir: Path) -> List[str]:
+    """Return top-relative paths of directories under *working_dir* that cannot be read.
+
+    ``git add -A`` can fail hard (rc=128) when the working tree contains
+    directories it cannot open — e.g. root-owned ``/tmp/systemd-private-*``
+    trees — even though it only prints warnings. Callers can exclude these
+    from staging with ``:(exclude,top)<rel>`` pathspecs so one inaccessible
+    subtree does not silently kill every checkpoint of the project (#127).
+    """
+    unreadable: List[str] = []
+    for root, dirs, _files in os.walk(working_dir):
+        kept: List[str] = []
+        for name in dirs:
+            path = Path(root) / name
+            if os.access(path, os.R_OK | os.X_OK):
+                kept.append(name)
+            else:
+                try:
+                    unreadable.append(str(path.relative_to(working_dir)))
+                except ValueError:
+                    unreadable.append(str(path))
+        dirs[:] = kept
+    return unreadable
+
+
 # ---------------------------------------------------------------------------
 # Store initialisation + legacy migration
 # ---------------------------------------------------------------------------
@@ -1261,8 +1286,30 @@ class CheckpointManager:
             timeout=_GIT_TIMEOUT * 2, index_file=index_file,
         )
         if not ok:
-            logger.debug("Checkpoint git-add failed: %s", err)
-            return False
+            # #127: `git add -A` fails rc=128 when the working tree contains
+            # directories the agent cannot read (e.g. root-owned
+            # /tmp/systemd-private-* dirs), even when git only prints warnings
+            # for them. Every subsequent checkpoint of that project then fails
+            # and session snapshots silently stop being persisted. Locate the
+            # unreadable paths, exclude them from staging, and retry once —
+            # the checkpoint still captures everything readable.
+            work_path = _normalize_path(working_dir)
+            unreadable = _unreadable_dirs(work_path) if work_path.is_dir() else []
+            if unreadable:
+                pathspecs = [f":(exclude,top){rel}" for rel in unreadable]
+                logger.warning(
+                    "Checkpoint git-add failed — excluding %d unreadable "
+                    "path(s) from staging and retrying: %s",
+                    len(unreadable), ", ".join(pathspecs),
+                )
+                ok, _, err = _run_git(
+                    ["add", "-A", "--ignore-errors", "--", *pathspecs],
+                    store, working_dir,
+                    timeout=_GIT_TIMEOUT * 2, index_file=index_file,
+                )
+            if not ok:
+                logger.error("Checkpoint git-add failed after retry: %s", err)
+                return False
 
         if self.max_file_size_mb > 0:
             self._drop_oversize_from_index(store, working_dir, index_file)


### PR DESCRIPTION
Automated evolution PR for issue #127 (checkpoint_manager `git add -A` fails rc=128 — session checkpoints silently not persisted).

**Problem:** 31+ failures on 08-26, 6 on 08-27: `git add -A` returns rc=128 when
the checkpointed working tree contains root-owned directories the agent cannot
read (e.g. `/tmp/systemd-private-<hash>-<service>.service-*/`). Git only prints
warnings for them, but the add fails — so every checkpoint of that project
silently stops being persisted (recovery/rollback data goes stale).

**Fix:**
- New `_unreadable_dirs()` helper: walks the working tree and collects
  top-relative paths the agent cannot read (pruning them from the walk).
- On `git add -A` failure, retry once with `--ignore-errors` and
  `:(exclude,top)<rel>` pathspecs for each unreadable path — the checkpoint
  still captures everything readable.
- If the retry also fails, log at ERROR level (loud, not silent).

**Checks (local):**
- `ruff check tools/checkpoint_manager.py tests/tools/test_checkpoint_manager.py` — passed
- `pytest tests/tools/test_checkpoint_manager.py` — 49 passed (2 new regression tests)
- Exclude-pathspec staging verified against a bare store + worktree sandbox

Closes https://github.com/Da-Mikey/hermes-agent-evolution/issues/127