### PR TITLE
fix(evolution): watchdog audit tolerates nested effort_budget shapes (Closes #168)

### DIFF
--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -58,6 +58,71 @@ def _num(x: Any) -> Optional[float]:
     return None
 
 
+# Keys under which a nested ``effort_budget`` dict may carry its scalar value.
+# Observed shapes (analysis reports): ``{"limit": 3.0, ...}`` (2026-08-29),
+# ``{"max": 3.0, "used": 2.7, ...}`` (2026-08-28). The audit must read the
+# scalar explicitly from whichever key the producer chose (#168).
+_EFFORT_BUDGET_KEYS: Tuple[str, ...] = ("limit", "max", "selected_total", "used")
+
+
+def _scalar_effort_budget(report: Dict[str, Any], default: float = 3.0) -> float:
+    """Extract a scalar effort budget from scalar OR nested report shapes.
+
+    The analysis report's ``effort_budget`` was historically a scalar float;
+    some producers now emit a nested dict (``{"limit": ...}`` /
+    ``{"max": ..., "used": ...}``). ``float(dict)`` raises TypeError, which
+    crashed the meta-skill trace step of the watchdog audit (#168). Read the
+    scalar explicitly, falling back to the default when no scalar is present.
+    """
+    eb = report.get("effort_budget")
+    if isinstance(eb, bool):
+        return default
+    if isinstance(eb, (int, float)):
+        return float(eb)
+    if isinstance(eb, dict):
+        for key in _EFFORT_BUDGET_KEYS:
+            val = eb.get(key)
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, (int, float)):
+                return float(val)
+    return default
+
+
+def check_effort_budget_shape(report: Dict[str, Any]) -> List[str]:
+    """Schema check on the report's ``effort_budget`` field (loud, no crash).
+
+    Returns violation strings (empty == shape is readable). A future shape
+    change surfaces here as a flagged violation at write/audit time instead of
+    a TypeError crash in the consumer (#168). The audit tolerates both the
+    scalar and the known nested dict shapes; anything else is flagged so the
+    producer is told loudly rather than the watchdog dying silently.
+    """
+    if not isinstance(report, dict):
+        return []
+    eb = report.get("effort_budget")
+    if eb is None:
+        return []
+    if isinstance(eb, (int, float)) and not isinstance(eb, bool):
+        return []
+    if isinstance(eb, dict):
+        if any(
+            isinstance(eb.get(k), (int, float)) and not isinstance(eb.get(k), bool)
+            for k in _EFFORT_BUDGET_KEYS
+        ):
+            return []
+        return [
+            "EFFORT_BUDGET_SHAPE: report.effort_budget is a dict without a "
+            f"scalar under any of {list(_EFFORT_BUDGET_KEYS)} (got {sorted(eb)}) "
+            "— consumer cannot read a budget; update the producer or the "
+            "_EFFORT_BUDGET_KEYS contract"
+        ]
+    return [
+        "EFFORT_BUDGET_SHAPE: report.effort_budget is neither a number nor a "
+        f"dict (got {type(eb).__name__}) — expected scalar or nested shape"
+    ]
+
+
 def _selection_constraints(report: Dict[str, Any]) -> Dict[str, Any]:
     """``max_total_effort`` lives under ``scoring_model.selection_constraints``
     (observed shape), but tolerate a top-level ``selection_constraints`` too so a
@@ -82,6 +147,12 @@ def audit_analysis(
     if not isinstance(report, dict):
         return []
     out: List[str] = []
+
+    # Schema check (#168): effort_budget may be scalar or a known nested dict.
+    # Flag (not crash) when the producer shipped a shape the consumer can't
+    # read, so a future report-schema change fails loudly at audit time
+    # instead of the watchdog dying with a TypeError.
+    out.extend(check_effort_budget_shape(report))
 
     sc = _selection_constraints(report)
     budget = _num(sc.get("max_total_effort"))
@@ -365,7 +436,7 @@ def _record_meta_skill_trace(report: Dict[str, Any], evolution_dir: Path) -> Non
         merged=0,  # filled post-merge by the implementation stage
         selected_issue_ids=selected_issue_ids,
         merged_issue_ids=merged_issue_ids,
-        effort_budget=float(report.get("effort_budget", 3.0)),
+        effort_budget=_scalar_effort_budget(report),
     )
     try:
         append_trace(trace, evolution_dir=evolution_dir)

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -283,6 +283,46 @@ def run_local_triage(evolution_dir: Path, repo_root: Optional[Path] = None) -> d
     return output
 
 
+def _load_check_effort_budget_shape():
+    """Resolve the producer-side shape check without import fragility.
+
+    The gate copies this script (sometimes alone, sometimes with the audit
+    module) into an isolated working dir — see
+    test_missing_access_gate_fails_closed. ``scripts.evolution_analysis_audit``
+    is unresolvable there, so fall back to a bare import, then to loading the
+    module by path next to this file. Returns None when the module is
+    genuinely unavailable; the caller must degrade to a stderr warning and
+    still write the report (#168) — a missing check must never abort triage.
+    """
+    try:
+        from scripts.evolution_analysis_audit import check_effort_budget_shape
+
+        return check_effort_budget_shape
+    except ImportError:
+        pass
+    try:
+        from evolution_analysis_audit import check_effort_budget_shape
+
+        return check_effort_budget_shape
+    except ImportError:
+        pass
+    try:
+        import importlib.util
+
+        audit_path = Path(__file__).resolve().parent / "evolution_analysis_audit.py"
+        if audit_path.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "evolution_analysis_audit", audit_path
+            )
+            if spec is not None and spec.loader is not None:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                return module.check_effort_budget_shape
+    except Exception:  # pragma: no cover - degraded install; any failure is fine
+        pass
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
@@ -325,6 +365,34 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 0
+
+    # Producer-side schema check (#168): fail loudly AT WRITE TIME if the
+    # report shape would crash a consumer later (the watchdog's meta-skill
+    # trace died with TypeError: float() got 'dict' because a producer shipped
+    # a nested effort_budget the consumer couldn't read). The audit module is
+    # the single source of truth for the shape contract. A missing module
+    # (isolated/degraded install — the gate copies this script alone) must
+    # degrade to a warning, never abort the write: Phase 0 output is the
+    # gate's core guarantee.
+    check_shape = _load_check_effort_budget_shape()
+    shape_violations = []
+    if check_shape is None:
+        print(
+            "Warning: evolution_analysis_audit unavailable — skipping producer "
+            "shape check; report still written (#168).",
+            file=sys.stderr,
+        )
+    else:
+        shape_violations = check_shape(output)
+    if shape_violations:
+        for v in shape_violations:
+            print(f"REPORT_SHAPE_VIOLATION: {v}", file=sys.stderr)
+        print(
+            "Refusing to write an analysis report whose shape would crash "
+            "consumers — fix the producer before it lands.",
+            file=sys.stderr,
+        )
+        return 1
 
     output_path.write_text(
         json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"

--- a/tests/scripts/test_evolution_meta_skill_trace_wiring.py
+++ b/tests/scripts/test_evolution_meta_skill_trace_wiring.py
@@ -27,6 +27,59 @@ def test_record_meta_skill_trace_writes_jsonl(tmp_path: Path):
     assert data["merged"] == 0  # not known at audit time
 
 
+def test_record_meta_skill_trace_nested_effort_budget_dict_limit(tmp_path: Path):
+    """#168: nested effort_budget {\"limit\": ...} must not crash the audit."""
+    report = {
+        "date": "2026-08-29",
+        "effort_budget": {"limit": 3.0, "selected_total": 3.0, "note": "x"},
+    }
+    _record_meta_skill_trace(report, tmp_path)  # must not raise TypeError
+    data = json.loads((tmp_path / "meta-skill-traces.jsonl").read_text().strip())
+    assert data["effort_budget"] == 3.0
+
+
+def test_record_meta_skill_trace_nested_effort_budget_dict_max(tmp_path: Path):
+    """#168: nested effort_budget {\"max\": ...} must not crash the audit."""
+    report = {
+        "date": "2026-08-28",
+        "effort_budget": {"max": 3.0, "used": 2.7, "selected_count": 8},
+    }
+    _record_meta_skill_trace(report, tmp_path)  # must not raise TypeError
+    data = json.loads((tmp_path / "meta-skill-traces.jsonl").read_text().strip())
+    assert data["effort_budget"] == 3.0
+
+
+def test_check_effort_budget_shape_tolerates_scalar_and_known_dicts():
+    """#168: scalar, limit-dict and max-dict shapes are all readable."""
+    from scripts.evolution_analysis_audit import check_effort_budget_shape
+
+    assert check_effort_budget_shape({"effort_budget": 3.0}) == []
+    assert check_effort_budget_shape({"effort_budget": {"limit": 3.0}}) == []
+    assert check_effort_budget_shape({"effort_budget": {"max": 3.0, "used": 2.7}}) == []
+    assert check_effort_budget_shape({}) == []
+    assert check_effort_budget_shape({"effort_budget": None}) == []
+
+
+def test_check_effort_budget_shape_flags_unreadable_shapes():
+    """#168: an unreadable shape is a loud violation, not a crash."""
+    from scripts.evolution_analysis_audit import (
+        audit_analysis,
+        check_effort_budget_shape,
+    )
+
+    weird_dict = {"effort_budget": {"spent": 2.7}}  # no scalar under known keys
+    violations = check_effort_budget_shape(weird_dict)
+    assert violations and violations[0].startswith("EFFORT_BUDGET_SHAPE")
+
+    # The audit surfaces it as a violation string instead of dying.
+    assert audit_analysis(weird_dict) == violations
+
+    # Non-dict non-scalar (e.g. a string) is flagged too.
+    assert check_effort_budget_shape({"effort_budget": "high"})
+    # bool is not a valid budget scalar.
+    assert check_effort_budget_shape({"effort_budget": True})
+
+
 def test_record_meta_skill_trace_missing_selected(tmp_path: Path):
     """Handles a report with no selected_for_implementation gracefully."""
     report = {"date": "2026-08-09"}


### PR DESCRIPTION
Automated evolution PR for issue #168: meta-skill trace crashed with TypeError when effort_budget was a nested dict (08-28/08-29 reports). Now reads scalar explicitly + loud shape check at producer and consumer.