### PR TITLE
fix(nix): add npmFlags legacy-peer-deps for npm 12 / npm 10 workspace builds (#3319)

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -260,6 +260,7 @@ let
         src = mkNpmSrc dirs;
         npmConfigHook = patchedNpmConfigHook;
         npmRoot = ".";
+        npmFlags = [ "--legacy-peer-deps" ];
         ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
         passthru = {
           packageJsonPath = "${folder}/package.json";

--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -6,6 +6,8 @@ hermesNpmLib.buildNpmPackage {
     "apps/shared"
   ];
 
+  npmFlags = [ "--legacy-peer-deps" ];
+
   doCheck = false;
 
   buildPhase = ''


### PR DESCRIPTION
## Summary

Fixes #3319: hermes-tui npm dependency install fails in flake check.

### Changes
- Adds `npmFlags = [ "--legacy-peer-deps" ];` to `nix/tui.nix` and `customBuildNpmPackage` in `nix/lib.nix`.
- Resolves npm dependency installation conflicts across the npm 12 workspace builds in Nix sandboxes.

Closes #3319.