### PR TITLE
fix(tools): count exception-path terminal timeouts in retry spiral and warn about partial work (Closes #3347)

### DIFF
--- a/tests/tools/test_terminal_retry_spiral.py
+++ b/tests/tools/test_terminal_retry_spiral.py
@@ -249,3 +249,78 @@ class TestTerminalSpiralBreak:
             data = json.loads(terminal_tool.terminal_tool(cmd, task_id="spiral-test"))
             assert data["failure_class"] == "persistent_error"
         assert len(fake.calls) == 6
+
+
+# ---------------------------------------------------------------------------
+# Integration: execute()-exception timeouts feed the spiral guard (#3347)
+# ---------------------------------------------------------------------------
+#
+# A wall-clock timeout that surfaces as an execute() exception previously
+# returned early WITHOUT calling _note_terminal_failure, so re-running the
+# same long-running command foreground never escalated no matter how many
+# times it timed out.  These tests pin the fix: exception timeouts are now
+# counted like any other identical failure, and escalate to a retry_spiral
+# diagnostic beyond the budget.
+
+
+class TimingOutEnvironment:
+    """Environment double whose execute() raises a timeout every call."""
+
+    def __init__(self, message="Command 'cmd' timed out after 120 seconds"):
+        self._message = message
+        self.calls = []
+        self.env = {}
+        self.cwd = ""
+
+    def execute(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        raise TimeoutError(self._message)
+
+
+class TestExceptionTimeoutSpiral:
+    def test_exception_timeout_counted_and_escalates_after_budget(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        # Budget 3: the first three identical exception timeouts keep the
+        # normal timeout classification; the fourth escalates to retry_spiral.
+        for _ in range(3):
+            data = json.loads(
+                terminal_tool.terminal_tool("longjob", task_id="spiral-test")
+            )
+            assert data["exit_code"] == 124
+            assert data["failure_class"] != "retry_spiral"
+
+        data = json.loads(terminal_tool.terminal_tool("longjob", task_id="spiral-test"))
+        assert data["failure_class"] == "retry_spiral"
+        assert data["should_retry"] is False
+        assert data["failure_repeat_count"] == 4
+        assert len(fake.calls) == 4
+
+    def test_exception_timeout_first_run_reports_partial_output_warning(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        data = json.loads(terminal_tool.terminal_tool("longjob", task_id="spiral-test"))
+        assert data["exit_code"] == 124
+        # #3347 point (a): the warning about possibly-running/partial work.
+        assert "may still be running" in data["error"]
+        assert "partial output" in data["error"]
+        # #3347 point (b): the concrete background re-run directive.
+        assert "background=true" in data["error"]
+        assert "notify_on_complete=true" in data["error"]
+        assert terminal_tool.get_terminal_failure_repeat("spiral-test") == 1
+
+    def test_exception_timeout_different_command_does_not_escalate(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        for cmd in ("cmd_a", "cmd_b", "cmd_a", "cmd_b", "cmd_a", "cmd_b"):
+            data = json.loads(terminal_tool.terminal_tool(cmd, task_id="spiral-test"))
+            assert data["failure_class"] != "retry_spiral"
+        assert len(fake.calls) == 6

--- a/tests/tools/test_terminal_timeout_hint.py
+++ b/tests/tools/test_terminal_timeout_hint.py
@@ -1,34 +1,94 @@
-"""Tests for terminal timeout error enrichment (#1789).
+"""Tests for terminal timeout error enrichment (#1789, #3347).
 
-The timeout error message now includes a background-mode suggestion so the
-model knows to re-run long commands with background=true instead of blind-
-retrying in foreground mode.
+The timeout error message includes a background-mode suggestion so the model
+knows to re-run long commands with background=true instead of blind-retrying
+in foreground mode.  Since #3347 it also warns that the process may still be
+running or have produced partial output when a wall-clock timeout interrupts
+it, so the agent checks for side effects before re-running.
+
+These are real contract tests: they drive ``terminal_tool`` with an
+environment double whose ``execute()`` raises a timeout and assert on the
+tool's actual returned payload (not on a locally reconstructed string).
 """
+
+import json
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+class TimingOutEnvironment:
+    """Environment double whose execute() raises a timeout every call."""
+
+    def __init__(self, message: str = "Command 'cmd' timed out after 120 seconds"):
+        self._message = message
+        self.calls = []
+        self.env = {}
+        self.cwd = ""
+
+    def execute(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        raise TimeoutError(self._message)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    for key in ("timeout-hint", "default"):
+        terminal_tool._reset_terminal_streak(key)
+        terminal_tool._reset_terminal_failure_repeats(key)
+    yield
+    for key in ("timeout-hint", "default"):
+        terminal_tool._reset_terminal_streak(key)
+        terminal_tool._reset_terminal_failure_repeats(key)
 
 
 class TestTimeoutErrorEnrichment:
-    """Verify the timeout error message includes actionable guidance."""
+    """Verify the timeout error payload includes actionable guidance."""
 
-    def test_timeout_error_mentions_background(self):
-        """The enriched timeout error should tell the model to use background
-        mode (#1789). We test the message format used by the terminal tool
-        when a command times out."""
-        effective_timeout = 180
-        enriched_error = (
-            f"Command timed out after {effective_timeout} seconds. "
-            "This command looks long-running — re-run with "
-            "background=true and notify_on_complete=true."
+    def test_timeout_error_mentions_background_and_partial_output(self, monkeypatch):
+        """#1789 + #3347 — the enriched timeout error must tell the model to
+        use background mode AND warn that the process may still be running or
+        have produced partial output."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        data = json.loads(
+            terminal_tool.terminal_tool("sleep 900", task_id="timeout-hint")
         )
-        assert "timed out" in enriched_error.lower()
-        assert "background=true" in enriched_error
-        assert "notify_on_complete=true" in enriched_error
-        assert "re-run" in enriched_error.lower()
+        error = data["error"].lower()
 
-    def test_timeout_error_includes_timeout_value(self):
+        assert data["exit_code"] == 124
+        assert "timed out" in error
+        assert "background=true" in error
+        assert "notify_on_complete=true" in error
+        assert "re-run" in error
+        # #3347 — partial-work warning (point a of the issue).
+        assert "may still be running" in error
+        assert "partial output" in error
+
+    def test_timeout_error_includes_timeout_value(self, monkeypatch):
         """The timeout value should still be present in the enriched message."""
-        enriched_error = (
-            "Command timed out after 300 seconds. "
-            "This command looks long-running — re-run with "
-            "background=true and notify_on_complete=true."
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        data = json.loads(
+            terminal_tool.terminal_tool(
+                "sleep 900", timeout=300, task_id="timeout-hint"
+            )
         )
-        assert "300 seconds" in enriched_error
+        assert "300 seconds" in data["error"]
+
+    def test_timeout_is_not_marked_retryable(self, monkeypatch):
+        """#1841 — timeouts are deterministic; the payload must not invite a
+        blind foreground retry."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        fake = TimingOutEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": fake})
+
+        data = json.loads(
+            terminal_tool.terminal_tool("sleep 900", task_id="timeout-hint")
+        )
+        assert data["should_retry"] is False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -4306,8 +4306,9 @@ def terminal_tool(
                             "exit_code": 124,
                             "error": (
                                 f"Command timed out after {effective_timeout} seconds. "
-                                "This command looks long-running — re-run with "
-                                "background=true and notify_on_complete=true."
+                                "The process may still be running or have produced "
+                                "partial output. This command looks long-running — "
+                                "re-run with background=true and notify_on_complete=true."
                             ),
                             "failure_class": classification.category.value,
                             "suggestion": classification.hint,
@@ -4318,6 +4319,25 @@ def terminal_tool(
                             "should_retry": False,
                             "terminal_streak": streak,
                         }
+                        # Retry-spiral detection (issue #3347): a timeout that
+                        # surfaces as an execute() exception was previously
+                        # returned early WITHOUT feeding the identical-failure
+                        # tracker, so repeated timeouts of the same command shape
+                        # never escalated. Mirror the normal-result path (#1022):
+                        # count the timeout as a failure and escalate to a
+                        # `retry_spiral` diagnostic once the same command times
+                        # out back-to-back beyond the budget. A changed command
+                        # resets the counter, so distinct commands never trip it.
+                        repeat = _note_terminal_failure(task_id, command, 124, "")
+                        budget = _get_max_command_repeats()
+                        if repeat > budget:
+                            diagnostic = spiral_break_diagnostic(
+                                command, repeat, budget
+                            )
+                            result_dict["error"] = diagnostic
+                            result_dict["suggestion"] = diagnostic
+                            result_dict["failure_class"] = "retry_spiral"
+                            result_dict["failure_repeat_count"] = repeat
                         rec = streak_recommendation(streak)
                         if rec:
                             result_dict["recommendation"] = rec


### PR DESCRIPTION
Closes #3347

## Summary

Terminal wall-clock timeouts that surface as **execution exceptions** (e.g. `subprocess.TimeoutExpired` raised by `env.execute()`) now:

1. **Warn that the command may still be running or have produced partial output** — so the agent checks for side effects (partial writes, half-downloaded artifacts) before re-running (#3347 point a).
2. **Feed the retry spiral guard** — previously this path returned early *without* calling `_note_terminal_failure`, so identical timeout re-runs of the same command never incremented the repeat counter and never escalated to `retry_spiral`. They now count and escalate after the same budget, mirroring the exit_code=124 normal-result path (#3347 point c).
3. Retain the existing background+notify re-run directive verbatim (#1789, point b).

## Root cause

The execute-exception branch in `terminal_tool` classified the timeout, built `result_dict` with the directive message (added in the #1789 era), and returned at `json.dumps(...)` — **one line before** the normal-result path's `_note_terminal_failure` bookkeeping. Result: the "self-correcting" behavior requested in #3347 could never trigger on exception-path timeouts, which is the majority of wall-clock timeouts in local execution, so the same per-session timeout rate kept recurring.

## Change

`tools/terminal_tool.py` — 2 hunks, **+20 lines**:

- Enriched timeout error text (the "may still be running / partial output" sentence).
- Spiral escalation block mirroring lines ~4435-4446: `_note_terminal_failure(task_id, command, 124, "")` + budget check → `failure_class: "retry_spiral"`, `should_retry: false`, `failure_repeat_count`.

## Tests

- `tests/tools/test_terminal_timeout_hint.py` — rewritten from a tautological self-referential test (it built its own string locally) into a **real contract test** driving the actual tool with a `TimeoutError`-raising env double; asserts exit_code 124, "may still be running", `background=true` directive, `notify_on_complete=true`, timeout value, `should_retry=false`, repeat counter = 1.
- `tests/tools/test_terminal_retry_spiral.py` — new `TimingOutEnvironment` double + 3 integration tests: first exception timeout classified normally (with repeat count 1), 4th identical timeout escalates to `retry_spiral` (count 4), alternating commands never escalate (6 calls).
- `tests/agent/test_evolution_spiral_fixes.py` — unaffected (its fixture string is self-constructed; "timed out" / "background=true" assertions still hold of the new message).

## Validation

- Targeted: `pytest tests/tools/test_terminal_retry_spiral.py tests/tools/test_terminal_timeout_hint.py` → **25 passed**
- Sweep: `pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_failure_classifier.py tests/agent/test_evolution_spiral_fixes.py` → **112 passed**
- `scripts/evolution_pre_pr_test_runner.py --changed-files ...` → **PASSED** (shard: tests/tools/test_terminal_tool.py)
- `ruff check` on all 3 changed files → clean; `ruff format` clean on both test files.
- Note: `ruff format --check tools/terminal_tool.py` reports dozens of **pre-existing** violations on `origin/main` (lines 609…5153); **none are in the changed region** (verified: my diff has exactly 2 hunks @ 4306/4319 and touches no flagged line). Left untouched to keep this diff surgical.
- Diff: 3 files, +182/−27 (implementation delta +20; remainder is tests).

## Risk

Message text change is additive; the only behavioral delta is the spiral escalation on exception-path timeouts, which is the intended #3347 behavior. Existing consumers pinning the old message: none found (`grep tests/ → only self-constructed fixtures`).