### PR TITLE
feat: retrieval-time supersession freshness signals for governed memory (Closes #3336)

### DIFF
--- a/evolution/lib/governed_shared_memory.py
+++ b/evolution/lib/governed_shared_memory.py
@@ -155,9 +155,7 @@ class GovernedSharedMemory:
             return None, FreshnessSignal(status="unknown")
         if not record.is_active and record.superseded_by:
             successor = self._records.get(record.superseded_by)
-            superseded_at = (
-                successor.created_at_ms if successor is not None else None
-            )
+            superseded_at = successor.created_at_ms if successor is not None else None
             return record, FreshnessSignal(
                 status="superseded",
                 superseded_by=record.superseded_by,

--- a/evolution/lib/governed_shared_memory.py
+++ b/evolution/lib/governed_shared_memory.py
@@ -43,6 +43,24 @@ class MemoryProvenance:
 
 
 @dataclass
+class FreshnessSignal:
+    """Retrieval-time freshness verdict for a memory key (#3336).
+
+    Attributes:
+        status: One of ``"current"`` (record exists and is active),
+            ``"superseded"`` (record exists but a newer record replaced it),
+            or ``"unknown"`` (no record under this key).
+        superseded_by: Key of the newer record, when ``status`` is
+            ``"superseded"``.
+        superseded_at_ms: Epoch-ms timestamp of the supersession, when known.
+    """
+
+    status: str
+    superseded_by: Optional[str] = None
+    superseded_at_ms: Optional[float] = None
+
+
+@dataclass
 class GovernedMemoryRecord:
     """A governed memory entry with scope, provenance, and supersession links."""
 
@@ -119,6 +137,33 @@ class GovernedSharedMemory:
         if active_only and not record.is_active:
             return None
         return record
+
+    def read_with_freshness(
+        self, key: str
+    ) -> tuple[Optional[GovernedMemoryRecord], FreshnessSignal]:
+        """Read a record together with its supersession freshness signal (#3336).
+
+        Unlike :meth:`read` with ``active_only=True`` — which silently hides a
+        superseded record — this always returns the record (when it exists) and
+        a :class:`FreshnessSignal` telling the caller whether the constraint it
+        is about to act on has been withdrawn by a newer authoritative record.
+        A superseded record is never silently served as if it were current:
+        the caller gets an explicit review signal instead.
+        """
+        record = self._records.get(key)
+        if record is None:
+            return None, FreshnessSignal(status="unknown")
+        if not record.is_active and record.superseded_by:
+            successor = self._records.get(record.superseded_by)
+            superseded_at = (
+                successor.created_at_ms if successor is not None else None
+            )
+            return record, FreshnessSignal(
+                status="superseded",
+                superseded_by=record.superseded_by,
+                superseded_at_ms=superseded_at,
+            )
+        return record, FreshnessSignal(status="current")
 
     def list_by_scope(
         self, scope: str, active_only: bool = True

--- a/run_agent.py
+++ b/run_agent.py
@@ -9891,6 +9891,21 @@ class AIAgent:
         """Read a governed memory record."""
         return self.governed_memory.read(key=key, active_only=active_only)
 
+    def read_governed_memory_with_freshness(
+        self, key: str
+    ) -> tuple[Any, "FreshnessSignal"]:
+        """Read a governed memory record plus its supersession freshness signal (#3336).
+
+        Before the agent acts on an inherited constraint, this surfaces whether
+        a newer record has withdrawn it — the review signal proposed by #3336
+        (stale-constraint retrieval failure mode). Returns
+        ``(record, FreshnessSignal)`` where ``signal.status`` is ``"current"``,
+        ``"superseded"``, or ``"unknown"``.
+        """
+        from evolution.lib.governed_shared_memory import FreshnessSignal
+
+        return self.governed_memory.read_with_freshness(key)
+
     def redistribute_subagent_memory(
         self, superseded_subagent_id: str, successor_subagent_id: str
     ) -> int:

--- a/tests/evolution/test_governed_shared_memory_freshness.py
+++ b/tests/evolution/test_governed_shared_memory_freshness.py
@@ -1,0 +1,79 @@
+"""Retrieval-time freshness signals for governed memory (#3336).
+
+Covers ``GovernedSharedMemory.read_with_freshness`` and the agent-level
+``read_governed_memory_with_freshness`` wrapper: superseded constraints must
+surface an explicit review signal instead of being silently served as current
+(or silently hidden by ``active_only`` reads).
+"""
+
+import unittest
+
+from evolution.lib.governed_shared_memory import (
+    FreshnessSignal,
+    GovernedSharedMemory,
+)
+
+
+class ReadWithFreshnessTests(unittest.TestCase):
+    def test_unknown_key_returns_unknown_signal(self) -> None:
+        store = GovernedSharedMemory()
+        record, signal = store.read_with_freshness("missing")
+        self.assertIsNone(record)
+        self.assertEqual(signal.status, "unknown")
+        self.assertIsNone(signal.superseded_by)
+        self.assertIsNone(signal.superseded_at_ms)
+
+    def test_active_record_returns_current_signal(self) -> None:
+        store = GovernedSharedMemory()
+        store.write(key="rule", value="keep logs 7d", author_id="a1")
+        record, signal = store.read_with_freshness("rule")
+        self.assertIsNotNone(record)
+        self.assertEqual(signal.status, "current")
+        self.assertIsNone(signal.superseded_by)
+
+    def test_superseded_record_is_flagged_with_successor(self) -> None:
+        store = GovernedSharedMemory()
+        store.write(key="rule", value="keep logs 7d", author_id="a1")
+        successor = store.write(
+            key="rule-v2", value="keep logs 30d", author_id="a2",
+            supersedes_key="rule",
+        )
+        record, signal = store.read_with_freshness("rule")
+        self.assertIsNotNone(record)
+        self.assertEqual(record.value, "keep logs 7d")
+        self.assertEqual(signal.status, "superseded")
+        self.assertEqual(signal.superseded_by, "rule-v2")
+        self.assertEqual(signal.superseded_at_ms, successor.created_at_ms)
+
+    def test_superseded_signal_differs_from_active_only_read(self) -> None:
+        """The whole point of #3336: active_only read silently hides; freshness read flags."""
+        store = GovernedSharedMemory()
+        store.write(key="rule", value="old constraint", author_id="a1")
+        store.write(key="rule-v2", value="new constraint", author_id="a1",
+                    supersedes_key="rule")
+        self.assertIsNone(store.read(key="rule", active_only=True))
+        _, signal = store.read_with_freshness("rule")
+        self.assertEqual(signal.status, "superseded")
+        self.assertIsInstance(signal, FreshnessSignal)
+
+    def test_inactive_record_without_successor_reads_current(self) -> None:
+        """An inactive record with no supersession pointer is not claimed superseded."""
+        store = GovernedSharedMemory()
+        rec = store.write(key="rule", value="x", author_id="a1")
+        rec.is_active = False
+        rec.superseded_by = None
+        _, signal = store.read_with_freshness("rule")
+        self.assertEqual(signal.status, "current")
+
+    def test_freshness_signal_is_independent_of_read_order(self) -> None:
+        store = GovernedSharedMemory()
+        store.write(key="a", value="1", author_id="x")
+        store.write(key="b", value="2", author_id="x", supersedes_key="a")
+        _, sig_a = store.read_with_freshness("a")
+        _, sig_b = store.read_with_freshness("b")
+        self.assertEqual(sig_a.status, "superseded")
+        self.assertEqual(sig_b.status, "current")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evolution/test_governed_shared_memory_freshness.py
+++ b/tests/evolution/test_governed_shared_memory_freshness.py
@@ -35,7 +35,9 @@ class ReadWithFreshnessTests(unittest.TestCase):
         store = GovernedSharedMemory()
         store.write(key="rule", value="keep logs 7d", author_id="a1")
         successor = store.write(
-            key="rule-v2", value="keep logs 30d", author_id="a2",
+            key="rule-v2",
+            value="keep logs 30d",
+            author_id="a2",
             supersedes_key="rule",
         )
         record, signal = store.read_with_freshness("rule")
@@ -49,8 +51,9 @@ class ReadWithFreshnessTests(unittest.TestCase):
         """The whole point of #3336: active_only read silently hides; freshness read flags."""
         store = GovernedSharedMemory()
         store.write(key="rule", value="old constraint", author_id="a1")
-        store.write(key="rule-v2", value="new constraint", author_id="a1",
-                    supersedes_key="rule")
+        store.write(
+            key="rule-v2", value="new constraint", author_id="a1", supersedes_key="rule"
+        )
         self.assertIsNone(store.read(key="rule", active_only=True))
         _, signal = store.read_with_freshness("rule")
         self.assertEqual(signal.status, "superseded")


### PR DESCRIPTION
Automated evolution PR for issue #3336.

## What
- `GovernedSharedMemory.read_with_freshness(key)` — returns `(record, FreshnessSignal)`. Unlike `read(active_only=True)`, which silently hides a superseded record, this surfaces the record together with an explicit `current` / `superseded` / `unknown` verdict and the superseding key + timestamp.
- `FreshnessSignal` dataclass (status, superseded_by, superseded_at_ms).
- `AIAgent.read_governed_memory_with_freshness()` — agent-level review signal before acting on an inherited constraint.

## Scope
Data-structure + retrieval-policy change only (as the issue specifies): no core toolset growth, no model calls. Extends the existing supersession machinery from #2488.

## Checks
- Pre-PR targeted test runner: PASSED (tests/evolution shard, 28.9s)
- ruff check: clean; ruff format: applied to changed files
- Tests: 12 passed (6 new freshness tests + 6 existing governed-memory tests)
- Diff: +140 lines (3 files) — under the 200-line merge cap

Closes #3336

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>