### PR TITLE
fix(cron): repair CLI create path — _no_agent NameError + repin stub reasoning_effort drift (Closes #3314)

### DIFF
--- a/tests/cron/test_cron_repin.py
+++ b/tests/cron/test_cron_repin.py
@@ -143,6 +143,10 @@ class TestCronRepin:
         args.monitor_url = None
         args.continuity = None
         args.pin = True
+        # Explicit None: a MagicMock auto-attribute would leak through
+        # getattr(args, "reasoning_effort", None) and be rejected by
+        # create_job's spelling validation as an invalid level.
+        args.reasoning_effort = None
 
         with cron_jobs.use_cron_store(tmp_path),              patch("cron.jobs._compute_provider_model_snapshots", return_value=("nous", "hermes-3-llama-3.1-405b")):
             code = cron_command(args)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1806,7 +1806,7 @@ def cronjob(
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
-            if _no_agent:
+            if no_agent:
                 if not script:
                     return tool_error(
                         "create with no_agent=True requires a script — "
@@ -1893,7 +1893,7 @@ def cronjob(
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
-                    no_agent=_no_agent,
+                    no_agent=no_agent,
                     attach_to_session=attach_to_session,
                     approval_mode=approval_mode,
                     delivery_verbosity=delivery_verbosity,


### PR DESCRIPTION
Automated evolution PR for issue #3314.

**Layer 3 of the CI unblock chain** (after #3297 runner temproot, #3305 base test fixes). Without this, the repin test stays red on main even after #3305 merges, keeping every PR CI red.

## What was broken (reproduced live on origin/main cc37e84)

1. `tools/cronjob_tools.py:1809,1896` referenced undefined `_no_agent` (the parameter is `no_agent`) — every `cronjob(action="create")` via the CLI died with `Failed to create job: name '_no_agent' is not defined`. PR #3305 fixed the update path (2222+) but missed these two create-path sites.
2. `tests/cron/test_cron_repin.py::test_cli_create_with_pin` used a `MagicMock` args stub predating the `reasoning_effort` feature (4e1dd1a74b); `getattr(args, "reasoning_effort", None)` returned a MagicMock which `create_job` spelling validation rejected (`Invalid reasoning_effort <MagicMock ...>`).

Sequential blockers on the same path: fixing only #1 surfaces #2.

## Fix
- `tools/cronjob_tools.py`: `if _no_agent:` → `if no_agent:` (L1809); `no_agent=_no_agent` → `no_agent=no_agent` (L1896) — same pattern as the update-path fix.
- `tests/cron/test_cron_repin.py`: explicit `args.reasoning_effort = None` + comment explaining the MagicMock auto-attribute trap so the next CLI knob gets stubbed.

Audited for the same drift: other create-path tests (`test_gateway_restart_loop.py`) use `Namespace` — safe.

## Verification (local, before PR)
- Red→green: `test_cli_create_with_pin` failed with the exact NameError on clean origin/main, passes after the fix.
- `tests/cron/` — 1245 passed, 1 skipped (82.96s)
- `tests/hermes_cli/test_cron.py` + `test_cron_parser_builder.py` + `test_gateway_restart_loop.py` — 315 passed
- Pre-PR targeted shard (`scripts/evolution_pre_pr_test_runner.py`): **PASS** (tests/tools/test_cronjob_tools.py)
- `ruff check .` — clean
- Diff: 6 insertions, 2 deletions (merge-gate cap 200 ✓)

Note: PR #3305's diff also touches these two `cronjob_tools.py` lines identically — this PR carries the same fix against current main so the chain is unblocked regardless of merge order; the changes are identical and conflict-free in effect.

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>