### PR TITLE
perf(tool_search): catalog cache + degraded discovery (Closes #140)

### DIFF
--- a/tests/tools/test_tool_search_catalog_cache.py
+++ b/tests/tools/test_tool_search_catalog_cache.py
@@ -1,0 +1,207 @@
+"""Cache + degraded-discovery for the deferred-tool search catalog (issue #140).
+
+``dispatch_tool_search`` rebuilt the full catalog (classify + tokenize + stem
++ BM25 index) on every call; under load that per-call cost was the dominant
+contributor to the tool_search timeout failures (~0.71 per session). These
+tests pin the signature-keyed catalog cache and the degraded-discovery path
+that surfaces the tool list instead of failing silently.
+"""
+
+import json
+
+import pytest
+
+
+def _td(name, desc="Deferred capability."):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": desc,
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    }
+
+
+def _register(name, toolset="mcp-test", desc="Deferred capability."):
+    from tools.registry import registry
+
+    registry.register(
+        name=name,
+        handler=lambda args, **kw: json.dumps({"ok": True}),
+        schema=_td(name, desc),
+        toolset=toolset,
+    )
+    return _td(name, desc)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    from tools.tool_search import clear_search_catalog_cache
+
+    clear_search_catalog_cache()
+    yield
+    clear_search_catalog_cache()
+
+
+@pytest.fixture
+def defs():
+    return [
+        _register("create_issue", desc="File an issue on a repository."),
+        _register("send_slack", desc="Post a message to a Slack channel."),
+    ]
+
+
+class TestSearchCatalogCache:
+    def test_catalog_built_once_per_signature(self, defs, monkeypatch):
+        from tools.tool_search import ToolSearchConfig, build_catalog, dispatch_tool_search
+
+        calls = {"n": 0}
+        real_build = build_catalog
+
+        def counting(tool_defs):
+            calls["n"] += 1
+            return real_build(tool_defs)
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", counting)
+        cfg = ToolSearchConfig.from_raw({})
+        for _ in range(5):
+            dispatch_tool_search(
+                {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+            )
+        assert calls["n"] == 1
+
+    def test_invalidates_on_toolset_change(self, defs, monkeypatch):
+        from tools.tool_search import ToolSearchConfig, build_catalog, dispatch_tool_search
+
+        calls = {"n": 0}
+        real_build = build_catalog
+
+        def counting(tool_defs):
+            calls["n"] += 1
+            return real_build(tool_defs)
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", counting)
+        cfg = ToolSearchConfig.from_raw({})
+        dispatch_tool_search(
+            {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+        )
+        assert calls["n"] == 1
+
+        # A new tool joins the session -> new signature -> rebuild.
+        grown = defs + [_register("post_tweet", desc="Post to a Twitter account.")]
+        dispatch_tool_search(
+            {"queries": ["tweet"]}, current_tool_defs=grown, config=cfg
+        )
+        assert calls["n"] == 2
+
+    def test_invalidates_on_config_change(self, defs, monkeypatch):
+        from tools.tool_search import ToolSearchConfig, build_catalog, dispatch_tool_search
+
+        calls = {"n": 0}
+        real_build = build_catalog
+
+        def counting(tool_defs):
+            calls["n"] += 1
+            return real_build(tool_defs)
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", counting)
+        cfg_a = ToolSearchConfig.from_raw({})
+        cfg_b = ToolSearchConfig.from_raw({"defer_core_toolsets": ["mcp-test"]})
+        dispatch_tool_search(
+            {"queries": ["issue"]}, current_tool_defs=defs, config=cfg_a
+        )
+        dispatch_tool_search(
+            {"queries": ["issue"]}, current_tool_defs=defs, config=cfg_b
+        )
+        assert calls["n"] == 2
+
+    def test_cache_hit_preserves_results(self, defs):
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_search
+
+        cfg = ToolSearchConfig.from_raw({})
+        first = json.loads(
+            dispatch_tool_search(
+                {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+            )
+        )
+        second = json.loads(
+            dispatch_tool_search(
+                {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+            )
+        )
+        assert first == second
+        assert "create_issue" in first["results"][0]["matches"]
+
+    def test_clear_search_catalog_cache(self, defs, monkeypatch):
+        from tools.tool_search import (
+            ToolSearchConfig,
+            build_catalog,
+            clear_search_catalog_cache,
+            dispatch_tool_search,
+        )
+
+        calls = {"n": 0}
+        real_build = build_catalog
+
+        def counting(tool_defs):
+            calls["n"] += 1
+            return real_build(tool_defs)
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", counting)
+        cfg = ToolSearchConfig.from_raw({})
+        dispatch_tool_search(
+            {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+        )
+        clear_search_catalog_cache()
+        dispatch_tool_search(
+            {"queries": ["issue"]}, current_tool_defs=defs, config=cfg
+        )
+        assert calls["n"] == 2
+
+
+class TestDegradedDiscovery:
+    def test_build_failure_surfaces_tool_list(self, defs, monkeypatch):
+        from tools.tool_search import ToolSearchConfig, build_catalog, dispatch_tool_search
+
+        def boom(tool_defs):
+            raise RuntimeError("index corrupt")
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", boom)
+        resp = json.loads(
+            dispatch_tool_search(
+                {"queries": ["issue"]},
+                current_tool_defs=defs,
+                config=ToolSearchConfig.from_raw({}),
+            )
+        )
+        assert resp["degraded"] is True
+        assert "catalog build failed" in resp["degraded_reason"]
+        # The tool list still surfaces instead of an empty catalog.
+        assert resp["total_available"] >= 2
+        assert "create_issue" in resp["results"][0]["matches"]
+        # Bridge tools never leak into the degraded listing.
+        assert "tool_call" not in resp["results"][0]["matches"]
+
+    def test_build_failure_multiquery(self, defs, monkeypatch):
+        from tools.tool_search import ToolSearchConfig, build_catalog, dispatch_tool_search
+
+        def boom(tool_defs):
+            raise ValueError("schema parse failed")
+
+        monkeypatch.setattr("tools.tool_search.build_catalog", boom)
+        resp = json.loads(
+            dispatch_tool_search(
+                {"queries": ["issue", "slack"]},
+                current_tool_defs=defs,
+                config=ToolSearchConfig.from_raw({}),
+            )
+        )
+        assert resp["degraded"] is True
+        by_query = {r["query"]: r["matches"] for r in resp["results"]}
+        assert "create_issue" in by_query["issue"]
+        assert "send_slack" in by_query["slack"]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1267,6 +1267,100 @@ def _toolset_signature(tool_defs: List[Dict[str, Any]]) -> str:
     return "|".join(names)
 
 
+# #140 — signature-keyed search-catalog cache. dispatch_tool_search rebuilt the
+# full deferred catalog (classify + tokenize + stem + BM25 index) on EVERY
+# call; under load that per-call cost was the dominant contributor to the
+# tool_search timeout failures (~0.71/session). The catalog is a pure function
+# of the toolset signature + the deferral-relevant config, so cache it exactly
+# like _describe_cache above and let the key invalidate naturally when the tool
+# set or config changes. Names-keyed, same assumption as _describe_cache: two
+# tool sets with identical name sets produce the same catalog.
+_search_catalog_cache: dict[
+    tuple[str, str], tuple[List[Dict[str, Any]], List[CatalogEntry], _CorpusStats]
+] = {}
+_SEARCH_CATALOG_CACHE_MAX = 16
+
+
+def _search_catalog_key(
+    tool_defs: List[Dict[str, Any]], config: ToolSearchConfig
+) -> tuple[str, str]:
+    """Cache key for the search catalog: toolset signature + deferral config."""
+    sig = _toolset_signature(tool_defs)
+    cfg = "|".join(
+        str(getattr(config, f, ""))
+        for f in ("enabled", "threshold_pct", "defer_core_toolsets")
+    )
+    return (sig, cfg)
+
+
+def _build_search_catalog(
+    tool_defs: List[Dict[str, Any]], config: ToolSearchConfig
+) -> tuple[List[Dict[str, Any]], List[CatalogEntry], _CorpusStats]:
+    """classify + build_catalog with a signature-keyed cache (issue #140).
+
+    Returns ``(deferrable, catalog, corpus_stats)``. The deferrable list is
+    cached alongside the catalog because the streak-nudge response surfaces
+    the full deferrable tool list. Bounded like ``_describe_cache``: when the
+    cache exceeds ``_SEARCH_CATALOG_CACHE_MAX`` entries the whole cache is
+    dropped (a fresh toolset signature arrives at most on session/toolset
+    changes, so evicting all is simpler than LRU and never hot).
+    """
+    key = _search_catalog_key(tool_defs, config)
+    cached = _search_catalog_cache.get(key)
+    if cached is not None:
+        return cached
+    _, deferrable = classify_tools(tool_defs, config)
+    catalog = build_catalog(deferrable)
+    corpus_stats = _corpus_stats(catalog)
+    if len(_search_catalog_cache) >= _SEARCH_CATALOG_CACHE_MAX:
+        _search_catalog_cache.clear()
+    _search_catalog_cache[key] = (deferrable, catalog, corpus_stats)
+    return deferrable, catalog, corpus_stats
+
+
+def clear_search_catalog_cache() -> None:
+    """Drop the search-catalog cache (tests, and post-registry-change hooks)."""
+    _search_catalog_cache.clear()
+
+
+def _degraded_search_response(
+    queries: List[str],
+    tool_defs: List[Dict[str, Any]],
+    limit: int,
+    exc: BaseException,
+) -> str:
+    """Issue #140 — degraded-discovery response when the catalog build fails.
+
+    A catalog/index failure must never look like an empty catalog (the agent
+    would conclude the capability is missing and move on silently). Return a
+    valid tool_search payload listing every available tool name, substring-
+    matched per query, with an explicit ``degraded`` flag + reason so the
+    failure is visible and the tool list still surfaces.
+    """
+    names = sorted(
+        (td.get("function") or {}).get("name", "")
+        for td in tool_defs
+        if (td.get("function") or {}).get("name")
+        and (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES
+    )
+    results = []
+    for q in queries:
+        ql = q.lower()
+        matches = [n for n in names if ql in n.lower()][:limit]
+        results.append({"query": q, "matches": matches})
+    return json.dumps(
+        {
+            "queries": queries,
+            "total_available": len(names),
+            "results": results,
+            "tools": {},
+            "degraded": True,
+            "degraded_reason": f"catalog build failed: {exc!r}",
+        },
+        ensure_ascii=False,
+    )
+
+
 def _shared_tool_record(entry: CatalogEntry) -> Dict[str, Any]:
     """One record for the response's shared ``tools`` map.
 
@@ -1372,12 +1466,17 @@ def dispatch_tool_search(
             ),
         )
 
-    _, deferrable = classify_tools(current_tool_defs, config)
-    catalog = build_catalog(deferrable)
+    try:
+        deferrable, catalog, corpus_stats = _build_search_catalog(
+            current_tool_defs, config
+        )
+    except Exception as exc:  # pragma: no cover - defensive (pure local code)
+        # Issue #140 — degraded discovery: never fail silently. Surface the
+        # tool list with a diagnostic instead of an empty/error catalog.
+        return _degraded_search_response(queries, current_tool_defs, limit, exc)
 
     results: List[Dict[str, Any]] = []
     tools_map: Dict[str, Dict[str, Any]] = {}
-    corpus_stats = _corpus_stats(catalog)
     available_sources = _available_source_summary(catalog) if catalog else []
     all_hits: List[CatalogEntry] = []
     for query in queries:


### PR DESCRIPTION
Automated evolution PR for issue #140.

tool_search timed out ~0.71 times per session (225 in a 319-session week) because the full deferred catalog was rebuilt on every call. This:

1. Caches the (deferrable, catalog, corpus_stats) triple keyed by toolset signature + deferral config (mirrors the existing _describe_cache pattern; bounded, clearable).
2. Adds a degraded-discovery path: a catalog-build failure returns the full tool name list with an explicit 'degraded' flag + reason instead of failing silently — capability loss is never invisible again.

Regression tests cover build-once-per-signature, invalidation on toolset/config change, cache clear, and degraded single- + multi-query responses.