### PR TITLE
fix(memory): auto-evict oldest entries on replace-overflow (Closes #129)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 from pathlib import Path
+from typing import Any, Dict
 
 from tools.memory_tool import (
     MemoryStore,
@@ -825,7 +826,7 @@ class TestMemoryToolDispatcher:
             memory_tool(action="add", target=42, content="via tool", store=store)
         )
         assert result["success"] is False
-        assert "Invalid target" in result["error"]
+        assert "Invalid memory target" in result["error"]
 
     def test_unknown_action(self, store):
         result = json.loads(memory_tool(action="unknown", store=store))
@@ -1426,6 +1427,89 @@ class TestAutoEvictOnFull:
         s = MemoryStore(memory_char_limit=100)
         assert s.auto_evict_on_full is True
         assert s.auto_evict_keep_min >= 1
+
+
+class TestAutoEvictionOnReplaceOverflow:
+    """Issue #129 — replace-overflow auto-eviction, twin of the #1283 add path.
+
+    The nightly dreaming pipeline's memory REPLACE writes at cap were
+    hard-rejected ('Replacement would put memory at N/M chars') while a bare
+    add auto-evicted — so consolidation died exactly when memory was fullest.
+    These pin the replace path to evict the OLDEST entries (never the entry
+    being replaced) until the replaced set fits, degrading to the pre-#129
+    hard-reject only when eviction can't fit it.
+    """
+
+    @staticmethod
+    def _store(tmp_path, monkeypatch, **kw):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        defaults: Dict[str, Any] = dict(memory_char_limit=80, user_char_limit=80)
+        defaults.update(kw)
+        s = MemoryStore(**defaults)
+        s.load_from_disk()
+        return s
+
+    def test_replace_overflow_evicts_oldest_others(self, tmp_path, monkeypatch):
+        # a,b,c = 9 chars with the "\n§\n" delimiter; limit 80.
+        s = self._store(tmp_path, monkeypatch)
+        for entry in ("a", "b", "c"):
+            s.add("memory", entry)
+        replacement = "x" * 75  # 83 chars total -> needs exactly one eviction
+        result = s.replace("memory", "c", replacement)
+        assert result["success"] is True
+        assert "evicted" in json.dumps(result)
+        assert "1 oldest entr" in json.dumps(result)
+        # Oldest OTHER entry ("a") went; the replacement and "b" survived.
+        assert s._entries_for("memory") == ["b", replacement]
+
+    def test_replace_overflow_never_evicts_the_replacement(self, tmp_path, monkeypatch):
+        # Replacing the OLDEST entry: the replacement must survive and the
+        # next-oldest goes instead.
+        s = self._store(tmp_path, monkeypatch)
+        for entry in ("a", "b", "c"):
+            s.add("memory", entry)
+        replacement = "x" * 75  # x\n§\nb\n§\nc = 83 > 80 -> evict "b"
+        result = s.replace("memory", "a", replacement)
+        assert result["success"] is True
+        assert s._entries_for("memory") == [replacement, "c"]
+
+    def test_replace_overflow_respects_safety_floor(self, tmp_path, monkeypatch):
+        # keep_min=2 with 3 entries: only one eviction is allowed, which is
+        # not enough to fit -> fall through to the consolidation failure.
+        s = self._store(
+            tmp_path, monkeypatch, memory_char_limit=60, auto_evict_keep_min=2
+        )
+        for entry in ("a", "b", "c"):
+            s.add("memory", entry)
+        result = s.replace("memory", "c", "x" * 58)  # 66 > 60; one evict -> 62 > 60
+        assert result["success"] is False
+        assert "current_entries" in result
+        assert "retry" in result["error"].lower()
+
+    def test_opt_out_restores_hard_reject(self, tmp_path, monkeypatch):
+        s = self._store(tmp_path, monkeypatch, auto_evict_on_full=False)
+        for entry in ("a", "b", "c"):
+            s.add("memory", entry)
+        result = s.replace("memory", "c", "x" * 75)
+        assert result["success"] is False
+        assert "evicted" not in json.dumps(result)
+        assert "current_entries" in result
+
+    def test_user_target_never_auto_evicts(self, tmp_path, monkeypatch):
+        # User profile facts are scarce/high-value: keep the manual path.
+        s = self._store(tmp_path, monkeypatch, memory_char_limit=80, user_char_limit=40)
+        s.add("user", "a")
+        result = s.replace("user", "a", "y" * 60)
+        assert result["success"] is False
+        assert "evicted" not in json.dumps(result)
+
+    def test_replacement_alone_over_limit_still_rejects(self, tmp_path, monkeypatch):
+        # The new entry itself exceeds the limit -> eviction cannot help.
+        s = self._store(tmp_path, monkeypatch, memory_char_limit=20)
+        s.add("memory", "a")
+        result = s.replace("memory", "a", "z" * 40)
+        assert result["success"] is False
+        assert "current_entries" in result
 
 
 class TestBomToleranceInMemoryFiles:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -659,6 +659,52 @@ class MemoryStore:
                 return None
             evicted.append(parse_provenance(working.pop(0))[0])
 
+    def _evict_replacement_to_fit(
+        self,
+        target: str,
+        entries: List[str],
+        new_text: str,
+        limit: int,
+    ) -> Optional[Tuple[List[str], List[str]]]:
+        """Evict OLDEST entries (never ``new_text``) until the list fits ``limit``.
+
+        Issue #129 — the replace-path twin of ``_evict_to_fit`` (#1283): the
+        add path auto-evicts on overflow but replace still hard-rejected, so
+        nightly consolidation (dreaming) writes at cap died with
+        'Replacement would put memory at N/M chars'. The caller passes the
+        working list ALREADY containing the replacement at its target index;
+        this evicts the oldest OTHER entries (matched by stored text so the
+        replacement itself is never a victim) until the list fits.
+
+        Returns ``(evicted_display_texts, surviving_entries)`` — oldest-first
+        texts plus the exact surviving list — or ``None`` when it still
+        doesn't fit (the replacement alone exceeds the limit, or the safety
+        floor ``auto_evict_keep_min`` was reached). Callers must treat
+        ``None`` as "give up and return the consolidation-failure response",
+        exactly like the add path. Only the ``memory`` target is eligible;
+        ``user`` facts are scarce/high-value and keep the manual path.
+        """
+        if not self.auto_evict_on_full or target != "memory":
+            return None
+
+        working = list(entries)
+        evicted: List[str] = []
+
+        while True:
+            if len(ENTRY_DELIMITER.join(working)) <= limit:
+                return evicted, working
+            # Can't evict further without breaching the safety floor.
+            if len(working) <= self.auto_evict_keep_min:
+                return None
+            # Oldest entry that is not the replacement itself.
+            victim = next(
+                (i for i, e in enumerate(working) if e != new_text),
+                None,
+            )
+            if victim is None:
+                return None
+            evicted.append(parse_provenance(working.pop(victim))[0])
+
     def _char_limit(self, target: str, dynamic_limit: Optional[int] = None) -> int:
         """Return the effective char limit for ``target``.
 
@@ -914,6 +960,28 @@ class MemoryStore:
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
+                # Issue #129 — mirror the add-path auto-eviction (#1283) for
+                # replace-overflow: evict the OLDEST entries (never the entry
+                # being replaced) until the replaced set fits, instead of
+                # hard-rejecting the nightly consolidation (dreaming) writes
+                # that run at cap. ``None`` degrades to the pre-#129 response.
+                outcome = self._evict_replacement_to_fit(
+                    target, test_entries, stored_new, limit
+                )
+                if outcome is not None:
+                    evicted, surviving = outcome
+                    self._set_entries(target, surviving)
+                    self.save_to_disk(target)
+                    logger.info(
+                        "memory replace overflow: evicted %d old entr%s to fit",
+                        len(evicted),
+                        "y" if len(evicted) == 1 else "ies",
+                    )
+                    return self._success_response(
+                        target,
+                        "Entry replaced (evicted %d oldest entr%s to make room)."
+                        % (len(evicted), "y" if len(evicted) == 1 else "ies"),
+                    )
                 current = self._char_count(target)
                 return self._consolidation_failure({
                     "success": False,


### PR DESCRIPTION
Automated evolution PR for issue #129.

The nightly dreaming pipeline was blocked 2 nights running: memory REPLACE writes at the 8k cap were hard-rejected while a bare add auto-evicted (#1283) — consolidation died exactly when memory was fullest.

This extends the #1283 add-path eviction to replace-overflow:
- New _evict_replacement_to_fit evicts the OLDEST entries (never the entry being replaced) until the replaced set fits; honors auto_evict_keep_min, is memory-target-only, and returns None to degrade to the pre-#129 consolidation-failure response.
- replace() wires it in on overflow with the evicted count in the success message.
- Includes the pre-existing stale-assertion fix in test_memory_tool.py (same change as PR #3326 — identical on both sides, auto-merges cleanly).

Regression tests: evicts-oldest-others, never-evicts-the-replacement, safety floor, opt-out hard reject, user-target never evicts, replacement-alone-over-limit.