### PR TITLE
feat: capture model reasoning traces into the trajectory store (Closes #112)

### DIFF
--- a/agent/tool_call_capture.py
+++ b/agent/tool_call_capture.py
@@ -81,6 +81,54 @@ __all__ = [
 #: pre-truncation payload so a huge tool result is not held in memory twice.
 _MAX_RESULT_CHARS = 2000
 
+#: Bounded reasoning trace captured per tool call (issue #112). Reasoning can
+#: be long; the store only needs the diagnostic layer, not a full CoT dump.
+_MAX_REASONING_CHARS = 2000
+
+
+def _extract_reasoning(msg: Dict[str, Any]) -> str:
+    """Pull a compact reasoning trace out of an assistant message dict (issue #112).
+
+    Reasoning appears on the wire in three shapes, depending on provider:
+
+    * ``msg["reasoning"]`` — a plain string on some transports.
+    * ``msg["reasoning_content"]`` — the OpenAI chat wire's streaming field.
+    * content blocks: ``msg["content"]`` is a list containing
+      ``{"type": "reasoning", ...}`` entries (Responses API). Their payload
+      lives under ``summary`` (list of ``{"type": "summary_text", "text": ...}``
+      parts), ``content`` (string), or a nested ``reasoning`` object.
+
+    Returns a bounded string (``_MAX_REASONING_CHARS``) or ``""`` when the
+    message carries no reasoning. Never raises: a shape we do not recognise
+    is treated as "no reasoning", not an error — capture must not be able to
+    break the turn it is instrumenting.
+    """
+    if not isinstance(msg, dict):
+        return ""
+    for key in ("reasoning", "reasoning_content"):
+        raw = msg.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()[:_MAX_REASONING_CHARS]
+    content = msg.get("content")
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "reasoning":
+                continue
+            payload = block.get("reasoning") or block
+            summary = payload.get("summary") if isinstance(payload, dict) else None
+            if isinstance(summary, list):
+                for part in summary:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        parts.append(part["text"])
+            body = payload.get("content") if isinstance(payload, dict) else None
+            if isinstance(body, str):
+                parts.append(body)
+        joined = " ".join(p.strip() for p in parts if p and p.strip())
+        return joined[:_MAX_REASONING_CHARS]
+    return ""
+
+
 #: Opt-in. Default OFF.
 #
 # Even redacted, tool arguments carry paths containing usernames, SQL, code
@@ -205,6 +253,7 @@ def extract_tool_calls(
     for msg in messages:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
+        reasoning = _extract_reasoning(msg)
         for tc in msg.get("tool_calls") or []:
             if not isinstance(tc, dict):
                 continue
@@ -235,6 +284,7 @@ def extract_tool_calls(
                 "result": content,
                 "status": _result_status(content) if has_result else "pending",
                 "duration_ms": timings.get(cid) if cid else None,
+                "reasoning_summary": reasoning,
             })
     return calls
 
@@ -307,6 +357,7 @@ def build_trajectory_log(
             result=call["result"],
             status=call["status"],
             duration_ms=call.get("duration_ms"),
+            reasoning_summary=call.get("reasoning_summary", ""),
         )
     return log
 

--- a/scripts/evolution_trajectory_logger.py
+++ b/scripts/evolution_trajectory_logger.py
@@ -137,6 +137,7 @@ class TrajectoryEntry:
     result_summary: str = ""
     timestamp: str = ""
     duration_ms: Optional[int] = None
+    reasoning_summary: str = ""
 
     def __post_init__(self) -> None:
         if not self.timestamp:
@@ -152,6 +153,12 @@ class TrajectoryEntry:
         }
         if self.duration_ms is not None:
             d["duration_ms"] = self.duration_ms
+        # Emitted only when set (same back-compat pattern as `completed` /
+        # `task_key` on TrajectoryLog): readers written against the pre-reasoning
+        # shape see no new key on the cron-stage trajectories they already
+        # handle (issue #112).
+        if self.reasoning_summary:
+            d["reasoning_summary"] = self.reasoning_summary
         return d
 
     @classmethod
@@ -162,6 +169,7 @@ class TrajectoryEntry:
         result: Any = None,
         status: str = "success",
         duration_ms: Optional[int] = None,
+        reasoning_summary: str = "",
     ) -> "TrajectoryEntry":
         return cls(
             tool=tool,
@@ -169,6 +177,7 @@ class TrajectoryEntry:
             result_status=status,
             result_summary=summarize_result(result),
             duration_ms=duration_ms,
+            reasoning_summary=reasoning_summary,
         )
 
     @classmethod
@@ -241,9 +250,12 @@ class TrajectoryLog:
         result: Any = None,
         status: str = "success",
         duration_ms: Optional[int] = None,
+        reasoning_summary: str = "",
     ) -> None:
         self.add(
-            TrajectoryEntry.from_tool_call(tool, args, result, status, duration_ms)
+            TrajectoryEntry.from_tool_call(
+                tool, args, result, status, duration_ms, reasoning_summary
+            )
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/agent/test_tool_call_capture.py
+++ b/tests/agent/test_tool_call_capture.py
@@ -142,6 +142,109 @@ class TestExtractToolCalls:
         assert extract_tool_calls([{"role": "assistant", "content": "just text"}]) == []
 
 
+class TestReasoningCapture:
+    """Reasoning traces ride the same tool-call envelope (issue #112)."""
+
+    def test_captures_string_reasoning_field(self):
+        msg = _call("read_file", {"path": "a.py"}, "c1")
+        msg["reasoning"] = "checking imports first"
+        calls = extract_tool_calls([msg, _ok("c1")])
+        assert calls[0]["reasoning_summary"] == "checking imports first"
+
+    def test_captures_reasoning_content_field(self):
+        """OpenAI chat wire carries reasoning as `reasoning_content`."""
+        msg = _call("patch", {}, "c2")
+        msg["reasoning_content"] = "the hunk is off by one"
+        calls = extract_tool_calls([msg, _ok("c2")])
+        assert calls[0]["reasoning_summary"] == "the hunk is off by one"
+
+    def test_captures_responses_api_summary_blocks(self):
+        """Responses API emits reasoning as content blocks with summary parts."""
+        msg = _call("terminal", {"command": "ls"}, "c3")
+        msg["content"] = [
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "list the dir"},
+                    {"type": "summary_text", "text": "then grep"},
+                ],
+            },
+            {"type": "output_text", "text": "visible prose"},
+        ]
+        calls = extract_tool_calls([msg, _ok("c3")])
+        assert calls[0]["reasoning_summary"] == "list the dir then grep"
+
+    def test_captures_reasoning_content_block_string(self):
+        msg = _call("read_file", {"path": "x"}, "c4")
+        msg["content"] = [{"type": "reasoning", "content": "need the header"}]
+        calls = extract_tool_calls([msg, _ok("c4")])
+        assert calls[0]["reasoning_summary"] == "need the header"
+
+    def test_reasoning_attached_to_every_call_in_batch(self):
+        msg = {
+            "role": "assistant",
+            "reasoning": "batch reasoning",
+            "tool_calls": [
+                {
+                    "id": "a1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                },
+                {
+                    "id": "a2",
+                    "type": "function",
+                    "function": {"name": "patch", "arguments": "{}"},
+                },
+            ],
+        }
+        calls = extract_tool_calls([msg, _ok("a1"), _ok("a2")])
+        assert [c["reasoning_summary"] for c in calls] == [
+            "batch reasoning",
+            "batch reasoning",
+        ]
+
+    def test_reasoning_is_bounded(self):
+        msg = _call("read_file", {}, "c5")
+        msg["reasoning"] = "x" * 5000
+        calls = extract_tool_calls([msg, _ok("c5")])
+        assert len(calls[0]["reasoning_summary"]) == 2000
+
+    def test_no_reasoning_is_empty_string(self):
+        calls = extract_tool_calls([_call("read_file", {}, "c6"), _ok("c6")])
+        assert calls[0]["reasoning_summary"] == ""
+
+    def test_unknown_shapes_do_not_raise(self):
+        """A shape we do not recognise is 'no reasoning', not an error."""
+        for bad in (
+            {"role": "assistant", "reasoning": 42, "tool_calls": []},
+            {"role": "assistant", "reasoning": {"nested": True}, "tool_calls": []},
+            {"role": "assistant", "content": [{"type": "reasoning", "summary": "nope"}],
+             "tool_calls": []},
+            {"role": "assistant", "content": [42, None], "tool_calls": []},
+        ):
+            assert extract_tool_calls([bad]) == []
+
+    def test_build_trajectory_log_roundtrips_reasoning(self, tmp_path):
+        msg = _call("read_file", {"path": "a.py"}, "c7")
+        msg["reasoning"] = "checking imports first"
+        log = build_trajectory_log(
+            [msg, _ok("c7")], session_id="s1", trajectory_dir=tmp_path
+        )
+        assert log is not None
+        entry = log.to_dict()["entries"][0]
+        assert entry["reasoning_summary"] == "checking imports first"
+
+    def test_backcompat_no_reasoning_key_when_empty(self, tmp_path):
+        """Readers written against the pre-#112 shape see no new key."""
+        log = build_trajectory_log(
+            [_call("read_file", {"path": "a.py"}, "c8"), _ok("c8")],
+            session_id="s1",
+            trajectory_dir=tmp_path,
+        )
+        assert log is not None
+        assert "reasoning_summary" not in log.to_dict()["entries"][0]
+
+
 class TestBuildTrajectoryLog:
     def test_carries_outcome_and_pairing_key(self, tmp_path):
         msgs = [_call("read_file", {"path": "a.py"}, "c1"), _ok("c1")]


### PR DESCRIPTION
Automated evolution PR for issue #112.

Reasoning traces were dropped at capture time: `TrajectoryEntry` had no field for them and `extract_tool_calls` only read `tool_calls`. This adds a bounded `reasoning_summary` to the entry envelope (emitted only when set, preserving the pre-\#112 JSON shape for existing readers) and extracts it from the three wire shapes reasoning arrives in (top-level `reasoning`, `reasoning_content`, Responses API `content` blocks with `type: reasoning`), attached to the tool call(s) the reasoning preceded.

- 10 new tests in tests/agent/test_tool_call_capture.py covering all three shapes, batch attachment, bounding, back-compat (no new key when empty), and malformed-shape safety.
- Local gate: ruff check clean; 48/48 tests pass in tests/agent/test_tool_call_capture.py.