### PR TITLE
feat(memory): TEPA revocable memory — explicit validity state on episodic events (Closes #154)

### DIFF
--- a/agent/memory_importance.py
+++ b/agent/memory_importance.py
@@ -13,6 +13,11 @@ A self-contained module (stdlib only) that:
 4. Deduplicates events via Jaccard similarity on tokenized text, merging
    groups while keeping the highest-importance event and combining tags.
 5. Persists the whole store to / loads it from a JSON file.
+6. Tracks explicit validity state (TEPA, #154): a stored event
+   contradicted by fresh evidence is *revoked* — marked with validity
+   state, superseding id and reason — rather than overwritten, and
+   revoked entries are excluded from normal retrieval while staying
+   queryable for audits.
 
 Import-safe: importing this module has no side effects and requires no
 third-party packages.  Designed to be unit-testable with only stdlib +
@@ -40,6 +45,9 @@ __all__ = [
     "DEFAULT_HALF_LIFE_DAYS",
     "DEFAULT_SIGNAL_WEIGHTS",
     "SIGNAL_WEIGHTS",
+    "VALIDITY_ACTIVE",
+    "VALIDITY_REVOKED",
+    "REVOCATION_REASON_CONTRADICTION",
 ]
 
 # ---------------------------------------------------------------------------
@@ -62,6 +70,17 @@ DEFAULT_SIGNAL_WEIGHTS: dict[str, float] = {
 
 #: Public alias matching the task spec wording.
 SIGNAL_WEIGHTS: dict[str, float] = DEFAULT_SIGNAL_WEIGHTS
+
+#: Explicit validity state (TEPA, #154): an active precedent is *revoked*
+#: when fresh evidence contradicts it, rather than overwritten or left to
+#: age out. Revocation is recorded state, not deletion — the entry stays
+#: queryable through revocation audits.
+VALIDITY_ACTIVE: str = "active"
+VALIDITY_REVOKED: str = "revoked"
+
+#: Default reason recorded when a stored event is revoked by newer,
+#: contradictory evidence on the memory write path.
+REVOCATION_REASON_CONTRADICTION: str = "contradicted_by_new_evidence"
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 
@@ -240,6 +259,10 @@ class MemoryEvent:
     tags: list[str] = field(default_factory=list)
     context_refs: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    validity: str = VALIDITY_ACTIVE  # VALIDITY_ACTIVE | VALIDITY_REVOKED (#154)
+    revoked_at: str = ""  # ISO timestamp of revocation; "" while active
+    revoked_by: str = ""  # event_id of the superseding evidence, if any
+    revocation_reason: str = ""  # why it was revoked (e.g. contradicted)
 
     def __post_init__(self) -> None:
         # Coerce common alternate types so the dataclass is forgiving.
@@ -254,6 +277,19 @@ class MemoryEvent:
         self.tags = list(self.tags) if self.tags else []
         self.context_refs = list(self.context_refs) if self.context_refs else []
         self.metadata = dict(self.metadata) if self.metadata else {}
+        # Normalize explicit validity state (TEPA, #154): anything that is
+        # not the literal revoked marker is treated as active, and the
+        # revocation trace fields are strings (legacy data lacks them).
+        if self.validity != VALIDITY_REVOKED:
+            self.validity = VALIDITY_ACTIVE
+        self.revoked_at = self.revoked_at or ""
+        self.revoked_by = self.revoked_by or ""
+        self.revocation_reason = self.revocation_reason or ""
+
+    @property
+    def is_revoked(self) -> bool:
+        """True when this event has been revoked (TEPA, #154)."""
+        return self.validity == VALIDITY_REVOKED
 
     # -- scoring -----------------------------------------------------------
 
@@ -310,6 +346,10 @@ class MemoryEvent:
             "tags": list(self.tags),
             "context_refs": list(self.context_refs),
             "metadata": dict(self.metadata),
+            "validity": self.validity,
+            "revoked_at": self.revoked_at,
+            "revoked_by": self.revoked_by,
+            "revocation_reason": self.revocation_reason,
         }
 
     @classmethod
@@ -330,6 +370,10 @@ class MemoryEvent:
             "tags",
             "context_refs",
             "metadata",
+            "validity",
+            "revoked_at",
+            "revoked_by",
+            "revocation_reason",
         }
         kwargs = {k: v for k, v in data.items() if k in known}
         return cls(**kwargs)
@@ -387,8 +431,65 @@ class EpisodicMemoryStore:
         return event_id in self.events
 
     def all(self) -> list[MemoryEvent]:
-        """Return all events in insertion order."""
+        """Return all events in insertion order, revoked included.
+
+        This is the raw audit view; normal retrieval methods exclude
+        revoked events by default (see :meth:`_events`).
+        """
         return list(self.events.values())
+
+    def _events(self, include_revoked: bool = False) -> Iterable[MemoryEvent]:
+        """Yield events, skipping revoked ones unless ``include_revoked``.
+
+        Retrieval defaults to active-only so a revoked claim never
+        resurfaces in later prompts (TEPA, #154); audits pass
+        ``include_revoked=True`` to see the full history.
+        """
+        for ev in self.events.values():
+            if include_revoked or ev.validity == VALIDITY_ACTIVE:
+                yield ev
+
+    def active_events(self) -> list[MemoryEvent]:
+        """All active (non-revoked) events in insertion order."""
+        return [ev for ev in self.events.values() if ev.validity == VALIDITY_ACTIVE]
+
+    def revoke(
+        self,
+        event_id: str,
+        *,
+        by_event_id: str = "",
+        reason: str = REVOCATION_REASON_CONTRADICTION,
+    ) -> bool:
+        """Mark an event revoked without deleting it (TEPA, #154).
+
+        Sets explicit validity state — ``validity`` becomes ``revoked``
+        with a timestamp, the superseding evidence id (``by_event_id``)
+        and a ``reason`` — so the entry stays queryable through
+        :meth:`revoked_events` and is excluded from normal retrieval.
+        Returns False when the event does not exist or is already revoked.
+        """
+        ev = self.events.get(event_id)
+        if ev is None or ev.validity == VALIDITY_REVOKED:
+            return False
+        ev.validity = VALIDITY_REVOKED
+        ev.revoked_at = _now_iso()
+        ev.revoked_by = by_event_id
+        ev.revocation_reason = reason
+        return True
+
+    def revoked_events(self) -> list[MemoryEvent]:
+        """All revoked events, newest revocation first (revocation audit).
+
+        Each entry carries ``revoked_at`` / ``revoked_by`` /
+        ``revocation_reason`` so a memory audit can answer *why we believed
+        X earlier and what replaced it* (TEPA, #154).
+        """
+        out = [ev for ev in self.events.values() if ev.validity == VALIDITY_REVOKED]
+        out.sort(
+            key=lambda e: (_parse_iso(e.revoked_at or e.when), e.event_id),
+            reverse=True,
+        )
+        return out
 
     # -- retrieval ---------------------------------------------------------
 
@@ -409,12 +510,16 @@ class EpisodicMemoryStore:
         end: str | datetime | None = None,
         *,
         inclusive: bool = True,
+        include_revoked: bool = False,
     ) -> list[MemoryEvent]:
-        """Return events with ``when`` in ``[start, end]`` (open-ended if None)."""
+        """Return events with ``when`` in ``[start, end]`` (open-ended if None).
+
+        Revoked events are excluded unless ``include_revoked`` is True.
+        """
         s = _parse_iso(start) if start is not None else None
         e = _parse_iso(end) if end is not None else None
         out: list[MemoryEvent] = []
-        for ev in self.events.values():
+        for ev in self._events(include_revoked):
             t = _parse_iso(ev.when)
             if s is not None:
                 if inclusive and t < s:
@@ -430,12 +535,16 @@ class EpisodicMemoryStore:
         return self._ordered(out)
 
     def retrieve_by_category(
-        self, category: str | None = None, *, tags: Iterable[str] | None = None
+        self,
+        category: str | None = None,
+        *,
+        tags: Iterable[str] | None = None,
+        include_revoked: bool = False,
     ) -> list[MemoryEvent]:
         """Return events matching a category and/or any of the given tags."""
         tag_set = set(tags) if tags is not None else None
         out: list[MemoryEvent] = []
-        for ev in self.events.values():
+        for ev in self._events(include_revoked):
             if category is not None and ev.category != category:
                 continue
             if tag_set is not None:
@@ -450,10 +559,11 @@ class EpisodicMemoryStore:
         *,
         decayed: bool = False,
         reference_time: str | datetime | None = None,
+        include_revoked: bool = False,
     ) -> list[MemoryEvent]:
         """Return events with importance >= ``threshold`` (descending)."""
         out: list[MemoryEvent] = []
-        for ev in self.events.values():
+        for ev in self._events(include_revoked):
             score = (
                 ev.decayed_importance(
                     reference_time=reference_time,
@@ -468,13 +578,20 @@ class EpisodicMemoryStore:
         out.sort(key=lambda e: e.importance, reverse=True)
         return out
 
-    def text_search(self, query: str, *, min_score: float = 0.0) -> list[MemoryEvent]:
+    def text_search(
+        self,
+        query: str,
+        *,
+        min_score: float = 0.0,
+        include_revoked: bool = False,
+    ) -> list[MemoryEvent]:
         """Bag-of-words TF-IDF-like search over event text.
 
         Each event's token bag is built from ``what`` + ``outcome`` + ``tags``.
         IDF is computed over the store corpus; the query is scored by summed
         ``tf * idf`` over query tokens present in each event, normalized by
         event token count.  Results are returned in descending score order.
+        Revoked events are excluded unless ``include_revoked`` is True.
         """
         if not query.strip():
             return []
@@ -482,7 +599,7 @@ class EpisodicMemoryStore:
         if not q_tokens:
             return []
 
-        corpus = [ev.tokens() for ev in self.events.values()]
+        corpus = [ev.tokens() for ev in self._events(include_revoked)]
         n_docs = len(corpus)
         # document frequency per token
         df: dict[str, int] = {}
@@ -493,7 +610,7 @@ class EpisodicMemoryStore:
             return []
 
         scored: list[tuple[float, MemoryEvent]] = []
-        for ev, toks in zip(self.events.values(), corpus):
+        for ev, toks in zip(self._events(include_revoked), corpus):
             if not toks:
                 continue
             tf: dict[str, int] = {}
@@ -518,6 +635,7 @@ class EpisodicMemoryStore:
         *,
         limit: int = 10,
         max_window_days: float | None = None,
+        include_revoked: bool = False,
     ) -> list[MemoryEvent]:
         """Return the ``limit`` events closest in time to ``reference``.
 
@@ -526,7 +644,7 @@ class EpisodicMemoryStore:
         """
         ref = _parse_iso(reference)
         scored: list[tuple[float, MemoryEvent]] = []
-        for ev in self.events.values():
+        for ev in self._events(include_revoked):
             delta = abs((_parse_iso(ev.when) - ref).total_seconds()) / 86400.0
             if max_window_days is not None and delta > max_window_days:
                 continue
@@ -554,7 +672,9 @@ class EpisodicMemoryStore:
         set; when False the store is untouched and only the merged list is
         returned.
         """
-        events = list(self.events.values())
+        # Only active events participate: a revoked event must never be
+        # merged back into an active one (TEPA, #154).
+        events = list(self._events(include_revoked=False))
         # Deterministic grouping: sort by when so earlier events seed groups.
         events.sort(key=lambda e: (_parse_iso(e.when), e.event_id))
         groups: list[list[MemoryEvent]] = []

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -34,7 +34,12 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.memory_importance import EpisodicMemoryStore, MemoryEvent, score_importance
+from agent.memory_importance import (
+    REVOCATION_REASON_CONTRADICTION,
+    EpisodicMemoryStore,
+    MemoryEvent,
+    score_importance,
+)
 from agent.memory_contradiction import ContradictionFlag, detect_contradictions
 from agent.memory_provider import MemoryProvider, PRE_COMPRESS_CHECKPOINT_API_VERSION
 from agent.skill_commands import extract_user_instruction_from_skill_message
@@ -156,7 +161,8 @@ def inject_memory_provider_tools(agent: Any) -> int:
         # return 0 here made #81014 undiagnosable: the provider looked
         # "half on" with no clue which config key suppressed its tools.
         _providers = [
-            p for p in (getattr(memory_manager, "providers", None) or [])
+            p
+            for p in (getattr(memory_manager, "providers", None) or [])
             if getattr(p, "name", "") != "builtin"
         ]
         if _providers:
@@ -1009,7 +1015,12 @@ class MemoryManager:
         # Non-fatal and bounded: flags are logged with both timestamps, never
         # silently overwriting or deleting the stored event.
         if user_content and user_content.strip():
-            self.check_contradictions(user_content)
+            flags = self.check_contradictions(user_content)
+            # TEPA (#154): contradictory evidence revokes the stored event —
+            # explicit validity state, superseding id, reason — instead of
+            # leaving both at full weight. Non-fatal: a revocation failure
+            # must never fail the turn sync.
+            self._revoke_contradicted(flags, by_event_id=event.event_id)
         self.episodic_store.add(event)
         logger.debug(
             "score_memories: recorded turn (importance=%.3f, signals=%s)",
@@ -1042,7 +1053,7 @@ class MemoryManager:
         if not observation or not observation.strip():
             return []
         flags = detect_contradictions(
-            self.episodic_store.events.values(),
+            self.episodic_store.active_events(),
             observation,
             limit=limit,
             min_importance=min_importance,
@@ -1072,6 +1083,47 @@ class MemoryManager:
                 observation[:200],
             )
         return flags
+
+    def _revoke_contradicted(
+        self,
+        flags: List[ContradictionFlag],
+        *,
+        by_event_id: str = "",
+    ) -> int:
+        """Revoke stored events contradicted by new evidence (TEPA, #154).
+
+        Runs on the memory write path after :meth:`check_contradictions`:
+        each flagged stored event is *revoked* — marked with explicit
+        validity state and the superseding event id — rather than
+        overwritten or left at full weight. Non-fatal by design: a failed
+        revocation is logged and skipped so a turn sync never fails
+        because of a storage hiccup.
+
+        Returns the number of events revoked.
+        """
+        revoked = 0
+        for flag in flags:
+            try:
+                if self.episodic_store.revoke(
+                    flag.event_id,
+                    by_event_id=by_event_id,
+                    reason=REVOCATION_REASON_CONTRADICTION,
+                ):
+                    revoked += 1
+                    logger.info(
+                        "memory revocation (#154): stored %s (%s) revoked by %s — %s",
+                        flag.event_id,
+                        flag.stored_when,
+                        by_event_id or "(unknown)",
+                        flag.reason,
+                    )
+            except Exception:
+                logger.debug(
+                    "memory revocation failed (non-fatal): %s",
+                    flag.event_id,
+                    exc_info=True,
+                )
+        return revoked
 
     def sync_all(
         self,

--- a/tests/agent/test_memory_validity.py
+++ b/tests/agent/test_memory_validity.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""Tests for TEPA revocable memory state (#154).
+
+Covers the explicit-validity extension of the episodic tier
+(``agent.memory_importance``): a stored event contradicted by fresh
+evidence is *revoked* (marked with validity state, superseding id and
+reason) rather than overwritten or left at full weight; revocation is
+queryable; and revoked entries never resurface in normal retrieval.
+
+Only stdlib + pytest + unittest.mock. No live network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from agent.memory_importance import (
+    REVOCATION_REASON_CONTRADICTION,
+    VALIDITY_ACTIVE,
+    VALIDITY_REVOKED,
+    EpisodicMemoryStore,
+    MemoryEvent,
+)
+
+
+def _event(
+    what: str, *, importance: float = 0.7, when: str | None = None
+) -> MemoryEvent:
+    """Build a MemoryEvent with a fixed (or auto) timestamp."""
+    if when is None:
+        when = datetime.now(timezone.utc).isoformat()
+    return MemoryEvent(what=what, importance=importance, when=when)
+
+
+class TestMemoryEventValidity:
+    def test_default_validity_is_active(self):
+        ev = _event("the nas is healthy")
+        assert ev.validity == VALIDITY_ACTIVE
+        assert not ev.is_revoked
+        assert ev.revoked_at == ""
+        assert ev.revoked_by == ""
+        assert ev.revocation_reason == ""
+
+    def test_serialization_roundtrip_preserves_validity(self):
+        ev = _event("the nas is healthy")
+        assert ev.to_dict()["validity"] == VALIDITY_ACTIVE
+        clone = MemoryEvent.from_dict(ev.to_dict())
+        assert clone.validity == VALIDITY_ACTIVE
+
+    def test_revoked_state_serializes(self):
+        ev = _event("the nas is healthy")
+        ev.validity = VALIDITY_REVOKED
+        ev.revoked_at = "2026-08-31T12:00:00+00:00"
+        ev.revoked_by = "new-event-id"
+        ev.revocation_reason = REVOCATION_REASON_CONTRADICTION
+        clone = MemoryEvent.from_dict(ev.to_dict())
+        assert clone.validity == VALIDITY_REVOKED
+        assert clone.revoked_at == "2026-08-31T12:00:00+00:00"
+        assert clone.revoked_by == "new-event-id"
+        assert clone.revocation_reason == REVOCATION_REASON_CONTRADICTION
+
+    def test_legacy_dict_without_validity_loads_active(self):
+        # Old serializations (pre-#154) have no validity keys: they must load
+        # as active so revocation is strictly opt-in state.
+        legacy = {
+            "event_id": "legacy-1",
+            "what": "the nas is healthy",
+            "when": "2026-01-01T00:00:00+00:00",
+            "outcome": "",
+            "importance": 0.7,
+            "friction_signals": {},
+            "category": "",
+            "tags": [],
+            "context_refs": [],
+            "metadata": {},
+        }
+        ev = MemoryEvent.from_dict(legacy)
+        assert ev.validity == VALIDITY_ACTIVE
+        assert not ev.is_revoked
+
+
+class TestStoreRevocation:
+    def test_revoke_marks_event_and_keeps_record(self):
+        store = EpisodicMemoryStore()
+        old = _event("the nas is healthy")
+        new = _event("the nas is not healthy")
+        store.add(old)
+        store.add(new)
+        assert store.revoke(old.event_id, by_event_id=new.event_id) is True
+        # Revoke != delete: the record survives, marked.
+        assert old.event_id in store.events
+        assert old.validity == VALIDITY_REVOKED
+        assert old.is_revoked
+        assert old.revoked_by == new.event_id
+        assert old.revocation_reason == REVOCATION_REASON_CONTRADICTION
+        assert old.revoked_at != ""
+
+    def test_revoke_unknown_id_returns_false(self):
+        store = EpisodicMemoryStore()
+        assert store.revoke("does-not-exist") is False
+
+    def test_revoke_is_idempotent(self):
+        store = EpisodicMemoryStore()
+        ev = _event("the nas is healthy")
+        store.add(ev)
+        assert store.revoke(ev.event_id) is True
+        assert store.revoke(ev.event_id) is False  # already revoked
+
+    def test_revoked_events_audit_listing(self):
+        store = EpisodicMemoryStore()
+        a = _event("stale ip is 10.0.0.99")
+        b = _event("ip is 10.0.0.60")
+        c = _event("unrelated")
+        store.add(a)
+        store.add(b)
+        store.add(c)
+        store.revoke(a.event_id, by_event_id=b.event_id)
+        revoked = store.revoked_events()
+        assert [e.event_id for e in revoked] == [a.event_id]
+        entry = revoked[0]
+        assert entry.revoked_by == b.event_id
+        assert entry.revocation_reason == REVOCATION_REASON_CONTRADICTION
+        assert store.active_events() == [b, c]
+
+
+class TestRetrievalExcludesRevoked:
+    def _store_with_revoked(self) -> EpisodicMemoryStore:
+        store = EpisodicMemoryStore()
+        old = _event("the nas is healthy", importance=0.9)
+        new = _event("the nas is not healthy", importance=0.9)
+        store.add(old)
+        store.add(new)
+        store.revoke(old.event_id, by_event_id=new.event_id)
+        return store
+
+    def test_text_search_skips_revoked_by_default(self):
+        store = self._store_with_revoked()
+        hit_texts = {e.what for e in store.text_search("nas")}
+        assert "the nas is healthy" not in hit_texts
+        assert "the nas is not healthy" in hit_texts
+
+    def test_retrieval_methods_default_to_active_only(self):
+        store = self._store_with_revoked()
+        active_ids = {e.event_id for e in store.active_events()}
+        # Every retrieval surface must exclude the revoked event by default.
+        assert {e.event_id for e in store.text_search("nas")} == active_ids
+        assert {e.event_id for e in store.retrieve_by_time_range()} == active_ids
+        assert {e.event_id for e in store.retrieve_by_category()} == active_ids
+        assert {e.event_id for e in store.retrieve_by_importance()} == active_ids
+        assert {
+            e.event_id
+            for e in store.retrieve_by_temporal_proximity(store.active_events()[0].when)
+        } == active_ids
+
+    def test_include_revoked_flag_restores_audit_view(self):
+        store = self._store_with_revoked()
+        store_texts = {e.what for e in store.text_search("nas", include_revoked=True)}
+        assert "the nas is healthy" in store_texts
+        assert "the nas is not healthy" in store_texts
+
+    def test_deduplicate_never_resurrects_revoked(self):
+        store = EpisodicMemoryStore()
+        old = _event("the nas is healthy")
+        dup = _event("the nas is healthy and mounted", importance=0.9)
+        store.add(old)
+        store.add(dup)
+        store.revoke(old.event_id, by_event_id=dup.event_id)
+        store.deduplicate(threshold=0.5)
+        # The revoked event must not be merged back into an active one.
+        assert all(e.validity == VALIDITY_ACTIVE for e in store.active_events())
+        assert old.event_id not in {e.event_id for e in store.active_events()}
+
+    def test_save_load_preserves_revocation(self, tmp_path):
+        store = self._store_with_revoked()
+        path = tmp_path / "memory.json"
+        store.save(path)
+        loaded = EpisodicMemoryStore.load(path)
+        revoked = loaded.revoked_events()
+        assert len(revoked) == 1
+        assert revoked[0].revoked_by == store.active_events()[0].event_id
+        assert revoked[0].validity == VALIDITY_REVOKED
+
+
+class TestWritePathRevocation:
+    def test_score_memories_revokes_contradicted_stored_event(self):
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        stored = _event("the nas is healthy", importance=0.8)
+        manager.episodic_store.add(stored)
+        manager.score_memories("the nas is not healthy", "ok", session_id="s1")
+        # Stored event revoked, new event active, nothing deleted.
+        assert stored.validity == VALIDITY_REVOKED
+        assert stored.revoked_by in manager.episodic_store.events
+        assert stored.revocation_reason == REVOCATION_REASON_CONTRADICTION
+        assert len(manager.episodic_store.events) == 2
+        assert len(manager.episodic_store.active_events()) == 1
+
+    def test_unrelated_turn_revokes_nothing(self):
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        stored = _event("the nas is healthy")
+        manager.episodic_store.add(stored)
+        manager.score_memories(
+            "what is the weather in cape town", "sunny", session_id="s1"
+        )
+        assert stored.validity == VALIDITY_ACTIVE
+        assert manager.episodic_store.revoked_events() == []
+
+    def test_revocation_failure_is_non_fatal(self):
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        stored = _event("the nas is healthy")
+        manager.episodic_store.add(stored)
+
+        def boom(event_id, **kwargs):  # noqa: ARG001
+            raise RuntimeError("storage exploded")
+
+        manager.episodic_store.revoke = boom  # type: ignore[method-assign]
+        # The turn must still succeed even if revocation fails.
+        ev = manager.score_memories("the nas is not healthy", "ok", session_id="s1")
+        assert ev is not None
+        assert ev in manager.episodic_store.events.values()
+
+    def test_contradiction_scan_skips_revoked_events(self):
+        from agent.memory_manager import MemoryManager
+
+        manager = MemoryManager()
+        stored = _event("the nas is healthy")
+        manager.episodic_store.add(stored)
+        manager.score_memories("the nas is not healthy", "ok", session_id="s1")
+        # A second conflicting observation no longer flags the revoked entry:
+        # dead memories do not generate noise.
+        assert manager.check_contradictions("the nas is not healthy") == []


### PR DESCRIPTION
Automated evolution PR for issue #154 — **TEPA: revocable evidence-memory**.

## What & why
Long-term memory accumulates stale beliefs (renumbered IPs, superseded creds, dead crons) that stay retrievable and pollute the prompt. Current mitigations are cleanup heuristics (overwrite, rank-down, age-out) that lose the *reason* a belief was replaced. This change models memory observations as keyed precedents with **validity as explicit state**: an active precedent is **revoked** when fresh evidence contradicts it, rather than overwritten or left to age out.

## Implementation (issue's 3-step plan)
1. **Explicit validity field on the entry schema** — `MemoryEvent` gains `validity` (`active`/`revoked`), `revoked_at`, `revoked_by` (superseding evidence id), `revocation_reason`. Serialization is backward-compatible: legacy dicts without the new keys load as `active`.
2. **Revocation on contradictory evidence in the write path** — `MemoryManager.score_memories` (the episodic write path) now revokes each stored event flagged by the existing contradiction detector instead of leaving both sides at full weight. Non-fatal by design: a revocation failure logs and is skipped; the turn sync never fails.
3. **Revocation queryable** — `EpisodicMemoryStore.revoked_events()` returns the audit trail (what/when/by-whom/why); every retrieval surface (`text_search`, time-range, category, importance, temporal proximity) gains `include_revoked` and **excludes revoked entries by default**, so a stale claim never resurfaces in later prompts.

**Revoke ≠ delete**: the record is kept (coordinates with the graveyard/purge flow); `deduplicate` only ever merges active events, so a revoked entry can never be resurrected; the contradiction scan now runs over active events only, so dead memories stop generating noise.

## Files
- `agent/memory_importance.py` — schema fields, `revoke()`, `revoked_events()`, `active_events()`, `_events()` filter, `include_revoked` on all retrieval + dedup
- `agent/memory_manager.py` — write-path revocation (`_revoke_contradicted`), contradiction scan over active events
- `tests/agent/test_memory_validity.py` — 16 new tests (schema, serialization/legacy compat, revocation semantics, retrieval exclusion, dedup safety, save/load, write-path wiring, non-fatal failure, no-noise-after-revocation)

## Validation (local, matching CI)
- `ruff check` clean, `ruff format --check` clean
- `pytest tests/agent/test_memory_validity.py tests/agent/test_memory_importance.py tests/agent/test_memory_contradiction.py` → **81 passed** (16 new + 65 existing, no regressions)
