### PR TITLE
fix(approval): stop hard-blocking benign compound read-only commands (Closes #122)

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -207,6 +207,15 @@ _HARDLINE_ALLOW = [
     "npm run build",
     "sudo apt update",
     "curl https://example.com | head",
+    # #122 — compound READ-ONLY inspection: grep inside $(...) command
+    # substitution within double quotes used to hard-block as "malformed
+    # executable payload" (lexer started mid-quote and saw an unbalanced
+    # outer quote). These are bread-and-butter source-inspection shapes.
+    'sed -n "$(grep -n "def detect_hardline_command" tools/approval.py | head -1 | cut -d: -f1)p" tools/approval.py',
+    'echo "$(grep -rn "hardline" tools/)"',
+    'x="$(grep -l foo .)" && echo "$x"',
+    'grep -rn "hardline" tools/approval.py | head -20',
+    'sed -n "1,30p" tools/approval.py | grep -n "hardline"',
 ]
 
 
@@ -222,6 +231,24 @@ def test_hardline_detection_allows(command):
     is_hl, desc = detect_hardline_command(command)
     assert not is_hl, f"expected hardline NOT to match {command!r} (got: {desc})"
     assert desc is None
+
+
+# #122 — the same quoting shapes must NOT become a bypass for destructive
+# payloads: masking/parse-skip applies to grep operands only, never to the
+# command as a whole, so rm/wipe content inside $(...) still hits the floor.
+_DESTRUCTIVE_SUBSTITUTION = [
+    'sed -n "$(rm -rf /)"',
+    'echo "$(rm -rf ~)"',
+    'grep -rn "x" /etc | sudo rm -rf /',
+    'x="$(rm -rf $HOME)"',
+]
+
+
+@pytest.mark.parametrize("command", _DESTRUCTIVE_SUBSTITUTION)
+def test_destructive_substitution_still_hardline_blocked(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"expected hardline to match {command!r}"
+    assert desc, "hardline match must provide a description"
 
 
 # Commands written with the ordinary quoting / brace shell idioms that

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1709,6 +1709,47 @@ _GREP_OPTIONS_WITH_ARG = {
 _GREP_SHORT_OPTIONS_WITH_ARG = {"A", "B", "C", "D", "d", "e", "f", "m"}
 
 
+def _inside_quote_or_substitution(command: str, start: int) -> bool:
+    """Return True when *start* sits inside an enclosing quote or ``$(...)``.
+
+    Used to skip command words that lex mid-quote (e.g. a ``grep`` inside
+    ``"$(grep -n ...)"``): tokenizing from there sees the enclosing quote as
+    unbalanced and reports a malformed parse, which the hardline detector
+    treats as an unconditional block. Such a word is not the top-level
+    command whose quoted PCRE operands get masked, so skipping it is
+    fail-safe — raw detection still sees the full command.
+    """
+    quote: str | None = None
+    escaped = False
+    sub_depth = 0
+    backtick_open = False
+    i = 0
+    while i < start:
+        char = command[i]
+        if escaped:
+            escaped = False
+        elif char == "\\" and quote != "'":
+            escaped = True
+        elif quote:
+            if char == quote:
+                quote = None
+            elif quote == '"' and char == "$" and i + 1 < start and command[i + 1] == "(":
+                sub_depth += 1
+            elif quote == '"' and char == "`":
+                backtick_open = True
+        else:
+            if char in {"'", '"'}:
+                quote = char
+            elif char == "$" and i + 1 < start and command[i + 1] == "(":
+                sub_depth += 1
+            elif char == "`":
+                backtick_open = True
+            elif char == ")" and sub_depth > 0:
+                sub_depth -= 1
+        i += 1
+    return quote is not None or sub_depth > 0 or backtick_open
+
+
 def _quoted_grep_pattern_spans(command: str) -> tuple[list[tuple[int, int]], bool]:
     """Structurally locate quoted grep PCRE operands.
 
@@ -1725,6 +1766,14 @@ def _quoted_grep_pattern_spans(command: str) -> tuple[list[tuple[int, int]], boo
             if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() not in {
                 "grep", "egrep",
             }:
+                continue
+            # #122 — a grep word inside an enclosing quote or $(...)
+            # substitution (e.g. `sed -n "$(grep -n ...)"`) cannot be
+            # tokenized from mid-quote: the lexer sees the outer quote as
+            # unbalanced, which previously hard-blocked benign compound
+            # read-only inspection commands as "malformed". Skipping it is
+            # fail-safe: raw detection still sees the full command.
+            if _inside_quote_or_substitution(segment, start):
                 continue
             tokens = _shell_tokens_with_spans(segment, start)
             if tokens is None:


### PR DESCRIPTION
Automated evolution PR for issue #122.

**Root cause**: a `grep` command word inside a double-quoted `$(...)` substitution (e.g. `sed -n "$(grep -n ...)"`) was tokenized from mid-quote — the lexer saw the enclosing quote as unbalanced, reported 'malformed executable payload', and `detect_hardline_command` turned that into an *unconditional* block of a harmless source-inspection one-liner. No actionable message; agents re-shaped the same intent repeatedly (11 blocks over 3 days).

**Fix**: `_quoted_grep_pattern_spans` now skips grep words that sit inside an enclosing quote or command substitution (new `_inside_quote_or_substitution` scanner). Those words are not the top-level command whose quoted PCRE operands get masked; skipping is fail-safe — raw detection still sees the full command.

**Security invariant preserved** (tested): destructive payloads in the same quoting shapes — `sed -n "$(rm -rf /)"`, `echo "$(rm -rf ~)"`, `grep ... | sudo rm -rf /` — remain hardline-blocked.

**Validation**: 257 tests in test_hardline_blocklist.py pass (incl. 5 new allow-cases + 4 new destructive-substitution cases); 154 tests across the approval cluster (test_approval, deny_rules, smart_approval_policy/injection, request_tool_approval, config_readonly) pass; ruff clean.
