### PR TITLE
fix(tools): re-wire contracts clobbered by the v2026.8.27 sync (Closes #3346)

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -357,10 +357,11 @@ class DDGSWebSearchProvider(WebSearchProvider):
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}
 
         # Empty result set can mean the provider is rate-limiting / blocking
-        # automated queries (#467). If a fallback chain is configured we surface
-        # a failure so the dispatcher tries the next backend; otherwise we keep
-        # success=True because a healthy provider returning no hits is a valid
-        # outcome (and the regression test expects success=True for an empty
+        # automated queries (#467). If the dispatcher's fallback rescue tier
+        # is available we surface a failure so the dispatcher serves the next
+        # attempt (one-shot keyless rescue); otherwise we keep success=True
+        # because a healthy provider returning no hits is a valid outcome
+        # (and the regression test expects success=True for an empty
         # mocked primary).
         if not web_results:
             logger.warning(
@@ -368,12 +369,19 @@ class DDGSWebSearchProvider(WebSearchProvider):
             )
             from tools import web_tools
 
-            if web_tools._search_backend_fallback_chain():
+            # The v2026.8.3 upstream sync (2cb73632ac) superseded the
+            # configured-fallback-chain check (`_search_backend_fallback_chain`)
+            # with the one-shot keyless rescue tier: a success=False from an
+            # eligible non-ring provider triggers `_rescue_search` in the
+            # dispatcher, which walks the keyless ring for this call only.
+            if web_tools._rescue_eligible(self):
                 return {
                     "success": False,
                     "error": (
                         "DuckDuckGo returned no results. The provider is likely blocking "
-                        "automated queries. Falling back to next search_backend fallback in config.yaml."
+                        "automated queries; the dispatcher's fallback rescue tier will "
+                        "serve the next attempt. If this persists, configure a different "
+                        "search_backend (e.g. searxng) via `hermes tools` or config.yaml."
                     ),
                 }
 

--- a/tests/tools/test_tool_search_skill_routing.py
+++ b/tests/tools/test_tool_search_skill_routing.py
@@ -39,8 +39,8 @@ def test_tool_search_default_off_preserves_bm25_order():
         out = dispatch_tool_search({"query": "read a file"}, current_tool_defs=[], config=cfg)
     import json
 
-    matches = json.loads(out)["matches"]
-    assert [m["name"] for m in matches] == ["send_email", "read_file"]
+    matches = json.loads(out)["results"][0]["matches"]
+    assert list(matches) == ["send_email", "read_file"]
 
 
 def test_tool_search_listwise_rerank_promotes_best_match():
@@ -53,11 +53,11 @@ def test_tool_search_listwise_rerank_promotes_best_match():
         out = dispatch_tool_search({"query": "read a file"}, current_tool_defs=[], config=cfg)
     import json
 
-    matches = json.loads(out)["matches"]
+    matches = json.loads(out)["results"][0]["matches"]
     # reranked: the strong lexical match rises to the top
-    assert matches[0]["name"] == "read_file"
+    assert matches[0] == "read_file"
     # strict reordering — same set of tools returned
-    assert {m["name"] for m in matches} == {"send_email", "read_file"}
+    assert set(matches) == {"send_email", "read_file"}
 
 
 def test_tool_search_rerank_failure_degrades_gracefully():
@@ -72,5 +72,5 @@ def test_tool_search_rerank_failure_degrades_gracefully():
     import json
 
     # the try/except in dispatch keeps the original hits on any rerank error
-    matches = json.loads(out)["matches"]
-    assert [m["name"] for m in matches] == ["send_email", "read_file"]
+    matches = json.loads(out)["results"][0]["matches"]
+    assert list(matches) == ["send_email", "read_file"]

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -180,10 +180,10 @@ class TestDDGSProviderSearch:
         assert "rate limited" in result["error"] or "failed" in result["error"].lower()
 
     def test_empty_results_return_provider_dead_error(self, monkeypatch):
-        """Issue #467: an empty DDGS result is treated as a provider failure only
-        when a fallback chain is configured, so the agent tries the next
-        backend instead of looping on "no results". Without a fallback chain
-        the empty result stays a successful response.
+        """Issue #467: an empty DDGS result is treated as a provider failure
+        only when the dispatcher's fallback rescue tier is available, so the
+        agent tries the rescue path instead of looping on "no results".
+        Without a rescue path the empty result stays a successful response.
         """
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
         _install_fake_ddgs(monkeypatch, text_results=[])
@@ -195,17 +195,14 @@ class TestDDGSProviderSearch:
         # cannot see a fake ``ddgs`` installed in this interpreter.
         _force_inprocess_search(monkeypatch, _prov)
 
-        # With no fallback chain: success=True (regression coverage).
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        # With no rescue path: success=True (regression coverage).
+        monkeypatch.setattr(web_tools, "_keyless_rescue_enabled", lambda: False)
         result = DDGSWebSearchProvider().search("nothing", limit=5)
         assert result["success"] is True
 
-        # With a fallback chain: success=False so dispatcher switches provider.
-        monkeypatch.setattr(
-            web_tools,
-            "_load_web_config",
-            lambda: {"search_backend_fallback_chain": "brave-free"},
-        )
+        # With the fallback rescue tier available: success=False so the
+        # dispatcher's one-shot keyless rescue can serve the next attempt.
+        monkeypatch.setattr(web_tools, "_keyless_rescue_enabled", lambda: True)
         result = DDGSWebSearchProvider().search("nothing", limit=5)
         assert result["success"] is False
         assert "no results" in result["error"].lower()
@@ -328,8 +325,11 @@ class TestDDGSProviderSearch:
     def test_empty_results(self, monkeypatch):
         _install_fake_ddgs(monkeypatch, text_results=[])
         import plugins.web.ddgs.provider as prov
+        from tools import web_tools
 
         _force_inprocess_search(monkeypatch, prov)
+        # Deterministic: rescue disabled → empty is a valid provider outcome.
+        monkeypatch.setattr(web_tools, "_keyless_rescue_enabled", lambda: False)
 
         result = prov.DDGSWebSearchProvider().search("nothing", limit=5)
         assert result["success"] is True

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1976,8 +1976,14 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
+        # Pass the RESOLVED path (str(_resolved)) to FileOperations.read_file
+        # so the shell commands inside (wc -c, sed, head) use the fully-
+        # qualified absolute path.  Passing the raw *path* here means a
+        # relative path is resolved by the shell's cwd, which may differ
+        # from the terminal env's tracked cwd — the root cause of the
+        # read_file file-not-found spiral (#1044, #886, #970).
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(str(_resolved), offset, limit)
         result_dict = result.to_dict()
 
         # ── Populate negative-result cache on not-found ───────────────


### PR DESCRIPTION
## What breaks today

A bare `main` checkout (`82ed6b8849`) fails 7 tests across three fork-side
contract files — CI slices 2–8 of **every** open PR (#3338–#3358) are red on the
same signatures, so nothing in the queue can go green:

| Failing file (local reproduction) | Symptom |
|---|---|
| `tests/tools/test_web_providers_ddgs.py` (2) | `AttributeError: ... has no attribute '_search_backend_fallback_chain'` at `plugins/web/ddgs/provider.py:371` |
| `tests/tools/test_read_file_resolved_path.py` (2) | `read_file_tool` forwards the raw relative path to `FileOperations.read_file` → shell re-resolves against its own cwd → #1044 file-not-found spiral |
| `tests/tools/test_tool_search_skill_routing.py` (3) | `KeyError: 'matches'` — tests expect the pre-`#1137` output shape |

## Root cause

Fork-only contract tests (upstream has none of the three files) vs. the
v2026.8.3 sync (`2cb73632ac`, "21 of 87") which shipped production redesigns
without carrying the fork's stale tests / call site along:

- `tools/web_tools.py` replaced the configured fallback chain with the
  **one-shot keyless rescue tier** (`_keyless_rescue_enabled` L433 /
  `_rescue_eligible` L451, contract-tested in
  `tests/tools/test_web_keyless_rescue.py`). The ddgs provider's empty-results
  check still calls the removed helper → AttributeError. Grep: the symbol has
  exactly one remaining reference repo-wide — this call site.
- `tools/file_tools.py` lost `7bb72543f6` (#1066, fork's own fix for #1044):
  `file_ops.read_file(path, ...)` re-introduced while `_resolved` is computed
  at L1770 and used by every guard around it.
- `dispatch_tool_search` now returns
  `{"results": [{"query", "matches": [names]}]}` — documented in its docstring
  (L1425) and emitted by the degraded path too. The `#1137` tests predate the
  shape.

## The fix (re-wire, per the DoD's "renamed successor" option)

1. **ddgs provider** → `if web_tools._rescue_eligible(self):` — ddgs is a
   non-ring backend, so it remains rescue-eligible; `#467` semantics preserved
   (empty + rescue tier available → `success=False` → dispatcher rescues via
   the keyless ring; no rescue path → `success=True`). Error text still carries
   "no results" + "fallback" for the regression assertions.
2. **read_file_tool** → re-applies `file_ops.read_file(str(_resolved), ...)`
   verbatim from the fork's own `7bb72543f6` (pattern already used by
   `patch_replace` and `write_file` in the same file).
3. **Two stale test files** updated to the shipped contracts
   (`_keyless_rescue_enabled` gate; `results[0]["matches"]` name list).

## Evidence

- Before: 40 tests in the four suites → 7 failed.
- After: **40 passed, 1 skipped** (`test_web_providers_ddgs.py`,
  `test_read_file_resolved_path.py`, `test_tool_search_skill_routing.py`,
  `test_web_keyless_rescue.py`).
- 287 passed across `test_file_tools*`, `test_file_tools_cwd_resolution`,
  `test_file_read_guards`, `test_tool_search*`, `test_web_tools_*` — no
  regressions from these changes.

## Notes

- 3 failures in `tests/tools/test_web_tools_config.py` (parallel client
  config, limit clamp) reproduce identically on pristine `main` (verified via
  stash) — pre-existing, separate stale-contract class, **not** part of
  #3346's DoD; worth a follow-up issue.
- `hermes_cli/config_defaults.py:517` still ships the now-unread
  `"search_backend_fallback_chain": ""` default — optional cleanup.
- Complements Da-Mikey's broader restoration bundle #3349 / #162; this PR
  carries the full bare-main DoD of #3346 so any PR re-based on main goes
  green.

Closes #3346