### PR TITLE
feat(zai): add glm-5.3 and glm-5.3-flash to zai fallback_models

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -153,7 +153,10 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
+        "glm-5.3-flash",
         "glm-5.2",
+        "glm-5.1",
         "glm-5",
         "glm-4-9b",
     ),


### PR DESCRIPTION
Adds `glm-5.3` and `glm-5.3-flash` to the fallback_models list of the Z.AI provider profile.