### PR TITLE
feat(recovery): symptom-driven intervention for tool and execution failures (#3284)

### DIFF
--- a/agent/symptom_intervention.py
+++ b/agent/symptom_intervention.py
@@ -1,0 +1,292 @@
+"""Symptom-driven intervention engine for failure diagnosis and repair.
+
+Implements #3284: Replaces unguided rerun/resample loops with deterministic,
+symptom-anchored interventions based on empirical failure classification.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class SymptomCategory(str, Enum):
+    syntax_error = "syntax_error"
+    import_error = "import_error"
+    assertion_failure = "assertion_failure"
+    file_not_found = "file_not_found"
+    permission_denied = "permission_denied"
+    rate_limit_stall = "rate_limit_stall"
+    timeout_stall = "timeout_stall"
+    schema_violation = "schema_violation"
+    unknown = "unknown"
+
+
+@dataclass(frozen=True)
+class SymptomClassification:
+    category: SymptomCategory
+    target_file: Optional[str] = None
+    target_line: Optional[int] = None
+    failing_symbol: Optional[str] = None
+    root_cause_snippet: str = ""
+    is_deterministic: bool = True
+
+
+@dataclass(frozen=True)
+class InterventionPlan:
+    symptom: SymptomClassification
+    directive: str
+    suggested_action: str
+    prevent_blind_retry: bool = True
+
+    def render_markdown(self) -> str:
+        lines = [
+            f"[SYMPTOM INTERVENTION: {self.symptom.category.value.upper()}]",
+            f"• Root Cause: {self.symptom.root_cause_snippet or self.symptom.category.value}",
+        ]
+        if self.symptom.target_file:
+            loc = self.symptom.target_file
+            if self.symptom.target_line:
+                loc += f":{self.symptom.target_line}"
+            lines.append(f"• Location: {loc}")
+        if self.symptom.failing_symbol:
+            lines.append(f"• Symbol: {self.symptom.failing_symbol}")
+        lines.append(f"• Directive: {self.directive}")
+        lines.append(f"• Action: {self.suggested_action}")
+        return "\n".join(lines)
+
+
+_SYNTAX_RE = re.compile(
+    r'(?:SyntaxError|IndentationError|TabError):\s*([^\n]+)|(?:File\s+"([^"]+)",\s+line\s+(\d+))',
+    re.IGNORECASE,
+)
+_IMPORT_RE = re.compile(
+    r'(?:ModuleNotFoundError|ImportError):\s*(?:No module named\s+[\'"]([^\'"]+)[\'"]|cannot import name\s+[\'"]([^\'"]+)[\'"])',
+    re.IGNORECASE,
+)
+_ASSERT_RE = re.compile(
+    r'(?:AssertionError|assert\s+[^\n]+|E\s+AssertionError:\s*([^\n]+))',
+    re.IGNORECASE,
+)
+_FNF_RE = re.compile(
+    r'(?:FileNotFoundError|NoSuchFileException|No such file or directory).*?:\s*[\'"]?([^\n\'"]+)[\'"]?',
+    re.IGNORECASE,
+)
+_PERM_RE = re.compile(
+    r'(?:PermissionError|AccessDeniedException|Permission denied)',
+    re.IGNORECASE,
+)
+_RATE_LIMIT_RE = re.compile(
+    r'(?:429\s+Too\s+Many\s+Requests|rate_limit_exceeded|QuotaExceeded|rate limit reached)',
+    re.IGNORECASE,
+)
+_TIMEOUT_RE = re.compile(
+    r'(?:TimeoutError|Timed out after|stale timeout|deadline exceeded)',
+    re.IGNORECASE,
+)
+_SCHEMA_RE = re.compile(
+    r'(?:ValidationError|SchemaError|JSONDecodeError|invalid JSON|schema validation failed)',
+    re.IGNORECASE,
+)
+
+
+def classify_failure_symptom(
+    error_text: str, tool_name: Optional[str] = None
+) -> SymptomClassification:
+    """Classify a raw error output or trace failure into a structured symptom."""
+    text = (error_text or "").strip()
+    if not text:
+        return SymptomClassification(
+            category=SymptomCategory.unknown,
+            root_cause_snippet="empty error output",
+            is_deterministic=False,
+        )
+
+    # 1. Syntax / Indentation Error
+    m_syntax = _SYNTAX_RE.search(text)
+    if m_syntax:
+        # Extract file / line if present
+        file_matches = re.findall(r'File\s+"([^"]+)",\s+line\s+(\d+)', text)
+        target_file = file_matches[-1][0] if file_matches else None
+        target_line = int(file_matches[-1][1]) if file_matches else None
+        snippet = m_syntax.group(1) or m_syntax.group(0)
+        return SymptomClassification(
+            category=SymptomCategory.syntax_error,
+            target_file=target_file,
+            target_line=target_line,
+            root_cause_snippet=snippet.strip(),
+            is_deterministic=True,
+        )
+
+    # 2. Module / Import Error
+    m_import = _IMPORT_RE.search(text)
+    if m_import:
+        symbol = m_import.group(1) or m_import.group(2) or ""
+        return SymptomClassification(
+            category=SymptomCategory.import_error,
+            failing_symbol=symbol.strip(),
+            root_cause_snippet=m_import.group(0).strip(),
+            is_deterministic=True,
+        )
+
+    # 3. Assertion Failure
+    m_assert = _ASSERT_RE.search(text)
+    if m_assert:
+        # Extract test file/line if present
+        test_file_match = re.search(r'([\w\-\./]+test[\w\-\.]*\.py):(\d+):', text)
+        t_file = test_file_match.group(1) if test_file_match else None
+        t_line = int(test_file_match.group(2)) if test_file_match else None
+        return SymptomClassification(
+            category=SymptomCategory.assertion_failure,
+            target_file=t_file,
+            target_line=t_line,
+            root_cause_snippet=m_assert.group(0).strip(),
+            is_deterministic=True,
+        )
+
+    # 4. File Not Found
+    if "filenotfounderror" in text.lower() or "no such file or directory" in text.lower():
+        path_match = re.search(
+            r'(?:No such file or directory|FileNotFoundError).*?[\'"]([^\n\'"]+)[\'"]',
+            text,
+        )
+        missing_path = path_match.group(1) if path_match else None
+        return SymptomClassification(
+            category=SymptomCategory.file_not_found,
+            target_file=missing_path.strip() if missing_path else None,
+            root_cause_snippet="File or directory not found",
+            is_deterministic=True,
+        )
+
+    # 5. Permission Denied
+    if _PERM_RE.search(text):
+        return SymptomClassification(
+            category=SymptomCategory.permission_denied,
+            root_cause_snippet="Permission denied or insufficient access rights",
+            is_deterministic=True,
+        )
+
+    # 6. Rate Limit
+    if _RATE_LIMIT_RE.search(text):
+        return SymptomClassification(
+            category=SymptomCategory.rate_limit_stall,
+            root_cause_snippet="Rate limit / quota exceeded on remote provider",
+            is_deterministic=False,
+        )
+
+    # 7. Timeout
+    if _TIMEOUT_RE.search(text):
+        return SymptomClassification(
+            category=SymptomCategory.timeout_stall,
+            root_cause_snippet="Execution or network request timed out",
+            is_deterministic=False,
+        )
+
+    # 8. Schema Violation
+    m_schema = _SCHEMA_RE.search(text)
+    if m_schema:
+        return SymptomClassification(
+            category=SymptomCategory.schema_violation,
+            root_cause_snippet=m_schema.group(0).strip(),
+            is_deterministic=True,
+        )
+
+    return SymptomClassification(
+        category=SymptomCategory.unknown,
+        root_cause_snippet=text.split("\n")[0][:100],
+        is_deterministic=False,
+    )
+
+
+def plan_symptom_intervention(
+    symptom: SymptomClassification,
+) -> InterventionPlan:
+    """Generate a deterministic intervention plan to repair the diagnosed symptom."""
+    cat = symptom.category
+    if cat == SymptomCategory.syntax_error:
+        loc = f" at {symptom.target_file}:{symptom.target_line}" if symptom.target_file else ""
+        return InterventionPlan(
+            symptom=symptom,
+            directive=f"Do NOT rerun unchanged code. Fix syntax error{loc} first.",
+            suggested_action="Read the exact lines around the error and apply targeted patch.",
+            prevent_blind_retry=True,
+        )
+
+    if cat == SymptomCategory.import_error:
+        sym = f" '{symptom.failing_symbol}'" if symptom.failing_symbol else ""
+        return InterventionPlan(
+            symptom=symptom,
+            directive=f"Missing module or import{sym}. Verify import paths or requirements.",
+            suggested_action="Check package installation via package manager or correct the module path.",
+            prevent_blind_retry=True,
+        )
+
+    if cat == SymptomCategory.assertion_failure:
+        return InterventionPlan(
+            symptom=symptom,
+            directive="Test assertion failed. Inspect the expected invariant versus actual output.",
+            suggested_action="Review test logic, check actual variable states, and update implementation.",
+            prevent_blind_retry=True,
+        )
+
+    if cat == SymptomCategory.file_not_found:
+        f = f" '{symptom.target_file}'" if symptom.target_file else ""
+        return InterventionPlan(
+            symptom=symptom,
+            directive=f"Target file{f} not found. Check relative vs absolute path and verify directory tree.",
+            suggested_action="Use search_files or list_dir to locate the target path before accessing.",
+            prevent_blind_retry=True,
+        )
+
+    if cat == SymptomCategory.permission_denied:
+        return InterventionPlan(
+            symptom=symptom,
+            directive="Action blocked by OS permission or security policy.",
+            suggested_action="Verify file write permissions or use a permitted workspace location.",
+            prevent_blind_retry=True,
+        )
+
+    if cat == SymptomCategory.rate_limit_stall:
+        return InterventionPlan(
+            symptom=symptom,
+            directive="Provider rate limited. Exponential backoff or provider fallback required.",
+            suggested_action="Wait for cooldown or switch to fallback model/provider.",
+            prevent_blind_retry=False,
+        )
+
+    if cat == SymptomCategory.timeout_stall:
+        return InterventionPlan(
+            symptom=symptom,
+            directive="Operation timed out. Simplify workload or extend operation timeout.",
+            suggested_action="Break task into smaller sub-tasks or increase timeout configuration.",
+            prevent_blind_retry=False,
+        )
+
+    if cat == SymptomCategory.schema_violation:
+        return InterventionPlan(
+            symptom=symptom,
+            directive="Output failed schema validation. Format output strictly per required schema.",
+            suggested_action="Validate JSON keys and data types against schema before submitting.",
+            prevent_blind_retry=True,
+        )
+
+    return InterventionPlan(
+        symptom=symptom,
+        directive="Unknown error encountered. Diagnose logs before proceeding.",
+        suggested_action="Inspect full failure stack trace and verify prerequisites.",
+        prevent_blind_retry=False,
+    )
+
+
+def apply_symptom_intervention(
+    error_text: str, tool_name: Optional[str] = None
+) -> str:
+    """Classify and append symptom intervention directive to error text."""
+    symptom = classify_failure_symptom(error_text, tool_name)
+    plan = plan_symptom_intervention(symptom)
+    rendered = plan.render_markdown()
+    if error_text and str(error_text).strip():
+        return f"{str(error_text).strip()}\n\n{rendered}"
+    return rendered

--- a/tests/agent/test_symptom_intervention.py
+++ b/tests/agent/test_symptom_intervention.py
@@ -1,0 +1,66 @@
+"""Tests for symptom-driven failure classification and intervention (Issue #3284)."""
+
+from agent.symptom_intervention import (
+    SymptomCategory,
+    apply_symptom_intervention,
+    classify_failure_symptom,
+    plan_symptom_intervention,
+)
+
+
+def test_classify_syntax_error():
+    err = '''  File "agent/my_module.py", line 42
+    def bad_syntax(:
+                  ^
+SyntaxError: invalid syntax'''
+    symptom = classify_failure_symptom(err)
+    assert symptom.category == SymptomCategory.syntax_error
+    assert symptom.target_file == "agent/my_module.py"
+    assert symptom.target_line == 42
+    assert symptom.is_deterministic is True
+
+
+def test_classify_import_error():
+    err = "ModuleNotFoundError: No module named 'nonexistent_package'"
+    symptom = classify_failure_symptom(err)
+    assert symptom.category == SymptomCategory.import_error
+    assert symptom.failing_symbol == "nonexistent_package"
+
+
+def test_classify_assertion_failure():
+    err = """FAILED tests/test_math.py:15: AssertionError: assert 2 + 2 == 5
+E       AssertionError: assert 4 == 5"""
+    symptom = classify_failure_symptom(err)
+    assert symptom.category == SymptomCategory.assertion_failure
+    assert symptom.target_file == "tests/test_math.py"
+    assert symptom.target_line == 15
+
+
+def test_classify_file_not_found():
+    err = "FileNotFoundError: [Errno 2] No such file or directory: 'config/missing.yaml'"
+    symptom = classify_failure_symptom(err)
+    assert symptom.category == SymptomCategory.file_not_found
+    assert symptom.target_file == "config/missing.yaml"
+
+
+def test_classify_rate_limit_and_timeout():
+    rate_err = "HTTP 429 Too Many Requests: Rate limit exceeded"
+    assert classify_failure_symptom(rate_err).category == SymptomCategory.rate_limit_stall
+
+    timeout_err = "stale timeout after 90.0s waiting for LLM stream response"
+    assert classify_failure_symptom(timeout_err).category == SymptomCategory.timeout_stall
+
+
+def test_plan_symptom_intervention():
+    symptom = classify_failure_symptom('SyntaxError: invalid syntax')
+    plan = plan_symptom_intervention(symptom)
+    assert plan.prevent_blind_retry is True
+    assert "Do NOT rerun unchanged code" in plan.directive
+
+
+def test_apply_symptom_intervention():
+    raw_error = "ImportError: cannot import name 'foo' from 'bar'"
+    result = apply_symptom_intervention(raw_error)
+    assert "[SYMPTOM INTERVENTION: IMPORT_ERROR]" in result
+    assert "cannot import name 'foo'" in result
+    assert "Verify import paths" in result

--- a/tools/recovery_strategy_dispatcher.py
+++ b/tools/recovery_strategy_dispatcher.py
@@ -248,7 +248,7 @@ def recover_from_failure(
 RECOVERY_GUIDANCE_PREFIX = "Recovery strategy"
 
 
-def _format_recovery_guidance(action: RecoveryAction) -> str:
+def _format_recovery_guidance(action: RecoveryAction, raw_error: str = "") -> str:
     """Render a single structured guidance line for a recovery action."""
     parts = [
         f"{RECOVERY_GUIDANCE_PREFIX}: {action.strategy.value}",
@@ -258,7 +258,24 @@ def _format_recovery_guidance(action: RecoveryAction) -> str:
     if action.backoff_seconds is not None:
         parts.append(f"backoff={action.backoff_seconds:g}s")
     line = "; ".join(parts)
-    return f"\n\n[{line}. {action.directive}]"
+    rendered = f"\n\n[{line}. {action.directive}]"
+
+    # Symptom-driven intervention (#3284)
+    if raw_error:
+        try:
+            from agent.symptom_intervention import (
+                classify_failure_symptom,
+                plan_symptom_intervention,
+            )
+
+            symptom = classify_failure_symptom(raw_error)
+            if symptom.category.value != "unknown":
+                plan = plan_symptom_intervention(symptom)
+                rendered += f"\n\n{plan.render_markdown()}"
+        except Exception:
+            pass
+
+    return rendered
 
 
 def _terminal_exit_code(result: str) -> int | None:
@@ -307,4 +324,4 @@ def maybe_append_recovery_guidance(
         )
     except Exception:
         return text
-    return text + _format_recovery_guidance(action)
+    return text + _format_recovery_guidance(action, raw_error=text[:2000])


### PR DESCRIPTION
## Summary

Implements #3284: Symptom-driven failure intervention to eliminate unguided, stochastic rerun-repair loops.

### Key Changes
- **Symptom Classification Engine** (`agent/symptom_intervention.py`):
  - Classifies raw failure text/traces into granular symptom categories: `syntax_error`, `import_error`, `assertion_failure`, `file_not_found`, `permission_denied`, `rate_limit_stall`, `timeout_stall`, and `schema_violation`.
  - Extracts precise failure anchors (file path, line number, missing symbol, failing assertion diff).
- **Deterministic Intervention Planning**:
  - Maps diagnosed symptoms to actionable, non-retryable directives preventing the agent from re-running unchanged code.
- **Integration into Recovery Strategy Dispatcher** (`tools/recovery_strategy_dispatcher.py`):
  - Formats symptom interventions directly into structured recovery directives for the agent loop.
- **Tests**:
  - Unit tests in `tests/agent/test_symptom_intervention.py` and runtime integration tests in `tests/run_agent/test_recovery_dispatcher_runtime.py` pass 100%.

Closes #3284.