### PR TITLE
feat: ranked memory eviction with archive-not-delete (Closes #123)

### DIFF
--- a/agent/memory_eviction.py
+++ b/agent/memory_eviction.py
@@ -1,0 +1,366 @@
+"""Ranked memory eviction with archive-not-delete semantics (issue #123, slice A).
+
+The memory store has a write-everything-then-panic history: capacity pressure
+blocks downstream consumers (the nightly dreaming pipeline hard-blocked twice
+in Aug 2026 on a full store) because there is no *eviction* policy — only
+write-path filters (``agent.memory_addition_gate``, #1270) and a capacity
+guard (#129). This module adds the missing "learned forgetting" half: it
+ranks existing entries and selects the lowest-value tail for archiving when
+the store approaches its cap.
+
+Design contract (mirrors :mod:`agent.memory_guard` and
+:mod:`agent.memory_staleness` deliberately):
+
+* **Pure and side-effect free.** The module never writes to disk, never
+  mutates the store, and never logs. It returns an :class:`EvictionPlan`;
+  the caller owns I/O and archiving (archive-not-delete is enforced by the
+  plan's shape — evicted entries are handed back in an ``archive`` list,
+  never a "delete" list, and never discarded).
+* **Deterministic.** Same entries + same parameters always yield the same
+  plan. All clock inputs (``now``) are explicit parameters; ties break on
+  the entry ``id``. No randomness, no network.
+* **Default-off.** :meth:`MemoryEvictionPolicy.maybe_plan` returns ``None``
+  unless explicitly enabled *and* usage exceeds the cap. Existing store
+  behaviour is untouched until a caller opts in.
+
+Ranking (per the issue: recency × access × provenance):
+
+* *recency* — exponential temporal decay over a configurable half-life
+  (same shape as ``agent.memory_importance.apply_temporal_decay``);
+* *access* — log-scaled access frequency, normalized against the hottest
+  entry in the candidate set;
+* *provenance* — ``trust_tier`` weight (high/medium/low) scaled by an
+  optional ``source_class`` boost, reusing the #316 provenance tags.
+
+The combined score is a multiplicative blend (``recency**w_r *
+access**w_a * provenance**w_p``, weights summing to 1): a single weak
+dimension sinks the entry, which is exactly what eviction wants.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Default ranking weights (sum to 1.0). Recency dominates; provenance is the
+# smallest lever so that a low-trust entry only loses ties, it does not get
+# evicted purely for its origin while a same-age entry survives.
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "recency": 0.5,
+    "access": 0.3,
+    "provenance": 0.2,
+}
+
+# Trust-tier weights for the provenance factor (#316 tags). Unknown tiers
+# land at 0.5 — treated as "no evidence", not "hostile".
+TRUST_TIER_WEIGHTS: Dict[str, float] = {
+    "high": 1.0,
+    "medium": 0.6,
+    "low": 0.3,
+}
+UNKNOWN_TRUST_TIER_WEIGHT: float = 0.5
+
+# Optional per-source multipliers on top of the trust tier. Unknown sources
+# are neutral (1.0) — the module never guesses a source's trustworthiness.
+SOURCE_BOOSTS: Dict[str, float] = {
+    "human": 1.1,
+    "user": 1.1,
+    "agent": 0.9,
+    "system": 0.9,
+}
+UNKNOWN_SOURCE_BOOST: float = 1.0
+
+DEFAULT_HALF_LIFE_DAYS: float = 30.0
+
+# Where archiving is expected to land (caller-owned; the plan only names it).
+DEFAULT_ARCHIVE_NAMESPACE: str = "archive"
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single memory-store entry as seen by the eviction policy.
+
+    The schema is deliberately store-agnostic: callers map their store rows
+    (tqmemory notes, MEMORY.md blocks, provider records) onto these fields.
+    ``size_bytes`` is computed from ``content`` when not supplied.
+    """
+
+    id: str
+    content: str
+    created_at: float  # epoch seconds
+    last_access: float  # epoch seconds; may equal created_at
+    access_count: int = 0
+    source_class: str = "unknown"
+    trust_tier: str = "unknown"
+    size_bytes: Optional[int] = None
+
+    def size(self) -> int:
+        if self.size_bytes is not None:
+            return max(0, self.size_bytes)
+        return len(self.content.encode("utf-8"))
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "id": self.id,
+            "content": self.content,
+            "created_at": self.created_at,
+            "last_access": self.last_access,
+            "access_count": self.access_count,
+            "source_class": self.source_class,
+            "trust_tier": self.trust_tier,
+        }
+        if self.size_bytes is not None:
+            d["size_bytes"] = self.size_bytes
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "MemoryEntry":
+        return cls(
+            id=str(d["id"]),
+            content=str(d.get("content", "")),
+            created_at=float(d.get("created_at", 0.0)),
+            last_access=float(d.get("last_access", d.get("created_at", 0.0))),
+            access_count=int(d.get("access_count", 0)),
+            source_class=str(d.get("source_class", "unknown")),
+            trust_tier=str(d.get("trust_tier", "unknown")),
+            size_bytes=(
+                int(d["size_bytes"]) if d.get("size_bytes") is not None else None
+            ),
+        )
+
+
+def _age_days(entry: MemoryEntry, now: float) -> float:
+    """Age of the entry in fractional days (clamped at 0)."""
+    return max(0.0, (now - entry.created_at) / 86400.0)
+
+
+def recency_score(
+    entry: MemoryEntry,
+    now: float,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+) -> float:
+    """Exponential temporal decay: 2 ** (-age/half-life), in [0, 1]."""
+    if half_life_days <= 0:
+        return 0.0
+    return 2.0 ** (-_age_days(entry, now) / half_life_days)
+
+
+def access_score(entry: MemoryEntry, max_access: int) -> float:
+    """Log-scaled access frequency normalized against the hottest entry.
+
+    A neutral 1.0 when no entry in the candidate set has been accessed
+    (nothing differentiates on access, so the factor must not punish).
+    """
+    if max_access <= 0:
+        return 1.0
+    return min(1.0, math.log1p(max(0, entry.access_count)) / math.log1p(max_access))
+
+
+def provenance_score(entry: MemoryEntry) -> float:
+    """Trust-tier weight scaled by an optional source-class boost."""
+    tier = TRUST_TIER_WEIGHTS.get(entry.trust_tier, UNKNOWN_TRUST_TIER_WEIGHT)
+    boost = SOURCE_BOOSTS.get(entry.source_class, UNKNOWN_SOURCE_BOOST)
+    return min(1.0, max(0.0, tier * boost))
+
+
+def score_entry(
+    entry: MemoryEntry,
+    now: float,
+    max_access: int = 0,
+    weights: Optional[Dict[str, float]] = None,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+) -> float:
+    """Multiplicative blend of recency × access × provenance, in [0, 1].
+
+    ``max_access`` must be the maximum ``access_count`` across the candidate
+    set (callers compute it once via :func:`max_access_count`); passing 0
+    makes the access factor neutral.
+    """
+    w = dict(DEFAULT_WEIGHTS if weights is None else weights)
+    w_sum = sum(w.values()) or 1.0
+    r = w.get("recency", 0.0) / w_sum
+    a = w.get("access", 0.0) / w_sum
+    p = w.get("provenance", 0.0) / w_sum
+    rec = recency_score(entry, now, half_life_days)
+    acc = access_score(entry, max_access)
+    prov = provenance_score(entry)
+    return (rec**r) * (acc**a) * (prov**p)
+
+
+def max_access_count(entries: List[MemoryEntry]) -> int:
+    """Largest access count in the candidate set (0 when empty)."""
+    return max((e.access_count for e in entries), default=0)
+
+
+def rank_entries(
+    entries: List[MemoryEntry],
+    now: float,
+    weights: Optional[Dict[str, float]] = None,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+) -> List[Tuple[MemoryEntry, float]]:
+    """Rank entries by score, highest (most valuable) first.
+
+    Ties break on ``id`` ascending so the ranking is a pure function of its
+    inputs. Entries are never modified; the caller owns the store.
+    """
+    max_acc = max_access_count(entries)
+    scored = [
+        (
+            entry,
+            score_entry(
+                entry,
+                now=now,
+                max_access=max_acc,
+                weights=weights,
+                half_life_days=half_life_days,
+            ),
+        )
+        for entry in entries
+    ]
+    scored.sort(key=lambda t: (-t[1], t[0].id))
+    return scored
+
+
+@dataclass(frozen=True)
+class EvictionPlan:
+    """What to archive and what to keep, plus why.
+
+    Archive-not-delete is structural: the plan carries the evicted entries in
+    ``entries_to_archive`` (never a "delete" list) and names the archive
+    destination; the caller decides how to move them there. Nothing in this
+    module discards data.
+    """
+
+    entries_to_archive: List[MemoryEntry] = field(default_factory=list)
+    entries_to_keep: List[MemoryEntry] = field(default_factory=list)
+    freed_bytes: int = 0
+    target_bytes: int = 0
+    usage_bytes: int = 0
+    reason: str = ""
+    archive_namespace: str = DEFAULT_ARCHIVE_NAMESPACE
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.entries_to_archive
+
+    def render_markdown(self) -> str:
+        """Human-readable summary for logs/reports (no store writes)."""
+        if self.is_empty:
+            return (
+                f"Eviction plan: nothing to archive "
+                f"(usage {self.usage_bytes}B <= cap {self.target_bytes}B). "
+                f"{self.reason}".strip()
+            )
+        lines = [
+            f"Eviction plan: archive {len(self.entries_to_archive)} entries "
+            f"to '{self.archive_namespace}' (frees ~{self.freed_bytes}B).",
+            f"Reason: {self.reason}",
+        ]
+        for e in self.entries_to_archive:
+            lines.append(f"  - {e.id} ({e.size()}B, trust={e.trust_tier})")
+        return "\n".join(lines)
+
+
+def build_eviction_plan(
+    entries: List[MemoryEntry],
+    cap_bytes: int,
+    usage_bytes: int,
+    now: Optional[float] = None,
+    weights: Optional[Dict[str, float]] = None,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+    archive_namespace: str = DEFAULT_ARCHIVE_NAMESPACE,
+) -> EvictionPlan:
+    """Select the lowest-value tail for archiving when usage exceeds the cap.
+
+    * usage <= cap → empty plan (no eviction needed).
+    * cap <= 0 → empty plan (misconfiguration; never destroy data on a bad
+      cap, and never archive everything because a caller passed 0).
+    * otherwise → evict lowest-scoring entries (ascending rank) until the
+      projected usage drops to the cap, or the candidate set is exhausted.
+
+    ``now`` defaults to ``time.time()`` but should be passed explicitly by
+    callers that need reproducible plans (tests, dry runs).
+    """
+    now_ts = time.time() if now is None else now
+    empty_reason = (
+        f"usage {usage_bytes}B <= cap {cap_bytes}B"
+        if usage_bytes <= cap_bytes
+        else f"invalid cap {cap_bytes}B"
+    )
+    if not entries or usage_bytes <= cap_bytes or cap_bytes <= 0:
+        return EvictionPlan(
+            entries_to_archive=[],
+            entries_to_keep=list(entries),
+            freed_bytes=0,
+            target_bytes=cap_bytes,
+            usage_bytes=usage_bytes,
+            reason="nothing to evict: " + empty_reason,
+            archive_namespace=archive_namespace,
+        )
+
+    ranked = rank_entries(
+        entries, now=now_ts, weights=weights, half_life_days=half_life_days
+    )
+    # Ascending value: evict the least valuable first.
+    ranked_asc = list(reversed(ranked))
+    projected = usage_bytes
+    archive: List[MemoryEntry] = []
+    for entry, _score in ranked_asc:
+        if projected <= cap_bytes:
+            break
+        archive.append(entry)
+        projected -= entry.size()
+        if projected < 0:
+            projected = 0
+
+    archived_ids = {e.id for e in archive}
+    keep = [e for e in entries if e.id not in archived_ids]
+    return EvictionPlan(
+        entries_to_archive=archive,
+        entries_to_keep=keep,
+        freed_bytes=usage_bytes - projected,
+        target_bytes=cap_bytes,
+        usage_bytes=usage_bytes,
+        reason=(
+            f"usage {usage_bytes}B exceeds cap {cap_bytes}B; archiving "
+            f"{len(archive)} lowest-value entr{'y' if len(archive) == 1 else 'ies'}"
+        ),
+        archive_namespace=archive_namespace,
+    )
+
+
+@dataclass(frozen=True)
+class MemoryEvictionPolicy:
+    """Capacity trigger with a hard default-off contract.
+
+    The store's write path can call :meth:`maybe_plan` at capacity pressure;
+    it returns ``None`` unless eviction is explicitly enabled AND usage
+    exceeds the cap — so existing store behaviour is byte-identical until a
+    caller opts in.
+    """
+
+    enabled: bool = False
+    cap_bytes: int = 0
+    weights: Optional[Dict[str, float]] = None
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS
+    archive_namespace: str = DEFAULT_ARCHIVE_NAMESPACE
+
+    def maybe_plan(
+        self,
+        entries: List[MemoryEntry],
+        usage_bytes: int,
+        now: Optional[float] = None,
+    ) -> Optional[EvictionPlan]:
+        if not self.enabled or usage_bytes <= self.cap_bytes:
+            return None
+        return build_eviction_plan(
+            entries,
+            cap_bytes=self.cap_bytes,
+            usage_bytes=usage_bytes,
+            now=now,
+            weights=self.weights,
+            half_life_days=self.half_life_days,
+            archive_namespace=self.archive_namespace,
+        )

--- a/tests/agent/test_memory_eviction.py
+++ b/tests/agent/test_memory_eviction.py
@@ -1,0 +1,237 @@
+"""Tests for ranked memory eviction with archive-not-delete (issue #123, slice A).
+
+Covers the pure eviction module (``agent.memory_eviction``): ranking math,
+capacity-trigger behaviour, determinism, and the archive-not-delete contract.
+No store I/O, no network — stdlib + pytest only.
+"""
+
+import pytest
+
+from agent.memory_eviction import (
+    DEFAULT_ARCHIVE_NAMESPACE,
+    DEFAULT_HALF_LIFE_DAYS,
+    DEFAULT_WEIGHTS,
+    EvictionPlan,
+    MemoryEntry,
+    MemoryEvictionPolicy,
+    access_score,
+    build_eviction_plan,
+    max_access_count,
+    provenance_score,
+    rank_entries,
+    recency_score,
+    score_entry,
+)
+
+NOW = 1_800_000_000.0  # fixed clock for determinism
+DAY = 86400.0
+
+
+def entry(
+    eid: str,
+    age_days: float = 0.0,
+    access_count: int = 0,
+    trust_tier: str = "medium",
+    source_class: str = "unknown",
+    content: str = "entry content",
+) -> MemoryEntry:
+    created = NOW - age_days * DAY
+    return MemoryEntry(
+        id=eid,
+        content=content,
+        created_at=created,
+        last_access=created,
+        access_count=access_count,
+        source_class=source_class,
+        trust_tier=trust_tier,
+    )
+
+
+# ── scoring primitives ───────────────────────────────────────────────────────
+
+
+def test_recency_score_half_life_halves_value():
+    old = entry("old", age_days=DEFAULT_HALF_LIFE_DAYS)
+    fresh = entry("fresh", age_days=0.0)
+    assert recency_score(fresh, NOW) == pytest.approx(1.0)
+    assert recency_score(old, NOW) == pytest.approx(0.5)
+    assert recency_score(old, NOW) < recency_score(fresh, NOW)
+
+
+def test_recency_score_clamps_negative_age():
+    future = entry("future", age_days=-5.0)
+    assert recency_score(future, NOW) == pytest.approx(1.0)
+
+
+def test_access_score_normalizes_against_hottest():
+    hot = entry("hot", access_count=100)
+    cold = entry("cold", access_count=0)
+    assert access_score(hot, max_access=100) == pytest.approx(1.0)
+    assert access_score(cold, max_access=100) < access_score(hot, max_access=100)
+    # Neutral when nothing has been accessed.
+    assert access_score(cold, max_access=0) == pytest.approx(1.0)
+
+
+def test_provenance_score_respects_tiers_and_sources():
+    high = entry("h", trust_tier="high")
+    low = entry("l", trust_tier="low")
+    unknown = entry("u", trust_tier="totally-made-up")
+    human_medium = entry("m", trust_tier="medium", source_class="human")
+    medium = entry("mm", trust_tier="medium")
+    assert provenance_score(high) > provenance_score(unknown) > provenance_score(low)
+    # Source boost lifts a score but never pushes it past the 1.0 ceiling.
+    assert provenance_score(human_medium) > provenance_score(medium)
+    assert provenance_score(high) == pytest.approx(1.0)
+    assert provenance_score(unknown) == pytest.approx(0.5)
+
+
+def test_score_entry_combines_dimensions():
+    fresh_high = entry("fh", age_days=0.0, access_count=10, trust_tier="high")
+    old_low = entry("ol", age_days=300.0, access_count=0, trust_tier="low")
+    assert score_entry(fresh_high, NOW, max_access=10) > score_entry(
+        old_low, NOW, max_access=10
+    )
+
+
+# ── ranking ──────────────────────────────────────────────────────────────────
+
+
+def test_rank_entries_sorts_descending_and_ties_break_on_id():
+    a = entry("a", age_days=1.0)
+    b = entry("b", age_days=2.0)
+    c = entry("c", age_days=1.0)  # same age as a → tie on score
+    ranked = rank_entries([b, c, a], NOW)
+    assert [e.id for e, _ in ranked] == ["a", "c", "b"]
+    scores = [s for _, s in ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_rank_entries_is_deterministic():
+    entries = [entry(f"e{i}", age_days=float(i % 7)) for i in range(20)]
+    r1 = rank_entries(entries, NOW)
+    r2 = rank_entries(list(reversed(entries)), NOW)
+    assert [e.id for e, _ in r1] == [e.id for e, _ in r2]
+    assert [s for _, s in r1] == [s for _, s in r2]
+
+
+def test_max_access_count_empty_is_zero():
+    assert max_access_count([]) == 0
+
+
+# ── eviction plans (archive-not-delete) ──────────────────────────────────────
+
+
+def test_under_cap_produces_empty_plan():
+    entries = [entry("a"), entry("b")]
+    usage = 100
+    plan = build_eviction_plan(entries, cap_bytes=200, usage_bytes=usage, now=NOW)
+    assert plan.is_empty
+    assert plan.entries_to_archive == []
+    assert plan.entries_to_keep == entries
+
+
+def test_over_cap_evicts_lowest_value_until_under_cap():
+    # 3 entries of equal size; old-low-trust one must go first.
+    valuable = entry("valuable", age_days=0.0, access_count=50, trust_tier="high")
+    mid = entry("mid", age_days=10.0, access_count=5, trust_tier="medium")
+    stale = entry("stale", age_days=400.0, access_count=0, trust_tier="low")
+    entries = [valuable, mid, stale]
+    size = stale.size()
+    usage = 3 * size
+    plan = build_eviction_plan(entries, cap_bytes=2 * size, usage_bytes=usage, now=NOW)
+    assert plan.entries_to_archive == [stale]
+    assert plan.entries_to_keep == [valuable, mid]
+    assert plan.freed_bytes == size
+    assert plan.usage_bytes - plan.freed_bytes <= plan.target_bytes
+
+
+def test_archive_not_delete_structural_contract():
+    entries = [entry("a", age_days=1.0), entry("b", age_days=100.0)]
+    size = entries[0].size()
+    plan = build_eviction_plan(entries, cap_bytes=size, usage_bytes=2 * size, now=NOW)
+    archived_ids = {e.id for e in plan.entries_to_archive}
+    kept_ids = {e.id for e in plan.entries_to_keep}
+    # Every entry appears exactly once across the two lists — nothing dropped.
+    assert archived_ids | kept_ids == {"a", "b"}
+    assert archived_ids & kept_ids == set()
+    assert plan.archive_namespace == DEFAULT_ARCHIVE_NAMESPACE
+    assert "archive" in plan.render_markdown().lower()
+
+
+def test_invalid_cap_never_evicts():
+    entries = [entry("a"), entry("b")]
+    plan = build_eviction_plan(entries, cap_bytes=0, usage_bytes=10_000, now=NOW)
+    assert plan.is_empty
+    assert plan.entries_to_keep == entries
+
+
+def test_empty_candidates_never_evict():
+    plan = build_eviction_plan([], cap_bytes=10, usage_bytes=10_000, now=NOW)
+    assert plan.is_empty
+    assert plan.entries_to_keep == []
+
+
+def test_plan_determinism_across_call_order():
+    a = entry("a", age_days=3.0)
+    b = entry("b", age_days=30.0)
+    size = a.size()
+    p1 = build_eviction_plan([a, b], cap_bytes=size, usage_bytes=2 * size, now=NOW)
+    p2 = build_eviction_plan([b, a], cap_bytes=size, usage_bytes=2 * size, now=NOW)
+    assert [e.id for e in p1.entries_to_archive] == [
+        e.id for e in p2.entries_to_archive
+    ]
+    assert p1.freed_bytes == p2.freed_bytes
+
+
+def test_access_frequency_protects_entries():
+    # Same age, same tier: the frequently-accessed one must survive.
+    hot = entry("hot", age_days=20.0, access_count=500)
+    cold = entry("cold", age_days=20.0, access_count=0)
+    size = hot.size()
+    plan = build_eviction_plan(
+        [hot, cold], cap_bytes=size, usage_bytes=2 * size, now=NOW
+    )
+    assert plan.entries_to_archive == [cold]
+    assert plan.entries_to_keep == [hot]
+
+
+# ── policy trigger (default-off) ─────────────────────────────────────────────
+
+
+def test_policy_disabled_returns_none_even_over_cap():
+    policy = MemoryEvictionPolicy(enabled=False, cap_bytes=100)
+    assert policy.maybe_plan([entry("a")], usage_bytes=10_000, now=NOW) is None
+
+
+def test_policy_enabled_under_cap_returns_none():
+    policy = MemoryEvictionPolicy(enabled=True, cap_bytes=10_000)
+    assert policy.maybe_plan([entry("a")], usage_bytes=100, now=NOW) is None
+
+
+def test_policy_enabled_over_cap_returns_plan():
+    policy = MemoryEvictionPolicy(enabled=True, cap_bytes=50)
+    plan = policy.maybe_plan([entry("a")], usage_bytes=10_000, now=NOW)
+    assert plan is not None
+    assert not plan.is_empty
+
+
+# ── serialization ────────────────────────────────────────────────────────────
+
+
+def test_memory_entry_round_trip():
+    e = entry("rt", age_days=2.0, access_count=7, trust_tier="high")
+    restored = MemoryEntry.from_dict(e.to_dict())
+    assert restored == e
+
+
+def test_memory_entry_size_computed_when_absent():
+    e = MemoryEntry(id="x", content="héllo", created_at=0.0, last_access=0.0)
+    assert e.size() == len("héllo".encode("utf-8"))
+    e2 = MemoryEntry(
+        id="x", content="héllo", created_at=0.0, last_access=0.0, size_bytes=1
+    )
+    assert e2.size() == 1
+
+
+def test_eviction_plan_is_empty_property():
+    assert EvictionPlan().is_empty


### PR DESCRIPTION
Automated evolution PR for issue #123 (slice A: eviction half — 'learned forgetting').

- New pure module `agent/memory_eviction.py`: ranks memory entries by recency × access × provenance (exponential temporal decay + log-scaled access + #316 provenance tags), returns an EvictionPlan with archive-not-delete semantics (evicted entries handed back in an `entries_to_archive` list; caller owns I/O).
- `MemoryEvictionPolicy.maybe_plan` capacity trigger: default-off, returns None unless enabled AND usage exceeds cap — existing store behaviour untouched.
- 21 new tests in `tests/agent/test_memory_eviction.py` (determinism, ranking, archive-not-delete contract, capacity trigger, default-off, serialization).
- Local gate green: ruff check + format clean, 21/21 tests pass.

Slice B (contradiction-aware supersede marking on the memory_addition_gate write path) stays open on #123.