### PR TITLE
fix(delegate): substitute single-word date markers and {{...}} forms at dispatch (Closes #139)

### DIFF
--- a/tests/tools/test_delegate_template_markers.py
+++ b/tests/tools/test_delegate_template_markers.py
@@ -164,6 +164,82 @@ def test_batch_with_unknown_marker_still_rejected():
     assert "template" in result["error"].lower()
 
 
+# --- issue #139: single-word date markers + double-brace forms -------------
+
+
+def test_expand_substitutes_single_word_date_markers():
+    # The cron evolution jobs use {date}/{today} in goal templates; these
+    # single-word markers must be substituted, not left as residual (issue
+    # #139 — regression of the #95 fix).
+    expanded, substituted, residual = expand_template_markers(
+        "write EVOLUTION/research/{date}.md and tag {{today}}",
+        now_iso="2026-08-30T03:15:46Z",
+    )
+    assert "{date}" not in expanded
+    assert "{{today}}" not in expanded
+    assert expanded.count("2026-08-30") == 2
+    assert set(substituted) == {"{date}", "{{today}}"}
+    assert residual == []
+
+
+def test_expand_substitutes_double_brace_now():
+    expanded, substituted, residual = expand_template_markers(
+        "dispatch at {{now}} and <current_date>",
+        now_iso="2026-08-30T03:15:46Z",
+    )
+    assert "{{now}}" not in expanded
+    assert "<current_date>" not in expanded
+    assert "2026-08-30T03:15:46Z" in expanded
+    assert "2026-08-30" in expanded
+    assert residual == []
+
+
+def test_expand_single_word_code_braces_still_untouched():
+    # f-string safety preserved: {i}, {a,b}, generics and HTML tags are not
+    # template markers and must pass through byte-identical (issue #139).
+    text = "iterate {i} over Vec<T> in a <div> and pick {a,b}"
+    expanded, substituted, residual = expand_template_markers(
+        text, now_iso="2026-08-30T03:15:46Z"
+    )
+    assert expanded == text
+    assert substituted == []
+    assert residual == []
+
+
+def test_expand_unresolvable_double_brace_reported_residual():
+    # {{key}} is matched as a template shape but unresolvable — it stays in
+    # the expanded text and is reported residual for the caller to reject,
+    # exactly like <real citation>.
+    expanded, substituted, residual = expand_template_markers(
+        "emit {{key}} in the payload", now_iso="2026-08-30T03:15:46Z"
+    )
+    assert expanded == "emit {{key}} in the payload"
+    assert substituted == []
+    assert residual == ["{{key}}"]
+    # And the batch gate still rejects it loudly.
+    result = _call([{"goal": GOOD_A}, {"goal": "emit {{key}} in the payload"}])
+    assert "error" in result
+    assert "template" in result["error"].lower()
+
+
+def test_marker_token_strips_double_braces():
+    assert _marker_token("{{date}}") == "date"
+    assert _marker_token("{{current_date}}") == "current-date"
+    assert _marker_token("{date}") == "date"
+    assert _marker_token("{{now}}") == "now"
+
+
+def test_batch_with_date_marker_proceeds_after_substitution():
+    # The exact production shape that regressed: a goal carrying the cron
+    # {date} marker must be substituted and dispatched, not rejected.
+    goal = "write EVOLUTION/research/{date}.md from the gathered notes"
+    with patch("tools.delegate_tool._run_single_child") as mock_run:
+        mock_run.side_effect = [_completed(0), _completed(1)]
+        result = _call([{"goal": GOOD_A}, {"goal": goal}])
+    assert "error" not in result
+    assert len(result["results"]) == 2
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -5106,8 +5106,16 @@ def _recover_tasks_from_json_string(
 # style (`{i}`) must never be rejected (post-merge audit of #81141).
 _PLACEHOLDER_GOAL_RE = re.compile(r"^(todo|task\s*\d+)$", re.IGNORECASE)
 _TEMPLATE_MARKER_RE = re.compile(
-    r"<[A-Za-z][A-Za-z0-9]*(?:[ _-][A-Za-z0-9]+)+>"
+    # The double-brace form {{...}} is unambiguous template syntax (no
+    # legitimate code shape uses it), so it is matched at any word count —
+    # this is the shape LLM templates most often leave behind (issue #139).
+    # The single-word alternative matches only the exact known date keys
+    # below, so bare single-word brackets in legit code stay untouched.
+    r"\{\{[A-Za-z][A-Za-z0-9]*(?:[ _-][A-Za-z0-9]+)*\}\}"
+    r"|<[A-Za-z][A-Za-z0-9]*(?:[ _-][A-Za-z0-9]+)+>"
     r"|\{[A-Za-z][A-Za-z0-9]*(?:[ _-][A-Za-z0-9]+)+\}"
+    r"|[<{](?:date|current_date|today)[>}]",
+    re.IGNORECASE,
 )
 _MIN_BATCH_GOAL_LEN = 10
 
@@ -5129,18 +5137,31 @@ _TIMESTAMP_MARKER_KEYS = frozenset(
         "now-iso",
         "generated-timestamp",
         "current-datetime",
-        "current-date",
+        "now",
     }
 )
+# Marker keys that resolve to the current UTC date (YYYY-MM-DD) — the shape
+# the evolution stage jobs use in output filenames
+# (research/{current_date}.md, issues/{date}.json, ...). The single-word
+# forms {date}/{today} (and {{...}} spellings) are matched by
+# _TEMPLATE_MARKER_RE (issue #139).
+_DATE_MARKER_KEYS = frozenset({"date", "current-date", "today"})
 # Marker keys that resolve to the originating session id.
 _SESSION_MARKER_KEYS = frozenset({"session-id"})
 
 
 def _marker_token(marker: str) -> str:
-    """Normalize a matched marker (e.g. ``<NOW-ISO>``) to a canonical key."""
+    """Normalize a matched marker (e.g. ``<NOW-ISO>``) to a canonical key.
+
+    Strips up to two bracket pairs so the double-brace template form
+    ``{{date}}`` normalizes to the same key as ``{date}`` (issue #139).
+    """
     inner = (marker or "").strip()
-    if len(inner) >= 2 and inner[0] in "<{" and inner[-1] in ">}":
-        inner = inner[1:-1]
+    for _ in range(2):
+        if len(inner) >= 2 and inner[0] in "<{" and inner[-1] in ">}":
+            inner = inner[1:-1]
+        else:
+            break
     return _MARKER_SEP_RE.sub("-", inner.strip().lower())
 
 
@@ -5164,7 +5185,11 @@ def expand_template_markers(
       remain in ``expanded`` (to be stripped or rejected by the caller).
     """
     now_iso = now_iso if now_iso is not None else _now_iso_utc()
+    # Date-only value (YYYY-MM-DD, UTC) for the date-shaped markers the
+    # evolution stage jobs use in output filenames (research/{current_date}.md).
+    today = now_iso[:10]
     values: Dict[str, str] = {key: now_iso for key in _TIMESTAMP_MARKER_KEYS}
+    values.update({key: today for key in _DATE_MARKER_KEYS})
     if session_id:
         values.update({key: session_id for key in _SESSION_MARKER_KEYS})
 


### PR DESCRIPTION
Automated evolution PR for issue #139.

Regression of #95: cron dispatch again passed unexpanded template markers ({date}, {today}, {{now}}) into delegate_task goals. The existing marker regex only matched multi-word placeholders, so single-word date markers were neither substituted nor reported residual.

- Extends _TEMPLATE_MARKER_RE with the {{...}} double-brace form (matched at any word count) and single-word date keys {date}/{today}/<current_date>.
- Adds _DATE_MARKER_KEYS (date/current-date/today -> YYYY-MM-DD).
- Regression tests: single-word date markers, double-brace forms.