### PR TITLE
fix(tests): remove undefined temproot reference in parallel runner (Closes #3296)

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -451,12 +451,6 @@ def _run_one_file_once(
         _kill_tree(proc, pgid=pgid)
 
         output +=  "\n"
-    finally:
-        # Delete the temp root for this attempt. Nothing reads it after the
-        # subprocess exits. More than 3000 of them fill the disk of the
-        # runner over one suite.
-        shutil.rmtree(temproot, ignore_errors=True)
-
     if rc == 4 and not _file_present(file):
         # Tripwire (#85): the file existed at plan time (its tests were
         # counted by the bulk --collect-only) but is genuinely gone now.


### PR DESCRIPTION
Fixes a conflict-resolution regression in #3208 that left the parallel test runner referencing undefined name 'temproot', causing every Python test slice to fail with 'runner crashed' on every PR based on main.

What changed:
- Removed the stray finally block that called shutil.rmtree(temproot, ignore_errors=True) on a non-existent temproot variable.
- Cleanup is already handled on all paths by the _reclaim_basetemp() helper introduced in #3234.

This unblocks the CI failure reported in #3296 and restores green Python test slices for all open PRs based on main.

Closes #3296