### PR TITLE
fix(delegate): gate blocks only unambiguous shell work — file/gh children unblocked (Closes #150)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3900,3 +3900,41 @@ class TestChildExecCapabilityGate(unittest.TestCase):
         )
         self.assertEqual(out["status"], "blocked")
         child.run_conversation.assert_not_called()
+
+    def test_soft_verb_file_goal_proceeds_without_terminal(self):
+        """#150 regression: goals that merely mention ambiguous verbs
+        (run/check/test/gh/...) must NOT be blocked for file-capable children.
+        This is what deadlocked the evolution pipeline in restricted cron
+        sessions: every delegate_task dispatch returned blocked_no_terminal
+        even for purely file/gh-based stages."""
+        from tools.delegate_tool import _child_blocked_no_terminal
+
+        for goal in [
+            "check the analysis JSON in ~/.hermes/evolution and draft issues",
+            "run the analysis stage over the latest scan output",
+            "test the drafted issue bodies against the template",
+            "file the drafted issues with gh",
+            "build the report from the merged analysis",
+        ]:
+            child = self._child(["file", "web"])
+            out = _child_blocked_no_terminal(0, goal, child)
+            self.assertIsNone(out, f"soft-verb goal must not block: {goal!r}")
+
+    def test_hard_verb_without_terminal_still_blocked(self):
+        """#150: the gate must STILL block genuinely shell-required work —
+        unambiguous verbs (git/ssh/docker/pytest/...) are not covered by the
+        fail-open relaxation."""
+        from tools.delegate_tool import _child_blocked_no_terminal
+
+        for goal in [
+            "ssh into the host and check uptime",
+            "docker build the image and push it",
+            "run pytest on the new test file",
+            "pip install the pinned dependencies",
+            "restart the service with systemctl",
+        ]:
+            child = self._child(["file", "web"])
+            out = _child_blocked_no_terminal(0, goal, child)
+            self.assertIsNotNone(out, f"hard-verb goal must still block: {goal!r}")
+            assert out is not None
+            self.assertEqual(out["exit_reason"], "blocked_no_terminal")

--- a/tests/tools/test_delegate_terminal_compat.py
+++ b/tests/tools/test_delegate_terminal_compat.py
@@ -9,7 +9,53 @@ Verifies that:
 
 from types import SimpleNamespace
 
-from tools.delegate_tool import _goal_needs_terminal, _strip_blocked_tools
+from tools.delegate_tool import (
+    _goal_hard_requires_terminal,
+    _goal_needs_terminal,
+    _strip_blocked_tools,
+)
+
+
+class TestGoalHardRequiresTerminal:
+    """#150: the dispatch gate's strict detector — only unambiguous shell
+    verbs count, so file/gh-capable children are not blocked on soft
+    mentions (run/check/test/gh/...)."""
+
+    def test_hard_verbs_detected(self):
+        for goal in [
+            "git status in the repo",
+            "ssh into the host",
+            "docker build the image",
+            "Run pytest on the new test file",
+            "restart the daemon with systemctl",
+            "pip install the dependency",
+            "curl the endpoint",
+        ]:
+            assert _goal_hard_requires_terminal(goal), f"Expected for: {goal!r}"
+
+    def test_soft_verbs_not_detected(self):
+        """Ambiguous verbs alone must NOT satisfy the strict detector."""
+        for goal in [
+            "run the analysis stage over the latest scan output",
+            "check the draft JSON in ~/.hermes/evolution",
+            "test the parser output against the template",
+            "file the drafted issues with gh",
+            "make the edits and format the file",
+        ]:
+            assert not _goal_hard_requires_terminal(goal), f"Unexpected for: {goal!r}"
+
+    def test_context_scanned_too(self):
+        assert _goal_hard_requires_terminal(
+            "Analyze the results",
+            context="ssh to the host first, then summarize.",
+        )
+
+    def test_empty_and_none_return_false(self):
+        assert not _goal_hard_requires_terminal("")
+        assert not _goal_hard_requires_terminal(None)
+
+    def test_word_boundary_no_false_positive(self):
+        assert not _goal_hard_requires_terminal("The digit count is fidget-driven")
 
 
 class TestGoalNeedsTerminal:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1989,6 +1989,36 @@ _SHELL_DEPENDENT_VERBS = frozenset({
     "check",
 })
 
+# Ambiguous verbs that routinely appear in file/web/gh goals and do not by
+# themselves prove a shell is required — e.g. "run the analysis stage",
+# "check the draft JSON", "test the parser output", "file the issues with gh".
+# Used to separate the AUTO-ADD decision (conservative, full verb set) from
+# the #2826 dispatch GATE (strict, hard verbs only): in sessions where the
+# parent cannot provide `terminal` at all (restricted cron sessions), gating
+# on soft mentions blocked purely file/gh-capable children and deadlocked the
+# evolution pipeline for 14 consecutive cycles (issue #150).
+_SHELL_AMBIGUOUS_VERBS = frozenset({
+    "gh",
+    "build",
+    "test",
+    "run",
+    "install",
+    "make",
+    "service",
+    "compile",
+    "deploy",
+    "lint",
+    "format",
+    "check",
+})
+
+# Verbs that unambiguously require a shell. Matching one of these in a goal
+# while no terminal is available means the dispatch is genuinely doomed, so
+# the #2826 gate still blocks on them.
+_SHELL_REQUIRED_VERBS = frozenset(
+    v for v in _SHELL_DEPENDENT_VERBS if v not in _SHELL_AMBIGUOUS_VERBS
+)
+
 # Verbs that strongly indicate the task requires filesystem access (#3093).
 _FILESYSTEM_DEPENDENT_VERBS = frozenset({
     "file",
@@ -2059,6 +2089,36 @@ def _goal_needs_terminal(goal: str, context: Optional[str] = None) -> bool:
     # Word-boundary match so "git" doesn't match "digit" / "fidget".
     pattern = re.compile(
         r"\b(" + "|".join(re.escape(v) for v in _SHELL_DEPENDENT_VERBS) + r")\b",
+        re.IGNORECASE,
+    )
+    return bool(pattern.search(text))
+
+
+def _goal_hard_requires_terminal(goal: str, context: Optional[str] = None) -> bool:
+    """Return True only for UNambiguous shell-required work (issue #150).
+
+    Same static word-boundary heuristic as ``_goal_needs_terminal`` but
+    matches only ``_SHELL_REQUIRED_VERBS`` — verbs that cannot be satisfied
+    without a shell (git, ssh, docker, pytest, systemctl, ...). Ambiguous
+    verbs (run/check/test/gh/make/...) do not count: they appear in purely
+    file/web/gh goals ("run the analysis stage", "check the draft"), and
+    gating on them blocked file-capable children in sessions where the parent
+    cannot provision `terminal` at all, deadlocking the evolution pipeline.
+
+    The #1369 auto-add keeps the conservative full-verb set — when the parent
+    CAN provide terminal it should always be added for shell-ish goals. This
+    strict variant is for the #2826 dispatch gate, which must not refuse a
+    dispatch the child could actually complete with its other tools.
+    """
+    import re
+
+    text = goal or ""
+    if context:
+        text = f"{text}\n{context}"
+    if not text:
+        return False
+    pattern = re.compile(
+        r"\b(" + "|".join(re.escape(v) for v in _SHELL_REQUIRED_VERBS) + r")\b",
         re.IGNORECASE,
     )
     return bool(pattern.search(text))
@@ -3450,8 +3510,18 @@ def _child_blocked_no_terminal(task_index: int, goal: str, child) -> Optional[Di
     the task needs one). The _build_child_agent auto-add already widened the
     child when the parent could provide terminal; reaching here without it
     means dispatch would be doomed, so we block visibly instead.
+
+    Issue #150: the gate matches only UNAMBIGUOUS shell verbs
+    (_goal_hard_requires_terminal), not the conservative full set used by the
+    auto-add. In sessions where the parent itself has no `terminal` to give
+    (restricted cron sessions), goals that merely mention ambiguous verbs
+    ("run the analysis stage", "check the draft JSON", "file the issues with
+    gh") previously blocked purely file/gh-capable children, deadlocking the
+    evolution pipeline for 14 consecutive cycles. A dispatch the child can
+    complete with its other tools must not be refused; a bounded failed child
+    run is strictly better than a hard block that never retries.
     """
-    if not _goal_needs_terminal(goal):
+    if not _goal_hard_requires_terminal(goal):
         return None
     _child_ts = getattr(child, "enabled_toolsets", None)
     # Fail-open: only gate when the child declares a concrete toolset list.


### PR DESCRIPTION
Automated evolution PR for issue #150.

The #2826 exec-capability gate matched the conservative full shell-verb set, so in restricted cron sessions (parent cannot provision terminal) every delegate_task dispatch returned blocked_no_terminal — even for purely file/gh-based stages, deadlocking the evolution pipeline for 14 consecutive cycles.

- Adds _SHELL_AMBIGUOUS_VERBS / _SHELL_REQUIRED_VERBS split
- New _goal_hard_requires_terminal() strict detector for the gate
- Auto-add path (#1369) unchanged (conservative full set)
- Regression + hardening tests (23 passing locally, ruff clean)