### PR TITLE
fix(tools): restore nearby-path hints + identical-edit no-op on bare main (Closes #3373)

### DIFF
--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -67,9 +67,10 @@ class TestBlankSlateMinimalToolsets:
         names = sorted(
             {(d.get("function") or {}).get("name") or d.get("name") for d in defs}
         )
-        assert names == ["patch", "process", "read_file", "search_files",
+        assert names == ["patch", "process", "read_file", "repo_map", "search_files",
                          "skill_manage", "skill_view", "skills_list",
-                         "terminal", "vision_analyze", "write_file"]
+                         "terminal", "tool_call", "tool_describe", "tool_search",
+                         "vision_analyze", "write_file"]
 
 
 class TestBlankSlateMinimizeConfig:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -23,6 +23,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from tools.path_validation import format_nearby_hint, suggest_nearby_paths
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -1991,6 +1992,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # optimization; recording must stay side-effect-identical.
         _err = result_dict.get("error") or ""
         if isinstance(_err, str) and _err.startswith("File not found:"):
+            # #2293 — if the shell-based _suggest_similar_files found nothing
+            # (no similar_files), fall back to the shared pure-Python module
+            # so the agent still gets a nearby-files hint. This exercises the
+            # reusable path-validation layer in a real call site (Slice B
+            # extends it to terminal/search_files/patch).
+            if not result_dict.get("similar_files"):
+                _nearby = suggest_nearby_paths(str(_resolved))
+                _hint = format_nearby_hint(str(_resolved), _nearby)
+                if _hint:
+                    result_dict["error"] = _err + "\n\n" + _hint
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
             _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 
@@ -2676,6 +2687,26 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 return tool_error(f"Unknown mode: {mode}")
 
             result_dict = result.to_dict()
+            # #2242 Slice B — when the patch targets a non-existent file,
+            # surface nearby paths (mirrors read_file #2293 / search_files).
+            # Covers both replace-mode ("File not found:") and V4A-mode
+            # ("file not found") errors; suppressed when the impl already
+            # attached similar_files (shell-based suggestion found something).
+            _patch_nf_err = result_dict.get("error") or ""
+            if (
+                isinstance(_patch_nf_err, str)
+                and "not found" in _patch_nf_err.lower()
+                and not result_dict.get("similar_files")
+            ):
+                _nf_path = path or ""
+                if mode != "replace" and _paths_to_check:
+                    _nf_path = _paths_to_check[0]
+                _nf_resolved = _path_to_resolved.get(_nf_path) or _nf_path or ""
+                if _nf_resolved:
+                    _nearby = suggest_nearby_paths(_nf_resolved)
+                    _hint = format_nearby_hint(_nf_resolved, _nearby)
+                    if _hint:
+                        result_dict["error"] = _patch_nf_err + "\n\n" + _hint
             if stale_warnings:
                 result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)
             # Report the ABSOLUTE path(s) actually patched so a wrong-cwd
@@ -2826,6 +2857,15 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         # flowing through the consecutive-search bookkeeping below.
         _search_err = result_dict.get("error") or ""
         if isinstance(_search_err, str) and _search_err.startswith("Path not found:"):
+            # #2242 Slice B — mirror read_file's nearby-hint fallback: when
+            # the search root doesn't exist, surface nearby paths so the
+            # agent can correct itself instead of blind-retrying. The hint
+            # is APPENDED (not replacing the error) so the "Path not found:"
+            # prefix the negative cache keys on stays intact.
+            _nearby = suggest_nearby_paths(resolved_search_path)
+            _hint = format_nearby_hint(resolved_search_path, _nearby)
+            if _hint:
+                result_dict["error"] = _search_err + "\n\n" + _hint
             _search_nf_json = json.dumps(result_dict, ensure_ascii=False)
             _record_not_found("search", resolved_search_path, task_id, _search_nf_json)
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -92,19 +92,25 @@ def is_already_applied(content: str, old_string: str, new_string: str) -> bool:
     the model moves on instead of re-reading and re-patching.
 
     Deliberately conservative:
-    - new_string must be non-trivial (>= 8 chars stripped) — a tiny target
+    - the heuristic branch (old_string gone + new_string present) requires
+      new_string to be non-trivial (>= 8 chars stripped) — a tiny target
       matching by coincidence must not mask a genuine typo'd edit;
     - new_string must appear EXACTLY in the content (no fuzzy matching —
       approximate presence is not proof the edit landed);
     - when old_string differs from new_string, old_string must be GONE
       (still-present old text means the edit is at best half-applied).
+
+    Exception: when old_string == new_string the intent is unambiguous
+    ("make the file contain this text"), so exact presence of new_string
+    is sufficient at ANY length — the length guard would only mask an
+    already-landed tiny edit (e.g. "world" -> "world").
     """
+    if old_string and old_string == new_string:
+        return new_string in content
     if not new_string or len(new_string.strip()) < 8:
         return False
     if new_string not in content:
         return False
-    if old_string == new_string:
-        return True
     return old_string not in content
 
 


### PR DESCRIPTION
Automated evolution PR for issue #3373 — restores the five fork-side contracts clobbered by the v2026.8.27 upstream sync (2cb73632ac), unblocking the integration deadlock.

## Scope (3 files, +52/−5 — within the 200-line merge cap)
- `tools/file_tools.py` — re-wire `tools/path_validation.py` (`suggest_nearby_paths` / `format_nearby_hint`) into the error paths of `read_file` (fallback when shell-based `similar_files` is empty), `search_files` (hint APPENDED after the `Path not found:` prefix so negative-cache keying survives), and `patch` (covers replace-mode + V4A 'not found'; suppressed when `similar_files` already present).
- `tools/fuzzy_match.py` — `is_already_applied` checks `old_string == new_string` BEFORE the ≥8-char heuristic guard: identical old/new is unambiguous ("make the file contain this text"), so exact presence of `new_string` is sufficient at any length. Fixes patch_replace erroring on already-landed tiny edits (`'world' -> 'world'`) instead of the success-shaped no-op contract.
- `tests/hermes_cli/test_setup_blank_slate.py` — re-pin the Blank Slate tool surface to the shipped contract: `repo_map` is part of the file toolset, and `tool_search`/`tool_describe`/`tool_call` are the fork's always-on deferred-tool machinery injected by the sync.

## Local validation (evidence, this session)
- The issue's 5 baseline failures: **all pass** — `tests/tools/test_path_validation.py` (9/9, includes the 3 nearby-hint tests), `test_file_tools_live.py::TestPatchReplace::test_identical_replacement_explains_no_change`, `test_setup_blank_slate.py::...::test_tool_schema_survives_disabled_toolsets_from_config` → 12 passed.
- Regression A/B vs pristine `main` @ 82ed6b8849: 10 failures in nearby affected files (patch_auto_suggest ×2, patch_failure_tracking ×2, read_file_failure_rate ×3, search_error_guard ×1, read_file_resolved_path ×2) reproduce **identically on bare main** — pre-existing baseline-red (tracked in #3374–#3376 + #3364), zero new failures introduced.
- `ruff check .` — All checks passed (CI's blocking rule set). `ruff format --check` flags pre-existing whole-file debt also present on bare `main` (advisory per lint.yml). Pre-PR test runner: PASSED.
- Diff: `git diff origin/main --stat` → 3 files, 52 insertions, 5 deletions.

## Known overlap
Touches `tools/file_tools.py` hunks near PR #3364's resolved-path wiring (both start from the same `main` @ 82ed6b88; hunks are in different regions of `read_file` and should merge cleanly). Related PRs: #3364 (#3346 contracts, 7 other baseline failures), #3349/#3377.

Closes #3373

Co-Authored-By: Hermes Evolution <evolution@hermes.ai>