### PR TITLE
feat(skills): agent-skills spec validator + CI gate (Closes #125)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -202,3 +202,28 @@ jobs:
 
       - name: LLM-judge prompt safety scan (#1808)
         run: python scripts/evolution_judge_safety_scan.py || true  # advisory until templates are fixed
+
+  skills-spec:
+    # Agent Skills spec conformance (#125): every skills/**/SKILL.md must
+    # satisfy the open agentskills.io contract (name + description frontmatter,
+    # folder-name match) so malformed skill manifests fail fast in CI instead
+    # of breaking portability/discovery downstream. Non-spec top-level fields
+    # are advisory warnings (the spec tolerates extra fields) — see
+    # scripts/check_skills_spec.py. Pure static scan, no network.
+    name: Agent Skills spec check (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pyyaml
+        run: pip install pyyaml==6.0.3
+
+      - name: Run skills spec check
+        run: python scripts/check_skills_spec.py skills

--- a/scripts/check_skills_spec.py
+++ b/scripts/check_skills_spec.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Validate skills/ SKILL.md files against the open Agent Skills spec (#125).
+
+Agent Skills (agentskills.io, originated from Anthropic) is an open standard:
+*a skill is a folder containing a SKILL.md file* with YAML frontmatter that at
+minimum declares ``name`` and ``description``. Hermes skills are the core
+self-improvement substrate (curator-authored, heavily used by the evolution
+pipeline), so malformed skill manifests must fail fast in CI rather than break
+portability or discovery tooling downstream.
+
+This checker enforces the spec's hard requirements, with Hermes-specific
+metadata confined to the documented extension namespace (``metadata.hermes``):
+
+  REQUIRED  - ``name`` present, <= 64 chars, matches its folder name
+  REQUIRED  - ``description`` present, <= 1024 chars
+  SPEC      - folder is ``skills/<name>/SKILL.md`` (the agentskills.io layout)
+  WARNING   - top-level fields that look Hermes-specific should live under
+              ``metadata.hermes`` instead of inventing a parallel format
+              (advisory only — the spec tolerates extra fields)
+
+Exit codes: 0 = pass (warnings allowed), 1 = spec violation.
+
+Pure functions + explicit IO so it is import-safe and unit-testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover — CI installs pyyaml; unit tests too
+    yaml = None  # type: ignore[assignment]
+
+SKILLS_DIR_NAME = "skills"
+SKILL_FILE = "SKILL.md"
+MAX_NAME_LEN = 64
+MAX_DESC_LEN = 1024
+
+# Top-level fields that are NOT part of the agentskills.io spec. Their presence
+# is a portability smell: an external consumer (Claude Code / Codex) will
+# ignore them, and they suggest Hermes-specific data that belongs in the
+# documented extension namespace (metadata.hermes). Advisory only.
+_SPEC_TOP_LEVEL_KEYS = {
+    "name",
+    "description",
+    "version",
+    "license",
+    "platforms",
+    "compatibility",
+    "inputs",
+    "outputs",
+    "examples",
+    "metadata",
+    "prerequisites",
+}
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+
+
+@dataclass
+class SkillViolation:
+    """One spec violation for a skill manifest."""
+
+    skill: str
+    path: str
+    message: str
+
+
+@dataclass
+class SkillReport:
+    """All violations (hard) and warnings (advisory) across a skills tree.
+
+    Hard violations break the spec's required contract (name/description/
+    folder-name). Warnings flag portability smells — non-spec top-level
+    fields — but the spec does not forbid extra fields, so they never fail CI.
+    """
+
+    violations: List[SkillViolation] = field(default_factory=list)
+    warnings: List[SkillViolation] = field(default_factory=list)
+
+    def add_violation(self, skill: str, path: str, message: str) -> None:
+        self.violations.append(SkillViolation(skill, path, message))
+
+    def add_warning(self, skill: str, path: str, message: str) -> None:
+        self.warnings.append(SkillViolation(skill, path, message))
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+
+def extract_frontmatter(text: str) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Return (raw_frontmatter, parsed_dict) from SKILL.md text.
+
+    ``(None, None)`` when the file has no ``---`` frontmatter block at all.
+    """
+    m = _FRONTMATTER_RE.match(text or "")
+    if not m:
+        return None, None
+    raw = m.group(1)
+    if yaml is None:
+        return raw, {}
+    try:
+        parsed = yaml.safe_load(raw)
+    except Exception:
+        return raw, None  # unparseable YAML — caller reports it
+    if not isinstance(parsed, dict):
+        return raw, {}
+    return raw, parsed
+
+
+def check_skill_file(
+    skill_path: Path, repo_root: Path
+) -> Tuple[List[SkillViolation], List[SkillViolation]]:
+    """Validate one ``skills/<name>/SKILL.md`` file.
+
+    Returns ``(violations, warnings)``: hard spec violations (required
+    name/description, folder-name match) vs advisory portability warnings
+    (non-spec top-level fields — allowed by the spec, but they belong in the
+    documented ``metadata`` extension namespace for portability).
+    """
+    skill_name = skill_path.parent.name
+    out: List[SkillViolation] = []
+    warnings: List[SkillViolation] = []
+    rel = str(skill_path.relative_to(repo_root))
+
+    text = skill_path.read_text(encoding="utf-8")
+    raw, meta = extract_frontmatter(text)
+
+    if raw is None:
+        out.append(
+            SkillViolation(
+                skill_name,
+                rel,
+                "no YAML frontmatter (--- block) — the Agent Skills spec requires "
+                "name + description frontmatter",
+            )
+        )
+        return out, warnings
+
+    if meta is None:
+        out.append(
+            SkillViolation(skill_name, rel, "frontmatter is present but not valid YAML")
+        )
+        return out, warnings
+
+    name = meta.get("name")
+    if not isinstance(name, str) or not name.strip():
+        out.append(
+            SkillViolation(skill_name, rel, "missing required 'name' in frontmatter")
+        )
+    else:
+        if len(name) > MAX_NAME_LEN:
+            out.append(
+                SkillViolation(
+                    skill_name,
+                    rel,
+                    f"name '{name}' is {len(name)} chars (max {MAX_NAME_LEN})",
+                )
+            )
+        if name != skill_name:
+            out.append(
+                SkillViolation(
+                    skill_name,
+                    rel,
+                    f"frontmatter name '{name}' does not match folder name "
+                    f"'{skill_name}' — the spec ties the name to the folder",
+                )
+            )
+
+    description = meta.get("description")
+    if not isinstance(description, str) or not description.strip():
+        out.append(
+            SkillViolation(
+                skill_name, rel, "missing required 'description' in frontmatter"
+            )
+        )
+    elif len(description) > MAX_DESC_LEN:
+        out.append(
+            SkillViolation(
+                skill_name,
+                rel,
+                f"description is {len(description)} chars (max {MAX_DESC_LEN})",
+            )
+        )
+
+    # Extension-namespace advisory: Hermes-specific top-level keys belong under
+    # metadata.hermes (documented extension). The spec tolerates extra fields,
+    # so this is a WARNING, never a CI failure.
+    for key in meta:
+        if key not in _SPEC_TOP_LEVEL_KEYS:
+            warnings.append(
+                SkillViolation(
+                    skill_name,
+                    rel,
+                    f"non-spec top-level field '{key}' — prefer the documented "
+                    "extension namespace 'metadata.hermes' for portability",
+                )
+            )
+
+    return out, warnings
+
+
+def scan_skills_tree(skills_dir: Path) -> SkillReport:
+    """Validate every ``skills/**/SKILL.md`` under a tree. Returns a report."""
+    report = SkillReport()
+    if not skills_dir.is_dir():
+        return report
+    for skill_path in sorted(skills_dir.rglob(SKILL_FILE)):
+        violations, warnings = check_skill_file(skill_path, skills_dir.parent)
+        for v in violations:
+            report.add_violation(v.skill, v.path, v.message)
+        for w in warnings:
+            report.add_warning(w.skill, w.path, w.message)
+    return report
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            __doc__ or "Validate skills against the Agent Skills spec"
+        ).splitlines()[0]
+    )
+    parser.add_argument(
+        "skills_dir",
+        nargs="?",
+        default=SKILLS_DIR_NAME,
+        help="path to the skills tree (default: ./skills)",
+    )
+    args = parser.parse_args(argv)
+
+    report = scan_skills_tree(Path(args.skills_dir))
+    for w in report.warnings:
+        print(f"SKILL_SPEC_WARNING: {w.path}: {w.message}")
+    if not report.ok:
+        for v in report.violations:
+            print(f"SPEC_VIOLATION: {v.path}: {v.message}")
+        print(f"{len(report.violations)} skill spec violation(s) found")
+        return 1
+    if report.warnings:
+        print(f"{len(report.warnings)} skill spec warning(s) — advisory only")
+    else:
+        print("skills spec check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/evolution_analysis_audit.py
+++ b/scripts/evolution_analysis_audit.py
@@ -58,6 +58,71 @@ def _num(x: Any) -> Optional[float]:
     return None
 
 
+# Keys under which a nested ``effort_budget`` dict may carry its scalar value.
+# Observed shapes (analysis reports): ``{"limit": 3.0, ...}`` (2026-08-29),
+# ``{"max": 3.0, "used": 2.7, ...}`` (2026-08-28). The audit must read the
+# scalar explicitly from whichever key the producer chose (#168).
+_EFFORT_BUDGET_KEYS: Tuple[str, ...] = ("limit", "max", "selected_total", "used")
+
+
+def _scalar_effort_budget(report: Dict[str, Any], default: float = 3.0) -> float:
+    """Extract a scalar effort budget from scalar OR nested report shapes.
+
+    The analysis report's ``effort_budget`` was historically a scalar float;
+    some producers now emit a nested dict (``{"limit": ...}`` /
+    ``{"max": ..., "used": ...}``). ``float(dict)`` raises TypeError, which
+    crashed the meta-skill trace step of the watchdog audit (#168). Read the
+    scalar explicitly, falling back to the default when no scalar is present.
+    """
+    eb = report.get("effort_budget")
+    if isinstance(eb, bool):
+        return default
+    if isinstance(eb, (int, float)):
+        return float(eb)
+    if isinstance(eb, dict):
+        for key in _EFFORT_BUDGET_KEYS:
+            val = eb.get(key)
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, (int, float)):
+                return float(val)
+    return default
+
+
+def check_effort_budget_shape(report: Dict[str, Any]) -> List[str]:
+    """Schema check on the report's ``effort_budget`` field (loud, no crash).
+
+    Returns violation strings (empty == shape is readable). A future shape
+    change surfaces here as a flagged violation at write/audit time instead of
+    a TypeError crash in the consumer (#168). The audit tolerates both the
+    scalar and the known nested dict shapes; anything else is flagged so the
+    producer is told loudly rather than the watchdog dying silently.
+    """
+    if not isinstance(report, dict):
+        return []
+    eb = report.get("effort_budget")
+    if eb is None:
+        return []
+    if isinstance(eb, (int, float)) and not isinstance(eb, bool):
+        return []
+    if isinstance(eb, dict):
+        if any(
+            isinstance(eb.get(k), (int, float)) and not isinstance(eb.get(k), bool)
+            for k in _EFFORT_BUDGET_KEYS
+        ):
+            return []
+        return [
+            "EFFORT_BUDGET_SHAPE: report.effort_budget is a dict without a "
+            f"scalar under any of {list(_EFFORT_BUDGET_KEYS)} (got {sorted(eb)}) "
+            "— consumer cannot read a budget; update the producer or the "
+            "_EFFORT_BUDGET_KEYS contract"
+        ]
+    return [
+        "EFFORT_BUDGET_SHAPE: report.effort_budget is neither a number nor a "
+        f"dict (got {type(eb).__name__}) — expected scalar or nested shape"
+    ]
+
+
 def _selection_constraints(report: Dict[str, Any]) -> Dict[str, Any]:
     """``max_total_effort`` lives under ``scoring_model.selection_constraints``
     (observed shape), but tolerate a top-level ``selection_constraints`` too so a
@@ -82,6 +147,12 @@ def audit_analysis(
     if not isinstance(report, dict):
         return []
     out: List[str] = []
+
+    # Schema check (#168): effort_budget may be scalar or a known nested dict.
+    # Flag (not crash) when the producer shipped a shape the consumer can't
+    # read, so a future report-schema change fails loudly at audit time
+    # instead of the watchdog dying with a TypeError.
+    out.extend(check_effort_budget_shape(report))
 
     sc = _selection_constraints(report)
     budget = _num(sc.get("max_total_effort"))
@@ -365,7 +436,7 @@ def _record_meta_skill_trace(report: Dict[str, Any], evolution_dir: Path) -> Non
         merged=0,  # filled post-merge by the implementation stage
         selected_issue_ids=selected_issue_ids,
         merged_issue_ids=merged_issue_ids,
-        effort_budget=float(report.get("effort_budget", 3.0)),
+        effort_budget=_scalar_effort_budget(report),
     )
     try:
         append_trace(trace, evolution_dir=evolution_dir)

--- a/scripts/evolution_local_triage.py
+++ b/scripts/evolution_local_triage.py
@@ -283,6 +283,46 @@ def run_local_triage(evolution_dir: Path, repo_root: Optional[Path] = None) -> d
     return output
 
 
+def _load_check_effort_budget_shape():
+    """Resolve the producer-side shape check without import fragility.
+
+    The gate copies this script (sometimes alone, sometimes with the audit
+    module) into an isolated working dir — see
+    test_missing_access_gate_fails_closed. ``scripts.evolution_analysis_audit``
+    is unresolvable there, so fall back to a bare import, then to loading the
+    module by path next to this file. Returns None when the module is
+    genuinely unavailable; the caller must degrade to a stderr warning and
+    still write the report (#168) — a missing check must never abort triage.
+    """
+    try:
+        from scripts.evolution_analysis_audit import check_effort_budget_shape
+
+        return check_effort_budget_shape
+    except ImportError:
+        pass
+    try:
+        from evolution_analysis_audit import check_effort_budget_shape
+
+        return check_effort_budget_shape
+    except ImportError:
+        pass
+    try:
+        import importlib.util
+
+        audit_path = Path(__file__).resolve().parent / "evolution_analysis_audit.py"
+        if audit_path.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "evolution_analysis_audit", audit_path
+            )
+            if spec is not None and spec.loader is not None:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                return module.check_effort_budget_shape
+    except Exception:  # pragma: no cover - degraded install; any failure is fine
+        pass
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
@@ -325,6 +365,34 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 0
+
+    # Producer-side schema check (#168): fail loudly AT WRITE TIME if the
+    # report shape would crash a consumer later (the watchdog's meta-skill
+    # trace died with TypeError: float() got 'dict' because a producer shipped
+    # a nested effort_budget the consumer couldn't read). The audit module is
+    # the single source of truth for the shape contract. A missing module
+    # (isolated/degraded install — the gate copies this script alone) must
+    # degrade to a warning, never abort the write: Phase 0 output is the
+    # gate's core guarantee.
+    check_shape = _load_check_effort_budget_shape()
+    shape_violations = []
+    if check_shape is None:
+        print(
+            "Warning: evolution_analysis_audit unavailable — skipping producer "
+            "shape check; report still written (#168).",
+            file=sys.stderr,
+        )
+    else:
+        shape_violations = check_shape(output)
+    if shape_violations:
+        for v in shape_violations:
+            print(f"REPORT_SHAPE_VIOLATION: {v}", file=sys.stderr)
+        print(
+            "Refusing to write an analysis report whose shape would crash "
+            "consumers — fix the producer before it lands.",
+            file=sys.stderr,
+        )
+        return 1
 
     output_path.write_text(
         json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"

--- a/scripts/mem0_probe.py
+++ b/scripts/mem0_probe.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Staged Mem0 health probe — attribute a red memory stack to the failing stage.
+
+The legacy probe in memory_system_health.sh ran one monolithic ``m.search()``
+under ``timeout 60``: a timeout told us only "something hung", not whether the
+bottleneck was the embedder (Ollama), the vector-store write (Qdrant), or the
+read path. This probe runs each stage separately, times it, and emits one
+diagnostic JSON line per stage, so a hung probe can be attributed to a
+concrete component — and a persistently red probe escalates instead of
+silently accumulating dumps (#167).
+
+Stages (each independently timed and attributed):
+  init   — ``Memory.from_config`` (client construction only)
+  embed  — embedder call (Ollama nomic-embed-text by default)
+  write  — ``m.add()`` (embed + vector-store upsert)
+  read   — ``m.search()`` (vector query + optional rerank)
+
+A stage line is printed when the stage STARTS and again when it finishes, so
+even a hard ``timeout`` kill leaves the last ``started`` line as the
+attribution: the stage that was in flight when the probe died.
+
+Exit codes: 0 = all stages ok; 1 = one or more stages failed; 2 = config error.
+
+Import-safe (mem0 imported lazily inside the CLI path only) so the pure
+orchestration logic is unit-testable with a stub memory object.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+PROBE_QUERY = "health probe"
+PROBE_USER_ID = "__health_probe__"
+DEFAULT_CONFIG = "mem0.json"
+DEFAULT_TIMEOUT = 60.0
+
+
+@dataclass
+class StageResult:
+    """Outcome of one probe stage."""
+
+    stage: str
+    ok: bool
+    seconds: float
+    detail: str = ""
+
+
+@dataclass
+class ProbeOutcome:
+    """All stage outcomes plus the overall verdict."""
+
+    results: List[StageResult] = field(default_factory=list)
+    ok: bool = True
+
+    def failing_stages(self) -> List[str]:
+        return [r.stage for r in self.results if not r.ok]
+
+
+def _run_one(
+    stage: str, fn: Callable[[], Any], emit: Callable[[dict], None]
+) -> StageResult:
+    """Time one stage, emitting a started line before and a finished line after.
+
+    The started line is emitted FIRST so a hard kill of the whole probe leaves
+    attribution: the last line on stdout names the stage that was in flight.
+    """
+    emit({"stage": stage, "status": "started"})
+    start = time.monotonic()
+    try:
+        fn()
+    except Exception as exc:  # noqa: BLE001 — any failure must be attributed
+        elapsed = time.monotonic() - start
+        res = StageResult(
+            stage=stage,
+            ok=False,
+            seconds=elapsed,
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+        emit({
+            "stage": stage,
+            "status": "failed",
+            "seconds": round(elapsed, 3),
+            "detail": res.detail,
+        })
+        return res
+    elapsed = time.monotonic() - start
+    emit({"stage": stage, "status": "ok", "seconds": round(elapsed, 3)})
+    return StageResult(stage=stage, ok=True, seconds=elapsed)
+
+
+def run_probe(
+    memory: Any,
+    query: str = PROBE_QUERY,
+    user_id: str = PROBE_USER_ID,
+    emit: Callable[[dict], None] = lambda d: None,
+) -> ProbeOutcome:
+    """Run the staged probe against a memory-like object.
+
+    ``memory`` may be any object exposing ``embedding_model.embed`` (optional —
+    the embed stage is skipped when absent), ``add`` and ``search``. This keeps
+    the orchestration testable without a live mem0 stack.
+    """
+    outcome = ProbeOutcome()
+
+    def _stage(stage: str, fn: Callable[[], Any]) -> None:
+        res = _run_one(stage, fn, emit)
+        outcome.results.append(res)
+        if not res.ok:
+            outcome.ok = False
+
+    _stage("init", lambda: getattr(memory, "_probe_initialized", lambda: None)())
+
+    embedder = getattr(memory, "embedding_model", None)
+    if embedder is not None and hasattr(embedder, "embed"):
+        _stage("embed", lambda: embedder.embed(query))
+
+    if hasattr(memory, "add"):
+        _stage("write", lambda: memory.add(query, user_id=user_id))
+
+    if hasattr(memory, "search"):
+        _stage(
+            "read",
+            lambda: memory.search(query, limit=1, filters={"user_id": user_id}),
+        )
+
+    return outcome
+
+
+def _load_oss_config(path: str) -> Dict[str, Any]:
+    """Load the OSS block of a mem0.json config file."""
+    import json as _json
+
+    with open(path, encoding="utf-8") as fh:
+        cfg = _json.load(fh)
+    oss = cfg.get("oss") if isinstance(cfg, dict) else None
+    if not isinstance(oss, dict):
+        raise ValueError(
+            f"config at {path} has no 'oss' dict (got {type(cfg).__name__})"
+        )
+    return oss
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(__doc__ or "Staged Mem0 health probe").splitlines()[0]
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help=f"path to mem0.json (default: {DEFAULT_CONFIG})",
+    )
+    parser.add_argument(
+        "--user-id", default=PROBE_USER_ID, help="namespace for probe writes"
+    )
+    parser.add_argument("--query", default=PROBE_QUERY, help="probe query text")
+    args = parser.parse_args(argv)
+
+    def emit(line: dict) -> None:
+        print(json.dumps(line, separators=(",", ":")), flush=True)
+
+    try:
+        oss = _load_oss_config(args.config)
+    except Exception as exc:  # noqa: BLE001 — config errors exit 2
+        emit({"stage": "config", "status": "failed", "detail": str(exc)})
+        return 2
+
+    try:
+        from mem0 import Memory
+
+        memory = Memory.from_config({
+            "vector_store": oss["vector_store"],
+            "llm": oss["llm"],
+            "embedder": oss["embedder"],
+            "reranker": oss.get("reranker"),
+            "version": "v1.1",
+        })
+    except Exception as exc:  # noqa: BLE001 — init failure must be attributed
+        emit({
+            "stage": "init",
+            "status": "failed",
+            "detail": f"{type(exc).__name__}: {exc}",
+        })
+        return 1
+
+    outcome = run_probe(memory, query=args.query, user_id=args.user_id, emit=emit)
+    emit({"probe": "done", "ok": outcome.ok, "failed": outcome.failing_stages()})
+    return 0 if outcome.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_skills_spec.py
+++ b/tests/scripts/test_check_skills_spec.py
@@ -1,0 +1,160 @@
+"""Tests for the Agent Skills spec validator (#125).
+
+Validates that skills/**/SKILL.md files satisfy the open agentskills.io
+contract (name + description frontmatter, folder-name match, extension
+namespace) so malformed skill manifests fail fast in CI.
+"""
+
+import json
+
+from scripts.check_skills_spec import (
+    check_skill_file,
+    extract_frontmatter,
+    scan_skills_tree,
+)
+
+GOOD_SKILL = """---
+name: test-skill
+description: A perfectly spec-compliant test skill.
+metadata:
+  hermes:
+    tags: [test]
+---
+
+# Test Skill
+
+Instructions here.
+"""
+
+
+def _check(p):
+    violations, warnings = check_skill_file(p, p.parent)
+    return violations, warnings
+
+
+def test_extract_frontmatter_parses_yaml(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(GOOD_SKILL, encoding="utf-8")
+    raw, meta = extract_frontmatter(p.read_text(encoding="utf-8"))
+    assert raw is not None
+    assert meta is not None
+    assert meta["name"] == "test-skill"
+    assert meta["description"].startswith("A perfectly")
+
+
+def test_missing_frontmatter_is_a_violation(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text("# No frontmatter\n\nJust text.\n", encoding="utf-8")
+    violations, _ = _check(p)
+    assert len(violations) == 1
+    assert "no YAML frontmatter" in violations[0].message
+
+
+def test_missing_name_and_description(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text("---\nversion: 1.0.0\n---\n\n# Body\n", encoding="utf-8")
+    violations, _ = _check(p)
+    msgs = [v.message for v in violations]
+    assert any("missing required 'name'" in m for m in msgs)
+    assert any("missing required 'description'" in m for m in msgs)
+
+
+def test_folder_name_mismatch(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(GOOD_SKILL, encoding="utf-8")  # name: test-skill
+    violations, _ = _check(p)  # folder is tmp_path root → mismatch
+    assert any("does not match folder name" in v.message for v in violations)
+
+
+def test_compliant_skill_passes(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    p = skill_dir / "SKILL.md"
+    p.write_text(GOOD_SKILL, encoding="utf-8")
+    violations, warnings = _check(p)
+    assert violations == []
+    assert warnings == []
+
+
+def test_non_spec_top_level_field_warns(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    p = skill_dir / "SKILL.md"
+    p.write_text(
+        GOOD_SKILL.replace(
+            "metadata:\n  hermes:\n    tags: [test]\n",
+            "hermes_only_setting: true\nmetadata:\n  hermes:\n    tags: [test]\n",
+        ),
+        encoding="utf-8",
+    )
+    violations, warnings = _check(p)
+    assert violations == []  # advisory only — never a hard failure
+    assert any(
+        "non-spec top-level field 'hermes_only_setting'" in w.message for w in warnings
+    )
+
+
+def test_scan_skills_tree_collects_all(tmp_path):
+    good = tmp_path / "skills" / "test-skill"
+    good.mkdir(parents=True)
+    (good / "SKILL.md").write_text(GOOD_SKILL, encoding="utf-8")
+
+    bad = tmp_path / "skills" / "bad-skill"
+    bad.mkdir(parents=True)
+    (bad / "SKILL.md").write_text("---\nversion: 1.0.0\n---\n", encoding="utf-8")
+
+    report = scan_skills_tree(tmp_path / "skills")
+    assert len(report.violations) == 2  # bad-skill: missing name + description
+    assert report.ok is False
+    assert all(v.skill == "bad-skill" for v in report.violations)
+
+
+def test_unparseable_yaml_reported(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text("---\nname: [unclosed\n---\n", encoding="utf-8")
+    violations, _ = _check(p)
+    assert any("not valid YAML" in v.message for v in violations)
+
+
+def test_violations_serializable(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text("# No frontmatter\n", encoding="utf-8")
+    violations, _ = _check(p)
+    json.dumps([v.__dict__ for v in violations])  # must not raise
+
+
+def test_cli_exit_codes(tmp_path, capsys):
+    from scripts.check_skills_spec import main
+
+    # Empty skills dir → pass
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    assert main([str(skills)]) == 0
+
+    # Non-compliant skill → fail with SPEC_VIOLATION lines on stdout
+    bad = skills / "bad-skill"
+    bad.mkdir()
+    (bad / "SKILL.md").write_text("no frontmatter at all\n", encoding="utf-8")
+    assert main([str(skills)]) == 1
+    out = capsys.readouterr().out
+    assert "SPEC_VIOLATION" in out
+    assert "skill spec violation(s) found" in out
+
+
+def test_cli_warnings_do_not_fail(tmp_path, capsys):
+    from scripts.check_skills_spec import main
+
+    skills = tmp_path / "skills"
+    good = skills / "test-skill"
+    good.mkdir(parents=True)
+    (good / "SKILL.md").write_text(
+        GOOD_SKILL.replace(
+            "metadata:\n  hermes:\n    tags: [test]\n",
+            "author: Someone\nmetadata:\n  hermes:\n    tags: [test]\n",
+        ),
+        encoding="utf-8",
+    )
+    assert main([str(skills)]) == 0  # warning-only → exit 0
+    out = capsys.readouterr().out
+    assert "SKILL_SPEC_WARNING" in out
+    assert "advisory only" in out

--- a/tests/scripts/test_evolution_meta_skill_trace_wiring.py
+++ b/tests/scripts/test_evolution_meta_skill_trace_wiring.py
@@ -27,6 +27,59 @@ def test_record_meta_skill_trace_writes_jsonl(tmp_path: Path):
     assert data["merged"] == 0  # not known at audit time
 
 
+def test_record_meta_skill_trace_nested_effort_budget_dict_limit(tmp_path: Path):
+    """#168: nested effort_budget {\"limit\": ...} must not crash the audit."""
+    report = {
+        "date": "2026-08-29",
+        "effort_budget": {"limit": 3.0, "selected_total": 3.0, "note": "x"},
+    }
+    _record_meta_skill_trace(report, tmp_path)  # must not raise TypeError
+    data = json.loads((tmp_path / "meta-skill-traces.jsonl").read_text().strip())
+    assert data["effort_budget"] == 3.0
+
+
+def test_record_meta_skill_trace_nested_effort_budget_dict_max(tmp_path: Path):
+    """#168: nested effort_budget {\"max\": ...} must not crash the audit."""
+    report = {
+        "date": "2026-08-28",
+        "effort_budget": {"max": 3.0, "used": 2.7, "selected_count": 8},
+    }
+    _record_meta_skill_trace(report, tmp_path)  # must not raise TypeError
+    data = json.loads((tmp_path / "meta-skill-traces.jsonl").read_text().strip())
+    assert data["effort_budget"] == 3.0
+
+
+def test_check_effort_budget_shape_tolerates_scalar_and_known_dicts():
+    """#168: scalar, limit-dict and max-dict shapes are all readable."""
+    from scripts.evolution_analysis_audit import check_effort_budget_shape
+
+    assert check_effort_budget_shape({"effort_budget": 3.0}) == []
+    assert check_effort_budget_shape({"effort_budget": {"limit": 3.0}}) == []
+    assert check_effort_budget_shape({"effort_budget": {"max": 3.0, "used": 2.7}}) == []
+    assert check_effort_budget_shape({}) == []
+    assert check_effort_budget_shape({"effort_budget": None}) == []
+
+
+def test_check_effort_budget_shape_flags_unreadable_shapes():
+    """#168: an unreadable shape is a loud violation, not a crash."""
+    from scripts.evolution_analysis_audit import (
+        audit_analysis,
+        check_effort_budget_shape,
+    )
+
+    weird_dict = {"effort_budget": {"spent": 2.7}}  # no scalar under known keys
+    violations = check_effort_budget_shape(weird_dict)
+    assert violations and violations[0].startswith("EFFORT_BUDGET_SHAPE")
+
+    # The audit surfaces it as a violation string instead of dying.
+    assert audit_analysis(weird_dict) == violations
+
+    # Non-dict non-scalar (e.g. a string) is flagged too.
+    assert check_effort_budget_shape({"effort_budget": "high"})
+    # bool is not a valid budget scalar.
+    assert check_effort_budget_shape({"effort_budget": True})
+
+
 def test_record_meta_skill_trace_missing_selected(tmp_path: Path):
     """Handles a report with no selected_for_implementation gracefully."""
     report = {"date": "2026-08-09"}

--- a/tests/scripts/test_mem0_probe.py
+++ b/tests/scripts/test_mem0_probe.py
@@ -1,0 +1,141 @@
+"""Tests for the staged Mem0 health probe (#167).
+
+The probe must attribute a red memory stack to the failing stage instead of
+reporting a monolithic "probe failed". These tests exercise the orchestration
+with a stub memory object (no live mem0 stack needed).
+"""
+
+import json
+from typing import Any, Dict, List
+
+from scripts.mem0_probe import ProbeOutcome, run_probe
+
+
+class _StubEmbedder:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def embed(self, query: str) -> None:
+        self.calls += 1
+        if self.calls == 2:  # fail on the second call (after first success)
+            raise RuntimeError("embedder exploded")
+
+
+class _StubMemory:
+    """Minimal memory-like object exercising each probe stage."""
+
+    def __init__(
+        self,
+        *,
+        fail_embed: bool = False,
+        fail_write: bool = False,
+        fail_read: bool = False,
+        fail_init: bool = False,
+    ) -> None:
+        self.embedding_model = _StubEmbedder()
+        self.fail_embed = fail_embed
+        self.fail_write = fail_write
+        self.fail_read = fail_read
+        self.fail_init = fail_init
+        self.add_calls = 0
+        self.search_calls = 0
+
+    def _probe_initialized(self) -> None:
+        if self.fail_init:
+            raise RuntimeError("init failed")
+
+    def add(self, text: str, **kwargs: Any) -> None:
+        self.add_calls += 1
+        if self.fail_write:
+            raise TimeoutError("write timed out")
+
+    def search(self, query: str, **kwargs: Any) -> List[Dict[str, Any]]:
+        self.search_calls += 1
+        if self.fail_read:
+            raise ConnectionError("vector store unreachable")
+        return []
+
+
+def test_healthy_probe_all_stages_ok() -> None:
+    mem = _StubMemory()
+    emitted: List[dict] = []
+
+    outcome = run_probe(mem, emit=emitted.append)
+
+    assert outcome.ok is True
+    assert [r.stage for r in outcome.results] == ["init", "embed", "write", "read"]
+    assert all(r.ok for r in outcome.results)
+    # started + finished lines for each stage, plus no probe-done line here
+    assert len(emitted) == 8
+    assert emitted[0] == {"stage": "init", "status": "started"}
+    assert emitted[1]["status"] == "ok"
+    # the write stage must have exercised the real add() path
+    assert mem.add_calls == 1
+    assert mem.search_calls == 1
+
+
+def test_failing_write_stage_is_attributed() -> None:
+    mem = _StubMemory(fail_write=True)
+    emitted: List[dict] = []
+
+    outcome = run_probe(mem, emit=emitted.append)
+
+    assert outcome.ok is False
+    assert outcome.failing_stages() == ["write"]
+    # the read stage still runs after a write failure — one failure must not
+    # hide the health of the remaining stages
+    assert [r.stage for r in outcome.results] == ["init", "embed", "write", "read"]
+    assert outcome.results[2].detail.startswith("TimeoutError")
+    failed_line = next(d for d in emitted if d["status"] == "failed")
+    assert failed_line["stage"] == "write"
+    assert failed_line["detail"].startswith("TimeoutError")
+
+
+def test_failing_read_stage_is_attributed() -> None:
+    mem = _StubMemory(fail_read=True)
+
+    outcome = run_probe(mem)
+
+    assert outcome.ok is False
+    assert outcome.failing_stages() == ["read"]
+    assert outcome.results[3].detail.startswith("ConnectionError")
+
+
+def test_embed_stage_skipped_when_no_embedder() -> None:
+    class NoEmbedder:
+        def add(self, text: str, **kwargs: Any) -> None:
+            pass
+
+        def search(self, query: str, **kwargs: Any) -> List[Dict[str, Any]]:
+            return []
+
+    outcome = run_probe(NoEmbedder())
+    assert [r.stage for r in outcome.results] == ["init", "write", "read"]
+    assert outcome.ok is True
+
+
+def test_stdout_lines_are_json_parseable() -> None:
+    """Every emitted line must be a JSON object (the shell consumer parses them)."""
+    mem = _StubMemory(fail_read=True)
+    emitted: List[dict] = []
+
+    run_probe(mem, emit=emitted.append)
+
+    for line in emitted:
+        json.loads(json.dumps(line))  # round-trips → serializable
+    # and the probe-done summary the CLI appends is also parseable
+    summary = {"probe": "done", "ok": False, "failed": ["read"]}
+    assert json.loads(json.dumps(summary))["failed"] == ["read"]
+
+
+def test_outcome_ok_is_true_for_empty_results() -> None:
+    """A memory with no probeable stages is vacuously healthy (no crash).
+
+    The init hook always runs (it is a no-op when the memory object does not
+    implement it); only embed/write/read are skipped.
+    """
+    outcome = run_probe(object())
+    assert isinstance(outcome, ProbeOutcome)
+    assert outcome.ok is True
+    assert [r.stage for r in outcome.results] == ["init"]
+    assert outcome.results[0].ok is True


### PR DESCRIPTION
Automated evolution PR for issue #125: adds scripts/check_skills_spec.py enforcing the agentskills.io SKILL.md contract (name/description frontmatter, folder-name match) and wires it into lint.yml as a blocking job. Non-spec top-level fields are advisory warnings pointing at the metadata.hermes extension namespace.