### PR TITLE
fix(tests): restore 25 pre-existing main test failures blocking all PRs (Closes #3298)

### DIFF
--- a/tests/plugins/test_a2a_schema_registration.py
+++ b/tests/plugins/test_a2a_schema_registration.py
@@ -27,7 +27,7 @@ def test_a2a_call_schema_round_trips_through_tool_describe(monkeypatch):
     monkeypatch.setattr(
         tool_search,
         "is_deferrable_tool_name",
-        lambda name: name == "a2a_call",
+        lambda name, config=None: name == "a2a_call",
     )
 
     described = json.loads(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -147,6 +147,10 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self, timeout: float = 5.0) -> bool:
+            """Barrier DB stub: token flush is a no-op for the test fixture."""
+            return True
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True
@@ -3122,7 +3126,7 @@ class TestRunConversation:
             patch.object(agent, "_invoke_api_request_error_hook", side_effect=lambda **kw: hook_events.append(kw)),
             patch(
                 "agent.relay_llm.complete_logical_call",
-                side_effect=lambda request_id, *, outcome: logical_completions.append(
+                side_effect=lambda request_id, *, outcome, **kwargs: logical_completions.append(
                     (request_id, outcome)
                 ),
             ),
@@ -5109,7 +5113,7 @@ class TestRetryExhaustion:
             patch("agent.relay_llm.execute", side_effect=execute),
             patch(
                 "agent.relay_llm.complete_logical_call",
-                side_effect=lambda request_id, *, outcome: logical_completions.append(
+                side_effect=lambda request_id, *, outcome, **kwargs: logical_completions.append(
                     (request_id, outcome)
                 ),
             ),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2457,6 +2457,7 @@ class TestAgentRuntimePostHookOwnershipSync:
         ("setup_mcp", {"server": "linear", "action": "install"}),
         ("tour", {"action": "stop"}),
         ("delegate_task", {"goal": "Check the child path"}),
+        ("compact_context", {}),
     )
 
     @pytest.mark.parametrize(("tool_name", "tool_args"), _CASES)
@@ -2509,6 +2510,10 @@ class TestAgentRuntimePostHookOwnershipSync:
         )
         monkeypatch.setattr(
             "tools.read_window_tool.read_window_below_tool",
+            lambda **kwargs: '{"ok":true}',
+        )
+        monkeypatch.setattr(
+            "tools.compact_context_tool.compact_context_tool",
             lambda **kwargs: '{"ok":true}',
         )
         monkeypatch.setattr(agent, "_get_session_db_for_recall", lambda: None)
@@ -3143,8 +3148,15 @@ class TestRunConversation:
         assert hook_events[0]["error_type"] == "ContentPolicyBlocked"
         assert hook_events[0]["retryable"] is False
         assert hook_events[0]["reason"] == FailoverReason.content_policy_blocked.value
-        assert logical_completions == [
-            (hook_events[0]["api_request_id"], "success")
+        # The auxiliary lane (e.g. background title generation) also closes
+        # its relay call through complete_logical_call with an 'aux-*'
+        # request id. Only the main logical call's completion is under test.
+        _main_request_id = hook_events[0]["api_request_id"]
+        _main_call_completions = [
+            entry for entry in logical_completions if entry[0] == _main_request_id
+        ]
+        assert _main_call_completions == [
+            (_main_request_id, "success")
         ]
 
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
@@ -3641,7 +3653,7 @@ class TestRunConversation:
 
         fallback_called = {"called": False}
 
-        def _mock_fallback():
+        def _mock_fallback(*args, **kwargs):
             fallback_called["called"] = True
             # Simulate what _try_activate_fallback does: just advance the
             # index and set the flag (the client is already mocked).
@@ -3678,7 +3690,7 @@ class TestRunConversation:
             empty_resp, empty_resp, empty_resp, empty_resp,  # fallback exhausted
         ]
 
-        def _mock_fallback():
+        def _mock_fallback(*args, **kwargs):
             if agent._fallback_index >= len(agent._fallback_chain):
                 return False
             agent._fallback_index += 1
@@ -5041,6 +5053,14 @@ class TestRetryExhaustion:
         agent._use_prompt_caching = False
         agent.compression_enabled = False
         agent.save_trajectories = False
+        # The fast-time mock jumps time.time() forward by 500s per call to
+        # collapse backoff waits. The retry wall-clock budget (#3113,
+        # agent.api_retry_wall_clock_seconds, default 300s) would trip on the
+        # second such jump and abort with retry_wall_clock_exceeded before
+        # any API call is made — raise the deadline out of the way so these
+        # tests exercise retry exhaustion, not the wall-clock guard.
+        agent._api_retry_wall_clock_seconds = 10**9
+        agent._cron_api_retry_wall_clock_seconds = 10**9
 
     @staticmethod
     def _make_fast_time_mock():
@@ -5130,7 +5150,14 @@ class TestRetryExhaustion:
             attempt["metadata"]["api_request_id"] for attempt in relay_attempts
         }
         assert len(request_ids) == 1
-        assert logical_completions == [(request_ids.pop(), "success")]
+        main_request_id = request_ids.pop()
+        # The auxiliary lane (e.g. background title generation) also closes
+        # its relay call through complete_logical_call with an 'aux-*'
+        # request id. Only the main logical call's completion is under test.
+        main_call_completions = [
+            entry for entry in logical_completions if entry[0] == main_request_id
+        ]
+        assert main_call_completions == [(main_request_id, "success")]
 
     def test_content_filter_refusal_surfaced_not_retried(self, agent):
         """A model refusal must be surfaced immediately, NOT laundered into

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1806,7 +1806,7 @@ def cronjob(
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
-            if _no_agent:
+            if no_agent:
                 if not script:
                     return tool_error(
                         "create with no_agent=True requires a script — "
@@ -1893,7 +1893,7 @@ def cronjob(
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
-                    no_agent=_no_agent,
+                    no_agent=no_agent,
                     attach_to_session=attach_to_session,
                     approval_mode=approval_mode,
                     delivery_verbosity=delivery_verbosity,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2442,6 +2442,76 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         return tool_error(str(e))
 
 
+
+def _build_no_match_hint(
+    path: str,
+    pattern: str,
+    target: str,
+    resolved_path: "Path | PurePosixPath | None",
+) -> "str | None":
+    """Build a hint for the agent when search_files finds zero matches.
+
+    Lists what *does* exist in the search directory so the agent can correct
+    its pattern or verify the path instead of blind-retrying.  Returns None
+    when no useful hint can be constructed (e.g. the directory doesn't exist
+    or is empty), so the caller can skip adding an empty field.
+    """
+    search_dir = resolved_path if resolved_path else Path(path)
+
+    try:
+        search_dir = Path(os.path.expanduser(str(search_dir)))
+        if not search_dir.is_dir():
+            if search_dir.exists() and search_dir.is_file():
+                return (
+                    f"Pattern {pattern!r} matched nothing in {path!r}. "
+                    "The path is a single file — verify the pattern or "
+                    "read_file the file directly."
+                )
+            return None
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+    try:
+        children = sorted(
+            search_dir.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())
+        )
+    except (OSError, PermissionError):
+        return None
+
+    _max = 10
+    dirs = [c.name + "/" for c in children if c.is_dir() and not c.name.startswith(".")]
+    files_list = [c.name for c in children if c.is_file() and not c.name.startswith(".")]
+    entries = dirs[:_max]
+    remaining = _max - len(entries)
+    if remaining > 0:
+        entries.extend(files_list[:remaining])
+
+    if not entries:
+        return (
+            f"Pattern {pattern!r} matched nothing in {path!r}. "
+            "The directory exists but contains no visible entries. "
+            "Verify the path is correct."
+        )
+
+    mode_desc = "file search" if target == "files" else "content search"
+    listing = ", ".join(entries)
+    hint = (
+        f"Pattern {pattern!r} matched nothing in {path!r} ({mode_desc}). "
+        f"Entries that DO exist in this directory: {listing}"
+    )
+    if target == "files":
+        hint += (
+            ". Try a broader glob (e.g. '*.py' instead of a specific name), "
+            "or use target='content' to search inside files."
+        )
+    else:
+        hint += (
+            ". Try a different regex pattern, or use target='files' with a "
+            "glob like '*.py' to list files first."
+        )
+    return hint
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
@@ -2764,6 +2834,66 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 f"You have run this exact search {count} times consecutively. "
                 "The results have not changed. Use the information you already have."
             )
+
+        #1486 — when the pattern matches nothing the agent has no hint about
+        # what *does* exist, so it blind-retries or falls back to a terminal
+        # directory listing, burning extra turns (95 file-not-found events/7d,
+        # 27-deep spirals observed). The FIRST empty result is enriched with
+        # what actually exists in the search path.
+        #
+        # #1372/#1149/#1589 — the tool_guardrails spiral_failure_cap only
+        # counts errors, so diverse-query spirals (the agent reformulates each
+        # time and gets empty each time) slip through. Empty results are
+        # tracked per session; at 3 an advisory directive is injected, and at
+        # 6 it escalates to a real error key so classify_tool_failure sees the
+        # failure and the cross-turn spiral_failure_cap (search_files is in
+        # _SPIRAL_PRONE_TOOLS) can accumulate and halt. The advisory alone had
+        # no teeth — 31 sessions hit 11 consecutive empty searches.
+        _SEARCH_EMPTY_HARD_CAP = 6
+        if result_dict.get("total_count", 0) == 0 and not result_dict.get("error"):
+            with _read_tracker_lock:
+                td = _read_tracker.setdefault(
+                    task_id,
+                    {"last_key": None, "consecutive": 0, "read_history": set()},
+                )
+                td["empty_searches"] = td.get("empty_searches", 0) + 1
+                _es = td["empty_searches"]
+
+            # ── #1486: immediate no-match hint on the FIRST empty result ─
+            # List what *does* exist in the search directory so the agent can
+            # correct the pattern instead of blind-retrying.  Runs before the
+            # spiral directive so even the first miss gets actionable info.
+            if _es == 1:
+                _hint = _build_no_match_hint(path, pattern, target, resolved_path)
+                if _hint:
+                    result_dict["_no_match_hint"] = _hint
+
+            if _es >= _SEARCH_EMPTY_HARD_CAP:
+                result_dict["error"] = (
+                    f"search_files has returned 0 results {_es} times. Your "
+                    "queries are consistently not matching anything — this is a "
+                    "deterministic dead end. STOP searching and switch strategy: "
+                    "(a) use search_files target='files' with a glob like '*.py', "
+                    "(b) call repo_map for a structural overview, or "
+                    "(c) read_file on a known path instead of searching."
+                )
+            elif _es >= 3:
+                result_dict.setdefault(
+                    "_search_directive",
+                    (
+                        f"search_files has returned 0 results {_es} times. "
+                        "Your queries are not matching anything. SWITCH STRATEGY: "
+                        "(a) use search_files target='files' with a glob like '*.py', "
+                        "(b) call repo_map for a structural overview, or "
+                        "(c) read_file on a known path instead of searching."
+                    ),
+                )
+        elif result_dict.get("total_count", 0) > 0:
+            # Successful search with results — reset the empty counter.
+            with _read_tracker_lock:
+                td = _read_tracker.get(task_id)
+                if td is not None:
+                    td["empty_searches"] = 0
 
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1190,6 +1190,125 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
         for rp in resolved_paths:
             task_failures.pop(rp, None)
 
+# ── #1703 — empty-old_string loop guard ────────────────────────────────────
+# When the model calls the patch tool in replace mode with an EMPTY (falsy)
+# old_string, no valid replace can ever match — it is a usage error, not a
+# match failure. The old "is None" guard at the top of patch_tool let an empty
+# string fall through to patch_replace, which returned a generic error the
+# model then retried 5-8 times (#1703). We return a targeted, actionable
+# diagnostic at the tool boundary, and track consecutive identical failures
+# per task+path so the second one escalates to a hard STOP — breaking the
+# spiral at 2 instead of 8.
+_empty_old_string_lock = threading.Lock()
+_empty_old_string_tracker: dict = {}  # {task_id: {path: count}}
+
+
+def _record_empty_old_string(task_id: str, path: str) -> int:
+    """Increment and return the consecutive empty-old_string count for a path."""
+    with _empty_old_string_lock:
+        per_task = _empty_old_string_tracker.setdefault(task_id, {})
+        if len(per_task) >= 64 and path not in per_task:
+            try:
+                first_key = next(iter(per_task))
+                del per_task[first_key]
+            except StopIteration:
+                pass
+        per_task[path] = per_task.get(path, 0) + 1
+        return per_task[path]
+
+
+def _reset_empty_old_string(task_id: str, path: str) -> None:
+    """Clear the empty-old_string counter for a path — called when the model
+    supplies a non-empty old_string (it has moved past the empty shape) or
+    when a patch to that path succeeds."""
+    if not path:
+        return
+    with _empty_old_string_lock:
+        per_task = _empty_old_string_tracker.get(task_id)
+        if per_task:
+            per_task.pop(path, None)
+
+
+def _empty_old_string_error(path: str, task_id: str) -> str:
+    """Non-retryable diagnostic for replace-mode with an empty old_string."""
+    count = _record_empty_old_string(task_id, path)
+    msg = (
+        "replace mode requires a non-empty old_string. The old_string is the "
+        "exact text to find and replace in the file; an empty string cannot be "
+        "matched. Either supply the text to replace, or use mode=patch (V4A "
+        "format) for insertions."
+    )
+    if count >= 2:
+        suffix = {2: "nd", 3: "rd"}.get(count % 10, "th")
+        msg += (
+            f" STOP: this is the {count}{suffix} consecutive replace-mode call with an "
+            f"empty old_string on {path!r}. Do not retry this shape — re-read the "
+            f"file to see the exact text, then supply a real old_string, or use "
+            f"mode=patch / write_file instead."
+        )
+    return tool_error(msg)
+
+
+# #3238 — patch preflight counter: every replace-mode call blocked for an
+# empty/short/ambiguous old_string increments this per-task counter.  It is
+# surfaced in the structured error so the spiral guard can act on it.
+_patch_preflight_blocked_lock = threading.Lock()
+_patch_preflight_blocked_counter: dict[str, int] = {}
+
+
+def _record_patch_preflight_blocked(task_id: str) -> int:
+    """Increment and return the per-task patch-preflight block count."""
+    with _patch_preflight_blocked_lock:
+        _patch_preflight_blocked_counter[task_id] = (
+            _patch_preflight_blocked_counter.get(task_id, 0) + 1
+        )
+        return _patch_preflight_blocked_counter[task_id]
+
+
+def _patch_preflight_blocked_structured(
+    path: str, reason: str, task_id: str, extra_message: str = ""
+) -> str:
+    """Return a structured re_read_file instruction for a blocked patch.
+
+    The payload is a non-retryable correction request that tells the model to
+    re-read the target file and try again with a more precise old_string.
+    """
+    count = _record_empty_old_string(task_id, path)
+    preflight_count = _record_patch_preflight_blocked(task_id)
+    msg = (
+        "replace mode requires a non-empty old_string. The old_string is the "
+        "exact text to find and replace in the file; an empty string cannot be "
+        "matched. Either supply the text to replace, or use mode=patch (V4A "
+        "format) for insertions."
+    )
+    if count >= 2:
+        suffix = {2: "nd", 3: "rd"}.get(count % 10, "th")
+        msg += (
+            f" STOP: this is the {count}{suffix} consecutive replace-mode call with an "
+            f"empty old_string on {path!r}. Do not retry this shape — re-read the "
+            f"file to see the exact text, then supply a real old_string, or use "
+            f"mode=patch / write_file instead."
+        )
+    message = (
+        f"Patch blocked by preflight: {reason}. "
+        f"Re-read {path!r} with read_file, copy the exact text you want to replace, "
+        f"and retry with a longer, unambiguous old_string."
+    )
+    if extra_message:
+        message += " " + extra_message
+    return json.dumps(
+        {
+            "error": msg,
+            "action": "re_read_file",
+            "path": path,
+            "reason": reason,
+            "message": message,
+            "patch_preflight_blocked": preflight_count,
+            "argument_shape_spiral": preflight_count >= 3,
+        },
+        ensure_ascii=False,
+    )
+
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
 # caps, a 10k-read session would accumulate ~1.5MB of dict/set state that
@@ -2453,7 +2572,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             if mode == "replace":
                 if not path:
                     return tool_error("path required")
-                if old_string is None or new_string is None:
+                # #1703/#3238 — Preflight: reject empty old_string before
+                # attempting the patch. Return a structured re_read_file
+                # instruction so the model fixes the shape instead of blind-retrying.
+                _old = (old_string or "").strip()
+                if not _old:
+                    return _patch_preflight_blocked_structured(
+                        path, "empty old_string", task_id
+                    )
+                _reset_empty_old_string(task_id, path)
+                if new_string is None:
                     return tool_error("old_string and new_string required")
                 # Pass the resolved ABSOLUTE path to the shell layer so it
                 # operates on the exact file the tool layer resolved — the

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1530,6 +1530,117 @@ def _tool_schema_payload(
     return None
 
 
+def _dispatch_tool_describe_inner(
+    args: Dict[str, Any],
+    name: str,
+    current_tool_defs: List[Dict[str, Any]],
+    config: "ToolSearchConfig",
+) -> str:
+    """Inner logic for dispatch_tool_describe, separated for caching."""
+    if not is_deferrable_tool_name(name, config):
+        # #107 — a directly-available (non-deferrable) tool's schema is in
+        # the active toolset. Return it instead of the "not a deferrable
+        # tool" error: the model asked for the schema and it is right here.
+        # This also covers mcp__*/plugin tools granted to the session whose
+        # registry entry is transiently missing at dispatch time — the def
+        # list is the session's truth.
+        payload = _tool_schema_payload(current_tool_defs, name)
+        if payload is not None:
+            return json.dumps(payload, ensure_ascii=False)
+        # #978 — fuzzy name matching even for non-deferrable names: the
+        # model may have slightly misspelled a deferrable tool. Suggest
+        # close matches from the current tool defs so it can self-correct
+        # without a separate tool_search round-trip.
+        _, deferrable = classify_tools(current_tool_defs, config)
+        available_names = [
+            (td.get("function") or {}).get("name", "") for td in deferrable
+        ]
+        suggestions = _fuzzy_tool_names(name, available_names)
+        if suggestions:
+            return json.dumps(
+                {
+                    "error": (
+                        f"'{name}' is not a deferrable tool. Did you mean one of: "
+                        f"{', '.join(suggestions)}? Use the exact name with "
+                        f"tool_describe or tool_call."
+                    ),
+                    "suggestions": suggestions,
+                    # #2309 — structured reason + recovery so the agent gets
+                    # a concrete path instead of an opaque "other" error.
+                    "reason": "not_deferrable",
+                    "recovery": (
+                        "This tool is not in the deferred set — it may already be in "
+                        "your active toolset (call it directly) or it may be misspelled. "
+                        "Use a suggested name with tool_describe or tool_call, or re-run "
+                        "tool_search to list available deferred tools."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {
+                "error": (
+                    f"'{name}' is not a deferrable tool. If you see it in the tools list "
+                    "already, call it directly; otherwise check the spelling against tool_search."
+                ),
+                "reason": "not_deferrable",
+                "recovery": (
+                    "This tool is not in the deferred set. If it is in your active "
+                    "toolset, call it directly. Otherwise re-run tool_search to find "
+                    "the correct name — do NOT retry tool_describe with the same name."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    _, deferrable = classify_tools(current_tool_defs, config)
+    for td in deferrable:
+        fn = td.get("function") or {}
+        if fn.get("name") == name:
+            return json.dumps(
+                {
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                },
+                ensure_ascii=False,
+            )
+    # #978 — fuzzy name matching: suggest closest matches so the agent can
+    # self-correct without a separate tool_search round-trip.
+    available_names = [(td.get("function") or {}).get("name", "") for td in deferrable]
+    suggestions = _fuzzy_tool_names(name, available_names)
+    if suggestions:
+        return json.dumps(
+            {
+                "error": (
+                    f"'{name}' is not currently available. Did you mean one of: "
+                    f"{', '.join(suggestions)}? Use the exact name with tool_describe "
+                    f"or tool_call."
+                ),
+                "suggestions": suggestions,
+                # #2309 — structured reason + recovery.
+                "reason": "not_available",
+                "recovery": (
+                    "The tool name is deferrable but not in the current toolset scope. "
+                    "Use a suggested name, or re-run tool_search to refresh the deferred "
+                    "catalog — do NOT retry tool_describe with the same name unchanged."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    return json.dumps(
+        {
+            "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
+            "reason": "not_available",
+            "recovery": (
+                "The tool name is deferrable but not registered in the current session. "
+                "Re-run tool_search to refresh the deferred catalog, then use the exact "
+                "name returned — do NOT retry tool_describe with the same name."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
 def dispatch_tool_describe(
     args: Dict[str, Any],
     *,
@@ -1538,18 +1649,71 @@ def dispatch_tool_describe(
 ) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string.
 
-    Accepts ``names: [str, ...]`` and returns a map keyed by tool name::
+    Two request shapes, two response contracts:
 
-        {
-          "tools": {"<name>": {"description": ..., "parameters": {...}}, ...},
-          "not_found": ["<name>", ...],   # only when some names missed
-          "errors": {"<name>": "..."}     # only for non-deferrable names
-        }
+    - ``{"names": [str, ...]}`` — batched (upstream) contract. Returns a map
+      keyed by tool name::
 
-    Unknown/unregistered names and registered deferrable names absent from the
-    current assembly land in ``not_found`` instead of failing the whole call.
-    Registered non-deferrable names keep their per-name message in ``errors``.
-    Duplicates are deduped silently.
+          {
+            "tools": {"<name>": {"description": ..., "parameters": {...}}, ...},
+            "not_found": ["<name>", ...],   # only when some names missed
+            "errors": {"<name>": "..."}     # only for non-deferrable names
+          }
+
+      Unknown/unregistered names and registered deferrable names absent from
+      the current assembly land in ``not_found`` instead of failing the whole
+      call. Registered non-deferrable names keep their per-name message in
+      ``errors``. Duplicates are deduped silently.
+
+    - ``{"name": str}`` — singular (fork) contract (#107/#978/#2309/#1015).
+      Returns the schema flat — ``{"name", "description", "parameters"}`` —
+      including for directly-available (non-deferrable) tools whose def is
+      already in the active toolset, or a structured ``{"error", "reason",
+      "recovery"[, "suggestions"]}`` on a miss. Successful results are cached
+      per (name, toolset signature) (#1015).
+    """
+    if args.get("names") is not None:
+        return _dispatch_tool_describe_batched(
+            args, current_tool_defs=current_tool_defs, config=config
+        )
+    if config is None:
+        config = load_config()
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return json.dumps({"error": "name is required"}, ensure_ascii=False)
+
+    # #1015 — check the describe cache first. Repeated calls for the same
+    # tool name (common when the model forgets the schema between turns)
+    # hit the cache and skip the full catalog scan, eliminating the
+    # re-classification overhead that was a top failure source.
+    sig = _toolset_signature(current_tool_defs)
+    cache_key = (name, sig)
+    cached = _describe_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    result = _dispatch_tool_describe_inner(args, name, current_tool_defs, config)
+    # Cache successful results (not error responses — those may change as
+    # tools are added/removed).
+    if '"error"' not in result:
+        if len(_describe_cache) >= _DESCRIBE_CACHE_MAX:
+            # Evict oldest entries (dict preserves insertion order in 3.7+).
+            _oldest_key = next(iter(_describe_cache))
+            del _describe_cache[_oldest_key]
+        _describe_cache[cache_key] = result
+    return result
+
+
+def _dispatch_tool_describe_batched(
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> str:
+    """Batched (upstream) ``tool_describe`` path — ``{"names": [...]}``.
+
+    Kept verbatim from the v2026.8.27 upstream sync so the batched contract
+    (map + not_found + errors) stays byte-compatible with upstream tests.
     """
     if config is None:
         config = load_config_readonly()
@@ -1585,53 +1749,20 @@ def dispatch_tool_describe(
     tools: Dict[str, Dict[str, Any]] = {}
     not_found: List[str] = []
     errors: Dict[str, str] = {}
-    result_suggestions: Dict[str, List[str]] = {}
     for name in names:
         fn = by_name.get(name)
-        direct_payload = _tool_schema_payload(current_tool_defs, name)
         if fn is not None:
             tools[name] = {
                 "description": fn.get("description", ""),
                 "parameters": fn.get("parameters", {}),
             }
-        elif direct_payload is not None:
-            # #107 — a directly-available (non-deferrable) tool's schema is
-            # in the active toolset the caller handed us. Return it instead
-            # of the "not a deferrable tool" error: the model asked for the
-            # schema and it is right here. Exact-match only, so typos and
-            # genuinely absent names keep their #978/#2309 error paths.
-            # This also covers mcp__*/plugin tools granted to the session
-            # whose registry entry is transiently missing at dispatch time —
-            # the def list is the session's truth.
-            direct_payload.pop("name", None)
-            tools[name] = direct_payload
         elif _describe_classification(name, config) == "not_deferrable":
-            # #978 — fuzzy name matching even for non-deferrable names: the
-            # model may have slightly misspelled a deferrable tool. Suggest
-            # close matches from the current tool defs so it can self-correct
-            # without a separate tool_search round-trip.
-            suggestions = _fuzzy_tool_names(name, list(by_name))
-            if suggestions:
-                errors[name] = (
-                    f"'{name}' is not a deferrable tool. Did you mean one of: "
-                    f"{', '.join(suggestions)}? Use the exact name with "
-                    f"tool_describe or tool_call."
-                )
-                result_suggestions[name] = suggestions
-            else:
-                errors[name] = (
-                    f"'{name}' is not a deferrable tool. If you see it in the tools list "
-                    "already, call it directly; otherwise check the spelling against tool_search."
-                )
+            errors[name] = (
+                f"'{name}' is not a deferrable tool. If you see it in the tools list "
+                "already, call it directly; otherwise check the spelling against tool_search."
+            )
         else:
-            # #978 — a deferrable-but-absent name may just be misspelled;
-            # suggest close matches from the current deferrable set.
-            suggestions = _fuzzy_tool_names(name, list(by_name))
-            if suggestions:
-                not_found.append(name)
-                result_suggestions[name] = suggestions
-            else:
-                not_found.append(name)
+            not_found.append(name)
 
     result: Dict[str, Any] = {"tools": tools}
     if not_found:
@@ -1639,8 +1770,6 @@ def dispatch_tool_describe(
         result["hint"] = "Names in not_found are not currently available. Re-run tool_search to refresh."
     if errors:
         result["errors"] = errors
-    if result_suggestions:
-        result["suggestions"] = result_suggestions
     return json.dumps(result, ensure_ascii=False)
 
 

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1585,20 +1585,53 @@ def dispatch_tool_describe(
     tools: Dict[str, Dict[str, Any]] = {}
     not_found: List[str] = []
     errors: Dict[str, str] = {}
+    result_suggestions: Dict[str, List[str]] = {}
     for name in names:
         fn = by_name.get(name)
+        direct_payload = _tool_schema_payload(current_tool_defs, name)
         if fn is not None:
             tools[name] = {
                 "description": fn.get("description", ""),
                 "parameters": fn.get("parameters", {}),
             }
+        elif direct_payload is not None:
+            # #107 — a directly-available (non-deferrable) tool's schema is
+            # in the active toolset the caller handed us. Return it instead
+            # of the "not a deferrable tool" error: the model asked for the
+            # schema and it is right here. Exact-match only, so typos and
+            # genuinely absent names keep their #978/#2309 error paths.
+            # This also covers mcp__*/plugin tools granted to the session
+            # whose registry entry is transiently missing at dispatch time —
+            # the def list is the session's truth.
+            direct_payload.pop("name", None)
+            tools[name] = direct_payload
         elif _describe_classification(name, config) == "not_deferrable":
-            errors[name] = (
-                f"'{name}' is not a deferrable tool. If you see it in the tools list "
-                "already, call it directly; otherwise check the spelling against tool_search."
-            )
+            # #978 — fuzzy name matching even for non-deferrable names: the
+            # model may have slightly misspelled a deferrable tool. Suggest
+            # close matches from the current tool defs so it can self-correct
+            # without a separate tool_search round-trip.
+            suggestions = _fuzzy_tool_names(name, list(by_name))
+            if suggestions:
+                errors[name] = (
+                    f"'{name}' is not a deferrable tool. Did you mean one of: "
+                    f"{', '.join(suggestions)}? Use the exact name with "
+                    f"tool_describe or tool_call."
+                )
+                result_suggestions[name] = suggestions
+            else:
+                errors[name] = (
+                    f"'{name}' is not a deferrable tool. If you see it in the tools list "
+                    "already, call it directly; otherwise check the spelling against tool_search."
+                )
         else:
-            not_found.append(name)
+            # #978 — a deferrable-but-absent name may just be misspelled;
+            # suggest close matches from the current deferrable set.
+            suggestions = _fuzzy_tool_names(name, list(by_name))
+            if suggestions:
+                not_found.append(name)
+                result_suggestions[name] = suggestions
+            else:
+                not_found.append(name)
 
     result: Dict[str, Any] = {"tools": tools}
     if not_found:
@@ -1606,6 +1639,8 @@ def dispatch_tool_describe(
         result["hint"] = "Names in not_found are not currently available. Re-run tool_search to refresh."
     if errors:
         result["errors"] = errors
+    if result_suggestions:
+        result["suggestions"] = result_suggestions
     return json.dumps(result, ensure_ascii=False)
 
 


### PR DESCRIPTION
Automated evolution PR for issue #3298.

## What

Restores 25 pre-existing test failures on fork main so the merge funnel can move again. All 25 failures reproduce on plain `origin/main` (cc37e8466e) and are NOT caused by any open PR — they block PRs #3295 and #3297 (and every future selection) alike.

## Root causes fixed (verified locally this session)

1. **run_agent session stub drift** (5 failures in `tests/run_agent/test_run_agent.py`): `run_agent.py:2318` calls `self._session_db.flush_token_counts()` unconditionally in `_persist_session`, but the `_BarrierDB` test stub lacks that method. The real DB has it (`hermes_state.py:8670`). Aligned the stubs with the upstream-sync v2026.8.27 behavior (incl. `complete_logical_call` signature).
2. **cronjob `_no_agent` NameError** (1 failure in `tests/cron/test_cron_no_agent.py`): `tools/cronjob_tools.py:1809/1896` referenced an undefined `_no_agent`; only the `no_agent` parameter exists. Fixed the typo.
3. **cronjob tool return-shape mismatch** (10 failures in `tests/tools/test_cronjob_tools.py`): the created-payload lost `success` / `job_id` / `deliver` keys in a sync. Restored the fork contract.
4. **patch preflight return-shape mismatch** (2 failures in `tests/tools/test_patch_preflight.py`): payload lost `action` / `patch_preflight_blocked`. Restored.
5. **tool_describe fallback shape** (7 failures in `tests/tools/test_tool_describe_direct.py` + search_files hint regression): `tool_describe_direct` must return the flat direct-tool schema `{name, description, parameters}` with fuzzy suggestions, not the tool_search fallback shape `{hint, not_found, tools}`. Restored the flat contract (refs #107/#978) and the `search_files` no-match hint + empty-search spiral guard lost in sync (refs #1486/#1372).

## Verification

- On `origin/main`: 25 failed, 366 passed (reproduced).
- On this branch: 408 passed, 0 failed across all six affected test files (`tests/run_agent/test_run_agent.py`, `tests/cron/test_cron_no_agent.py`, `tests/tools/test_cronjob_tools.py`, `tests/tools/test_patch_preflight.py`, `tests/tools/test_tool_describe_direct.py`, `tests/tools/test_tool_describe_fuzzy.py`).
- `ruff check` clean (the blocking CI lint check).

## Size note

~475 changed lines, above the 200-line autonomous self-merge cap. No coherent smaller slice exists: the five subsystems have verified-distinct root causes, and because main itself is red, any partial fix leaves CI red and unmergeable — the funnel only unblocks when the full set lands. Recording this as an autonomous-landing MISS for the merge gate to hold for human review.

Closes #3298
