### PR TITLE
fix(evolution): inject pre-computed introspection digest in the wake gate (Closes #115)

### DIFF
--- a/scripts/evolution_access_gate.sh
+++ b/scripts/evolution_access_gate.sh
@@ -63,6 +63,24 @@ fi
 
 if [ "$ok" = "1" ]; then
     echo "evolution access-gate: write access to $REPO confirmed — waking agent."
+    # #115 — evolution-introspection works from a pre-computed, ANONYMIZED
+    # digest of session problem-signals (scripts/introspection_extract.py,
+    # issue #89) instead of raw transcripts. Emit it BEFORE the wake-gate
+    # JSON (Hermes cron treats the LAST stdout line as the gate), so the
+    # agent gets the digest without re-deriving it every cycle. Fail-open:
+    # if the extractor is missing or errors, wake anyway — the digest is an
+    # optimization for the prompt, not a gate.
+    _gate_dir="$(cd "$(dirname "$0")" && pwd)"
+    if command -v python3 >/dev/null 2>&1 && [ -f "$_gate_dir/introspection_extract.py" ]; then
+        if command -v timeout >/dev/null 2>&1; then
+            _digest="$(timeout 30 python3 "$_gate_dir/introspection_extract.py" 2>/dev/null)"
+        else
+            _digest="$(python3 "$_gate_dir/introspection_extract.py" 2>/dev/null)"
+        fi
+        if [ -n "$_digest" ]; then
+            printf '\n## Introspection Digest\n%s\n' "$_digest"
+        fi
+    fi
     echo '{"wakeAgent": true}'
 else
     echo "evolution access-gate: no WRITE access to $REPO — skipping agent to avoid burning LLM tokens / web-search quota on work that cannot be pushed (a reachable read-only account still cannot open branches/PRs). Grant the authenticated account push access on $REPO (or run as a writer), then 'gh auth login'."


### PR DESCRIPTION
Automated evolution PR for issue #115.

evolution-introspection's step 1 expects a pre-computed '## Introspection Digest' in the prompt; the pre-run gate (evolution_access_gate.sh) only checked GitHub write access, so the agent re-derived the digest from raw transcripts every cycle (absent 5+ consecutive cycles).

The gate now runs scripts/introspection_extract.py (deterministic, ANONYMIZED problem-signal extractor, #89) and emits its JSON digest under '## Introspection Digest' BEFORE the wake-gate JSON (last stdout line is the gate per the cron contract). Fail-open: missing python3/extractor or a 30s timeout still wakes the agent — the digest is a prompt optimization, not a gate.

Validated: bash -n clean; live run emits status line + digest (354 sessions scanned) + wake JSON as final line.